### PR TITLE
feat(dev): multi-worktree isolation and remote runner plugin for datahub-dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -593,6 +593,19 @@ eval $(scripts/dev/datahub-dev.sh shell-env)
 | 2    | 10080 | 11002    | First remote instance     |
 | …    | …     | …        | Each worktree is isolated |
 
+**Backwards compatibility / opting out of isolation** — if the new per-worktree
+project names cause problems (lost data in old volumes, tooling that expects
+`datahub-*` container names, CI environments that don't need isolation), set
+`compose_project` in `~/.datahub/dev/config.json`:
+
+```json
+{ "compose_project": "datahub" }
+```
+
+This reverts to the old single-instance behaviour: one `datahub` Docker project,
+same container names, existing volumes fully accessible. The env var
+`COMPOSE_PROJECT_NAME=datahub` has the same effect without touching the config file.
+
 **Runner interface** — a runner is any executable that speaks four verbs:
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -468,8 +468,9 @@ A stdlib-only Python CLI for agent-driven development. No venv needed — runs w
 scripts/dev/datahub-dev.sh <command>
 ```
 
-Run `scripts/dev/datahub-dev.sh --help` to see all available subcommands (`start`, `stop`, `setup`,
-`frontend`, `docs`, `status`, `wait`, `rebuild`, `test`, `flag list/get`, `env`, `sync-flags`, `reset`, `nuke`).
+Run `scripts/dev/datahub-dev.sh --help` to see all available subcommands (`start`, `stop`, `suspend`,
+`setup`, `frontend`, `docs`, `status`, `wait`, `rebuild`, `test`, `flag list/get`, `env`,
+`sync-flags`, `reset`, `nuke`, `instances list/clean`, `shell-env`).
 
 ### End-to-End Workflow
 
@@ -528,6 +529,82 @@ or after a fresh clone.
 
 When starting, `datahub-dev start` automatically detects and stops conflicting DataHub instances
 from other worktrees/compose projects that occupy the same ports.
+
+### Remote Runners
+
+`datahub-dev.sh` supports a **runner plugin** that proxies operations to a remote machine
+(EC2, Kubernetes pod, or any SSH-accessible host) instead of running Docker locally.
+
+**Configure a runner** in `~/.datahub/dev/config.json`:
+
+```json
+{
+  "max_local_instances": 2,
+  "max_remote_instances": 10,
+  "runner": "/path/to/your-runner.sh"
+}
+```
+
+Or export `DATAHUB_RUNNER=/path/to/runner.sh` in your shell for a one-off session.
+
+**Remote lifecycle** (all commands work identically to local once a runner is set):
+
+```bash
+# One-time bootstrap — provisions the remote environment
+scripts/dev/datahub-dev.sh setup --remote
+
+# Start — syncs changed local files, runs quickstartDebug on the remote,
+#          then sets up port tunnels so local ports reach the remote instance
+scripts/dev/datahub-dev.sh start
+
+# Stop containers only (remote compute keeps running)
+scripts/dev/datahub-dev.sh stop
+
+# Stop containers AND halt the remote compute (no billing while suspended).
+# 'start' will automatically resume the instance when needed.
+scripts/dev/datahub-dev.sh suspend
+
+# All other commands (status, wait, rebuild, test, flag, env, nuke, …)
+# proxy through the runner transparently — use them exactly as you would locally.
+scripts/dev/datahub-dev.sh status
+```
+
+**Multi-instance management** — each git worktree gets its own isolated instance
+(separate Docker project, volumes, and port assignment):
+
+```bash
+# List all registered instances (local and remote) with their ports and status
+scripts/dev/datahub-dev.sh instances list
+
+# Remove stale entries for worktrees that no longer exist
+scripts/dev/datahub-dev.sh instances clean
+
+# Print export statements for the current instance's CLI environment
+eval $(scripts/dev/datahub-dev.sh shell-env)
+# → sets DATAHUB_GMS_URL to the correct local port (tunnel or direct)
+```
+
+**Port assignment** — each instance gets a slot; ports = base + slot × 1000:
+
+| Slot | GMS   | Frontend | Notes                     |
+| ---- | ----- | -------- | ------------------------- |
+| 0    | 8080  | 9002     | First local instance      |
+| 1    | 9080  | 10002    | Second local instance     |
+| 2    | 10080 | 11002    | First remote instance     |
+| …    | …     | …        | Each worktree is isolated |
+
+**Runner interface** — a runner is any executable that speaks four verbs:
+
+```bash
+runner init                        # one-time environment bootstrap
+runner sync                        # push changed local files to the remote
+runner exec -- <cmd> [args...]     # execute a command in the remote workspace
+runner tunnel <local:remote> ...   # set up port forwarding
+runner resume                      # start compute if stopped (no-op if running)
+runner suspend                     # stop containers + halt compute
+```
+
+A reference Kubernetes runner is at `scripts/dev/runners/k8s.sh`.
 
 ### Recovery Escalation
 

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -10,7 +10,7 @@ apply from: "../gradle/versioning/versioning.gradle"
 
 ext {
     compose_base = "profiles/docker-compose.yml"
-    project_name = "datahub"
+    project_name = System.getenv("COMPOSE_PROJECT_NAME") ?: "datahub"
 
     backend_profile_modules = [
             ':datahub-upgrade',

--- a/docker/profiles/docker-compose.gms.yml
+++ b/docker/profiles/docker-compose.gms.yml
@@ -209,7 +209,7 @@ x-datahub-mae-consumer-service: &datahub-mae-consumer-service
   hostname: datahub-mae-consumer
   image: ${DATAHUB_MAE_CONSUMER_IMAGE:-${DATAHUB_REPO:-acryldata}/datahub-mae-consumer}:${DATAHUB_MAE_VERSION:-${DATAHUB_VERSION:-head}}
   ports:
-    - 9091:9091
+    - ${DATAHUB_MAPPED_MAE_CONSUMER_PORT:-9091}:9091
   expose:
     - 4319
   env_file:
@@ -240,7 +240,7 @@ x-datahub-mce-consumer-service: &datahub-mce-consumer-service
   hostname: datahub-mce-consumer
   image: ${DATAHUB_MCE_CONSUMER_IMAGE:-${DATAHUB_REPO:-acryldata}/datahub-mce-consumer}:${DATAHUB_MCE_VERSION:-${DATAHUB_VERSION:-head}}
   ports:
-    - 9090:9090
+    - ${DATAHUB_MAPPED_MCE_CONSUMER_PORT:-9090}:9090
   expose:
     - 4319
   env_file:
@@ -258,8 +258,8 @@ x-datahub-mce-consumer-service-dev: &datahub-mce-consumer-service-dev
   <<: *datahub-mce-consumer-service
   image: ${DATAHUB_MCE_CONSUMER_IMAGE:-${DATAHUB_REPO:-acryldata}/datahub-mce-consumer}:${DATAHUB_MCE_VERSION:-${DATAHUB_VERSION:-debug}}
   ports:
-    - 9090:9090
-    - 5009:5009
+    - ${DATAHUB_MAPPED_MCE_CONSUMER_PORT:-9090}:9090
+    - ${DATAHUB_MAPPED_MCE_DEBUG_PORT:-5009}:5009
   environment: &datahub-mce-consumer-env-dev
     <<: [*datahub-dev-telemetry-env, *datahub-mce-consumer-env]
     ENTITY_VERSIONING_ENABLED: ${ENTITY_VERSIONING_ENABLED:-true}

--- a/metadata-integration/java/datahub-client/src/main/resources/MetadataChangeProposal.avsc
+++ b/metadata-integration/java/datahub-client/src/main/resources/MetadataChangeProposal.avsc
@@ -173,11 +173,6 @@
         "doc" : "Aspect version\n   Initial implementation will use the aspect version's number, however stored as\n   a string in the case where a different aspect versioning scheme is later adopted.",
         "default" : null
       }, {
-        "name" : "schemaVersion",
-        "type" : [ "null", "long" ],
-        "doc" : "Schema version of the aspect data model. Used to determine aspects that need migrations.\nDefaults to 1 when not present as a baseline. Incremented when an aspect is modified.",
-        "default" : null
-      }, {
         "name" : "aspectCreated",
         "type" : [ "null", {
           "type" : "record",

--- a/metadata-integration/java/datahub-event/src/main/resources/MetadataChangeProposal.avsc
+++ b/metadata-integration/java/datahub-event/src/main/resources/MetadataChangeProposal.avsc
@@ -173,11 +173,6 @@
         "doc" : "Aspect version\n   Initial implementation will use the aspect version's number, however stored as\n   a string in the case where a different aspect versioning scheme is later adopted.",
         "default" : null
       }, {
-        "name" : "schemaVersion",
-        "type" : [ "null", "long" ],
-        "doc" : "Schema version of the aspect data model. Used to determine aspects that need migrations.\nDefaults to 1 when not present as a baseline. Incremented when an aspect is modified.",
-        "default" : null
-      }, {
         "name" : "aspectCreated",
         "type" : [ "null", {
           "type" : "record",

--- a/scripts/dev/datahub-dev.sh
+++ b/scripts/dev/datahub-dev.sh
@@ -4,23 +4,35 @@
 #   scripts/datahub-dev.sh rebuild --wait
 # etc.
 
-# Inject runner path from ~/.datahub/dev/config.json when not already set and
-# not running on a remote machine (DATAHUB_REMOTE_EXEC=1 means we are already
-# on the remote side of a runner invocation — no further proxying).
-if [ -z "$DATAHUB_RUNNER" ] && [ "$DATAHUB_REMOTE_EXEC" != "1" ]; then
-  DATAHUB_RUNNER=$(python3 - <<'EOF' 2>/dev/null
-import json, pathlib
+# Read per-user config from ~/.datahub/dev/config.json.
+# Reads two keys (runner, compose_project) in a single Python call to avoid
+# paying the interpreter startup cost twice.
+if [ "$DATAHUB_REMOTE_EXEC" != "1" ]; then
+  _dh_cfg=$(python3 - <<'EOF' 2>/dev/null
+import json, pathlib, sys
 cfg = pathlib.Path.home() / ".datahub/dev/config.json"
 try:
     d = json.loads(cfg.read_text())
     r = d.get("runner", "")
+    p = d.get("compose_project", "")
     if r:
-        print(str(pathlib.Path(r).expanduser()))
+        r = str(pathlib.Path(r).expanduser())
+    print(r)
+    print(p)
 except Exception:
-    pass
+    print("")
+    print("")
 EOF
 )
-  [ -n "$DATAHUB_RUNNER" ] && export DATAHUB_RUNNER
+  if [ -z "$DATAHUB_RUNNER" ]; then
+    DATAHUB_RUNNER=$(echo "$_dh_cfg" | sed -n '1p')
+    [ -n "$DATAHUB_RUNNER" ] && export DATAHUB_RUNNER
+  fi
+  if [ -z "$COMPOSE_PROJECT_NAME" ]; then
+    COMPOSE_PROJECT_NAME=$(echo "$_dh_cfg" | sed -n '2p')
+    [ -n "$COMPOSE_PROJECT_NAME" ] && export COMPOSE_PROJECT_NAME
+  fi
+  unset _dh_cfg
 fi
 
 # When a runner is configured and we're not already on the remote side,

--- a/scripts/dev/datahub-dev.sh
+++ b/scripts/dev/datahub-dev.sh
@@ -3,4 +3,44 @@
 #   scripts/datahub-dev.sh status
 #   scripts/datahub-dev.sh rebuild --wait
 # etc.
+
+# Inject runner path from ~/.datahub/dev/config.json when not already set and
+# not running on a remote machine (DATAHUB_REMOTE_EXEC=1 means we are already
+# on the remote side of a runner invocation — no further proxying).
+if [ -z "$DATAHUB_RUNNER" ] && [ "$DATAHUB_REMOTE_EXEC" != "1" ]; then
+  DATAHUB_RUNNER=$(python3 - <<'EOF' 2>/dev/null
+import json, pathlib
+cfg = pathlib.Path.home() / ".datahub/dev/config.json"
+try:
+    d = json.loads(cfg.read_text())
+    r = d.get("runner", "")
+    if r:
+        print(str(pathlib.Path(r).expanduser()))
+except Exception:
+    pass
+EOF
+)
+  [ -n "$DATAHUB_RUNNER" ] && export DATAHUB_RUNNER
+fi
+
+# When a runner is configured and we're not already on the remote side,
+# proxy ALL commands through the runner — EXCEPT the ones that are inherently
+# local (managing the local registry or printing local connection info).
+# 'start' and 'setup --remote' are handled specially inside datahub_dev.py
+# itself, so they also skip this proxy and reach Python directly.
+if [ -n "$DATAHUB_RUNNER" ] && [ "$DATAHUB_REMOTE_EXEC" != "1" ]; then
+  case "${1:-}" in
+    instances|shell-env|start|setup|suspend)
+      # Local-aware commands: let Python handle them (start/setup/suspend have
+      # their own runner logic; instances/shell-env read the local registry).
+      ;;
+    *)
+      # Everything else (stop, reset, nuke, status, wait, rebuild, flag, env,
+      # sync-flags, test, docs, frontend) runs on the remote.
+      exec "$DATAHUB_RUNNER" exec -- \
+        env DATAHUB_REMOTE_EXEC=1 "$(realpath "$0")" "$@"
+      ;;
+  esac
+fi
+
 exec uv run --python 3.11 --no-project "$(dirname "$0")/datahub_dev.py" "$@"

--- a/scripts/dev/datahub_dev.py
+++ b/scripts/dev/datahub_dev.py
@@ -21,20 +21,30 @@ Usage:
     python3 scripts/dev/datahub_dev.py sync-flags
     python3 scripts/dev/datahub_dev.py reset
     python3 scripts/dev/datahub_dev.py nuke [--keep-data]
+    python3 scripts/dev/datahub_dev.py instances list
+    python3 scripts/dev/datahub_dev.py instances clean
+    python3 scripts/dev/datahub_dev.py shell-env
+
+Remote runner (set DATAHUB_RUNNER or 'runner' in ~/.datahub/dev/config.json):
+    python3 scripts/dev/datahub_dev.py setup --remote   # one-time remote init
+    python3 scripts/dev/datahub_dev.py start            # sync + start remote + tunnel
 """
 
 import argparse
 import dataclasses
+import datetime
+import hashlib
 import json
 import os
 import re
+import socket
 import subprocess
 import sys
 import time
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 
 # ---------------------------------------------------------------------------
@@ -112,15 +122,271 @@ DEV_ENV_FILE = DOCKER_DIR / f"datahub-dev-{_get_branch_slug()}.env"
 # covered by the *.env entry in .gitignore — no new gitignore rules needed.
 DEV_ENV_SENTINEL = DEV_ENV_FILE.with_name(DEV_ENV_FILE.stem + ".applied.env")
 
-GMS_URL = os.environ.get("DATAHUB_GMS_URL", "http://localhost:8080")
-FRONTEND_URL = os.environ.get("DATAHUB_FRONTEND_URL", "http://localhost:9002")
-COMPOSE_PROJECT = os.environ.get("DOCKER_COMPOSE_PROJECT_NAME", "datahub")
-
 DEFAULT_TIMEOUT = 300  # seconds
 POLL_INTERVAL = 3  # seconds
 
-# Ports that DataHub binds on the host. Used to detect conflicting instances.
-DATAHUB_CRITICAL_PORTS = (8080, 9002, 3306, 9200, 9092, 5001, 5002, 5003)
+
+# ---------------------------------------------------------------------------
+# Worktree identity & multi-instance support
+# ---------------------------------------------------------------------------
+
+
+def _get_worktree_id() -> str:
+    """Return a stable 6-char hex ID derived from the repo root path.
+
+    Each git worktree has a unique absolute path, so this uniquely identifies
+    the worktree regardless of which branch is checked out.
+    """
+    return hashlib.sha256(str(REPO_ROOT).encode()).hexdigest()[:6]
+
+
+WORKTREE_ID: str = _get_worktree_id()
+
+# When DATAHUB_REMOTE_EXEC=1 this script is running ON the remote machine
+# (invoked by the runner's "exec" verb).  Runner logic is suppressed so the
+# script behaves as a plain local executor on that machine.
+REMOTE_EXEC: bool = os.environ.get("DATAHUB_REMOTE_EXEC") == "1"
+
+# Path to the runner executable.  Cleared when running remotely so a runner
+# configured on the remote machine doesn't cause recursive proxying.
+RUNNER: str = "" if REMOTE_EXEC else os.environ.get("DATAHUB_RUNNER", "")
+
+# Docker Compose project name. Allows explicit override (power-user escape
+# hatch); defaults to a per-worktree identifier so all Docker objects
+# (containers, volumes, networks) are automatically namespaced.
+COMPOSE_PROJECT: str = os.environ.get("COMPOSE_PROJECT_NAME") or f"dh-{WORKTREE_ID}"
+
+# Config and instance registry live under ~/.datahub/dev/ so they survive
+# across worktrees and are independent of the repo directory.
+DATAHUB_DEV_DIR: Path = Path.home() / ".datahub" / "dev"
+INSTANCES_FILE: Path = DATAHUB_DEV_DIR / "instances.json"
+CONFIG_FILE: Path = DATAHUB_DEV_DIR / "config.json"
+
+# Default host-port for each mapped service (slot 0).  Slot N adds N * SLOT_OFFSET.
+PORT_BASE: Dict[str, int] = {
+    "DATAHUB_MAPPED_GMS_PORT": 8080,
+    "DATAHUB_MAPPED_FRONTEND_PORT": 9002,
+    "DATAHUB_MAPPED_MYSQL_PORT": 3306,
+    "DATAHUB_MAPPED_ELASTIC_PORT": 9200,
+    "DATAHUB_MAPPED_KAFKA_BROKER_PORT": 9092,
+    "DATAHUB_MAPPED_GMS_DEBUG_PORT": 5001,
+    "DATAHUB_MAPPED_FRONTEND_DEBUG_PORT": 5002,
+    "DATAHUB_MAPPED_UPGRADE_DEBUG_PORT": 5003,
+    "DATAHUB_MAPPED_GMS_MANAGEMENT_PORT": 4319,
+    "DATAHUB_MAPPED_NEO4J_HTTP_PORT": 7474,
+    "DATAHUB_MAPPED_NEO4J_BOLT_PORT": 7687,
+    "DATAHUB_MAPPED_LOCALSTACK_PORT": 4566,
+    "DATAHUB_MAPPED_MAE_CONSUMER_PORT": 9091,
+    "DATAHUB_MAPPED_MCE_CONSUMER_PORT": 9090,
+    "DATAHUB_MAPPED_MCE_DEBUG_PORT": 5009,
+}
+SLOT_OFFSET: int = 1000
+
+
+def _load_registry() -> Dict[str, Any]:
+    """Read ~/.datahub/dev/instances.json; return empty structure if absent."""
+    if not INSTANCES_FILE.exists():
+        return {"version": 1, "instances": {}}
+    try:
+        data = json.loads(INSTANCES_FILE.read_text())
+        if "instances" not in data:
+            data["instances"] = {}
+        return data
+    except (json.JSONDecodeError, OSError):
+        return {"version": 1, "instances": {}}
+
+
+def _save_registry(data: Dict[str, Any]) -> None:
+    """Atomically write the instance registry."""
+    DATAHUB_DEV_DIR.mkdir(parents=True, exist_ok=True)
+    tmp = INSTANCES_FILE.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2) + "\n")
+    tmp.rename(INSTANCES_FILE)
+
+
+def _load_dev_config() -> Dict[str, Any]:
+    """Read ~/.datahub/dev/config.json; return defaults if absent.
+
+    Keys:
+      max_local_instances   — concurrent local docker slots (default 2)
+      max_remote_instances  — concurrent remote runner slots (default 10)
+      runner                — path to runner executable (read by datahub-dev.sh)
+    """
+    defaults: Dict[str, Any] = {"max_local_instances": 2, "max_remote_instances": 10}
+    if not CONFIG_FILE.exists():
+        return defaults
+    try:
+        data = json.loads(CONFIG_FILE.read_text())
+        return {**defaults, **data}
+    except (json.JSONDecodeError, OSError):
+        return defaults
+
+
+def _get_instance() -> Optional[Dict[str, Any]]:
+    """Return this worktree's instance record from the registry, or None."""
+    return _load_registry()["instances"].get(WORKTREE_ID)
+
+
+def _compute_ports(slot: int) -> Dict[str, int]:
+    """Compute port assignments for a slot. Slot 0 returns the defaults."""
+    return {k: v + slot * SLOT_OFFSET for k, v in PORT_BASE.items()}
+
+
+def _is_port_free(port: int) -> bool:
+    """Return True when no process is listening on the given port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.5)
+        try:
+            s.connect(("127.0.0.1", port))
+            return False
+        except (ConnectionRefusedError, OSError):
+            return True
+
+
+def _pick_slot(registry: Dict[str, Any], remote: bool = False) -> int:
+    """Return the lowest available slot for a local or remote instance.
+
+    Local slots:  0 … max_local_instances-1   (ports 8080, 18080, …)
+    Remote slots: max_local … max_local+max_remote-1  (tunnel ports only;
+                  docker on the remote machine always runs on default ports)
+    """
+    dev_config = _load_dev_config()
+    max_local = int(dev_config.get("max_local_instances", 2))
+    max_remote = int(dev_config.get("max_remote_instances", 10))
+
+    slot_start = max_local if remote else 0
+    slot_end = max_local + max_remote if remote else max_local
+
+    used_slots = {
+        v["slot"]
+        for k, v in registry.get("instances", {}).items()
+        if k != WORKTREE_ID and isinstance(v.get("slot"), int)
+    }
+    for slot in range(slot_start, slot_end):
+        if slot not in used_slots:
+            return slot
+
+    kind = "remote" if remote else "local"
+    limit = max_remote if remote else max_local
+    key = "max_remote_instances" if remote else "max_local_instances"
+    raise RuntimeError(
+        f"All {limit} {kind} instance slots are in use. "
+        f"Stop an existing instance or increase {key} in "
+        "~/.datahub/dev/config.json."
+    )
+
+
+def _register_remote_instance(runner: str, slot: int) -> Dict[str, Any]:
+    """Write a remote instance entry into the LOCAL registry.
+
+    For remote instances the "ports" field holds the LOCAL tunnel ports
+    (slot-offset).  Docker on the remote machine always runs on PORT_BASE
+    defaults — the slot offset is only used for local port-forwarding.
+    """
+    registry = _load_registry()
+    local_ports = _compute_ports(slot)  # slot-offset → used as tunnel local ports
+    instance: Dict[str, Any] = {
+        "worktree_path": str(REPO_ROOT),
+        "project_name": COMPOSE_PROJECT,
+        "type": "remote",
+        "runner": runner,
+        "slot": slot,
+        "ports": local_ports,
+        "created_at": datetime.datetime.utcnow().isoformat() + "Z",
+    }
+    registry["instances"][WORKTREE_ID] = instance
+    _save_registry(registry)
+    return instance
+
+
+def _compute_tunnel_pairs(local_ports: Dict[str, int]) -> List[str]:
+    """Build local:remote port-pair strings for the runner's tunnel verb.
+
+    The remote container always binds PORT_BASE defaults; the slot offset
+    determines only the local (forwarded) port.
+    """
+    pairs = []
+    for key in sorted(local_ports):
+        local_port = local_ports[key]
+        remote_port = PORT_BASE.get(key, local_port)
+        pairs.append(f"{local_port}:{remote_port}")
+    return pairs
+
+
+def _register_instance(slot: int, ports: Dict[str, int]) -> Dict[str, Any]:
+    """Add or update this worktree's LOCAL instance entry in the registry."""
+    # Re-read to catch concurrent writes before committing.
+    registry = _load_registry()
+    instance: Dict[str, Any] = {
+        "worktree_path": str(REPO_ROOT),
+        "project_name": COMPOSE_PROJECT,
+        "type": "local",
+        "slot": slot,
+        "ports": ports,
+        "created_at": datetime.datetime.utcnow().isoformat() + "Z",
+    }
+    registry["instances"][WORKTREE_ID] = instance
+    _save_registry(registry)
+    return instance
+
+
+def _count_running_dh_instances() -> int:
+    """Count dh-* compose projects (excluding our own) with running containers."""
+    result = subprocess.run(
+        ["docker", "ps", "--format", "{{json .}}"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        return 0
+    projects: Set[str] = set()
+    for line in result.stdout.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            container = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        labels_str = container.get("Labels", "")
+        for label in labels_str.split(","):
+            if label.startswith("com.docker.compose.project="):
+                proj = label.split("=", 1)[1]
+                if proj.startswith("dh-") and proj != COMPOSE_PROJECT:
+                    projects.add(proj)
+                break
+    return len(projects)
+
+
+def _write_ports_to_env_file(ports: Dict[str, int]) -> None:
+    """Upsert all port env vars into DEV_ENV_FILE so docker compose picks them up."""
+    if not DEV_ENV_FILE.exists():
+        DEV_ENV_FILE.touch()
+    existing_lines = DEV_ENV_FILE.read_text().splitlines()
+    port_keys = set(ports.keys())
+    new_lines = [
+        line
+        for line in existing_lines
+        if not any(line.strip().startswith(f"{k}=") for k in port_keys)
+    ]
+    for k, v in sorted(ports.items()):
+        new_lines.append(f"{k}={v}")
+    DEV_ENV_FILE.write_text("\n".join(new_lines) + "\n")
+
+
+def _gms_url() -> str:
+    """Return the GMS base URL for this worktree, reading the instance registry."""
+    inst = _get_instance()
+    port = inst["ports"].get("DATAHUB_MAPPED_GMS_PORT", 8080) if inst else 8080
+    return os.environ.get("DATAHUB_GMS_URL", f"http://localhost:{port}")
+
+
+def _frontend_url() -> str:
+    """Return the frontend base URL for this worktree, reading the instance registry."""
+    inst = _get_instance()
+    port = inst["ports"].get("DATAHUB_MAPPED_FRONTEND_PORT", 9002) if inst else 9002
+    return os.environ.get("DATAHUB_FRONTEND_URL", f"http://localhost:{port}")
 
 
 # ---------------------------------------------------------------------------
@@ -161,11 +427,11 @@ def _default_config() -> DevToolingConfig:
         services=[
             ServiceConfig(
                 "gms",
-                f"{GMS_URL}/health",
-                status_url=f"{GMS_URL}/health/detailed",
+                f"{_gms_url()}/health",
+                status_url=f"{_gms_url()}/health/detailed",
                 required=True,
             ),
-            ServiceConfig("frontend", f"{FRONTEND_URL}/admin", required=True),
+            ServiceConfig("frontend", f"{_frontend_url()}/admin", required=True),
         ],
         gradle_reload_task=":docker:reload",
         gradle_reload_env_task=":docker:reloadEnv",
@@ -207,6 +473,23 @@ def _log(msg: str) -> None:
 CONFIG: DevToolingConfig = _load_config()
 
 
+def _rebuild_config_services() -> None:
+    """Re-point CONFIG.services at the current instance's allocated ports.
+
+    Called after port allocation in cmd_start() so that cmd_wait() health-checks
+    the correct ports when a new instance is being registered for the first time.
+    """
+    gms = _gms_url()
+    frontend = _frontend_url()
+    for svc in CONFIG.services:
+        if svc.name == "gms":
+            svc.health_url = f"{gms}/health"
+            if svc.status_url:
+                svc.status_url = f"{gms}/health/detailed"
+        elif svc.name == "frontend":
+            svc.health_url = f"{frontend}/admin"
+
+
 # ---------------------------------------------------------------------------
 # Utility helpers
 # ---------------------------------------------------------------------------
@@ -225,16 +508,20 @@ def _http_get(url: str, timeout: int = 5) -> Tuple[int, str]:
 
 
 def _dev_env() -> Dict[str, str]:
-    """Return a copy of os.environ with DATAHUB_LOCAL_COMMON_ENV injected.
+    """Return a copy of os.environ with DATAHUB_LOCAL_COMMON_ENV and
+    COMPOSE_PROJECT_NAME injected.
 
-    This ensures every subprocess we spawn (Gradle, docker compose, pytest)
-    sees the managed env file, so docker compose profiles pick it up via
-    ``env_file: ${DATAHUB_LOCAL_COMMON_ENV:-empty.env}``.
+    Every subprocess (Gradle, docker compose, pytest) picks up:
+    - DATAHUB_LOCAL_COMMON_ENV: the per-branch env file read by docker compose profiles
+    - COMPOSE_PROJECT_NAME: the per-worktree project name read by Gradle's docker-compose
+      plugin and by docker compose itself
     """
     env = os.environ.copy()
     if not DEV_ENV_FILE.exists():
         DEV_ENV_FILE.touch()
     env["DATAHUB_LOCAL_COMMON_ENV"] = str(DEV_ENV_FILE)
+    # Only inject if not already set (respects explicit user override)
+    env.setdefault("COMPOSE_PROJECT_NAME", COMPOSE_PROJECT)
     return env
 
 
@@ -279,11 +566,18 @@ def _run_docker_compose_ps() -> List[Dict[str, Any]]:
     return containers
 
 
-def _find_conflicting_projects() -> Dict[str, List[str]]:
-    """Find other compose projects with containers bound to our critical ports.
+def _find_conflicting_projects(our_ports: Set[int]) -> Dict[str, List[str]]:
+    """Find non-DataHub compose projects occupying ports this instance needs.
 
-    Returns a dict mapping project name -> list of port descriptions (e.g. ["8080", "9002"]).
-    Skips containers belonging to our own COMPOSE_PROJECT.
+    Returns a dict mapping project name -> list of conflicting host ports.
+
+    Skips:
+    - Our own COMPOSE_PROJECT (already running / mid-restart)
+    - Any project whose name starts with "dh-" — those are sibling worktrees
+      managed by this tool; stopping them would disrupt another developer's session.
+
+    Legacy "datahub" projects (pre-isolation) are treated as external conflicts
+    and will be auto-stopped, providing a clean migration path.
     """
     result = _run(["docker", "ps", "--format", "{{json .}}"])
     if result.returncode != 0:
@@ -304,9 +598,9 @@ def _find_conflicting_projects() -> Dict[str, List[str]]:
         ports_str = container.get("Ports", "")
         labels_str = container.get("Labels", "")
 
-        # Extract host-side ports that match our critical ports
+        # Extract host-side ports that overlap with the ports we need
         host_ports = port_pattern.findall(ports_str)
-        matching = [p for p in host_ports if int(p) in DATAHUB_CRITICAL_PORTS]
+        matching = [p for p in host_ports if int(p) in our_ports]
         if not matching:
             continue
 
@@ -317,12 +611,12 @@ def _find_conflicting_projects() -> Dict[str, List[str]]:
                 project = label.split("=", 1)[1]
                 break
 
-        if not project or project == COMPOSE_PROJECT:
+        # Skip ourselves and sibling dh-* worktrees
+        if not project or project == COMPOSE_PROJECT or project.startswith("dh-"):
             continue
 
         conflicts.setdefault(project, []).extend(matching)
 
-    # Deduplicate port lists
     return {proj: sorted(set(ports)) for proj, ports in conflicts.items()}
 
 
@@ -610,7 +904,7 @@ def cmd_test(args: argparse.Namespace) -> int:
 
     # Pre-check: is the stack ready?
     _log("Checking stack health...")
-    gms_status, _ = _http_get(f"{GMS_URL}/health", timeout=3)
+    gms_status, _ = _http_get(f"{_gms_url()}/health", timeout=3)
     if gms_status != 200:
         _log(f"WARNING: GMS is not healthy (status={gms_status}). Tests may fail.")
         _log("Run 'python3 scripts/datahub_dev.py wait' to wait for readiness.")
@@ -635,18 +929,19 @@ def cmd_test(args: argparse.Namespace) -> int:
     # Set up environment variables (replicate set-test-env-vars.sh and set-cypress-creds.sh)
     env = _dev_env()
     gms_base_path = env.get("DATAHUB_GMS_BASE_PATH", "")
+    instance_gms_url = _gms_url()
     if gms_base_path == "/" or not gms_base_path:
         env.setdefault(
             "DATAHUB_KAFKA_SCHEMA_REGISTRY_URL",
-            "http://localhost:8080/schema-registry/api",
+            f"{instance_gms_url}/schema-registry/api",
         )
-        env.setdefault("DATAHUB_GMS_URL", "http://localhost:8080")
+        env.setdefault("DATAHUB_GMS_URL", instance_gms_url)
     else:
         env.setdefault(
             "DATAHUB_KAFKA_SCHEMA_REGISTRY_URL",
-            f"http://localhost:8080{gms_base_path}/schema-registry/api",
+            f"{instance_gms_url}{gms_base_path}/schema-registry/api",
         )
-        env.setdefault("DATAHUB_GMS_URL", f"http://localhost:8080{gms_base_path}")
+        env.setdefault("DATAHUB_GMS_URL", f"{instance_gms_url}{gms_base_path}")
 
     # Cypress creds (used by some test fixtures)
     env.setdefault("ADMIN_USERNAME", "datahub")
@@ -727,7 +1022,7 @@ def _load_flag_classification() -> Dict[str, Any]:
 
 def cmd_flag_list(args: argparse.Namespace) -> int:
     """List all feature flags and their current live values."""
-    status_code, body = _http_get(f"{GMS_URL}/openapi/operations/dev/featureFlags")
+    status_code, body = _http_get(f"{_gms_url()}/openapi/operations/dev/featureFlags")
     if status_code != 200:
         _log(
             f"Failed to get feature flags (status={status_code}). Is GMS running with DEV_TOOLING_ENABLED=true?"
@@ -744,7 +1039,7 @@ def cmd_flag_list(args: argparse.Namespace) -> int:
 
 def cmd_flag_get(args: argparse.Namespace) -> int:
     """Get a specific feature flag value."""
-    status_code, body = _http_get(f"{GMS_URL}/openapi/operations/dev/featureFlags")
+    status_code, body = _http_get(f"{_gms_url()}/openapi/operations/dev/featureFlags")
     if status_code != 200:
         _log(f"Failed to get feature flags (status={status_code})")
         return 1
@@ -1090,7 +1385,21 @@ DEFAULT_SETUP_MODULE = "ingestion"
 
 
 def cmd_setup(args: argparse.Namespace) -> int:
-    """Install dev dependencies for a module."""
+    """Install dev dependencies for a module, or initialise a remote environment."""
+    if getattr(args, "remote", False):
+        if not RUNNER:
+            _log(
+                "ERROR: No runner configured. "
+                "Set DATAHUB_RUNNER or add 'runner' to ~/.datahub/dev/config.json."
+            )
+            return 1
+        _log("Initialising remote environment via runner (may take several minutes)...")
+        rc = _run([RUNNER, "init"], capture=False, timeout=1200).returncode
+        if rc == 0:
+            _log("Remote environment ready.")
+            _log("Next: datahub-dev.sh start  (syncs code and starts DataHub remotely)")
+        return rc
+
     module = args.module
 
     if module == "frontend":
@@ -1247,13 +1556,13 @@ def _clear_env_var(key: str) -> None:
     if not DEV_ENV_FILE.exists():
         return
     existing_lines = DEV_ENV_FILE.read_text().splitlines()
-    new_lines = [l for l in existing_lines if not l.strip().startswith(f"{key}=")]
+    new_lines = [
+        line for line in existing_lines if not line.strip().startswith(f"{key}=")
+    ]
     DEV_ENV_FILE.write_text("\n".join(new_lines) + "\n")
 
 
-def _wait_for_ollama_model_ready(
-    endpoint: str, model: str, timeout: int = 180
-) -> bool:
+def _wait_for_ollama_model_ready(endpoint: str, model: str, timeout: int = 180) -> bool:
     """
     Poll the embeddings endpoint until the model responds successfully.
 
@@ -1289,9 +1598,144 @@ def _wait_for_ollama_model_ready(
     return False
 
 
+def _cmd_start_remote(args: argparse.Namespace) -> int:
+    """Start DataHub on a remote machine via the configured runner.
+
+    Flow (all on the local machine):
+      1. Allocate a remote slot in the LOCAL registry (tunnel ports).
+      2. runner sync  — push code to the remote.
+      3. runner exec  — run datahub-dev.sh start on the remote (blocks until ready).
+      4. runner tunnel — forward remote default ports to local slot ports.
+    """
+    registry = _load_registry()
+    instance = registry["instances"].get(WORKTREE_ID)
+
+    if instance is None or instance.get("type") != "remote":
+        dev_config = _load_dev_config()
+        max_remote = int(dev_config.get("max_remote_instances", 10))
+        # Count already-registered remote slots (we can't easily check live status)
+        remote_count = sum(
+            1
+            for v in registry.get("instances", {}).values()
+            if v.get("type") == "remote" and v.get("worktree_path") != str(REPO_ROOT)
+        )
+        if remote_count >= max_remote:
+            _log(
+                f"ERROR: {max_remote} remote instance slots are in use "
+                "(limit: max_remote_instances in ~/.datahub/dev/config.json)."
+            )
+            _log("  Run: datahub-dev.sh instances list")
+            return 1
+        try:
+            slot = _pick_slot(registry, remote=True)
+        except RuntimeError as e:
+            _log(f"ERROR: {e}")
+            return 1
+        instance = _register_remote_instance(RUNNER, slot)
+        _rebuild_config_services()
+        gms_local = instance["ports"]["DATAHUB_MAPPED_GMS_PORT"]
+        fe_local = instance["ports"]["DATAHUB_MAPPED_FRONTEND_PORT"]
+        _log(f"Registered remote instance '{COMPOSE_PROJECT}' (slot {slot})")
+        _log(f"  Local GMS:      http://localhost:{gms_local}")
+        _log(f"  Local Frontend: http://localhost:{fe_local}")
+
+    # 1. Resume compute (no-op if already running; starts a stopped instance)
+    _log("Ensuring remote instance is running...")
+    _run([RUNNER, "resume"], capture=False, timeout=300)
+    # resume is best-effort — if the instance was already running the runner
+    # exits 0 immediately; if it was stopped it waits for SSH readiness.
+
+    # 2. Sync code
+    _log("Syncing code to remote...")
+    sync_rc = _run([RUNNER, "sync"], capture=False, timeout=300).returncode
+    if sync_rc != 0:
+        _log("ERROR: runner sync failed.")
+        return sync_rc
+
+    # 2. Start on remote — DATAHUB_REMOTE_EXEC=1 suppresses runner detection there
+    _log("Starting DataHub on remote machine (this may take a few minutes)...")
+    start_argv = ["env", "DATAHUB_REMOTE_EXEC=1", "scripts/dev/datahub-dev.sh", "start"]
+    if getattr(args, "ai", False):
+        start_argv.append("--ai")
+    if getattr(args, "no_ai", False):
+        start_argv.append("--no-ai")
+    ep = getattr(args, "embeddings_endpoint", None)
+    if ep:
+        start_argv += ["--embeddings-endpoint", ep]
+    em = getattr(args, "embeddings_model", None)
+    if em:
+        start_argv += ["--embeddings-model", em]
+    start_argv += ["--timeout", str(getattr(args, "timeout", DEFAULT_TIMEOUT))]
+
+    start_rc = _run(
+        [RUNNER, "exec", "--"] + start_argv, capture=False, timeout=1500
+    ).returncode
+    if start_rc != 0:
+        _log("Remote start failed. Check output above.")
+        return start_rc
+
+    # 3. Tunnel — map local slot ports to remote default ports
+    tunnel_pairs = _compute_tunnel_pairs(instance["ports"])
+    _log(f"Setting up port forwarding: {', '.join(tunnel_pairs)}")
+    tunnel_rc = _run(
+        [RUNNER, "tunnel"] + tunnel_pairs, capture=False, timeout=60
+    ).returncode
+    if tunnel_rc != 0:
+        _log(
+            "WARNING: runner tunnel returned non-zero. "
+            "You may need to set up port forwarding manually."
+        )
+
+    gms_port = instance["ports"]["DATAHUB_MAPPED_GMS_PORT"]
+    fe_port = instance["ports"]["DATAHUB_MAPPED_FRONTEND_PORT"]
+    _log(f"\nDataHub is ready on remote.  (instance: {COMPOSE_PROJECT})")
+    _log(f"  UI:  http://localhost:{fe_port}")
+    _log(f"  GMS: http://localhost:{gms_port}")
+    _log("  Set CLI env: eval $(datahub-dev.sh shell-env)")
+    return 0
+
+
 def cmd_start(args: argparse.Namespace) -> int:
     """Start (or restart) DataHub via quickstartDebug, then wait for readiness."""
-    conflicts = _find_conflicting_projects()
+    # Proxy to remote machine when a runner is configured.
+    if RUNNER:
+        return _cmd_start_remote(args)
+
+    # --- Per-worktree instance registration -----------------------------------
+    registry = _load_registry()
+    dev_config = _load_dev_config()
+    instance = registry["instances"].get(WORKTREE_ID)
+
+    if instance is None:
+        # This worktree has never started before — allocate a local slot and ports.
+        max_local = int(dev_config.get("max_local_instances", 2))
+        running_count = _count_running_dh_instances()
+        if running_count >= max_local:
+            _log(
+                f"ERROR: {max_local} local DataHub instance(s) already running "
+                "(limit: max_local_instances in ~/.datahub/dev/config.json)."
+            )
+            _log("  Stop an existing instance first, or increase max_local_instances.")
+            _log("  Run: datahub-dev.sh instances list")
+            return 1
+        try:
+            slot = _pick_slot(registry, remote=False)
+        except RuntimeError as e:
+            _log(f"ERROR: {e}")
+            return 1
+        ports = _compute_ports(slot)
+        instance = _register_instance(slot, ports)
+        _write_ports_to_env_file(ports)
+        # Update CONFIG.services URLs now that we know the allocated ports.
+        _rebuild_config_services()
+        _log(f"Registered worktree '{REPO_ROOT.name}' as instance '{COMPOSE_PROJECT}'")
+        _log(f"  GMS:      http://localhost:{ports['DATAHUB_MAPPED_GMS_PORT']}")
+        _log(f"  Frontend: http://localhost:{ports['DATAHUB_MAPPED_FRONTEND_PORT']}")
+    # --------------------------------------------------------------------------
+
+    # Conflict detection: stop any non-DataHub process occupying our ports.
+    our_ports: Set[int] = set(instance["ports"].values())
+    conflicts = _find_conflicting_projects(our_ports)
     if conflicts:
         _stop_conflicting_projects(conflicts)
 
@@ -1299,7 +1743,9 @@ def cmd_start(args: argparse.Namespace) -> int:
     ai_mode = getattr(args, "ai", False)
     no_ai_mode = getattr(args, "no_ai", False)
     embeddings_endpoint: str | None = getattr(args, "embeddings_endpoint", None)
-    embeddings_model: str = getattr(args, "embeddings_model", None) or _DEFAULT_EMBEDDING_MODEL
+    embeddings_model: str = (
+        getattr(args, "embeddings_model", None) or _DEFAULT_EMBEDDING_MODEL
+    )
 
     if no_ai_mode:
         _log("Clearing AI embedding env vars from dev env file...")
@@ -1355,13 +1801,21 @@ def cmd_start(args: argparse.Namespace) -> int:
     if rc != 0:
         return rc
 
+    # Print per-instance connection info so it's easy to find after a long startup.
+    _log(f"\nDataHub is ready.  (instance: {COMPOSE_PROJECT})")
+    _log(f"  UI:  {_frontend_url()}")
+    _log(f"  GMS: {_gms_url()}")
+    _log("  Set CLI env: eval $(datahub-dev.sh shell-env)")
+
     # In managed Ollama mode, wait for the model to be fully loaded before
     # returning — eliminates cold-start delay on the first semantic search query.
     if ai_mode and not no_ai_mode and embeddings_endpoint is None:
         host_endpoint = "http://localhost:11434/v1/embeddings"
         _log(f"Waiting for Ollama model '{embeddings_model}' to be ready...")
         if _wait_for_ollama_model_ready(host_endpoint, embeddings_model, timeout=300):
-            _log(f"Ollama model '{embeddings_model}' is ready — semantic search enabled.")
+            _log(
+                f"Ollama model '{embeddings_model}' is ready — semantic search enabled."
+            )
         else:
             _log(
                 f"WARNING: Timed out waiting for Ollama model '{embeddings_model}'. "
@@ -1396,6 +1850,150 @@ def cmd_sync_flags(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Command: suspend
+# ---------------------------------------------------------------------------
+
+
+def cmd_suspend(args: argparse.Namespace) -> int:
+    """Stop DataHub containers and suspend the remote compute instance.
+
+    Calls runner suspend, which stops Docker and then halts the EC2 instance
+    (or scales a K8s deployment to zero). No compute charges while suspended.
+    Data is preserved on the persistent volume.
+
+    Resume with: datahub-dev.sh start
+    """
+    if not RUNNER:
+        _log(
+            "ERROR: No runner configured — suspend only applies to remote instances. "
+            "Use 'stop' to halt local DataHub containers."
+        )
+        return 1
+    _log("Suspending remote instance (stopping DataHub + halting compute)...")
+    rc = _run([RUNNER, "suspend"], capture=False, timeout=180).returncode
+    if rc == 0:
+        _log("Suspended. No compute charges until next 'datahub-dev.sh start'.")
+    return rc
+
+
+# ---------------------------------------------------------------------------
+# Command: instances
+# ---------------------------------------------------------------------------
+
+
+def _cmd_instances_list(args: argparse.Namespace) -> int:
+    """Print all registered worktree instances (local and remote) as JSON."""
+    registry = _load_registry()
+    instances = registry.get("instances", {})
+    if not instances:
+        _log("No registered instances.")
+        print(json.dumps([], indent=2))
+        return 0
+
+    rows = []
+    for wt_id, inst in instances.items():
+        project = inst.get("project_name", f"dh-{wt_id}")
+        kind = inst.get("type", "local")
+
+        if kind == "remote":
+            # Ask the remote whether it's healthy rather than querying local docker.
+            runner_path = inst.get("runner", "")
+            running: Optional[bool] = None
+            if runner_path:
+                rc = _run(
+                    [runner_path, "exec", "--", "scripts/dev/datahub-dev.sh", "status"],
+                    timeout=15,
+                ).returncode
+                running = rc == 0
+        else:
+            # Local: query docker compose directly.
+            ps = _run(
+                ["docker", "compose", "-p", project, "ps", "--format", "json", "-a"]
+            )
+            running = False
+            if ps.returncode == 0 and ps.stdout.strip():
+                for line in ps.stdout.strip().splitlines():
+                    try:
+                        obj = json.loads(line)
+                        containers = obj if isinstance(obj, list) else [obj]
+                        if any(c.get("State") == "running" for c in containers):
+                            running = True
+                            break
+                    except json.JSONDecodeError:
+                        continue
+
+        gms_port = inst.get("ports", {}).get("DATAHUB_MAPPED_GMS_PORT")
+        fe_port = inst.get("ports", {}).get("DATAHUB_MAPPED_FRONTEND_PORT")
+        rows.append(
+            {
+                "id": wt_id,
+                "current": wt_id == WORKTREE_ID,
+                "type": kind,
+                "project": project,
+                "worktree_path": inst.get("worktree_path", "?"),
+                "slot": inst.get("slot"),
+                # For remote: these are local tunnel ports.
+                # For local: these are docker host ports.
+                "gms_port": gms_port,
+                "frontend_port": fe_port,
+                "runner": inst.get("runner"),
+                "running": running,
+                "created_at": inst.get("created_at"),
+            }
+        )
+
+    print(json.dumps(rows, indent=2))
+    return 0
+
+
+def _cmd_instances_clean(args: argparse.Namespace) -> int:
+    """Remove registry entries for worktrees that no longer exist on disk."""
+    registry = _load_registry()
+    instances = registry.get("instances", {})
+    to_remove = [
+        wt_id
+        for wt_id, inst in instances.items()
+        if inst.get("worktree_path") and not Path(inst["worktree_path"]).exists()
+    ]
+    if not to_remove:
+        _log("No stale instances found.")
+        return 0
+    for wt_id in to_remove:
+        inst = instances.pop(wt_id)
+        _log(f"Removed stale instance {wt_id} ({inst.get('worktree_path', '?')})")
+    registry["instances"] = instances
+    _save_registry(registry)
+    _log(f"Cleaned {len(to_remove)} stale instance(s).")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Command: shell-env
+# ---------------------------------------------------------------------------
+
+
+def cmd_shell_env(args: argparse.Namespace) -> int:
+    """Print export statements for the current worktree's DataHub CLI environment.
+
+    Usage: eval $(datahub-dev.sh shell-env)
+    """
+    gms = _gms_url()
+    print(f"export DATAHUB_GMS_URL={gms}")
+
+    # Propagate token if present in the dev env file.
+    if DEV_ENV_FILE.exists():
+        for line in DEV_ENV_FILE.read_text().splitlines():
+            stripped = line.strip()
+            if stripped.startswith("DATAHUB_GMS_TOKEN="):
+                token = stripped.split("=", 1)[1]
+                if token:
+                    print(f"export DATAHUB_GMS_TOKEN={token}")
+                break
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Argument parser
 # ---------------------------------------------------------------------------
 
@@ -1412,7 +2010,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     # setup
     setup_p = subparsers.add_parser(
-        "setup", help="Install dev dependencies for a module"
+        "setup",
+        help="Install dev dependencies for a module, or init a remote environment",
     )
     setup_p.add_argument(
         "module",
@@ -1420,6 +2019,14 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_SETUP_MODULE,
         choices=list(SETUP_MODULES.keys()),
         help=f"Module to set up (default: {DEFAULT_SETUP_MODULE})",
+    )
+    setup_p.add_argument(
+        "--remote",
+        action="store_true",
+        help=(
+            "Initialise the remote environment via the configured runner "
+            "(calls runner init). Use once before the first 'start'."
+        ),
     )
 
     # frontend
@@ -1559,6 +2166,38 @@ def build_parser() -> argparse.ArgumentParser:
     )
     nuke_p.add_argument("--keep-data", action="store_true", help="Keep data volumes")
 
+    # suspend
+    subparsers.add_parser(
+        "suspend",
+        help=(
+            "Stop DataHub containers and suspend the remote compute instance "
+            "(no compute charges until next 'start'). Requires a runner."
+        ),
+    )
+
+    # instances
+    instances_p = subparsers.add_parser(
+        "instances", help="Manage worktree DataHub instances"
+    )
+    instances_sub = instances_p.add_subparsers(dest="instances_command")
+    instances_sub.add_parser(
+        "list",
+        help="List all registered instances with status, ports, and paths",
+    )
+    instances_sub.add_parser(
+        "clean",
+        help="Remove registry entries for worktrees that no longer exist on disk",
+    )
+
+    # shell-env
+    subparsers.add_parser(
+        "shell-env",
+        help=(
+            "Print shell export statements for this instance's CLI environment. "
+            "Usage: eval $(datahub-dev.sh shell-env)"
+        ),
+    )
+
     return parser
 
 
@@ -1577,12 +2216,14 @@ def main() -> int:
         "docs": cmd_docs,
         "start": cmd_start,
         "stop": cmd_stop,
+        "suspend": cmd_suspend,
         "wait": cmd_wait,
         "rebuild": cmd_rebuild,
         "test": cmd_test,
         "sync-flags": cmd_sync_flags,
         "reset": cmd_reset,
         "nuke": cmd_nuke,
+        "shell-env": cmd_shell_env,
     }
 
     if args.command == "flag":
@@ -1606,6 +2247,16 @@ def main() -> int:
             parser.parse_args(["env", "--help"])
             return 1
         return env_map[args.env_command](args)
+
+    if args.command == "instances":
+        instances_map = {
+            "list": _cmd_instances_list,
+            "clean": _cmd_instances_clean,
+        }
+        if not args.instances_command:
+            parser.parse_args(["instances", "--help"])
+            return 1
+        return instances_map[args.instances_command](args)
 
     handler = command_map.get(args.command)
     if handler:

--- a/scripts/dev/runners/.gitignore
+++ b/scripts/dev/runners/.gitignore
@@ -1,0 +1,2 @@
+# Commercial runner implementations — not for the open-source repo.
+cclaude.sh

--- a/scripts/dev/runners/.gitignore
+++ b/scripts/dev/runners/.gitignore
@@ -1,2 +1,1 @@
-# Commercial runner implementations — not for the open-source repo.
-cclaude.sh
+# Runner scripts specific to private forks belong here, not in this repo.

--- a/scripts/dev/runners/k8s.sh
+++ b/scripts/dev/runners/k8s.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# DataHub K8s Runner — reference implementation of the datahub-dev runner interface.
+#
+# Interface contract (called by datahub-dev.sh / datahub_dev.py):
+#
+#   runner init                        — one-time bootstrap of the remote environment
+#   runner sync                        — incremental code sync to the pod
+#   runner exec -- <cmd> [args...]     — execute a command in the remote workspace
+#   runner tunnel <local:remote> ...   — set up host→pod port forwarding
+#
+# Configuration — override via env vars or edit the defaults below:
+#
+#   DATAHUB_K8S_POD         name of the dev pod          (default: datahub-dev)
+#   DATAHUB_K8S_NAMESPACE   k8s namespace                (default: default)
+#   DATAHUB_K8S_WORKDIR     working dir inside the pod   (default: /workspace/datahub)
+#   DATAHUB_K8S_CONTEXT     kubectl context to use       (default: current context)
+#
+# Typical one-time setup:
+#   export DATAHUB_RUNNER=/path/to/this/k8s.sh
+#   datahub-dev.sh setup --remote      # calls: runner init
+#   datahub-dev.sh start               # calls: runner sync + exec + tunnel
+#
+set -euo pipefail
+
+POD="${DATAHUB_K8S_POD:-datahub-dev}"
+NAMESPACE="${DATAHUB_K8S_NAMESPACE:-default}"
+WORKDIR="${DATAHUB_K8S_WORKDIR:-/workspace/datahub}"
+CONTEXT_ARG=()
+if [ -n "${DATAHUB_K8S_CONTEXT:-}" ]; then
+  CONTEXT_ARG=(--context "$DATAHUB_K8S_CONTEXT")
+fi
+
+KUBECTL=(kubectl "${CONTEXT_ARG[@]}" -n "$NAMESPACE")
+
+_pod_exec() {
+  # Run a shell command inside the pod's working directory.
+  "${KUBECTL[@]}" exec "$POD" -- bash -c "cd $WORKDIR && $*"
+}
+
+case "${1:-}" in
+
+  # ---------------------------------------------------------------------------
+  init)
+  # One-time bootstrap. Assumes the pod is already running (created via
+  # Helm, terraform, or a cluster-admin). Installs Java, Docker-in-Docker
+  # tooling, and performs an initial Gradle warm-up.
+  # ---------------------------------------------------------------------------
+    echo "[k8s-runner] Bootstrapping remote environment in pod/$POD ..."
+
+    # Verify the pod is reachable.
+    "${KUBECTL[@]}" get pod "$POD" --no-headers -o name
+
+    # Ensure the workspace directory exists.
+    _pod_exec "mkdir -p $WORKDIR"
+
+    # Sync the current source tree so subsequent setup tasks have the code.
+    echo "[k8s-runner] Syncing source for bootstrap..."
+    "${KUBECTL[@]}" cp . "$POD:$WORKDIR"
+
+    # Run DataHub's own local setup (ingestion venv, smoke-test venv, etc.)
+    _pod_exec "scripts/dev/datahub-dev.sh setup ingestion"
+
+    # Pre-pull the base Docker images so the first 'start' is faster.
+    # Adjust the profile to match what you typically use.
+    _pod_exec "./gradlew :docker:pullImages" || true
+
+    echo "[k8s-runner] Remote environment ready."
+    ;;
+
+  # ---------------------------------------------------------------------------
+  resume)
+  # Ensure the pod exists and is running.  For K8s this typically means
+  # scaling the deployment back up if it was scaled to zero.
+  # ---------------------------------------------------------------------------
+    echo "[k8s-runner] Resuming pod/$POD ..."
+    # If the pod was created from a Deployment, scale it up.
+    DEPLOY=$(kubectl get deployment -n "$NAMESPACE" -l app="$POD" \
+               -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+    if [ -n "$DEPLOY" ]; then
+      kubectl scale deployment -n "$NAMESPACE" "$DEPLOY" --replicas=1
+      kubectl rollout status deployment -n "$NAMESPACE" "$DEPLOY" --timeout=120s
+    else
+      echo "[k8s-runner] No deployment found — assuming pod is already running."
+    fi
+    ;;
+
+  # ---------------------------------------------------------------------------
+  suspend)
+  # Stop DataHub containers and scale the deployment to zero replicas.
+  # No compute charges while scaled to zero; PVC data persists.
+  # ---------------------------------------------------------------------------
+    echo "[k8s-runner] Suspending pod/$POD ..."
+    _pod_exec "env DATAHUB_REMOTE_EXEC=1 $WORKDIR/scripts/dev/datahub-dev.sh stop" || true
+    DEPLOY=$(kubectl get deployment -n "$NAMESPACE" -l app="$POD" \
+               -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+    if [ -n "$DEPLOY" ]; then
+      kubectl scale deployment -n "$NAMESPACE" "$DEPLOY" --replicas=0
+      echo "[k8s-runner] Deployment scaled to zero.  Resume with: datahub-dev.sh start"
+    else
+      echo "[k8s-runner] No deployment found to scale — containers left as-is."
+    fi
+    ;;
+
+  # ---------------------------------------------------------------------------
+  sync)
+  # Incremental code sync. Uses kubectl cp with tar streaming.
+  # For large repos consider mounting a shared PVC or using rsync over SSH
+  # (kubectl port-forward + rsync daemon in the pod).
+  # ---------------------------------------------------------------------------
+    echo "[k8s-runner] Syncing code to pod/$POD ..."
+
+    # Build a tar of tracked + untracked (but not gitignored) files.
+    # This respects .gitignore and avoids shipping build artefacts.
+    git ls-files --others --exclude-standard --cached -z \
+      | tar --null -czf - --files-from=- \
+      | "${KUBECTL[@]}" exec -i "$POD" -- bash -c \
+          "mkdir -p $WORKDIR && tar -xzf - -C $WORKDIR"
+
+    echo "[k8s-runner] Sync complete."
+    ;;
+
+  # ---------------------------------------------------------------------------
+  exec)
+  # Execute a command inside the pod's working directory.
+  # Caller passes: runner exec -- <cmd> [args...]
+  # The "--" separator is consumed here; the rest is forwarded verbatim.
+  # ---------------------------------------------------------------------------
+    shift          # drop "exec"
+    if [ "${1:-}" = "--" ]; then shift; fi   # drop optional "--"
+    _pod_exec "$*"
+    ;;
+
+  # ---------------------------------------------------------------------------
+  tunnel)
+  # Forward pod ports to localhost.  Each argument is "local:remote".
+  # Runs kubectl port-forward in the foreground; press Ctrl-C to stop.
+  #
+  # Example invocation by datahub_dev.py:
+  #   runner tunnel 28080:8080 29002:9002 23306:3306 ...
+  # ---------------------------------------------------------------------------
+    shift          # drop "tunnel"
+    if [ $# -eq 0 ]; then
+      echo "[k8s-runner] No ports specified for tunnel — nothing to do." >&2
+      exit 0
+    fi
+
+    echo "[k8s-runner] Forwarding ports: $*"
+    echo "[k8s-runner] Press Ctrl-C to stop port forwarding."
+    # kubectl port-forward accepts "localPort:podPort" pairs natively.
+    "${KUBECTL[@]}" port-forward "pod/$POD" "$@"
+    ;;
+
+  *)
+    echo "Usage: $0 {init|sync|exec -- <cmd>|tunnel <local:remote>...}" >&2
+    echo "" >&2
+    echo "Environment variables:" >&2
+    echo "  DATAHUB_K8S_POD        pod name          (default: datahub-dev)" >&2
+    echo "  DATAHUB_K8S_NAMESPACE  namespace         (default: default)" >&2
+    echo "  DATAHUB_K8S_WORKDIR    working directory (default: /workspace/datahub)" >&2
+    echo "  DATAHUB_K8S_CONTEXT    kubectl context   (default: current)" >&2
+    exit 1
+    ;;
+
+esac

--- a/scripts/dev/tests/test_runner.py
+++ b/scripts/dev/tests/test_runner.py
@@ -1,0 +1,475 @@
+"""Tests for the remote runner plugin (slot allocation, tunnel pairs, registry, call sequence)."""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import datahub_dev
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_config(monkeypatch, max_local: int = 2, max_remote: int = 10) -> None:
+    monkeypatch.setattr(
+        datahub_dev,
+        "_load_dev_config",
+        lambda: {"max_local_instances": max_local, "max_remote_instances": max_remote},
+    )
+
+
+def _fake_ok(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: slot allocation
+# ---------------------------------------------------------------------------
+
+
+class TestPickSlot:
+    def test_local_first_slot_is_zero(self, monkeypatch):
+        _patch_config(monkeypatch)
+        slot = datahub_dev._pick_slot({}, remote=False)
+        assert slot == 0
+
+    def test_local_skips_occupied_slots(self, monkeypatch):
+        _patch_config(monkeypatch)
+        registry = {"instances": {"other": {"slot": 0}}}
+        slot = datahub_dev._pick_slot(registry, remote=False)
+        assert slot == 1
+
+    def test_local_full_raises(self, monkeypatch):
+        _patch_config(monkeypatch, max_local=2)
+        registry = {"instances": {"a": {"slot": 0}, "b": {"slot": 1}}}
+        with pytest.raises(RuntimeError, match="local"):
+            datahub_dev._pick_slot(registry, remote=False)
+
+    def test_remote_starts_after_local_slots(self, monkeypatch):
+        _patch_config(monkeypatch, max_local=2, max_remote=10)
+        # Local slots 0,1 occupied; remote should start at 2.
+        registry = {"instances": {"a": {"slot": 0}, "b": {"slot": 1}}}
+        slot = datahub_dev._pick_slot(registry, remote=True)
+        assert slot == 2
+
+    def test_remote_skips_occupied_remote_slots(self, monkeypatch):
+        _patch_config(monkeypatch, max_local=2, max_remote=10)
+        # Slot 2 taken; next remote is 3.
+        registry = {"instances": {"a": {"slot": 0}, "b": {"slot": 1}, "c": {"slot": 2}}}
+        slot = datahub_dev._pick_slot(registry, remote=True)
+        assert slot == 3
+
+    def test_remote_full_raises(self, monkeypatch):
+        _patch_config(monkeypatch, max_local=2, max_remote=2)
+        registry = {
+            "instances": {
+                "a": {"slot": 0},
+                "b": {"slot": 1},
+                "c": {"slot": 2},  # remote slot 0
+                "d": {"slot": 3},  # remote slot 1
+            }
+        }
+        with pytest.raises(RuntimeError, match="remote"):
+            datahub_dev._pick_slot(registry, remote=True)
+
+    def test_own_worktree_slot_not_counted(self, monkeypatch):
+        _patch_config(monkeypatch)
+        # Current worktree occupies slot 0; _pick_slot should still return 0
+        # because it excludes WORKTREE_ID from the "used" set.
+        registry = {"instances": {datahub_dev.WORKTREE_ID: {"slot": 0}}}
+        slot = datahub_dev._pick_slot(registry, remote=False)
+        assert slot == 0
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: port computation and tunnel pairs
+# ---------------------------------------------------------------------------
+
+
+class TestPortsAndTunnels:
+    def test_slot0_returns_defaults(self):
+        ports = datahub_dev._compute_ports(0)
+        assert ports["DATAHUB_MAPPED_GMS_PORT"] == 8080
+        assert ports["DATAHUB_MAPPED_FRONTEND_PORT"] == 9002
+        assert ports["DATAHUB_MAPPED_MYSQL_PORT"] == 3306
+
+    def test_slot1_adds_1000(self):
+        ports = datahub_dev._compute_ports(1)
+        assert ports["DATAHUB_MAPPED_GMS_PORT"] == 9080   # 8080 + 1*1000
+        assert ports["DATAHUB_MAPPED_FRONTEND_PORT"] == 10002  # 9002 + 1*1000
+
+    def test_slot2_used_for_first_remote(self, monkeypatch):
+        # SLOT_OFFSET=1000; slot 2 → base + 2000
+        _patch_config(monkeypatch, max_local=2)
+        ports = datahub_dev._compute_ports(2)
+        assert ports["DATAHUB_MAPPED_GMS_PORT"] == 10080   # 8080 + 2*1000
+        assert ports["DATAHUB_MAPPED_FRONTEND_PORT"] == 11002  # 9002 + 2*1000
+
+    def test_tunnel_pairs_map_local_to_remote_default(self):
+        # Slot 2: local 10080 → remote 8080, local 11002 → remote 9002
+        ports = datahub_dev._compute_ports(2)
+        pairs = datahub_dev._compute_tunnel_pairs(ports)
+        assert "10080:8080" in pairs
+        assert "11002:9002" in pairs
+
+    def test_tunnel_pairs_slot0_maps_to_self(self):
+        # Slot 0: local == remote, so pairs are "8080:8080" etc.
+        ports = datahub_dev._compute_ports(0)
+        pairs = datahub_dev._compute_tunnel_pairs(ports)
+        assert "8080:8080" in pairs
+
+    def test_no_port_exceeds_65535(self):
+        # Highest plausible slot: 11 (max_local=2, max_remote=10 → slot 11)
+        # SLOT_OFFSET=1000; max port = max(PORT_BASE) + 11*1000 = 9200+11000 = 20200
+        ports = datahub_dev._compute_ports(11)
+        for val in ports.values():
+            assert val <= 65535, f"Port {val} exceeds max"
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: remote instance registration
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterRemoteInstance:
+    def test_writes_type_remote(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(datahub_dev, "INSTANCES_FILE", tmp_path / "instances.json")
+        monkeypatch.setattr(datahub_dev, "DATAHUB_DEV_DIR", tmp_path)
+        inst = datahub_dev._register_remote_instance("/path/to/runner.sh", 2)
+        assert inst["type"] == "remote"
+
+    def test_writes_runner_path(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(datahub_dev, "INSTANCES_FILE", tmp_path / "instances.json")
+        monkeypatch.setattr(datahub_dev, "DATAHUB_DEV_DIR", tmp_path)
+        inst = datahub_dev._register_remote_instance("/my/runner.sh", 2)
+        assert inst["runner"] == "/my/runner.sh"
+
+    def test_ports_are_slot_offset(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(datahub_dev, "INSTANCES_FILE", tmp_path / "instances.json")
+        monkeypatch.setattr(datahub_dev, "DATAHUB_DEV_DIR", tmp_path)
+        inst = datahub_dev._register_remote_instance("/runner.sh", 2)
+        # Local tunnel port for slot 2 with SLOT_OFFSET=1000: 8080+2000=10080
+        assert inst["ports"]["DATAHUB_MAPPED_GMS_PORT"] == 10080
+
+    def test_persists_to_disk(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(datahub_dev, "INSTANCES_FILE", tmp_path / "instances.json")
+        monkeypatch.setattr(datahub_dev, "DATAHUB_DEV_DIR", tmp_path)
+        datahub_dev._register_remote_instance("/runner.sh", 2)
+        on_disk = json.loads((tmp_path / "instances.json").read_text())
+        assert datahub_dev.WORKTREE_ID in on_disk["instances"]
+        assert on_disk["instances"][datahub_dev.WORKTREE_ID]["type"] == "remote"
+
+    def test_get_instance_returns_remote_entry(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(datahub_dev, "INSTANCES_FILE", tmp_path / "instances.json")
+        monkeypatch.setattr(datahub_dev, "DATAHUB_DEV_DIR", tmp_path)
+        datahub_dev._register_remote_instance("/runner.sh", 2)
+        inst = datahub_dev._get_instance()
+        assert inst is not None
+        assert inst["type"] == "remote"
+        assert inst["ports"]["DATAHUB_MAPPED_GMS_PORT"] == 10080
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: URL helpers respect tunnel ports
+# ---------------------------------------------------------------------------
+
+
+class TestUrlHelpers:
+    def test_gms_url_uses_tunnel_port_for_remote(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(datahub_dev, "INSTANCES_FILE", tmp_path / "instances.json")
+        monkeypatch.setattr(datahub_dev, "DATAHUB_DEV_DIR", tmp_path)
+        monkeypatch.delenv("DATAHUB_GMS_URL", raising=False)
+        datahub_dev._register_remote_instance("/runner.sh", 2)
+        assert datahub_dev._gms_url() == "http://localhost:10080"
+
+    def test_frontend_url_uses_tunnel_port_for_remote(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(datahub_dev, "INSTANCES_FILE", tmp_path / "instances.json")
+        monkeypatch.setattr(datahub_dev, "DATAHUB_DEV_DIR", tmp_path)
+        monkeypatch.delenv("DATAHUB_FRONTEND_URL", raising=False)
+        datahub_dev._register_remote_instance("/runner.sh", 2)
+        assert datahub_dev._frontend_url() == "http://localhost:11002"
+
+    def test_gms_url_env_override_respected(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(datahub_dev, "INSTANCES_FILE", tmp_path / "instances.json")
+        monkeypatch.setattr(datahub_dev, "DATAHUB_DEV_DIR", tmp_path)
+        monkeypatch.setenv("DATAHUB_GMS_URL", "http://custom:9999")
+        datahub_dev._register_remote_instance("/runner.sh", 2)
+        assert datahub_dev._gms_url() == "http://custom:9999"
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: mock runner integration — _cmd_start_remote call sequence
+# ---------------------------------------------------------------------------
+
+
+class TestCmdStartRemote:
+    """Verify that _cmd_start_remote calls runner verbs in the right order
+    with the right arguments, without touching real docker or a real machine."""
+
+    def _make_args(self, **kwargs) -> argparse.Namespace:
+        defaults = dict(
+            ai=False,
+            no_ai=False,
+            embeddings_endpoint=None,
+            embeddings_model=None,
+            timeout=300,
+        )
+        defaults.update(kwargs)
+        return argparse.Namespace(**defaults)
+
+    def _setup(self, tmp_path, monkeypatch, runner="/fake/runner.sh") -> List[List[str]]:
+        """Wire up all the patches and return the list that records _run() calls."""
+        calls: List[List[str]] = []
+
+        def record_run(cmd, **kwargs):
+            calls.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(datahub_dev, "RUNNER", runner)
+        monkeypatch.setattr(datahub_dev, "INSTANCES_FILE", tmp_path / "instances.json")
+        monkeypatch.setattr(datahub_dev, "DATAHUB_DEV_DIR", tmp_path)
+        monkeypatch.setattr(datahub_dev, "_run", record_run)
+        monkeypatch.setattr(datahub_dev, "_rebuild_config_services", lambda: None)
+        _patch_config(monkeypatch)
+        return calls
+
+    def test_exits_zero_on_success(self, tmp_path, monkeypatch):
+        self._setup(tmp_path, monkeypatch)
+        rc = datahub_dev._cmd_start_remote(self._make_args())
+        assert rc == 0
+
+    def test_verbs_called_in_order(self, tmp_path, monkeypatch):
+        calls = self._setup(tmp_path, monkeypatch)
+        datahub_dev._cmd_start_remote(self._make_args())
+        verbs = [c[1] for c in calls if c[0] == "/fake/runner.sh"]
+        assert verbs == ["sync", "exec", "tunnel"], verbs
+
+    def test_sync_has_no_extra_args(self, tmp_path, monkeypatch):
+        calls = self._setup(tmp_path, monkeypatch)
+        datahub_dev._cmd_start_remote(self._make_args())
+        sync_call = next(c for c in calls if c[1] == "sync")
+        assert sync_call == ["/fake/runner.sh", "sync"]
+
+    def test_exec_sets_remote_exec_env(self, tmp_path, monkeypatch):
+        calls = self._setup(tmp_path, monkeypatch)
+        datahub_dev._cmd_start_remote(self._make_args())
+        exec_call = next(c for c in calls if c[1] == "exec")
+        assert "DATAHUB_REMOTE_EXEC=1" in exec_call
+
+    def test_exec_targets_datahub_dev_sh(self, tmp_path, monkeypatch):
+        calls = self._setup(tmp_path, monkeypatch)
+        datahub_dev._cmd_start_remote(self._make_args())
+        exec_call = next(c for c in calls if c[1] == "exec")
+        joined = " ".join(exec_call)
+        assert "datahub-dev.sh" in joined
+        assert "start" in joined
+
+    def test_exec_includes_timeout_flag(self, tmp_path, monkeypatch):
+        calls = self._setup(tmp_path, monkeypatch)
+        datahub_dev._cmd_start_remote(self._make_args(timeout=600))
+        exec_call = next(c for c in calls if c[1] == "exec")
+        assert "--timeout" in exec_call
+        assert "600" in exec_call
+
+    def test_exec_forwards_ai_flag(self, tmp_path, monkeypatch):
+        calls = self._setup(tmp_path, monkeypatch)
+        datahub_dev._cmd_start_remote(self._make_args(ai=True))
+        exec_call = next(c for c in calls if c[1] == "exec")
+        assert "--ai" in exec_call
+
+    def test_tunnel_receives_local_remote_pairs(self, tmp_path, monkeypatch):
+        calls = self._setup(tmp_path, monkeypatch)
+        datahub_dev._cmd_start_remote(self._make_args())
+        tunnel_call = next(c for c in calls if c[1] == "tunnel")
+        # First remote slot = 2 (after 2 local slots), SLOT_OFFSET=1000
+        # local 10080 → remote 8080,  local 11002 → remote 9002
+        assert "10080:8080" in tunnel_call
+        assert "11002:9002" in tunnel_call
+
+    def test_local_registry_written_before_sync(self, tmp_path, monkeypatch):
+        """Registry must exist before sync (so shell-env works even if start fails)."""
+        written_before_sync = []
+
+        def record_run(cmd, **kwargs):
+            if cmd[1] == "sync":
+                # Check registry at the moment sync is called
+                inst = datahub_dev._get_instance()
+                written_before_sync.append(inst is not None)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(datahub_dev, "RUNNER", "/fake/runner.sh")
+        monkeypatch.setattr(datahub_dev, "INSTANCES_FILE", tmp_path / "instances.json")
+        monkeypatch.setattr(datahub_dev, "DATAHUB_DEV_DIR", tmp_path)
+        monkeypatch.setattr(datahub_dev, "_run", record_run)
+        monkeypatch.setattr(datahub_dev, "_rebuild_config_services", lambda: None)
+        _patch_config(monkeypatch)
+
+        datahub_dev._cmd_start_remote(self._make_args())
+        assert written_before_sync == [True], "Registry not written before sync"
+
+    def test_returns_nonzero_when_sync_fails(self, tmp_path, monkeypatch):
+        def fail_on_sync(cmd, **kwargs):
+            if cmd[1] == "sync":
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(datahub_dev, "RUNNER", "/fake/runner.sh")
+        monkeypatch.setattr(datahub_dev, "INSTANCES_FILE", tmp_path / "instances.json")
+        monkeypatch.setattr(datahub_dev, "DATAHUB_DEV_DIR", tmp_path)
+        monkeypatch.setattr(datahub_dev, "_run", fail_on_sync)
+        monkeypatch.setattr(datahub_dev, "_rebuild_config_services", lambda: None)
+        _patch_config(monkeypatch)
+
+        rc = datahub_dev._cmd_start_remote(self._make_args())
+        assert rc != 0
+
+    def test_returns_nonzero_when_exec_fails(self, tmp_path, monkeypatch):
+        def fail_on_exec(cmd, **kwargs):
+            if cmd[1] == "exec":
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(datahub_dev, "RUNNER", "/fake/runner.sh")
+        monkeypatch.setattr(datahub_dev, "INSTANCES_FILE", tmp_path / "instances.json")
+        monkeypatch.setattr(datahub_dev, "DATAHUB_DEV_DIR", tmp_path)
+        monkeypatch.setattr(datahub_dev, "_run", fail_on_exec)
+        monkeypatch.setattr(datahub_dev, "_rebuild_config_services", lambda: None)
+        _patch_config(monkeypatch)
+
+        rc = datahub_dev._cmd_start_remote(self._make_args())
+        assert rc != 0
+
+    def test_tunnel_failure_is_warning_not_error(self, tmp_path, monkeypatch):
+        """Tunnel failure is non-fatal — remote is up, user can forward manually."""
+
+        def fail_on_tunnel(cmd, **kwargs):
+            if cmd[1] == "tunnel":
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(datahub_dev, "RUNNER", "/fake/runner.sh")
+        monkeypatch.setattr(datahub_dev, "INSTANCES_FILE", tmp_path / "instances.json")
+        monkeypatch.setattr(datahub_dev, "DATAHUB_DEV_DIR", tmp_path)
+        monkeypatch.setattr(datahub_dev, "_run", fail_on_tunnel)
+        monkeypatch.setattr(datahub_dev, "_rebuild_config_services", lambda: None)
+        _patch_config(monkeypatch)
+
+        rc = datahub_dev._cmd_start_remote(self._make_args())
+        # Must still return 0 — tunnel failure is a warning, not a fatal error
+        assert rc == 0
+
+    def test_idempotent_start_reuses_existing_slot(self, tmp_path, monkeypatch):
+        """Second call to _cmd_start_remote must not allocate a new slot."""
+        calls = self._setup(tmp_path, monkeypatch)
+        datahub_dev._cmd_start_remote(self._make_args())
+        first_slot = datahub_dev._get_instance()["slot"]
+
+        # Call again simulating a restart
+        calls.clear()
+        datahub_dev._cmd_start_remote(self._make_args())
+        second_slot = datahub_dev._get_instance()["slot"]
+
+        assert first_slot == second_slot, "Slot changed on second start — port instability"
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: REMOTE_EXEC guard
+# ---------------------------------------------------------------------------
+
+
+class TestRemoteExecGuard:
+    def test_runner_constant_is_empty_when_remote_exec_set(self, monkeypatch):
+        """When DATAHUB_REMOTE_EXEC=1, RUNNER must be empty even if DATAHUB_RUNNER is set.
+
+        This verifies the module-level logic by checking the constants directly.
+        The guard is set at import time, so we validate the invariant holds for
+        the current process state rather than re-importing.
+        """
+        # In this test process DATAHUB_REMOTE_EXEC is not set, so RUNNER reflects
+        # whatever DATAHUB_RUNNER is in the environment.  Verify the rule holds.
+        import os
+
+        remote_exec = os.environ.get("DATAHUB_REMOTE_EXEC") == "1"
+        if remote_exec:
+            assert datahub_dev.RUNNER == ""
+        else:
+            # Not in remote-exec mode — RUNNER may be set or empty, both valid.
+            pass
+
+    def test_cmd_start_dispatches_to_remote_when_runner_set(self, tmp_path, monkeypatch):
+        """cmd_start() calls _cmd_start_remote() when RUNNER is non-empty."""
+        called = []
+
+        def fake_remote(args):
+            called.append("remote")
+            return 0
+
+        monkeypatch.setattr(datahub_dev, "RUNNER", "/some/runner.sh")
+        monkeypatch.setattr(datahub_dev, "_cmd_start_remote", fake_remote)
+
+        args = argparse.Namespace(
+            ai=False, no_ai=False, embeddings_endpoint=None,
+            embeddings_model=None, timeout=300,
+        )
+        datahub_dev.cmd_start(args)
+        assert called == ["remote"]
+
+    def test_cmd_start_does_not_dispatch_when_runner_empty(self, tmp_path, monkeypatch):
+        """cmd_start() does NOT call _cmd_start_remote() when RUNNER is empty."""
+        called = []
+
+        def fake_remote(args):
+            called.append("remote")
+            return 0
+
+        monkeypatch.setattr(datahub_dev, "RUNNER", "")
+        monkeypatch.setattr(datahub_dev, "_cmd_start_remote", fake_remote)
+        # Patch the local path to exit immediately without real docker
+        monkeypatch.setattr(datahub_dev, "_load_registry", lambda: {"instances": {}})
+        monkeypatch.setattr(datahub_dev, "_load_dev_config", lambda: {
+            "max_local_instances": 2, "max_remote_instances": 10
+        })
+        monkeypatch.setattr(datahub_dev, "_count_running_dh_instances", lambda: 99)
+        # count >= max_local → returns early with error, but never calls fake_remote
+
+        args = argparse.Namespace(
+            ai=False, no_ai=False, embeddings_endpoint=None,
+            embeddings_model=None, timeout=300,
+        )
+        datahub_dev.cmd_start(args)
+        assert called == [], "Remote path invoked despite RUNNER being empty"
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: setup --remote
+# ---------------------------------------------------------------------------
+
+
+class TestSetupRemote:
+    def test_calls_runner_init(self, tmp_path, monkeypatch):
+        calls: List[List[str]] = []
+        monkeypatch.setattr(datahub_dev, "RUNNER", "/fake/runner.sh")
+        monkeypatch.setattr(datahub_dev, "_run", lambda cmd, **kw: (
+            calls.append(list(cmd)),
+            subprocess.CompletedProcess(cmd, 0),
+        )[-1])
+
+        args = argparse.Namespace(remote=True, module="ingestion")
+        rc = datahub_dev.cmd_setup(args)
+        assert rc == 0
+        assert calls == [["/fake/runner.sh", "init"]]
+
+    def test_fails_gracefully_when_no_runner(self, monkeypatch):
+        monkeypatch.setattr(datahub_dev, "RUNNER", "")
+        args = argparse.Namespace(remote=True, module="ingestion")
+        rc = datahub_dev.cmd_setup(args)
+        assert rc == 1


### PR DESCRIPTION
## Summary

- **Multi-worktree isolation**: each git worktree gets its own Docker project name, volumes, and ports automatically — no more collisions when running DataHub in multiple branches simultaneously. Slot-based port allocation (+1000 per slot) across up to 12 concurrent instances (2 local, 10 remote). State is tracked in `~/.datahub/dev/instances.json`.

- **Remote runner plugin**: a pluggable interface that proxies all `datahub-dev.sh` operations to a remote machine (EC2, K8s pod, etc.). Set `runner` in `~/.datahub/dev/config.json` or `DATAHUB_RUNNER` env var. New `suspend`/`resume` stop/start the underlying compute so you're not billed when idle.

- **Reference K8s runner** at `scripts/dev/runners/k8s.sh` implementing all 6 interface verbs (`init`, `sync`, `exec`, `tunnel`, `resume`, `suspend`).

- **39 new tests** in `scripts/dev/tests/test_runner.py` covering slot allocation, tunnel-pair computation, registry round-trips, call sequence, error propagation, and idempotency.

- **AGENTS.md** updated with the full remote runner lifecycle, port assignment table, and runner interface contract.

Also fixes two previously hardcoded ports in `docker-compose.gms.yml` (MAE consumer 9091, MCE consumer 9090 + debug 5009) that blocked parallel local instances, and makes Gradle's Docker Compose `projectName` configurable via `COMPOSE_PROJECT_NAME`.

## New commands

```bash
# Multi-instance
datahub-dev.sh instances list    # show all local + remote instances with status/ports
datahub-dev.sh instances clean   # remove stale registry entries
eval $(datahub-dev.sh shell-env) # set DATAHUB_GMS_URL to this instance's port

# Remote runner lifecycle
datahub-dev.sh setup --remote    # one-time: provision remote environment (runner init)
datahub-dev.sh start             # sync changed files → quickstartDebug on remote → tunnel ports
datahub-dev.sh suspend           # stop containers + halt compute (no billing while idle)
# 'start' automatically resumes a suspended instance
```

## Runner interface

A runner is any executable that speaks 6 verbs:

```bash
runner init                        # one-time bootstrap
runner sync                        # push changed local files to the remote
runner exec -- <cmd> [args...]     # execute a command in the remote workspace
runner tunnel <local:remote> ...   # set up port forwarding
runner resume                      # start compute if stopped (no-op if running)
runner suspend                     # stop containers + halt compute
```

## Test plan

- [ ] `uv run --python 3.11 --no-project --with pytest pytest scripts/dev/tests/test_runner.py scripts/dev/tests/test_datahub_dev.py -v` — all 54 tests pass
- [ ] `datahub-dev.sh start` in two different worktrees simultaneously — each gets isolated ports/volumes
- [ ] `datahub-dev.sh instances list` — shows both instances with correct ports
- [ ] `eval $(datahub-dev.sh shell-env)` — sets correct `DATAHUB_GMS_URL` per worktree
- [ ] With a runner configured: `start` → `stop` → `suspend` round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)