### PR TITLE
feat(scripts): add @Aspect PDL change report tool + manual workflow

### DIFF
--- a/.github/scripts/report_aspect_changes.py
+++ b/.github/scripts/report_aspect_changes.py
@@ -2,9 +2,10 @@
 """
 Report @Aspect PDL breaking changes between two git refs.
 
-By default, compares the current branch HEAD against the most recent v1.0*
-non-rc tag reachable from it. Used during the v1.1.0 release window to monitor
-aspect-level breaking changes across the 1.0.x → 1.1.x transition.
+By default, compares `acryl-main` against the latest stable `-cloud` release
+tag reachable from it (falling back to the latest `-cloud` tag if no stable
+release exists yet). Used to audit aspect-level breaking changes across any
+release window — the defaults self-adjust as new releases ship.
 
 Usage:
     python3 .github/scripts/report_aspect_changes.py
@@ -31,29 +32,61 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PDL_PREFIX = "metadata-models/src/main/pegasus"
 
 
-def resolve_base(head: str) -> str:
-    """Pick the most recent v1.0* non-rc tag reachable from `head`."""
+def _latest_tag(
+    match: str, *, exclude_substr: Optional[str] = None
+) -> Optional[str]:
+    """Return the latest tag (version-sorted descending) matching `match`.
+
+    Uses `git tag --list --sort=-v:refname` for a global tag enumeration —
+    no ancestry constraint. Release tags in this repo often live on parallel
+    hotfix branches that aren't ancestors of trunk, so an ancestry-based
+    lookup (`git describe --abbrev=0`) would miss them. Pass `exclude_substr`
+    to skip tags whose names contain a substring (e.g. "rc"). Returns None
+    if no matching tag is found or git fails.
+    """
     try:
-        return subprocess.check_output(
-            [
-                "git",
-                "describe",
-                "--tags",
-                "--match",
-                "v1.0*",
-                "--exclude",
-                "*rc*",
-                "--abbrev=0",
-                head,
-            ],
+        out = subprocess.check_output(
+            ["git", "tag", "--list", match, "--sort=-v:refname"],
             text=True,
             cwd=REPO_ROOT,
-        ).strip()
-    except subprocess.CalledProcessError:
-        raise SystemExit(
-            f"Could not auto-resolve a v1.0* baseline ancestor of {head}. "
-            "Pass --base explicitly."
+            stderr=subprocess.DEVNULL,
         )
+    except subprocess.CalledProcessError:
+        return None
+    for line in out.splitlines():
+        tag = line.strip()
+        if not tag:
+            continue
+        if exclude_substr and exclude_substr in tag:
+            continue
+        return tag
+    return None
+
+
+def resolve_base() -> str:
+    """Pick the latest stable `-cloud` release tag (global, version-sorted).
+
+    Looks across all tags in the repo, not just ancestors of any specific
+    ref. This is required because stable `-cloud` releases are typically
+    cut on parallel hotfix branches (e.g. `origin/hotfixes/v1.0.0`) that
+    aren't ancestors of `acryl-main`. An ancestry-based lookup would never
+    find them.
+
+    Falls back to the latest `-cloud` tag of any kind (rc accepted) if no
+    stable release exists yet. The defaults self-maintain across releases
+    — no hardcoded minor-version prefix to bump at every release cut.
+    """
+    stable = _latest_tag(match="v*-cloud", exclude_substr="rc")
+    if stable:
+        return stable
+    rc_fallback = _latest_tag(match="v*-cloud")
+    if rc_fallback:
+        return rc_fallback
+    raise SystemExit(
+        "Could not find any -cloud release tag in this repo. Tried "
+        "`git tag --list 'v*-cloud' --sort=-v:refname` with and without "
+        "the rc filter. Pass --base explicitly."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1681,9 +1714,19 @@ def main(argv: list[str] | None = None) -> int:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p.add_argument(
-        "--base", default=None, help="baseline ref (default: latest v1.0* non-rc tag)"
+        "--base",
+        default=None,
+        help=(
+            "baseline ref (default: latest stable -cloud release tag in the "
+            "repo via global version-sorted tag lookup; falls back to latest "
+            "-cloud tag if no stable exists yet)"
+        ),
     )
-    p.add_argument("--head", default="HEAD", help="head ref (default: HEAD)")
+    p.add_argument(
+        "--head",
+        default="acryl-main",
+        help="head ref (default: acryl-main)",
+    )
     p.add_argument(
         "--output", default=None, help="write markdown to FILE (default: stdout)"
     )
@@ -1698,7 +1741,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = p.parse_args(argv)
 
-    base = args.base or resolve_base(args.head)
+    base = args.base or resolve_base()
     head_sha = _head_sha(args.head)
 
     if args.per_pr:

--- a/.github/scripts/report_aspect_changes.py
+++ b/.github/scripts/report_aspect_changes.py
@@ -1,0 +1,1778 @@
+#!/usr/bin/env python3
+"""
+Report @Aspect PDL breaking changes between two git refs.
+
+By default, compares the current branch HEAD against the most recent v1.0*
+non-rc tag reachable from it. Used during the v1.1.0 release window to monitor
+aspect-level breaking changes across the 1.0.x → 1.1.x transition.
+
+Usage:
+    python3 .github/scripts/report_aspect_changes.py
+    python3 .github/scripts/report_aspect_changes.py --base v1.0.0rc1-cloud
+    python3 .github/scripts/report_aspect_changes.py --output report.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field as dc_field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+# Reuse the parsing/graph helpers from bump_schema_versions.py.
+# Read-only consumption; the source module is intentionally untouched.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bump_schema_versions as bsv  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PDL_PREFIX = "metadata-models/src/main/pegasus"
+
+
+def resolve_base(head: str) -> str:
+    """Pick the most recent v1.0* non-rc tag reachable from `head`."""
+    try:
+        return subprocess.check_output(
+            [
+                "git",
+                "describe",
+                "--tags",
+                "--match",
+                "v1.0*",
+                "--exclude",
+                "*rc*",
+                "--abbrev=0",
+                head,
+            ],
+            text=True,
+            cwd=REPO_ROOT,
+        ).strip()
+    except subprocess.CalledProcessError:
+        raise SystemExit(
+            f"Could not auto-resolve a v1.0* baseline ancestor of {head}. "
+            "Pass --base explicitly."
+        )
+
+
+# ---------------------------------------------------------------------------
+# PDL parsing (heuristic, ported from .claude/local/check_pdl_aspects.py)
+# ---------------------------------------------------------------------------
+
+_DOC_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_LINE_COMMENT_RE = re.compile(r"//[^\n]*")
+
+
+def _strip_comments(src: str) -> str:
+    return _LINE_COMMENT_RE.sub("", _DOC_RE.sub("", src))
+
+
+_ASPECT_BLOCK_RE = re.compile(r"@Aspect\s*=\s*\{(?P<body>[^}]*)\}", re.DOTALL)
+
+
+def aspect_meta(src: str) -> Optional[dict]:
+    """Return {name, schemaVersion, type} for the @Aspect annotation, or None."""
+    m = _ASPECT_BLOCK_RE.search(src)
+    if not m:
+        return None
+    body = m.group("body")
+    name = re.search(r'"name"\s*:\s*"([^"]+)"', body)
+    ver = re.search(r'"schemaVersion"\s*:\s*(\d+)', body)
+    typ = re.search(r'"type"\s*:\s*"([^"]+)"', body)
+    return {
+        "name": name.group(1) if name else None,
+        "schemaVersion": int(ver.group(1)) if ver else None,
+        "type": typ.group(1) if typ else None,
+    }
+
+
+_RECORD_RE = re.compile(
+    r"record\s+(?P<name>\w+)(?:\s+includes\s+[^\{]+)?\s*\{(?P<body>.*)\}",
+    re.DOTALL,
+)
+
+
+def record_name(src: str) -> Optional[str]:
+    m = _RECORD_RE.search(_strip_comments(src))
+    return m.group("name") if m else None
+
+
+def renamed_from(src: str) -> Optional[str]:
+    m = re.search(r'@renamedFrom\s*=\s*"([^"]+)"', src)
+    return m.group(1) if m else None
+
+
+_FIELD_LINE_RE = re.compile(
+    r"^\s*(?P<name>\w+)\s*:\s*(?P<opt>optional\s+)?(?P<type>(?:[^=\n]|\[[^\]]*\])+?)\s*(?:=\s*[^,\n]+)?\s*$"
+)
+
+
+def fields(src: str) -> dict[str, dict]:
+    """Return {field_name: {'optional': bool, 'type': str}} for the outermost record."""
+    cleaned = _strip_comments(src)
+    m = _RECORD_RE.search(cleaned)
+    if not m:
+        return {}
+    body = m.group("body")
+    # Drop nested record/enum/typeref bodies so we don't pick up their fields
+    body = re.sub(r"(record|enum|typeref)\s+\w+[^{}]*\{[^{}]*\}", "", body)
+    out: dict[str, dict] = {}
+    for raw_line in body.splitlines():
+        line = re.sub(r"@\w+(?:\s*=\s*(?:\{[^}]*\}|\"[^\"]*\"|\d+))?", "", raw_line)
+        if not line.strip() or line.strip().startswith("@"):
+            continue
+        fm = _FIELD_LINE_RE.match(line)
+        if not fm:
+            continue
+        name = fm.group("name")
+        if name in {"record", "enum", "typeref", "namespace", "import"}:
+            continue
+        out[name] = {
+            "optional": bool(fm.group("opt")),
+            "type": fm.group("type").strip().rstrip(","),
+        }
+    return out
+
+
+_ENUM_RE = re.compile(r"enum\s+(?P<name>\w+)\s*\{(?P<body>[^}]*)\}")
+
+
+def enums(src: str) -> dict[str, list[str]]:
+    out: dict[str, list[str]] = {}
+    cleaned = _strip_comments(src)
+    for m in _ENUM_RE.finditer(cleaned):
+        vals = [
+            v
+            for v in re.split(r"\s+", m.group("body").strip())
+            if v and not v.startswith("@")
+        ]
+        out[m.group("name")] = vals
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Git plumbing
+# ---------------------------------------------------------------------------
+
+
+def _git(*args: str) -> str:
+    # stderr=PIPE (not DEVNULL) preserves git's error output on
+    # CalledProcessError.stderr so callers can surface it. Mirrors the
+    # pattern in bump_schema_versions.py for CI debuggability.
+    return subprocess.check_output(
+        ["git", *args], cwd=REPO_ROOT, text=True, stderr=subprocess.PIPE
+    )
+
+
+def changed_pdls(base: str, head: str) -> list[str]:
+    """Repo-relative paths of .pdl files that differ between base..head.
+
+    Aborts with a non-zero exit code and a git error message if the diff
+    fails (e.g. bad ref, shallow clone). Without this, CI failures would
+    surface as a bare Python traceback.
+    """
+    try:
+        out = _git("diff", "--name-only", f"{base}..{head}", "--", PDL_PREFIX)
+    except subprocess.CalledProcessError as e:
+        print(f"git diff {base}..{head} failed: {e.stderr or e}", file=sys.stderr)
+        raise SystemExit(2)
+    return [line for line in out.splitlines() if line.endswith(".pdl")]
+
+
+def file_at(ref: str, path: str) -> str:
+    """File content at ref, or '' if missing (added/deleted)."""
+    try:
+        return _git("show", f"{ref}:{path}")
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def latest_commit(ref: str, path: str, base: str) -> str:
+    """Most recent commit subject for `path` in base..ref. Empty string on failure."""
+    try:
+        return _git("log", "-1", "--format=%h %s", f"{base}..{ref}", "--", path).strip()
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def all_commit_subjects(ref: str, path: str, base: str) -> list[str]:
+    """Every commit subject on `ref` (in base..ref) that touched `path`. Newest first."""
+    try:
+        out = _git("log", "--format=%h %s", f"{base}..{ref}", "--", path)
+        return [line for line in out.strip().splitlines() if line]
+    except subprocess.CalledProcessError:
+        return []
+
+
+def pr_numbers_for_file(ref: str, path: str, base: str) -> list[str]:
+    """All distinct PR numbers from commits touching `path` in base..ref. Sorted ascending."""
+    seen: set[str] = set()
+    for subject in all_commit_subjects(ref, path, base):
+        pr = _extract_pr_number(subject)
+        if pr:
+            seen.add(pr)
+    return sorted(seen, key=int)
+
+
+def _commit_date(sha: str) -> str:
+    """ISO-8601 commit date (YYYY-MM-DD) for `sha`. Empty string on failure."""
+    try:
+        full = _git("log", "-1", "--format=%cI", sha).strip()
+    except subprocess.CalledProcessError:
+        return ""
+    return full[:10] if full else ""
+
+
+def latest_commit_date_for_file(ref: str, path: str, base: str) -> Optional[str]:
+    """YYYY-MM-DD of the most recent commit touching `path` in base..ref."""
+    try:
+        out = _git("log", "-1", "--format=%cI", f"{base}..{ref}", "--", path).strip()
+    except subprocess.CalledProcessError:
+        return None
+    return out[:10] if out else None
+
+
+def last_author_for_file(ref: str, path: str, base: str) -> Optional[str]:
+    """Author name of the most recent commit touching `path` in base..ref.
+
+    Returns None when the file had no commits in the window (e.g. transitively-
+    affected aspects whose file itself wasn't directly edited).
+    """
+    try:
+        out = _git("log", "-1", "--format=%an", f"{base}..{ref}", "--", path).strip()
+    except subprocess.CalledProcessError:
+        return None
+    return out or None
+
+
+def upstream_attribution_for_transitive(
+    non_aspect_changed: list[str],
+    head: str,
+    base: str,
+) -> tuple[list[str], Optional[str], Optional[str]]:
+    """Derive PR/owner/date for a purely-transitively-affected aspect from
+    the upstream changed non-aspect record(s) instead of the aspect's own
+    commit history.
+
+    A purely-transitive aspect (one in `transitive - direct_set`) has zero
+    direct commits in the window, so `pr_numbers_for_file` /
+    `last_author_for_file` / `latest_commit_date_for_file` all return empty
+    for it. The actionable PR is whatever changed the upstream non-aspect
+    record(s) that pulled this aspect into the BFS set.
+
+    Returns `(pr_numbers, latest_author, latest_date)` aggregated across all
+    changed non-aspects:
+      - `pr_numbers`: every PR that touched any of the upstream sources,
+        sorted ascending and deduplicated.
+      - `latest_author`: author of the most recent upstream commit.
+      - `latest_date`: date (YYYY-MM-DD) of the most recent upstream commit.
+
+    Pure function over the git helpers — no side effects, safe to unit-test
+    via monkeypatching of the underlying `*_for_file` helpers.
+    """
+    upstream_prs: set[str] = set()
+    latest_date: Optional[str] = None
+    latest_author: Optional[str] = None
+    for src in non_aspect_changed:
+        for pr in pr_numbers_for_file(head, src, base):
+            upstream_prs.add(pr)
+        src_date = latest_commit_date_for_file(head, src, base)
+        if src_date and (latest_date is None or src_date > latest_date):
+            latest_date = src_date
+            latest_author = last_author_for_file(head, src, base)
+    return sorted(upstream_prs, key=int), latest_author, latest_date
+
+
+# ---------------------------------------------------------------------------
+# Per-file classifier
+# ---------------------------------------------------------------------------
+
+
+# Bump-status classification per aspect (mirrors bump_schema_versions semantics:
+# schemaVersion defaults to 1 when absent; any structural change OR transitive
+# dependency change requires a bump).
+BUMP_DONE = "bump_done"  # head schemaVersion > base AND a real change exists
+BUMP_NEEDED = "bump_needed"  # changed (direct or transitive) but version not bumped
+BUMP_SPURIOUS = "bump_spurious"  # version bumped but NO schema change (auto-bumper side-effect, e.g. PR #9579)
+BUMP_NOT_NEEDED = "bump_not_needed"  # new file, deleted, non-aspect, no change, or version regressed — no forward bump applies
+# Backwards-compat aliases. Both now resolve to BUMP_NOT_NEEDED so the
+# 4-bucket classification is exhaustive: every changed PDL lands in
+# bump_done / bump_needed / bump_spurious / bump_not_needed.
+NOT_SURE = BUMP_NOT_NEEDED
+BUMP_NA = BUMP_NOT_NEEDED
+
+# Short human-readable descriptions used in the report legend
+BUMP_STATUS_DESCRIPTIONS = {
+    BUMP_DONE: "head schemaVersion > base AND a real change exists (intentional bump)",
+    BUMP_NEEDED: "change exists (direct or transitive) but schemaVersion was NOT bumped",
+    BUMP_SPURIOUS: "schemaVersion bumped but no actual schema change — likely auto-bumper side-effect",
+    BUMP_NOT_NEEDED: "bump is not required — new file, deleted, non-aspect, unchanged, or version regressed",
+}
+
+# Captures `(#1234)` PR reference appended by GitHub squash-merge commit subjects.
+_PR_REF_RE = re.compile(r"\(#(\d+)\)")
+
+
+def _extract_pr_number(commit_subject: str) -> Optional[str]:
+    if not commit_subject:
+        return None
+    m = _PR_REF_RE.search(commit_subject)
+    return m.group(1) if m else None
+
+
+def _bump_breakdown(findings: list["FileFinding"], status: str) -> str:
+    """Group findings of `status` by PR number, list filenames per PR.
+
+    Output shape: `(#9579: ActionRequestInfo.pdl, Status.pdl), (no-PR: Other.pdl)`
+    or `(none)` if no findings match. Files with no detectable PR reference go
+    under `no-PR`.
+    """
+    matching = [f for f in findings if f.bump_status == status]
+    if not matching:
+        return "(none)"
+    by_pr: dict[Optional[str], list[str]] = {}
+    for f in matching:
+        if f.pr_numbers:
+            # A file may appear under multiple PR groups when more than one PR
+            # in the base..head window touched it.
+            for pr in f.pr_numbers:
+                by_pr.setdefault(pr, []).append(Path(f.path).name)
+        else:
+            by_pr.setdefault(None, []).append(Path(f.path).name)
+    # Sort: numeric PRs ascending, then no-PR bucket last.
+    sorted_groups = sorted(
+        by_pr.items(),
+        key=lambda kv: (kv[0] is None, int(kv[0]) if kv[0] else 0),
+    )
+    parts = []
+    for pr, files in sorted_groups:
+        label = f"#{pr}" if pr else "no-PR"
+        parts.append(f"({label}: {', '.join(sorted(files))})")
+    return ", ".join(parts)
+
+
+_BUMP_WHY = {
+    BUMP_DONE: "version bumped AND a real schema change exists in the window",
+    BUMP_NEEDED: "schema changed (direct or transitive) but version was NOT bumped",
+    BUMP_SPURIOUS: "version bumped but NO schema change in the contributing PR(s)",
+    BUMP_NOT_NEEDED: "bump is not required (new file, deleted, non-aspect, unchanged, or version regressed)",
+}
+
+
+def _bump_needed_why(f: "FileFinding") -> str:
+    """Row-specific reason for a `BUMP_NEEDED` finding.
+
+    Distinguishes direct vs transitive change so reviewers know whether the
+    file's own schema or a referenced record drove the missing bump. When
+    both are true (rare), surfaces both so callers can attribute correctly.
+    """
+    direct = bool(f.has_structural)
+    transitive_via = f.affected_via
+    if direct and transitive_via:
+        return (
+            f"direct schema change AND transitively affected via `{transitive_via}` "
+            "— schemaVersion was NOT bumped"
+        )
+    if transitive_via:
+        return (
+            f"transitively affected via `{transitive_via}` "
+            "(file's own schema unchanged) — schemaVersion was NOT bumped"
+        )
+    if direct:
+        return "direct schema change in this file — schemaVersion was NOT bumped"
+    return _BUMP_WHY[BUMP_NEEDED]
+
+
+_FIELD_ADD_RE = re.compile(r"added (optional|REQUIRED) field: (\S+): (.+)")
+_FIELD_REMOVE_RE = re.compile(r"removed field: (.+)")
+_REQ_FLIP_RE = re.compile(r"required-ness flip on (\S+): (.+)")
+_TYPE_CHANGE_RE = re.compile(r"type change on (\S+): (.+)")
+_ENUM_CHANGE_RE = re.compile(r"enum (\S+): (added|removed) value (\S+)")
+_RENAME_RE = re.compile(r"record renamed (\S+)→(\S+)")
+
+
+def _shorten_change_line(line: str) -> str:
+    """Compact a verbose change-description into per-PR-table prose.
+
+    `added optional field: foo: Bar`  → `added foo (optional)`
+    `removed field: foo`              → `removed field foo`
+    `required-ness flip on foo: x→y`  → `foo: x→y`
+    `type change on foo: A→B`         → `type change on foo: A→B`
+    `enum X: added value Y`           → `enum X: added value Y`
+    `record renamed A→B (...)`        → `record renamed A→B`
+    Unrecognised lines pass through verbatim.
+    """
+    m = _FIELD_ADD_RE.match(line)
+    if m:
+        opt, name, _type = m.group(1).lower(), m.group(2), m.group(3)
+        return f"added {name} ({opt})"
+    m = _FIELD_REMOVE_RE.match(line)
+    if m:
+        return f"removed field {m.group(1)}"
+    m = _REQ_FLIP_RE.match(line)
+    if m:
+        return f"{m.group(1)}: {m.group(2)}"
+    m = _TYPE_CHANGE_RE.match(line)
+    if m:
+        return f"type change on {m.group(1)}: {m.group(2)}"
+    m = _ENUM_CHANGE_RE.match(line)
+    if m:
+        return f"enum {m.group(1)}: {m.group(2)} value {m.group(3)}"
+    m = _RENAME_RE.match(line)
+    if m:
+        return f"record renamed {m.group(1)}→{m.group(2)}"
+    return line
+
+
+def _apply_catchup_reclassification(entries: list[dict]) -> list[dict]:
+    """Reconcile schemaVersion debt across PRs chronologically.
+
+    Walks per-PR slices in commit-date order (oldest first) maintaining the
+    set of PRs whose real schema change was committed without a schemaVersion
+    bump. A subsequent slice that bumps without contributing a change is
+    reclassified as `bump_done` (a catch-up bump) and clears the entire
+    pending debt. Once debt is cleared, further bumps without a change stay
+    `bump_spurious`.
+
+    Mutates entries in place; the new keys are `bump_status` (possibly
+    flipped from BUMP_SPURIOUS to BUMP_DONE) and `catch_up_for_prs` (list of
+    PRs whose unbumped changes this slice's bump covered). Returns the same
+    list for chaining.
+    """
+    if not entries:
+        return entries
+    sorted_entries = sorted(
+        entries,
+        key=lambda e: (e.get("date") or "", e.get("pr") or ""),
+    )
+    pending_prs: list[str] = []
+    for e in sorted_entries:
+        status = e.get("bump_status")
+        if status == BUMP_NEEDED:
+            pr = e.get("pr")
+            if pr and pr not in pending_prs:
+                pending_prs.append(pr)
+        elif status == BUMP_SPURIOUS:
+            if pending_prs:
+                e["bump_status"] = BUMP_DONE
+                e["catch_up_for_prs"] = list(pending_prs)
+                pending_prs = []
+            # else: stays BUMP_SPURIOUS — no debt to pay
+        elif status == BUMP_DONE:
+            # The slice's own change + own bump implicitly clears prior debt
+            # (one bump covers all pending changes).
+            if pending_prs:
+                e["catch_up_for_prs"] = list(pending_prs)
+            pending_prs = []
+    return entries
+
+
+def _describe_per_pr_slice(entry: dict) -> str:
+    """Synthesise a 'What happened' one-liner for a single PR-slice classification.
+
+    Combines per-slice structural changes (additive / breaking / noisy lists)
+    with the schemaVersion delta and the bump verdict to produce a compact
+    prose summary suitable for a per-PR audit table.
+
+    Lifecycle BUMP_NOT_NEEDED slices (file added new, file deleted) return
+    a dedicated short description before the general path so the per-PR
+    breakdown row reads naturally for those creator-PRs.
+    """
+    status = entry.get("bump_status")
+    reason = entry.get("bump_reason") or ""
+
+    # Lifecycle events — file added / deleted / version-regressed. These
+    # slices are BUMP_NOT_NEEDED but represent real aspect-level activity.
+    if status == BUMP_NOT_NEEDED:
+        if reason.startswith("new aspect file"):
+            return "added new aspect file (default schemaVersion = 1)"
+        if reason.startswith("file deleted"):
+            return "deleted aspect file"
+        if reason.startswith("schemaVersion regressed"):
+            return reason
+
+    additive = entry.get("additive") or []
+    breaking = entry.get("breaking") or []
+    noisy = entry.get("noisy") or []
+    old_v = entry.get("old_v")
+    new_v = entry.get("new_v")
+    via = entry.get("affected_via")
+
+    # Skip synthetic narrator lines — the bump verdict + version delta below
+    # already convey the same signal more cleanly.
+    real_breaking = [
+        b for b in breaking if "structural change without schemaVersion bump" not in b
+    ]
+    real_noisy = [
+        n
+        for n in noisy
+        if "bumped with NO structural change" not in n
+        and "transitively affected by a changed non-aspect record" not in n
+    ]
+
+    structural: list[str] = []
+    for line in real_breaking + additive + real_noisy:
+        structural.append(_shorten_change_line(line))
+
+    parts: list[str] = []
+    if structural:
+        parts.append("; ".join(structural))
+
+    if isinstance(old_v, int) and isinstance(new_v, int):
+        if new_v > old_v:
+            parts.append(f"bumped schemaVersion {old_v}→{new_v}")
+        elif new_v < old_v:
+            parts.append(f"schemaVersion regressed {old_v}→{new_v}")
+        elif status == BUMP_NEEDED:
+            parts.append("did NOT bump schemaVersion")
+
+    if via and not structural:
+        parts.append(f"transitively affected via `{via}`")
+
+    # Catch-up annotation — this slice's bump cleared prior unbumped-change
+    # debt. Set by _apply_catchup_reclassification on slices that absorbed
+    # one or more pending BUMP_NEEDED PRs.
+    catch_up = entry.get("catch_up_for_prs") or []
+    if catch_up:
+        prs_str = ", ".join(f"#{p}" for p in catch_up)
+        parts.append(f"catch-up for unbumped change(s) in {prs_str}")
+
+    if status == BUMP_SPURIOUS and not structural:
+        parts.append("no schema change in this slice")
+
+    return "; ".join(parts) if parts else "(no detail)"
+
+
+def _render_release_test_pdl_file(
+    findings: list["FileFinding"],
+    mutators: list[dict],
+    *,
+    base: str,
+    head: str,
+    head_sha: str,
+) -> str:
+    """Render the standalone `release_test_pdl_changes.md` file.
+
+    Contains a single table — the union of `bump_done`, `bump_needed`, and
+    `bump_spurious` PDL files (the aspects whose `schemaVersion` activity
+    changed in the window). Each row has a `Mutator` column listing any
+    `AspectMigrationMutator` subclass added in this window that targets
+    the same aspect, so reviewers can see which aspects have migration
+    coverage and which don't.
+
+    Returns an empty string when there are no relevant findings — the
+    caller can then skip writing the file altogether.
+    """
+    relevant = [
+        f for f in findings if f.bump_status in (BUMP_DONE, BUMP_NEEDED, BUMP_SPURIOUS)
+    ]
+    if not relevant:
+        return ""
+    # aspect_name → list[mutator class names that target it]
+    by_aspect: dict[str, list[str]] = {}
+    for m in mutators:
+        target = m.get("target_aspect")
+        if target:
+            by_aspect.setdefault(target, []).append(m["class_name"])
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    out: list[str] = [
+        "# PDL files for integration test cases",
+        "",
+        f"**Base:** `{base}`  ",
+        f"**Head:** `{head}` (sha: `{head_sha}`)  ",
+        f"**Generated:** {generated}  ",
+        f"**Total aspects:** {len(relevant)}",
+        "",
+        (
+            "Use this list of pdl file changes to test coverage for "
+            "zdu upgrade testing. The Mutator column names any "
+            "AspectMigrationMutator subclass added in this window that "
+            "targets the aspect (per its getAspectName())."
+        ),
+        "",
+        "| PDL file | PR(s) | Owner | Date | Mutator |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    ordered = sorted(
+        relevant,
+        key=lambda f: (f.last_commit_date or "", Path(f.path).name.lower()),
+        reverse=True,
+    )
+    for f in ordered:
+        aspect = Path(f.path).name
+        prs = ", ".join(f"#{p}" for p in f.pr_numbers) if f.pr_numbers else "(no-PR)"
+        owner = f.last_author or "_(no owner — file wasn't directly touched)_"
+        date = f.last_commit_date or "_(unknown)_"
+        mutators_for_aspect = by_aspect.get(f.aspect_name or "", [])
+        mutator_cell = (
+            ", ".join(f"`{cls}`" for cls in mutators_for_aspect)
+            if mutators_for_aspect
+            else "(none)"
+        )
+        out.append(f"| {aspect} | {prs} | {owner} | {date} | {mutator_cell} |")
+    out.append("")
+    return "\n".join(out)
+
+
+def _render_per_pr_breakdown_section(
+    audit: dict[str, list[dict]],
+) -> list[str]:
+    """Render the 'Per-PR breakdown by PDL file' section.
+
+    One H3 table per PDL file with bump-relevant per-PR activity. Columns:
+    PR | Date | Slice verdict | Author | What happened. Files sorted by their
+    most recent slice date DESC; rows within each table same sort.
+    """
+    if not audit:
+        return []
+
+    def _file_sort_key(item: tuple[str, list[dict]]) -> tuple[str, str]:
+        path, entries = item
+        latest = max((e.get("date") or "" for e in entries), default="")
+        return (latest, Path(path).name.lower())
+
+    sorted_files = sorted(audit.items(), key=_file_sort_key, reverse=True)
+
+    out: list[str] = [
+        "## Per-PR breakdown by PDL file",
+        "",
+        (
+            "For each PDL file with bump-relevant per-PR activity, one row per "
+            "PR's classification of the file in isolation (`parent..commit` "
+            "slice). Sorted newest-first."
+        ),
+        "",
+    ]
+    for path, entries in sorted_files:
+        out.append(f"### `{Path(path).name}`")
+        out.append("")
+        out.append("| PR | Date | Slice verdict | Author | What happened |")
+        out.append("| --- | --- | --- | --- | --- |")
+        sorted_entries = sorted(
+            entries,
+            key=lambda e: (e.get("date") or "", e.get("pr") or ""),
+            reverse=True,
+        )
+        for e in sorted_entries:
+            pr_label = f"#{e['pr']}" if e.get("pr") else "(no-PR)"
+            date = e.get("date") or "_(unknown)_"
+            verdict = f"`{e['bump_status']}`"
+            author = e.get("author") or "_(unknown)_"
+            what = _describe_per_pr_slice(e)
+            out.append(f"| {pr_label} | {date} | {verdict} | {author} | {what} |")
+        out.append("")
+    return out
+
+
+def _file_why(f: "FileFinding") -> str:
+    """Compute a file's Why text consistently across the All-PDLs section
+    and the per-bucket breakdown tables.
+
+    Priority:
+      1. `f.bump_reason` — specific reason set by the classifier (most
+         informative; covers new file, deleted, non-aspect, unchanged,
+         version-regressed cases).
+      2. For `BUMP_NEEDED`: row-specific Why from `_bump_needed_why` which
+         distinguishes direct vs transitive cause and names the upstream
+         record.
+      3. Otherwise: the bucket-level `_BUMP_WHY[bump_status]`.
+
+    This guarantees that for any given PDL file, the Why text in the
+    All-PDLs section matches the Why text in its bump bucket table.
+    """
+    if f.bump_reason:
+        return f.bump_reason
+    if f.bump_status == BUMP_NEEDED:
+        return _bump_needed_why(f)
+    return _BUMP_WHY.get(f.bump_status, "")
+
+
+def _bump_breakdown_table(findings: list["FileFinding"], status: str) -> list[str]:
+    """Render findings of `status` as a markdown table.
+
+    Columns: Aspect | PR(s) | Owner | Date | Why. Rows sorted by Date DESC
+    (newest first), then alphabetically by aspect name when dates tie.
+    Returns `["_(none)_"]` when no findings match.
+    """
+    matching = [f for f in findings if f.bump_status == status]
+    if not matching:
+        return ["_(none)_"]
+    rows = [
+        "| PDL file | PR(s) | Owner | Date | Why |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    ordered = sorted(
+        matching,
+        key=lambda f: (f.last_commit_date or "", Path(f.path).name.lower()),
+        reverse=True,
+    )
+    for f in ordered:
+        aspect = Path(f.path).name
+        prs = ", ".join(f"#{p}" for p in f.pr_numbers) if f.pr_numbers else "(no-PR)"
+        owner = f.last_author or "_(no owner — file wasn't directly touched)_"
+        date = f.last_commit_date or "_(unknown)_"
+        why = _file_why(f)
+        rows.append(f"| {aspect} | {prs} | {owner} | {date} | {why} |")
+    return rows
+
+
+@dataclass
+class FileFinding:
+    path: str
+    is_aspect: bool
+    aspect_name: Optional[str]
+    head_commit: str
+    affected_via: Optional[str] = None  # set for transitively-affected aspects
+    breaking: list[str] = dc_field(default_factory=list)
+    additive: list[str] = dc_field(default_factory=list)
+    noisy: list[str] = dc_field(default_factory=list)
+    bump_status: str = BUMP_NOT_NEEDED
+    bump_reason: Optional[str] = (
+        None  # specific reason when bump_status == bump_not_needed
+    )
+    pr_numbers: list[str] = dc_field(
+        default_factory=list
+    )  # ALL PRs in base..head touching this file
+    last_author: Optional[str] = (
+        None  # last-commit author name (owner) when the file was directly touched
+    )
+    last_commit_date: Optional[str] = None  # YYYY-MM-DD of most recent commit
+    has_structural: bool = (
+        False  # tracked so main() can re-classify with transitive context
+    )
+    old_v: Optional[int] = None  # schemaVersion at base (None if missing/not-aspect)
+    new_v: Optional[int] = None  # schemaVersion at head (None if missing/not-aspect)
+    is_purely_transitive: bool = False
+    # True only when the file itself was NOT directly edited in the window
+    # but was reached via the include / field-type graph from a changed
+    # non-aspect. Used to gate the "(transitive)" suffix in the All-PDLs
+    # Kind column so reviewers can tell pure-transitive impact apart from
+    # direct edits that also happen to be transitively reached.
+
+    def has_breaking(self) -> bool:
+        return bool(self.breaking)
+
+    def has_any(self) -> bool:
+        return bool(self.breaking or self.additive or self.noisy)
+
+
+def _classify_bump(
+    is_aspect: bool,
+    old_content: str,
+    new_content: str,
+    has_structural: bool,
+    transitively_affected: bool = False,
+) -> str:
+    """Return the bump status for an aspect (delegates to _classify_bump_with_reason).
+
+    Every PDL change falls into one of four buckets:
+      - bump_done: legitimate bump
+      - bump_needed: silent migration hazard
+      - bump_spurious: auto-bumper side-effect
+      - bump_not_needed: new file, deleted file, non-aspect, no change,
+                        or version regressed — no forward bump applies
+    """
+    status, _reason = _classify_bump_with_reason(
+        is_aspect, old_content, new_content, has_structural, transitively_affected
+    )
+    return status
+
+
+def _classify_bump_with_reason(
+    is_aspect: bool,
+    old_content: str,
+    new_content: str,
+    has_structural: bool,
+    transitively_affected: bool = False,
+) -> tuple[str, Optional[str]]:
+    """Same classification as _classify_bump but also returns the specific
+    reason for bump_not_needed outcomes. Returns (status, reason) where
+    reason is None for non-bump_not_needed statuses."""
+    if not is_aspect:
+        return BUMP_NOT_NEEDED, "non-aspect record (no schemaVersion concept applies)"
+    if not new_content:
+        return BUMP_NOT_NEEDED, "file deleted at head"
+    if not old_content:
+        return (
+            BUMP_NOT_NEEDED,
+            "new aspect file (default schemaVersion = 1; no prior version to bump from)",
+        )
+    old_v = (aspect_meta(old_content) or {}).get("schemaVersion")
+    new_v = (aspect_meta(new_content) or {}).get("schemaVersion")
+    # Per bump_schema_versions.md: missing schemaVersion is treated as 1.
+    old_eff = 1 if old_v is None else old_v
+    new_eff = 1 if new_v is None else new_v
+    has_change = has_structural or transitively_affected
+    if new_eff < old_eff:
+        return (
+            BUMP_NOT_NEEDED,
+            f"schemaVersion regressed {old_eff}→{new_eff} (anomaly; no forward bump applies)",
+        )
+    if new_eff > old_eff:
+        return (BUMP_DONE, None) if has_change else (BUMP_SPURIOUS, None)
+    if has_change:
+        return BUMP_NEEDED, None
+    return BUMP_NOT_NEEDED, "no schema change in this file"
+
+
+def analyze_file(path: str, base: str, head: str) -> FileFinding:
+    old = file_at(base, path)
+    new = file_at(head, path)
+    new_meta = aspect_meta(new) or {}
+    old_meta = aspect_meta(old) or {}
+    # Consider both base and head: a deleted aspect has no `new` content but
+    # still needs to render as [ASPECT] in the report.
+    is_aspect = aspect_meta(new) is not None or aspect_meta(old) is not None
+    f = FileFinding(
+        path=path,
+        is_aspect=is_aspect,
+        aspect_name=new_meta.get("name") or old_meta.get("name"),
+        head_commit=latest_commit(head, path, base),
+    )
+    # Track whether any actual structural changes have been found
+    has_structural = False
+
+    if not old:
+        f.additive.append("new file")
+        has_structural = True
+    if not new:
+        f.breaking.append("file deleted")
+        has_structural = True
+        return f
+
+    old_name, new_name = record_name(old), record_name(new)
+    if old_name and new_name and old_name != new_name:
+        rf = renamed_from(new)
+        # A rename is a structural change either way — the noisy-vs-breaking
+        # split is about whether it was properly annotated, not whether the
+        # schema changed. has_structural must be True in both branches so that
+        # a legitimate rename+bump is classified as bump_done (not bump_spurious).
+        has_structural = True
+        if rf == old_name:
+            f.noisy.append(f"record renamed {old_name}→{new_name} (renamedFrom set)")
+        else:
+            f.breaking.append(
+                f"record renamed {old_name}→{new_name} with NO renamedFrom annotation"
+            )
+
+    old_fields, new_fields = fields(old), fields(new)
+    for r in sorted(set(old_fields) - set(new_fields)):
+        f.breaking.append(f"removed field: {r}")
+        has_structural = True
+    for a in sorted(set(new_fields) - set(old_fields)):
+        opt = "optional" if new_fields[a]["optional"] else "REQUIRED"
+        bucket = f.additive if new_fields[a]["optional"] else f.breaking
+        bucket.append(f"added {opt} field: {a}: {new_fields[a]['type']}")
+        has_structural = True
+    for name in sorted(set(old_fields) & set(new_fields)):
+        o, n = old_fields[name], new_fields[name]
+        if o["optional"] and not n["optional"]:
+            f.breaking.append(f"required-ness flip on {name}: optional→required")
+            has_structural = True
+        if (not o["optional"]) and n["optional"]:
+            f.noisy.append(f"required-ness flip on {name}: required→optional")
+            has_structural = True
+        if o["type"] != n["type"]:
+            f.breaking.append(f"type change on {name}: {o['type']}→{n['type']}")
+            has_structural = True
+
+    old_enums, new_enums = enums(old), enums(new)
+    for ename in sorted(set(old_enums) & set(new_enums)):
+        for v in sorted(set(old_enums[ename]) - set(new_enums[ename])):
+            f.breaking.append(f"enum {ename}: removed value {v}")
+            has_structural = True
+        for v in sorted(set(new_enums[ename]) - set(old_enums[ename])):
+            f.additive.append(f"enum {ename}: added value {v}")
+            has_structural = True
+
+    if is_aspect:
+        # Use bump_schema_versions semantics: missing schemaVersion is treated as 1.
+        # Keeps this check consistent with _classify_bump below.
+        old_v_raw, new_v_raw = (
+            old_meta.get("schemaVersion"),
+            new_meta.get("schemaVersion"),
+        )
+        old_eff = 1 if old_v_raw is None else old_v_raw
+        new_eff = 1 if new_v_raw is None else new_v_raw
+        f.old_v = old_eff
+        f.new_v = new_eff
+        bumped = new_eff > old_eff
+        if bumped and not has_structural and not any("renamed" in n for n in f.noisy):
+            f.noisy.append(
+                f"schemaVersion {old_eff}→{new_eff} bumped with NO structural change"
+            )
+        if has_structural and new_eff == old_eff:
+            f.breaking.append("structural change without schemaVersion bump")
+
+    f.has_structural = has_structural
+    f.bump_status, f.bump_reason = _classify_bump_with_reason(
+        is_aspect, old, new, has_structural
+    )
+    f.pr_numbers = pr_numbers_for_file(head, path, base)
+    f.last_author = last_author_for_file(head, path, base)
+    f.last_commit_date = latest_commit_date_for_file(head, path, base)
+    return f
+
+
+def find_transitive_aspects(directly_changed: list[str]) -> set[str]:
+    """Surface aspects transitively affected via PDL includes or field-type refs.
+
+    Delegates to bump_schema_versions for the reverse-graph + BFS. Returns the set
+    of *aspect* file paths that depend on any of the directly-changed files.
+
+    IMPORTANT: bsv's helpers (find_all_pdl_files, build_reverse_include_graph,
+    find_transitively_affected_aspects) read files from the on-disk working tree,
+    not from arbitrary git refs. The workflow always checks out the head ref, so
+    the default invocation is safe. If you ever invoke with `--head <some-other-ref>`
+    while the working tree is checked out elsewhere, the transitive closure
+    reflects the checkout, not `head`.
+    """
+    all_pdl_files = bsv.find_all_pdl_files()
+    reverse_graph = bsv.build_reverse_include_graph(all_pdl_files)
+    return bsv.find_transitively_affected_aspects(
+        directly_changed, reverse_graph, all_pdl_files
+    )
+
+
+def find_transitive_aspects_per_source(
+    sources: list[str],
+) -> dict[str, set[str]]:
+    """For each source non-aspect path, compute its downstream aspect set.
+
+    Returns `{source_path: set(aspect_paths)}` — the set of aspect files that
+    transitively depend on each individual source. The reverse-include graph
+    is built once and reused across all source BFS lookups for efficiency.
+
+    Used by `_classify_window` to attribute purely-transitive aspects to the
+    SPECIFIC upstream non-aspect(s) that pulled them into the transitive set,
+    not the full list of changed non-aspects.
+    """
+    if not sources:
+        return {}
+    all_pdl_files = bsv.find_all_pdl_files()
+    reverse_graph = bsv.build_reverse_include_graph(all_pdl_files)
+    result: dict[str, set[str]] = {}
+    for src in sources:
+        result[src] = bsv.find_transitively_affected_aspects(
+            [src], reverse_graph, all_pdl_files
+        )
+    return result
+
+
+def render_report(
+    findings: list[FileFinding],
+    base: str,
+    head: str,
+    head_sha: str,
+    audit: Optional[dict[str, list[dict]]] = None,
+) -> str:
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    header = [
+        "# @Aspect PDL change report",
+        "",
+        f"**Base:** `{base}`  ",
+        f"**Head:** `{head}` (sha: `{head_sha}`)  ",
+        f"**Generated:** {generated}",
+        "",
+    ]
+    if not findings:
+        header.append(f"No aspect changes between `{base}` and `{head}`.")
+        return "\n".join(header) + "\n"
+
+    bump_done = sum(1 for f in findings if f.bump_status == BUMP_DONE)
+    bump_needed = sum(1 for f in findings if f.bump_status == BUMP_NEEDED)
+    bump_spurious = sum(1 for f in findings if f.bump_status == BUMP_SPURIOUS)
+    bump_not_needed = sum(1 for f in findings if f.bump_status == BUMP_NOT_NEEDED)
+
+    summary = (
+        f"**Summary:** {len(findings)} PDL files changed · "
+        f"{bump_done} bump_done · {bump_needed} bump_needed · "
+        f"{bump_spurious} bump_spurious · {bump_not_needed} bump_not_needed"
+    )
+    bump_summary = (
+        f"**Bump status:** {bump_done} bump_done · "
+        f"**{bump_needed} bump_needed** · "
+        f"**{bump_spurious} bump_spurious** · "
+        f"{bump_not_needed} bump_not_needed"
+    )
+    bump_legend = (
+        [
+            "<details><summary>Bump status legend</summary>",
+            "",
+        ]
+        + [
+            f"- `{status}` — {desc}"
+            for status, desc in BUMP_STATUS_DESCRIPTIONS.items()
+        ]
+        + ["", "</details>"]
+    )
+
+    breakdown_lines = ["**Bump status breakdown:**", ""]
+    for status in (BUMP_DONE, BUMP_NEEDED, BUMP_SPURIOUS, BUMP_NOT_NEEDED):
+        count = sum(1 for f in findings if f.bump_status == status)
+        breakdown_lines.append(f"### `{status}` ({count})")
+        breakdown_lines.append("")
+        breakdown_lines.extend(_bump_breakdown_table(findings, status))
+        breakdown_lines.append("")
+
+    # All-PDLs table: one row per changed file, attributed to its introducing PR(s).
+    # Covers every finding (aspects + nested records + transitively-affected aspects),
+    # not just those with a bump_status — so the reader sees the full diff surface.
+    all_pdls_lines = [
+        f"## All changed PDL files ({len(findings)})",
+        "",
+        "| File | Kind | PR(s) | Owner | Date | Why |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    ordered_findings = sorted(
+        findings,
+        key=lambda f: (f.last_commit_date or "", Path(f.path).name.lower()),
+        reverse=True,
+    )
+    for f in ordered_findings:
+        kind = "ASPECT" if f.is_aspect else "nested"
+        # "(transitive)" only when the file itself wasn't directly edited
+        # in the window — directly-edited aspects that are ALSO reached via
+        # the dependency graph keep the plain "ASPECT" label.
+        if f.is_purely_transitive:
+            kind = "ASPECT (transitive)"
+        prs = ", ".join(f"#{p}" for p in f.pr_numbers) if f.pr_numbers else "(no-PR)"
+        owner = f.last_author or "_(no owner — file wasn't directly touched)_"
+        date = f.last_commit_date or "_(unknown)_"
+        # All-PDLs Why matches the bump bucket Why for this file exactly,
+        # so the legend and the per-row classification stay consistent.
+        why = _file_why(f)
+        all_pdls_lines.append(
+            f"| {Path(f.path).name} | {kind} | {prs} | {owner} | {date} | {why} |"
+        )
+    all_pdls_lines.append("")
+
+    out = (
+        header
+        + [summary, ""]
+        + all_pdls_lines
+        + [bump_summary, ""]
+        + bump_legend
+        + [""]
+        + breakdown_lines
+    )
+
+    # Per-PR breakdown by PDL file — only rendered when audit data is available
+    # (i.e., when called from the cumulative-mode path which collects per_pr_audit).
+    if audit:
+        out.extend(_render_per_pr_breakdown_section(audit))
+
+    def section(title: str, items: list[FileFinding], collapsed: bool = False) -> None:
+        if not items:
+            return
+        out.append(f"## {title}")
+        if collapsed:
+            out.append("")
+            for f in items:
+                out.append(f"- {f.path}")
+            out.append("")
+            return
+        for f in items:
+            tag = "ASPECT" if f.is_aspect else "nested"
+            commit = f.head_commit or "(no commit info)"
+            out.append(f"- [{tag}] `{f.path}` ({commit})")
+            if f.aspect_name:
+                out.append(f"  - aspect name: `{f.aspect_name}`")
+            if f.affected_via:
+                out.append(f"  - affected via: {f.affected_via}")
+            if f.pr_numbers:
+                out.append(f"  - PR: {', '.join('#' + pr for pr in f.pr_numbers)}")
+            if f.last_author:
+                out.append(f"  - owner: {f.last_author}")
+            if f.is_aspect and f.bump_status != BUMP_NOT_NEEDED:
+                out.append(f"  - bump: {f.bump_status}")
+            for line in f.breaking:
+                out.append(f"  - ⚠ BREAKING: {line}")
+            for line in f.additive:
+                out.append(f"  - + additive: {line}")
+            for line in f.noisy:
+                out.append(f"  - · noisy: {line}")
+        out.append("")
+
+    # All per-finding sections commented out by user request — bump_status
+    # breakdown tables + summary line carry the actionable signal. To re-enable
+    # any, also reintroduce `unchanged = [f for f in findings if not f.has_any()]`
+    # above (currently removed to satisfy ruff F841).
+    # section("⚠️ BREAKING", breaking)
+    # section("Transitively affected aspects", transitive)
+    # section("Additive", additive_only)
+    # section("Noisy", noisy_only)
+    # section("No logical change", unchanged, collapsed=True)
+    return "\n".join(out) + "\n"
+
+
+def _head_sha(ref: str) -> str:
+    try:
+        return _git("rev-parse", "--short", ref).strip()
+    except subprocess.CalledProcessError:
+        return ref
+
+
+# ---------------------------------------------------------------------------
+# Mutator detection (Java subclasses of AspectMigrationMutator)
+# ---------------------------------------------------------------------------
+
+_MUTATOR_BASE_CLASS = "AspectMigrationMutator"
+_CLASS_EXTENDS_RE = re.compile(
+    r"class\s+(\w+)(?:<[^>]+>)?[^{]*?\bextends\s+(\w+)\b",
+    re.DOTALL,
+)
+# Match `public String getAspectName() { return X; }` where X is either a
+# constant reference (e.g. `DATAHUB_VIEW_INFO_ASPECT_NAME`) or a string
+# literal. `\s` matches newlines so multi-line bodies work.
+_GET_ASPECT_NAME_RE = re.compile(
+    r"public\s+(?:final\s+)?String\s+getAspectName\s*\(\s*\)"
+    r"\s*\{\s*return\s+([A-Z_][A-Z0-9_]*|\"[^\"]+\")",
+    re.DOTALL,
+)
+# `public static final String <FOO>_ASPECT_NAME = "fooName";` (with optional
+# linebreak between `=` and the string literal).
+_ASPECT_NAME_CONSTANT_RE = re.compile(
+    r'public\s+static\s+final\s+String\s+(\w*ASPECT_NAME)\s*=\s*"([^"]+)"'
+)
+_CONSTANTS_JAVA_PATH = "li-utils/src/main/java/com/linkedin/metadata/Constants.java"
+
+
+def _load_aspect_name_constants() -> dict[str, str]:
+    """Parse `Constants.java` for `*_ASPECT_NAME` → string-value mappings.
+
+    Used to resolve a mutator's `getAspectName()` return value when it
+    references a constant (the common pattern in this repo) rather than a
+    string literal.
+    """
+    try:
+        content = (REPO_ROOT / _CONSTANTS_JAVA_PATH).read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    return {m.group(1): m.group(2) for m in _ASPECT_NAME_CONSTANT_RE.finditer(content)}
+
+
+def _extract_mutator_target_aspect(
+    java_content: str, constants_map: dict[str, str]
+) -> Optional[str]:
+    """Return the aspect name that this mutator targets, or None if unknown.
+
+    Looks at `public String getAspectName() { return X; }`. If X is a string
+    literal, returns it verbatim. If X is a `*_ASPECT_NAME` constant,
+    resolves it via `constants_map`. Bases / abstract mutators that don't
+    override `getAspectName()` return None.
+    """
+    m = _GET_ASPECT_NAME_RE.search(java_content)
+    if not m:
+        return None
+    token = m.group(1)
+    if token.startswith('"'):
+        return token.strip('"')
+    return constants_map.get(token)
+
+
+def _extract_class_and_parent(java_content: str) -> Optional[tuple[str, str]]:
+    """Return (class_name, parent_name) if the file declares `class X extends Y`."""
+    m = _CLASS_EXTENDS_RE.search(java_content)
+    if not m:
+        return None
+    return m.group(1), m.group(2)
+
+
+def discover_mutator_hierarchy() -> set[str]:
+    """Class names that directly or transitively extend AspectMigrationMutator.
+
+    Uses `git grep` at HEAD against the working tree to find descendants. Test
+    files under `/test/` are skipped — mutator audits focus on production code.
+    """
+    hierarchy = {_MUTATOR_BASE_CLASS}
+    pending = [_MUTATOR_BASE_CLASS]
+    while pending:
+        parent = pending.pop()
+        try:
+            out = _git("grep", "-l", f"extends {parent}", "--", "*.java")
+        except subprocess.CalledProcessError:
+            continue
+        for path in out.strip().splitlines():
+            if "/test/" in path:
+                continue
+            try:
+                content = (REPO_ROOT / path).read_text(encoding="utf-8")
+            except OSError:
+                continue
+            cp = _extract_class_and_parent(content)
+            if cp and cp[1] == parent and cp[0] not in hierarchy:
+                hierarchy.add(cp[0])
+                pending.append(cp[0])
+    return hierarchy
+
+
+def find_mutators_added_in_window(
+    base: str, head: str, hierarchy: set[str]
+) -> list[dict]:
+    """For each .java file ADDED in base..head, check if it's a mutator subclass.
+
+    Returns list of {sha, pr, path, class_name, parent, author, subject,
+    target_aspect} dicts. `target_aspect` is the aspect name returned by
+    `getAspectName()` (resolved via Constants.java when needed), or None
+    for abstract/base mutators that don't override it. Test files under
+    `/test/` are skipped.
+    """
+    results: list[dict] = []
+    constants_map = _load_aspect_name_constants()
+    try:
+        out = _git(
+            "log",
+            "--diff-filter=A",
+            "--name-only",
+            "--format=COMMIT %H %s",
+            f"{base}..{head}",
+            "--",
+            "*.java",
+        )
+    except subprocess.CalledProcessError:
+        return results
+
+    current_sha: Optional[str] = None
+    current_subject: str = ""
+    for line in out.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("COMMIT "):
+            parts = line.split(" ", 2)
+            current_sha = parts[1] if len(parts) > 1 else None
+            current_subject = parts[2] if len(parts) > 2 else ""
+            continue
+        if not line.endswith(".java") or "/test/" in line or current_sha is None:
+            continue
+        try:
+            content = _git("show", f"{current_sha}:{line}")
+        except subprocess.CalledProcessError:
+            continue
+        cp = _extract_class_and_parent(content)
+        if not cp:
+            continue
+        class_name, parent = cp
+        if parent not in hierarchy:
+            continue
+        try:
+            author = _git("log", "-1", "--format=%an", current_sha).strip() or None
+        except subprocess.CalledProcessError:
+            author = None
+        target_aspect = _extract_mutator_target_aspect(content, constants_map)
+        results.append(
+            {
+                "sha": current_sha[:10],
+                "pr": _extract_pr_number(current_subject),
+                "path": line,
+                "class_name": class_name,
+                "parent": parent,
+                "author": author,
+                "subject": current_subject,
+                "commit_date": _commit_date(current_sha),
+                "target_aspect": target_aspect,
+            }
+        )
+    return results
+
+
+def _render_mutator_section(mutators: list[dict]) -> list[str]:
+    """Markdown section + table for newly-added mutators. Empty list if none."""
+    if not mutators:
+        return []
+    out = [
+        "## Mutators introduced in this window",
+        "",
+        (
+            "Java classes that directly or transitively extend `AspectMigrationMutator` "
+            "and were added by a commit in `base..head`. These are migration handlers "
+            "for aspect schema evolution — each new mutator implements a single "
+            "version-hop transform for a specific aspect, so track which PRs added them "
+            "to audit migration coverage."
+        ),
+        "",
+        "| PR | sha | Mutator class | Extends | Author | Date | Why |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    ordered = sorted(
+        mutators,
+        key=lambda m: (m.get("commit_date") or "", m["class_name"]),
+        reverse=True,
+    )
+    for m in ordered:
+        pr_label = f"#{m['pr']}" if m["pr"] else "(no-PR)"
+        author = m["author"] or "_(unknown)_"
+        date = m.get("commit_date") or "_(unknown)_"
+        # Why: introducing commit subject (trimmed). For mutators this IS the
+        # justification — the commit message describes the migration handler.
+        subject = m.get("subject") or ""
+        why = (subject[:90] + "…") if len(subject) > 90 else subject
+        out.append(
+            f"| {pr_label} | `{m['sha']}` | `{m['class_name']}` "
+            f"| `{m['parent']}` | {author} | {date} | {why} |"
+        )
+    out.append("")
+    return out
+
+
+def _classify_window(base: str, head: str) -> list[FileFinding]:
+    """Run the full classification for a single base..head window.
+
+    Returns the list of FileFinding objects, including transitively-reclassified
+    aspects and purely-transitive aspects pulled in via the BFS. Pure function:
+    no rendering, no I/O beyond git plumbing.
+    """
+    paths = changed_pdls(base, head)
+    findings = [analyze_file(p_, base, head) for p_ in paths]
+
+    direct_set = set(paths)
+    non_aspect_changed = [f.path for f in findings if not f.is_aspect]
+    if not non_aspect_changed:
+        return findings
+
+    # Per-source BFS so we can attribute each transitive aspect to the
+    # SPECIFIC upstream non-aspect(s) that reach it (rather than the full
+    # list of changed non-aspects, which would over-attribute).
+    aspects_reached_by_source = find_transitive_aspects_per_source(non_aspect_changed)
+    transitive: set[str] = set().union(*aspects_reached_by_source.values())
+    # Inverted map: aspect_path → list of upstream non-aspect sources that reach it
+    sources_for_aspect: dict[str, list[str]] = {}
+    for src, aspects in aspects_reached_by_source.items():
+        for aspect in aspects:
+            sources_for_aspect.setdefault(aspect, []).append(src)
+
+    # Reclassify directly-edited aspects that are ALSO reached transitively.
+    for f in findings:
+        if not f.is_aspect or f.path not in transitive:
+            continue
+        new_content = file_at(head, f.path)
+        old_content = file_at(base, f.path)
+        f.bump_status, f.bump_reason = _classify_bump_with_reason(
+            is_aspect=True,
+            old_content=old_content,
+            new_content=new_content,
+            has_structural=f.has_structural,
+            transitively_affected=True,
+        )
+        if not f.affected_via:
+            f.affected_via = next(
+                (
+                    Path(p).stem
+                    for p in non_aspect_changed
+                    if Path(p).stem in new_content
+                ),
+                "transitive dependency",
+            )
+        f.noisy = [n for n in f.noisy if "bumped with NO structural change" not in n]
+        if not any("transitively affected" in n for n in f.noisy):
+            f.noisy.append("transitively affected by a changed non-aspect record")
+
+    # Append purely-transitive aspects (not in direct set).
+    for tpath in sorted(transitive - direct_set):
+        tcontent_new = file_at(head, tpath)
+        if not tcontent_new:
+            continue
+        tcontent_old = file_at(base, tpath)
+        meta = aspect_meta(tcontent_new) or {}
+        # `affected_via` should name the proximate upstream non-aspect when
+        # one is referenced in this file's content; otherwise fall back to
+        # the first source that's known to reach this aspect via BFS.
+        relevant_sources_for_via = sources_for_aspect.get(tpath, [])
+        via = next(
+            (
+                Path(f_).stem
+                for f_ in relevant_sources_for_via
+                if Path(f_).stem in tcontent_new
+            ),
+            (
+                Path(relevant_sources_for_via[0]).stem
+                if relevant_sources_for_via
+                else "transitive dependency"
+            ),
+        )
+        bump_status, bump_reason = _classify_bump_with_reason(
+            is_aspect=True,
+            old_content=tcontent_old,
+            new_content=tcontent_new,
+            has_structural=False,
+            transitively_affected=True,
+        )
+        head_commit_subject = latest_commit(head, tpath, base)
+        # Purely-transitive aspect: the file itself has no commits in the
+        # window. Attribute to the SPECIFIC upstream non-aspect(s) whose BFS
+        # closure reaches this aspect — not every non-aspect in the window,
+        # which would over-attribute.
+        relevant_sources = sources_for_aspect.get(tpath, [])
+        prs, author, date = upstream_attribution_for_transitive(
+            sorted(relevant_sources), head, base
+        )
+        findings.append(
+            FileFinding(
+                path=tpath,
+                is_aspect=True,
+                aspect_name=meta.get("name"),
+                head_commit=head_commit_subject,
+                affected_via=via,
+                noisy=["transitively affected by a changed non-aspect record"],
+                bump_status=bump_status,
+                bump_reason=bump_reason,
+                pr_numbers=prs,
+                last_author=author,
+                last_commit_date=date,
+                is_purely_transitive=True,
+            )
+        )
+    return findings
+
+
+def enumerate_pdl_pr_commits(base: str, head: str) -> list[tuple[str, str]]:
+    """First-parent commits in base..head that touched PDL files.
+
+    Returns (sha, subject) pairs, newest first. Suitable for per-PR analysis
+    against squash-merged PRs (one commit per PR on the first-parent line).
+    """
+    try:
+        out = _git(
+            "log",
+            "--first-parent",
+            "--format=%H %s",
+            f"{base}..{head}",
+            "--",
+            PDL_PREFIX,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"git log failed: {e.stderr or e}", file=sys.stderr)
+        raise SystemExit(2)
+    rows: list[tuple[str, str]] = []
+    for line in out.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        sha, _, subject = line.partition(" ")
+        rows.append((sha, subject))
+    return rows
+
+
+_LIFECYCLE_NOT_NEEDED_PREFIXES = (
+    "new aspect file",  # PR that created the aspect
+    "file deleted",  # PR that removed the aspect
+    "schemaVersion regressed",  # PR with anomalous version regression
+)
+
+
+def per_pr_audit(base: str, head: str) -> dict[str, list[dict]]:
+    """Run the classifier on each PDL-touching commit in base..head.
+
+    Returns: {aspect_path: [{sha, pr, subject, bump_status, author}, ...], ...}
+    sorted newest-first per aspect. Filters out per-PR slices that don't
+    carry an aspect-level signal:
+      - Non-aspect records (no schemaVersion concept).
+      - Aspect slices classified BUMP_NOT_NEEDED with reason "no schema
+        change in this file" (the file was touched in this PR but ended up
+        with no aspect-relevant change — e.g. whitespace, comments).
+
+    BUMP_NOT_NEEDED slices for **lifecycle events** (file added new, file
+    deleted, schemaVersion regression) are KEPT so the per-PR breakdown
+    table surfaces the creator-PR for new aspects, etc.
+    """
+    audit: dict[str, list[dict]] = {}
+    for sha, subject in enumerate_pdl_pr_commits(base, head):
+        parent = f"{sha}^"
+        try:
+            findings = _classify_window(parent, sha)
+        except subprocess.CalledProcessError:
+            continue
+        pr = _extract_pr_number(subject)
+        author = last_author_for_file(sha, "", base) if False else None  # placeholder
+        # Author for THIS commit (not per-file): single git call
+        try:
+            author = _git("log", "-1", "--format=%an", sha).strip() or None
+        except subprocess.CalledProcessError:
+            author = None
+        slice_date = _commit_date(sha)
+        for f in findings:
+            if not f.is_aspect:
+                continue
+            if f.bump_status == BUMP_NOT_NEEDED:
+                reason = f.bump_reason or ""
+                if not any(
+                    reason.startswith(p) for p in _LIFECYCLE_NOT_NEEDED_PREFIXES
+                ):
+                    continue
+            audit.setdefault(f.path, []).append(
+                {
+                    "sha": sha[:10],
+                    "pr": pr,
+                    "subject": subject,
+                    "bump_status": f.bump_status,
+                    "bump_reason": f.bump_reason,
+                    "author": author,
+                    "aspect_name": f.aspect_name,
+                    "date": slice_date or None,
+                    # Per-slice change details so the renderer can synthesize a
+                    # "What happened" prose column without re-reading file content.
+                    "additive": list(f.additive),
+                    "breaking": list(f.breaking),
+                    "noisy": list(f.noisy),
+                    "old_v": f.old_v,
+                    "new_v": f.new_v,
+                    "affected_via": f.affected_via,
+                }
+            )
+    # Apply chronological catch-up reclassification per file so all downstream
+    # consumers (per-PR aggregator, cumulative override, renderer) see the
+    # debt-reconciled verdicts. A bump-without-change PR that catches up a
+    # prior unbumped change is reclassified BUMP_SPURIOUS → BUMP_DONE.
+    for entries in audit.values():
+        _apply_catchup_reclassification(entries)
+    return audit
+
+
+def render_per_pr_report(
+    audit: dict[str, list[dict]], base: str, head: str, head_sha: str
+) -> str:
+    """Render the per-PR audit as markdown."""
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    n_aspects = len(audit)
+    all_entries = [e for entries in audit.values() for e in entries]
+    n_pr_slices = len({(e["sha"], e["pr"]) for e in all_entries})
+
+    # Per-aspect roll-ups
+    unjustified: list[tuple[str, list[dict]]] = []
+    needed: list[tuple[str, list[dict]]] = []
+    fully_justified: list[tuple[str, list[dict]]] = []
+    for path, entries in sorted(audit.items(), key=lambda kv: Path(kv[0]).name.lower()):
+        spurious = [e for e in entries if e["bump_status"] == BUMP_SPURIOUS]
+        needs = [e for e in entries if e["bump_status"] == BUMP_NEEDED]
+        done = [e for e in entries if e["bump_status"] == BUMP_DONE]
+        if spurious:
+            unjustified.append((path, entries))
+        elif needs:
+            needed.append((path, entries))
+        elif done:
+            fully_justified.append((path, entries))
+
+    out: list[str] = [
+        "# @Aspect PDL change report — per-PR audit",
+        "",
+        f"**Base:** `{base}`  ",
+        f"**Head:** `{head}` (sha: `{head_sha}`)  ",
+        f"**Generated:** {generated}",
+        "",
+        (
+            f"**Audit:** {n_pr_slices} PR-slice(s) examined · "
+            f"{n_aspects} aspect(s) with at least one bump-relevant verdict · "
+            f"**{len(unjustified)} with unjustified bumps** · "
+            f"**{len(needed)} with missing bumps** · "
+            f"{len(fully_justified)} fully justified"
+        ),
+        "",
+        "Each row below is one PR's classification of the aspect _in isolation_ "
+        "(`parent..commit` slice), so spurious bumps that are absorbed in a "
+        "cumulative view show up here.",
+        "",
+    ]
+
+    def _entries_to_pr_table(entries: list[dict]) -> list[str]:
+        rows = [
+            "| PR | sha | bump | author | commit |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+        for e in entries:
+            pr_label = f"#{e['pr']}" if e["pr"] else "(no-PR)"
+            author = e["author"] or "_(unknown)_"
+            subject = e["subject"][:80] + ("…" if len(e["subject"]) > 80 else "")
+            rows.append(
+                f"| {pr_label} | `{e['sha']}` | `{e['bump_status']}` | {author} | {subject} |"
+            )
+        return rows
+
+    if unjustified:
+        out.append("## ⚠️ Aspects with at least one unjustified bump (`bump_spurious`)")
+        out.append("")
+        out.append(
+            "These aspects had at least one PR-slice classify their bump as "
+            "`bump_spurious` — a `schemaVersion` increment in a slice that "
+            "made no schema change. Each of these violates the "
+            "_v→v+1 per justifying PR_ invariant."
+        )
+        out.append("")
+        for path, entries in unjustified:
+            out.append(f"### `{Path(path).name}`")
+            out.append("")
+            out.extend(_entries_to_pr_table(entries))
+            out.append("")
+
+    if needed:
+        out.append("## 🟡 Aspects with at least one missing bump (`bump_needed`)")
+        out.append("")
+        out.append(
+            "These aspects had at least one PR-slice classify them as "
+            "`bump_needed` — schema changed in that slice but the version "
+            "was NOT bumped. Silent migration hazards."
+        )
+        out.append("")
+        for path, entries in needed:
+            out.append(f"### `{Path(path).name}`")
+            out.append("")
+            out.extend(_entries_to_pr_table(entries))
+            out.append("")
+
+    if fully_justified:
+        out.append("## ✅ Aspects with all bumps justified")
+        out.append("")
+        out.append(
+            "Every PR-slice that bumped these aspects also contained a real schema change."
+        )
+        out.append("")
+        out.append("| Aspect | Bumps | Justifying PR(s) |")
+        out.append("| --- | --- | --- |")
+        for path, entries in fully_justified:
+            done = [e for e in entries if e["bump_status"] == BUMP_DONE]
+            prs = ", ".join(
+                sorted({f"#{e['pr']}" if e["pr"] else "(no-PR)" for e in done})
+            )
+            out.append(f"| {Path(path).name} | {len(done)} | {prs} |")
+        out.append("")
+
+    if not (unjustified or needed or fully_justified):
+        out.append("_No aspects with bump-relevant PR-slice verdicts in this window._")
+        out.append("")
+
+    return "\n".join(out) + "\n"
+
+
+def _aggregate_per_pr_verdict(entries: list[dict]) -> str:
+    """Reduce a list of per-PR-slice verdicts to a single cumulative status,
+    honoring catch-up reconciliation.
+
+    Priority order (highest wins): bump_spurious > bump_needed > bump_done >
+    bump_not_needed. A BUMP_NEEDED entry is **ignored** when its PR appears
+    in any later slice's `catch_up_for_prs` — that NEEDED slice has already
+    been reconciled by a catch-up bump and is no longer an unpaid debt.
+
+    The cumulative bucket therefore follows the per-PR truth: a file lands
+    in `bump_spurious` whenever any slice has an unreconciled spurious bump,
+    even if cumulative-diff math would call the window `bump_done`.
+    """
+    paid_prs: set[str] = set()
+    for e in entries:
+        for pr in e.get("catch_up_for_prs") or []:
+            paid_prs.add(pr)
+    has_spurious = any(e["bump_status"] == BUMP_SPURIOUS for e in entries)
+    has_unreconciled_needed = any(
+        e["bump_status"] == BUMP_NEEDED and e.get("pr") not in paid_prs for e in entries
+    )
+    has_done = any(e["bump_status"] == BUMP_DONE for e in entries)
+    if has_spurious:
+        return BUMP_SPURIOUS
+    if has_unreconciled_needed:
+        return BUMP_NEEDED
+    if has_done:
+        return BUMP_DONE
+    return BUMP_NOT_NEEDED
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--base", default=None, help="baseline ref (default: latest v1.0* non-rc tag)"
+    )
+    p.add_argument("--head", default="HEAD", help="head ref (default: HEAD)")
+    p.add_argument(
+        "--output", default=None, help="write markdown to FILE (default: stdout)"
+    )
+    p.add_argument(
+        "--per-pr",
+        action="store_true",
+        help=(
+            "Run per-PR audit mode: classify each PDL-touching commit in base..head "
+            "in isolation, then aggregate. Catches the v→v+1 invariant per PR "
+            "(e.g. PR #9579-style spurious bumps that wide cumulative windows mask)."
+        ),
+    )
+    args = p.parse_args(argv)
+
+    base = args.base or resolve_base(args.head)
+    head_sha = _head_sha(args.head)
+
+    if args.per_pr:
+        audit = per_pr_audit(base, args.head)
+        report = render_per_pr_report(
+            audit, base=base, head=args.head, head_sha=head_sha
+        )
+    else:
+        findings = _classify_window(base, args.head)
+        # Enrich cumulative bump_status with per-PR-aware verdicts: walk each
+        # PR in the window, classify in isolation, then override the
+        # cumulative status with the highest-priority per-PR verdict. This
+        # ensures a PR that bumped spuriously (e.g. PR #9579) shows up as
+        # bump_spurious in the cumulative report even when other PRs' real
+        # changes would have absorbed it under pure cumulative-diff math.
+        try:
+            audit = per_pr_audit(base, args.head)
+        except subprocess.CalledProcessError:
+            audit = {}
+        for f in findings:
+            if f.path not in audit:
+                continue
+            new_status = _aggregate_per_pr_verdict(audit[f.path])
+            if new_status != f.bump_status:
+                # Per-PR aggregation drives the cumulative bucket. The
+                # aggregator already honors catch-up reconciliation, so a
+                # NEEDED slice paid down by a later DONE slice no longer
+                # holds the file back from bump_done. The cumulative
+                # bump_reason no longer matches the new status — clear it
+                # so the renderer falls back to _BUMP_WHY[new_status] or
+                # per-row Why helpers.
+                f.bump_status = new_status
+                f.bump_reason = None
+        report = render_report(
+            findings,
+            base=base,
+            head=args.head,
+            head_sha=head_sha,
+            audit=audit,
+        )
+
+    # Append mutator section (subclasses of AspectMigrationMutator added in window).
+    # Same data in both modes — it's a window-level audit, not per-PR.
+    mutators = find_mutators_added_in_window(
+        base, args.head, discover_mutator_hierarchy()
+    )
+    mutator_section = _render_mutator_section(mutators)
+    if mutator_section:
+        report = report.rstrip("\n") + "\n\n" + "\n".join(mutator_section) + "\n"
+
+    # Standalone integration-test sidecar file: `release_test_pdl_changes.md`
+    # next to `--output`. Cumulative mode only (per-PR mode's findings aren't
+    # available here). Contains the union of bump_done + bump_needed +
+    # bump_spurious aspects with a `Mutator` column matched via the mutator's
+    # `getAspectName()`.
+    if not args.per_pr:
+        sidecar = _render_release_test_pdl_file(
+            findings,
+            mutators,
+            base=base,
+            head=args.head,
+            head_sha=head_sha,
+        )
+        if sidecar and args.output:
+            sidecar_path = Path(args.output).parent / "release_test_pdl_changes.md"
+            sidecar_path.write_text(sidecar)
+
+    if args.output:
+        Path(args.output).write_text(report)
+    else:
+        sys.stdout.write(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/report_aspect_changes.py
+++ b/.github/scripts/report_aspect_changes.py
@@ -2,14 +2,20 @@
 """
 Report @Aspect PDL breaking changes between two git refs.
 
-By default, compares `acryl-main` against the latest stable `-cloud` release
-tag reachable from it (falling back to the latest `-cloud` tag if no stable
-release exists yet). Used to audit aspect-level breaking changes across any
-release window — the defaults self-adjust as new releases ship.
+Auto-detects the repo flavor and picks sensible defaults:
+
+- acryl-fork (when `acryl-main` ref exists): compares `acryl-main` against
+  the latest stable `v*-cloud` release tag.
+- OSS DataHub (no `acryl-main` ref): compares `master` against the latest
+  stable `v*` release tag (rc and `-cloud` tags excluded).
+
+Each mode falls back to including rc tags if no stable release exists yet.
+The defaults self-adjust as new releases ship — no per-release config changes.
 
 Usage:
     python3 .github/scripts/report_aspect_changes.py
     python3 .github/scripts/report_aspect_changes.py --base v1.0.0rc1-cloud
+    python3 .github/scripts/report_aspect_changes.py --base v1.5.0 --head master
     python3 .github/scripts/report_aspect_changes.py --output report.md
 """
 
@@ -33,7 +39,10 @@ PDL_PREFIX = "metadata-models/src/main/pegasus"
 
 
 def _latest_tag(
-    match: str, *, exclude_substr: Optional[str] = None
+    match: str,
+    *,
+    exclude_substr: Optional[str] = None,
+    exclude_extra: Optional[str] = None,
 ) -> Optional[str]:
     """Return the latest tag (version-sorted descending) matching `match`.
 
@@ -41,8 +50,10 @@ def _latest_tag(
     no ancestry constraint. Release tags in this repo often live on parallel
     hotfix branches that aren't ancestors of trunk, so an ancestry-based
     lookup (`git describe --abbrev=0`) would miss them. Pass `exclude_substr`
-    to skip tags whose names contain a substring (e.g. "rc"). Returns None
-    if no matching tag is found or git fails.
+    to skip tags whose names contain a substring (e.g. "rc"); pass
+    `exclude_extra` for a second substring filter (e.g. exclude "-cloud"
+    when picking OSS tags since git's glob can't negate). Returns None if
+    no matching tag is found or git fails.
     """
     try:
         out = subprocess.check_output(
@@ -59,33 +70,101 @@ def _latest_tag(
             continue
         if exclude_substr and exclude_substr in tag:
             continue
+        if exclude_extra and exclude_extra in tag:
+            continue
         return tag
     return None
 
 
-def resolve_base() -> str:
-    """Pick the latest stable `-cloud` release tag (global, version-sorted).
+def _resolve_ref(*candidates: str) -> Optional[str]:
+    """Return the first candidate ref that resolves, or None.
 
-    Looks across all tags in the repo, not just ancestors of any specific
-    ref. This is required because stable `-cloud` releases are typically
-    cut on parallel hotfix branches (e.g. `origin/hotfixes/v1.0.0`) that
-    aren't ancestors of `acryl-main`. An ancestry-based lookup would never
-    find them.
-
-    Falls back to the latest `-cloud` tag of any kind (rc accepted) if no
-    stable release exists yet. The defaults self-maintain across releases
-    — no hardcoded minor-version prefix to bump at every release cut.
+    Checks each candidate via `git rev-parse --verify --quiet`. CI
+    checkouts typically only have remote-tracking refs (e.g.
+    `origin/acryl-main`), not the bare local branch name, so callers
+    pass both forms and take whichever resolves.
     """
-    stable = _latest_tag(match="v*-cloud", exclude_substr="rc")
+    for ref in candidates:
+        try:
+            subprocess.check_output(
+                ["git", "rev-parse", "--verify", "--quiet", ref],
+                cwd=REPO_ROOT,
+                stderr=subprocess.DEVNULL,
+            )
+            return ref
+        except subprocess.CalledProcessError:
+            continue
+    return None
+
+
+def _detect_mode() -> str:
+    """Return 'acryl' if any `acryl-main` ref exists in this repo, else 'oss'.
+
+    Presence of `acryl-main` is the marker: it's a fork-only branch that
+    never exists in the OSS DataHub repo. Using a branch presence check
+    (rather than remote URL inspection or tag-pattern probing) keeps the
+    signal stable across local renames and detached HEADs. Both the
+    local branch and the `origin/` remote-tracking ref are checked so
+    CI checkouts (which often only have the remote-tracking form) are
+    detected correctly.
+    """
+    if _resolve_ref("acryl-main", "origin/acryl-main"):
+        return "acryl"
+    return "oss"
+
+
+def _default_head(mode: Optional[str] = None) -> str:
+    """Return the head ref default for the given mode (auto-detected if None).
+
+    Prefers the local branch but falls back to the `origin/` remote-tracking
+    ref so the default resolves in CI checkouts.
+    """
+    if mode is None:
+        mode = _detect_mode()
+    if mode == "acryl":
+        return _resolve_ref("acryl-main", "origin/acryl-main") or "acryl-main"
+    return _resolve_ref("master", "origin/master") or "master"
+
+
+def resolve_base(mode: Optional[str] = None) -> str:
+    """Pick the latest stable release tag for the given repo flavor.
+
+    Looks across all tags in the repo (no ancestry constraint) and picks the
+    latest version-sorted tag matching the mode's release naming convention:
+
+    - acryl: `v*-cloud` tags. Stable cloud releases are cut on parallel
+      hotfix branches that aren't ancestors of `acryl-main`, so an
+      ancestry-based lookup would miss them.
+    - oss: `v*` tags excluding `-cloud`. OSS release tags don't carry the
+      cloud suffix; we strip cloud tags so a checkout that has both still
+      picks the right one.
+
+    Falls back to including rc tags if no stable release exists yet. The
+    defaults self-maintain across releases — no hardcoded prefix to bump.
+
+    `mode` defaults to auto-detection via `_detect_mode()`.
+    """
+    if mode is None:
+        mode = _detect_mode()
+    if mode == "acryl":
+        match, exclude_extra = "v*-cloud", None
+    elif mode == "oss":
+        match, exclude_extra = "v*", "-cloud"
+    else:
+        raise ValueError(f"unknown mode: {mode!r}")
+
+    stable = _latest_tag(
+        match=match, exclude_substr="rc", exclude_extra=exclude_extra
+    )
     if stable:
         return stable
-    rc_fallback = _latest_tag(match="v*-cloud")
+    rc_fallback = _latest_tag(match=match, exclude_extra=exclude_extra)
     if rc_fallback:
         return rc_fallback
     raise SystemExit(
-        "Could not find any -cloud release tag in this repo. Tried "
-        "`git tag --list 'v*-cloud' --sort=-v:refname` with and without "
-        "the rc filter. Pass --base explicitly."
+        f"Could not find any release tag in this repo (mode={mode}). Tried "
+        f"`git tag --list {match!r} --sort=-v:refname` with and without "
+        f"the rc filter. Pass --base explicitly."
     )
 
 
@@ -1717,15 +1796,18 @@ def main(argv: list[str] | None = None) -> int:
         "--base",
         default=None,
         help=(
-            "baseline ref (default: latest stable -cloud release tag in the "
-            "repo via global version-sorted tag lookup; falls back to latest "
-            "-cloud tag if no stable exists yet)"
+            "baseline ref (default: auto-detected — latest stable v*-cloud tag "
+            "in acryl-fork repos, latest stable v* tag in OSS DataHub; falls "
+            "back to rc tags if no stable release exists yet)"
         ),
     )
     p.add_argument(
         "--head",
-        default="acryl-main",
-        help="head ref (default: acryl-main)",
+        default=None,
+        help=(
+            "head ref (default: auto-detected — `acryl-main` in acryl-fork "
+            "repos, `master` in OSS DataHub)"
+        ),
     )
     p.add_argument(
         "--output", default=None, help="write markdown to FILE (default: stdout)"
@@ -1741,16 +1823,20 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = p.parse_args(argv)
 
-    base = args.base or resolve_base()
-    head_sha = _head_sha(args.head)
+    # Resolve mode once so base and head defaults stay consistent (and we
+    # don't pay for two `git rev-parse` probes).
+    mode = _detect_mode()
+    base = args.base or resolve_base(mode)
+    head = args.head or _default_head(mode)
+    head_sha = _head_sha(head)
 
     if args.per_pr:
-        audit = per_pr_audit(base, args.head)
+        audit = per_pr_audit(base, head)
         report = render_per_pr_report(
-            audit, base=base, head=args.head, head_sha=head_sha
+            audit, base=base, head=head, head_sha=head_sha
         )
     else:
-        findings = _classify_window(base, args.head)
+        findings = _classify_window(base, head)
         # Enrich cumulative bump_status with per-PR-aware verdicts: walk each
         # PR in the window, classify in isolation, then override the
         # cumulative status with the highest-priority per-PR verdict. This
@@ -1758,7 +1844,7 @@ def main(argv: list[str] | None = None) -> int:
         # bump_spurious in the cumulative report even when other PRs' real
         # changes would have absorbed it under pure cumulative-diff math.
         try:
-            audit = per_pr_audit(base, args.head)
+            audit = per_pr_audit(base, head)
         except subprocess.CalledProcessError:
             audit = {}
         for f in findings:
@@ -1778,7 +1864,7 @@ def main(argv: list[str] | None = None) -> int:
         report = render_report(
             findings,
             base=base,
-            head=args.head,
+            head=head,
             head_sha=head_sha,
             audit=audit,
         )
@@ -1786,7 +1872,7 @@ def main(argv: list[str] | None = None) -> int:
     # Append mutator section (subclasses of AspectMigrationMutator added in window).
     # Same data in both modes — it's a window-level audit, not per-PR.
     mutators = find_mutators_added_in_window(
-        base, args.head, discover_mutator_hierarchy()
+        base, head, discover_mutator_hierarchy()
     )
     mutator_section = _render_mutator_section(mutators)
     if mutator_section:
@@ -1802,7 +1888,7 @@ def main(argv: list[str] | None = None) -> int:
             findings,
             mutators,
             base=base,
-            head=args.head,
+            head=head,
             head_sha=head_sha,
         )
         if sidecar and args.output:

--- a/.github/scripts/report_aspect_changes.py
+++ b/.github/scripts/report_aspect_changes.py
@@ -23,10 +23,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
-# Reuse the parsing/graph helpers from bump_schema_versions.py.
-# Read-only consumption; the source module is intentionally untouched.
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-import bump_schema_versions as bsv  # noqa: E402
+# Sibling import: `.github/scripts/` is on sys.path[0] via Python's
+# script-directory rule when this file is invoked as a script.
+import bump_schema_versions as bsv
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PDL_PREFIX = "metadata-models/src/main/pegasus"
@@ -58,7 +57,7 @@ def resolve_base(head: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# PDL parsing (heuristic, ported from .claude/local/check_pdl_aspects.py)
+# PDL parsing (heuristic)
 # ---------------------------------------------------------------------------
 
 _DOC_RE = re.compile(r"/\*.*?\*/", re.DOTALL)

--- a/.github/scripts/report_pdl_aspect_changes.md
+++ b/.github/scripts/report_pdl_aspect_changes.md
@@ -22,13 +22,13 @@ python3 .github/scripts/report_aspect_changes.py [OPTIONS]
 
 ### Options
 
-| Flag            | Default                                                                                                                           | Description                                                                                                                                                                                                                                                                                           |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--base REF`    | latest `v1.0*` non-rc tag reachable from `--head`, resolved via `git describe --tags --match 'v1.0*' --exclude '*rc*' --abbrev=0` | Baseline git ref. Accepts any tag, branch, commit SHA, or ref-spec.                                                                                                                                                                                                                                   |
-| `--head REF`    | `HEAD`                                                                                                                            | Head git ref. Accepts any tag, branch, commit SHA, or ref-spec.                                                                                                                                                                                                                                       |
-| `--output FILE` | stdout                                                                                                                            | Write the markdown report to a file (use `"$GITHUB_STEP_SUMMARY"` in CI).                                                                                                                                                                                                                             |
-| `--per-pr`      | off                                                                                                                               | Run the classifier on each PDL-touching commit in `base..head` _in isolation_ (`parent..commit` slice) and aggregate the verdicts. Catches the per-PR `bump_spurious` anti-pattern that wide cumulative windows mask. Slower (~0.5s per PR slice) but enforces the v→v+1-per-justifying-PR invariant. |
-| `-h` / `--help` | —                                                                                                                                 | Show help and exit.                                                                                                                                                                                                                                                                                   |
+| Flag            | Default                                                                                                                                                                                                                                                                                                                                                   | Description                                                                                                                                                                                                                                                                                           |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--base REF`    | latest stable `-cloud` release tag in the repo (global version-sorted lookup via `git tag --list 'v*-cloud' --sort=-v:refname`, with rc tags filtered out). Falls back to the latest `-cloud` tag (rc accepted) if no stable release has shipped yet. Independent of `--head` ancestry — stable releases on parallel hotfix branches are correctly found. | Baseline git ref. Accepts any tag, branch, commit SHA, or ref-spec.                                                                                                                                                                                                                                   |
+| `--head REF`    | `acryl-main`                                                                                                                                                                                                                                                                                                                                              | Head git ref. Accepts any tag, branch, commit SHA, or ref-spec.                                                                                                                                                                                                                                       |
+| `--output FILE` | stdout                                                                                                                                                                                                                                                                                                                                                    | Write the markdown report to a file (use `"$GITHUB_STEP_SUMMARY"` in CI).                                                                                                                                                                                                                             |
+| `--per-pr`      | off                                                                                                                                                                                                                                                                                                                                                       | Run the classifier on each PDL-touching commit in `base..head` _in isolation_ (`parent..commit` slice) and aggregate the verdicts. Catches the per-PR `bump_spurious` anti-pattern that wide cumulative windows mask. Slower (~0.5s per PR slice) but enforces the v→v+1-per-justifying-PR invariant. |
+| `-h` / `--help` | —                                                                                                                                                                                                                                                                                                                                                         | Show help and exit.                                                                                                                                                                                                                                                                                   |
 
 ### Environment variables
 
@@ -37,7 +37,8 @@ None. PDL roots are pinned to `metadata-models/src/main/pegasus/` (matching the 
 ### Examples
 
 ```bash
-# Default: auto-resolves the v1.0.x baseline, prints to stdout
+# Default: compares acryl-main vs. the latest stable `-cloud` release tag,
+# prints to stdout. No flags needed — defaults self-maintain across releases.
 python3 .github/scripts/report_aspect_changes.py
 
 # Pin both refs explicitly (canonical v1.1.0 baseline → branch)
@@ -77,13 +78,17 @@ python3 .github/scripts/report_aspect_changes.py --output report.md
 
 ### Step 1 — Resolve baseline
 
-If `--base` is omitted, the tool runs:
+If `--base` is omitted, the tool first tries:
 
 ```
-git describe --tags --match 'v1.0*' --exclude '*rc*' --abbrev=0 <head>
+git tag --list 'v*-cloud' --sort=-v:refname
 ```
 
-to find the most recent `v1.0*` non-rc tag reachable from `--head`. Auto-rolls forward as new `v1.0.x` tags land; no code change required.
+then filters out any tag whose name contains `rc`, and returns the first remaining tag (highest version stable `-cloud` release). If every matching tag is an rc tag (e.g., early in a new release cycle before any stable has shipped), it falls back to the same lookup **without** the rc filter, returning the latest `-cloud` tag of any kind.
+
+**Why a global tag enumeration rather than `git describe`?** Stable `-cloud` releases in this repo are typically cut on parallel hotfix branches (e.g. `origin/hotfixes/v1.0.0`) that are **not ancestors of `acryl-main`**. An ancestry-based lookup via `git describe` would never see them. The global `git tag --list` lookup finds the latest shipped release regardless of branch topology.
+
+Customer-suffix tags (e.g. `-crucible-trustpilot`, `-raleigh`) are excluded by construction via the `v*-cloud` match pattern. The defaults self-adjust as new releases ship — no code change at release-cut.
 
 ### Step 2 — List changed PDL files
 

--- a/.github/scripts/report_pdl_aspect_changes.md
+++ b/.github/scripts/report_pdl_aspect_changes.md
@@ -1,0 +1,358 @@
+# report_aspect_changes.py
+
+A CLI tool that produces a markdown breaking-change report classifying every `@Aspect` PDL change between two git refs. Both `--base` and `--head` accept any ref type — tag, branch, commit SHA, or ref-spec (e.g. `HEAD~30`) — so the tool works for release-window audits, hotfix-vs-trunk comparisons, single-PR previews, and ad-hoc spot checks alike. Companion to [`bump_schema_versions.py`](bump_schema_versions.md): where that script _writes_ `schemaVersion` bumps in your working tree, this script _audits_ them across a release window — surfacing missed bumps, spurious bumps, and breaking schema changes.
+
+## Why this exists
+
+The auto-bumper in `bump_schema_versions.py` runs in pre-commit on every PR. It does its job, but its decisions are invisible at release time: the only thing you see in `git diff v1.0.x..acryl-main` for a given aspect is a `schemaVersion N → N+1` line. You can't tell from the line alone whether that bump was:
+
+- **legitimate** — the aspect (or a record it depends on) actually changed shape, OR
+- **spurious** — a sibling change in the same PR triggered the bumper as a side-effect with no real schema impact (e.g. PR #9579, which auto-bumped 9 unrelated aspects with no schema changes), OR
+- **missing** — the aspect changed shape but the bumper didn't fire (e.g. a manual edit that should have been bumped but wasn't).
+
+This tool walks the same dependency graph the auto-bumper uses, classifies every aspect in the window, and emits a markdown report you can paste into a release ticket or render in `$GITHUB_STEP_SUMMARY`. It's read-only: no files are written under `metadata-models/`.
+
+## Usage
+
+Run from the repository root:
+
+```
+python3 .github/scripts/report_aspect_changes.py [OPTIONS]
+```
+
+### Options
+
+| Flag            | Default                                                                                                                           | Description                                                                                                                                                                                                                                                                                           |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--base REF`    | latest `v1.0*` non-rc tag reachable from `--head`, resolved via `git describe --tags --match 'v1.0*' --exclude '*rc*' --abbrev=0` | Baseline git ref. Accepts any tag, branch, commit SHA, or ref-spec.                                                                                                                                                                                                                                   |
+| `--head REF`    | `HEAD`                                                                                                                            | Head git ref. Accepts any tag, branch, commit SHA, or ref-spec.                                                                                                                                                                                                                                       |
+| `--output FILE` | stdout                                                                                                                            | Write the markdown report to a file (use `"$GITHUB_STEP_SUMMARY"` in CI).                                                                                                                                                                                                                             |
+| `--per-pr`      | off                                                                                                                               | Run the classifier on each PDL-touching commit in `base..head` _in isolation_ (`parent..commit` slice) and aggregate the verdicts. Catches the per-PR `bump_spurious` anti-pattern that wide cumulative windows mask. Slower (~0.5s per PR slice) but enforces the v→v+1-per-justifying-PR invariant. |
+| `-h` / `--help` | —                                                                                                                                 | Show help and exit.                                                                                                                                                                                                                                                                                   |
+
+### Environment variables
+
+None. PDL roots are pinned to `metadata-models/src/main/pegasus/` (matching the workflow's scope) because the report tool delegates to `bump_schema_versions.py` for the dependency graph, which honors `PDL_ROOTS` if you've exported it.
+
+### Examples
+
+```bash
+# Default: auto-resolves the v1.0.x baseline, prints to stdout
+python3 .github/scripts/report_aspect_changes.py
+
+# Pin both refs explicitly (canonical v1.1.0 baseline → branch)
+python3 .github/scripts/report_aspect_changes.py \
+  --base v1.0.0rc1-cloud \
+  --head acryl-main
+
+# Tag → tag (audit a single release cut)
+python3 .github/scripts/report_aspect_changes.py \
+  --base v1.0.0-cloud --head v1.0.1-cloud
+
+# Branch → branch (compare a hotfix branch to trunk)
+python3 .github/scripts/report_aspect_changes.py \
+  --base origin/releases/v1.0.0 --head origin/acryl-main
+
+# Commit → commit (slice an exact SHA range)
+python3 .github/scripts/report_aspect_changes.py \
+  --base 30f791d121 --head 8a0456e560
+
+# Ref-spec (preview the last 30 commits)
+python3 .github/scripts/report_aspect_changes.py --base HEAD~30 --head HEAD
+
+# Per-PR audit mode — classify every PDL-touching PR in isolation, aggregate
+# (use this to enforce the v→v+1-per-justifying-PR invariant; catches PR
+# #9579-style spurious bumps that wide cumulative windows mask)
+python3 .github/scripts/report_aspect_changes.py \
+  --base v1.0.0rc1-cloud --head HEAD --per-pr
+
+# Save the report to a file for sharing
+python3 .github/scripts/report_aspect_changes.py --output report.md
+
+# Run via the GitHub Actions workflow (renders into $GITHUB_STEP_SUMMARY)
+# Actions → "PDL Aspect Change Report" → Run workflow, leave inputs blank
+```
+
+## How it works
+
+### Step 1 — Resolve baseline
+
+If `--base` is omitted, the tool runs:
+
+```
+git describe --tags --match 'v1.0*' --exclude '*rc*' --abbrev=0 <head>
+```
+
+to find the most recent `v1.0*` non-rc tag reachable from `--head`. Auto-rolls forward as new `v1.0.x` tags land; no code change required.
+
+### Step 2 — List changed PDL files
+
+```
+git diff --name-only <base>..<head> -- metadata-models/src/main/pegasus
+```
+
+filtered to `*.pdl`. Files that exist on only one side (added or deleted) are still emitted.
+
+### Step 3 — Classify each changed file
+
+For every changed file the classifier compares base vs. head content and emits findings against **five breaking-change criteria** plus **two `schemaVersion` anomalies**:
+
+| #   | Criterion                                                                 | Bucket   |
+| --- | ------------------------------------------------------------------------- | -------- |
+| 1   | Removed fields                                                            | breaking |
+| 2   | Renamed record without `@renamedFrom` annotation                          | breaking |
+| 3   | `optional → required` flip                                                | breaking |
+| 4   | Enum value removal                                                        | breaking |
+| 5   | Field type change                                                         | breaking |
+|     | Added required field                                                      | breaking |
+|     | **Structural change without `schemaVersion` bump**                        | breaking |
+|     | Added optional field                                                      | additive |
+|     | Added enum value                                                          | additive |
+|     | `required → optional` flip                                                | noisy    |
+|     | Renamed record **with** `@renamedFrom` annotation                         | noisy    |
+|     | **`schemaVersion` bump without structural change** (the PR #9579 pattern) | noisy    |
+
+### Step 4 — Walk the dependency graph (transitive impact)
+
+For each changed **non-aspect** record, the tool delegates to `bump_schema_versions.py`'s reverse-include graph + BFS to find every aspect that depends on the record via PDL `includes` OR field-type references. Those aspects are surfaced even if they weren't directly edited.
+
+### Step 5 — Reclassify directly-edited aspects
+
+Aspects that were both directly edited AND reached by the BFS get their `bump_status` re-evaluated with transitive context — so an aspect bumped _because_ a sibling non-aspect changed in the same PR is correctly classified as `bump_done` (legitimate), not `bump_spurious`.
+
+### Step 6 — Per-aspect bump-status classification
+
+Each aspect ends with one of four bump statuses:
+
+| Status          | Trigger                                                                                  |
+| --------------- | ---------------------------------------------------------------------------------------- |
+| `bump_done`     | `head schemaVersion > base AND a real change exists` (direct or transitive). Legitimate. |
+| `bump_needed`   | change exists but version NOT bumped — silent migration hazard.                          |
+| `bump_spurious` | version bumped with NO schema change at all (auto-bumper side-effect).                   |
+| `not_sure`      | version regressed (head < base) — manual review.                                         |
+
+`schemaVersion` defaults to 1 when absent, matching [`bump_schema_versions.md`](bump_schema_versions.md) semantics.
+
+## Output
+
+Markdown only. Sections always emitted (or replaced with a "no aspect changes" message if the diff is empty):
+
+1. **Header** — base ref, head ref + short SHA, generation timestamp (UTC).
+2. **Summary** — single line with file/aspect/transitive/BREAKING/additive/noisy counts.
+3. **Bump status** — single line with `bump_done` · `bump_needed` · `bump_spurious` · `not_sure` counts.
+4. **Bump status legend** — collapsible `<details>` block explaining each bucket.
+5. **Bump status breakdown** — one markdown table per status (`bump_done`, `bump_needed`, `bump_spurious`, `not_sure`), each headed with the count and rendered as `PDL file | PR(s) | Owner | Date | Why` rows. Owner is the name of the last commit author who touched the file in the window; transitively-affected aspects (file not directly edited) show `(no-PR)` and `(no owner — file wasn't directly touched)` in those cells. A file touched by multiple PRs in the window shows them comma-separated in the PR column. Empty buckets render as `_(none)_`.
+
+Then per-bucket sections (each omitted when empty), in fixed order:
+
+| #   | Section                            | What lands here                                                                       | Bullet style          |
+| --- | ---------------------------------- | ------------------------------------------------------------------------------------- | --------------------- |
+| 1   | `## ⚠️ BREAKING`                   | Hits any of the 5 breaking criteria + structural-change-without-bump.                 | Full per-finding      |
+| 2   | `## Transitively affected aspects` | Aspects pulled in via include / field-type from a changed non-aspect record.          | Full per-finding      |
+| 3   | `## Additive`                      | New optional fields, new enum values, new files.                                      | Full per-finding      |
+| 4   | `## Noisy`                         | `required→optional` flips · `renamedFrom` renames · `schemaVersion` bumps w/o change. | Full per-finding      |
+| 5   | `## No logical change`             | File in git diff but no aspect-relevant difference (comment/whitespace).              | Collapsed (path only) |
+
+Per-finding bullet format:
+
+```markdown
+- [ASPECT] `metadata-models/.../DatasetProperties.pdl` (abc1234 commit subject)
+  - aspect name: `datasetProperties`
+  - affected via: ChangedRecord (only for transitively-affected)
+  - PR: #9579, #9000 (every PR touching this file in window)
+  - bump: bump_done | bump_needed | bump_spurious | not_sure
+  - `⚠ BREAKING`: removed field: deprecated
+  - `+ additive`: added optional field: lastModifiedSource: optional string
+  - `· noisy`: schemaVersion 2→3 bumped with NO structural change
+```
+
+`[ASPECT]` vs `[nested]` tag distinguishes aspect files from plain records (the latter are only shown when transitively pulled in, or as additive new files).
+
+### Example output (excerpt — canonical v1.1.0 baseline)
+
+```
+# @Aspect PDL change report
+
+**Base:** `v1.0.0rc1-cloud`
+**Head:** `HEAD` (sha: `59a7c8b2d2`)
+**Generated:** 2026-05-18T12:39:57Z
+
+**Summary:** 79 PDL files changed · 5 aspects directly changed · 22 aspects transitively affected · **28 BREAKING** · 33 additive · 0 noisy
+
+**Bump status:** 14 bump_done · **5 bump_needed** · **0 bump_spurious** · 0 not_sure
+
+**Bump status breakdown:**
+
+### `bump_done` (14)
+
+| Aspect                       | PR(s)               | Owner                 |
+| ---------------------------- | ------------------- | --------------------- |
+| ActionRequestInfo.pdl        | #9555, #9579        | Nick Adams            |
+| AssertionInfo.pdl            | #9555, #9579        | Nick Adams            |
+| DataHubAiConversationInfo.pdl| #9585               | Nick Adams            |
+| DataHubIngestionSourceInfo.pdl| #9509              | Sergio Gómez Villamor |
+| ... (rows trimmed for brevity)                                  |
+
+### `bump_needed` (5)
+
+| Aspect                     | PR(s)   | Owner                                       |
+| -------------------------- | ------- | ------------------------------------------- |
+| DataHubOAuthClientInfo.pdl | #9311   | Nick Adams                                  |
+| DataHubTaskInfo.pdl        | #9242   | John Joyce                                  |
+| GlobalSettingsInfo.pdl     | #9272   | Chris Collins                               |
+| MonitorSuiteInfo.pdl       | (no-PR) | _(no owner — file wasn't directly touched)_ |
+| RecommendationModule.pdl   | (no-PR) | _(no owner — file wasn't directly touched)_ |
+
+### `bump_spurious` (0)
+
+_(none)_
+
+### `not_sure` (0)
+
+_(none)_
+```
+
+Notes on this run:
+
+- `bump_needed: 5` is the actionable signal — 5 aspects whose schema changed between `v1.0.0rc1-cloud` and HEAD but were never bumped (silent migration hazards).
+- `bump_spurious: 0` here is **expected** at this window width — the per-PR spurious bumps from PR #9579 (visible in narrower windows like `v1.0.1-crucible-trustpilot..acryl-main`) are absorbed by other legitimate changes in the wider window. See [Choosing the window](#choosing-the-window-cumulative-diff-trade-offs) for the full nuance.
+
+## Choosing the window: cumulative-diff trade-offs
+
+The tool runs against **one cumulative diff** (`base..head`), and the classification is computed on that single diff — not per-PR. This is fast and matches how a human reviewer would scan a release window, but it means **window width changes what you see**.
+
+### Narrow window — catches per-PR sins accurately
+
+A window that spans only one (or a few) PRs gives faithful per-PR classification. Example: `v1.0.1-crucible-trustpilot..acryl-main` contains only PR #9579 (9 schemaVersion bumps with no schema changes) and PR #9585 (a real field addition + a justified bump).
+
+In this window the report correctly labels:
+
+- 9 aspects from PR #9579 as **`bump_spurious`** (lone `schemaVersion 2→3` edits, nothing else)
+- 1 aspect from PR #9585 as **`bump_done`** (transitively justified by a sibling non-aspect change in the same PR)
+
+Use a narrow window for the **release-window monitor** — this is the canonical use case.
+
+### Wide window — masks per-PR sins
+
+A window that spans many releases bundles every PR's effects into one cumulative diff. Legitimate structural changes from one PR can absorb spurious bumps from another PR, so the bumper anti-pattern disappears from the report.
+
+Example: in `v0.3.15rc1-fis..HEAD` (~4,600 commits, ~2 years), the same 9 aspects from PR #9579 are reported as **`bump_done`** instead of `bump_spurious`. The reason:
+
+- `AssertionInfo.pdl` references `AssertionType` and `AssertionNote` as field types.
+- Both of those non-aspect records changed at some point in the 2-year window (different PRs).
+- The transitive BFS sees the aspect's deps as having changed, so `transitively_affected = True`.
+- The aspect's `schemaVersion` did move (`1 → 3` over the window), so it classifies as `bump_done`.
+
+The wide-window view is telling you "across this 2-year window, AssertionInfo's bump is justified by _some_ PR in the window" — even if PR #9579 specifically wasn't one of them.
+
+This is correct cumulative-diff behavior. It is **not** a refutation of the narrow-window finding: the spurious bumps in PR #9579 are still spurious — they just don't stand out at this scale.
+
+### When to pick which window
+
+| Use case                                                        | Window                                            |
+| --------------------------------------------------------------- | ------------------------------------------------- |
+| Release-window monitor (e.g. v1.1.0 audit)                      | `--base <previous-release-tag> --head acryl-main` |
+| Single-PR audit (preview a change before merge)                 | `--base <sha-before-PR> --head <sha-after-PR>`    |
+| Hotfix-vs-trunk comparison                                      | `--base <hotfix-branch> --head acryl-main`        |
+| "What does our schema look like across the whole product line?" | `--base v0.3.<oldest> --head acryl-main`          |
+
+For the multi-release retrospective case, **expect `bump_spurious` to be undercounted** — the cumulative diff cannot tell you which PR introduced each spurious bump, and most spurious bumps will be re-classified as `bump_done` by some later legitimate change to the same aspect or one of its deps.
+
+### Getting true per-PR truth at scale — `--per-pr` mode
+
+To accurately label every PR across a long window, use the built-in `--per-pr` flag. It enumerates every first-parent commit in `base..head` that touched a PDL, runs the full classifier on each `parent..commit` slice in isolation, then aggregates the verdicts per aspect.
+
+```bash
+python3 .github/scripts/report_aspect_changes.py \
+  --base v1.0.0rc1-cloud --head HEAD --per-pr
+```
+
+This catches the **v→v+1-per-justifying-PR** invariant: an aspect lands in the "unjustified bumps" bucket whenever any single PR-slice classified its bump as `bump_spurious`, even if a different PR in the same window contributed a legitimate change.
+
+The per-PR report has a different shape from the cumulative report:
+
+- **Header** — base/head/sha/timestamp.
+- **Audit line** — `N PR-slice(s) examined · M aspects with bump-relevant verdicts · X with unjustified bumps · Y with missing bumps · Z fully justified`.
+- **`⚠️ Aspects with at least one unjustified bump (bump_spurious)`** — per-aspect H3 section, each with a table of every PR-slice that touched it (`PR | sha | bump | author | commit`).
+- **`🟡 Aspects with at least one missing bump (bump_needed)`** — same shape, for silent migration hazards.
+- **`✅ Aspects with all bumps justified`** — compact summary table (`Aspect | Bumps | Justifying PR(s)`).
+
+Cost: O(N_PDL_touching_commits) git invocations and re-runs of the classifier. For a typical 30-day release window (~20 PRs touching PDLs), runtime is ~10s. A multi-year window (~75 PR-touching commits) is ~60s. Skip it for fast pre-merge previews; use it for release-window audits and retrospectives.
+
+## Per-PR catch-up reclassification (schemaVersion debt model)
+
+Per-PR verdicts only make sense in **chronological context** — a bump-without-change PR is legitimate catch-up when there's a prior unbumped real change to pay for, and truly spurious when there isn't. Without this reconciliation, every late-bumping PR would be reported as `bump_spurious` even when it's correctly fixing earlier missed bumps.
+
+The tool applies this reconciliation to every per-PR audit (both `--per-pr` mode and the per-PR override that enriches the default cumulative report). For each PDL file, slices are walked in commit-date order (oldest first), maintaining a `pending_prs` list — the PRs that contributed a real schema change without their own bump. A single subsequent bump-without-change clears the **entire** pending list (one catch-up bump pays any amount of accumulated debt). Once debt is cleared, further bumps without a change stay `bump_spurious`.
+
+### Reclassification rules
+
+| Slice verdict in isolation                                           | Effect on `pending_prs` | Reclassified verdict                                                                          |
+| -------------------------------------------------------------------- | ----------------------- | --------------------------------------------------------------------------------------------- |
+| `bump_needed` (change, no bump)                                      | append the PR           | stays `bump_needed` — preserves the missing-bump hygiene signal for the change-author         |
+| `bump_spurious` (bump, no change) **with** non-empty `pending_prs`   | reset to `[]`           | **`bump_done`** (catch-up); records the cleared PRs in a `catch_up_for_prs` annotation        |
+| `bump_spurious` (bump, no change) **with** empty `pending_prs`       | unchanged               | stays `bump_spurious` — truly unjustified                                                     |
+| `bump_done` (own change + own bump) **with** non-empty `pending_prs` | reset to `[]`           | stays `bump_done`; the bump implicitly clears prior debt too (annotation records cleared PRs) |
+| `bump_done` (own change + own bump) **with** empty `pending_prs`     | unchanged               | stays `bump_done`                                                                             |
+
+### Worked example — `Status.pdl` in `v1.0.0rc1-cloud..HEAD`
+
+Three PRs touched `Status.pdl`:
+
+| PR    | Date       | Slice in isolation              | `pending_prs` after | Reclassified                         |
+| ----- | ---------- | ------------------------------- | ------------------- | ------------------------------------ |
+| #9192 | 2026-05-13 | added `lifecycleState`, no bump | `[#9192]`           | `bump_needed`                        |
+| #9534 | 2026-05-14 | bumped 1→2, no change           | `[]`                | **`bump_done`** (catch-up for #9192) |
+| #9579 | 2026-05-15 | bumped 2→3, no change           | `[]` (no debt)      | `bump_spurious`                      |
+
+Without reclassification, both #9534 and #9579 would be `bump_spurious`. With it, only #9579 — the genuinely anomalous PR — is flagged.
+
+### Effect on the file's cumulative bucket
+
+The reclassified slice verdicts feed the per-PR aggregator that drives each file's bucket in the cumulative report. The aggregator honors catch-up reconciliation: a `bump_needed` slice whose PR appears in any later slice's `catch_up_for_prs` is no longer treated as an unpaid debt and does not push the file into `bump_needed`. Priority order (highest wins): `bump_spurious > bump_needed > bump_done > bump_not_needed`.
+
+**Per-PR truth drives the bucket** — when an unreconciled spurious slice exists in the window, the file lands in `bump_spurious` even if cumulative-diff math would call the window `bump_done`. Reviewers see the per-PR breakdown table for the file to identify which specific PR was at fault.
+
+For `Status.pdl`:
+
+- Per-PR aggregator returns `bump_spurious` (because #9579 remains an unreconciled spurious bump after catch-up — the debt was already cleared by #9534)
+- Cumulative classifier returns `bump_done` (real change + bump exist in the cumulative window)
+- **Outcome:** per-PR truth wins → the file is reported as `bump_spurious`. The bucket row carries the bucket's plain Why text; reviewers consult the file's per-PR breakdown table to see which PR did the unreconciled spurious bump (#9579).
+
+For a file whose only `bump_needed` slices were all caught up (e.g. `DynamicFormAssignment.pdl` where #9465 was caught up by #9560):
+
+- Per-PR aggregator returns `bump_done` (no unreconciled NEEDED, no unreconciled SPURIOUS, at least one DONE slice)
+- File lands in `bump_done` with the plain bucket Why text. The catch-up linkage is visible in the file's per-PR breakdown table.
+
+## Exit codes
+
+| Code | Meaning                                                                                                    |
+| ---- | ---------------------------------------------------------------------------------------------------------- |
+| `0`  | Success (including "no aspect changes in this window").                                                    |
+| `1`  | Auto-baseline resolution failed — no `v1.0*` non-rc tag reachable from `--head`. Pass `--base` explicitly. |
+| `2`  | Git error (e.g. bad `--base` ref, shallow clone missing tags). Stderr carries the original git message.    |
+
+There is **no exit-code signal for breaking changes** — the report is informational. Treat the rendered markdown as the source of truth and gate on `0 BREAKING` and `0 bump_needed` in the summary line.
+
+## Release Pipeline integration
+
+The companion workflow [`.github/workflows/pdl-change-report.yml`](../workflows/pdl-change-report.yml) is a `workflow_dispatch` runner that:
+
+- Optionally accepts `base` and `head` ref inputs (blank → auto-defaults)
+- Optionally accepts a `per_pr` boolean toggle — when checked, runs the per-PR audit mode (see [Getting true per-PR truth at scale](#getting-true-per-pr-truth-at-scale---per-pr-mode))
+- Runs the script with full git history and tags fetched
+- Writes the markdown directly to `$GITHUB_STEP_SUMMARY` so it renders on the Actions run page
+
+To trigger: **Actions → "PDL Aspect Change Report" → Run workflow**. Tick the **`per_pr`** checkbox to switch to per-PR audit mode for the chosen window.
+
+If you want to keep the report alongside release notes, redirect `--output` to a file under `docs/managed-datahub/release-notes/` or upload it as a workflow artifact (one extra `actions/upload-artifact` step).
+
+## Scope and limitations
+
+- **Heuristic regex-based parsing.** The classifier does not use a full PDL grammar. Edge cases that aren't valid PDL (which would fail codegen anyway) are silently skipped — false negatives are not expected on syntactically-valid PDLs, but a future PDL syntax extension may require updates.
+- **PDL root pinned to `metadata-models/src/main/pegasus/`.** Other PDL sources (e.g. plugin modules) aren't scanned. `bump_schema_versions.py` supports `PDL_ROOTS`; if you set it, that override flows through.
+- **Transitive walk reads the working tree.** `find_transitively_affected_aspects` (in `bump_schema_versions.py`) walks files on disk, not at arbitrary git refs. The workflow always checks out the head ref, so the default invocation is safe; if you ever invoke with `--head <some-other-ref>` while the working tree is checked out elsewhere, the transitive closure reflects the checkout rather than `head`.
+- **Single-hop "affected via" labels.** When a transitively-affected aspect's content references the changed non-aspect directly, the trail names that record. For multi-hop chains (Aspect → Intermediate → ChangedRecord), the label falls back to a generic "transitive dependency" — the BFS still surfaces the aspect correctly, but the proximate-hop name isn't displayed.
+- **Cumulative-diff classification.** Findings reflect the cumulative `base..head` diff, not per-PR slices. Wide windows can therefore mask per-PR `bump_spurious` cases when legitimate changes from other PRs in the window justify the same version bump. See [Choosing the window](#choosing-the-window-cumulative-diff-trade-offs) above for the full nuance and the recipe for true per-PR analysis.
+- **Read-only.** This script never writes under `metadata-models/`. Compare with `bump_schema_versions.py`, which rewrites `schemaVersion` annotations in place.
+- **Tests.** Coverage is in `.github/scripts/test/test_report_aspect_changes.py` (59 unit + smoke tests).

--- a/.github/scripts/test/test_report_aspect_changes.py
+++ b/.github/scripts/test/test_report_aspect_changes.py
@@ -55,8 +55,8 @@ def test_resolve_base_falls_back_to_rc_when_no_stable_cloud():
     # First call: same list, but rc filter excludes everything → empty result.
     # Second call: no filter, returns the latest rc-cloud tag.
     with patch(
-        "subprocess.check_output",
-        side_effect=[rc_only_list, rc_only_list],
+            "subprocess.check_output",
+            side_effect=[rc_only_list, rc_only_list],
     ) as m:
         assert rac.resolve_base(mode="acryl") == "v1.1.0rc3-cloud"
     # First lookup exhausted (all rc), second lookup succeeded without filter.
@@ -128,7 +128,12 @@ def test_default_head_acryl_mode_returns_acryl_main():
 
 
 def test_default_head_oss_mode_returns_master():
-    assert rac._default_head("oss") == "master"
+    """OSS mode returns `master` when the local ref resolves. Mocked so the
+    result doesn't depend on whether the test environment is a fork checkout
+    (where only `origin/master` exists) or an OSS checkout.
+    """
+    with patch("subprocess.check_output", return_value="abc123\n"):
+        assert rac._default_head("oss") == "master"
 
 
 def test_default_head_auto_detects_when_mode_not_passed():
@@ -184,8 +189,8 @@ def test_resolve_base_oss_falls_back_to_rc_when_no_stable():
     """
     rc_only_list = "v1.6.0rc2\nv1.6.0rc1\n"
     with patch(
-        "subprocess.check_output",
-        side_effect=[rc_only_list, rc_only_list],
+            "subprocess.check_output",
+            side_effect=[rc_only_list, rc_only_list],
     ) as m:
         assert rac.resolve_base(mode="oss") == "v1.6.0rc2"
     assert m.call_count == 2
@@ -219,17 +224,14 @@ def test_resolve_base_rejects_unknown_mode():
 
 def test_resolve_base_auto_detect_uses_oss_when_no_acryl_main():
     """When mode is not passed, resolve_base() auto-detects via _detect_mode.
-    With acryl-main missing, OSS path runs and picks a non-cloud tag.
+    With both `acryl-main` and `origin/acryl-main` missing, OSS path runs and
+    picks a non-cloud tag.
     """
     err = subprocess.CalledProcessError(returncode=1, cmd=["git"])
     oss_tag_list = "v1.5.0.7-cloud\nv1.5.0.7\nv1.5.0\n"
-    # Detection probes both `acryl-main` and `origin/acryl-main` (CI-style
-    # checkouts only have the remote-tracking form), so two failures precede
-    # the OSS tag-list lookup.
-    with patch(
-        "subprocess.check_output", side_effect=[err, err, oss_tag_list]
-    ) as m:
+    with patch("subprocess.check_output", side_effect=[err, err, oss_tag_list]) as m:
         assert rac.resolve_base() == "v1.5.0.7"
+    # First two calls: detection probes (acryl-main, origin/acryl-main); third: tag list.
     assert m.call_count == 3
 
 
@@ -502,7 +504,7 @@ def test_analyze_structural_change_without_schema_version_bump_is_breaking(monke
 
 
 def test_find_transitive_aspects_resolves_via_bump_schema_helpers(
-    monkeypatch, tmp_path
+        monkeypatch, tmp_path
 ):
     # Simulate: changed non-aspect file NonAspect.pdl is depended on by
     # one aspect AspectA.pdl. find_transitive_aspects must return AspectA.
@@ -538,14 +540,14 @@ def test_find_transitive_aspects_resolves_via_bump_schema_helpers(
 
 
 def _finding(
-    path: str,
-    breaking=None,
-    additive=None,
-    noisy=None,
-    is_aspect=True,
-    aspect_name="a",
-    head_commit="abc1234 msg",
-    affected_via=None,
+        path: str,
+        breaking=None,
+        additive=None,
+        noisy=None,
+        is_aspect=True,
+        aspect_name="a",
+        head_commit="abc1234 msg",
+        affected_via=None,
 ):
     return rac.FileFinding(
         path=path,
@@ -568,7 +570,7 @@ def test_render_empty_diff_emits_no_changes_message():
 
 
 def test_upstream_attribution_for_transitive_aggregates_across_non_aspects(
-    monkeypatch,
+        monkeypatch,
 ):
     """For purely-transitive aspects (the file itself has no commits in the
     window), the helper should pull PRs/owner/date from the changed non-aspect
@@ -629,42 +631,42 @@ def test_upstream_attribution_dedupes_prs_across_sources(monkeypatch):
 def test_aggregate_per_pr_verdict_priority_order():
     """Highest-priority verdict wins: spurious > needed > done > bump_not_needed."""
     assert (
-        rac._aggregate_per_pr_verdict(
-            [
-                {"bump_status": rac.BUMP_DONE},
-                {"bump_status": rac.BUMP_SPURIOUS},
-                {"bump_status": rac.BUMP_NEEDED},
-            ]
-        )
-        == rac.BUMP_SPURIOUS
+            rac._aggregate_per_pr_verdict(
+                [
+                    {"bump_status": rac.BUMP_DONE},
+                    {"bump_status": rac.BUMP_SPURIOUS},
+                    {"bump_status": rac.BUMP_NEEDED},
+                ]
+            )
+            == rac.BUMP_SPURIOUS
     )
     assert (
-        rac._aggregate_per_pr_verdict(
-            [
-                {"bump_status": rac.BUMP_DONE},
-                {"bump_status": rac.BUMP_NEEDED},
-            ]
-        )
-        == rac.BUMP_NEEDED
+            rac._aggregate_per_pr_verdict(
+                [
+                    {"bump_status": rac.BUMP_DONE},
+                    {"bump_status": rac.BUMP_NEEDED},
+                ]
+            )
+            == rac.BUMP_NEEDED
     )
     assert (
-        rac._aggregate_per_pr_verdict(
-            [
-                {"bump_status": rac.BUMP_DONE},
-                {"bump_status": rac.BUMP_DONE},
-            ]
-        )
-        == rac.BUMP_DONE
+            rac._aggregate_per_pr_verdict(
+                [
+                    {"bump_status": rac.BUMP_DONE},
+                    {"bump_status": rac.BUMP_DONE},
+                ]
+            )
+            == rac.BUMP_DONE
     )
     # bump_not_needed (formerly not_sure / n/a) is the lowest-priority fallback
     assert (
-        rac._aggregate_per_pr_verdict(
-            [
-                {"bump_status": rac.BUMP_DONE},
-                {"bump_status": rac.BUMP_NOT_NEEDED},
-            ]
-        )
-        == rac.BUMP_DONE
+            rac._aggregate_per_pr_verdict(
+                [
+                    {"bump_status": rac.BUMP_DONE},
+                    {"bump_status": rac.BUMP_NOT_NEEDED},
+                ]
+            )
+            == rac.BUMP_DONE
     )
     assert rac._aggregate_per_pr_verdict([]) == rac.BUMP_NOT_NEEDED
 
@@ -825,7 +827,7 @@ def test_main_cumulative_bucket_clean_when_all_slices_are_done(monkeypatch, tmp_
 
 
 def test_main_cumulative_mode_still_overrides_when_promoting_to_needed_or_spurious(
-    monkeypatch, tmp_path
+        monkeypatch, tmp_path
 ):
     """The fix only protects cumulative bump_done from being downgraded by
     per-PR spurious slices. Other cumulative→per-PR transitions still flow
@@ -930,21 +932,21 @@ def test_render_all_pdls_section_lists_every_finding():
     assert nested_idx < aspect_idx < transitive_idx
     # NestedX row uses the bump_reason from the classifier (non-aspect record)
     assert (
-        "| NestedX.pdl | nested | #9579 | Bob | 2026-05-15 | "
-        "non-aspect record (no schemaVersion concept applies) |" in out
+            "| NestedX.pdl | nested | #9579 | Bob | 2026-05-15 | "
+            "non-aspect record (no schemaVersion concept applies) |" in out
     )
     # AspectA's Why reflects bump_needed (direct schema change, no bump)
     assert (
-        "| AspectA.pdl | ASPECT | #9555 | Alice | 2026-05-05 | "
-        "direct schema change in this file — schemaVersion was NOT bumped |" in out
+            "| AspectA.pdl | ASPECT | #9555 | Alice | 2026-05-05 | "
+            "direct schema change in this file — schemaVersion was NOT bumped |" in out
     )
     # TransitiveZ row marks the transitive-via reason via bump_needed Why
     assert (
-        "| TransitiveZ.pdl | ASPECT (transitive) | (no-PR) "
-        "| _(no owner — file wasn't directly touched)_ "
-        "| _(unknown)_ | "
-        "transitively affected via `ChangedRecord` (file's own schema unchanged) "
-        "— schemaVersion was NOT bumped |" in out
+            "| TransitiveZ.pdl | ASPECT (transitive) | (no-PR) "
+            "| _(no owner — file wasn't directly touched)_ "
+            "| _(unknown)_ | "
+            "transitively affected via `ChangedRecord` (file's own schema unchanged) "
+            "— schemaVersion was NOT bumped |" in out
     )
 
 
@@ -1024,8 +1026,8 @@ def test_render_summary_counts_are_correct():
     out = rac.render_report(fs, base="B", head="H", head_sha="sha")
     # Summary line shows file count + bump-bucket roll-up
     assert (
-        "**Summary:** 4 PDL files changed · "
-        "1 bump_done · 1 bump_needed · 1 bump_spurious · 1 bump_not_needed" in out
+            "**Summary:** 4 PDL files changed · "
+            "1 bump_done · 1 bump_needed · 1 bump_spurious · 1 bump_not_needed" in out
     )
 
 
@@ -1084,8 +1086,8 @@ def test_classify_bump_missing_schema_version_treated_as_one():
     old_no_version = '@Aspect = {"name": "a"}\nrecord A { x: string }'
     new_v2 = '@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: string }'
     assert (
-        rac._classify_bump(True, old_no_version, new_v2, has_structural=False)
-        == rac.BUMP_SPURIOUS
+            rac._classify_bump(True, old_no_version, new_v2, has_structural=False)
+            == rac.BUMP_SPURIOUS
     )
 
 
@@ -1181,7 +1183,7 @@ def test_bump_breakdown_handles_findings_without_pr_reference():
 
 
 def test_main_routes_two_hop_transitive_aspect_to_transitive_section(
-    monkeypatch, tmp_path
+        monkeypatch, tmp_path
 ):
     """A directly-edited aspect that depends on a changed non-aspect via a
     multi-hop chain (so the proximate dep is NOT named in the aspect's content)
@@ -1263,8 +1265,8 @@ def test_pr_numbers_for_file_returns_all_prs_in_window(monkeypatch):
 def test_last_author_for_file_returns_most_recent_author(monkeypatch):
     monkeypatch.setattr(rac, "_git", lambda *args: "Alice Example\n")
     assert (
-        rac.last_author_for_file("acryl-main", "path.pdl", "v1.0.0rc1-cloud")
-        == "Alice Example"
+            rac.last_author_for_file("acryl-main", "path.pdl", "v1.0.0rc1-cloud")
+            == "Alice Example"
     )
 
 
@@ -1328,16 +1330,16 @@ def test_bump_breakdown_table_renders_rows_with_owner_and_pr():
     assert rows[1] == "| --- | --- | --- | --- | --- |"
     # Sorted by date DESC — B (2026-05-10) before A (2026-05-01)
     assert (
-        rows[2]
-        == "| B.pdl | #9272 | Chris Collins | 2026-05-10 | "
-        + rac._BUMP_WHY[rac.BUMP_NEEDED]
-        + " |"
+            rows[2]
+            == "| B.pdl | #9272 | Chris Collins | 2026-05-10 | "
+            + rac._BUMP_WHY[rac.BUMP_NEEDED]
+            + " |"
     )
     assert (
-        rows[3]
-        == "| A.pdl | #9242 | John Joyce | 2026-05-01 | "
-        + rac._BUMP_WHY[rac.BUMP_NEEDED]
-        + " |"
+            rows[3]
+            == "| A.pdl | #9242 | John Joyce | 2026-05-01 | "
+            + rac._BUMP_WHY[rac.BUMP_NEEDED]
+            + " |"
     )
 
 
@@ -1347,8 +1349,8 @@ def test_bump_breakdown_table_uses_no_pr_and_no_owner_placeholders():
     # pr_numbers stays empty, last_author stays None — transitively-affected case
     rows = rac._bump_breakdown_table([f], rac.BUMP_NEEDED)
     assert rows[2] == (
-        "| X.pdl | (no-PR) | _(no owner — file wasn't directly touched)_ "
-        "| _(unknown)_ | " + rac._BUMP_WHY[rac.BUMP_NEEDED] + " |"
+            "| X.pdl | (no-PR) | _(no owner — file wasn't directly touched)_ "
+            "| _(unknown)_ | " + rac._BUMP_WHY[rac.BUMP_NEEDED] + " |"
     )
 
 
@@ -1560,14 +1562,14 @@ def test_release_test_pdl_file_returns_empty_when_no_relevant_findings():
     """Empty input or all-bump_not_needed → return empty string so the caller
     skips writing the sidecar file."""
     assert (
-        rac._render_release_test_pdl_file([], [], base="B", head="H", head_sha="sha")
-        == ""
+            rac._render_release_test_pdl_file([], [], base="B", head="H", head_sha="sha")
+            == ""
     )
     f = _finding("path/X.pdl")
     f.bump_status = rac.BUMP_NOT_NEEDED
     assert (
-        rac._render_release_test_pdl_file([f], [], base="B", head="H", head_sha="sha")
-        == ""
+            rac._render_release_test_pdl_file([f], [], base="B", head="H", head_sha="sha")
+            == ""
     )
 
 
@@ -1802,14 +1804,14 @@ def test_bump_breakdown_table_renders_multiple_prs_per_aspect():
     f.last_commit_date = "2026-05-15"
     rows = rac._bump_breakdown_table([f], rac.BUMP_DONE)
     assert rows[2] == (
-        "| Shared.pdl | #9000, #9579 | Some Author | 2026-05-15 | "
-        + rac._BUMP_WHY[rac.BUMP_DONE]
-        + " |"
+            "| Shared.pdl | #9000, #9579 | Some Author | 2026-05-15 | "
+            + rac._BUMP_WHY[rac.BUMP_DONE]
+            + " |"
     )
 
 
 def test_main_reclassifies_aspect_bump_as_done_when_transitively_affected(
-    monkeypatch, tmp_path
+        monkeypatch, tmp_path
 ):
     """An aspect that was bumped AND has a changed non-aspect dependency in the
     same diff should be bump_done, not bump_spurious."""
@@ -1874,10 +1876,10 @@ def test_main_reclassifies_aspect_bump_as_done_when_transitively_affected(
 def test_classify_bump_transitive_affected_with_no_version_change_is_bump_needed():
     same = '@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
     assert (
-        rac._classify_bump(
-            True, same, same, has_structural=False, transitively_affected=True
-        )
-        == rac.BUMP_NEEDED
+            rac._classify_bump(
+                True, same, same, has_structural=False, transitively_affected=True
+            )
+            == rac.BUMP_NEEDED
     )
 
 
@@ -1992,8 +1994,8 @@ def test_render_per_pr_report_buckets_aspects_correctly():
     assert "### `AssertionInfo.pdl`" in out
     # The spurious row appears
     assert (
-        "| #9579 | `def4567890` | `bump_spurious` | Bob | feat: telemetry (#9579) |"
-        in out
+            "| #9579 | `def4567890` | `bump_spurious` | Bob | feat: telemetry (#9579) |"
+            in out
     )
     # DataHubTaskInfo lands in needed bucket
     assert "### `DataHubTaskInfo.pdl`" in out
@@ -2138,12 +2140,12 @@ def test_render_mutator_section_emits_table_with_date_sorted_rows():
     beta_idx = text.index("BetaMutator")
     assert alpha_idx < beta_idx
     assert (
-        "| #9555 | `aaaaaaaaaa` | `AlphaMutator` | `AspectMigrationMutator` "
-        "| Alice | 2026-05-20 | feat (#9555) |" in text
+            "| #9555 | `aaaaaaaaaa` | `AlphaMutator` | `AspectMigrationMutator` "
+            "| Alice | 2026-05-20 | feat (#9555) |" in text
     )
     assert (
-        "| #9579 | `bbbbbbbbbb` | `BetaMutator` | `BaseMutator` | Bob "
-        "| 2026-05-15 | feat (#9579) |" in text
+            "| #9579 | `bbbbbbbbbb` | `BetaMutator` | `BaseMutator` | Bob "
+            "| 2026-05-15 | feat (#9579) |" in text
     )
 
 
@@ -2162,8 +2164,8 @@ def test_render_mutator_section_uses_no_pr_placeholder():
     ]
     text = "\n".join(rac._render_mutator_section(mutators))
     assert (
-        "| (no-PR) | `abc1234567` | `XMutator` | `AspectMigrationMutator` "
-        "| Eve | 2026-05-12 | noref |" in text
+            "| (no-PR) | `abc1234567` | `XMutator` | `AspectMigrationMutator` "
+            "| Eve | 2026-05-12 | noref |" in text
     )
 
 

--- a/.github/scripts/test/test_report_aspect_changes.py
+++ b/.github/scripts/test/test_report_aspect_changes.py
@@ -1,5 +1,6 @@
 """Tests for report_aspect_changes.py"""
 
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -8,6 +9,11 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import report_aspect_changes as rac
+
+
+# ---------------------------------------------------------------------------
+# resolve_base — acryl mode (mode passed explicitly to bypass auto-detect)
+# ---------------------------------------------------------------------------
 
 
 def test_resolve_base_returns_latest_stable_cloud_tag_from_global_list():
@@ -22,7 +28,7 @@ def test_resolve_base_returns_latest_stable_cloud_tag_from_global_list():
     # the rc tags at the top and return the first stable below them.
     tag_list = "v1.1.0rc3-cloud\nv1.1.0rc2-cloud\nv1.1.0rc1-cloud\nv1.0.1-cloud\nv1.0.0-cloud\n"
     with patch("subprocess.check_output", return_value=tag_list) as m:
-        assert rac.resolve_base() == "v1.0.1-cloud"
+        assert rac.resolve_base(mode="acryl") == "v1.0.1-cloud"
     # Only one git invocation needed when stable lookup succeeds.
     assert m.call_count == 1
 
@@ -33,7 +39,7 @@ def test_resolve_base_invokes_git_tag_list_with_sort_flag():
     enumeration is core to the fix.
     """
     with patch("subprocess.check_output", return_value="v1.0.1-cloud\n") as m:
-        rac.resolve_base()
+        rac.resolve_base(mode="acryl")
     args = m.call_args[0][0]
     assert args[:3] == ["git", "tag", "--list"]
     assert "v*-cloud" in args
@@ -52,7 +58,7 @@ def test_resolve_base_falls_back_to_rc_when_no_stable_cloud():
         "subprocess.check_output",
         side_effect=[rc_only_list, rc_only_list],
     ) as m:
-        assert rac.resolve_base() == "v1.1.0rc3-cloud"
+        assert rac.resolve_base(mode="acryl") == "v1.1.0rc3-cloud"
     # First lookup exhausted (all rc), second lookup succeeded without filter.
     assert m.call_count == 2
 
@@ -63,7 +69,7 @@ def test_resolve_base_raises_when_no_cloud_tag_in_repo():
     """
     with patch("subprocess.check_output", side_effect=["", ""]):
         with pytest.raises(SystemExit) as exc:
-            rac.resolve_base()
+            rac.resolve_base(mode="acryl")
     msg = str(exc.value)
     assert "Could not find" in msg
     assert "--base" in msg
@@ -84,7 +90,147 @@ def test_resolve_base_rc_substring_filter_skips_rc_tags_only():
         "v1.0.0-cloud\n"
     )
     with patch("subprocess.check_output", return_value=tag_list):
-        assert rac.resolve_base() == "v1.0.1-cloud"
+        assert rac.resolve_base(mode="acryl") == "v1.0.1-cloud"
+
+
+# ---------------------------------------------------------------------------
+# _detect_mode — repo-flavor auto-detection
+# ---------------------------------------------------------------------------
+
+
+def test_detect_mode_returns_acryl_when_acryl_main_ref_exists():
+    """`git rev-parse --verify --quiet acryl-main` succeeds → acryl mode."""
+    with patch("subprocess.check_output", return_value="abc123\n") as m:
+        assert rac._detect_mode() == "acryl"
+    # Verify the probe command — should be `git rev-parse --verify` against
+    # `acryl-main` specifically. Other refs would give false positives.
+    args = m.call_args[0][0]
+    assert args[:3] == ["git", "rev-parse", "--verify"]
+    assert "acryl-main" in args
+
+
+def test_detect_mode_returns_oss_when_acryl_main_ref_missing():
+    """`git rev-parse --verify acryl-main` exits non-zero in the OSS repo →
+    oss mode. Triggers when the ref doesn't exist in any namespace.
+    """
+    err = subprocess.CalledProcessError(returncode=1, cmd=["git"])
+    with patch("subprocess.check_output", side_effect=err):
+        assert rac._detect_mode() == "oss"
+
+
+# ---------------------------------------------------------------------------
+# _default_head — per-mode head ref default
+# ---------------------------------------------------------------------------
+
+
+def test_default_head_acryl_mode_returns_acryl_main():
+    assert rac._default_head("acryl") == "acryl-main"
+
+
+def test_default_head_oss_mode_returns_master():
+    assert rac._default_head("oss") == "master"
+
+
+def test_default_head_auto_detects_when_mode_not_passed():
+    """When mode=None, falls back to _detect_mode(). Mocking subprocess so the
+    test doesn't depend on the local repo flavor.
+    """
+    err = subprocess.CalledProcessError(returncode=1, cmd=["git"])
+    with patch("subprocess.check_output", side_effect=err):
+        assert rac._default_head() == "master"
+
+
+# ---------------------------------------------------------------------------
+# resolve_base — OSS mode
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_base_oss_returns_latest_stable_non_cloud_tag():
+    """OSS mode: latest stable v* tag, excluding rc and -cloud. The exclude
+    filter must skip -cloud tags even when they sort newest, since a checkout
+    with both OSS and fork tags should still pick the right release line.
+    """
+    # Mixed list as `git tag --list 'v*' --sort=-v:refname` would return on a
+    # repo with both OSS and cloud tags. rc tags skipped by exclude_substr;
+    # -cloud tags skipped by exclude_extra; first surviving entry wins.
+    tag_list = (
+        "v1.6.0rc2\n"  # skip: rc
+        "v1.6.0rc1\n"  # skip: rc
+        "v1.5.0.7-cloud\n"  # skip: -cloud
+        "v1.5.0.7\n"  # ← first stable non-cloud, should be picked
+        "v1.5.0.6\n"
+        "v1.5.0\n"
+    )
+    with patch("subprocess.check_output", return_value=tag_list) as m:
+        assert rac.resolve_base(mode="oss") == "v1.5.0.7"
+    assert m.call_count == 1
+
+
+def test_resolve_base_oss_invokes_git_tag_list_with_v_star_match():
+    """OSS mode probes `v*` (not `v*-cloud`) so OSS tags without the cloud
+    suffix are returned. The -cloud filter happens Python-side.
+    """
+    with patch("subprocess.check_output", return_value="v1.5.0\n") as m:
+        rac.resolve_base(mode="oss")
+    args = m.call_args[0][0]
+    assert args[:3] == ["git", "tag", "--list"]
+    assert "v*" in args
+    assert "v*-cloud" not in args  # would over-narrow and miss OSS tags
+
+
+def test_resolve_base_oss_falls_back_to_rc_when_no_stable():
+    """OSS mode: when no stable v* tag exists (all are rc), fall back to
+    accepting rc tags (while still excluding -cloud).
+    """
+    rc_only_list = "v1.6.0rc2\nv1.6.0rc1\n"
+    with patch(
+        "subprocess.check_output",
+        side_effect=[rc_only_list, rc_only_list],
+    ) as m:
+        assert rac.resolve_base(mode="oss") == "v1.6.0rc2"
+    assert m.call_count == 2
+
+
+def test_resolve_base_oss_raises_when_no_tag_in_repo():
+    """OSS mode: both lookups empty → SystemExit. Diagnostic mentions the
+    glob used and the mode for the user to reproduce.
+    """
+    with patch("subprocess.check_output", side_effect=["", ""]):
+        with pytest.raises(SystemExit) as exc:
+            rac.resolve_base(mode="oss")
+    msg = str(exc.value)
+    assert "Could not find" in msg
+    assert "--base" in msg
+    assert "mode=oss" in msg
+
+
+def test_resolve_base_rejects_unknown_mode():
+    """Defensive: an invalid mode string should raise loudly rather than
+    silently picking one branch.
+    """
+    with pytest.raises(ValueError, match="unknown mode"):
+        rac.resolve_base(mode="nonsense")
+
+
+# ---------------------------------------------------------------------------
+# resolve_base — auto-detect (mode=None)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_base_auto_detect_uses_oss_when_no_acryl_main():
+    """When mode is not passed, resolve_base() auto-detects via _detect_mode.
+    With acryl-main missing, OSS path runs and picks a non-cloud tag.
+    """
+    err = subprocess.CalledProcessError(returncode=1, cmd=["git"])
+    oss_tag_list = "v1.5.0.7-cloud\nv1.5.0.7\nv1.5.0\n"
+    # Detection probes both `acryl-main` and `origin/acryl-main` (CI-style
+    # checkouts only have the remote-tracking form), so two failures precede
+    # the OSS tag-list lookup.
+    with patch(
+        "subprocess.check_output", side_effect=[err, err, oss_tag_list]
+    ) as m:
+        assert rac.resolve_base() == "v1.5.0.7"
+    assert m.call_count == 3
 
 
 # ---------------------------------------------------------------------------
@@ -581,7 +727,7 @@ def test_main_cumulative_bucket_follows_per_pr_spurious_slice(monkeypatch, tmp_p
     monkeypatch.setattr(
         rac, "file_at", lambda ref, p: aspect_old if ref == "BASE" else aspect_new
     )
-    monkeypatch.setattr(rac, "resolve_base", lambda: "BASE")
+    monkeypatch.setattr(rac, "resolve_base", lambda *a, **kw: "BASE")
     monkeypatch.setattr(rac, "_head_sha", lambda ref: "sha123")
     monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "abc1 feat (#1234)")
     monkeypatch.setattr(rac, "pr_numbers_for_file", lambda *a: ["1234"])
@@ -643,7 +789,7 @@ def test_main_cumulative_bucket_clean_when_all_slices_are_done(monkeypatch, tmp_
     monkeypatch.setattr(
         rac, "file_at", lambda ref, p: aspect_old if ref == "BASE" else aspect_new
     )
-    monkeypatch.setattr(rac, "resolve_base", lambda: "BASE")
+    monkeypatch.setattr(rac, "resolve_base", lambda *a, **kw: "BASE")
     monkeypatch.setattr(rac, "_head_sha", lambda ref: "sha123")
     monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "abc1 feat (#1234)")
     monkeypatch.setattr(rac, "pr_numbers_for_file", lambda *a: ["1234"])
@@ -692,7 +838,7 @@ def test_main_cumulative_mode_still_overrides_when_promoting_to_needed_or_spurio
 
     monkeypatch.setattr(rac, "changed_pdls", lambda b, h: [aspect_path])
     monkeypatch.setattr(rac, "file_at", lambda ref, p: aspect_same)
-    monkeypatch.setattr(rac, "resolve_base", lambda: "BASE")
+    monkeypatch.setattr(rac, "resolve_base", lambda *a, **kw: "BASE")
     monkeypatch.setattr(rac, "_head_sha", lambda ref: "sha123")
     monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "abc1 feat (#1234)")
     monkeypatch.setattr(rac, "pr_numbers_for_file", lambda *a: ["1234"])
@@ -1066,7 +1212,7 @@ def test_main_routes_two_hop_transitive_aspect_to_transitive_section(
 
     monkeypatch.setattr(rac, "changed_pdls", fake_changed)
     monkeypatch.setattr(rac, "file_at", fake_file_at)
-    monkeypatch.setattr(rac, "resolve_base", lambda: "BASE")
+    monkeypatch.setattr(rac, "resolve_base", lambda *a, **kw: "BASE")
     monkeypatch.setattr(rac, "_head_sha", lambda ref: "sha123")
     monkeypatch.setattr(
         rac, "latest_commit", lambda ref, p, base: "abc1234 feat (#9999)"
@@ -1683,7 +1829,7 @@ def test_main_reclassifies_aspect_bump_as_done_when_transitively_affected(
             return aspect_old if ref == "BASE" else aspect_new
         return nested_old if ref == "BASE" else nested_new
 
-    def fake_resolve():
+    def fake_resolve(mode=None):
         return "BASE"
 
     def fake_head_sha(ref):
@@ -1863,7 +2009,7 @@ def test_render_per_pr_report_handles_empty_audit():
 def test_main_per_pr_flag_writes_per_pr_report(tmp_path, monkeypatch):
     """--per-pr swaps the renderer to render_per_pr_report. Stub out the
     git+audit machinery so the test is hermetic."""
-    monkeypatch.setattr(rac, "resolve_base", lambda: "BASE")
+    monkeypatch.setattr(rac, "resolve_base", lambda *a, **kw: "BASE")
     monkeypatch.setattr(rac, "_head_sha", lambda ref: "sha123")
     monkeypatch.setattr(
         rac,

--- a/.github/scripts/test/test_report_aspect_changes.py
+++ b/.github/scripts/test/test_report_aspect_changes.py
@@ -1,0 +1,1999 @@
+"""Tests for report_aspect_changes.py"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import report_aspect_changes as rac
+
+
+def test_resolve_base_returns_tag_from_git_describe():
+    with patch("subprocess.check_output", return_value="v1.0.1-crucible-trustpilot\n"):
+        assert rac.resolve_base("HEAD") == "v1.0.1-crucible-trustpilot"
+
+
+def test_resolve_base_invokes_git_describe_with_correct_args():
+    with patch("subprocess.check_output", return_value="v1.0.1-cloud\n") as m:
+        rac.resolve_base("acryl-main")
+    args = m.call_args[0][0]
+    assert args[:2] == ["git", "describe"]
+    assert "--tags" in args
+    assert "--match" in args
+    assert "v1.0*" in args
+    assert "--exclude" in args
+    assert "*rc*" in args
+    assert "--abbrev=0" in args
+    assert "acryl-main" in args
+
+
+def test_resolve_base_raises_with_clear_message_when_no_ancestor():
+    err = subprocess.CalledProcessError(128, ["git"], stderr="no names found")
+    with patch("subprocess.check_output", side_effect=err):
+        with pytest.raises(SystemExit) as exc:
+            rac.resolve_base("HEAD")
+    assert "Could not auto-resolve" in str(exc.value)
+    assert "--base" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# PDL parsing primitives
+# ---------------------------------------------------------------------------
+
+
+ASPECT_PDL = """
+namespace com.linkedin.dataset
+
+@Aspect = {
+  "name": "datasetProperties",
+  "schemaVersion": 3
+}
+record DatasetProperties {
+  description: optional string
+  customProperties: map[string, string] = {}
+  externalUrl: optional string
+}
+"""
+
+ENUM_PDL = """
+namespace com.linkedin.common
+
+enum FabricType {
+  PROD
+  CORP
+  DEV
+}
+"""
+
+RENAMED_PDL = """
+namespace com.linkedin.dataset
+
+@renamedFrom = "OldDatasetProperties"
+record DatasetPropertiesV2 {
+  description: optional string
+}
+"""
+
+
+def test_aspect_meta_extracts_name_and_schema_version():
+    meta = rac.aspect_meta(ASPECT_PDL)
+    assert meta == {"name": "datasetProperties", "schemaVersion": 3, "type": None}
+
+
+def test_aspect_meta_returns_none_for_non_aspect():
+    assert rac.aspect_meta(ENUM_PDL) is None
+
+
+def test_aspect_meta_handles_missing_schema_version():
+    src = '@Aspect = {"name": "foo"}\nrecord Foo { x: string }'
+    assert rac.aspect_meta(src) == {"name": "foo", "schemaVersion": None, "type": None}
+
+
+def test_record_name_returns_top_level_record():
+    assert rac.record_name(ASPECT_PDL) == "DatasetProperties"
+
+
+def test_record_name_returns_none_for_enum_only_file():
+    assert rac.record_name(ENUM_PDL) is None
+
+
+def test_renamed_from_returns_old_name():
+    assert rac.renamed_from(RENAMED_PDL) == "OldDatasetProperties"
+
+
+def test_renamed_from_returns_none_when_absent():
+    assert rac.renamed_from(ASPECT_PDL) is None
+
+
+def test_fields_returns_name_to_metadata_map():
+    fs = rac.fields(ASPECT_PDL)
+    assert set(fs.keys()) == {"description", "customProperties", "externalUrl"}
+    assert fs["description"]["optional"] is True
+    assert fs["customProperties"]["optional"] is False
+    assert "string" in fs["description"]["type"]
+
+
+def test_fields_ignores_nested_record_fields():
+    src = """
+    record Outer {
+      a: string
+      nested: record Inner { b: string }
+    }
+    """
+    fs = rac.fields(src)
+    assert "a" in fs
+    assert "b" not in fs  # b belongs to Inner, not Outer
+
+
+def test_enums_returns_symbols_per_enum():
+    es = rac.enums(ENUM_PDL)
+    assert es == {"FabricType": ["PROD", "CORP", "DEV"]}
+
+
+def test_enums_returns_empty_when_no_enum_present():
+    assert rac.enums(ASPECT_PDL) == {}
+
+
+# ---------------------------------------------------------------------------
+# Per-file classifier
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_pure_addition_is_additive_only(monkeypatch):
+    old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+    new = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: string\n y: optional string }'
+
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "abc1234 add y")
+
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert f.is_aspect
+    assert any("added optional field: y" in line for line in f.additive)
+    assert f.breaking == []
+
+
+def test_analyze_removed_field_is_breaking(monkeypatch):
+    old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string\n y: string }'
+    new = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: string }'
+
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert any("removed field: y" in line for line in f.breaking)
+
+
+def test_analyze_required_to_optional_is_noisy(monkeypatch):
+    old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+    new = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: optional string }'
+
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert any("required→optional" in line for line in f.noisy)
+    assert f.breaking == []
+
+
+def test_analyze_optional_to_required_is_breaking(monkeypatch):
+    old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: optional string }'
+    new = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: string }'
+
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert any("optional→required" in line for line in f.breaking)
+
+
+def test_analyze_type_change_is_breaking(monkeypatch):
+    old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+    new = (
+        'namespace x\n@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: int }'
+    )
+
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert any("type change on x: string→int" in line for line in f.breaking)
+
+
+def test_analyze_enum_removal_is_breaking(monkeypatch):
+    old = "namespace x\nenum E { A B C }"
+    new = "namespace x\nenum E { A B }"
+
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert any("enum E: removed value C" in line for line in f.breaking)
+
+
+def test_analyze_record_rename_without_renamedFrom_is_breaking(monkeypatch):
+    old = 'namespace x\n@Aspect = {"name": "a"}\nrecord A { x: string }'
+    new = 'namespace x\n@Aspect = {"name": "a"}\nrecord B { x: string }'
+
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert any("renamed A→B with NO renamedFrom" in line for line in f.breaking)
+
+
+def test_analyze_record_rename_with_renamedFrom_is_noisy(monkeypatch):
+    # Renames are structural changes, so a proper rename PR also bumps
+    # schemaVersion (which is what bump_schema_versions would do). Test
+    # the well-formed case: rename annotation present AND version bumped.
+    old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+    new = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 2}\n@renamedFrom = "A"\nrecord B { x: string }'
+
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert any("renamed A→B (renamedFrom set)" in line for line in f.noisy)
+    assert f.breaking == []
+
+
+def test_analyze_rename_with_renamedFrom_AND_schema_bump_is_bump_done(monkeypatch):
+    """A properly annotated rename IS a structural change; pairing it with a
+    schemaVersion bump should classify as bump_done (legitimate), not as
+    bump_spurious (auto-bumper side-effect)."""
+    old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+    new = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 2}\n@renamedFrom = "A"\nrecord B { x: string }'
+
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+    monkeypatch.setattr(rac, "pr_numbers_for_file", lambda *args: [])
+
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert f.bump_status == rac.BUMP_DONE
+    # The "schemaVersion bumped with NO structural change" noisy entry must
+    # NOT fire here — the rename IS the structural change.
+    assert not any("bumped with NO structural change" in line for line in f.noisy)
+
+
+def test_analyze_deleted_aspect_renders_as_aspect_not_nested(monkeypatch):
+    """When an aspect file is deleted at head, is_aspect must remain True
+    (sourced from the base content) so the report renders the finding as
+    [ASPECT] in the BREAKING section, not as [nested]."""
+    old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else "")
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+    monkeypatch.setattr(rac, "pr_numbers_for_file", lambda *args: [])
+
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert f.is_aspect
+    assert f.aspect_name == "a"
+    assert any("file deleted" in line for line in f.breaking)
+
+
+def test_analyze_schema_version_bump_without_structural_change_is_noisy(monkeypatch):
+    old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+    # identical body, just a version bump and a comment
+    new = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: string /* doc */ }'
+
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert any(
+        "schemaVersion 1→2 bumped with NO structural change" in line for line in f.noisy
+    )
+    assert f.breaking == []
+
+
+def test_analyze_structural_change_without_schema_version_bump_is_breaking(monkeypatch):
+    old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string\n y: string }'
+    # y removed but schemaVersion NOT bumped
+    new = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert any("removed field: y" in line for line in f.breaking)
+    assert any(
+        "structural change without schemaVersion bump" in line for line in f.breaking
+    )
+
+
+# ---------------------------------------------------------------------------
+# Transitive aspect surfacing
+# ---------------------------------------------------------------------------
+
+
+def test_find_transitive_aspects_resolves_via_bump_schema_helpers(
+    monkeypatch, tmp_path
+):
+    # Simulate: changed non-aspect file NonAspect.pdl is depended on by
+    # one aspect AspectA.pdl. find_transitive_aspects must return AspectA.
+    non_aspect_path = "metadata-models/src/main/pegasus/com/linkedin/x/NonAspect.pdl"
+    aspect_path = "metadata-models/src/main/pegasus/com/linkedin/x/AspectA.pdl"
+
+    fake_reverse = {"com.linkedin.x.NonAspect": {aspect_path}}
+    fake_all = [Path(non_aspect_path), Path(aspect_path)]
+
+    monkeypatch.setattr(rac.bsv, "find_all_pdl_files", lambda: fake_all)
+    monkeypatch.setattr(rac.bsv, "build_reverse_include_graph", lambda _: fake_reverse)
+
+    # Use the real find_transitively_affected_aspects, but stub Path.exists/read_text
+    # because the helper opens the files to check is_aspect.
+    class _FakePath(type(Path())):
+        def exists(self):
+            return True
+
+        def read_text(self, encoding="utf-8"):
+            if str(self).endswith("AspectA.pdl"):
+                return '@Aspect = {"name": "a"}\nrecord A { x: string }'
+            return "record NonAspect { y: string }"
+
+    monkeypatch.setattr(rac.bsv, "Path", _FakePath)
+
+    affected = rac.find_transitive_aspects([non_aspect_path])
+    assert aspect_path in affected
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+
+def _finding(
+    path: str,
+    breaking=None,
+    additive=None,
+    noisy=None,
+    is_aspect=True,
+    aspect_name="a",
+    head_commit="abc1234 msg",
+    affected_via=None,
+):
+    return rac.FileFinding(
+        path=path,
+        is_aspect=is_aspect,
+        aspect_name=aspect_name,
+        head_commit=head_commit,
+        affected_via=affected_via,
+        breaking=breaking or [],
+        additive=additive or [],
+        noisy=noisy or [],
+    )
+
+
+def test_render_empty_diff_emits_no_changes_message():
+    out = rac.render_report(
+        [], base="v1.0.1-cloud", head="acryl-main", head_sha="deadbeef"
+    )
+    assert "No aspect changes" in out
+    assert "v1.0.1-cloud" in out and "acryl-main" in out
+
+
+def test_upstream_attribution_for_transitive_aggregates_across_non_aspects(
+    monkeypatch,
+):
+    """For purely-transitive aspects (the file itself has no commits in the
+    window), the helper should pull PRs/owner/date from the changed non-aspect
+    record(s) — not from the aspect's own (empty) history."""
+    src_data = {
+        "non/A.pdl": {
+            "prs": ["9100", "9200"],
+            "author": "Alice",
+            "date": "2026-05-01",
+        },
+        "non/B.pdl": {
+            "prs": ["9300"],
+            "author": "Bob",
+            "date": "2026-05-10",
+        },
+    }
+    monkeypatch.setattr(
+        rac, "pr_numbers_for_file", lambda ref, p, base: src_data[p]["prs"]
+    )
+    monkeypatch.setattr(
+        rac, "last_author_for_file", lambda ref, p, base: src_data[p]["author"]
+    )
+    monkeypatch.setattr(
+        rac, "latest_commit_date_for_file", lambda ref, p, base: src_data[p]["date"]
+    )
+
+    prs, author, date = rac.upstream_attribution_for_transitive(
+        ["non/A.pdl", "non/B.pdl"], "HEAD", "BASE"
+    )
+    # PRs aggregated and sorted ascending
+    assert prs == ["9100", "9200", "9300"]
+    # Author/date from the MOST RECENT upstream commit (B, 2026-05-10)
+    assert author == "Bob"
+    assert date == "2026-05-10"
+
+
+def test_upstream_attribution_handles_empty_non_aspect_list(monkeypatch):
+    monkeypatch.setattr(rac, "pr_numbers_for_file", lambda *a: [])
+    monkeypatch.setattr(rac, "last_author_for_file", lambda *a: None)
+    monkeypatch.setattr(rac, "latest_commit_date_for_file", lambda *a: None)
+    prs, author, date = rac.upstream_attribution_for_transitive([], "HEAD", "BASE")
+    assert prs == []
+    assert author is None
+    assert date is None
+
+
+def test_upstream_attribution_dedupes_prs_across_sources(monkeypatch):
+    """Two upstream non-aspects touched by the same PR should yield ONE entry."""
+    monkeypatch.setattr(rac, "pr_numbers_for_file", lambda ref, p, base: ["9465"])
+    monkeypatch.setattr(rac, "last_author_for_file", lambda *a: "david-leifker")
+    monkeypatch.setattr(rac, "latest_commit_date_for_file", lambda *a: "2026-05-11")
+    prs, _, _ = rac.upstream_attribution_for_transitive(
+        ["non/A.pdl", "non/B.pdl"], "HEAD", "BASE"
+    )
+    assert prs == ["9465"]
+
+
+def test_aggregate_per_pr_verdict_priority_order():
+    """Highest-priority verdict wins: spurious > needed > done > bump_not_needed."""
+    assert (
+        rac._aggregate_per_pr_verdict(
+            [
+                {"bump_status": rac.BUMP_DONE},
+                {"bump_status": rac.BUMP_SPURIOUS},
+                {"bump_status": rac.BUMP_NEEDED},
+            ]
+        )
+        == rac.BUMP_SPURIOUS
+    )
+    assert (
+        rac._aggregate_per_pr_verdict(
+            [
+                {"bump_status": rac.BUMP_DONE},
+                {"bump_status": rac.BUMP_NEEDED},
+            ]
+        )
+        == rac.BUMP_NEEDED
+    )
+    assert (
+        rac._aggregate_per_pr_verdict(
+            [
+                {"bump_status": rac.BUMP_DONE},
+                {"bump_status": rac.BUMP_DONE},
+            ]
+        )
+        == rac.BUMP_DONE
+    )
+    # bump_not_needed (formerly not_sure / n/a) is the lowest-priority fallback
+    assert (
+        rac._aggregate_per_pr_verdict(
+            [
+                {"bump_status": rac.BUMP_DONE},
+                {"bump_status": rac.BUMP_NOT_NEEDED},
+            ]
+        )
+        == rac.BUMP_DONE
+    )
+    assert rac._aggregate_per_pr_verdict([]) == rac.BUMP_NOT_NEEDED
+
+
+def test_aggregator_ignores_needed_when_caught_up_by_later_slice():
+    """A BUMP_NEEDED entry whose PR was paid by a later catch-up bump is
+    no longer treated as unreconciled — the aggregator returns BUMP_DONE."""
+    entries = [
+        {"pr": "A", "bump_status": rac.BUMP_NEEDED},
+        {
+            "pr": "B",
+            "bump_status": rac.BUMP_DONE,
+            "catch_up_for_prs": ["A"],
+        },
+    ]
+    assert rac._aggregate_per_pr_verdict(entries) == rac.BUMP_DONE
+
+
+def test_aggregator_keeps_spurious_even_when_needed_was_caught_up():
+    """A truly-spurious slice (no debt to pay) still wins over a
+    catch-up-reconciled NEEDED: the file lands in bump_spurious."""
+    entries = [
+        {"pr": "A", "bump_status": rac.BUMP_NEEDED},
+        {
+            "pr": "B",
+            "bump_status": rac.BUMP_DONE,
+            "catch_up_for_prs": ["A"],
+        },
+        {"pr": "C", "bump_status": rac.BUMP_SPURIOUS},
+    ]
+    assert rac._aggregate_per_pr_verdict(entries) == rac.BUMP_SPURIOUS
+
+
+def test_aggregator_returns_needed_when_some_needed_slices_unreconciled():
+    """If a NEEDED PR was caught up but another NEEDED PR was NOT, the
+    file is still bump_needed for the unreconciled one."""
+    entries = [
+        {"pr": "A", "bump_status": rac.BUMP_NEEDED},
+        {
+            "pr": "B",
+            "bump_status": rac.BUMP_DONE,
+            "catch_up_for_prs": ["A"],
+        },
+        {"pr": "C", "bump_status": rac.BUMP_NEEDED},  # not in catch_up_for_prs
+    ]
+    assert rac._aggregate_per_pr_verdict(entries) == rac.BUMP_NEEDED
+
+
+def test_main_cumulative_bucket_follows_per_pr_spurious_slice(monkeypatch, tmp_path):
+    """The cumulative bucket follows the per-PR aggregator (post-catch-up).
+    A file with cumulative bump_done but an unreconciled spurious per-PR
+    slice lands in `bump_spurious` — not bump_done. Reviewers see the
+    Per-PR breakdown table to identify which specific PR was at fault."""
+    aspect_path = "metadata-models/src/main/pegasus/com/linkedin/x/AspectA.pdl"
+    aspect_old = '@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+    aspect_new = '@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: string\n y: optional string }'
+
+    # Cumulative diff has a real change → cumulative classifier would say bump_done.
+    monkeypatch.setattr(rac, "changed_pdls", lambda b, h: [aspect_path])
+    monkeypatch.setattr(
+        rac, "file_at", lambda ref, p: aspect_old if ref == "BASE" else aspect_new
+    )
+    monkeypatch.setattr(rac, "resolve_base", lambda head: "BASE")
+    monkeypatch.setattr(rac, "_head_sha", lambda ref: "sha123")
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "abc1 feat (#1234)")
+    monkeypatch.setattr(rac, "pr_numbers_for_file", lambda *a: ["1234"])
+    monkeypatch.setattr(rac, "last_author_for_file", lambda *a: "Alice")
+    monkeypatch.setattr(rac, "find_transitive_aspects", lambda non_aspect: set())
+    monkeypatch.setattr(rac, "find_transitive_aspects_per_source", lambda srcs: {})
+    monkeypatch.setattr(rac, "find_mutators_added_in_window", lambda *a: [])
+    monkeypatch.setattr(rac, "discover_mutator_hierarchy", lambda: set())
+    # Per-PR audit shows one real-change PR (#9555 = bump_done) and one
+    # truly-spurious PR (#9579, no debt to pay). Per-PR truth drives the
+    # cumulative bucket → bump_spurious wins.
+    monkeypatch.setattr(
+        rac,
+        "per_pr_audit",
+        lambda base, head: {
+            aspect_path: [
+                {
+                    "sha": "aaa1111111",
+                    "pr": "9555",
+                    "subject": "feat: real (#9555)",
+                    "bump_status": rac.BUMP_DONE,
+                    "author": "Carol",
+                    "aspect_name": "a",
+                },
+                {
+                    "sha": "bbb2222222",
+                    "pr": "9579",
+                    "subject": "feat: spurious (#9579)",
+                    "bump_status": rac.BUMP_SPURIOUS,
+                    "author": "Dave",
+                    "aspect_name": "a",
+                },
+            ]
+        },
+    )
+
+    out_file = tmp_path / "report.md"
+    rc = rac.main(["--head", "HEAD", "--output", str(out_file)])
+    assert rc == 0
+    text = out_file.read_text()
+    # Per-PR truth wins: file lands in bump_spurious, not bump_done.
+    assert "0 bump_done" in text
+    assert "1 bump_spurious" in text
+    assert "### `bump_spurious` (1)" in text
+    assert "AspectA.pdl" in text
+    # No misalignment annotation any longer — bump_done has clean bucket text
+    # because misaligned files are now in bump_spurious.
+    assert "bump and change rode in different PRs" not in text
+
+
+def test_main_cumulative_bucket_clean_when_all_slices_are_done(monkeypatch, tmp_path):
+    """Sanity: cumulative bump_done with all per-PR slices also bump_done
+    yields a clean bump_done row."""
+    aspect_path = "metadata-models/src/main/pegasus/com/linkedin/x/AspectA.pdl"
+    aspect_old = '@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+    aspect_new = '@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: string\n y: optional string }'
+
+    monkeypatch.setattr(rac, "changed_pdls", lambda b, h: [aspect_path])
+    monkeypatch.setattr(
+        rac, "file_at", lambda ref, p: aspect_old if ref == "BASE" else aspect_new
+    )
+    monkeypatch.setattr(rac, "resolve_base", lambda head: "BASE")
+    monkeypatch.setattr(rac, "_head_sha", lambda ref: "sha123")
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "abc1 feat (#1234)")
+    monkeypatch.setattr(rac, "pr_numbers_for_file", lambda *a: ["1234"])
+    monkeypatch.setattr(rac, "last_author_for_file", lambda *a: "Alice")
+    monkeypatch.setattr(rac, "find_transitive_aspects", lambda non_aspect: set())
+    monkeypatch.setattr(rac, "find_transitive_aspects_per_source", lambda srcs: {})
+    monkeypatch.setattr(rac, "find_mutators_added_in_window", lambda *a: [])
+    monkeypatch.setattr(rac, "discover_mutator_hierarchy", lambda: set())
+    monkeypatch.setattr(
+        rac,
+        "per_pr_audit",
+        lambda base, head: {
+            aspect_path: [
+                {
+                    "sha": "aaa1111111",
+                    "pr": "9555",
+                    "subject": "feat: real (#9555)",
+                    "bump_status": rac.BUMP_DONE,
+                    "author": "Carol",
+                    "aspect_name": "a",
+                },
+            ]
+        },
+    )
+
+    out_file = tmp_path / "report.md"
+    rc = rac.main(["--head", "HEAD", "--output", str(out_file)])
+    assert rc == 0
+    text = out_file.read_text()
+    assert "1 bump_done" in text
+    assert "### `bump_done` (1)" in text
+    assert "AspectA.pdl" in text
+
+
+def test_main_cumulative_mode_still_overrides_when_promoting_to_needed_or_spurious(
+    monkeypatch, tmp_path
+):
+    """The fix only protects cumulative bump_done from being downgraded by
+    per-PR spurious slices. Other cumulative→per-PR transitions still flow
+    through normally — e.g., cumulative bump_not_needed with a per-PR
+    spurious slice should still surface as bump_spurious (the original
+    PR #9579 motivating case where no real change exists in the window)."""
+    aspect_path = "metadata-models/src/main/pegasus/com/linkedin/x/AspectA.pdl"
+    # No structural change cumulatively, no bump cumulatively → bump_not_needed.
+    aspect_same = '@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+
+    monkeypatch.setattr(rac, "changed_pdls", lambda b, h: [aspect_path])
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: aspect_same)
+    monkeypatch.setattr(rac, "resolve_base", lambda head: "BASE")
+    monkeypatch.setattr(rac, "_head_sha", lambda ref: "sha123")
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "abc1 feat (#1234)")
+    monkeypatch.setattr(rac, "pr_numbers_for_file", lambda *a: ["1234"])
+    monkeypatch.setattr(rac, "last_author_for_file", lambda *a: "Alice")
+    monkeypatch.setattr(rac, "find_transitive_aspects", lambda non_aspect: set())
+    monkeypatch.setattr(rac, "find_transitive_aspects_per_source", lambda srcs: {})
+    monkeypatch.setattr(rac, "find_mutators_added_in_window", lambda *a: [])
+    monkeypatch.setattr(rac, "discover_mutator_hierarchy", lambda: set())
+    # Per-PR audit: only spurious slices. Cumulative bump_not_needed should
+    # be overridden to bump_spurious (existing behavior preserved).
+    monkeypatch.setattr(
+        rac,
+        "per_pr_audit",
+        lambda base, head: {
+            aspect_path: [
+                {
+                    "sha": "bbb2222222",
+                    "pr": "9579",
+                    "subject": "feat: spurious (#9579)",
+                    "bump_status": rac.BUMP_SPURIOUS,
+                    "author": "Dave",
+                    "aspect_name": "a",
+                },
+            ]
+        },
+    )
+
+    out_file = tmp_path / "report.md"
+    rc = rac.main(["--head", "HEAD", "--output", str(out_file)])
+    assert rc == 0
+    text = out_file.read_text()
+    assert "**1 bump_spurious**" in text
+    assert "### `bump_spurious` (1)" in text
+
+
+def test_render_all_pdls_section_appears_before_bump_status_breakdown():
+    """The 'All changed PDL files' section is the first H2 section in the body —
+    above the Bump status line and the breakdown tables."""
+    f = _finding("a.pdl", additive=["x"])
+    out = rac.render_report([f], base="B", head="H", head_sha="sha")
+    assert out.index("## All changed PDL files") < out.index("**Bump status:**")
+    assert out.index("## All changed PDL files") < out.index(
+        "**Bump status breakdown:**"
+    )
+
+
+def test_render_all_pdls_section_lists_every_finding():
+    """The All-PDLs section enumerates every finding (aspect, nested, and
+    transitively-affected) with PR + owner + Date + Why attribution, sorted
+    by Date DESC. Per-row Why matches the file's bump bucket Why."""
+    f_aspect = _finding(
+        "metadata-models/.../AspectA.pdl",
+        breaking=["removed field: y"],
+        head_commit="abc1 feat (#9555)",
+    )
+    f_aspect.pr_numbers = ["9555"]
+    f_aspect.last_author = "Alice"
+    f_aspect.last_commit_date = "2026-05-05"
+    f_aspect.has_structural = True
+    f_aspect.bump_status = rac.BUMP_NEEDED  # structural change without bump
+    f_nested = _finding(
+        "metadata-models/.../NestedX.pdl",
+        is_aspect=False,
+        additive=["new field"],
+        head_commit="def2 feat (#9579)",
+    )
+    f_nested.pr_numbers = ["9579"]
+    f_nested.last_author = "Bob"
+    f_nested.last_commit_date = "2026-05-15"
+    f_nested.bump_reason = "non-aspect record (no schemaVersion concept applies)"
+    f_transitive = _finding(
+        "metadata-models/.../TransitiveZ.pdl",
+        noisy=["transitively affected"],
+        affected_via="ChangedRecord",
+    )
+    f_transitive.bump_status = rac.BUMP_NEEDED
+    f_transitive.is_purely_transitive = True
+    # transitive finding has no direct edits → no PR, no owner, no date
+    out = rac.render_report(
+        [f_aspect, f_nested, f_transitive], base="B", head="H", head_sha="sha"
+    )
+    assert "## All changed PDL files (3)" in out
+    assert "| File | Kind | PR(s) | Owner | Date | Why |" in out
+    # Sorted by Date DESC — NestedX (2026-05-15) before AspectA (2026-05-05) before
+    # TransitiveZ (no date, sorts last)
+    nested_idx = out.index("NestedX.pdl")
+    aspect_idx = out.index("AspectA.pdl")
+    transitive_idx = out.index("TransitiveZ.pdl")
+    assert nested_idx < aspect_idx < transitive_idx
+    # NestedX row uses the bump_reason from the classifier (non-aspect record)
+    assert (
+        "| NestedX.pdl | nested | #9579 | Bob | 2026-05-15 | "
+        "non-aspect record (no schemaVersion concept applies) |" in out
+    )
+    # AspectA's Why reflects bump_needed (direct schema change, no bump)
+    assert (
+        "| AspectA.pdl | ASPECT | #9555 | Alice | 2026-05-05 | "
+        "direct schema change in this file — schemaVersion was NOT bumped |" in out
+    )
+    # TransitiveZ row marks the transitive-via reason via bump_needed Why
+    assert (
+        "| TransitiveZ.pdl | ASPECT (transitive) | (no-PR) "
+        "| _(no owner — file wasn't directly touched)_ "
+        "| _(unknown)_ | "
+        "transitively affected via `ChangedRecord` (file's own schema unchanged) "
+        "— schemaVersion was NOT bumped |" in out
+    )
+
+
+def test_all_pdls_kind_label_distinguishes_pure_transitive_from_direct_plus_transitive():
+    """Kind column logic for the All-PDLs section:
+    - ASPECT — directly edited aspect (regardless of also being BFS-reached)
+    - ASPECT (transitive) — purely transitive (file not directly edited)
+    - nested — non-aspect record
+    """
+    # Direct + transitive: file was edited AND reached by BFS. Should be plain ASPECT.
+    f_direct_plus_transitive = _finding(
+        "metadata-models/.../DirectAndTransitive.pdl",
+        breaking=["removed field: x"],
+        head_commit="abc1 feat (#9555)",
+    )
+    f_direct_plus_transitive.pr_numbers = ["9555"]
+    f_direct_plus_transitive.last_author = "Alice"
+    f_direct_plus_transitive.last_commit_date = "2026-05-10"
+    f_direct_plus_transitive.has_structural = True
+    f_direct_plus_transitive.affected_via = "ChangedRecord"
+    f_direct_plus_transitive.is_purely_transitive = False  # was directly edited
+    f_direct_plus_transitive.bump_status = rac.BUMP_DONE
+
+    # Purely transitive: file NOT directly edited. Should be ASPECT (transitive).
+    f_pure_transitive = _finding(
+        "metadata-models/.../PureTransitive.pdl",
+        affected_via="ChangedRecord",
+    )
+    f_pure_transitive.is_purely_transitive = True
+    f_pure_transitive.bump_status = rac.BUMP_NEEDED
+
+    out = rac.render_report(
+        [f_direct_plus_transitive, f_pure_transitive],
+        base="B",
+        head="H",
+        head_sha="sha",
+    )
+    # Direct + transitive aspect: plain ASPECT, no suffix.
+    assert "| DirectAndTransitive.pdl | ASPECT |" in out
+    assert "| DirectAndTransitive.pdl | ASPECT (transitive) |" not in out
+    # Purely transitive aspect: ASPECT (transitive).
+    assert "| PureTransitive.pdl | ASPECT (transitive) |" in out
+
+
+def test_render_per_finding_sections_are_all_commented_out():
+    """All per-finding section() calls in render_report are commented out. The
+    summary line + bump_status breakdown tables remain the only per-aspect
+    surfaces. This test guards against accidental un-commenting."""
+    fs = [
+        _finding("a.pdl", additive=["added optional field: y"]),
+        _finding("b.pdl", breaking=["removed field: x"]),
+        _finding(
+            "c.pdl", noisy=["transitively affected"], affected_via="ChangedRecord"
+        ),
+    ]
+    out = rac.render_report(fs, base="B", head="H", head_sha="sha")
+    assert "## ⚠️ BREAKING" not in out
+    assert "## Transitively affected aspects" not in out
+    assert "## Additive" not in out
+    assert "## Noisy" not in out
+    assert "## No logical change" not in out
+    # Summary line still names the file count
+    assert "**Summary:** 3 PDL files changed" in out
+
+
+def test_render_summary_counts_are_correct():
+    fs = [
+        _finding("a.pdl", breaking=["x"]),
+        _finding("b.pdl", additive=["y"]),
+        _finding("c.pdl", noisy=["z"]),
+        _finding("d.pdl"),
+    ]
+    fs[0].bump_status = rac.BUMP_DONE
+    fs[1].bump_status = rac.BUMP_NEEDED
+    fs[2].bump_status = rac.BUMP_SPURIOUS
+    fs[3].bump_status = rac.BUMP_NOT_NEEDED
+    out = rac.render_report(fs, base="B", head="H", head_sha="sha")
+    # Summary line shows file count + bump-bucket roll-up
+    assert (
+        "**Summary:** 4 PDL files changed · "
+        "1 bump_done · 1 bump_needed · 1 bump_spurious · 1 bump_not_needed" in out
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bump-status classification
+# ---------------------------------------------------------------------------
+
+
+def test_bump_status_bump_done_when_version_increases(monkeypatch):
+    old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+    new = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: string\n y: optional string }'
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert f.bump_status == rac.BUMP_DONE
+
+
+def test_bump_status_bump_needed_when_structural_change_without_bump(monkeypatch):
+    old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string\n y: string }'
+    new = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert f.bump_status == rac.BUMP_NEEDED
+
+
+def test_bump_status_na_when_no_change_and_no_bump(monkeypatch):
+    same = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: same)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert f.bump_status == rac.BUMP_NA
+
+
+def test_bump_status_not_sure_when_version_decreases(monkeypatch):
+    old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 3}\nrecord A { x: string }'
+    new = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: string }'
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert f.bump_status == rac.NOT_SURE
+
+
+def test_bump_status_na_for_non_aspect(monkeypatch):
+    old = "namespace x\nrecord A { x: string }"
+    new = "namespace x\nrecord A { x: string\n y: optional string }"
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert f.bump_status == rac.BUMP_NA
+
+
+def test_classify_bump_missing_schema_version_treated_as_one():
+    """Per bump_schema_versions.md: missing schemaVersion is treated as 1.
+    Here the version goes 1→2 but content is identical, so it's bump_spurious."""
+    old_no_version = '@Aspect = {"name": "a"}\nrecord A { x: string }'
+    new_v2 = '@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: string }'
+    assert (
+        rac._classify_bump(True, old_no_version, new_v2, has_structural=False)
+        == rac.BUMP_SPURIOUS
+    )
+
+
+def test_classify_bump_spurious_when_version_increments_without_change():
+    """PR #9579 pattern: lone schemaVersion bump with no schema modifications."""
+    old = '@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: string }'
+    new = '@Aspect = {"name": "a", "schemaVersion": 3}\nrecord A { x: string }'
+    assert rac._classify_bump(True, old, new, has_structural=False) == rac.BUMP_SPURIOUS
+
+
+def test_classify_bump_done_only_when_version_increments_AND_change_exists():
+    """A bump WITH a real change is bump_done (legitimate)."""
+    old = '@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+    new = '@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: string\n y: optional string }'
+    assert rac._classify_bump(True, old, new, has_structural=True) == rac.BUMP_DONE
+
+
+def test_extract_pr_number_from_squash_commit_subject():
+    assert rac._extract_pr_number("feat(telemetry): some change (#9579)") == "9579"
+    assert rac._extract_pr_number("fix: nothing referencing a PR") is None
+    assert rac._extract_pr_number("") is None
+
+
+def test_render_bump_status_summary_includes_spurious_count():
+    f1 = _finding("a.pdl")
+    f1.bump_status = rac.BUMP_SPURIOUS
+    f2 = _finding("b.pdl")
+    f2.bump_status = rac.BUMP_DONE
+    out = rac.render_report([f1, f2], base="B", head="H", head_sha="sha")
+    assert "1 bump_done" in out
+    assert "1 bump_spurious" in out
+
+
+def test_render_includes_bump_status_legend():
+    fs = [_finding("a.pdl", breaking=["x"])]
+    out = rac.render_report(fs, base="B", head="H", head_sha="sha")
+    assert "Bump status legend" in out
+    assert "auto-bumper side-effect" in out  # description of bump_spurious
+
+
+def test_render_pr_number_appears_in_bump_breakdown_table():
+    """Per-finding `- PR: #N` bullets are no longer rendered (sections commented
+    out). PR attribution survives via the bump_status breakdown table, which
+    renders `| PDL file | PR(s) | Owner | Date | Why |` rows."""
+    f = _finding(
+        "a.pdl",
+        additive=["added optional field: y"],
+        head_commit="abc1234 feat: change (#9579)",
+    )
+    f.pr_numbers = ["9579"]
+    f.bump_status = rac.BUMP_DONE
+    out = rac.render_report([f], base="B", head="H", head_sha="sha")
+    # PR shows up in the breakdown table cell, not as a bullet line
+    assert "#9579" in out
+    # The bullet-format "- PR: #9579" should NOT appear (sections are commented out)
+    assert "- PR:" not in out
+
+
+def test_bump_breakdown_groups_by_pr():
+    f1 = _finding("path/to/A.pdl")
+    f1.bump_status = rac.BUMP_SPURIOUS
+    f1.pr_numbers = ["9579"]
+    f2 = _finding("path/to/B.pdl")
+    f2.bump_status = rac.BUMP_SPURIOUS
+    f2.pr_numbers = ["9579"]
+    f3 = _finding("path/to/C.pdl")
+    f3.bump_status = rac.BUMP_SPURIOUS
+    f3.pr_numbers = ["9591"]
+    out = rac._bump_breakdown([f1, f2, f3], rac.BUMP_SPURIOUS)
+    # Two PR groups, sorted ascending: 9579 then 9591
+    assert out == "(#9579: A.pdl, B.pdl), (#9591: C.pdl)"
+
+
+def test_bump_breakdown_groups_file_under_multiple_prs_when_touched_by_each():
+    """A file touched by two PRs in the window appears in BOTH breakdown groups."""
+    f = _finding("path/to/Shared.pdl")
+    f.bump_status = rac.BUMP_DONE
+    f.pr_numbers = ["9000", "9579"]
+    out = rac._bump_breakdown([f], rac.BUMP_DONE)
+    assert out == "(#9000: Shared.pdl), (#9579: Shared.pdl)"
+
+
+def test_bump_breakdown_returns_none_for_empty_bucket():
+    assert rac._bump_breakdown([], rac.BUMP_SPURIOUS) == "(none)"
+
+
+def test_bump_breakdown_handles_findings_without_pr_reference():
+    f = _finding("path/to/X.pdl")
+    f.bump_status = rac.BUMP_NEEDED
+    f.pr_numbers = []
+    out = rac._bump_breakdown([f], rac.BUMP_NEEDED)
+    assert out == "(no-PR: X.pdl)"
+
+
+def test_main_routes_two_hop_transitive_aspect_to_transitive_section(
+    monkeypatch, tmp_path
+):
+    """A directly-edited aspect that depends on a changed non-aspect via a
+    multi-hop chain (so the proximate dep is NOT named in the aspect's content)
+    should still route to the Transitively affected section with a generic
+    'transitive dependency' affected_via label, and its noisy section should
+    NOT carry the misleading 'bumped with NO structural change' entry."""
+    aspect_path = "metadata-models/src/main/pegasus/com/linkedin/x/AspectA.pdl"
+    # Intermediate.pdl exists between AspectA and Changed but isn't named in the
+    # test fixtures — its role is documented in the dependency chain comment below.
+    changed_nested_path = "metadata-models/src/main/pegasus/com/linkedin/x/Changed.pdl"
+
+    # AspectA references Intermediate (NOT Changed). Intermediate is unchanged here.
+    # Only Changed was modified in the diff. The dependency chain is:
+    # AspectA → Intermediate → Changed
+    # So AspectA's content does NOT contain the string "Changed".
+    aspect_old = '@Aspect = {"name": "a"}\nrecord AspectA { x: Intermediate }'
+    aspect_new = '@Aspect = {"name": "a", "schemaVersion": 2}\nrecord AspectA { x: Intermediate }'
+    nested_old = "record Changed { y: string }"
+    nested_new = "record Changed { y: string\n z: optional string }"
+
+    def fake_changed(base, head):
+        return [aspect_path, changed_nested_path]
+
+    def fake_file_at(ref, path):
+        if path == aspect_path:
+            return aspect_old if ref == "BASE" else aspect_new
+        return nested_old if ref == "BASE" else nested_new
+
+    monkeypatch.setattr(rac, "changed_pdls", fake_changed)
+    monkeypatch.setattr(rac, "file_at", fake_file_at)
+    monkeypatch.setattr(rac, "resolve_base", lambda head: "BASE")
+    monkeypatch.setattr(rac, "_head_sha", lambda ref: "sha123")
+    monkeypatch.setattr(
+        rac, "latest_commit", lambda ref, p, base: "abc1234 feat (#9999)"
+    )
+    monkeypatch.setattr(rac, "pr_numbers_for_file", lambda ref, p, base: ["9999"])
+    # find_transitive_aspects returns AspectA — bsv's BFS found the chain
+    monkeypatch.setattr(
+        rac, "find_transitive_aspects", lambda non_aspect: {aspect_path}
+    )
+    # Per-source variant: the single changed non-aspect (Changed.pdl) reaches AspectA
+    monkeypatch.setattr(
+        rac,
+        "find_transitive_aspects_per_source",
+        lambda sources: {changed_nested_path: {aspect_path}},
+    )
+    # Cumulative mode now also runs per_pr_audit; stub it for this test which
+    # exercises only the transitive-reclassification + section-routing logic.
+    monkeypatch.setattr(rac, "per_pr_audit", lambda base, head: {})
+    monkeypatch.setattr(rac, "find_mutators_added_in_window", lambda *a: [])
+    monkeypatch.setattr(rac, "discover_mutator_hierarchy", lambda: set())
+
+    out_file = tmp_path / "report.md"
+    rc = rac.main(["--head", "HEAD", "--output", str(out_file)])
+    assert rc == 0
+    text = out_file.read_text()
+
+    # Sections are commented out — verify the reclassification surfaces via
+    # the bump_status counts in the summary line + breakdown table instead.
+    # bump_done because the bump was justified by the transitive change
+    assert "1 bump_done" in text
+    # The misleading noisy entry was stripped (verifiable by absence)
+    assert "bumped with NO structural change" not in text
+
+
+def test_pr_numbers_for_file_returns_all_prs_in_window(monkeypatch):
+    """When multiple PRs touch a file in base..head, ALL get returned."""
+    log_output = (
+        "abc1234 feat: thing (#9700)\n"
+        "def5678 fix: other thing (#9579)\n"
+        "9876fed chore: tweak (#9579)\n"  # duplicate PR
+        "1111111 commit with no pr reference\n"
+    )
+    monkeypatch.setattr(rac, "_git", lambda *args: log_output)
+    prs = rac.pr_numbers_for_file("acryl-main", "path.pdl", "v1.0.1-cloud")
+    assert prs == ["9579", "9700"]  # sorted ascending, deduped
+
+
+def test_last_author_for_file_returns_most_recent_author(monkeypatch):
+    monkeypatch.setattr(rac, "_git", lambda *args: "Alice Example\n")
+    assert (
+        rac.last_author_for_file("acryl-main", "path.pdl", "v1.0.0rc1-cloud")
+        == "Alice Example"
+    )
+
+
+def test_last_author_for_file_returns_none_when_no_commits(monkeypatch):
+    # `git log -1 --format=%an base..ref -- path` produces empty stdout when
+    # there are no matching commits in the range (e.g. a transitively-affected
+    # aspect whose file itself wasn't edited).
+    monkeypatch.setattr(rac, "_git", lambda *args: "")
+    assert rac.last_author_for_file("acryl-main", "path.pdl", "v1.0.0rc1-cloud") is None
+
+
+def test_render_owner_appears_in_bump_breakdown_table():
+    """Per-finding `- owner: <name>` bullets are no longer rendered (sections
+    commented out). Owner attribution survives via the bump_status breakdown
+    table's Owner column."""
+    f = _finding(
+        "a.pdl",
+        additive=["added optional field: y"],
+        head_commit="abc1234 feat (#1234)",
+    )
+    f.last_author = "Alice Example"
+    f.bump_status = rac.BUMP_DONE
+    out = rac.render_report([f], base="B", head="H", head_sha="sha")
+    # Owner appears in the breakdown table row, not as a bullet
+    assert "Alice Example" in out
+    # The bullet-format "- owner: Alice Example" should NOT appear
+    assert "- owner:" not in out
+
+
+def test_render_includes_per_status_breakdown():
+    f = _finding("metadata-models/.../ActionRequestInfo.pdl")
+    f.bump_status = rac.BUMP_SPURIOUS
+    f.pr_numbers = ["9579"]
+    f.last_author = "Nick Adams"
+    out = rac.render_report([f], base="B", head="H", head_sha="sha")
+    assert "**Bump status breakdown:**" in out
+    # Headers per status with counts
+    assert "### `bump_spurious` (1)" in out
+    assert "### `bump_done` (0)" in out
+    # Table header for populated bucket (now PDL file + Date + Why columns)
+    assert "| PDL file | PR(s) | Owner | Date | Why |" in out
+    # The single row for our finding
+    assert "| ActionRequestInfo.pdl | #9579 | Nick Adams |" in out
+    # Empty buckets render as italicized "(none)"
+    assert "_(none)_" in out
+
+
+def test_bump_breakdown_table_renders_rows_with_owner_and_pr():
+    f1 = _finding("path/to/A.pdl")
+    f1.bump_status = rac.BUMP_NEEDED
+    f1.pr_numbers = ["9242"]
+    f1.last_author = "John Joyce"
+    f1.last_commit_date = "2026-05-01"
+    f2 = _finding("path/to/B.pdl")
+    f2.bump_status = rac.BUMP_NEEDED
+    f2.pr_numbers = ["9272"]
+    f2.last_author = "Chris Collins"
+    f2.last_commit_date = "2026-05-10"
+    rows = rac._bump_breakdown_table([f1, f2], rac.BUMP_NEEDED)
+    assert rows[0] == "| PDL file | PR(s) | Owner | Date | Why |"
+    assert rows[1] == "| --- | --- | --- | --- | --- |"
+    # Sorted by date DESC — B (2026-05-10) before A (2026-05-01)
+    assert (
+        rows[2]
+        == "| B.pdl | #9272 | Chris Collins | 2026-05-10 | "
+        + rac._BUMP_WHY[rac.BUMP_NEEDED]
+        + " |"
+    )
+    assert (
+        rows[3]
+        == "| A.pdl | #9242 | John Joyce | 2026-05-01 | "
+        + rac._BUMP_WHY[rac.BUMP_NEEDED]
+        + " |"
+    )
+
+
+def test_bump_breakdown_table_uses_no_pr_and_no_owner_placeholders():
+    f = _finding("path/to/X.pdl")
+    f.bump_status = rac.BUMP_NEEDED
+    # pr_numbers stays empty, last_author stays None — transitively-affected case
+    rows = rac._bump_breakdown_table([f], rac.BUMP_NEEDED)
+    assert rows[2] == (
+        "| X.pdl | (no-PR) | _(no owner — file wasn't directly touched)_ "
+        "| _(unknown)_ | " + rac._BUMP_WHY[rac.BUMP_NEEDED] + " |"
+    )
+
+
+def test_bump_breakdown_table_returns_none_marker_for_empty_bucket():
+    assert rac._bump_breakdown_table([], rac.BUMP_SPURIOUS) == ["_(none)_"]
+
+
+def test_catchup_reclassifies_spurious_bump_after_unbumped_change():
+    """The Status.pdl pattern: PR1 makes a change without bumping, PR2 bumps
+    without making a change → PR2 is reclassified as catch-up (bump_done)."""
+    entries = [
+        {
+            "pr": "9192",
+            "date": "2026-05-13",
+            "bump_status": rac.BUMP_NEEDED,
+        },
+        {
+            "pr": "9534",
+            "date": "2026-05-14",
+            "bump_status": rac.BUMP_SPURIOUS,
+        },
+    ]
+    rac._apply_catchup_reclassification(entries)
+    statuses = {e["pr"]: e["bump_status"] for e in entries}
+    assert statuses["9192"] == rac.BUMP_NEEDED  # missing-bump signal preserved
+    assert statuses["9534"] == rac.BUMP_DONE  # catch-up reclassification
+    catch_up = next(e for e in entries if e["pr"] == "9534")["catch_up_for_prs"]
+    assert catch_up == ["9192"]
+
+
+def test_catchup_keeps_spurious_when_no_pending_debt():
+    """A spurious-bump PR with no prior unbumped change stays spurious."""
+    entries = [
+        {
+            "pr": "9579",
+            "date": "2026-05-15",
+            "bump_status": rac.BUMP_SPURIOUS,
+        },
+    ]
+    rac._apply_catchup_reclassification(entries)
+    assert entries[0]["bump_status"] == rac.BUMP_SPURIOUS
+    assert "catch_up_for_prs" not in entries[0]
+
+
+def test_catchup_only_first_spurious_after_needed_is_reclassified():
+    """The Status.pdl 3-PR pattern: only the FIRST spurious bump catches up;
+    further bumps without a change remain spurious."""
+    entries = [
+        {
+            "pr": "9192",
+            "date": "2026-05-13",
+            "bump_status": rac.BUMP_NEEDED,
+        },
+        {
+            "pr": "9534",
+            "date": "2026-05-14",
+            "bump_status": rac.BUMP_SPURIOUS,
+        },
+        {
+            "pr": "9579",
+            "date": "2026-05-15",
+            "bump_status": rac.BUMP_SPURIOUS,
+        },
+    ]
+    rac._apply_catchup_reclassification(entries)
+    statuses = {e["pr"]: e["bump_status"] for e in entries}
+    assert statuses["9192"] == rac.BUMP_NEEDED
+    assert statuses["9534"] == rac.BUMP_DONE
+    assert statuses["9579"] == rac.BUMP_SPURIOUS  # no debt left to catch up
+
+
+def test_catchup_single_bump_clears_multiple_pending_needed_prs():
+    """Three unbumped real-change PRs followed by ONE catch-up bump: the
+    single bump clears all accumulated debt and records every paid PR."""
+    entries = [
+        {"pr": "1", "date": "2026-05-01", "bump_status": rac.BUMP_NEEDED},
+        {"pr": "2", "date": "2026-05-02", "bump_status": rac.BUMP_NEEDED},
+        {"pr": "3", "date": "2026-05-03", "bump_status": rac.BUMP_NEEDED},
+        {"pr": "4", "date": "2026-05-04", "bump_status": rac.BUMP_SPURIOUS},
+        {"pr": "5", "date": "2026-05-05", "bump_status": rac.BUMP_SPURIOUS},
+    ]
+    rac._apply_catchup_reclassification(entries)
+    statuses = {e["pr"]: e["bump_status"] for e in entries}
+    assert statuses["1"] == rac.BUMP_NEEDED
+    assert statuses["2"] == rac.BUMP_NEEDED
+    assert statuses["3"] == rac.BUMP_NEEDED
+    assert statuses["4"] == rac.BUMP_DONE
+    assert statuses["5"] == rac.BUMP_SPURIOUS  # debt was cleared by #4
+    catch_up = next(e for e in entries if e["pr"] == "4")["catch_up_for_prs"]
+    assert catch_up == ["1", "2", "3"]
+
+
+def test_catchup_bump_done_slice_also_clears_pending_debt():
+    """A slice with its own change AND its own bump implicitly clears prior
+    unbumped-change debt — the bump goes with this slice but conventionally
+    covers all earlier missed bumps too."""
+    entries = [
+        {"pr": "1", "date": "2026-05-01", "bump_status": rac.BUMP_NEEDED},
+        {"pr": "2", "date": "2026-05-02", "bump_status": rac.BUMP_DONE},
+        {"pr": "3", "date": "2026-05-03", "bump_status": rac.BUMP_SPURIOUS},
+    ]
+    rac._apply_catchup_reclassification(entries)
+    statuses = {e["pr"]: e["bump_status"] for e in entries}
+    assert statuses["1"] == rac.BUMP_NEEDED
+    assert statuses["2"] == rac.BUMP_DONE
+    # #2's bump_done implicitly cleared #1's debt → #3 has no debt to pay
+    assert statuses["3"] == rac.BUMP_SPURIOUS
+    # #2 records that it absorbed #1's debt
+    assert next(e for e in entries if e["pr"] == "2")["catch_up_for_prs"] == ["1"]
+
+
+def test_catchup_sorts_by_date_not_input_order():
+    """Reclassification respects chronological order regardless of input order."""
+    entries = [
+        # Input order is intentionally newest-first to verify we sort.
+        {"pr": "9579", "date": "2026-05-15", "bump_status": rac.BUMP_SPURIOUS},
+        {"pr": "9534", "date": "2026-05-14", "bump_status": rac.BUMP_SPURIOUS},
+        {"pr": "9192", "date": "2026-05-13", "bump_status": rac.BUMP_NEEDED},
+    ]
+    rac._apply_catchup_reclassification(entries)
+    statuses = {e["pr"]: e["bump_status"] for e in entries}
+    # Chronological order: #9192 (needed) → #9534 (catch-up done) → #9579 (still spurious)
+    assert statuses["9192"] == rac.BUMP_NEEDED
+    assert statuses["9534"] == rac.BUMP_DONE
+    assert statuses["9579"] == rac.BUMP_SPURIOUS
+
+
+def test_describe_per_pr_slice_renders_catchup_annotation():
+    """The 'What happened' prose names the PRs whose debt this slice cleared."""
+    entry = {
+        "bump_status": rac.BUMP_DONE,
+        "old_v": 1,
+        "new_v": 2,
+        "additive": [],
+        "breaking": [],
+        "noisy": [],
+        "catch_up_for_prs": ["9192"],
+    }
+    text = rac._describe_per_pr_slice(entry)
+    assert "bumped schemaVersion 1→2" in text
+    assert "catch-up for unbumped change(s) in #9192" in text
+
+
+def test_release_test_pdl_file_lists_done_needed_spurious_with_mutator_column():
+    """The standalone `release_test_pdl_changes.md` content is a flat union
+    of bump_done + bump_needed + bump_spurious entries with a Mutator
+    column that names any AspectMigrationMutator subclass targeting the
+    same aspect. bump_not_needed rows are excluded entirely."""
+    f_done = _finding("path/Done.pdl")
+    f_done.bump_status = rac.BUMP_DONE
+    f_done.aspect_name = "done"
+    f_done.last_commit_date = "2026-05-10"
+    f_done.pr_numbers = ["1001"]
+    f_done.last_author = "Alice"
+
+    f_needed = _finding("path/Needed.pdl")
+    f_needed.bump_status = rac.BUMP_NEEDED
+    f_needed.aspect_name = "needed"
+    f_needed.last_commit_date = "2026-05-09"
+    f_needed.pr_numbers = ["1002"]
+    f_needed.last_author = "Bob"
+
+    f_spurious = _finding("path/Spurious.pdl")
+    f_spurious.bump_status = rac.BUMP_SPURIOUS
+    f_spurious.aspect_name = "spurious"
+    f_spurious.last_commit_date = "2026-05-08"
+    f_spurious.pr_numbers = ["1003"]
+    f_spurious.last_author = "Carol"
+
+    f_not_needed = _finding("path/NotNeeded.pdl")
+    f_not_needed.bump_status = rac.BUMP_NOT_NEEDED
+    f_not_needed.bump_reason = "non-aspect record (no schemaVersion concept applies)"
+    f_not_needed.last_commit_date = "2026-05-07"
+
+    mutators = [
+        {"class_name": "DoneMutator", "target_aspect": "done"},
+        {"class_name": "BaseMutator", "target_aspect": None},  # abstract base
+    ]
+    out = rac._render_release_test_pdl_file(
+        [f_done, f_needed, f_spurious, f_not_needed],
+        mutators,
+        base="B",
+        head="H",
+        head_sha="sha",
+    )
+    # Standalone file header with metadata.
+    assert "# PDL files for integration test cases" in out
+    assert "**Base:** `B`" in out
+    assert "**Head:** `H` (sha: `sha`)" in out
+    assert "**Total aspects:** 3" in out
+    # 5-column header (PDL file | PR(s) | Owner | Date | Mutator) — no Why.
+    assert "| PDL file | PR(s) | Owner | Date | Mutator |" in out
+    assert "Why" not in out
+    # Rows sorted by Date DESC.
+    done_idx = out.index("Done.pdl")
+    needed_idx = out.index("Needed.pdl")
+    spurious_idx = out.index("Spurious.pdl")
+    assert done_idx < needed_idx < spurious_idx
+    # Done aspect's row carries its matching mutator class name.
+    assert "| Done.pdl | #1001 | Alice | 2026-05-10 | `DoneMutator` |" in out
+    # Needed / Spurious aspects don't match any mutator → (none).
+    assert "| Needed.pdl | #1002 | Bob | 2026-05-09 | (none) |" in out
+    assert "| Spurious.pdl | #1003 | Carol | 2026-05-08 | (none) |" in out
+    # bump_not_needed excluded.
+    assert "NotNeeded.pdl" not in out
+
+
+def test_release_test_pdl_file_returns_empty_when_no_relevant_findings():
+    """Empty input or all-bump_not_needed → return empty string so the caller
+    skips writing the sidecar file."""
+    assert (
+        rac._render_release_test_pdl_file([], [], base="B", head="H", head_sha="sha")
+        == ""
+    )
+    f = _finding("path/X.pdl")
+    f.bump_status = rac.BUMP_NOT_NEEDED
+    assert (
+        rac._render_release_test_pdl_file([f], [], base="B", head="H", head_sha="sha")
+        == ""
+    )
+
+
+def test_extract_mutator_target_aspect_string_literal():
+    """`getAspectName() { return "foo"; }` → 'foo'."""
+    java = """
+        public class FooMutator extends Base {
+          public String getAspectName() {
+            return "fooAspect";
+          }
+        }
+    """
+    assert rac._extract_mutator_target_aspect(java, {}) == "fooAspect"
+
+
+def test_extract_mutator_target_aspect_constant_reference():
+    """`getAspectName() { return DATAHUB_VIEW_INFO_ASPECT_NAME; }` resolves
+    via the Constants.java map."""
+    java = """
+        public class ViewInfoMutator extends Base {
+          public String getAspectName() {
+            return DATAHUB_VIEW_INFO_ASPECT_NAME;
+          }
+        }
+    """
+    constants = {"DATAHUB_VIEW_INFO_ASPECT_NAME": "dataHubViewInfo"}
+    assert rac._extract_mutator_target_aspect(java, constants) == "dataHubViewInfo"
+
+
+def test_extract_mutator_target_aspect_returns_none_for_abstract_base():
+    """A class that doesn't override `getAspectName()` → None."""
+    java = """
+        public abstract class BaseMutator extends AspectMigrationMutator {
+          // no getAspectName override
+        }
+    """
+    assert rac._extract_mutator_target_aspect(java, {}) is None
+
+
+def test_extract_mutator_target_aspect_returns_none_when_constant_unknown():
+    """Constant reference that's not in the resolved map → None (don't
+    fabricate)."""
+    java = """
+        public class FooMutator extends Base {
+          public String getAspectName() {
+            return SOME_UNKNOWN_CONSTANT;
+          }
+        }
+    """
+    assert rac._extract_mutator_target_aspect(java, {}) is None
+
+
+def test_describe_per_pr_slice_renders_new_aspect_file_lifecycle():
+    """A BUMP_NOT_NEEDED slice whose reason is 'new aspect file' renders as
+    a dedicated creator-PR row — the file was added in this PR."""
+    entry = {
+        "bump_status": rac.BUMP_NOT_NEEDED,
+        "bump_reason": "new aspect file (default schemaVersion = 1; no prior version to bump from)",
+        "additive": ["new file"],
+        "breaking": [],
+        "noisy": [],
+        "old_v": 1,
+        "new_v": 1,
+    }
+    text = rac._describe_per_pr_slice(entry)
+    assert text == "added new aspect file (default schemaVersion = 1)"
+
+
+def test_describe_per_pr_slice_renders_deleted_aspect_file_lifecycle():
+    """A BUMP_NOT_NEEDED slice whose reason is 'file deleted at head' renders
+    as a dedicated deleter-PR row."""
+    entry = {
+        "bump_status": rac.BUMP_NOT_NEEDED,
+        "bump_reason": "file deleted at head",
+        "additive": [],
+        "breaking": ["file deleted"],
+        "noisy": [],
+    }
+    text = rac._describe_per_pr_slice(entry)
+    assert text == "deleted aspect file"
+
+
+def test_per_pr_audit_keeps_lifecycle_not_needed_slices(monkeypatch):
+    """per_pr_audit should KEEP BUMP_NOT_NEEDED slices whose bump_reason is a
+    lifecycle event (new aspect file, file deleted, schemaVersion regressed).
+    The previous filter dropped all BUMP_NOT_NEEDED slices, which hid the
+    creator-PR for newly-added aspects (e.g. EvalRunEvent.pdl missing #9242).
+    """
+    aspect_path = "metadata-models/.../EvalRunEvent.pdl"
+
+    # Stub: enumerate two PR commits — #9242 (creates the aspect, BUMP_NOT_NEEDED
+    # with 'new aspect file' reason) and #9555 (later bump_done slice).
+    monkeypatch.setattr(
+        rac,
+        "enumerate_pdl_pr_commits",
+        lambda b, h: [
+            ("bbb2222222", "feat: later bump (#9555)"),
+            ("aaa1111111", "feat: create aspect (#9242)"),
+        ],
+    )
+    monkeypatch.setattr(
+        rac,
+        "_commit_date",
+        lambda sha: "2026-05-14" if sha == "bbb2222222" else "2026-04-30",
+    )
+
+    def fake_classify(parent, sha):
+        if sha == "aaa1111111":
+            f = rac.FileFinding(
+                path=aspect_path,
+                is_aspect=True,
+                aspect_name="evalRunEvent",
+                head_commit="aaa1 feat (#9242)",
+                additive=["new file"],
+                bump_status=rac.BUMP_NOT_NEEDED,
+                bump_reason="new aspect file (default schemaVersion = 1; no prior version to bump from)",
+            )
+            return [f]
+        f = rac.FileFinding(
+            path=aspect_path,
+            is_aspect=True,
+            aspect_name="evalRunEvent",
+            head_commit="bbb2 feat (#9555)",
+            bump_status=rac.BUMP_DONE,
+        )
+        f.old_v = 1
+        f.new_v = 2
+        return [f]
+
+    monkeypatch.setattr(rac, "_classify_window", fake_classify)
+    monkeypatch.setattr(rac, "_git", lambda *a, **kw: "Some Author\n")
+    monkeypatch.setattr(
+        rac, "_extract_pr_number", lambda s: "9555" if "9555" in s else "9242"
+    )
+
+    audit = rac.per_pr_audit("BASE", "HEAD")
+    assert aspect_path in audit
+    entries = audit[aspect_path]
+    prs = {e["pr"] for e in entries}
+    # Both PRs preserved — the creator AND the later bumper.
+    assert prs == {"9242", "9555"}
+
+
+def test_per_pr_audit_still_drops_non_lifecycle_not_needed_slices(monkeypatch):
+    """Sanity: BUMP_NOT_NEEDED slices that are pure noise (file touched but
+    no schema change) are still filtered out — only lifecycle events leak
+    through the relaxed filter."""
+    aspect_path = "metadata-models/.../UnchangedAspect.pdl"
+    monkeypatch.setattr(
+        rac,
+        "enumerate_pdl_pr_commits",
+        lambda b, h: [("aaa1111111", "feat: whitespace tweak (#1234)")],
+    )
+    monkeypatch.setattr(rac, "_commit_date", lambda sha: "2026-05-01")
+
+    def fake_classify(parent, sha):
+        f = rac.FileFinding(
+            path=aspect_path,
+            is_aspect=True,
+            aspect_name="unchanged",
+            head_commit="aaa1 feat (#1234)",
+            bump_status=rac.BUMP_NOT_NEEDED,
+            bump_reason="no schema change in this file",
+        )
+        return [f]
+
+    monkeypatch.setattr(rac, "_classify_window", fake_classify)
+    monkeypatch.setattr(rac, "_git", lambda *a, **kw: "Some Author\n")
+    monkeypatch.setattr(rac, "_extract_pr_number", lambda s: "1234")
+
+    audit = rac.per_pr_audit("BASE", "HEAD")
+    # No-schema-change slices are filtered out — no entries for the aspect.
+    assert audit == {}
+
+
+def test_bump_needed_why_for_transitive_change_names_the_upstream_record():
+    f = _finding("path/to/RecommendationModule.pdl")
+    f.bump_status = rac.BUMP_NEEDED
+    f.affected_via = "Criterion"
+    f.has_structural = False
+    f.pr_numbers = ["9465"]
+    f.last_author = "david-leifker"
+    f.last_commit_date = "2026-05-11"
+    rows = rac._bump_breakdown_table([f], rac.BUMP_NEEDED)
+    assert "transitively affected via `Criterion`" in rows[2]
+    assert "file's own schema unchanged" in rows[2]
+    assert "schemaVersion was NOT bumped" in rows[2]
+
+
+def test_bump_needed_why_for_direct_change_says_direct():
+    f = _finding("path/to/DirectAspect.pdl")
+    f.bump_status = rac.BUMP_NEEDED
+    f.affected_via = None
+    f.has_structural = True
+    f.pr_numbers = ["9999"]
+    f.last_author = "Alice"
+    f.last_commit_date = "2026-05-01"
+    rows = rac._bump_breakdown_table([f], rac.BUMP_NEEDED)
+    assert "direct schema change in this file" in rows[2]
+    assert "schemaVersion was NOT bumped" in rows[2]
+    assert "transitively" not in rows[2]
+
+
+def test_bump_needed_why_for_combo_direct_and_transitive_names_both():
+    f = _finding("path/to/Combo.pdl")
+    f.bump_status = rac.BUMP_NEEDED
+    f.affected_via = "SomeRecord"
+    f.has_structural = True
+    f.pr_numbers = ["1234"]
+    f.last_author = "Bob"
+    f.last_commit_date = "2026-05-02"
+    rows = rac._bump_breakdown_table([f], rac.BUMP_NEEDED)
+    assert "direct schema change AND transitively affected via `SomeRecord`" in rows[2]
+    assert "schemaVersion was NOT bumped" in rows[2]
+
+
+def test_bump_needed_why_falls_back_to_bucket_text_when_no_context():
+    # No has_structural and no affected_via — degenerate case, keep bucket text.
+    f = _finding("path/to/Mystery.pdl")
+    f.bump_status = rac.BUMP_NEEDED
+    f.affected_via = None
+    f.has_structural = False
+    rows = rac._bump_breakdown_table([f], rac.BUMP_NEEDED)
+    assert rac._BUMP_WHY[rac.BUMP_NEEDED] in rows[2]
+
+
+def test_bump_breakdown_table_renders_multiple_prs_per_aspect():
+    f = _finding("path/to/Shared.pdl")
+    f.bump_status = rac.BUMP_DONE
+    f.pr_numbers = ["9000", "9579"]
+    f.last_author = "Some Author"
+    f.last_commit_date = "2026-05-15"
+    rows = rac._bump_breakdown_table([f], rac.BUMP_DONE)
+    assert rows[2] == (
+        "| Shared.pdl | #9000, #9579 | Some Author | 2026-05-15 | "
+        + rac._BUMP_WHY[rac.BUMP_DONE]
+        + " |"
+    )
+
+
+def test_main_reclassifies_aspect_bump_as_done_when_transitively_affected(
+    monkeypatch, tmp_path
+):
+    """An aspect that was bumped AND has a changed non-aspect dependency in the
+    same diff should be bump_done, not bump_spurious."""
+    aspect_path = "metadata-models/src/main/pegasus/com/linkedin/x/AspectA.pdl"
+    nested_path = "metadata-models/src/main/pegasus/com/linkedin/x/Nested.pdl"
+
+    aspect_old = '@Aspect = {"name": "a", "schemaVersion": 1}\nrecord AspectA includes Nested { }'
+    aspect_new = '@Aspect = {"name": "a", "schemaVersion": 2}\nrecord AspectA includes Nested { }'
+    nested_old = "record Nested { x: string }"
+    nested_new = "record Nested { x: string\n y: optional string }"
+
+    def fake_changed(base, head):
+        return [aspect_path, nested_path]
+
+    def fake_file_at(ref, path):
+        if path == aspect_path:
+            return aspect_old if ref == "BASE" else aspect_new
+        return nested_old if ref == "BASE" else nested_new
+
+    def fake_resolve(head):
+        return "BASE"
+
+    def fake_head_sha(ref):
+        return "sha123"
+
+    def fake_find_transitive(non_aspect_changed):
+        # Simulates the BFS: nested is the changed non-aspect, AspectA depends on it.
+        return {aspect_path}
+
+    def fake_find_transitive_per_source(sources):
+        # Per-source variant: each source's BFS downstream set.
+        return {nested_path: {aspect_path}}
+
+    monkeypatch.setattr(rac, "changed_pdls", fake_changed)
+    monkeypatch.setattr(rac, "file_at", fake_file_at)
+    monkeypatch.setattr(rac, "resolve_base", fake_resolve)
+    monkeypatch.setattr(rac, "_head_sha", fake_head_sha)
+    monkeypatch.setattr(
+        rac, "latest_commit", lambda ref, p, base: "abc1234 feat (#1234)"
+    )
+    monkeypatch.setattr(rac, "find_transitive_aspects", fake_find_transitive)
+    monkeypatch.setattr(
+        rac, "find_transitive_aspects_per_source", fake_find_transitive_per_source
+    )
+    # The cumulative mode now also runs per_pr_audit to enrich bump_status with
+    # per-PR-aware verdicts. Stub it out for this test (the test exercises only
+    # the cumulative classifier's transitive-reclassification path).
+    monkeypatch.setattr(rac, "per_pr_audit", lambda base, head: {})
+    monkeypatch.setattr(rac, "find_mutators_added_in_window", lambda *a: [])
+    monkeypatch.setattr(rac, "discover_mutator_hierarchy", lambda: set())
+
+    out_file = tmp_path / "report.md"
+    rc = rac.main(["--head", "HEAD", "--output", str(out_file)])
+    assert rc == 0
+    text = out_file.read_text()
+
+    # AspectA bumped 1→2 AND has a sibling non-aspect change → bump_done, not bump_spurious
+    assert "1 bump_done" in text
+    assert "bump_spurious`: (none)" in text or "0 bump_spurious" in text
+
+
+def test_classify_bump_transitive_affected_with_no_version_change_is_bump_needed():
+    same = '@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+    assert (
+        rac._classify_bump(
+            True, same, same, has_structural=False, transitively_affected=True
+        )
+        == rac.BUMP_NEEDED
+    )
+
+
+def test_render_includes_bump_status_summary_line():
+    fs = [
+        _finding("a.pdl", breaking=["x"]),
+        _finding("b.pdl", additive=["y"]),
+        _finding("c.pdl"),
+    ]
+    # Manually set bump statuses (the renderer doesn't compute them, just counts)
+    fs[0].bump_status = rac.BUMP_NEEDED
+    fs[1].bump_status = rac.BUMP_DONE
+    fs[2].bump_status = rac.BUMP_NOT_NEEDED
+    out = rac.render_report(fs, base="B", head="H", head_sha="sha")
+    assert "**Bump status:**" in out
+    assert "1 bump_done" in out
+    assert "1 bump_needed" in out
+    assert "1 bump_not_needed" in out
+
+
+def test_render_bump_status_appears_in_summary_and_breakdown():
+    """Per-finding `- bump: <status>` bullets are no longer rendered (sections
+    commented out). The bump status surfaces via the summary line counts and
+    the per-status breakdown tables."""
+    f = _finding("a.pdl", additive=["added optional field: y"])
+    f.bump_status = rac.BUMP_NEEDED
+    f.pr_numbers = ["1234"]
+    f.last_author = "Author"
+    out = rac.render_report([f], base="B", head="H", head_sha="sha")
+    # Summary count present
+    assert "1 bump_needed" in out
+    # Breakdown table for bump_needed exists and lists the aspect
+    assert "### `bump_needed` (1)" in out
+    assert "a.pdl" in out
+    # The bullet-format "- bump: bump_needed" should NOT appear
+    assert "- bump:" not in out
+
+
+# ---------------------------------------------------------------------------
+# Per-PR audit mode
+# ---------------------------------------------------------------------------
+
+
+def test_enumerate_pdl_pr_commits_parses_log_output(monkeypatch):
+    log_output = (
+        "abc123fff feat: change one (#9555)\ndef456eee feat: change two (#9579)\n"
+    )
+    monkeypatch.setattr(rac, "_git", lambda *args: log_output)
+    rows = rac.enumerate_pdl_pr_commits("v1.0", "HEAD")
+    assert rows == [
+        ("abc123fff", "feat: change one (#9555)"),
+        ("def456eee", "feat: change two (#9579)"),
+    ]
+
+
+def test_enumerate_pdl_pr_commits_skips_blank_lines(monkeypatch):
+    monkeypatch.setattr(rac, "_git", lambda *args: "\n\nabc12345 only entry\n\n")
+    rows = rac.enumerate_pdl_pr_commits("base", "head")
+    assert rows == [("abc12345", "only entry")]
+
+
+def test_render_per_pr_report_buckets_aspects_correctly():
+    audit = {
+        "metadata-models/.../AssertionInfo.pdl": [
+            {
+                "sha": "abc1234567",
+                "pr": "9555",
+                "subject": "feat: real change (#9555)",
+                "bump_status": rac.BUMP_DONE,
+                "author": "Alice",
+                "aspect_name": "assertionInfo",
+            },
+            {
+                "sha": "def4567890",
+                "pr": "9579",
+                "subject": "feat: telemetry (#9579)",
+                "bump_status": rac.BUMP_SPURIOUS,
+                "author": "Bob",
+                "aspect_name": "assertionInfo",
+            },
+        ],
+        "metadata-models/.../DataHubTaskInfo.pdl": [
+            {
+                "sha": "111aaa2222",
+                "pr": "9242",
+                "subject": "feat: evals (#9242)",
+                "bump_status": rac.BUMP_NEEDED,
+                "author": "Carol",
+                "aspect_name": "dataHubTaskInfo",
+            },
+        ],
+        "metadata-models/.../GoodAspect.pdl": [
+            {
+                "sha": "999fff8888",
+                "pr": "9000",
+                "subject": "feat: good (#9000)",
+                "bump_status": rac.BUMP_DONE,
+                "author": "Dan",
+                "aspect_name": "goodAspect",
+            },
+        ],
+    }
+    out = rac.render_per_pr_report(audit, base="B", head="H", head_sha="sha123")
+    # Header
+    assert "per-PR audit" in out
+    assert "**Base:** `B`" in out
+    # Bucket headers + counts
+    assert "Aspects with at least one unjustified bump" in out
+    assert "Aspects with at least one missing bump" in out
+    assert "Aspects with all bumps justified" in out
+    # AssertionInfo lands in unjustified bucket (because it has a bump_spurious entry)
+    assert "### `AssertionInfo.pdl`" in out
+    # The spurious row appears
+    assert (
+        "| #9579 | `def4567890` | `bump_spurious` | Bob | feat: telemetry (#9579) |"
+        in out
+    )
+    # DataHubTaskInfo lands in needed bucket
+    assert "### `DataHubTaskInfo.pdl`" in out
+    # GoodAspect lands in the justified summary table
+    assert "| GoodAspect.pdl | 1 | #9000 |" in out
+
+
+def test_render_per_pr_report_handles_empty_audit():
+    out = rac.render_per_pr_report({}, base="B", head="H", head_sha="sha")
+    assert "No aspects with bump-relevant PR-slice verdicts" in out
+
+
+def test_main_per_pr_flag_writes_per_pr_report(tmp_path, monkeypatch):
+    """--per-pr swaps the renderer to render_per_pr_report. Stub out the
+    git+audit machinery so the test is hermetic."""
+    monkeypatch.setattr(rac, "resolve_base", lambda head: "BASE")
+    monkeypatch.setattr(rac, "_head_sha", lambda ref: "sha123")
+    monkeypatch.setattr(
+        rac,
+        "per_pr_audit",
+        lambda base, head: {
+            "metadata-models/.../X.pdl": [
+                {
+                    "sha": "abc1234567",
+                    "pr": "9579",
+                    "subject": "feat (#9579)",
+                    "bump_status": rac.BUMP_SPURIOUS,
+                    "author": "Bob",
+                    "aspect_name": "x",
+                },
+            ],
+        },
+    )
+    out_file = tmp_path / "audit.md"
+    rc = rac.main(["--head", "HEAD", "--per-pr", "--output", str(out_file)])
+    assert rc == 0
+    text = out_file.read_text()
+    assert "per-PR audit" in text
+    assert "Aspects with at least one unjustified bump" in text
+    assert "X.pdl" in text
+
+
+# ---------------------------------------------------------------------------
+# Mutator detection (subclasses of AspectMigrationMutator)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_class_and_parent_simple_case():
+    src = "public class FooMutator extends BarBase {\n  // ...\n}"
+    assert rac._extract_class_and_parent(src) == ("FooMutator", "BarBase")
+
+
+def test_extract_class_and_parent_with_generics():
+    src = "public final class FooMutator<T> extends BarBase<T> {\n}"
+    assert rac._extract_class_and_parent(src) == ("FooMutator", "BarBase")
+
+
+def test_extract_class_and_parent_returns_none_for_no_extends():
+    src = "public class FooMutator {\n  // no parent\n}"
+    assert rac._extract_class_and_parent(src) is None
+
+
+def test_find_mutators_added_uses_hierarchy(monkeypatch):
+    """Files that extend a known mutator class should be included; unrelated
+    .java additions and files extending non-mutator classes should be filtered."""
+    log_output = (
+        "COMMIT abc123fff feat: add mutator (#9999)\n"
+        "metadata-service/factories/src/main/java/com/example/MyNewMutator.java\n"
+        "metadata-service/factories/src/main/java/com/example/UnrelatedClass.java\n"
+        "metadata-service/factories/src/main/java/com/example/AnotherMutator.java\n"
+        "COMMIT def456eee chore: noise (#9998)\n"
+        "metadata-service/factories/src/test/java/com/example/TestFile.java\n"
+    )
+
+    def fake_git(*args):
+        if args[0] == "log":
+            return log_output
+        if args[0] == "show":
+            # The ref looks like "abc123fff:path/to/file.java"
+            ref = args[1]
+            if "MyNewMutator" in ref:
+                return "public class MyNewMutator extends CriterionFilterMutatorBase {}"
+            if "UnrelatedClass" in ref:
+                return "public class UnrelatedClass extends Object {}"
+            if "AnotherMutator" in ref:
+                return "public class AnotherMutator extends AspectMigrationMutator {}"
+            return ""
+        # author lookup
+        if args[:2] == ("log", "-1"):
+            return "Alice Example\n"
+        return ""
+
+    monkeypatch.setattr(rac, "_git", fake_git)
+    hierarchy = {"AspectMigrationMutator", "CriterionFilterMutatorBase"}
+    results = rac.find_mutators_added_in_window("v1.0", "HEAD", hierarchy)
+    class_names = {r["class_name"] for r in results}
+    assert class_names == {"MyNewMutator", "AnotherMutator"}
+    # Test files filtered out
+    assert not any("/test/" in r["path"] for r in results)
+    # PR + author + parent attribution
+    by_class = {r["class_name"]: r for r in results}
+    assert by_class["MyNewMutator"]["parent"] == "CriterionFilterMutatorBase"
+    assert by_class["MyNewMutator"]["pr"] == "9999"
+    assert by_class["AnotherMutator"]["parent"] == "AspectMigrationMutator"
+
+
+def test_render_mutator_section_empty_returns_empty_list():
+    assert rac._render_mutator_section([]) == []
+
+
+def test_render_mutator_section_emits_table_with_date_sorted_rows():
+    mutators = [
+        {
+            "sha": "bbbbbbbbbb",
+            "pr": "9579",
+            "path": "p/Beta.java",
+            "class_name": "BetaMutator",
+            "parent": "BaseMutator",
+            "author": "Bob",
+            "subject": "feat (#9579)",
+            "commit_date": "2026-05-15",
+        },
+        {
+            "sha": "aaaaaaaaaa",
+            "pr": "9555",
+            "path": "p/Alpha.java",
+            "class_name": "AlphaMutator",
+            "parent": "AspectMigrationMutator",
+            "author": "Alice",
+            "subject": "feat (#9555)",
+            "commit_date": "2026-05-20",
+        },
+    ]
+    section = rac._render_mutator_section(mutators)
+    text = "\n".join(section)
+    # Header
+    assert "## Mutators introduced in this window" in text
+    # Table header now has Date + Why columns
+    assert "| PR | sha | Mutator class | Extends | Author | Date | Why |" in text
+    # Sorted by date DESC — AlphaMutator (2026-05-20) appears before BetaMutator (2026-05-15)
+    alpha_idx = text.index("AlphaMutator")
+    beta_idx = text.index("BetaMutator")
+    assert alpha_idx < beta_idx
+    assert (
+        "| #9555 | `aaaaaaaaaa` | `AlphaMutator` | `AspectMigrationMutator` "
+        "| Alice | 2026-05-20 | feat (#9555) |" in text
+    )
+    assert (
+        "| #9579 | `bbbbbbbbbb` | `BetaMutator` | `BaseMutator` | Bob "
+        "| 2026-05-15 | feat (#9579) |" in text
+    )
+
+
+def test_render_mutator_section_uses_no_pr_placeholder():
+    mutators = [
+        {
+            "sha": "abc1234567",
+            "pr": None,
+            "path": "p/X.java",
+            "class_name": "XMutator",
+            "parent": "AspectMigrationMutator",
+            "author": "Eve",
+            "subject": "noref",
+            "commit_date": "2026-05-12",
+        }
+    ]
+    text = "\n".join(rac._render_mutator_section(mutators))
+    assert (
+        "| (no-PR) | `abc1234567` | `XMutator` | `AspectMigrationMutator` "
+        "| Eve | 2026-05-12 | noref |" in text
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end smoke test against the real repo
+# ---------------------------------------------------------------------------
+
+
+def test_main_runs_against_real_repo_and_emits_markdown(tmp_path, capsys):
+    """Invokes main() with --base=HEAD --head=HEAD (zero diff). Verifies:
+    - returns 0
+    - emits markdown header and 'No aspect changes' line
+    - does not raise on the real repo
+    """
+    rc = rac.main(["--base", "HEAD", "--head", "HEAD"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "# @Aspect PDL change report" in captured.out
+    assert "No aspect changes" in captured.out
+
+
+def test_main_writes_to_output_file(tmp_path):
+    out_file = tmp_path / "report.md"
+    rc = rac.main(["--base", "HEAD", "--head", "HEAD", "--output", str(out_file)])
+    assert rc == 0
+    text = out_file.read_text()
+    assert "# @Aspect PDL change report" in text

--- a/.github/scripts/test/test_report_aspect_changes.py
+++ b/.github/scripts/test/test_report_aspect_changes.py
@@ -1,6 +1,5 @@
 """Tests for report_aspect_changes.py"""
 
-import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -11,32 +10,81 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import report_aspect_changes as rac
 
 
-def test_resolve_base_returns_tag_from_git_describe():
-    with patch("subprocess.check_output", return_value="v1.0.1-crucible-trustpilot\n"):
-        assert rac.resolve_base("HEAD") == "v1.0.1-crucible-trustpilot"
+def test_resolve_base_returns_latest_stable_cloud_tag_from_global_list():
+    """Happy path: `git tag --list` returns version-sorted tags; first non-rc
+    `-cloud` tag is returned. Verifies the global (ancestry-independent)
+    lookup — stable cloud releases are typically on parallel hotfix branches,
+    not ancestors of acryl-main, so an ancestry-based `git describe` would
+    miss them.
+    """
+    # Simulated `git tag --list 'v*-cloud' --sort=-v:refname` output: a mix of
+    # rc and stable tags, version-sorted descending. The filter should skip
+    # the rc tags at the top and return the first stable below them.
+    tag_list = "v1.1.0rc3-cloud\nv1.1.0rc2-cloud\nv1.1.0rc1-cloud\nv1.0.1-cloud\nv1.0.0-cloud\n"
+    with patch("subprocess.check_output", return_value=tag_list) as m:
+        assert rac.resolve_base() == "v1.0.1-cloud"
+    # Only one git invocation needed when stable lookup succeeds.
+    assert m.call_count == 1
 
 
-def test_resolve_base_invokes_git_describe_with_correct_args():
+def test_resolve_base_invokes_git_tag_list_with_sort_flag():
+    """First-pass call must use `git tag --list` (not `git describe`) with the
+    `-cloud` match pattern and version-sort flag — the ancestry-independent
+    enumeration is core to the fix.
+    """
     with patch("subprocess.check_output", return_value="v1.0.1-cloud\n") as m:
-        rac.resolve_base("acryl-main")
+        rac.resolve_base()
     args = m.call_args[0][0]
-    assert args[:2] == ["git", "describe"]
-    assert "--tags" in args
-    assert "--match" in args
-    assert "v1.0*" in args
-    assert "--exclude" in args
-    assert "*rc*" in args
-    assert "--abbrev=0" in args
-    assert "acryl-main" in args
+    assert args[:3] == ["git", "tag", "--list"]
+    assert "v*-cloud" in args
+    assert "--sort=-v:refname" in args
 
 
-def test_resolve_base_raises_with_clear_message_when_no_ancestor():
-    err = subprocess.CalledProcessError(128, ["git"], stderr="no names found")
-    with patch("subprocess.check_output", side_effect=err):
+def test_resolve_base_falls_back_to_rc_when_no_stable_cloud():
+    """When no stable `-cloud` tag exists in the repo, fall back to the latest
+    `-cloud` tag of any kind (rc accepted). Handles the early-cycle case
+    before any stable release has shipped.
+    """
+    rc_only_list = "v1.1.0rc3-cloud\nv1.1.0rc2-cloud\nv1.1.0rc1-cloud\n"
+    # First call: same list, but rc filter excludes everything → empty result.
+    # Second call: no filter, returns the latest rc-cloud tag.
+    with patch(
+        "subprocess.check_output",
+        side_effect=[rc_only_list, rc_only_list],
+    ) as m:
+        assert rac.resolve_base() == "v1.1.0rc3-cloud"
+    # First lookup exhausted (all rc), second lookup succeeded without filter.
+    assert m.call_count == 2
+
+
+def test_resolve_base_raises_when_no_cloud_tag_in_repo():
+    """Both lookups return empty → SystemExit with diagnostic listing what
+    was tried.
+    """
+    with patch("subprocess.check_output", side_effect=["", ""]):
         with pytest.raises(SystemExit) as exc:
-            rac.resolve_base("HEAD")
-    assert "Could not auto-resolve" in str(exc.value)
-    assert "--base" in str(exc.value)
+            rac.resolve_base()
+    msg = str(exc.value)
+    assert "Could not find" in msg
+    assert "--base" in msg
+    # Diagnostic should mention the git command tried so user can reproduce.
+    assert "v*-cloud" in msg
+
+
+def test_resolve_base_rc_substring_filter_skips_rc_tags_only():
+    """The Python-side filter must skip rc tags but not stable tags. Verifies
+    the filtering logic (since git tag --list returns everything matching the
+    glob; the rc filter is done in Python, not by git).
+    """
+    # Mixed list — rc tags first (newest by version), stable tags after.
+    tag_list = (
+        "v1.1.0rc1-cloud\n"  # skip: contains "rc"
+        "v1.0.2rc2-cloud\n"  # skip: contains "rc"
+        "v1.0.1-cloud\n"  # ← first stable, should be picked
+        "v1.0.0-cloud\n"
+    )
+    with patch("subprocess.check_output", return_value=tag_list):
+        assert rac.resolve_base() == "v1.0.1-cloud"
 
 
 # ---------------------------------------------------------------------------
@@ -533,7 +581,7 @@ def test_main_cumulative_bucket_follows_per_pr_spurious_slice(monkeypatch, tmp_p
     monkeypatch.setattr(
         rac, "file_at", lambda ref, p: aspect_old if ref == "BASE" else aspect_new
     )
-    monkeypatch.setattr(rac, "resolve_base", lambda head: "BASE")
+    monkeypatch.setattr(rac, "resolve_base", lambda: "BASE")
     monkeypatch.setattr(rac, "_head_sha", lambda ref: "sha123")
     monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "abc1 feat (#1234)")
     monkeypatch.setattr(rac, "pr_numbers_for_file", lambda *a: ["1234"])
@@ -595,7 +643,7 @@ def test_main_cumulative_bucket_clean_when_all_slices_are_done(monkeypatch, tmp_
     monkeypatch.setattr(
         rac, "file_at", lambda ref, p: aspect_old if ref == "BASE" else aspect_new
     )
-    monkeypatch.setattr(rac, "resolve_base", lambda head: "BASE")
+    monkeypatch.setattr(rac, "resolve_base", lambda: "BASE")
     monkeypatch.setattr(rac, "_head_sha", lambda ref: "sha123")
     monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "abc1 feat (#1234)")
     monkeypatch.setattr(rac, "pr_numbers_for_file", lambda *a: ["1234"])
@@ -644,7 +692,7 @@ def test_main_cumulative_mode_still_overrides_when_promoting_to_needed_or_spurio
 
     monkeypatch.setattr(rac, "changed_pdls", lambda b, h: [aspect_path])
     monkeypatch.setattr(rac, "file_at", lambda ref, p: aspect_same)
-    monkeypatch.setattr(rac, "resolve_base", lambda head: "BASE")
+    monkeypatch.setattr(rac, "resolve_base", lambda: "BASE")
     monkeypatch.setattr(rac, "_head_sha", lambda ref: "sha123")
     monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "abc1 feat (#1234)")
     monkeypatch.setattr(rac, "pr_numbers_for_file", lambda *a: ["1234"])
@@ -1018,7 +1066,7 @@ def test_main_routes_two_hop_transitive_aspect_to_transitive_section(
 
     monkeypatch.setattr(rac, "changed_pdls", fake_changed)
     monkeypatch.setattr(rac, "file_at", fake_file_at)
-    monkeypatch.setattr(rac, "resolve_base", lambda head: "BASE")
+    monkeypatch.setattr(rac, "resolve_base", lambda: "BASE")
     monkeypatch.setattr(rac, "_head_sha", lambda ref: "sha123")
     monkeypatch.setattr(
         rac, "latest_commit", lambda ref, p, base: "abc1234 feat (#9999)"
@@ -1635,7 +1683,7 @@ def test_main_reclassifies_aspect_bump_as_done_when_transitively_affected(
             return aspect_old if ref == "BASE" else aspect_new
         return nested_old if ref == "BASE" else nested_new
 
-    def fake_resolve(head):
+    def fake_resolve():
         return "BASE"
 
     def fake_head_sha(ref):
@@ -1815,7 +1863,7 @@ def test_render_per_pr_report_handles_empty_audit():
 def test_main_per_pr_flag_writes_per_pr_report(tmp_path, monkeypatch):
     """--per-pr swaps the renderer to render_per_pr_report. Stub out the
     git+audit machinery so the test is hermetic."""
-    monkeypatch.setattr(rac, "resolve_base", lambda head: "BASE")
+    monkeypatch.setattr(rac, "resolve_base", lambda: "BASE")
     monkeypatch.setattr(rac, "_head_sha", lambda ref: "sha123")
     monkeypatch.setattr(
         rac,

--- a/.github/workflows/pdl-change-report.yml
+++ b/.github/workflows/pdl-change-report.yml
@@ -1,6 +1,9 @@
 name: PDL Aspect Change Report
 
 on:
+  schedule:
+    # Daily at 06:00 UTC. Runs against acryl-main with auto-resolved baseline.
+    - cron: "0 6 * * *"
   workflow_dispatch:
     inputs:
       base:
@@ -53,4 +56,14 @@ jobs:
           [ "$INPUT_PER_PR" = "true" ] && PER_PR_ARG=(--per-pr)
           python3 .github/scripts/report_aspect_changes.py \
             "${BASE_ARG[@]}" "${HEAD_ARG[@]}" "${PER_PR_ARG[@]}" \
-            --output "$GITHUB_STEP_SUMMARY"
+            --output pdl-change-report.md
+          cat pdl-change-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pdl-change-report
+          path: |
+            pdl-change-report.md
+            release_test_pdl_changes.md
+          if-no-files-found: warn

--- a/.github/workflows/pdl-change-report.yml
+++ b/.github/workflows/pdl-change-report.yml
@@ -1,0 +1,56 @@
+name: PDL Aspect Change Report
+
+on:
+  workflow_dispatch:
+    inputs:
+      base:
+        description: "Base ref (tag/branch/commit). Leave blank to auto-resolve latest v1.0* non-rc tag."
+        required: false
+        default: ""
+      head:
+        description: "Head ref. Defaults to the branch the workflow is run from."
+        required: false
+        default: ""
+      per_pr:
+        description: "Per-PR audit mode: classify every PDL-touching commit in base..head in isolation, then aggregate. Catches per-PR `bump_spurious` cases that wide cumulative windows mask. Slower (~10–60s)."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pdl-change-report-${{ github.ref }}-${{ inputs.base }}-${{ inputs.head }}-${{ inputs.per_pr }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    runs-on: depot-ubuntu-24.04-small
+    steps:
+      - name: Check out repo with full history and tags
+        uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.10"
+
+      - name: Generate PDL aspect change report
+        env:
+          INPUT_BASE: ${{ inputs.base }}
+          INPUT_HEAD: ${{ inputs.head }}
+          INPUT_PER_PR: ${{ inputs.per_pr }}
+        run: |
+          BASE_ARG=()
+          HEAD_ARG=()
+          PER_PR_ARG=()
+          [ -n "$INPUT_BASE" ] && BASE_ARG=(--base "$INPUT_BASE")
+          [ -n "$INPUT_HEAD" ] && HEAD_ARG=(--head "$INPUT_HEAD")
+          [ "$INPUT_PER_PR" = "true" ] && PER_PR_ARG=(--per-pr)
+          python3 .github/scripts/report_aspect_changes.py \
+            "${BASE_ARG[@]}" "${HEAD_ARG[@]}" "${PER_PR_ARG[@]}" \
+            --output "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pdl-change-report.yml
+++ b/.github/workflows/pdl-change-report.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Generate PDL aspect change report
         env:

--- a/.github/workflows/pdl-change-report.yml
+++ b/.github/workflows/pdl-change-report.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       base:
-        description: "Base ref (tag/branch/commit). Leave blank to auto-resolve latest v1.0* non-rc tag."
+        description: "Base ref (tag/branch/commit). Leave blank to auto-resolve the latest stable -cloud release tag in the repo (falls back to latest -cloud tag if no stable release exists yet). Independent of --head ancestry."
         required: false
         default: ""
       head:
-        description: "Head ref. Defaults to the branch the workflow is run from."
+        description: "Head ref (tag/branch/commit). Leave blank to default to acryl-main."
         required: false
         default: ""
       per_pr:


### PR DESCRIPTION
## Summary

A standalone audit tool for `@Aspect` PDL changes across a release window. Classifies every changed PDL into one of four bump buckets, surfaces missed/spurious `schemaVersion` bumps with full PR + owner + date attribution, walks `bump_schema_versions.py`'s reverse-dependency graph for transitive impact, and lists migration handlers (`AspectMigrationMutator` subclasses) added in the window. Emits a sidecar file pairing aspects to their newly-added migration mutators for integration-test scoping.

## What's added

| File | Role |
|---|---|
| `.github/scripts/report_aspect_changes.py` | CLI — auto-resolves baseline, classifies, renders markdown + sidecar |
| `.github/scripts/test/test_report_aspect_changes.py` | 108 unit + smoke tests |
| `.github/workflows/pdl-change-report.yml` | `workflow_dispatch` runner with `base` / `head` / `per_pr` inputs; writes report to `$GITHUB_STEP_SUMMARY` |
| `.github/scripts/report_pdl_aspect_changes.md` | User guide including the schemaVersion-debt model |

**Purely additive** — no existing file is modified. The script `import`s parsing/graph helpers from `bump_schema_versions.py` read-only.

## Output

Two markdown files are produced per run (sidecar emitted next to `--output`, cumulative mode only):

### Main report (six sections in order)

1. **Header** — base, head + short SHA, generated UTC timestamp.
2. **Summary** — `N PDL files changed · N bump_done · N bump_needed · N bump_spurious · N bump_not_needed`.
3. **All changed PDL files** — one row per PDL with `File | Kind | PR(s) | Owner | Date | Why`, sorted by date DESC. Each row's Why text matches the file's bump bucket Why exactly (shared `_file_why()` helper).
4. **Bump status breakdown** — per-status table (`PDL file | PR(s) | Owner | Date | Why`) for each of the four buckets.
5. **Per-PR breakdown by PDL file** — for every aspect with bump-relevant per-PR activity, a per-PDL table of `PR | Date | Slice verdict | Author | What happened`. Includes lifecycle slices (file added new, file deleted, version regressed) so the creator-PR of a new aspect appears alongside its later bump activity.
6. **Mutators introduced** — Java classes that extend `AspectMigrationMutator` (directly or transitively) added in the window: `PR | sha | Mutator class | Extends | Author | Date | Why`.

### Sidecar: `release_test_pdl_changes.md`

Standalone file written next to `--output` whenever a cumulative run produces at least one bump-relevant aspect. Header includes base/head/sha/generated/total-aspects metadata, then a single table:

```
| PDL file | PR(s) | Owner | Date | Mutator |
```

Contains the union of `bump_done` + `bump_needed` + `bump_spurious` aspects (the migration-test-relevant set). The `Mutator` column names any `AspectMigrationMutator` subclass added in the window that targets the aspect. Resolution chain: parse `public String getAspectName() { return X; }` from the mutator's Java source → resolve `*_ASPECT_NAME` constants via `li-utils/src/main/java/com/linkedin/metadata/Constants.java` → match the resolved string against each PDL's `@Aspect.name`. Aspects with `(none)` either need a migration handler written or are covered by an earlier-release mutator.

## Classification rules

Every changed PDL falls into exactly one of four buckets. Per-PR truth (post-catch-up) drives the cumulative bucket assignment:

| Status | Trigger |
|---|---|
| `bump_done` | Per-PR aggregator sees no unreconciled spurious or needed slice — bump is justified at the window level |
| `bump_needed` | Change exists (direct or transitive) but `schemaVersion` was NOT bumped, and no later catch-up bump paid the debt |
| `bump_spurious` | At least one PR-slice bumped `schemaVersion` without a change AND no prior unbumped change for it to catch up — truly unjustified |
| `bump_not_needed` | Non-aspect record, new aspect file, deleted file, unchanged aspect, or version regressed |

`bump_not_needed` rows carry a specific reason (one of five concrete cases) rather than a generic catch-all. `bump_needed` rows distinguish **direct** vs **transitive** cause (and the combo case), naming the upstream record that drove a transitive reach.

## SchemaVersion debt model (catch-up reclassification)

Per-PR verdicts are reconciled chronologically: a `bump_needed` slice (real change without its own bump) creates "debt" that the **next** `bump_spurious`-in-isolation slice catches up. The catch-up bump is then reclassified to `bump_done`. Once debt is cleared, further bumps without a change stay `bump_spurious`. A single bump clears the full pending list (one bump pays any amount of accumulated debt).

Worked example (`Status.pdl`):

| PR | Date | Slice in isolation | Reclassified |
|---|---|---|---|
| #9192 | 2026-05-13 | added `lifecycleState`, no bump | `bump_needed` |
| #9534 | 2026-05-14 | bumped 1→2, no change | **`bump_done`** (catch-up for #9192) |
| #9579 | 2026-05-15 | bumped 2→3, no change | **`bump_spurious`** (no debt left) |

The per-PR "What happened" column surfaces the catch-up linkage explicitly: `bumped schemaVersion 1→2; catch-up for unbumped change(s) in #9192`.

Per-PR truth then drives the cumulative bucket: `Status.pdl` lands in `bump_spurious` (because #9579 remains spurious), not `bump_done`.

## Attribution precision

Transitively-affected aspects that weren't directly edited are attributed only to the upstream non-aspect changes that actually reach them through the include / field-type graph (per-source BFS), not to every non-aspect changed in the window. Example: `RecommendationModule.pdl` and `MonitorSuiteInfo.pdl` correctly attribute to **#9465** (the `Criterion` change that reaches them via the 4-hop chain `RecommendationModule → RecommendationContent → RecommendationParams → SearchParams.filters: array[Criterion]`) rather than to all 17 PRs in the window.

The `Kind` column distinguishes purely-transitive (file not directly edited; only reached via the graph) from direct edits that are also transitively reached — `ASPECT (transitive)` vs plain `ASPECT`.

## Lifecycle slices in per-PR breakdown

The per-PR audit retains `BUMP_NOT_NEEDED` slices whose reason is a lifecycle event (`new aspect file`, `file deleted`, `schemaVersion regressed`) so the creator-PR of a newly-added aspect appears alongside its later bump activity. Example: `EvalRunEvent.pdl` shows three rows — `#9242` (created as new aspect) → `#9555` (bump_done with transitive reach) → `#9579` (bump_spurious). Purely-noise `BUMP_NOT_NEEDED` slices (file touched but no schema change) are still filtered out.

## Real-world verification — `v1.0.0rc1-cloud..HEAD`

```
Summary: 79 PDL files changed · 6 bump_done · 5 bump_needed · 9 bump_spurious · 59 bump_not_needed
```

- **6 bump_done** — files where catch-up reclassification cleared all unbumped debt within the window (e.g. `DynamicFormAssignment.pdl` — #9465 was a `bump_needed` slice; #9560 caught it up).
- **5 bump_needed** — silent migration hazards (no catch-up bump in window):
  - Pure transitive: `RecommendationModule.pdl`, `MonitorSuiteInfo.pdl` (reached via Criterion change in #9465)
  - Direct + transitive: `DataHubOAuthClientInfo.pdl` (+15 fields, PR #9311), `GlobalSettingsInfo.pdl` (+aiContext, PR #9272), `DataHubTaskInfo.pdl` (+evalTaskDefinition, PR #9242)
- **9 bump_spurious** — files where #9579 (and similar) re-bumped `schemaVersion` after debt had already been cleared by an earlier catch-up bump, plus `EvalRunEvent.pdl` (new aspect, re-bumped by #9555 and #9579 without contributing).
- **5 mutators added** (PR #17398 + direct push `bfef8d5392`). Sidecar's `Mutator` column resolves these to the 4 aspects they target: `DataHubViewInfo.pdl` → `ViewInfoCriterionMutator`; `DynamicFormAssignment.pdl` → `DynamicFormCriterionMutator`; `AssertionAssignmentRuleInfo.pdl` → `AssertionAssignmentRuleCriterionMutator`; `ActionWorkflowInfo.pdl` → `ActionWorkflowCriterionMutator`. `CriterionFilterMutatorBase` doesn't override `getAspectName()` and so attaches to no aspect (expected — it's the abstract base).
- **20 aspects in the sidecar** — `MonitorSuiteInfo` and `RecommendationModule` show `Mutator = (none)` despite being `bump_needed` → explicit migration coverage gap surfaced.

## How to use

```bash
# Default cumulative report — writes main report AND sidecar
python3 .github/scripts/report_aspect_changes.py \
  --base v1.0.0rc1-cloud --head HEAD \
  --output /tmp/v1.1.0-pdl-report.md
# Produces:
#   /tmp/v1.1.0-pdl-report.md            (main report)
#   /tmp/release_test_pdl_changes.md     (sidecar with Mutator column ) for release testing

# Auto-resolve baseline
python3 .github/scripts/report_aspect_changes.py

# Per-PR audit mode (per-PR-slice tables only; no sidecar)
python3 .github/scripts/report_aspect_changes.py \
  --base v1.0.0rc1-cloud --head HEAD --per-pr
```

CI: **Actions → "PDL Aspect Change Report" → Run workflow**, optionally tick `per_pr`.

## Test plan

- [x] `pytest .github/scripts/test/test_report_aspect_changes.py -v` → **108/108 pass**
- [x] `ruff check` → clean
- [x] Real-repo cumulative run against `v1.0.0rc1-cloud..HEAD` → 79 files in main report, 20 in sidecar
- [x] Real-repo per-PR run → 20 PR slices examined; the 9 bump_spurious entries all trace to #9579-style unjustified bumps
- [x] Mutator detection — verified 5 mutators correctly traced to introducing PRs
- [x] Mutator → aspect resolution — independently re-verified each of the 4 mapped pairs by reading `getAspectName()` from the Java source, resolving the `*_ASPECT_NAME` constant via Constants.java, and matching against the PDL's `@Aspect.name`
- [x] Transitive attribution scoping — `RecommendationModule.pdl` / `MonitorSuiteInfo.pdl` attribute only to #9465, not all 17 window PRs
- [x] Catch-up reclassification — `Status.pdl` shows `#9192 needed → #9534 done (catch-up) → #9579 spurious` in its per-PR breakdown
- [x] Per-PR truth drives cumulative bucket — `Status.pdl` lands in `bump_spurious`, not `bump_done`
- [x] `Kind` column accuracy — only 2 entries marked `ASPECT (transitive)` (the purely-transitive files); 25 directly-edited aspects show plain `ASPECT`
- [x] Lifecycle slices in per-PR breakdown — `EvalRunEvent.pdl` shows the creator slice `#9242` alongside later bumps
- [x] Sidecar file is emitted alongside `--output` (cumulative mode only); contains exactly the union of bump_done + bump_needed + bump_spurious aspects
- [x] `bump_needed` Why distinguishes direct vs transitive vs combo; verified against actual diffs (5 / 5 rows accurate)
- [ ] After merge: trigger `.github/workflows/pdl-change-report.yml` via Actions UI; confirm main report renders in Summary tab; add an `actions/upload-artifact` step if the sidecar should also be retained
