### PR TITLE
perf(graphql): batch WeaklyTypedAspectsResolver via DataLoader

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -837,8 +837,7 @@ public class GmsGraphQLEngine {
         typeWiring ->
             typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
-                .dataFetcher(
-                    "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry)));
+                .dataFetcher("aspects", new WeaklyTypedAspectsResolver()));
     builder.type(
         "RoleAssociation",
         typeWiring ->
@@ -972,8 +971,7 @@ public class GmsGraphQLEngine {
                         documentService, entityClient, groupService))
                 .dataFetcher("entities", new ContainerEntitiesResolver(entityClient))
                 .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
-                .dataFetcher(
-                    "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                 .dataFetcher("exists", new EntityExistsResolver(entityService))
                 .dataFetcher(
                     "platform",
@@ -1885,8 +1883,7 @@ public class GmsGraphQLEngine {
                     .dataFetcher(
                         "assertions", new EntityAssertionsResolver(entityClient, graphClient))
                     .dataFetcher("testResults", new TestResultsResolver(entityClient))
-                    .dataFetcher(
-                        "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                    .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                     .dataFetcher("exists", new EntityExistsResolver(entityService))
                     .dataFetcher("runs", new EntityRunsResolver(entityClient))
                     .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
@@ -2053,8 +2050,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher("schemaMetadata", new AspectResolver())
                 .dataFetcher("parentNodes", new ParentNodesResolver(entityClient))
                 .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
-                .dataFetcher(
-                    "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                 .dataFetcher("exists", new EntityExistsResolver(entityService))
                 .dataFetcher(
                     "relatedDocuments",
@@ -2074,8 +2070,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher(
                     "glossaryChildrenSearch",
                     new GlossaryChildrenSearchResolver(this.entityClient, this.viewService))
-                .dataFetcher(
-                    "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                 .dataFetcher(
                     "relatedDocuments",
                     new com.linkedin.datahub.graphql.resolvers.knowledge.RelatedDocumentsResolver(
@@ -2138,8 +2133,7 @@ public class GmsGraphQLEngine {
             typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
                 .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
-                .dataFetcher(
-                    "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                 .dataFetcher("exists", new EntityExistsResolver(entityService)));
     builder.type(
         "CorpUserInfo",
@@ -2214,8 +2208,7 @@ public class GmsGraphQLEngine {
                     "relationships",
                     new EntityRelationshipsResultResolver(graphClient, entityService))
                 .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
-                .dataFetcher(
-                    "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                 .dataFetcher("exists", new EntityExistsResolver(entityService)));
     builder
         .type(
@@ -2260,8 +2253,7 @@ public class GmsGraphQLEngine {
         typeWiring ->
             typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
-                .dataFetcher(
-                    "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry)));
+                .dataFetcher("aspects", new WeaklyTypedAspectsResolver()));
     builder.type(
         "TagAssociation",
         typeWiring ->
@@ -2296,8 +2288,7 @@ public class GmsGraphQLEngine {
         typeWiring ->
             typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
-                .dataFetcher(
-                    "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                 .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.notebookType))
                 .dataFetcher(
                     "platform",
@@ -2336,8 +2327,7 @@ public class GmsGraphQLEngine {
                     "lineage",
                     new EntityLineageResultResolver(
                         siblingGraphService, restrictedService, this.authorizationConfiguration))
-                .dataFetcher(
-                    "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                 .dataFetcher(
                     "platform",
                     new LoadableTypeResolver<>(
@@ -2467,8 +2457,7 @@ public class GmsGraphQLEngine {
                     new com.linkedin.datahub.graphql.resolvers.knowledge.RelatedDocumentsResolver(
                         documentService, entityClient, groupService))
                 .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.chartType))
-                .dataFetcher(
-                    "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                 .dataFetcher(
                     "lineage",
                     new EntityLineageResultResolver(
@@ -2686,8 +2675,7 @@ public class GmsGraphQLEngine {
                             siblingGraphService,
                             restrictedService,
                             this.authorizationConfiguration))
-                    .dataFetcher(
-                        "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                    .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                     .dataFetcher(
                         "dataFlow",
                         new LoadableTypeResolver<>(
@@ -2791,8 +2779,7 @@ public class GmsGraphQLEngine {
                     "lineage",
                     new EntityLineageResultResolver(
                         siblingGraphService, restrictedService, this.authorizationConfiguration))
-                .dataFetcher(
-                    "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                 .dataFetcher(
                     "platform",
                     new LoadableTypeResolver<>(
@@ -2849,8 +2836,7 @@ public class GmsGraphQLEngine {
                             .RelatedDocumentsResolver(documentService, entityClient, groupService))
                     .dataFetcher(
                         "browsePaths", new EntityBrowsePathsResolver(this.mlFeatureTableType))
-                    .dataFetcher(
-                        "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                    .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                     .dataFetcher(
                         "lineage",
                         new EntityLineageResultResolver(
@@ -2951,8 +2937,7 @@ public class GmsGraphQLEngine {
                             restrictedService,
                             this.authorizationConfiguration))
                     .dataFetcher("exists", new EntityExistsResolver(entityService))
-                    .dataFetcher(
-                        "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                    .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                     .dataFetcher(
                         "platform",
                         new LoadableTypeResolver<>(
@@ -2997,8 +2982,7 @@ public class GmsGraphQLEngine {
                             .RelatedDocumentsResolver(documentService, entityClient, groupService))
                     .dataFetcher(
                         "browsePaths", new EntityBrowsePathsResolver(this.mlModelGroupType))
-                    .dataFetcher(
-                        "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                    .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                     .dataFetcher(
                         "lineage",
                         new EntityLineageResultResolver(
@@ -3038,8 +3022,7 @@ public class GmsGraphQLEngine {
                             siblingGraphService,
                             restrictedService,
                             this.authorizationConfiguration))
-                    .dataFetcher(
-                        "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                    .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                     .dataFetcher("exists", new EntityExistsResolver(entityService))
                     .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
                     .dataFetcher(
@@ -3069,8 +3052,7 @@ public class GmsGraphQLEngine {
                             siblingGraphService,
                             restrictedService,
                             this.authorizationConfiguration))
-                    .dataFetcher(
-                        "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                    .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                     .dataFetcher("exists", new EntityExistsResolver(entityService))
                     .dataFetcher(
                         "dataPlatformInstance",
@@ -3106,8 +3088,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher("entities", new DomainEntitiesResolver(this.entityClient))
                 .dataFetcher("parentDomains", new ParentDomainsResolver(this.entityClient))
                 .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
-                .dataFetcher(
-                    "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
                 .dataFetcher(
                     "relatedDocuments",
@@ -3204,8 +3185,7 @@ public class GmsGraphQLEngine {
             typeWiring
                 .dataFetcher("entities", new ListDataProductAssetsResolver(this.entityClient))
                 .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
-                .dataFetcher(
-                    "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
                 .dataFetcher(
                     "relatedDocuments",
@@ -3219,8 +3199,7 @@ public class GmsGraphQLEngine {
         typeWiring ->
             typeWiring
                 .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
-                .dataFetcher(
-                    "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
                 .dataFetcher(
                     "relatedDocuments",
@@ -3262,8 +3241,7 @@ public class GmsGraphQLEngine {
                               : null;
                         }))
                 .dataFetcher("runEvents", new AssertionRunEventResolver(entityClient))
-                .dataFetcher(
-                    "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry)));
+                .dataFetcher("aspects", new WeaklyTypedAspectsResolver()));
   }
 
   private void configureContractResolvers(final RuntimeWiring.Builder builder) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -913,6 +913,10 @@ public class GmsGraphQLEngine {
     builder
         .addDataLoaders(loaderSuppliers(loadableTypes))
         .addDataLoader("Aspect", context -> createDataLoader(aspectType, context))
+        .addDataLoader(
+            WeaklyTypedAspectsResolver.LOADER_NAME,
+            context ->
+                WeaklyTypedAspectsResolver.createDataLoader(entityClient, entityRegistry, context))
         .setGraphQLConfiguration(graphQLConfiguration)
         .setMetricUtils(metricUtils)
         .configureRuntimeWiring(this::configureRuntimeWiring);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/WeaklyTypedAspectsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/WeaklyTypedAspectsResolver.java
@@ -20,100 +20,232 @@ import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import io.datahubproject.metadata.context.OperationContext;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
+import org.dataloader.BatchLoaderContextProvider;
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderOptions;
 
 @Slf4j
 @AllArgsConstructor
 public class WeaklyTypedAspectsResolver implements DataFetcher<CompletableFuture<List<RawAspect>>> {
 
+  public static final String LOADER_NAME = "WeaklyTypedAspects";
+
   private final EntityClient _entityClient;
   private final EntityRegistry _entityRegistry;
   private static final JacksonDataCodec CODEC = new JacksonDataCodec();
 
-  private boolean shouldReturnAspect(AspectSpec aspectSpec, AspectParams params) {
-    return (params.getAutoRenderOnly() == null
-            || !params.getAutoRenderOnly()
-            || aspectSpec.isAutoRender())
-        && (params.getAspectNames() == null
-            || params.getAspectNames().isEmpty()
-            || params.getAspectNames().contains(aspectSpec.getName()));
-  }
-
   @Override
   public CompletableFuture<List<RawAspect>> get(DataFetchingEnvironment environment)
       throws Exception {
+    final QueryContext context = environment.getContext();
+    final String urnStr = ((Entity) environment.getSource()).getUrn();
+    final EntityType entityType = ((Entity) environment.getSource()).getType();
+    final String entityTypeName = EntityTypeMapper.getName(entityType);
+    final AspectParams input = bindArgument(environment.getArgument("input"), AspectParams.class);
+
+    final AspectsKey key = AspectsKey.from(urnStr, entityTypeName, input);
+
+    try {
+      DataLoader<AspectsKey, List<RawAspect>> loader = environment.getDataLoader(LOADER_NAME);
+      if (loader != null) {
+        return loader.load(key);
+      }
+    } catch (IllegalArgumentException e) {
+      // Loader not registered for this engine instance — fall through to per-URN path.
+    }
+
     return GraphQLConcurrencyUtils.supplyAsync(
-        () -> {
-          List<RawAspect> results = new ArrayList<>();
-
-          final QueryContext context = environment.getContext();
-          final String urnStr = ((Entity) environment.getSource()).getUrn();
-          final EntityType entityType = ((Entity) environment.getSource()).getType();
-          final String entityTypeName = EntityTypeMapper.getName(entityType);
-          final AspectParams input =
-              bindArgument(environment.getArgument("input"), AspectParams.class);
-
-          EntitySpec entitySpec = _entityRegistry.getEntitySpec(entityTypeName);
-          entitySpec.getAspectSpecs().stream()
-              .filter(aspectSpec -> shouldReturnAspect(aspectSpec, input))
-              .forEach(
-                  aspectSpec -> {
-                    try {
-                      Urn urn = Urn.createFromString(urnStr);
-                      RawAspect result = new RawAspect();
-                      EntityResponse entityResponse =
-                          _entityClient
-                              .batchGetV2(
-                                  context.getOperationContext(),
-                                  urn.getEntityType(),
-                                  Collections.singleton(urn),
-                                  Collections.singleton(aspectSpec.getName()))
-                              .get(urn);
-                      if (entityResponse == null
-                          || !entityResponse.getAspects().containsKey(aspectSpec.getName())) {
-                        return;
-                      }
-
-                      DataMap resolvedAspect =
-                          entityResponse.getAspects().get(aspectSpec.getName()).getValue().data();
-                      if (resolvedAspect == null) {
-                        return;
-                      }
-
-                      result.setPayload(CODEC.mapToString(resolvedAspect));
-                      result.setAspectName(aspectSpec.getName());
-
-                      DataMap renderSpec = aspectSpec.getRenderSpec();
-
-                      if (renderSpec != null) {
-                        AspectRenderSpec resultRenderSpec = new AspectRenderSpec();
-                        resultRenderSpec.setDisplayType(renderSpec.getString("displayType"));
-                        resultRenderSpec.setDisplayName(renderSpec.getString("displayName"));
-                        resultRenderSpec.setKey(renderSpec.getString("key"));
-                        result.setRenderSpec(resultRenderSpec);
-                      }
-
-                      results.add(result);
-                    } catch (IOException | RemoteInvocationException | URISyntaxException e) {
-                      throw new RuntimeException(
-                          "Failed to fetch aspect "
-                              + aspectSpec.getName()
-                              + " for urn "
-                              + urnStr
-                              + " ",
-                          e);
-                    }
-                  });
-          return results;
-        },
+        () -> fetchSingle(context.getOperationContext(), key, _entityClient, _entityRegistry),
         this.getClass().getSimpleName(),
         "get");
+  }
+
+  public static DataLoader<AspectsKey, List<RawAspect>> createDataLoader(
+      final EntityClient entityClient,
+      final EntityRegistry entityRegistry,
+      final QueryContext queryContext) {
+    final BatchLoaderContextProvider provider = () -> queryContext;
+    final DataLoaderOptions options =
+        DataLoaderOptions.newOptions().setBatchLoaderContextProvider(provider);
+    return DataLoader.newDataLoader(
+        (keys, env) ->
+            GraphQLConcurrencyUtils.supplyAsync(
+                () ->
+                    batchLoad(keys, (QueryContext) env.getContext(), entityClient, entityRegistry),
+                LOADER_NAME,
+                "batchLoad"),
+        options);
+  }
+
+  /**
+   * Batch-resolves a list of {@link AspectsKey}s. Keys are grouped by {@code (entityType,
+   * aspectNames, autoRenderOnly)} so that one {@code batchGetV2} call serves all URNs in a group.
+   * Returns a list of results in the same order as the input keys (DataLoader positional contract).
+   */
+  public static List<List<RawAspect>> batchLoad(
+      final List<AspectsKey> keys,
+      final QueryContext context,
+      final EntityClient entityClient,
+      final EntityRegistry entityRegistry) {
+    final OperationContext opContext = context.getOperationContext();
+    final List<List<RawAspect>> results = new ArrayList<>(Collections.nCopies(keys.size(), null));
+
+    final Map<GroupKey, List<Integer>> groups = new HashMap<>();
+    for (int i = 0; i < keys.size(); i++) {
+      final AspectsKey k = keys.get(i);
+      final GroupKey gk = new GroupKey(k.getEntityType(), k.getAspectNames(), k.isAutoRenderOnly());
+      groups.computeIfAbsent(gk, g -> new ArrayList<>()).add(i);
+    }
+
+    for (Map.Entry<GroupKey, List<Integer>> entry : groups.entrySet()) {
+      final GroupKey gk = entry.getKey();
+      final List<Integer> indices = entry.getValue();
+      final EntitySpec entitySpec = entityRegistry.getEntitySpec(gk.getEntityType());
+      final Set<String> aspectsToFetch =
+          computeAspectsToFetch(entitySpec, gk.getAspectNames(), gk.isAutoRenderOnly());
+
+      if (aspectsToFetch.isEmpty()) {
+        for (int idx : indices) {
+          results.set(idx, new ArrayList<>());
+        }
+        continue;
+      }
+
+      try {
+        final Set<Urn> urns = new HashSet<>();
+        final Map<Integer, Urn> indexToUrn = new HashMap<>();
+        for (int idx : indices) {
+          final Urn urn = Urn.createFromString(keys.get(idx).getUrn());
+          urns.add(urn);
+          indexToUrn.put(idx, urn);
+        }
+        final Map<Urn, EntityResponse> responses =
+            entityClient.batchGetV2(opContext, gk.getEntityType(), urns, aspectsToFetch);
+        for (int idx : indices) {
+          results.set(
+              idx,
+              buildRawAspectList(responses.get(indexToUrn.get(idx)), entitySpec, aspectsToFetch));
+        }
+      } catch (RemoteInvocationException | URISyntaxException e) {
+        throw new RuntimeException(
+            "Failed to batch-fetch aspects for entity type " + gk.getEntityType(), e);
+      }
+    }
+    return results;
+  }
+
+  private static List<RawAspect> fetchSingle(
+      final OperationContext opContext,
+      final AspectsKey key,
+      final EntityClient entityClient,
+      final EntityRegistry entityRegistry) {
+    final EntitySpec entitySpec = entityRegistry.getEntitySpec(key.getEntityType());
+    final Set<String> aspectsToFetch =
+        computeAspectsToFetch(entitySpec, key.getAspectNames(), key.isAutoRenderOnly());
+    if (aspectsToFetch.isEmpty()) {
+      return new ArrayList<>();
+    }
+    try {
+      final Urn urn = Urn.createFromString(key.getUrn());
+      final Map<Urn, EntityResponse> responses =
+          entityClient.batchGetV2(
+              opContext, key.getEntityType(), Collections.singleton(urn), aspectsToFetch);
+      return buildRawAspectList(responses.get(urn), entitySpec, aspectsToFetch);
+    } catch (RemoteInvocationException | URISyntaxException e) {
+      throw new RuntimeException("Failed to fetch aspects for urn " + key.getUrn(), e);
+    }
+  }
+
+  private static Set<String> computeAspectsToFetch(
+      final EntitySpec entitySpec, final Set<String> requestedNames, final boolean autoRenderOnly) {
+    return entitySpec.getAspectSpecs().stream()
+        .filter(spec -> matchesParams(spec, requestedNames, autoRenderOnly))
+        .map(AspectSpec::getName)
+        .collect(Collectors.toSet());
+  }
+
+  private static boolean matchesParams(
+      final AspectSpec spec, final Set<String> requestedNames, final boolean autoRenderOnly) {
+    return (!autoRenderOnly || spec.isAutoRender())
+        && (requestedNames.isEmpty() || requestedNames.contains(spec.getName()));
+  }
+
+  private static List<RawAspect> buildRawAspectList(
+      final EntityResponse response,
+      final EntitySpec entitySpec,
+      final Set<String> aspectsToFetch) {
+    final List<RawAspect> out = new ArrayList<>();
+    if (response == null) {
+      return out;
+    }
+    for (AspectSpec spec : entitySpec.getAspectSpecs()) {
+      if (!aspectsToFetch.contains(spec.getName())) {
+        continue;
+      }
+      if (!response.getAspects().containsKey(spec.getName())) {
+        continue;
+      }
+      final DataMap resolvedAspect = response.getAspects().get(spec.getName()).getValue().data();
+      if (resolvedAspect == null) {
+        continue;
+      }
+      final RawAspect raw = new RawAspect();
+      try {
+        raw.setPayload(CODEC.mapToString(resolvedAspect));
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to serialize aspect " + spec.getName(), e);
+      }
+      raw.setAspectName(spec.getName());
+      final DataMap renderSpec = spec.getRenderSpec();
+      if (renderSpec != null) {
+        final AspectRenderSpec resultRenderSpec = new AspectRenderSpec();
+        resultRenderSpec.setDisplayType(renderSpec.getString("displayType"));
+        resultRenderSpec.setDisplayName(renderSpec.getString("displayName"));
+        resultRenderSpec.setKey(renderSpec.getString("key"));
+        raw.setRenderSpec(resultRenderSpec);
+      }
+      out.add(raw);
+    }
+    return out;
+  }
+
+  @Value
+  public static class AspectsKey {
+    String urn;
+    String entityType;
+    Set<String> aspectNames;
+    boolean autoRenderOnly;
+
+    public static AspectsKey from(
+        final String urn, final String entityType, final AspectParams params) {
+      final Set<String> names =
+          (params == null || params.getAspectNames() == null)
+              ? Collections.emptySet()
+              : new HashSet<>(params.getAspectNames());
+      final boolean autoOnly = params != null && Boolean.TRUE.equals(params.getAutoRenderOnly());
+      return new AspectsKey(urn, entityType, names, autoOnly);
+    }
+  }
+
+  @Value
+  private static class GroupKey {
+    String entityType;
+    Set<String> aspectNames;
+    boolean autoRenderOnly;
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/WeaklyTypedAspectsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/WeaklyTypedAspectsResolver.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.dataloader.BatchLoaderContextProvider;
@@ -40,13 +39,10 @@ import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderOptions;
 
 @Slf4j
-@AllArgsConstructor
 public class WeaklyTypedAspectsResolver implements DataFetcher<CompletableFuture<List<RawAspect>>> {
 
   public static final String LOADER_NAME = "WeaklyTypedAspects";
 
-  private final EntityClient _entityClient;
-  private final EntityRegistry _entityRegistry;
   private static final JacksonDataCodec CODEC = new JacksonDataCodec();
 
   @Override

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/WeaklyTypedAspectsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/WeaklyTypedAspectsResolver.java
@@ -50,29 +50,14 @@ public class WeaklyTypedAspectsResolver implements DataFetcher<CompletableFuture
   private static final JacksonDataCodec CODEC = new JacksonDataCodec();
 
   @Override
-  public CompletableFuture<List<RawAspect>> get(DataFetchingEnvironment environment)
-      throws Exception {
-    final QueryContext context = environment.getContext();
+  public CompletableFuture<List<RawAspect>> get(DataFetchingEnvironment environment) {
     final String urnStr = ((Entity) environment.getSource()).getUrn();
     final EntityType entityType = ((Entity) environment.getSource()).getType();
     final String entityTypeName = EntityTypeMapper.getName(entityType);
     final AspectParams input = bindArgument(environment.getArgument("input"), AspectParams.class);
-
-    final AspectsKey key = AspectsKey.from(urnStr, entityTypeName, input);
-
-    try {
-      DataLoader<AspectsKey, List<RawAspect>> loader = environment.getDataLoader(LOADER_NAME);
-      if (loader != null) {
-        return loader.load(key);
-      }
-    } catch (IllegalArgumentException e) {
-      // Loader not registered for this engine instance — fall through to per-URN path.
-    }
-
-    return GraphQLConcurrencyUtils.supplyAsync(
-        () -> fetchSingle(context.getOperationContext(), key, _entityClient, _entityRegistry),
-        this.getClass().getSimpleName(),
-        "get");
+    final DataLoader<AspectsKey, List<RawAspect>> loader =
+        environment.getDataLoaderRegistry().getDataLoader(LOADER_NAME);
+    return loader.load(AspectsKey.from(urnStr, entityTypeName, input));
   }
 
   public static DataLoader<AspectsKey, List<RawAspect>> createDataLoader(
@@ -147,28 +132,6 @@ public class WeaklyTypedAspectsResolver implements DataFetcher<CompletableFuture
       }
     }
     return results;
-  }
-
-  private static List<RawAspect> fetchSingle(
-      final OperationContext opContext,
-      final AspectsKey key,
-      final EntityClient entityClient,
-      final EntityRegistry entityRegistry) {
-    final EntitySpec entitySpec = entityRegistry.getEntitySpec(key.getEntityType());
-    final Set<String> aspectsToFetch =
-        computeAspectsToFetch(entitySpec, key.getAspectNames(), key.isAutoRenderOnly());
-    if (aspectsToFetch.isEmpty()) {
-      return new ArrayList<>();
-    }
-    try {
-      final Urn urn = Urn.createFromString(key.getUrn());
-      final Map<Urn, EntityResponse> responses =
-          entityClient.batchGetV2(
-              opContext, key.getEntityType(), Collections.singleton(urn), aspectsToFetch);
-      return buildRawAspectList(responses.get(urn), entitySpec, aspectsToFetch);
-    } catch (RemoteInvocationException | URISyntaxException e) {
-      throw new RuntimeException("Failed to fetch aspects for urn " + key.getUrn(), e);
-    }
   }
 
   private static Set<String> computeAspectsToFetch(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentResolvers.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentResolvers.java
@@ -139,9 +139,7 @@ public class DocumentResolvers {
                               : null;
                         }))
                 .dataFetcher(
-                    "aspects",
-                    new com.linkedin.datahub.graphql.WeaklyTypedAspectsResolver(
-                        entityClient, entityRegistry))
+                    "aspects", new com.linkedin.datahub.graphql.WeaklyTypedAspectsResolver())
                 .dataFetcher(
                     "privileges",
                     new com.linkedin.datahub.graphql.resolvers.entity.EntityPrivilegesResolver(

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/WeaklyTypedAspectsResolverBatchTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/WeaklyTypedAspectsResolverBatchTest.java
@@ -1,0 +1,798 @@
+package com.linkedin.datahub.graphql;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.DataMap;
+import com.linkedin.datahub.graphql.WeaklyTypedAspectsResolver.AspectsKey;
+import com.linkedin.datahub.graphql.generated.AspectParams;
+import com.linkedin.datahub.graphql.generated.RawAspect;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.models.AspectSpec;
+import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.r2.RemoteInvocationException;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link WeaklyTypedAspectsResolver#batchLoad(java.util.List, QueryContext,
+ * EntityClient, EntityRegistry)}, the DataLoader batch function. Verifies grouping by {@code
+ * (entityType, aspectNames, autoRenderOnly)}, positional contract, key normalization, and error
+ * semantics.
+ */
+public class WeaklyTypedAspectsResolverBatchTest {
+
+  private static final String DATASET_TYPE = "dataset";
+  private static final String CHART_TYPE = "chart";
+
+  private static final String ASPECT_A = "aspectA";
+  private static final String ASPECT_B = "aspectB";
+  private static final String ASPECT_C = "aspectC";
+
+  private static final Urn DATASET_URN_1 =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:mysql,db.t1,PROD)");
+  private static final Urn DATASET_URN_2 =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:mysql,db.t2,PROD)");
+  private static final Urn DATASET_URN_3 =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:mysql,db.t3,PROD)");
+  private static final Urn CHART_URN_1 = UrnUtils.getUrn("urn:li:chart:(looker,chart1)");
+
+  // ---------- Helpers ----------
+
+  // Use doReturn(...).when(...) instead of when(...).thenReturn(...) so these helpers can be
+  // safely called inline as arguments to other .thenReturn(...) calls without tripping Mockito's
+  // "Unfinished stubbing detected" state machine.
+  private static AspectSpec mockAspectSpec(
+      final String name, final boolean autoRender, final DataMap renderSpec) {
+    final AspectSpec spec = Mockito.mock(AspectSpec.class);
+    Mockito.doReturn(name).when(spec).getName();
+    Mockito.doReturn(autoRender).when(spec).isAutoRender();
+    Mockito.doReturn(renderSpec).when(spec).getRenderSpec();
+    return spec;
+  }
+
+  private static EntitySpec mockEntitySpec(final List<AspectSpec> aspectSpecs) {
+    final EntitySpec entitySpec = Mockito.mock(EntitySpec.class);
+    Mockito.doReturn(aspectSpecs).when(entitySpec).getAspectSpecs();
+    return entitySpec;
+  }
+
+  private static void stubEntitySpec(
+      final EntityRegistry registry, final String entityType, final List<AspectSpec> aspectSpecs) {
+    final EntitySpec entitySpec = mockEntitySpec(aspectSpecs);
+    Mockito.doReturn(entitySpec).when(registry).getEntitySpec(entityType);
+  }
+
+  private static EntityResponse entityResponseWithAspects(
+      final Urn urn, final String... aspectNames) {
+    final EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    for (String name : aspectNames) {
+      aspectMap.put(name, new EnvelopedAspect().setValue(new Aspect(new DataMap())));
+    }
+    return new EntityResponse().setUrn(urn).setAspects(aspectMap);
+  }
+
+  private static QueryContext mockQueryContext() {
+    final QueryContext ctx = Mockito.mock(QueryContext.class);
+    Mockito.when(ctx.getOperationContext()).thenReturn(Mockito.mock(OperationContext.class));
+    return ctx;
+  }
+
+  private static AspectsKey datasetKey(final Urn urn, final Set<String> aspectNames) {
+    final AspectParams params = new AspectParams();
+    params.setAspectNames(ImmutableList.copyOf(aspectNames));
+    return AspectsKey.from(urn.toString(), DATASET_TYPE, params);
+  }
+
+  // ---------- Tests ----------
+
+  @Test
+  public void testSameGroupSingleBatchGetCall() throws Exception {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    final AspectSpec specA = mockAspectSpec(ASPECT_A, false, null);
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(specA));
+
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(ImmutableSet.of(DATASET_URN_1, DATASET_URN_2, DATASET_URN_3)),
+                eq(Collections.singleton(ASPECT_A))))
+        .thenReturn(
+            ImmutableMap.of(
+                DATASET_URN_1, entityResponseWithAspects(DATASET_URN_1, ASPECT_A),
+                DATASET_URN_2, entityResponseWithAspects(DATASET_URN_2, ASPECT_A),
+                DATASET_URN_3, entityResponseWithAspects(DATASET_URN_3, ASPECT_A)));
+
+    final List<AspectsKey> keys =
+        ImmutableList.of(
+            datasetKey(DATASET_URN_1, ImmutableSet.of(ASPECT_A)),
+            datasetKey(DATASET_URN_2, ImmutableSet.of(ASPECT_A)),
+            datasetKey(DATASET_URN_3, ImmutableSet.of(ASPECT_A)));
+
+    final List<List<RawAspect>> result =
+        WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry);
+
+    assertEquals(result.size(), 3);
+    for (List<RawAspect> per : result) {
+      assertEquals(per.size(), 1);
+      assertEquals(per.get(0).getAspectName(), ASPECT_A);
+    }
+    Mockito.verify(client, Mockito.times(1))
+        .batchGetV2(
+            nullable(OperationContext.class), eq(DATASET_TYPE), Mockito.anySet(), Mockito.anySet());
+  }
+
+  @Test
+  public void testMixedEntityTypesOneCallPerType() throws Exception {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    final AspectSpec datasetSpecA = mockAspectSpec(ASPECT_A, false, null);
+    final AspectSpec chartSpecA = mockAspectSpec(ASPECT_A, false, null);
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(datasetSpecA));
+    stubEntitySpec(registry, CHART_TYPE, ImmutableList.of(chartSpecA));
+
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(ImmutableSet.of(DATASET_URN_1, DATASET_URN_2)),
+                eq(Collections.singleton(ASPECT_A))))
+        .thenReturn(
+            ImmutableMap.of(
+                DATASET_URN_1, entityResponseWithAspects(DATASET_URN_1, ASPECT_A),
+                DATASET_URN_2, entityResponseWithAspects(DATASET_URN_2, ASPECT_A)));
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(CHART_TYPE),
+                eq(ImmutableSet.of(CHART_URN_1)),
+                eq(Collections.singleton(ASPECT_A))))
+        .thenReturn(ImmutableMap.of(CHART_URN_1, entityResponseWithAspects(CHART_URN_1, ASPECT_A)));
+
+    final AspectParams paramsA = new AspectParams();
+    paramsA.setAspectNames(ImmutableList.of(ASPECT_A));
+
+    final List<AspectsKey> keys =
+        ImmutableList.of(
+            datasetKey(DATASET_URN_1, ImmutableSet.of(ASPECT_A)),
+            AspectsKey.from(CHART_URN_1.toString(), CHART_TYPE, paramsA),
+            datasetKey(DATASET_URN_2, ImmutableSet.of(ASPECT_A)));
+
+    final List<List<RawAspect>> result =
+        WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry);
+
+    assertEquals(result.size(), 3);
+    assertEquals(result.get(0).get(0).getAspectName(), ASPECT_A);
+    assertEquals(result.get(1).get(0).getAspectName(), ASPECT_A);
+    assertEquals(result.get(2).get(0).getAspectName(), ASPECT_A);
+    Mockito.verify(client, Mockito.times(1))
+        .batchGetV2(
+            nullable(OperationContext.class), eq(DATASET_TYPE), Mockito.anySet(), Mockito.anySet());
+    Mockito.verify(client, Mockito.times(1))
+        .batchGetV2(
+            nullable(OperationContext.class), eq(CHART_TYPE), Mockito.anySet(), Mockito.anySet());
+  }
+
+  @Test
+  public void testDifferentAspectNamesSetsSeparateCalls() throws Exception {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    final AspectSpec specA = mockAspectSpec(ASPECT_A, false, null);
+    final AspectSpec specB = mockAspectSpec(ASPECT_B, false, null);
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(specA, specB));
+
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(Collections.singleton(DATASET_URN_1)),
+                eq(Collections.singleton(ASPECT_A))))
+        .thenReturn(
+            ImmutableMap.of(DATASET_URN_1, entityResponseWithAspects(DATASET_URN_1, ASPECT_A)));
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(Collections.singleton(DATASET_URN_2)),
+                eq(Collections.singleton(ASPECT_B))))
+        .thenReturn(
+            ImmutableMap.of(DATASET_URN_2, entityResponseWithAspects(DATASET_URN_2, ASPECT_B)));
+
+    final List<AspectsKey> keys =
+        ImmutableList.of(
+            datasetKey(DATASET_URN_1, ImmutableSet.of(ASPECT_A)),
+            datasetKey(DATASET_URN_2, ImmutableSet.of(ASPECT_B)));
+
+    final List<List<RawAspect>> result =
+        WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry);
+
+    assertEquals(result.get(0).get(0).getAspectName(), ASPECT_A);
+    assertEquals(result.get(1).get(0).getAspectName(), ASPECT_B);
+    Mockito.verify(client, Mockito.times(2))
+        .batchGetV2(
+            nullable(OperationContext.class), eq(DATASET_TYPE), Mockito.anySet(), Mockito.anySet());
+  }
+
+  @Test
+  public void testAspectNamesOrderIndependentKeyEquality() {
+    final AspectParams pAB = new AspectParams();
+    pAB.setAspectNames(Arrays.asList(ASPECT_A, ASPECT_B));
+    final AspectParams pBA = new AspectParams();
+    pBA.setAspectNames(Arrays.asList(ASPECT_B, ASPECT_A));
+
+    final AspectsKey k1 = AspectsKey.from(DATASET_URN_1.toString(), DATASET_TYPE, pAB);
+    final AspectsKey k2 = AspectsKey.from(DATASET_URN_1.toString(), DATASET_TYPE, pBA);
+
+    assertEquals(k1, k2);
+    assertEquals(k1.hashCode(), k2.hashCode());
+  }
+
+  @Test
+  public void testAspectsKeyNormalizesNulls() {
+    final AspectsKey nullParams = AspectsKey.from(DATASET_URN_1.toString(), DATASET_TYPE, null);
+    final AspectParams empty = new AspectParams(); // null aspectNames, null autoRenderOnly
+    final AspectsKey emptyParams = AspectsKey.from(DATASET_URN_1.toString(), DATASET_TYPE, empty);
+
+    assertEquals(nullParams, emptyParams);
+    assertEquals(nullParams.getAspectNames(), Collections.emptySet());
+    assertEquals(nullParams.isAutoRenderOnly(), false);
+  }
+
+  @Test
+  public void testAutoRenderOnlyNarrowsFetchedAspects() throws Exception {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    final AspectSpec specA = mockAspectSpec(ASPECT_A, true, null); // auto-render
+    final AspectSpec specB = mockAspectSpec(ASPECT_B, false, null);
+    final AspectSpec specC = mockAspectSpec(ASPECT_C, true, null); // auto-render
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(specA, specB, specC));
+
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(Collections.singleton(DATASET_URN_1)),
+                eq(ImmutableSet.of(ASPECT_A, ASPECT_C))))
+        .thenReturn(
+            ImmutableMap.of(
+                DATASET_URN_1, entityResponseWithAspects(DATASET_URN_1, ASPECT_A, ASPECT_C)));
+
+    final AspectParams autoOnly = new AspectParams();
+    autoOnly.setAutoRenderOnly(true);
+
+    final List<AspectsKey> keys =
+        ImmutableList.of(AspectsKey.from(DATASET_URN_1.toString(), DATASET_TYPE, autoOnly));
+
+    final List<List<RawAspect>> result =
+        WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry);
+
+    assertEquals(result.size(), 1);
+    final List<RawAspect> raws = result.get(0);
+    assertEquals(raws.size(), 2);
+    final Set<String> names = new HashSet<>();
+    for (RawAspect r : raws) {
+      names.add(r.getAspectName());
+    }
+    assertEquals(names, ImmutableSet.of(ASPECT_A, ASPECT_C));
+    Mockito.verify(client, Mockito.times(1))
+        .batchGetV2(
+            nullable(OperationContext.class), eq(DATASET_TYPE), Mockito.anySet(), Mockito.anySet());
+  }
+
+  @Test
+  public void testEmptyResolvedAspectSetSkipsClientCall() throws Exception {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    // Registry has aspectA only, but caller asks for aspectB (no match).
+    final AspectSpec specA = mockAspectSpec(ASPECT_A, false, null);
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(specA));
+
+    final List<AspectsKey> keys =
+        ImmutableList.of(datasetKey(DATASET_URN_1, ImmutableSet.of(ASPECT_B)));
+
+    final List<List<RawAspect>> result =
+        WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry);
+
+    assertEquals(result.size(), 1);
+    assertTrue(result.get(0).isEmpty());
+    Mockito.verify(client, Mockito.never())
+        .batchGetV2(any(), Mockito.anyString(), Mockito.anySet(), Mockito.anySet());
+  }
+
+  @Test
+  public void testMissingUrnInResponseYieldsEmptyList() throws Exception {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    final AspectSpec specA = mockAspectSpec(ASPECT_A, false, null);
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(specA));
+
+    // Response only has URN_1; URN_2 is missing (entity not found).
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(ImmutableSet.of(DATASET_URN_1, DATASET_URN_2)),
+                eq(Collections.singleton(ASPECT_A))))
+        .thenReturn(
+            ImmutableMap.of(DATASET_URN_1, entityResponseWithAspects(DATASET_URN_1, ASPECT_A)));
+
+    final List<AspectsKey> keys =
+        ImmutableList.of(
+            datasetKey(DATASET_URN_1, ImmutableSet.of(ASPECT_A)),
+            datasetKey(DATASET_URN_2, ImmutableSet.of(ASPECT_A)));
+
+    final List<List<RawAspect>> result =
+        WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry);
+
+    assertEquals(result.get(0).size(), 1);
+    assertEquals(result.get(0).get(0).getAspectName(), ASPECT_A);
+    assertTrue(result.get(1).isEmpty());
+  }
+
+  @Test
+  public void testPositionalContractPreservesInputOrder() throws Exception {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    final AspectSpec specA = mockAspectSpec(ASPECT_A, false, null);
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(specA));
+
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                Mockito.anySet(),
+                eq(Collections.singleton(ASPECT_A))))
+        .thenReturn(
+            ImmutableMap.of(
+                DATASET_URN_1, entityResponseWithAspects(DATASET_URN_1, ASPECT_A),
+                DATASET_URN_2, entityResponseWithAspects(DATASET_URN_2, ASPECT_A),
+                DATASET_URN_3, entityResponseWithAspects(DATASET_URN_3, ASPECT_A)));
+
+    // Input order: 3, 1, 2 — result must follow same order.
+    final List<AspectsKey> keys =
+        ImmutableList.of(
+            datasetKey(DATASET_URN_3, ImmutableSet.of(ASPECT_A)),
+            datasetKey(DATASET_URN_1, ImmutableSet.of(ASPECT_A)),
+            datasetKey(DATASET_URN_2, ImmutableSet.of(ASPECT_A)));
+
+    final List<List<RawAspect>> result =
+        WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry);
+
+    assertEquals(result.size(), 3);
+    // Each entry corresponds to its key's URN; payload is non-empty (aspectA was returned).
+    for (int i = 0; i < 3; i++) {
+      assertEquals(result.get(i).size(), 1, "index " + i);
+      assertEquals(result.get(i).get(0).getAspectName(), ASPECT_A);
+    }
+  }
+
+  /**
+   * Documents the actual current behavior: a {@code batchGetV2} failure inside any group bubbles
+   * out of {@code batchLoad} as a {@code RuntimeException}, failing all keys in the batch (not just
+   * the failing group). Recorded as an open question against the plan — current implementation does
+   * not isolate per-group failures.
+   */
+  @Test
+  public void testBatchGetV2ExceptionPropagatesAsRuntimeException() throws Exception {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    final AspectSpec specA = mockAspectSpec(ASPECT_A, false, null);
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(specA));
+
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                Mockito.anySet(),
+                Mockito.anySet()))
+        .thenThrow(new RemoteInvocationException("boom"));
+
+    final List<AspectsKey> keys =
+        ImmutableList.of(datasetKey(DATASET_URN_1, ImmutableSet.of(ASPECT_A)));
+
+    assertThrows(
+        RuntimeException.class,
+        () -> WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry));
+  }
+
+  @Test
+  public void testEmptyInputKeyListReturnsEmptyResult() {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    final List<List<RawAspect>> result =
+        WeaklyTypedAspectsResolver.batchLoad(Collections.emptyList(), ctx, client, registry);
+
+    assertTrue(result.isEmpty());
+    Mockito.verifyNoInteractions(client);
+    Mockito.verifyNoInteractions(registry);
+  }
+
+  /**
+   * When the same effective key is passed twice (same urn, entityType, aspectNames, autoRenderOnly)
+   * the batchLoad still produces the right number of slots in input order. DataLoader normally
+   * de-dupes before invoking batchLoad, but the batch function itself must not assume uniqueness.
+   */
+  @Test
+  public void testDuplicateKeysFillCorrespondingSlots() throws Exception {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    final AspectSpec specA = mockAspectSpec(ASPECT_A, false, null);
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(specA));
+
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(Collections.singleton(DATASET_URN_1)),
+                eq(Collections.singleton(ASPECT_A))))
+        .thenReturn(
+            ImmutableMap.of(DATASET_URN_1, entityResponseWithAspects(DATASET_URN_1, ASPECT_A)));
+
+    final AspectsKey k = datasetKey(DATASET_URN_1, ImmutableSet.of(ASPECT_A));
+    final List<List<RawAspect>> result =
+        WeaklyTypedAspectsResolver.batchLoad(ImmutableList.of(k, k), ctx, client, registry);
+
+    assertEquals(result.size(), 2);
+    assertEquals(result.get(0).get(0).getAspectName(), ASPECT_A);
+    assertEquals(result.get(1).get(0).getAspectName(), ASPECT_A);
+    // Single batchGetV2 call — the same URN is collapsed in the request set.
+    Mockito.verify(client, Mockito.times(1))
+        .batchGetV2(
+            nullable(OperationContext.class), eq(DATASET_TYPE), Mockito.anySet(), Mockito.anySet());
+  }
+
+  @Test
+  public void testRawAspectRenderSpecPopulated() throws Exception {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    final DataMap renderSpec = new DataMap();
+    renderSpec.put("displayType", "table");
+    renderSpec.put("displayName", "Aspect A");
+    renderSpec.put("key", "key-a");
+    final AspectSpec specA = mockAspectSpec(ASPECT_A, false, renderSpec);
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(specA));
+
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(Collections.singleton(DATASET_URN_1)),
+                eq(Collections.singleton(ASPECT_A))))
+        .thenReturn(
+            ImmutableMap.of(DATASET_URN_1, entityResponseWithAspects(DATASET_URN_1, ASPECT_A)));
+
+    final List<AspectsKey> keys =
+        ImmutableList.of(datasetKey(DATASET_URN_1, ImmutableSet.of(ASPECT_A)));
+
+    final List<List<RawAspect>> result =
+        WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry);
+
+    final RawAspect raw = result.get(0).get(0);
+    assertEquals(raw.getRenderSpec().getDisplayType(), "table");
+    assertEquals(raw.getRenderSpec().getDisplayName(), "Aspect A");
+    assertEquals(raw.getRenderSpec().getKey(), "key-a");
+  }
+
+  @Test
+  public void testAutoRenderOnlyFalseIncludesAllMatchingNames() throws Exception {
+    // Sanity check that autoRenderOnly=false (default) does not filter on auto-render flag.
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    final AspectSpec specA = mockAspectSpec(ASPECT_A, false, null);
+    final AspectSpec specB = mockAspectSpec(ASPECT_B, false, null);
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(specA, specB));
+
+    final Set<String> bothAspects = ImmutableSet.of(ASPECT_A, ASPECT_B);
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(Collections.singleton(DATASET_URN_1)),
+                eq(bothAspects)))
+        .thenReturn(
+            ImmutableMap.of(
+                DATASET_URN_1, entityResponseWithAspects(DATASET_URN_1, ASPECT_A, ASPECT_B)));
+
+    final List<AspectsKey> keys = ImmutableList.of(datasetKey(DATASET_URN_1, bothAspects));
+    final List<List<RawAspect>> result =
+        WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry);
+
+    assertEquals(result.get(0).size(), 2);
+    final Set<String> got = new HashSet<>();
+    for (RawAspect r : result.get(0)) {
+      got.add(r.getAspectName());
+    }
+    assertEquals(got, bothAspects);
+  }
+
+  /** Captures the empty-aspectNames-fetch-everything semantic (no name filter, no auto filter). */
+  @Test
+  public void testEmptyAspectNamesFetchesAllAspects() throws Exception {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    final AspectSpec specA = mockAspectSpec(ASPECT_A, false, null);
+    final AspectSpec specB = mockAspectSpec(ASPECT_B, false, null);
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(specA, specB));
+
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(Collections.singleton(DATASET_URN_1)),
+                eq(ImmutableSet.of(ASPECT_A, ASPECT_B))))
+        .thenReturn(
+            ImmutableMap.of(
+                DATASET_URN_1, entityResponseWithAspects(DATASET_URN_1, ASPECT_A, ASPECT_B)));
+
+    // Empty aspectNames → no filter → all aspects fetched.
+    final List<AspectsKey> keys =
+        ImmutableList.of(
+            AspectsKey.from(DATASET_URN_1.toString(), DATASET_TYPE, new AspectParams()));
+
+    final List<List<RawAspect>> result =
+        WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry);
+
+    assertEquals(result.get(0).size(), 2);
+  }
+
+  /**
+   * Constructed groups for the same entity type but different {@code autoRenderOnly} must not be
+   * merged.
+   */
+  @Test
+  public void testAutoRenderOnlySplitsGroups() throws Exception {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    final AspectSpec specA = mockAspectSpec(ASPECT_A, true, null);
+    final AspectSpec specB = mockAspectSpec(ASPECT_B, false, null);
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(specA, specB));
+
+    // Group 1: autoRenderOnly=true → fetch {ASPECT_A}
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(Collections.singleton(DATASET_URN_1)),
+                eq(Collections.singleton(ASPECT_A))))
+        .thenReturn(
+            ImmutableMap.of(DATASET_URN_1, entityResponseWithAspects(DATASET_URN_1, ASPECT_A)));
+    // Group 2: autoRenderOnly=false, empty names → fetch {ASPECT_A, ASPECT_B}
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(Collections.singleton(DATASET_URN_2)),
+                eq(ImmutableSet.of(ASPECT_A, ASPECT_B))))
+        .thenReturn(
+            ImmutableMap.of(
+                DATASET_URN_2, entityResponseWithAspects(DATASET_URN_2, ASPECT_A, ASPECT_B)));
+
+    final AspectParams autoOnly = new AspectParams();
+    autoOnly.setAutoRenderOnly(true);
+    final AspectParams allParams = new AspectParams();
+
+    final List<AspectsKey> keys =
+        ImmutableList.of(
+            AspectsKey.from(DATASET_URN_1.toString(), DATASET_TYPE, autoOnly),
+            AspectsKey.from(DATASET_URN_2.toString(), DATASET_TYPE, allParams));
+
+    final List<List<RawAspect>> result =
+        WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry);
+
+    assertEquals(result.get(0).size(), 1);
+    assertEquals(result.get(0).get(0).getAspectName(), ASPECT_A);
+    assertEquals(result.get(1).size(), 2);
+    Mockito.verify(client, Mockito.times(2))
+        .batchGetV2(
+            nullable(OperationContext.class), eq(DATASET_TYPE), Mockito.anySet(), Mockito.anySet());
+  }
+
+  @Test
+  public void testGroupKeyForSameUrnDifferentAspectNamesNotMerged() throws Exception {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    final AspectSpec specA = mockAspectSpec(ASPECT_A, false, null);
+    final AspectSpec specB = mockAspectSpec(ASPECT_B, false, null);
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(specA, specB));
+
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(Collections.singleton(DATASET_URN_1)),
+                eq(Collections.singleton(ASPECT_A))))
+        .thenReturn(
+            ImmutableMap.of(DATASET_URN_1, entityResponseWithAspects(DATASET_URN_1, ASPECT_A)));
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(Collections.singleton(DATASET_URN_1)),
+                eq(Collections.singleton(ASPECT_B))))
+        .thenReturn(
+            ImmutableMap.of(DATASET_URN_1, entityResponseWithAspects(DATASET_URN_1, ASPECT_B)));
+
+    final List<AspectsKey> keys =
+        ImmutableList.of(
+            datasetKey(DATASET_URN_1, ImmutableSet.of(ASPECT_A)),
+            datasetKey(DATASET_URN_1, ImmutableSet.of(ASPECT_B)));
+
+    final List<List<RawAspect>> result =
+        WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry);
+
+    assertEquals(result.get(0).get(0).getAspectName(), ASPECT_A);
+    assertEquals(result.get(1).get(0).getAspectName(), ASPECT_B);
+    Mockito.verify(client, Mockito.times(2))
+        .batchGetV2(
+            nullable(OperationContext.class), eq(DATASET_TYPE), Mockito.anySet(), Mockito.anySet());
+  }
+
+  /**
+   * Mixed entity-type keys where one group resolves to an empty aspect set must not affect the
+   * other group's results.
+   */
+  @Test
+  public void testEmptyGroupCoexistsWithNonEmptyGroup() throws Exception {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    // dataset: aspectA present
+    final AspectSpec datasetSpecA = mockAspectSpec(ASPECT_A, false, null);
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(datasetSpecA));
+    // chart: only aspectC, caller asks for aspectA — no match -> empty
+    final AspectSpec chartSpecC = mockAspectSpec(ASPECT_C, false, null);
+    stubEntitySpec(registry, CHART_TYPE, ImmutableList.of(chartSpecC));
+
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(Collections.singleton(DATASET_URN_1)),
+                eq(Collections.singleton(ASPECT_A))))
+        .thenReturn(
+            ImmutableMap.of(DATASET_URN_1, entityResponseWithAspects(DATASET_URN_1, ASPECT_A)));
+
+    final AspectParams params = new AspectParams();
+    params.setAspectNames(ImmutableList.of(ASPECT_A));
+
+    final List<AspectsKey> keys =
+        ImmutableList.of(
+            AspectsKey.from(DATASET_URN_1.toString(), DATASET_TYPE, params),
+            AspectsKey.from(CHART_URN_1.toString(), CHART_TYPE, params));
+
+    final List<List<RawAspect>> result =
+        WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry);
+
+    assertEquals(result.get(0).size(), 1);
+    assertTrue(result.get(1).isEmpty());
+    // Only the dataset group should have issued a batchGetV2 call.
+    Mockito.verify(client, Mockito.times(1))
+        .batchGetV2(
+            nullable(OperationContext.class), eq(DATASET_TYPE), Mockito.anySet(), Mockito.anySet());
+    Mockito.verify(client, Mockito.never())
+        .batchGetV2(
+            nullable(OperationContext.class), eq(CHART_TYPE), Mockito.anySet(), Mockito.anySet());
+  }
+
+  /**
+   * Verifies the resolver respects the aspectSpec iteration order in {@code buildRawAspectList}.
+   */
+  @Test
+  public void testRawAspectListOrderMatchesEntitySpecOrder() throws Exception {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    // EntitySpec exposes A then B then C; caller asks for {B, A, C}.
+    final AspectSpec specA = mockAspectSpec(ASPECT_A, false, null);
+    final AspectSpec specB = mockAspectSpec(ASPECT_B, false, null);
+    final AspectSpec specC = mockAspectSpec(ASPECT_C, false, null);
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(specA, specB, specC));
+
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(Collections.singleton(DATASET_URN_1)),
+                eq(ImmutableSet.of(ASPECT_A, ASPECT_B, ASPECT_C))))
+        .thenReturn(
+            ImmutableMap.of(
+                DATASET_URN_1,
+                entityResponseWithAspects(DATASET_URN_1, ASPECT_A, ASPECT_B, ASPECT_C)));
+
+    final List<AspectsKey> keys =
+        ImmutableList.of(datasetKey(DATASET_URN_1, ImmutableSet.of(ASPECT_B, ASPECT_A, ASPECT_C)));
+
+    final List<List<RawAspect>> result =
+        WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry);
+
+    final List<RawAspect> raws = result.get(0);
+    assertEquals(raws.size(), 3);
+    assertEquals(raws.get(0).getAspectName(), ASPECT_A);
+    assertEquals(raws.get(1).getAspectName(), ASPECT_B);
+    assertEquals(raws.get(2).getAspectName(), ASPECT_C);
+  }
+
+  @Test
+  public void testRawAspectListSkipsAspectsMissingFromResponse() throws Exception {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    // Caller asks for {A, B}; backend returns only A.
+    final AspectSpec specA = mockAspectSpec(ASPECT_A, false, null);
+    final AspectSpec specB = mockAspectSpec(ASPECT_B, false, null);
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(specA, specB));
+
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(Collections.singleton(DATASET_URN_1)),
+                eq(ImmutableSet.of(ASPECT_A, ASPECT_B))))
+        .thenReturn(
+            ImmutableMap.of(DATASET_URN_1, entityResponseWithAspects(DATASET_URN_1, ASPECT_A)));
+
+    final List<AspectsKey> keys =
+        ImmutableList.of(datasetKey(DATASET_URN_1, ImmutableSet.of(ASPECT_A, ASPECT_B)));
+
+    final List<List<RawAspect>> result =
+        WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry);
+
+    assertEquals(result.get(0).size(), 1);
+    assertEquals(result.get(0).get(0).getAspectName(), ASPECT_A);
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/WeaklyTypedAspectsResolverBatchTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/WeaklyTypedAspectsResolverBatchTest.java
@@ -87,7 +87,11 @@ public class WeaklyTypedAspectsResolverBatchTest {
       final Urn urn, final String... aspectNames) {
     final EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
     for (String name : aspectNames) {
-      aspectMap.put(name, new EnvelopedAspect().setValue(new Aspect(new DataMap())));
+      // Stamp the URN into each aspect payload so tests can verify which response landed
+      // in which result slot (the positional DataLoader contract).
+      final DataMap payload = new DataMap();
+      payload.put("_testUrn", urn.toString());
+      aspectMap.put(name, new EnvelopedAspect().setValue(new Aspect(payload)));
     }
     return new EntityResponse().setUrn(urn).setAspects(aspectMap);
   }
@@ -188,9 +192,14 @@ public class WeaklyTypedAspectsResolverBatchTest {
         WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry);
 
     assertEquals(result.size(), 3);
+    // Input order interleaves entity types ([dataset, chart, dataset]); grouping by type
+    // could easily re-order the output if the positional contract is broken.
     assertEquals(result.get(0).get(0).getAspectName(), ASPECT_A);
+    assertTrue(result.get(0).get(0).getPayload().contains(DATASET_URN_1.toString()));
     assertEquals(result.get(1).get(0).getAspectName(), ASPECT_A);
+    assertTrue(result.get(1).get(0).getPayload().contains(CHART_URN_1.toString()));
     assertEquals(result.get(2).get(0).getAspectName(), ASPECT_A);
+    assertTrue(result.get(2).get(0).getPayload().contains(DATASET_URN_2.toString()));
     Mockito.verify(client, Mockito.times(1))
         .batchGetV2(
             nullable(OperationContext.class), eq(DATASET_TYPE), Mockito.anySet(), Mockito.anySet());
@@ -384,7 +393,9 @@ public class WeaklyTypedAspectsResolverBatchTest {
                 DATASET_URN_2, entityResponseWithAspects(DATASET_URN_2, ASPECT_A),
                 DATASET_URN_3, entityResponseWithAspects(DATASET_URN_3, ASPECT_A)));
 
-    // Input order: 3, 1, 2 — result must follow same order.
+    // Input order: 3, 1, 2 — result slots must follow the same order. Each URN's mocked
+    // response stamps its URN into the aspect payload so we can detect any permutation.
+    final List<Urn> expectedOrder = ImmutableList.of(DATASET_URN_3, DATASET_URN_1, DATASET_URN_2);
     final List<AspectsKey> keys =
         ImmutableList.of(
             datasetKey(DATASET_URN_3, ImmutableSet.of(ASPECT_A)),
@@ -395,10 +406,12 @@ public class WeaklyTypedAspectsResolverBatchTest {
         WeaklyTypedAspectsResolver.batchLoad(keys, ctx, client, registry);
 
     assertEquals(result.size(), 3);
-    // Each entry corresponds to its key's URN; payload is non-empty (aspectA was returned).
     for (int i = 0; i < 3; i++) {
       assertEquals(result.get(i).size(), 1, "index " + i);
       assertEquals(result.get(i).get(0).getAspectName(), ASPECT_A);
+      assertTrue(
+          result.get(i).get(0).getPayload().contains(expectedOrder.get(i).toString()),
+          "slot " + i + " should hold response for " + expectedOrder.get(i));
     }
   }
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/WeaklyTypedAspectsResolverBatchTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/WeaklyTypedAspectsResolverBatchTest.java
@@ -15,6 +15,8 @@ import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.DataMap;
 import com.linkedin.datahub.graphql.WeaklyTypedAspectsResolver.AspectsKey;
 import com.linkedin.datahub.graphql.generated.AspectParams;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.RawAspect;
 import com.linkedin.entity.Aspect;
 import com.linkedin.entity.EntityResponse;
@@ -25,12 +27,17 @@ import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.r2.RemoteInvocationException;
+import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderRegistry;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -807,5 +814,76 @@ public class WeaklyTypedAspectsResolverBatchTest {
 
     assertEquals(result.get(0).size(), 1);
     assertEquals(result.get(0).get(0).getAspectName(), ASPECT_A);
+  }
+
+  /**
+   * Covers {@link WeaklyTypedAspectsResolver#get(DataFetchingEnvironment)}: the resolver pulls the
+   * named loader from the registry and dispatches an {@link AspectsKey} built from the source URN,
+   * the source entity type, and the {@code input} argument.
+   */
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testGetDispatchesToDataLoader() {
+    final DataFetchingEnvironment env = Mockito.mock(DataFetchingEnvironment.class);
+    final Entity source = Mockito.mock(Entity.class);
+    Mockito.when(source.getUrn()).thenReturn(DATASET_URN_1.toString());
+    Mockito.when(source.getType()).thenReturn(EntityType.DATASET);
+    Mockito.when(env.getSource()).thenReturn(source);
+    Mockito.when(env.getArgument("input")).thenReturn(null);
+
+    final DataLoader<AspectsKey, List<RawAspect>> loader =
+        (DataLoader<AspectsKey, List<RawAspect>>) Mockito.mock(DataLoader.class);
+    final DataLoaderRegistry registry = Mockito.mock(DataLoaderRegistry.class);
+    Mockito.doReturn(loader).when(registry).getDataLoader(WeaklyTypedAspectsResolver.LOADER_NAME);
+    Mockito.when(env.getDataLoaderRegistry()).thenReturn(registry);
+
+    final CompletableFuture<List<RawAspect>> expected =
+        CompletableFuture.completedFuture(Collections.emptyList());
+    Mockito.when(loader.load(any(AspectsKey.class))).thenReturn(expected);
+
+    final CompletableFuture<List<RawAspect>> result = new WeaklyTypedAspectsResolver().get(env);
+
+    assertEquals(result, expected);
+    final ArgumentCaptor<AspectsKey> captor = ArgumentCaptor.forClass(AspectsKey.class);
+    Mockito.verify(loader).load(captor.capture());
+    final AspectsKey actual = captor.getValue();
+    assertEquals(actual.getUrn(), DATASET_URN_1.toString());
+    assertEquals(actual.getEntityType(), DATASET_TYPE);
+    assertTrue(actual.getAspectNames().isEmpty());
+    assertEquals(actual.isAutoRenderOnly(), false);
+  }
+
+  /**
+   * Covers {@link WeaklyTypedAspectsResolver#createDataLoader(EntityClient, EntityRegistry,
+   * QueryContext)}: the returned loader, when dispatched, routes the registered key through {@code
+   * batchLoad} and emits a populated {@link RawAspect}.
+   */
+  @Test
+  public void testCreateDataLoaderRoutesThroughBatchLoad() throws Exception {
+    final EntityClient client = Mockito.mock(EntityClient.class);
+    final EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    final QueryContext ctx = mockQueryContext();
+
+    final AspectSpec specA = mockAspectSpec(ASPECT_A, false, null);
+    stubEntitySpec(registry, DATASET_TYPE, ImmutableList.of(specA));
+    Mockito.when(
+            client.batchGetV2(
+                nullable(OperationContext.class),
+                eq(DATASET_TYPE),
+                eq(Collections.singleton(DATASET_URN_1)),
+                eq(Collections.singleton(ASPECT_A))))
+        .thenReturn(
+            ImmutableMap.of(DATASET_URN_1, entityResponseWithAspects(DATASET_URN_1, ASPECT_A)));
+
+    final DataLoader<AspectsKey, List<RawAspect>> loader =
+        WeaklyTypedAspectsResolver.createDataLoader(client, registry, ctx);
+    final CompletableFuture<List<RawAspect>> future =
+        loader.load(datasetKey(DATASET_URN_1, ImmutableSet.of(ASPECT_A)));
+    loader.dispatch();
+
+    final List<RawAspect> result = future.get();
+    assertEquals(result.size(), 1);
+    assertEquals(result.get(0).getAspectName(), ASPECT_A);
+    assertTrue(result.get(0).getPayload().contains(DATASET_URN_1.toString()));
   }
 }


### PR DESCRIPTION
## Summary

- `aspects(input)` on every entity type previously issued one `EntityClient.batchGetV2` call per `(urn, aspectName)` pair via `WeaklyTypedAspectsResolver` — N × M single-row backend fetches for an operation returning N entities each selecting M matching aspect specs.
- Convert the resolver to use a per-request DataLoader keyed on `(urn, entityType, aspectNames, autoRenderOnly)`. The batch function groups accumulated keys by `(entityType, aspectNames, autoRenderOnly)` and issues one `batchGetV2` per group, then writes results back positionally per the DataLoader contract.

## Checklist

- [x] Conforms to the Contributing Guideline (PR title format `perf(graphql): ...`).
- [x] Tests added (`WeaklyTypedAspectsResolverBatchTest`).
- [ ] No docs changes — internal resolver refactor; GraphQL schema unchanged.
- [ ] No `updating-datahub.md` entry — non-breaking; pure perf optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)