### PR TITLE
ci(PR Labels): Detect community contributors via fork check instead of team list

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -18,27 +18,10 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: ".github/pr-labeler-config.yml"
-      - name: Check if internal contributor
-        id: check-internal
-        continue-on-error: true
-        env:
-          TEAM_MEMBERS: ${{ vars.DATAHUB_TEAM_MEMBERS }}
-          PR_AUTHOR: ${{ github.actor }}
-        run: |
-          # Team members list is managed via the DATAHUB_TEAM_MEMBERS repo variable.
-          # Update it in Settings > Variables > Actions when team members join or leave.
-          if [ -z "$TEAM_MEMBERS" ]; then
-            echo "⚠️  DATAHUB_TEAM_MEMBERS variable is not set — skipping community-contribution label"
-            echo "is_internal=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if echo "$TEAM_MEMBERS" | jq -e --arg actor "$PR_AUTHOR" '[.[].github] | map(ascii_downcase) | contains([($actor | ascii_downcase)])' > /dev/null 2>&1; then
-            echo "is_internal=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_internal=false" >> "$GITHUB_OUTPUT"
-          fi
       - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
-        if: steps.check-internal.outputs.is_internal == 'false'
+        # PRs from forks are community contributions. Internal contributors push branches
+        # to the upstream repo, so head.repo.full_name == github.repository for them.
+        if: github.event.pull_request.head.repo.full_name != github.repository
         with:
           github_token: ${{ github.token }}
           labels: |


### PR DESCRIPTION
## Summary

- Replaces the `DATAHUB_TEAM_MEMBERS` repo-variable lookup in `pr-labeler.yml` with the same `head.repo.full_name != github.repository` fork check used elsewhere (e.g. `docker-unified.yml`).
- Removes the need for manual upkeep of a teammate handle list — any PR from a fork is treated as a community contribution.
- The `datahub-community-champion` allowlist is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)