### PR TITLE
refactor(ingest/snowflake): extract named constants for prefix-batch …

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -925,13 +925,21 @@ class SnowflakeDataDictionary(SupportsAsObj):
         if not views_with_empty_definition:
             return []
 
+        # Max view names per prefix group; bounds the rows returned by
+        # each SHOW VIEWS LIKE 'prefix%' query.
+        _SHOW_VIEWS_MAX_BATCH_SIZE = 1000
+        # One prefix per batch: we issue one SHOW VIEWS query per group.
+        _SHOW_VIEWS_MAX_GROUPS_IN_BATCH = 1
+
         view_names = [view.name for view in views_with_empty_definition]
         # build_prefix_batches packs multiple PrefixGroups per batch; we issue one
         # SHOW VIEWS query per prefix, so flatten and iterate over every group.
         prefix_groups = [
             group
             for batch in build_prefix_batches(
-                view_names, max_batch_size=1000, max_groups_in_batch=1
+                view_names,
+                max_batch_size=_SHOW_VIEWS_MAX_BATCH_SIZE,
+                max_groups_in_batch=_SHOW_VIEWS_MAX_GROUPS_IN_BATCH,
             )
             for group in batch
         ]
@@ -1564,8 +1572,17 @@ class SnowflakeDataDictionary(SupportsAsObj):
             ]
         else:
             # Build batches for full schema scan
+            # Max object names per batch; bounds the WHERE clause size of the
+            # per-batch SELECT against information_schema.columns.
+            _COLUMN_FETCH_MAX_BATCH_SIZE = 10000
+            # Max prefix groups per batch; limits how many table_name LIKE
+            # clauses are OR'd together in one query.
+            _COLUMN_FETCH_MAX_GROUPS_IN_BATCH = 6
+
             object_batches = build_prefix_batches(
-                all_objects, max_batch_size=10000, max_groups_in_batch=6
+                all_objects,
+                max_batch_size=_COLUMN_FETCH_MAX_BATCH_SIZE,
+                max_groups_in_batch=_COLUMN_FETCH_MAX_GROUPS_IN_BATCH,
             )
 
         # Process batches

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_schema.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_schema.py
@@ -214,15 +214,15 @@ class TestSnowflakeDataDictionary:
 
         The original code took `batch[0]` from each batch returned by
         build_prefix_batches, assuming `max_groups_in_batch=1` meant one
-        group per batch. The packer's off-by-one (separately addressed
-        later in this series) silently let two groups land in one batch,
-        so every other prefix range was dropped. Construct a workload
-        that forces the packer to pair groups: one large group ("A")
-        that occupies a batch alone, and several small follow-on groups
-        that fit two-per-batch.
+        group per batch. The packer's off-by-one silently let two groups
+        land in one batch, so every other prefix range was dropped.
+        Construct a workload that forces the packer to pair groups: one
+        large group ("A") that occupies a batch alone, and several small
+        follow-on groups that fit two-per-batch.
         """
-        # 990 names under "A" plus 55 each under B and C => packer produces
-        # [[A], [B, C]]; the buggy code would skip the C group.
+        # 990 names under "A" plus 55 each under B and C. Under the old
+        # packer, B and C landed in one batch [[A], [B, C]] and the old
+        # batch[0]-only caller silently dropped C. Both fixes prevent that.
         view_names = (
             [f"A_VIEW_{i:04d}" for i in range(990)]
             + [f"B_VIEW_{i:02d}" for i in range(55)]

--- a/metadata-ingestion/tests/unit/utilities/test_prefix_patch_builder.py
+++ b/metadata-ingestion/tests/unit/utilities/test_prefix_patch_builder.py
@@ -69,7 +69,7 @@ def test_build_prefix_batches_exceeds_max_batch_size():
             1,
         ),
         # Production column-fetch parameters.
-        ([f"NAME_{i:05d}" for i in range(50000)], 10000, 5),
+        ([f"NAME_{i:05d}" for i in range(50000)], 10000, 6),
         # Pathological: many tiny groups that all want to pair up.
         ([f"{c}{i}" for c in "ABCDEFGHIJ" for i in range(3)], 10, 1),
         ([f"{c}{i}" for c in "ABCDEFGHIJ" for i in range(3)], 10, 3),


### PR DESCRIPTION
…parameters

Replace bare integer literals at both build_prefix_batches call sites with named constants so the values are self-documenting:

  _SHOW_VIEWS_MAX_BATCH_SIZE / _SHOW_VIEWS_MAX_GROUPS_IN_BATCH
  _COLUMN_FETCH_MAX_BATCH_SIZE / _COLUMN_FETCH_MAX_GROUPS_IN_BATCH

Also tighten two comments in the regression test that described the pre-fix packer behaviour inaccurately — the old inline comment showed [[A], [B, C]] as the new packer output when it is actually the old packer's output, and the docstring referenced a "series" of commits that does not exist. Update the production column-fetch test parameter from 5 → 6 to match the value in production after the schema-version fix landed.

