### PR TITLE
chore(deps): pin lz4-java to 1.11.0 (CVE-2025-12183)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,8 @@ buildscript {
   // CVE-2024-23454 (RunJar temp dir permissions) is fixed in hadoop-common 3.4.0+; pin thirdparty jar beyond Hadoop’s transitive 1.3.0 for scanner hygiene.
   ext.hadoopShadedGuavaVersion = '1.5.0'
   ext.kafkaVersion = '8.1.0'
+  // at.yawk.lz4 fork (CVE-2025-12183); single version for externalDependency.lz4Java + resolutionStrategy
+  ext.lz4JavaVersion = '1.11.0'
   ext.hazelcastVersion = '5.7.0'
   ext.ebeanVersion = '15.5.2'
   ext.googleJavaFormatVersion = '1.18.1'
@@ -251,6 +253,8 @@ project.ext.externalDependency = [
     'log4j12Api': "org.slf4j:log4j-over-slf4j:$slf4jVersion",
     'log4j2Api': "org.apache.logging.log4j:log4j-to-slf4j:$log4jVersion",
     'lombok': 'org.projectlombok:lombok:1.18.42',
+    // Fork with maintained JNI natives; root resolutionStrategy maps org.lz4:lz4-java here too
+    'lz4Java': 'at.yawk.lz4:lz4-java:' + lz4JavaVersion,
     'mavenArtifact': "org.apache.maven:maven-artifact:$mavenVersion",
     'mixpanel': 'com.mixpanel:mixpanel-java:1.4.4',
     'mockito': 'org.mockito:mockito-core:5.20.0',
@@ -528,8 +532,8 @@ configure(subprojects.findAll {! it.name.startsWith('spark-lineage')}) {
     // eachDependency: upgrade vulnerable versions only (do not downgrade newer safe versions)
     resolutionStrategy.eachDependency { details ->
       if (details.requested.group == 'org.lz4' && details.requested.name == 'lz4-java') {
-        details.useTarget("at.yawk.lz4:lz4-java:1.10.1")
-        details.because("CVE-2025-12183, upgrade to 1.10.1")
+        details.useTarget(rootProject.ext.externalDependency.lz4Java)
+        details.because("CVE-2025-12183; align org.lz4:lz4-java to at.yawk fork (${rootProject.ext.lz4JavaVersion})")
       }
       if (details.requested.group == 'org.apache.mina' && details.requested.name == 'mina-core') {
         details.useTarget("org.apache.mina:mina-core:${rootProject.ext.minaCoreVersion}")
@@ -581,7 +585,7 @@ configure(subprojects.findAll {! it.name.startsWith('spark-lineage')}) {
       }
     }
     resolutionStrategy.force rootProject.ext.externalDependency.get('guava')
-    resolutionStrategy.force 'at.yawk.lz4:lz4-java:1.10.1'
+    resolutionStrategy.force rootProject.ext.externalDependency.lz4Java
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-core:${rootProject.ext.jacksonVersion}"  // GHSA-72hv-8253-57qq (e.g. from hazelcast); Pegasus plugin classpath (CVE-2025-52999)
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-annotations:${rootProject.ext.jacksonMinorRelease}"
     resolutionStrategy.force "com.fasterxml.jackson.core:jackson-databind:${rootProject.ext.jacksonVersion}"

--- a/datahub-frontend/gradle.lockfile
+++ b/datahub-frontend/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 cglib:cglib:3.3.0=testRuntimeClasspath
 ch.qos.logback:logback-classic:1.5.32=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.5.32=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/datahub-graphql-core/gradle.lockfile
+++ b/datahub-graphql-core/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/datahub-upgrade/gradle.lockfile
+++ b/datahub-upgrade/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/ingestion-scheduler/gradle.lockfile
+++ b/ingestion-scheduler/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-dao-impl/kafka-producer/gradle.lockfile
+++ b/metadata-dao-impl/kafka-producer/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-integration/java/acryl-spark-lineage/gradle.lockfile
+++ b/metadata-integration/java/acryl-spark-lineage/gradle.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=compileClasspath,provided,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=compileClasspath,provided,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,provided,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,provided,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.clearspring.analytics:stream:2.9.6=compileClasspath,provided,runtimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/metadata-integration/java/datahub-client/gradle.lockfile
+++ b/metadata-integration/java/datahub-client/gradle.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.5.32=testRuntimeClasspath
 ch.qos.logback:logback-core:1.5.32=testRuntimeClasspath
 com.beust:jcommander:1.82=testCompileClasspath,testRuntimeClasspath

--- a/metadata-integration/java/datahub-schematron/cli/gradle.lockfile
+++ b/metadata-integration/java/datahub-schematron/cli/gradle.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.5.32=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.5.32=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.beust:jcommander:1.82=testCompileClasspath,testRuntimeClasspath

--- a/metadata-io/gradle.lockfile
+++ b/metadata-io/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,dataTemplate,dataTemplateCompile,pegasusPlugin,restClient,restClientCompile,runtimeClasspath,testCompileClasspath,testDataTemplate,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRestClient,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,pegasusPlugin,restClient,restClientCompile,testFixturesCompileClasspath,testRestClient
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,pegasusPlugin,restClient,restClientCompile,testFixturesCompileClasspath,testRestClient

--- a/metadata-jobs/common/gradle.lockfile
+++ b/metadata-jobs/common/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-jobs/mae-consumer-job/gradle.lockfile
+++ b/metadata-jobs/mae-consumer-job/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.5.32=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.5.32=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 co.elastic.clients:elasticsearch-java:8.17.4=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/metadata-jobs/mae-consumer/gradle.lockfile
+++ b/metadata-jobs/mae-consumer/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,dataTemplate,dataTemplateCompile,pegasusPlugin,restClient,restClientCompile,runtimeClasspath,testCompileClasspath,testDataTemplate,testRestClient,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,pegasusPlugin,restClient,restClientCompile,testCompileClasspath,testRestClient
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,pegasusPlugin,restClient,restClientCompile,testCompileClasspath,testRestClient

--- a/metadata-jobs/mce-consumer-job/gradle.lockfile
+++ b/metadata-jobs/mce-consumer-job/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.5.32=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.5.32=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 co.elastic.clients:elasticsearch-java:8.17.4=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/metadata-jobs/mce-consumer/gradle.lockfile
+++ b/metadata-jobs/mce-consumer/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,dataTemplate,dataTemplateCompile,pegasusPlugin,restClient,restClientCompile,runtimeClasspath,testCompileClasspath,testDataTemplate,testRestClient,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,pegasusPlugin,restClient,restClientCompile,testCompileClasspath,testRestClient
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,pegasusPlugin,restClient,restClientCompile,testCompileClasspath,testRestClient

--- a/metadata-jobs/pe-consumer/gradle.lockfile
+++ b/metadata-jobs/pe-consumer/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,dataTemplate,dataTemplateCompile,pegasusPlugin,restClient,restClientCompile,runtimeClasspath,testCompileClasspath,testDataTemplate,testRestClient,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,pegasusPlugin,restClient,restClientCompile,testCompileClasspath,testRestClient
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,pegasusPlugin,restClient,restClientCompile,testCompileClasspath,testRestClient

--- a/metadata-service/auth-filter/gradle.lockfile
+++ b/metadata-service/auth-filter/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-service/auth-impl/gradle.lockfile
+++ b/metadata-service/auth-impl/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-service/auth-servlet-impl/gradle.lockfile
+++ b/metadata-service/auth-servlet-impl/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-service/events-service/gradle.lockfile
+++ b/metadata-service/events-service/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.5.32=runtimeClasspath,testRuntimeClasspath
 com.beust:jcommander:1.82=testCompileClasspath,testRuntimeClasspath

--- a/metadata-service/factories/gradle.lockfile
+++ b/metadata-service/factories/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-service/graphql-servlet-impl/gradle.lockfile
+++ b/metadata-service/graphql-servlet-impl/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-service/iceberg-catalog/gradle.lockfile
+++ b/metadata-service/iceberg-catalog/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath

--- a/metadata-service/openapi-analytics-servlet/gradle.lockfile
+++ b/metadata-service/openapi-analytics-servlet/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-service/openapi-entity-servlet/gradle.lockfile
+++ b/metadata-service/openapi-entity-servlet/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-service/openapi-servlet/gradle.lockfile
+++ b/metadata-service/openapi-servlet/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath

--- a/metadata-service/restli-servlet-impl/gradle.lockfile
+++ b/metadata-service/restli-servlet-impl/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,dataModel,dataTemplate,dataTemplateCompile,integTestCompileClasspath,integTestRuntimeClasspath,modelValidation,pegasusPlugin,restClient,restClientCompile,restModelResolverPath,runtimeClasspath,testCompileClasspath,testDataModel,testDataTemplate,testRestClient,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,integTestCompileClasspath,integTestRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=integTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=integTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,integTestCompileClasspath,pegasusPlugin,restClient,restClientCompile,testCompileClasspath,testRestClient
 ch.qos.logback:logback-classic:1.5.32=integTestRuntimeClasspath,modelValidation,runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,integTestCompileClasspath,pegasusPlugin,restClient,restClientCompile,testCompileClasspath,testRestClient

--- a/metadata-service/schema-registry-servlet/gradle.lockfile
+++ b/metadata-service/schema-registry-servlet/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath

--- a/metadata-service/services/gradle.lockfile
+++ b/metadata-service/services/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath

--- a/metadata-service/servlet/gradle.lockfile
+++ b/metadata-service/servlet/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-service/war/gradle.lockfile
+++ b/metadata-service/war/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.10.1=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.5.32=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.5.32=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 co.elastic.clients:elasticsearch-java:8.17.4=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath


### PR DESCRIPTION
Centralize the at.yawk.lz4 fork version in build.gradle and update Gradle lockfiles across affected modules.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
