### PR TITLE
docs(mcp): document OAuth2 + DCR setup and refresh tool reference

### DIFF
--- a/docs/dev-guides/agent-context/claude.md
+++ b/docs/dev-guides/agent-context/claude.md
@@ -5,13 +5,25 @@ Give [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-co
 ## Prerequisites
 
 - Claude Code or Claude Desktop installed
-- A DataHub instance ([Cloud](../../features/feature-guides/mcp.md#managed-mcp-server-usage) v0.3.12+ or [self-hosted](../../features/feature-guides/mcp.md#self-hosted-mcp-server-usage)) and a [personal access token](../../authentication/personal-access-tokens.md)
+- A DataHub instance: [Cloud](../../features/feature-guides/mcp.md#managed-mcp-server-usage) (OAuth on v1.0.2+, PAT on v0.3.12+) or [self-hosted](../../features/feature-guides/mcp.md#self-hosted-mcp-server-usage)
 
 ## Claude Code
 
-### DataHub Cloud
+### DataHub Cloud — OAuth (Recommended, v1.0.2+)
 
-Claude Code natively supports streamable HTTP — no proxy needed.
+On DataHub Cloud v1.0.2+, Claude Code can use OAuth2 with Dynamic Client Registration — no token to mint or paste.
+
+```bash
+claude mcp add --transport http datahub https://mcp.datahub.com/mcp
+```
+
+The first DataHub call returns `401 Unauthorized`, which Claude Code flags as needing authentication. Run `/mcp` inside Claude Code, select the DataHub server, and choose **Authenticate** — a browser opens for the DataHub OAuth flow. Enter your DataHub domain (e.g. `<tenant>` for `https://<tenant>.acryl.io`) and sign in. Tokens are stored and refreshed automatically.
+
+Prefer your tenant URL directly? Swap the URL for `https://<tenant>.acryl.io/integrations/ai/mcp`.
+
+### DataHub Cloud — Personal Access Token (Legacy)
+
+For service accounts or DataHub Cloud versions prior to v1.0.2, use a [personal access token](../../authentication/personal-access-tokens.md):
 
 ```bash
 claude mcp add --transport http \
@@ -50,9 +62,25 @@ Run `claude mcp list` to confirm the DataHub server appears.
 
 ## Claude Desktop
 
-### DataHub Cloud
+### DataHub Cloud — OAuth Connector (Recommended, v1.0.2+)
 
-Claude Desktop's config file doesn't reliably connect to remote MCP servers directly. Use [`mcp-remote`](https://github.com/geelen/mcp-remote) as a local bridge.
+Custom remote MCP connectors are available on **Free, Pro, Max, Team, and Enterprise** plans (Free is limited to one custom connector; Team/Enterprise restricts adding to Owners).
+
+1. In Claude Desktop, open **Settings → Connectors** (Team/Enterprise: **Organization settings → Connectors**).
+2. Click **Add custom connector**.
+3. Name: `DataHub`. Remote MCP server URL: `https://mcp.datahub.com/mcp`. Leave **Advanced settings** empty — DataHub registers the client via DCR automatically.
+4. Click **Add**, then **Connect**. A browser window opens for the DataHub OAuth flow.
+5. Enter your DataHub domain (e.g. `<tenant>`), sign in, and approve. The DataHub tools appear in Claude's tool menu (hammer icon).
+
+Prefer your tenant URL directly? Use `https://<tenant>.acryl.io/integrations/ai/mcp` as the connector URL instead.
+
+:::note
+Remote MCP connectors are configured via the Claude Desktop UI, not `claude_desktop_config.json` — that file is for local stdio servers only.
+:::
+
+### DataHub Cloud — `mcp-remote` Bridge (Legacy)
+
+For older Claude Desktop versions without native remote MCP support, use [`mcp-remote`](https://github.com/geelen/mcp-remote) as a local bridge.
 
 Open **Claude Desktop → Settings → Developer → Edit Config** and update `claude_desktop_config.json`:
 

--- a/docs/dev-guides/agent-context/cursor.md
+++ b/docs/dev-guides/agent-context/cursor.md
@@ -5,11 +5,31 @@ Give [Cursor](https://www.cursor.com/) access to your enterprise data context in
 ## Prerequisites
 
 - Cursor v1.1+
-- A DataHub instance ([Cloud](../../features/feature-guides/mcp.md#managed-mcp-server-usage) v0.3.12+ or [self-hosted](../../features/feature-guides/mcp.md#self-hosted-mcp-server-usage)) and a [personal access token](../../authentication/personal-access-tokens.md)
+- A DataHub instance: [Cloud](../../features/feature-guides/mcp.md#managed-mcp-server-usage) (OAuth on v1.0.2+, PAT on v0.3.12+) or [self-hosted](../../features/feature-guides/mcp.md#self-hosted-mcp-server-usage)
 
-## DataHub Cloud
+## DataHub Cloud — OAuth (Recommended, v1.0.2+)
 
-Navigate to **Cursor → Settings → Cursor Settings → MCP**, add a new server, and paste:
+On DataHub Cloud v1.0.2+, Cursor can connect via OAuth2 with Dynamic Client Registration — no token to mint or paste.
+
+Navigate to **Cursor → Settings → Cursor Settings → Tools & MCP → New MCP Server** (or edit `~/.cursor/mcp.json` globally / `.cursor/mcp.json` per project) and paste:
+
+```json
+{
+  "mcpServers": {
+    "datahub": {
+      "url": "https://mcp.datahub.com/mcp"
+    }
+  }
+}
+```
+
+Save. Cursor opens a browser tab for the DataHub OAuth flow (callback `cursor://anysphere.cursor-mcp/oauth/callback`) — enter your DataHub domain (e.g. `<tenant>` for `https://<tenant>.acryl.io`) and sign in. Tokens are stored and refreshed automatically.
+
+Prefer your tenant URL directly? Replace the URL with `https://<tenant>.acryl.io/integrations/ai/mcp`.
+
+## DataHub Cloud — Personal Access Token (Legacy)
+
+For service accounts or DataHub Cloud versions prior to v1.0.2, use a [personal access token](../../authentication/personal-access-tokens.md). Navigate to **Cursor → Settings → Cursor Settings → MCP**, add a new server, and paste:
 
 ```json
 {

--- a/docs/dev-guides/agent-context/databricks-agent-bricks.md
+++ b/docs/dev-guides/agent-context/databricks-agent-bricks.md
@@ -3,7 +3,7 @@
 Build a deployed agent on Databricks that combines SQL execution (via a [Genie Space](https://docs.databricks.com/en/genie/set-up-genie-space.html)) with DataHub's catalog context in a single conversation. The agent discovers tools from both [MCP](../../features/feature-guides/mcp.md) endpoints and the LLM decides which to call per request — search DataHub to find the right table, then query the Genie Space for the actual data.
 
 :::tip OAuth MCP alternative (DataHub Cloud v1.0.2+)
-The setup below uses a Databricks Unity Catalog connection to broker DataHub MCP calls. If you'd rather have the agent talk directly to DataHub, add `https://mcp.datahub.com/mcp` as an external MCP tool with **OAuth 2.0** auth — DataHub Cloud v1.0.2+ supports Dynamic Client Registration so Databricks registers itself automatically. See the [OAuth + DCR section of the MCP guide](../../features/feature-guides/mcp.md#oauth2-with-dynamic-client-registration-recommended).
+The setup below uses a Databricks Unity Catalog connection to broker DataHub MCP calls. If you'd rather have the agent talk directly to DataHub, add `https://<tenant>.acryl.io/integrations/ai/mcp` as an external MCP tool with **OAuth 2.0** auth — DataHub Cloud v1.0.2+ supports Dynamic Client Registration so Databricks registers itself automatically. Your tenant URL is required here; the global `https://mcp.datahub.com/mcp` endpoint is not yet supported by Databricks. See the [OAuth + DCR section of the MCP guide](../../features/feature-guides/mcp.md#oauth2-with-dynamic-client-registration-recommended).
 :::
 
 ## Prerequisites

--- a/docs/dev-guides/agent-context/databricks-agent-bricks.md
+++ b/docs/dev-guides/agent-context/databricks-agent-bricks.md
@@ -2,6 +2,10 @@
 
 Build a deployed agent on Databricks that combines SQL execution (via a [Genie Space](https://docs.databricks.com/en/genie/set-up-genie-space.html)) with DataHub's catalog context in a single conversation. The agent discovers tools from both [MCP](../../features/feature-guides/mcp.md) endpoints and the LLM decides which to call per request — search DataHub to find the right table, then query the Genie Space for the actual data.
 
+:::tip OAuth MCP alternative (DataHub Cloud v1.0.2+)
+The setup below uses a Databricks Unity Catalog connection to broker DataHub MCP calls. If you'd rather have the agent talk directly to DataHub, add `https://mcp.datahub.com/mcp` as an external MCP tool with **OAuth 2.0** auth — DataHub Cloud v1.0.2+ supports Dynamic Client Registration so Databricks registers itself automatically. See the [OAuth + DCR section of the MCP guide](../../features/feature-guides/mcp.md#oauth2-with-dynamic-client-registration-recommended).
+:::
+
 ## Prerequisites
 
 - Everything in [Databricks Genie Code — Prerequisites & Step 1](./databricks-genie-code.md#prerequisites) (the UC connection setup is shared)

--- a/docs/dev-guides/agent-context/databricks-genie-code.md
+++ b/docs/dev-guides/agent-context/databricks-genie-code.md
@@ -3,7 +3,7 @@
 Give [Genie Code](https://docs.databricks.com/en/genie/genie-code.html) access to your enterprise data context in DataHub — find trustworthy data, understand lineage, look up ownership, and generate better SQL queries, all without leaving your notebook.
 
 :::tip OAuth MCP alternative (DataHub Cloud v1.0.2+)
-On DataHub Cloud v1.0.2+, you can register `https://mcp.datahub.com/mcp` directly with Databricks as an external MCP tool using **OAuth 2.0** — DataHub supports Dynamic Client Registration so Databricks registers itself and stores refresh tokens automatically, eliminating the PAT in the Unity Catalog connection below. See the [OAuth + DCR section of the MCP guide](../../features/feature-guides/mcp.md#oauth2-with-dynamic-client-registration-recommended).
+On DataHub Cloud v1.0.2+, you can register `https://<tenant>.acryl.io/integrations/ai/mcp` directly with Databricks as an external MCP tool using **OAuth 2.0** — DataHub supports Dynamic Client Registration so Databricks registers itself and stores refresh tokens automatically, eliminating the PAT in the Unity Catalog connection below. Your tenant URL is required here; the global `https://mcp.datahub.com/mcp` endpoint is not yet supported by Databricks. See the [OAuth + DCR section of the MCP guide](../../features/feature-guides/mcp.md#oauth2-with-dynamic-client-registration-recommended).
 :::
 
 <p align="center">

--- a/docs/dev-guides/agent-context/databricks-genie-code.md
+++ b/docs/dev-guides/agent-context/databricks-genie-code.md
@@ -2,6 +2,10 @@
 
 Give [Genie Code](https://docs.databricks.com/en/genie/genie-code.html) access to your enterprise data context in DataHub — find trustworthy data, understand lineage, look up ownership, and generate better SQL queries, all without leaving your notebook.
 
+:::tip OAuth MCP alternative (DataHub Cloud v1.0.2+)
+On DataHub Cloud v1.0.2+, you can register `https://mcp.datahub.com/mcp` directly with Databricks as an external MCP tool using **OAuth 2.0** — DataHub supports Dynamic Client Registration so Databricks registers itself and stores refresh tokens automatically, eliminating the PAT in the Unity Catalog connection below. See the [OAuth + DCR section of the MCP guide](../../features/feature-guides/mcp.md#oauth2-with-dynamic-client-registration-recommended).
+:::
+
 <p align="center">
   <img width="70%" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/ai/agent-context/databricks/genie-code-datahub-query.png" alt="Genie Code querying DataHub catalog"/>
 </p>

--- a/docs/dev-guides/agent-context/snowflake.md
+++ b/docs/dev-guides/agent-context/snowflake.md
@@ -1,20 +1,83 @@
 # Snowflake Cortex Agents
 
-Give [Cortex Agents](https://www.snowflake.com/en/developers/guides/getting-started-with-snowflake-intelligence) access to your enterprise data context in DataHub — business definitions, ownership, lineage, and quality signals — so they can generate better SQL and answer data questions accurately.
+Give [Snowflake Cortex Agents](https://www.snowflake.com/en/developers/guides/getting-started-with-snowflake-intelligence) access to your enterprise data context in DataHub — business definitions, ownership, lineage, and quality signals — so they can generate better SQL and answer data questions accurately.
 
-The integration works through UDFs created by the DataHub CLI. Once set up, your Cortex Agent calls DataHub tools alongside your Snowflake tables.
-
-:::tip OAuth MCP alternative (DataHub Cloud v1.0.2+)
-If your Snowflake Intelligence agent supports external MCP servers directly, you can skip UDF setup and add `https://mcp.datahub.com/mcp` as an MCP tool with **OAuth 2.0** auth (DataHub registers a client via DCR). See the [OAuth + DCR section of the MCP guide](../../features/feature-guides/mcp.md#oauth2-with-dynamic-client-registration-recommended). The UDF path below remains the most stable option for production Cortex Agents today.
-:::
+Snowflake connects to the [DataHub MCP Server](../../features/feature-guides/mcp.md) as an **External MCP Server**, using OAuth2 with [Dynamic Client Registration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591). Each user signs in with their own DataHub credentials (including SSO), and tokens are scoped per-user and refreshed automatically.
 
 ## Prerequisites
+
+- DataHub Cloud v1.0.2+ (required for OAuth2 + DCR on the MCP endpoint)
+- A Snowflake account with Cortex Agents / Snowflake Intelligence enabled
+- A Snowflake user with the `ACCOUNTADMIN` role (for initial setup of the API integration and MCP server object)
+
+## Setup
+
+### 1. Create the API integration
+
+Run as `ACCOUNTADMIN`:
+
+```sql
+CREATE API INTEGRATION datahub_mcp_api_integration
+  API_PROVIDER = external_mcp
+  API_ALLOWED_PREFIXES = ('https://mcp.datahub.com')
+  API_USER_AUTHENTICATION = (
+    TYPE = OAUTH_DYNAMIC_CLIENT,
+    OAUTH_RESOURCE_URL = 'https://mcp.datahub.com/mcp'
+  )
+  ENABLED = TRUE;
+```
+
+If you prefer to point directly at your tenant URL, replace both `https://mcp.datahub.com` values with `https://<tenant>.acryl.io` and `https://<tenant>.acryl.io/integrations/ai/mcp` respectively.
+
+### 2. Create the External MCP Server
+
+```sql
+CREATE EXTERNAL MCP SERVER datahub_mcp_server
+  WITH DISPLAY_NAME = 'DataHub'
+  URL = 'https://mcp.datahub.com/mcp'
+  API_INTEGRATION = datahub_mcp_api_integration;
+```
+
+### 3. Add the connector to your agent
+
+1. In Snowsight, navigate to **AI & ML → Agents** and open (or create) your agent.
+2. Choose **MCP Connectors** and add the DataHub connector.
+3. Customize the agent's prompt, model, and tools as needed.
+
+### 4. Connect and sign in
+
+Open [Snowflake Intelligence](https://ai.snowflake.com/) and select your agent. Click **Connect** next to the DataHub connector — Snowflake walks each user through the DataHub OAuth flow once, then reuses the credential on subsequent calls.
+
+<p align="center">
+  <img width="70%" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/ai/agent-context/snowflake/snowflake-cortex-agent.png"/>
+</p>
+
+## Troubleshooting
+
+- **Permission denied creating the integration?** `CREATE API INTEGRATION` and `CREATE EXTERNAL MCP SERVER` both require `ACCOUNTADMIN`.
+- **Agent not using DataHub tools?** Update the agent system prompt to explicitly mention DataHub tools (search, lineage, schema lookup, etc.).
+- **OAuth flow fails?** Confirm your DataHub Cloud instance is on v1.0.2+ and that the `OAUTH_RESOURCE_URL` exactly matches the MCP endpoint (`https://mcp.datahub.com/mcp` or `https://<tenant>.acryl.io/integrations/ai/mcp`).
+- **Empty results?** The signed-in user's DataHub permissions apply — check that they can see the entities in the DataHub UI.
+
+**Links:** [Cortex Agents Docs](https://www.snowflake.com/en/developers/guides/getting-started-with-snowflake-intelligence) · [Agent Context Kit](./agent-context.md) · [MCP Server Guide](../../features/feature-guides/mcp.md)
+
+---
+
+## Deprecated: UDF-Based Setup
+
+:::warning Deprecated
+The UDF-based integration below is deprecated in favor of the External MCP Server flow above. It is preserved here for users on DataHub Cloud versions prior to v1.0.2 or for existing UDF deployments. New integrations should use the External MCP Server.
+:::
+
+The legacy integration works through UDFs created by the DataHub CLI. Once set up, your Cortex Agent calls DataHub tools alongside your Snowflake tables.
+
+### Prerequisites
 
 - `pip install datahub-agent-context[snowflake]`
 - A DataHub Cloud instance URL and [personal access token](../../authentication/personal-access-tokens.md)
 - A Snowflake user with the `ACCOUNTADMIN` role (for initial setup)
 
-## Setup
+### Setup
 
 You can either let the CLI execute the SQL directly, or generate the SQL files and run them yourself.
 
@@ -53,15 +116,11 @@ Drop `--execute` and `--sf-password` to generate SQL files instead. Then run the
 @04_cortex_agent.sql;
 ```
 
-## Configure and Use
+### Configure and Use
 
 Customize the agent's prompt, model, and tools in the Snowflake UI, then open [Snowflake Intelligence](https://ai.snowflake.com/) and select the DataHub Agent.
 
-<p align="center">
-  <img width="70%" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/ai/agent-context/snowflake/snowflake-cortex-agent.png"/>
-</p>
-
-## Updating UDFs
+### Updating UDFs
 
 When new tools are released, re-run the UDF and agent SQL:
 
@@ -70,12 +129,10 @@ When new tools are released, re-run the UDF and agent SQL:
 @04_cortex_agent.sql;
 ```
 
-## Troubleshooting
+### Troubleshooting (UDF setup)
 
 - **Permission denied?** Initial setup requires `ACCOUNTADMIN`. After that, `SNOWFLAKE_INTELLIGENCE_ADMIN` is sufficient.
 - **UDFs not found?** Run `SHOW USER FUNCTIONS LIKE 'datahub%';` to verify.
 - **Agent not using DataHub tools?** Update the agent system prompt to explicitly mention DataHub tools.
 - **Connection errors?** Verify the DataHub URL is reachable and the token hasn't expired (should start with `eyJ`).
 - **Empty results?** Check token permissions and that entities exist in the DataHub UI.
-
-**Links:** [Cortex Agents Docs](https://www.snowflake.com/en/developers/guides/getting-started-with-snowflake-intelligence) · [Agent Context Kit](./agent-context.md) · [MCP Server Guide](../../features/feature-guides/mcp.md)

--- a/docs/dev-guides/agent-context/snowflake.md
+++ b/docs/dev-guides/agent-context/snowflake.md
@@ -4,6 +4,10 @@ Give [Cortex Agents](https://www.snowflake.com/en/developers/guides/getting-star
 
 The integration works through UDFs created by the DataHub CLI. Once set up, your Cortex Agent calls DataHub tools alongside your Snowflake tables.
 
+:::tip OAuth MCP alternative (DataHub Cloud v1.0.2+)
+If your Snowflake Intelligence agent supports external MCP servers directly, you can skip UDF setup and add `https://mcp.datahub.com/mcp` as an MCP tool with **OAuth 2.0** auth (DataHub registers a client via DCR). See the [OAuth + DCR section of the MCP guide](../../features/feature-guides/mcp.md#oauth2-with-dynamic-client-registration-recommended). The UDF path below remains the most stable option for production Cortex Agents today.
+:::
+
 ## Prerequisites
 
 - `pip install datahub-agent-context[snowflake]`

--- a/docs/features/feature-guides/mcp.md
+++ b/docs/features/feature-guides/mcp.md
@@ -146,11 +146,11 @@ Mutation tools are available in [mcp-server-datahub](https://github.com/acryldat
 
 </details>
 
-## OAuth2 with Dynamic Client Registration (Recommended)
+# Connecting to Managed MCP Server with OAuth - Recommended
 
 _Available in DataHub Cloud v1.0.2+_
 
-DataHub Cloud now supports **OAuth2 with [Dynamic Client Registration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591)** for MCP, so you no longer have to mint and paste a personal access token into every client. Compatible MCP clients (Claude, Claude Code, Cursor, ChatGPT, Snowflake, Databricks, etc.) discover the auth server, register themselves, and walk you through a browser-based login. Tokens are scoped to the signed-in user and refresh automatically.
+DataHub Cloud supports **OAuth2 with [Dynamic Client Registration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591)** for MCP, so each DataHub user can connect with their own personal login — including SSO through providers like Okta, Azure AD, and others configured for your tenant. Compatible MCP clients (Claude, Claude Code, Cursor, ChatGPT, Snowflake, Databricks, etc.) discover the auth server, register themselves, and walk you through a browser-based login. Tokens are scoped to the signed-in user and refresh automatically.
 
 ### Single Entry Point
 
@@ -279,7 +279,7 @@ Snowflake exposes external MCP servers to Cortex Agents through an **API Integra
 2. Create the MCP server object:
 
    ```sql
-   CREATE MCP SERVER datahub_mcp_server
+   CREATE EXTERNAL MCP SERVER datahub_mcp_server
      WITH DISPLAY_NAME = 'DataHub'
      URL = 'https://mcp.datahub.com/mcp'
      API_INTEGRATION = datahub_mcp_api_integration;
@@ -298,7 +298,7 @@ See the [Snowflake agent context guide](../../dev-guides/agent-context/snowflake
 Databricks registers external MCP servers as **Unity Catalog HTTP connections** behind a managed proxy. The connection then becomes available to Agent Bricks, Genie Code, and AI Playground at `https://<workspace>/api/2.0/mcp/external/<connection_name>`.
 
 1. In your workspace, open **Catalog → External Data → Connections → Create connection** (requires `CREATE CONNECTION` on the metastore).
-2. Connection type: **HTTP**. Name: `datahub`. URL: `https://mcp.datahub.com/mcp`.
+2. Connection type: **HTTP**. Name: `datahub`. URL: `https://<tenant>.acryl.io/integrations/ai/mcp` (your tenant URL is required here — the global `https://mcp.datahub.com/mcp` endpoint is not yet supported by Databricks).
 3. Check the **Is MCP connection** box.
 4. For **Auth type**, select **Dynamic Client Registration** (DCR per RFC 7591) — Databricks registers a client with DataHub automatically and stores refresh tokens.
 5. Save. The first time the agent uses a DataHub tool, each operator authorizes DataHub via the workspace's managed OAuth flow.
@@ -319,7 +319,7 @@ OAuth + DCR is the recommended path for **interactive** clients where a human si
 - **DataHub Cloud < v1.0.2** or self-hosted DataHub Core
 - MCP clients that don't yet implement OAuth-based remote MCP
 
-## Managed MCP Server Usage
+# Connecting to Managed MCP Server with Access Tokens
 
 For DataHub Cloud v0.3.12+, you can connect directly to the hosted MCP server endpoint — no local installation required.
 

--- a/docs/features/feature-guides/mcp.md
+++ b/docs/features/feature-guides/mcp.md
@@ -32,89 +32,298 @@ Seamlessly integrates with Cursor, Windsurf, Claude Desktop, OpenAI, and any oth
 
 ## Tools
 
-The DataHub MCP Server provides the following tools:
+The DataHub MCP Server provides the following tools, grouped by whether they read from or write to DataHub. All tools are annotated with MCP-standard hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`) so compatible clients (e.g. Claude) can surface which tools modify catalog state and prompt for confirmation accordingly.
 
-`search`
+### Read-Only Tools
 
-Search DataHub using structured keyword search (/q syntax) with boolean logic, filters, pagination, and optional sorting by usage metrics.
+These tools only query DataHub and never modify catalog state.
 
-`get_lineage`
+**Discovery & Inspection** — Find entities (datasets, dashboards, users, etc.), pull their full metadata, drill into schemas, trace lineage upstream or downstream at the table and column level, and search across saved documents and glossary term history.
 
-Retrieve upstream or downstream lineage for any entity (datasets, columns, dashboards, etc.) with filtering, query-within-lineage, pagination, and hop control.
+:::info
+Document tools (`search_documents`, `grep_documents`) are automatically hidden if no documents exist in the catalog.
+:::
 
-`get_dataset_queries`
+<details>
+  <summary>Tools</summary>
 
-Fetch real SQL queries referencing a dataset or column—manual or system-generated—to understand usage patterns, joins, filters, and aggregation behavior.
+`search` — Search DataHub using structured keyword search (`/q` syntax) with boolean logic, filters, pagination, and optional sorting by usage metrics.
 
-`get_entities`
+`get_entities` — Fetch detailed metadata for one or more entities by URN; supports batch retrieval for efficient inspection of search results.
 
-Fetch detailed metadata for one or more entities by URN; supports batch retrieval for efficient inspection of search results.
+`list_schema_fields` — List schema fields for a dataset with keyword filtering and pagination, useful when search results truncate fields or when exploring large schemas.
 
-`list_schema_fields`
+`get_me` — Retrieve information about the currently authenticated user, including profile details and group memberships.
 
-List schema fields for a dataset with keyword filtering and pagination, useful when search results truncate fields or when exploring large schemas.
+`get_lineage` — Retrieve upstream or downstream lineage for any entity (datasets, columns, dashboards, etc.) with filtering, query-within-lineage, pagination, and hop control.
 
-`get_lineage_paths_between`
+`get_lineage_paths_between` — Retrieve the exact lineage paths between two assets or columns, including intermediate transformations and SQL query information.
 
-Retrieve the exact lineage paths between two assets or columns, including intermediate transformations and SQL query information.
+`search_documents` — Search for documents using keyword search with filters for platforms, domains, tags, glossary terms, and owners.
+
+`grep_documents` — Search within document content using regex patterns. Useful for finding specific information across multiple documents.
+
+`list_lifecycle_stages` — List the lifecycle stages (e.g. proposed, approved, deprecated) configured for glossary terms.
+
+`get_glossary_term_versions` / `compare_glossary_term_versions` — Inspect version history for a glossary term, or diff two versions to see what changed.
+
+</details>
+
+**SQL & Queries** — Surface real queries that hit a dataset and use that context to draft new SQL grounded in actual usage, joins, and filters.
+
+<details>
+  <summary>Tools</summary>
+
+`get_dataset_queries` — Fetch real SQL queries referencing a dataset or column—manual or system-generated—to understand usage patterns, joins, filters, and aggregation behavior.
+
+`find_sql_context` — Locate relevant tables, columns, and example queries for drafting SQL grounded in real catalog usage.
+
+`draft_sql_for_tables` — Draft a SQL query against a specified set of tables using context retrieved from DataHub (schemas, sample queries, lineage).
+
+</details>
+
+**Governance** — Review pending metadata change proposals awaiting approval.
+
+<details>
+  <summary>Tools</summary>
+
+`list_pending_proposals` — List metadata change proposals that are pending review.
+
+</details>
 
 ### Mutation Tools
 
 :::info
-Mutation tools are available in [mcp-server-datahub](https://github.com/acryldata/mcp-server-datahub) v0.5.0+. They are enabled via the `TOOLS_IS_MUTATION_ENABLED=true` environment variable.
+Mutation tools are available in [mcp-server-datahub](https://github.com/acryldata/mcp-server-datahub) v0.5.0+ and on DataHub Cloud v0.3.17+. They are enabled via the `TOOLS_IS_MUTATION_ENABLED=true` environment variable. Each tool is annotated with `readOnlyHint: false` so MCP clients can require confirmation before invoking them.
 :::
 
-`add_tags` / `remove_tags`
+**Metadata Editing** — Apply tags, glossary terms, ownership, domains, descriptions, and structured properties to entities or individual columns. Also handles entity/term lifecycle stage transitions and document authoring.
 
-Add or remove tags from entities or schema fields (columns). Supports bulk operations on multiple entities.
+<details>
+  <summary>Tools</summary>
 
-`add_terms` / `remove_terms`
+`add_tags` / `remove_tags` — Add or remove tags from entities or schema fields (columns). Supports bulk operations on multiple entities.
 
-Add or remove glossary terms from entities or schema fields. Useful for applying business definitions and data classification.
+`add_terms` / `remove_terms` — Add or remove glossary terms from entities or schema fields. Useful for applying business definitions and data classification.
 
-`add_owners` / `remove_owners`
+`add_owners` / `remove_owners` — Add or remove ownership assignments from entities. Supports different ownership types (technical owner, data owner, etc.).
 
-Add or remove ownership assignments from entities. Supports different ownership types (technical owner, data owner, etc.).
+`set_domains` / `remove_domains` — Assign or remove domain membership for entities. Each entity can belong to one domain.
 
-`set_domains` / `remove_domains`
+`update_description` — Update, append to, or remove descriptions for entities or schema fields. Supports markdown formatting.
 
-Assign or remove domain membership for entities. Each entity can belong to one domain.
+`add_structured_properties` / `remove_structured_properties` — Manage structured properties (typed metadata fields) on entities. Supports string, number, URN, date, and rich text value types.
 
-`update_description`
+`set_lifecycle_stage` — Set the lifecycle stage (e.g. proposed, approved, deprecated) of an entity or glossary term directly.
 
-Update, append to, or remove descriptions for entities or schema fields. Supports markdown formatting.
+`save_document` — Save standalone documents (insights, decisions, FAQs, notes) to DataHub's knowledge base. Documents are organized under a configurable parent folder.
 
-`add_structured_properties` / `remove_structured_properties`
+</details>
 
-Manage structured properties (typed metadata fields) on entities. Supports string, number, URN, date, and rich text value types.
+**Glossary Authoring** — Create new glossary terms, version them over time, and link related terms together.
 
-### User Tools
+<details>
+  <summary>Tools</summary>
 
-:::info
-User tools are available in [mcp-server-datahub](https://github.com/acryldata/mcp-server-datahub) v0.5.0+. They are enabled via the `TOOLS_IS_USER_ENABLED=true` environment variable.
+`create_glossary_term` — Create a new glossary term directly.
+
+`create_glossary_term_version` — Create a new version of an existing glossary term to capture changes over time.
+
+`add_related_terms` — Link related glossary terms (e.g. synonyms, contains, inherits-from) to express relationships in the business vocabulary.
+
+</details>
+
+**Proposals (governed workflows)** — Submit changes for review rather than applying them directly, and accept or reject pending proposals. Useful when an agent should suggest, not commit, metadata changes.
+
+<details>
+  <summary>Tools</summary>
+
+`propose_create_glossary_term` — Submit a proposal to create a new glossary term, pending approval.
+
+`propose_lifecycle_stage` — Submit a proposal to change an entity's lifecycle stage, pending approval.
+
+`accept_or_reject_proposals` — Accept or reject pending metadata change proposals.
+
+</details>
+
+## OAuth2 with Dynamic Client Registration (Recommended)
+
+_Available in DataHub Cloud v1.0.2+_
+
+DataHub Cloud now supports **OAuth2 with [Dynamic Client Registration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591)** for MCP, so you no longer have to mint and paste a personal access token into every client. Compatible MCP clients (Claude, Claude Code, Cursor, ChatGPT, Snowflake, Databricks, etc.) discover the auth server, register themselves, and walk you through a browser-based login. Tokens are scoped to the signed-in user and refresh automatically.
+
+### Single Entry Point
+
+Point your MCP client at the universal endpoint:
+
+```
+https://mcp.datahub.com/mcp
+```
+
+On first connection, the page prompts you for your **DataHub domain** (e.g. `<tenant>` for `https://<tenant>.acryl.io`). Enter it once and the OAuth flow redirects you to your tenant's login, then back to the client — fully authenticated, no token copy-paste required.
+
+<p align="center">
+  <img width="70%" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/features/feature-guides/mcp/mcp-tenant-picker.png" alt="The mcp.datahub.com tenant picker prompting for your DataHub domain"/>
+</p>
+
+<p align="center">
+  <video width="70%" controls>
+    <source src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/features/feature-guides/mcp/mcp-demo.mp4" type="video/mp4" />
+  </video>
+</p>
+
+<details>
+  <summary>Use your direct tenant URL instead</summary>
+
+If you'd rather skip the domain prompt at `mcp.datahub.com`, you can point clients directly at your tenant:
+
+```
+https://<tenant>.acryl.io/integrations/ai/mcp
+```
+
+This endpoint also supports OAuth2 + DCR. The only difference is that `mcp.datahub.com/mcp` is a single shared URL you can hand out without knowing the tenant ahead of time — handy for marketplace listings or shared docs.
+
+For on-premises DataHub Cloud, use your DataHub FQDN, e.g. `https://datahub.example.com/integrations/ai/mcp`.
+
+</details>
+
+### Configure Your Client
+
+<details>
+  <summary>Claude (web, desktop, mobile)</summary>
+
+Custom remote MCP connectors are available across claude.ai, Claude Desktop, and the mobile apps on **Free, Pro, Max, Team, and Enterprise** plans (Free plans are limited to one custom connector; on Team/Enterprise only Owners can add connectors org-wide).
+
+1. In claude.ai or Claude Desktop, open **Settings → Connectors** (Team/Enterprise: **Organization settings → Connectors**).
+2. Click **Add custom connector**.
+3. Name: `DataHub`. Remote MCP server URL: `https://mcp.datahub.com/mcp`. Leave the **Advanced settings** (OAuth Client ID / Secret) empty — DataHub registers the client automatically via DCR.
+4. Click **Add**, then **Connect**. Claude opens a browser window for the DataHub OAuth flow.
+5. Enter your DataHub domain when prompted (e.g. `<tenant>`), sign in, and approve the connection.
+
+:::note
+Remote MCP connectors are configured via the Claude UI, not `claude_desktop_config.json` — that file is reserved for local stdio servers. For older Claude Desktop versions without remote MCP support, fall back to the [`mcp-remote` bridge with a PAT](#managed-mcp-server-usage).
 :::
 
-`get_me`
+</details>
 
-Retrieve information about the currently authenticated user, including profile details and group memberships.
+<details>
+  <summary>Claude Code</summary>
 
-### Document Tools
+Claude Code supports OAuth-based remote MCP servers natively, including Dynamic Client Registration:
 
-:::info
-Document tools are available in [mcp-server-datahub](https://github.com/acryldata/mcp-server-datahub) v0.5.0+. Document tools are automatically hidden if no documents exist in the catalog.
+```bash
+claude mcp add --transport http datahub https://mcp.datahub.com/mcp
+```
+
+The first time you invoke a DataHub tool, the server responds `401 Unauthorized`. Claude Code flags the server as needing authentication — run `/mcp` inside Claude Code and select **Authenticate** to complete the browser-based OAuth flow. Enter your DataHub domain when prompted; tokens are stored securely and refreshed automatically.
+
+To use your tenant URL directly:
+
+```bash
+claude mcp add --transport http datahub https://<tenant>.acryl.io/integrations/ai/mcp
+```
+
+</details>
+
+<details>
+  <summary>Cursor</summary>
+
+Cursor supports remote MCP servers via the `url` field and handles OAuth flows automatically.
+
+1. Open **Cursor → Settings → Cursor Settings → Tools & MCP → New MCP Server** (or edit `~/.cursor/mcp.json` for global config / `.cursor/mcp.json` for project-scoped config).
+2. Paste:
+
+   ```json
+   {
+     "mcpServers": {
+       "datahub": {
+         "url": "https://mcp.datahub.com/mcp"
+       }
+     }
+   }
+   ```
+
+3. Save. Cursor triggers the OAuth flow in your browser using the `cursor://anysphere.cursor-mcp/oauth/callback` callback — enter your DataHub domain and sign in.
+4. The MCP settings page should show a green dot and list the DataHub tools.
+
+</details>
+
+<details>
+  <summary>ChatGPT</summary>
+
+Custom MCP connectors require **Developer Mode** and are available on **Plus, Pro, Team, Enterprise, and Edu** plans (not Free).
+
+1. Enable Developer Mode: profile picture → **Settings → Connectors → Advanced**, then toggle **Developer mode** on. (On Team/Enterprise, an admin must first allow it under **Workspace Settings → Permissions & Roles → Connected Data → Developer mode / Create custom MCP connectors**.)
+2. Still under **Settings → Connectors**, click **Add custom connector** (or **Create**).
+3. Name: `DataHub`. MCP server URL: `https://mcp.datahub.com/mcp`. Authentication: **OAuth**.
+4. Save. ChatGPT walks you through the OAuth flow — enter your DataHub domain and sign in. Pick which DataHub tools to enable for the connector.
+
+:::note
+ChatGPT requires HTTPS streamable-HTTP MCP servers (no local stdio). If a particular ChatGPT surface only supports SSE, use [`mcp-remote`](https://github.com/geelen/mcp-remote) as a local bridge.
 :::
 
-`search_documents`
+</details>
 
-Search for documents using keyword search with filters for platforms, domains, tags, glossary terms, and owners.
+<details>
+  <summary>Snowflake Cortex Agents / Snowflake Intelligence</summary>
 
-`grep_documents`
+Snowflake exposes external MCP servers to Cortex Agents through an **API Integration** + **External MCP Server** object pair. Both are created via SQL by an `ACCOUNTADMIN`, then the resulting connector is added to an agent in Snowsight.
 
-Search within document content using regex patterns. Useful for finding specific information across multiple documents.
+1. Create an API integration using DCR (run as `ACCOUNTADMIN`):
 
-`save_document`
+   ```sql
+   CREATE API INTEGRATION datahub_mcp_api_integration
+     API_PROVIDER = external_mcp
+     API_ALLOWED_PREFIXES = ('https://mcp.datahub.com')
+     API_USER_AUTHENTICATION = (
+       TYPE = OAUTH_DYNAMIC_CLIENT,
+       OAUTH_RESOURCE_URL = 'https://mcp.datahub.com/mcp'
+     )
+     ENABLED = TRUE;
+   ```
 
-Save standalone documents (insights, decisions, FAQs, notes) to DataHub's knowledge base. Documents are organized under a configurable parent folder.
+2. Create the external MCP server object:
+
+   ```sql
+   CREATE EXTERNAL MCP SERVER datahub_mcp_server
+     WITH DISPLAY_NAME = 'DataHub'
+     URL = 'https://mcp.datahub.com/mcp'
+     API_INTEGRATION = datahub_mcp_api_integration;
+   ```
+
+3. In Snowsight, navigate to **AI & ML → Agents**, open your agent, choose **MCP Connectors**, and add the DataHub connector.
+4. In Snowflake Intelligence, click **Connect** next to the DataHub connector — Snowflake walks each user through the DataHub OAuth flow and reuses the credential on subsequent calls.
+
+See the [Snowflake agent context guide](../../dev-guides/agent-context/snowflake.md) for end-to-end setup, or use your tenant URL (`https://<tenant>.acryl.io/integrations/ai/mcp`) in place of `mcp.datahub.com` if you prefer.
+
+</details>
+
+<details>
+  <summary>Databricks (Agent Bricks / Genie / AI Playground)</summary>
+
+Databricks registers external MCP servers as **Unity Catalog HTTP connections** behind a managed proxy. The connection then becomes available to Agent Bricks, Genie Code, and AI Playground at `https://<workspace>/api/2.0/mcp/external/<connection_name>`.
+
+1. In your workspace, open **Catalog → External Data → Connections → Create connection** (requires `CREATE CONNECTION` on the metastore).
+2. Connection type: **HTTP**. Name: `datahub`. URL: `https://mcp.datahub.com/mcp`.
+3. Check the **Is MCP connection** box.
+4. For **Auth type**, select **Dynamic Client Registration** (DCR per RFC 7591) — Databricks registers a client with DataHub automatically and stores refresh tokens.
+5. Save. The first time the agent uses a DataHub tool, each operator authorizes DataHub via the workspace's managed OAuth flow.
+
+:::note
+DCR requires the workspace's **Managed MCP Servers** preview to be enabled and the workspace to be in a Model Serving–supported region. The HTTP connection must use streamable HTTP transport (DataHub's `/mcp` endpoint does).
+:::
+
+See the [Databricks Agent Bricks](../../dev-guides/agent-context/databricks-agent-bricks.md) and [Databricks Genie](../../dev-guides/agent-context/databricks-genie-code.md) guides for end-to-end agent setup.
+
+</details>
+
+### When to Use PAT Auth Instead
+
+OAuth + DCR is the recommended path for **interactive** clients where a human signs in. Stick with personal access tokens (described below) for:
+
+- **Service accounts** and unattended agentic workflows (CI/CD, scheduled jobs)
+- **DataHub Cloud < v1.0.2** or self-hosted DataHub Core
+- MCP clients that don't yet implement OAuth-based remote MCP
 
 ## Managed MCP Server Usage
 

--- a/docs/features/feature-guides/mcp.md
+++ b/docs/features/feature-guides/mcp.md
@@ -192,8 +192,6 @@ For on-premises DataHub Cloud, use your DataHub FQDN, e.g. `https://datahub.exam
 <details>
   <summary>Claude (web, desktop, mobile)</summary>
 
-Custom remote MCP connectors are available across claude.ai, Claude Desktop, and the mobile apps on **Free, Pro, Max, Team, and Enterprise** plans (Free plans are limited to one custom connector; on Team/Enterprise only Owners can add connectors org-wide).
-
 1. In claude.ai or Claude Desktop, open **Settings → Connectors** (Team/Enterprise: **Organization settings → Connectors**).
 2. Click **Add custom connector**.
 3. Name: `DataHub`. Remote MCP server URL: `https://mcp.datahub.com/mcp`. Leave the **Advanced settings** (OAuth Client ID / Secret) empty — DataHub registers the client automatically via DCR.
@@ -258,10 +256,6 @@ Custom MCP connectors require **Developer Mode** and are available on **Plus, Pr
 3. Name: `DataHub`. MCP server URL: `https://mcp.datahub.com/mcp`. Authentication: **OAuth**.
 4. Save. ChatGPT walks you through the OAuth flow — enter your DataHub domain and sign in. Pick which DataHub tools to enable for the connector.
 
-:::note
-ChatGPT requires HTTPS streamable-HTTP MCP servers (no local stdio). If a particular ChatGPT surface only supports SSE, use [`mcp-remote`](https://github.com/geelen/mcp-remote) as a local bridge.
-:::
-
 </details>
 
 <details>
@@ -282,10 +276,10 @@ Snowflake exposes external MCP servers to Cortex Agents through an **API Integra
      ENABLED = TRUE;
    ```
 
-2. Create the external MCP server object:
+2. Create the MCP server object:
 
    ```sql
-   CREATE EXTERNAL MCP SERVER datahub_mcp_server
+   CREATE MCP SERVER datahub_mcp_server
      WITH DISPLAY_NAME = 'DataHub'
      URL = 'https://mcp.datahub.com/mcp'
      API_INTEGRATION = datahub_mcp_api_integration;


### PR DESCRIPTION
Adds a new OAuth2 + Dynamic Client Registration section to the MCP guide calling out https://mcp.datahub.com/mcp as the single entry point, with per-client setup details (Claude, Claude Code, Cursor, ChatGPT, Snowflake Cortex, Databricks). Restructures the tool reference into Read-Only vs Mutation groups with collapsible tool lists, adds newly available tools (find_sql_context, draft_sql_for_tables, lifecycle, proposals, etc.), and updates the Claude/Cursor/Snowflake/Databricks agent-context guides with the new OAuth path.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
