### PR TITLE
docs: Docusaurus Linter

### DIFF
--- a/.github/path-filters/lint-jobs-filters.yml
+++ b/.github/path-filters/lint-jobs-filters.yml
@@ -3,6 +3,8 @@ lint-job:
   - ".github/path-filters/lint-job-filter.yml"
 markdown:
   - added|modified: "**/*.md"
+  - ".github/scripts/check_docusaurus_markdown.py"
+  - "datahub-web-react/build.gradle"
 github-actions:
   - added|modified: ".github/**/*.yml"
   - added|modified: ".github/**/*.yaml"

--- a/.github/scripts/check_docusaurus_markdown.py
+++ b/.github/scripts/check_docusaurus_markdown.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Lint Docusaurus-specific Markdown constructs that formatters do not validate."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+ADMONITION_TYPES = {
+    "caution",
+    "danger",
+    "important",
+    "info",
+    "note",
+    "secondary",
+    "success",
+    "tip",
+    "warning",
+}
+
+OPEN_DIRECTIVE_RE = re.compile(r"^([ \t]*)(:{3,})([A-Za-z][\w-]*)(?:\s+.*)?$")
+CLOSE_DIRECTIVE_RE = re.compile(r"^([ \t]*)(:{3,})\s*$")
+FENCE_RE = re.compile(r"^([ \t]*)(`{3,}|~{3,})")
+
+
+@dataclass(frozen=True)
+class LintError:
+    path: Path
+    line: int
+    message: str
+
+    def __str__(self) -> str:
+        return f"{self.path}:{self.line}: {self.message}"
+
+
+@dataclass
+class Directive:
+    line: int
+    indent: str
+    marker: str
+    kind: str
+
+
+def _tracked_markdown_files(root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "*.md", "*.mdx"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [root / line for line in result.stdout.splitlines() if line.strip()]
+
+
+def _normalize_paths(paths: Iterable[str], root: Path) -> list[Path]:
+    normalized: list[Path] = []
+    for raw_path in paths:
+        path = Path(raw_path)
+        if not path.is_absolute():
+            path = root / path
+        if path.suffix not in {".md", ".mdx"}:
+            continue
+        if path.exists():
+            normalized.append(path)
+    return normalized
+
+
+def lint_file(path: Path, root: Path) -> list[LintError]:
+    errors: list[LintError] = []
+    stack: list[Directive] = []
+    in_fence = False
+    fence_marker = ""
+    in_html_comment = False
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError:
+        return [
+            LintError(
+                path.relative_to(root),
+                1,
+                "Unable to decode Markdown file as UTF-8",
+            )
+        ]
+
+    relative_path = path.relative_to(root)
+
+    for index, line in enumerate(lines, start=1):
+        fence_match = FENCE_RE.match(line)
+        if fence_match:
+            marker = fence_match.group(2)
+            marker_char = marker[0]
+            if not in_fence:
+                in_fence = True
+                fence_marker = marker
+            elif marker_char == fence_marker[0] and len(marker) >= len(fence_marker):
+                in_fence = False
+                fence_marker = ""
+            continue
+
+        if in_fence:
+            continue
+
+        if in_html_comment:
+            if "-->" in line:
+                in_html_comment = False
+            continue
+
+        if "<!--" in line:
+            if "-->" not in line:
+                in_html_comment = True
+            continue
+
+        close_match = CLOSE_DIRECTIVE_RE.match(line)
+        if close_match:
+            indent = close_match.group(1)
+            marker = close_match.group(2)
+            if not stack:
+                errors.append(
+                    LintError(
+                        relative_path,
+                        index,
+                        "Docusaurus directive closing fence has no matching opening fence",
+                    )
+                )
+                continue
+
+            opening = stack.pop()
+            if marker != opening.marker:
+                errors.append(
+                    LintError(
+                        relative_path,
+                        index,
+                        f"Docusaurus directive closing fence uses {len(marker)} colons, "
+                        f"but {opening.kind} opened on line {opening.line} with "
+                        f"{len(opening.marker)} colons",
+                    )
+                )
+            if indent != opening.indent:
+                errors.append(
+                    LintError(
+                        relative_path,
+                        index,
+                        f"Docusaurus directive closing fence indentation does not match "
+                        f"{opening.kind} opened on line {opening.line}",
+                    )
+                )
+            continue
+
+        open_match = OPEN_DIRECTIVE_RE.match(line)
+        if open_match:
+            indent = open_match.group(1)
+            marker = open_match.group(2)
+            kind = open_match.group(3)
+            if kind not in ADMONITION_TYPES:
+                errors.append(
+                    LintError(
+                        relative_path,
+                        index,
+                        f"Unknown Docusaurus admonition type '{kind}'",
+                    )
+                )
+            stack.append(Directive(index, indent, marker, kind))
+
+    for directive in stack:
+        errors.append(
+            LintError(
+                relative_path,
+                directive.line,
+                f"Docusaurus directive '{directive.kind}' is missing a closing "
+                f"{directive.marker} fence",
+            )
+        )
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Markdown files to lint. Defaults to all tracked .md/.mdx files.",
+    )
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[2]
+    paths = _normalize_paths(args.paths, root) if args.paths else _tracked_markdown_files(root)
+
+    errors: list[LintError] = []
+    for path in sorted(set(paths)):
+        errors.extend(lint_file(path, root))
+
+    if errors:
+        print("Docusaurus Markdown lint failed:", file=sys.stderr)
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/pre-commit-override.yaml
+++ b/.github/scripts/pre-commit-override.yaml
@@ -46,6 +46,12 @@ repos:
         pass_filenames: false
         files: ^datahub-web-react/.*\.(ts|tsx|js)$
         entry: ./gradlew :datahub-web-react:lintFix
+      - id: docusaurus-markdown-lint
+        name: Lint Docusaurus Markdown
+        description: Catches Docusaurus-specific Markdown issues that Prettier cannot validate
+        language: system
+        files: ^.*\.mdx?$
+        entry: python3 .github/scripts/check_docusaurus_markdown.py
       - id: bump-schema-versions
         name: Bump PDL schema versions
         entry: python .github/scripts/bump_schema_versions.py

--- a/.github/scripts/test/test_check_docusaurus_markdown.py
+++ b/.github/scripts/test/test_check_docusaurus_markdown.py
@@ -1,0 +1,111 @@
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import check_docusaurus_markdown as linter
+
+
+def _lint(tmp_path: Path, content: str) -> list[linter.LintError]:
+    path = tmp_path / "doc.md"
+    path.write_text(content, encoding="utf-8")
+    return linter.lint_file(path, tmp_path)
+
+
+def test_valid_top_level_admonition(tmp_path: Path) -> None:
+    errors = _lint(
+        tmp_path,
+        """::::info
+
+Content
+
+::::
+""",
+    )
+
+    assert errors == []
+
+
+def test_valid_nested_list_admonition(tmp_path: Path) -> None:
+    errors = _lint(
+        tmp_path,
+        """1. Parent item
+
+   :::caution
+   Nested content
+   :::
+""",
+    )
+
+    assert errors == []
+
+
+def test_closing_fence_must_match_opening_indent(tmp_path: Path) -> None:
+    errors = _lint(
+        tmp_path,
+        """::::info
+
+1. List item
+   ::::
+""",
+    )
+
+    assert len(errors) == 1
+    assert "indentation does not match" in errors[0].message
+
+
+def test_closing_fence_must_match_opening_colon_count(tmp_path: Path) -> None:
+    errors = _lint(
+        tmp_path,
+        """::::info
+
+Content
+
+:::
+""",
+    )
+
+    assert len(errors) == 1
+    assert "uses 3 colons" in errors[0].message
+    assert "with 4 colons" in errors[0].message
+
+
+def test_unknown_admonition_type(tmp_path: Path) -> None:
+    errors = _lint(
+        tmp_path,
+        """:::inf
+Content
+:::
+""",
+    )
+
+    assert len(errors) == 1
+    assert "Unknown Docusaurus admonition type 'inf'" in errors[0].message
+
+
+def test_ignores_directives_in_code_fences(tmp_path: Path) -> None:
+    errors = _lint(
+        tmp_path,
+        """```markdown
+:::inf
+:::
+```
+""",
+    )
+
+    assert errors == []
+
+
+def test_ignores_directives_in_html_comments(tmp_path: Path) -> None:
+    errors = _lint(
+        tmp_path,
+        """<!--
+:::NOTE
+Commented template content
+:::
+-->
+""",
+    )
+
+    assert errors == []

--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -54,8 +54,8 @@ jobs:
           distribution: "zulu"
           java-version: 21
       - uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
-      - name: run prettier --check
-        run: ./gradlew :datahub-web-react:mdPrettierCheck
+      - name: run markdown checks
+        run: ./gradlew :datahub-web-react:mdPrettierCheck :datahub-web-react:docusaurusMarkdownLint
 
   github-actions-format:
     name: github_actions_format_check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -571,6 +571,14 @@ repos:
         files: ^datahub-web-react/.*\.(ts|tsx|js)$
         entry: ./gradlew :datahub-web-react:lintFix
 
+      - id: docusaurus-markdown-lint
+        name: Lint Docusaurus Markdown
+        description: Catches Docusaurus-specific Markdown issues that Prettier cannot
+          validate
+        language: system
+        files: ^.*\.mdx?$
+        entry: python3 .github/scripts/check_docusaurus_markdown.py
+
       - id: bump-schema-versions
         name: Bump PDL schema versions
         entry: python .github/scripts/bump_schema_versions.py

--- a/datahub-web-react/build.gradle
+++ b/datahub-web-react/build.gradle
@@ -294,6 +294,18 @@ externalPrettierConfigs.each { config ->
   }
 }
 
+tasks.register('docusaurusMarkdownLint', Exec) {
+  workingDir rootProject.projectDir
+  inputs.files(rootProject.fileTree(rootProject.projectDir) {
+    include '**/*.md'
+    include '**/*.mdx'
+    exclude '**/node_modules/**'
+    exclude '**/.gradle/**'
+    exclude '**/build/**'
+  })
+  commandLine 'python3', '.github/scripts/check_docusaurus_markdown.py'
+}
+
 clean {
   delete 'node_modules/.yarn-integrity'
   delete 'dist'

--- a/docs/assertions/snowflake/snowflake_dmfs.md
+++ b/docs/assertions/snowflake/snowflake_dmfs.md
@@ -184,7 +184,7 @@ snowsql -f dmf_definitions.sql
 snowsql -f dmf_associations.sql
 ```
 
-::: NOTE
+:::note
 Scheduling Data Metric Function on table incurs Serverless Credit Usage in Snowflake. Refer [Billing and Pricing](https://docs.snowflake.com/en/user-guide/data-quality-intro#billing-and-pricing) for more details.
 Please ensure you DROP Data Metric Function created via dmf_associations.sql if the assertion is no longer in use.
 :::
@@ -258,7 +258,7 @@ DataHub interprets the `VALUE` column from Snowflake's `DATA_QUALITY_MONITORING_
 
 This is because DataHub cannot interpret arbitrary return values (e.g., "100 null rows" - is that good or bad?). You must build the pass/fail logic into your DMF.
 
-::: warning What if my DMF returns other values?
+:::warning What if my DMF returns other values?
 If your DMF returns values other than 0 or 1, DataHub will mark the assertion result as **ERROR**:
 
 - `VALUE = 1` → **PASSED**
@@ -269,7 +269,8 @@ The ERROR state indicates that the DMF is not configured correctly for DataHub i
 
 1. Checking the ingestion logs for warnings like: `DMF 'my_dmf' returned invalid value 100. Expected 1 (pass) or 0 (fail). Marking as ERROR.`
 2. Looking for assertions with ERROR status in the DataHub UI
-   :::
+
+:::
 
 #### Example: Writing External DMFs Correctly
 

--- a/docs/authentication/guides/add-users.md
+++ b/docs/authentication/guides/add-users.md
@@ -98,7 +98,7 @@ using this mechanism. It is highly recommended that admins change or remove the 
 
 ## Adding new users using a user.props file
 
-:::NOTE
+:::note
 Adding users via the `user.props` will require disabling existence checks on GMS using the `METADATA_SERVICE_AUTH_ENFORCE_EXISTENCE_ENABLED=false` environment variable or using the API to enable the user prior to login.
 The directions below demonstrate using the API to enable the user.
 :::

--- a/docs/authorization/policies.md
+++ b/docs/authorization/policies.md
@@ -145,7 +145,7 @@ Note that these privilege _can_ and likely _should_ be altered inside the **Poli
 :::note Pro-Tip
 To login using the `datahub` account, simply navigate to `<your-datahub-domain>/login` and enter `datahub`, `datahub`. Note that the password can be customized for your
 deployment by changing the `user.props` file within the `datahub-frontend` module. Notice that JaaS authentication must be enabled.
-:::note
+:::
 
 ## Configuration
 

--- a/docs/authorization/roles.md
+++ b/docs/authorization/roles.md
@@ -10,7 +10,9 @@ import FeatureAvailability from '@site/src/components/FeatureAvailability';
 
 DataHub provides the ability to use **Roles** to manage permissions.
 
-:::tip **Roles** are the recommended way to manage permissions on DataHub. This should suffice for most use cases, but advanced users can use **Policies** if needed.
+:::tip
+**Roles** are the recommended way to manage permissions on DataHub. This should suffice for most use cases, but advanced users can use **Policies** if needed.
+:::
 
 ## Roles Setup, Prerequisites, and Permissions
 
@@ -22,7 +24,9 @@ The out-of-the-box Roles represent the most common types of DataHub users. Curre
 | Editor    | Can read and edit all metadata. Cannot take administrative actions.                     |
 | Reader    | Can read all metadata. Cannot edit anything by default, or take administrative actions. |
 
-:::note To manage roles, including viewing roles, or editing a user's role, you must either be an **Admin**, or have the **Manage Policies** privilege.
+:::note
+To manage roles, including viewing roles, or editing a user's role, you must either be an **Admin**, or have the **Manage Policies** privilege.
+:::
 
 ## Using Roles
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -343,8 +343,6 @@ The default is defined in `gradle.properties`
    datahub.dependencies.apkrepo.url=https://nexus.company.com/apk/
    ```
 
-   :::
-
 #### GitHub Base URL
 
 Docker images download JVM tooling (jattach, OpenTelemetry Java agent) from GitHub at build time.

--- a/docs/features/feature-guides/custom-asset-summaries.md
+++ b/docs/features/feature-guides/custom-asset-summaries.md
@@ -23,7 +23,8 @@ Asset Summaries are currently supported for:
 
 - **Logical Assets**: Domains, Data Products, Glossary Terms, and Glossary Term Groups - these help organize and group your physical data assets within DataHub
 - **Physical Assets**: Datasets - providing a comprehensive view of your actual data tables and collections
-  :::
+
+:::
 
 ## Why Use Asset Summaries?
 

--- a/docs/how/restore-indices.md
+++ b/docs/how/restore-indices.md
@@ -298,7 +298,7 @@ Run the system update job with the following environment variable `ELASTICSEARCH
 
 :::caution
 Remember to reset this after restoration completes!
-:::caution
+:::
 
 ##### Bulk Processing Improvements:
 

--- a/docs/managed-datahub/release-notes/v_0_3_17.md
+++ b/docs/managed-datahub/release-notes/v_0_3_17.md
@@ -192,7 +192,9 @@ Patch release on top of **v0.3.17-acryl**.
     authentication.tokenService.salt must be set and not be empty
     ```
 
-    :::note For backward compatibility you can set the value of these variables to the previous default values defined [here](https://github.com/datahub-project/datahub/blob/4efc55ccb469c5480c5bb45c17b933c590f18788/metadata-service/configuration/src/main/resources/application.yaml#L26). This is not recommended though, and it is advised to regenerate new tokens with updated keys as soon as possible. :::
+    :::note
+    For backward compatibility you can set the value of these variables to the previous default values defined [here](https://github.com/datahub-project/datahub/blob/4efc55ccb469c5480c5bb45c17b933c590f18788/metadata-service/configuration/src/main/resources/application.yaml#L26). This is not recommended though, and it is advised to regenerate new tokens with updated keys as soon as possible.
+    :::
 
 **Deprecations & Sunsets**
 

--- a/docs/modeling/extending-the-metadata-model.md
+++ b/docs/modeling/extending-the-metadata-model.md
@@ -362,7 +362,9 @@ It takes the following parameters:
 This annotation is applied to fields inside an Aspect. It instructs DataHub to index the field so it can be retrieved
 via the search APIs.
 
-:::note If you are adding @Searchable to a field that already has data, you'll want to restore indices [via api](https://docs.datahub.com/docs/api/restli/restore-indices/) or [via upgrade step](https://github.com/datahub-project/datahub/blob/master/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndices.java) to have it be populated with existing data.
+:::note
+If you are adding @Searchable to a field that already has data, you'll want to restore indices [via api](https://docs.datahub.com/docs/api/restli/restore-indices/) or [via upgrade step](https://github.com/datahub-project/datahub/blob/master/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndices.java) to have it be populated with existing data.
+:::
 
 It takes the following parameters:
 

--- a/metadata-ingestion/docs/sources/dbt/README.md
+++ b/metadata-ingestion/docs/sources/dbt/README.md
@@ -10,7 +10,8 @@ The DataHub integration for dbt covers core metadata entities such as datasets/t
 2. It generates column lineage between the `dbt` nodes (e.g. when a model/snapshot depends on a dbt source or ephemeral model) as well as lineage between the `dbt` nodes and the underlying target platform nodes (e.g. BigQuery Table -> dbt source, dbt model -> BigQuery table/view).
 3. It automatically generates "sibling" relationships between the dbt nodes and the target / data warehouse nodes. These nodes will show up in the UI with both platform logos.
 4. We also support automated actions (like add a tag, term or owner) based on properties defined in dbt meta.
-   :::
+
+:::
 
 ## Concept Mapping
 

--- a/metadata-ingestion/docs/sources/fabric-onelake/fabric-onelake_pre.md
+++ b/metadata-ingestion/docs/sources/fabric-onelake/fabric-onelake_pre.md
@@ -8,7 +8,8 @@ The `fabric-onelake` module ingests metadata from Fabric Onelake into DataHub. I
 2. **Grant permissions** - Ensure your identity has `Workspace.Read.All` and workspace access
 3. **Configure recipe** - Use `fabric-onelake_recipe.yml` as a template
 4. **Run ingestion** - Execute `datahub ingest -c fabric-onelake_recipe.yml`
-   :::
+
+:::
 
 #### Key Features
 

--- a/metadata-ingestion/docs/sources/mssql/mssql_pre.md
+++ b/metadata-ingestion/docs/sources/mssql/mssql_pre.md
@@ -9,7 +9,8 @@ Two source types are available:
 - `mssql`: Uses python-tds library (pure Python, easier to install)
 - `mssql-odbc`: Uses pyodbc library (required for encryption, Azure managed services)
 - If you need encryption (e.g., for Azure SQL), use source type `mssql-odbc` and configure `uri_args` with your ODBC driver settings.
-  :::
+
+:::
 
 ### Prerequisites
 

--- a/metadata-ingestion/docs/sources/presto/presto_pre.md
+++ b/metadata-ingestion/docs/sources/presto/presto_pre.md
@@ -62,7 +62,8 @@ source:
 **For complete details**, see:
 
 - [Hive Metastore Connector Documentation](../hive-metastore)
-  :::
+
+:::
 
 #### Related Documentation
 


### PR DESCRIPTION
## Summary

We have markdown linting and prettier, but this doesn't catch docusaurus issues like `admonitions` being misformatted. 

That's how we end up with issues like

This
<img width="1021" height="575" alt="image" src="https://github.com/user-attachments/assets/e9e7fdd6-f823-4a73-b1da-0fa75c28b1c1" />

or this

<img width="989" height="650" alt="image" src="https://github.com/user-attachments/assets/d0617726-961f-426b-922e-719672cc4107" />

I am adding some lightweight (0.34s runtime) linting rules to catch common docusaurus issues. 

Additionally, I ran this linter and fixed all of the issues it flagged (including the ones in the screenshots above)