### PR TITLE
fix(ui): apply Mulish to AntD Drawer chrome so portaled content matches app font

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Drawer/components.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Drawer/components.tsx
@@ -1,7 +1,18 @@
 import { Drawer } from 'antd';
 import styled from 'styled-components';
 
+// AntD's Drawer portals to document.body, escaping the app-wide `.themeV2 *`
+// Mulish override. Apply Mulish here so every descendant — chrome and body —
+// uses it instead of falling through to AntD's base @font-family (Manrope).
+const MULISH_STACK = `'Mulish', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif`;
+
 export const StyledDrawer = styled(Drawer)`
+    .ant-drawer-content,
+    .ant-drawer-header,
+    .ant-drawer-body {
+        font-family: ${MULISH_STACK};
+    }
+
     .ant-drawer-header {
         padding: 16px;
         box-shadow: ${({ theme }) => theme.colors.shadowSm};

--- a/datahub-web-react/src/app/govern/structuredProperties/styledComponents.ts
+++ b/datahub-web-react/src/app/govern/structuredProperties/styledComponents.ts
@@ -191,10 +191,11 @@ export const FlexContainer = styled.div`
     gap: 4px;
 `;
 
+// AntD's Drawer portals to document.body, escaping the `.themeV2 *` Mulish
+// override (src/AppV2.less). Without the font-family rule below the drawer
+// chrome falls through to AntD's base @font-family (Manrope) and mismatches
+// the rest of the app.
 export const StyledDrawer = styled(Drawer)`
-    // AntD's Drawer portals to document.body, escaping the `.themeV2 *` Mulish
-    // override (src/AppV2.less). Without this rule the drawer chrome falls
-    // through to AntD's base @font-family (Manrope), mismatching the app font.
     .ant-drawer-content,
     .ant-drawer-header,
     .ant-drawer-body {

--- a/datahub-web-react/src/app/govern/structuredProperties/styledComponents.ts
+++ b/datahub-web-react/src/app/govern/structuredProperties/styledComponents.ts
@@ -192,6 +192,15 @@ export const FlexContainer = styled.div`
 `;
 
 export const StyledDrawer = styled(Drawer)`
+    // AntD's Drawer portals to document.body, escaping the `.themeV2 *` Mulish
+    // override (src/AppV2.less). Without this rule the drawer chrome falls
+    // through to AntD's base @font-family (Manrope), mismatching the app font.
+    .ant-drawer-content,
+    .ant-drawer-header,
+    .ant-drawer-body {
+        font-family: ${typography.fonts.body};
+    }
+
     .ant-drawer-body {
         padding: 16px;
     }

--- a/e2e-test/ui/playwright/playwright.no-webserver.config.ts
+++ b/e2e-test/ui/playwright/playwright.no-webserver.config.ts
@@ -1,0 +1,32 @@
+/**
+ * Lightweight config for local dev runs against an already-running DataHub.
+ * Use:  npx playwright test --config=playwright.no-webserver.config.ts <spec>
+ *
+ * Differs from playwright.config.ts only in that it omits the webServer
+ * block, so Playwright never tries to launch quickstartDebug. Useful when
+ * iterating on a single spec against an existing instance.
+ */
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 60 * 1000,
+  fullyParallel: false,
+  forbidOnly: false,
+  retries: 0,
+  workers: 1,
+  reporter: [['list']],
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:9002',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'off',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+      testIgnore: /.*\.setup\.ts/,
+    },
+  ],
+});

--- a/e2e-test/ui/playwright/tests/structured-properties/structured-props-drawer-font.spec.ts
+++ b/e2e-test/ui/playwright/tests/structured-properties/structured-props-drawer-font.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Structured-Properties drawer font regression.
+ *
+ * AntD's <Drawer> portals its content to document.body, escaping the app-wide
+ * `.themeV2 *` Mulish override (defined in src/AppV2.less). Any drawer whose
+ * styled-components wrapper doesn't explicitly set font-family falls through
+ * to AntD's base @font-family — which is set to Manrope in
+ * src/conf/theme/global-variables.less — producing a visible font mismatch
+ * against the rest of the app.
+ *
+ * Two surfaces are affected in this repo:
+ *   - The shared alchemy <Drawer> at src/alchemy-components/components/Drawer
+ *   - The local StyledDrawer at src/app/govern/structuredProperties/styledComponents.ts
+ *
+ * This test opens the Structured-Properties "Create" drawer (which uses the
+ * govern-local StyledDrawer) and asserts every chrome element resolves to
+ * Mulish.
+ *
+ * Expected to FAIL before the fix and PASS after.
+ *
+ * Standalone — does not use the project's base-test fixtures because their
+ * pre-test login uses waitUntil:'networkidle', which never settles when the
+ * MFE loader keeps fetching.
+ */
+
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+const MULISH_RE = /^Mulish(\s*,|$)/;
+const USERNAME = process.env.DATAHUB_ADMIN_USERNAME || process.env.ADMIN_USERNAME || 'datahub';
+const PASSWORD = process.env.DATAHUB_ADMIN_PASSWORD || process.env.ADMIN_PASSWORD || 'datahub';
+
+test.describe('Structured-Properties Create drawer — font family', () => {
+  test('drawer chrome renders in Mulish', async ({ page }) => {
+    test.setTimeout(120_000);
+
+    // Suppress the welcome modal so it doesn't block clicks.
+    await page.addInitScript(() => {
+      localStorage.setItem('skipWelcomeModal', 'true');
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    if (page.url().includes('/login')) {
+      await page.locator('[data-testid="username"]').fill(USERNAME);
+      await page.locator('[data-testid="password"]').fill(PASSWORD);
+      await page.locator('[data-testid="sign-in"]').click();
+      await page.waitForURL((url) => !url.pathname.includes('login'), {
+        waitUntil: 'domcontentloaded',
+        timeout: 30_000,
+      });
+    }
+
+    // Dismiss any blocking modal/onboarding overlays.
+    for (const sel of ['.ant-modal-close', 'button:has-text("Skip Tour")', 'button:has-text("Got it")']) {
+      const m = page.locator(sel).first();
+      if ((await m.count()) && (await m.isVisible().catch(() => false))) {
+        await m.click().catch(() => {});
+      }
+    }
+    await page.keyboard.press('Escape').catch(() => {});
+
+    // ── Navigate to Structured Properties + open the Create drawer ───────────
+    await page.goto('/structured-properties', { waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('domcontentloaded');
+
+    const createBtn = page.getByRole('button', { name: /^Create/i }).first();
+    await expect(createBtn).toBeVisible({ timeout: 15_000 });
+    await createBtn.click();
+
+    // Wait for the drawer chrome to render.
+    const drawer = page.locator('.ant-drawer-content').first();
+    await expect(drawer).toBeVisible({ timeout: 10_000 });
+
+    // ── Assertions ───────────────────────────────────────────────────────────
+    // After the fix, every chrome element inside the portaled drawer must
+    // resolve to Mulish — not the Manrope it falls through to today.
+    await expectMulish(page, '.ant-drawer-header', 'drawer header chrome');
+    await expectMulish(page, '.ant-drawer-title', 'drawer title wrapper');
+    await expectMulish(page, '.ant-drawer-body', 'drawer body container');
+  });
+});
+
+async function expectMulish(page: Page, selector: string, label: string) {
+  await expectMulishElement(page.locator(selector).first(), label);
+}
+
+async function expectMulishElement(el: Locator, label: string) {
+  const family = await el.evaluate((node) => getComputedStyle(node as HTMLElement).fontFamily);
+  expect(family, `${label} — expected Mulish, got: ${family}`).toMatch(MULISH_RE);
+}


### PR DESCRIPTION
## Summary

AntD `<Drawer>` portals its content to `document.body`, which sits **outside** `.themeV2` — where the app-wide Mulish override `.themeV2 * { font-family: Mulish }` lives (`datahub-web-react/src/AppV2.less`). Any styled-components wrapper around an AntD Drawer that doesn't explicitly set `font-family` falls through to AntD's base `@font-family`, which is set to **Manrope** in `datahub-web-react/src/conf/theme/global-variables.less`.

Result: every drawer's chrome (`.ant-drawer-header`, `.ant-drawer-title`, `.ant-drawer-body`) renders in Manrope while the rest of the app renders in Mulish — a visible mismatch.

The first commit on this PR is a failing Playwright regression test that pins the expected behavior (Mulish on chrome). The fix commits follow.

## Affected surfaces in this repo

| Drawer wrapper | File |
| --- | --- |
| Shared alchemy `<Drawer>` | `datahub-web-react/src/alchemy-components/components/Drawer/components.tsx` |
| Govern Structured-Properties local `StyledDrawer` | `datahub-web-react/src/app/govern/structuredProperties/styledComponents.ts` |

## Failing computed `font-family` (today)

```
.ant-drawer-header  → Manrope, 14px, 500
.ant-drawer-title   → Manrope, 14px, 500
.ant-drawer-body    → Manrope, 12px, 500
```

## Fix

Add `font-family: Mulish` to `.ant-drawer-content / .ant-drawer-header / .ant-drawer-body` on each affected `StyledDrawer`. Small, targeted; no behavior change for any drawer body content that already sets `font-family` inline (those continue to win by specificity).

Other portaled AntD surfaces (Modal, Dropdown, Popover, Select dropdown) have the same root cause and could be addressed in a follow-up audit — out of scope here.

## Test plan

- [x] Test fails on `master` against a running DataHub (proof of repro — see commit 1)
- [ ] Test passes after the fix commits on this branch
- [ ] No other drawers regress (alchemy-Drawer change is additive)

## Run locally

```bash
cd e2e-test/ui/playwright
DATAHUB_ADMIN_USERNAME=datahub DATAHUB_ADMIN_PASSWORD=datahub \\
  BASE_URL=http://localhost:9002 \\
  npx playwright test --config=playwright.no-webserver.config.ts \\
  tests/structured-properties/structured-props-drawer-font.spec.ts
```

The `playwright.no-webserver.config.ts` is included as a local-dev escape hatch — the default config's `webServer` block tries to launch `quickstartDebug`, which can disrupt an already-running dev environment.

## Related

This same root cause was independently observed and fixed on Acryl's downstream fork for the Agents Chat drawer; this PR ports the underlying fix upstream and broadens it to cover the govern Structured-Properties drawer as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)