### PR TITLE
feat(unity): default Unity Catalog profiling to SQLAlchemy instead of Great Expectations

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -97,6 +97,20 @@ Requirements:
 
   **Deprecation notice:** The Great Expectations profiler is now considered legacy and is planned for removal in a future release. New deployments should rely on the default SQLAlchemy profiler. Existing users that still depend on `method: ge` should plan to migrate.
 
+- #17469 **Unity Catalog profiling now defaults to `method: sqlalchemy`** instead of `method: ge`. This aligns Unity Catalog with all other SQL connectors after #17465 flipped the global default. If your Unity Catalog recipe enables profiling and relied on the Great Expectations profiler, add the following to your recipe and install the extra:
+
+  ```bash
+  pip install 'acryl-datahub[unity-catalog,profiling-ge]'
+  ```
+
+  ```yaml
+  source:
+    config:
+      profiling:
+        enabled: true
+        method: ge
+  ```
+
 - **Search filters (REST, GraphQL, SDK):** The Pegasus `Criterion` record and GraphQL `FacetFilterInput` no longer expose a singular `value` field. Send match values only via `values` (a string array; use a one-element array where you previously passed a single string). Clients that still serialize `value` must migrate; server-side auto-conversion and related logging have been removed.
 
 - #16842: **(Ingestion / Athena) Upstream lineage URNs changed for Glue-backed catalogs.** Athena tables backed by the AWS Glue Data Catalog (i.e. using `awsdatacatalog` or any catalog whose type resolves to `GLUE`) now emit upstream lineage to Glue dataset URNs (`urn:li:dataPlatform:glue`) instead of S3 URNs (`urn:li:dataPlatform:s3`). Iceberg tables in non-Glue catalogs (e.g. Hive Metastore, Lambda, Federated) now emit upstream lineage to Iceberg dataset URNs (`urn:li:dataPlatform:iceberg`). If your upstream Glue or Iceberg connector is configured with a non-default `platform_instance`, set the new `glue_platform_instance` / `iceberg_platform_instance` options on the Athena source so the upstream URNs match. If you have downstream dashboards, saved searches, or lineage queries that reference the old S3 upstream URNs for Athena tables, update them after re-running ingestion.

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -97,7 +97,7 @@ Requirements:
 
   **Deprecation notice:** The Great Expectations profiler is now considered legacy and is planned for removal in a future release. New deployments should rely on the default SQLAlchemy profiler. Existing users that still depend on `method: ge` should plan to migrate.
 
-- #17469 **Unity Catalog profiling now defaults to `method: sqlalchemy`** instead of `method: ge`. This aligns Unity Catalog with all other SQL connectors after #17465 flipped the global default. If your Unity Catalog recipe enables profiling and relied on the Great Expectations profiler, add the following to your recipe and install the extra:
+- #17563 **Unity Catalog profiling now defaults to `method: sqlalchemy`** instead of `method: ge`. This aligns Unity Catalog with all other SQL connectors after #17465 flipped the global default. If your Unity Catalog recipe enables profiling and relied on the Great Expectations profiler, add the following to your recipe and install the extra:
 
   ```bash
   pip install 'acryl-datahub[unity-catalog,profiling-ge]'

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -373,7 +373,7 @@ class UnityCatalogSourceConfig(
         UnityCatalogAnalyzeProfilerConfig,
         UnityCatalogSQLAlchemyProfilerConfig,
     ] = Field(  # type: ignore
-        default=UnityCatalogGEProfilerConfig(),
+        default=UnityCatalogSQLAlchemyProfilerConfig(),
         description="Data profiling configuration",
         discriminator="method",
     )

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -460,6 +460,12 @@ class UnityCatalogSourceConfig(
     def is_ge_profiling(self) -> bool:
         return self.profiling.method == "ge"
 
+    def is_sqlalchemy_profiling(self) -> bool:
+        return self.profiling.method == "sqlalchemy"
+
+    def uses_table_level_profiler(self) -> bool:
+        return self.is_ge_profiling() or self.is_sqlalchemy_profiling()
+
     stateful_ingestion: Optional[StatefulStaleMetadataRemovalConfig] = pydantic.Field(
         default=None, description="Unity Catalog Stateful Ingestion Config."
     )

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -464,6 +464,13 @@ class UnityCatalogSourceConfig(
         default=None, description="Unity Catalog Stateful Ingestion Config."
     )
 
+    @field_validator("profiling", mode="before")
+    @classmethod
+    def _default_profiling_method(cls, v: object) -> object:
+        if isinstance(v, dict) and "method" not in v:
+            return {**v, "method": "sqlalchemy"}
+        return v
+
     @field_validator("start_time", mode="after")
     @classmethod
     def within_thirty_days(cls, v: datetime) -> datetime:

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -470,13 +470,6 @@ class UnityCatalogSourceConfig(
         default=None, description="Unity Catalog Stateful Ingestion Config."
     )
 
-    @field_validator("profiling", mode="before")
-    @classmethod
-    def _default_profiling_method(cls, v: object) -> object:
-        if isinstance(v, dict) and "method" not in v:
-            return {**v, "method": "sqlalchemy"}
-        return v
-
     @field_validator("start_time", mode="after")
     @classmethod
     def within_thirty_days(cls, v: datetime) -> datetime:
@@ -561,4 +554,11 @@ class UnityCatalogSourceConfig(
         cls, v: AllowDenyPattern
     ) -> AllowDenyPattern:
         v.deny.append(".*\\.information_schema")
+        return v
+
+    @field_validator("profiling", mode="before")
+    @classmethod
+    def _default_profiling_method(cls, v: object) -> object:
+        if isinstance(v, dict) and "method" not in v:
+            return {**v, "method": "sqlalchemy"}
         return v

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
@@ -681,7 +681,7 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
 
             if (
                 self.config.is_profiling_enabled()
-                and self.config.is_ge_profiling()
+                and self.config.uses_table_level_profiler()
                 and self.config.profiling.pattern.allowed(
                     table.ref.qualified_table_name
                 )

--- a/metadata-ingestion/tests/unit/test_unity_catalog_config.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_config.py
@@ -541,3 +541,35 @@ def test_profiling_explicit_ge_method_preserved():
     )
     assert isinstance(config.profiling, UnityCatalogGEProfilerConfig)
     assert config.profiling.method == "ge"
+
+
+def test_uses_table_level_profiler_helpers():
+    base = {
+        "token": "token",
+        "workspace_url": "https://test.databricks.com",
+        "include_hive_metastore": False,
+    }
+
+    # sqlalchemy → True
+    cfg = UnityCatalogSourceConfig.model_validate(
+        {**base, "profiling": {"method": "sqlalchemy", "warehouse_id": "wh"}}
+    )
+    assert cfg.is_sqlalchemy_profiling() is True
+    assert cfg.is_ge_profiling() is False
+    assert cfg.uses_table_level_profiler() is True
+
+    # ge → True
+    cfg = UnityCatalogSourceConfig.model_validate(
+        {**base, "profiling": {"method": "ge", "warehouse_id": "wh"}}
+    )
+    assert cfg.is_sqlalchemy_profiling() is False
+    assert cfg.is_ge_profiling() is True
+    assert cfg.uses_table_level_profiler() is True
+
+    # analyze → False
+    cfg = UnityCatalogSourceConfig.model_validate(
+        {**base, "profiling": {"method": "analyze"}}
+    )
+    assert cfg.is_sqlalchemy_profiling() is False
+    assert cfg.is_ge_profiling() is False
+    assert cfg.uses_table_level_profiler() is False

--- a/metadata-ingestion/tests/unit/test_unity_catalog_config.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_config.py
@@ -529,6 +529,35 @@ def test_profiling_dict_without_method_defaults_to_sqlalchemy():
     assert config.profiling.enabled is True
 
 
+def test_profiling_empty_dict_defaults_to_sqlalchemy():
+    # profiling: {} with no keys at all → SQLAlchemy variant
+    config = UnityCatalogSourceConfig.model_validate(
+        {
+            "token": "token",
+            "workspace_url": "https://test.databricks.com",
+            "include_hive_metastore": False,
+            "profiling": {},
+        }
+    )
+    assert isinstance(config.profiling, UnityCatalogSQLAlchemyProfilerConfig)
+    assert config.profiling.method == "sqlalchemy"
+
+
+def test_profiling_prebuilt_instance_passes_through():
+    # passing a pre-built config object bypasses the dict validator — must stay unchanged
+    prebuilt = UnityCatalogSQLAlchemyProfilerConfig()
+    config = UnityCatalogSourceConfig.model_validate(
+        {
+            "token": "token",
+            "workspace_url": "https://test.databricks.com",
+            "include_hive_metastore": False,
+            "profiling": prebuilt,
+        }
+    )
+    assert isinstance(config.profiling, UnityCatalogSQLAlchemyProfilerConfig)
+    assert config.profiling.method == "sqlalchemy"
+
+
 def test_profiling_explicit_ge_method_preserved():
     # profiling: {method: ge, ...} → GE variant unchanged
     config = UnityCatalogSourceConfig.model_validate(

--- a/metadata-ingestion/tests/unit/test_unity_catalog_config.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_config.py
@@ -3,7 +3,10 @@ from datetime import datetime, timedelta
 import pytest
 import time_machine
 
-from datahub.ingestion.source.unity.config import UnityCatalogSourceConfig
+from datahub.ingestion.source.unity.config import (
+    UnityCatalogSourceConfig,
+    UnityCatalogSQLAlchemyProfilerConfig,
+)
 from datahub.ingestion.source.unity.source import UnityCatalogSource
 
 FROZEN_TIME = datetime.fromisoformat("2023-01-01 00:00:00+00:00")
@@ -495,3 +498,15 @@ def test_usage_data_source_can_be_set_with_warehouse():
 
     assert config.usage_data_source == UsageDataSource.SYSTEM_TABLES
     assert config.warehouse_id == "test_warehouse"
+
+
+def test_profiling_default_method_is_sqlalchemy():
+    config = UnityCatalogSourceConfig.model_validate(
+        {
+            "token": "token",
+            "workspace_url": "https://test.databricks.com",
+            "include_hive_metastore": False,
+        }
+    )
+    assert isinstance(config.profiling, UnityCatalogSQLAlchemyProfilerConfig)
+    assert config.profiling.method == "sqlalchemy"

--- a/metadata-ingestion/tests/unit/test_unity_catalog_config.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_config.py
@@ -4,6 +4,7 @@ import pytest
 import time_machine
 
 from datahub.ingestion.source.unity.config import (
+    UnityCatalogGEProfilerConfig,
     UnityCatalogSourceConfig,
     UnityCatalogSQLAlchemyProfilerConfig,
 )
@@ -501,6 +502,7 @@ def test_usage_data_source_can_be_set_with_warehouse():
 
 
 def test_profiling_default_method_is_sqlalchemy():
+    # profiling absent → SQLAlchemy variant
     config = UnityCatalogSourceConfig.model_validate(
         {
             "token": "token",
@@ -510,3 +512,32 @@ def test_profiling_default_method_is_sqlalchemy():
     )
     assert isinstance(config.profiling, UnityCatalogSQLAlchemyProfilerConfig)
     assert config.profiling.method == "sqlalchemy"
+
+
+def test_profiling_dict_without_method_defaults_to_sqlalchemy():
+    # profiling: {enabled: true} with no method key → SQLAlchemy variant
+    config = UnityCatalogSourceConfig.model_validate(
+        {
+            "token": "token",
+            "workspace_url": "https://test.databricks.com",
+            "include_hive_metastore": False,
+            "profiling": {"enabled": True, "warehouse_id": "wh"},
+        }
+    )
+    assert isinstance(config.profiling, UnityCatalogSQLAlchemyProfilerConfig)
+    assert config.profiling.method == "sqlalchemy"
+    assert config.profiling.enabled is True
+
+
+def test_profiling_explicit_ge_method_preserved():
+    # profiling: {method: ge, ...} → GE variant unchanged
+    config = UnityCatalogSourceConfig.model_validate(
+        {
+            "token": "token",
+            "workspace_url": "https://test.databricks.com",
+            "include_hive_metastore": False,
+            "profiling": {"method": "ge", "enabled": True, "warehouse_id": "wh"},
+        }
+    )
+    assert isinstance(config.profiling, UnityCatalogGEProfilerConfig)
+    assert config.profiling.method == "ge"


### PR DESCRIPTION
Summary

GE profiling was the only option for Unity Catalog. This switches the default to SQLAlchemy, which is always available.

- profiling.method defaults to "sqlalchemy" (was implicitly "ge")
- Adds pydantic validator to set the default before other validation runs (fixes field ordering issue with pydantic's before-validator)
- Wires the SQLAlchemy profiler path end-to-end in source.py

Breaking change

Users who relied on GE profiling without explicitly setting profiling.method: ge will now use SQLAlchemy profiling. Set profiling.method: ge to restore previous behavior.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
