### PR TITLE
fix(datapack): use OpenAPI async_batch with per-file async_wait

### DIFF
--- a/docs/cli-commands/datapack.md
+++ b/docs/cli-commands/datapack.md
@@ -190,7 +190,7 @@ Data packs can consist of multiple files, referenced by an `index.json`:
 }
 ```
 
-Files are loaded sequentially. When `wait_for_completion` is set, the loader verifies all entities from that file exist on the server before proceeding to the next file. This ensures ordering dependencies are respected (e.g., structured property definitions must exist before assignments can reference them).
+Files are loaded sequentially via OpenAPI **`async_batch`** ingestion. When `wait_for_completion` is set, that file is emitted with **`async_wait`** so the loader blocks on OpenAPI trace completion before starting the next file. Other files use **`async`** (same batch sink, no trace wait). This ensures ordering dependencies are respected (e.g., structured property definitions must be persisted before assignments in a later file can reference them).
 
 Each entry in `files` can be a plain string (filename) or an object with `path` and optional `wait_for_completion`.
 

--- a/metadata-ingestion/src/datahub/cli/datapack/loader.py
+++ b/metadata-ingestion/src/datahub/cli/datapack/loader.py
@@ -1,5 +1,6 @@
 """Download, cache, verify, and load data packs into DataHub."""
 
+import contextlib
 import hashlib
 import json
 import logging
@@ -11,7 +12,7 @@ import tempfile
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Iterator, List, Optional
 from urllib.parse import urlparse
 
 import click
@@ -26,6 +27,8 @@ logger = logging.getLogger(__name__)
 
 CACHE_DIR = os.path.join(DATAHUB_ROOT_FOLDER, "datapack-cache")
 LOADS_DIR = os.path.join(DATAHUB_ROOT_FOLDER, "datapack-loads")
+
+EMIT_MODE_ENV = "DATAHUB_EMIT_MODE"
 
 
 def _cache_key(url: str) -> str:
@@ -287,44 +290,6 @@ def _resolve_index_file(
             "Check the URLs and your network connection."
         )
     return entries
-
-
-def _wait_for_entities(
-    urns: set[str],
-    client_config: DatahubClientConfig,
-    timeout_seconds: int = 60,
-    poll_interval: float = 0.5,
-) -> None:
-    """Wait until all given URNs exist on the server."""
-    if not urns:
-        return
-
-    from datahub.ingestion.graph.client import DataHubGraph
-
-    graph = DataHubGraph(client_config)
-    pending = set(urns)
-    deadline = time.time() + timeout_seconds
-
-    click.echo(f"Waiting for {len(pending)} entities to be processed...")
-    while pending and time.time() < deadline:
-        still_pending = set()
-        for urn in pending:
-            try:
-                if not graph.exists(urn):
-                    still_pending.add(urn)
-            except Exception:
-                still_pending.add(urn)
-        pending = still_pending
-        if pending:
-            time.sleep(poll_interval)
-
-    if pending:
-        click.echo(
-            f"Warning: {len(pending)} entities not yet available after "
-            f"{timeout_seconds}s (proceeding anyway)"
-        )
-    else:
-        click.echo("All entities available.")
 
 
 def check_trust(
@@ -653,22 +618,38 @@ def _check_referential_integrity(
         click.echo(f"  {ref_urn} (referenced by {len(referrers)} entities)")
 
 
-def _extract_urns_from_file(file_path: pathlib.Path) -> set[str]:
-    """Extract unique entity URNs from an MCP JSON file."""
+def _build_datapack_sink_config(client_config: DatahubClientConfig) -> dict[str, str]:
+    """Sink config for datapack ingest: OpenAPI endpoint with async_batch mode."""
+    sink_config: dict[str, str] = {
+        "server": str(client_config.server),
+        "endpoint": "openapi",
+        "mode": "async_batch",
+    }
+    if client_config.token:
+        sink_config["token"] = client_config.token
+    return sink_config
+
+
+@contextlib.contextmanager
+def _datapack_emit_mode(wait_for_completion: bool) -> Iterator[str]:
+    """Set DATAHUB_EMIT_MODE for one datapack file pipeline run."""
+    emit_mode = "async_wait" if wait_for_completion else "async"
+    prior = os.environ.get(EMIT_MODE_ENV)
+    os.environ[EMIT_MODE_ENV] = emit_mode
     try:
-        with open(file_path) as f:
-            data = json.load(f)
-        if isinstance(data, list):
-            return {m.get("entityUrn", "") for m in data if m.get("entityUrn")}
-    except Exception:
-        pass
-    return set()
+        yield emit_mode
+    finally:
+        if prior is None:
+            os.environ.pop(EMIT_MODE_ENV, None)
+        else:
+            os.environ[EMIT_MODE_ENV] = prior
 
 
 def _run_pipeline_for_file(
     file_path: pathlib.Path,
     run_id: str,
     sink_config: dict[str, str],
+    wait_for_completion: bool = False,
 ) -> None:
     """Run an ingestion pipeline for a single data file."""
     from datahub.ingestion.run.pipeline import Pipeline
@@ -684,9 +665,62 @@ def _run_pipeline_for_file(
             "config": sink_config,
         },
     }
-    pipeline = Pipeline.create(pipeline_config)
-    pipeline.run()
-    pipeline.pretty_print_summary()
+    with _datapack_emit_mode(wait_for_completion) as emit_mode:
+        if wait_for_completion:
+            click.echo(f"  Using OpenAPI async_batch with emit mode {emit_mode}")
+        pipeline = Pipeline.create(pipeline_config)
+        pipeline.run()
+        pipeline.pretty_print_summary()
+        pipeline.raise_from_status()
+
+
+def ingest_datapack_file_entries(
+    pack: DataPackInfo,
+    file_entries: List[IndexFileEntry],
+    run_id: str,
+    *,
+    client_config: Optional[DatahubClientConfig] = None,
+    no_time_shift: bool = False,
+    as_of: Optional[datetime] = None,
+    log_progress: bool = True,
+) -> None:
+    """Ingest datapack index files sequentially with per-file emit modes.
+
+    Uses OpenAPI async_batch for all files. Index entries with wait_for_completion
+    use async_wait (trace blocking) before the next file starts.
+    """
+    if client_config is None:
+        client_config = load_client_config()
+
+    sink_config = _build_datapack_sink_config(client_config)
+
+    for i, entry in enumerate(file_entries):
+        if log_progress:
+            click.echo(f"\n--- File {i + 1}/{len(file_entries)}: {entry.path.name} ---")
+            click.echo(f"Loading {entry.path.name} into DataHub (run_id={run_id})...")
+
+        effective_path = entry.path
+        effective_path = _apply_schema_filter(
+            effective_path, client_config=client_config
+        )
+
+        if i == len(file_entries) - 1:
+            _check_referential_integrity(effective_path, client_config=client_config)
+
+        if not no_time_shift and pack.reference_timestamp:
+            target_ts = int(as_of.timestamp() * 1000) if as_of else None
+            effective_path = time_shift_file(
+                input_path=effective_path,
+                reference_timestamp=pack.reference_timestamp,
+                target_timestamp=target_ts,
+            )
+
+        _run_pipeline_for_file(
+            effective_path,
+            run_id,
+            sink_config,
+            wait_for_completion=entry.wait_for_completion,
+        )
 
 
 def load_pack_into_datahub(
@@ -699,8 +733,8 @@ def load_pack_into_datahub(
     """Build and run ingestion pipelines to load the data pack.
 
     For index files with multiple entries, runs a separate pipeline per file.
-    Files marked with wait_for_completion=True will block until all emitted
-    entities exist on the server before proceeding to the next file.
+    Files marked with wait_for_completion=True use OpenAPI async_wait trace
+    blocking before the next file is ingested.
 
     Args:
         pack: The data pack metadata.
@@ -715,62 +749,23 @@ def load_pack_into_datahub(
     client_config = load_client_config()
     run_id = _generate_run_id(pack.name)
 
-    sink_config: dict[str, str] = {"server": str(client_config.server)}
-    if client_config.token:
-        sink_config["token"] = client_config.token
-
-    # Process each file entry
-    last_pipeline = None
-    for i, entry in enumerate(file_entries):
-        file_label = entry.path.name
-        click.echo(f"\n--- File {i + 1}/{len(file_entries)}: {file_label} ---")
-
-        effective_path = entry.path
-
-        # Apply schema compatibility filter (downshift)
-        effective_path = _apply_schema_filter(
-            effective_path, client_config=client_config
-        )
-
-        # Check referential integrity (only on last file to avoid noise)
-        if i == len(file_entries) - 1:
-            _check_referential_integrity(effective_path, client_config=client_config)
-
-        # Apply time-shifting if applicable
-        if not no_time_shift and pack.reference_timestamp:
-            target_ts = int(as_of.timestamp() * 1000) if as_of else None
-            effective_path = time_shift_file(
-                input_path=effective_path,
-                reference_timestamp=pack.reference_timestamp,
-                target_timestamp=target_ts,
-            )
-
-        if dry_run:
-            click.echo(f"Dry run - would load {effective_path}")
-            continue
-
-        click.echo(f"Loading {file_label} into DataHub (run_id={run_id})...")
-
-        # Collect URNs before loading if we need to wait
-        urns_to_wait: set[str] = set()
-        if entry.wait_for_completion:
-            urns_to_wait = _extract_urns_from_file(effective_path)
-
-        _run_pipeline_for_file(effective_path, run_id, sink_config)
-
-        # Wait for entities to be processed if flagged
-        if entry.wait_for_completion and urns_to_wait:
-            _wait_for_entities(urns_to_wait, client_config)
-
     if dry_run:
+        for i, entry in enumerate(file_entries):
+            click.echo(f"\n--- File {i + 1}/{len(file_entries)}: {entry.path.name} ---")
+            click.echo(f"Dry run - would load {entry.path}")
         click.echo(f"\nDry run complete for {len(file_entries)} files.")
         return run_id
 
-    # Save load record before raising so unload works even on partial failures
-    save_load_record(pack, run_id)
+    ingest_datapack_file_entries(
+        pack,
+        file_entries,
+        run_id,
+        client_config=client_config,
+        no_time_shift=no_time_shift,
+        as_of=as_of,
+    )
 
-    if last_pipeline:
-        last_pipeline.raise_from_status()
+    save_load_record(pack, run_id)
 
     click.echo(f"Data pack '{pack.name}' loaded successfully.")
     return run_id

--- a/metadata-ingestion/src/datahub/ingestion/source/demo_data.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/demo_data.py
@@ -17,7 +17,9 @@ Usage in a recipe:
         no_time_shift: false
 """
 
-import pathlib
+import json
+import tempfile
+import uuid
 from datetime import datetime, timezone
 from typing import Iterable, Optional
 
@@ -87,9 +89,12 @@ class DemoDataSource(Source):
         super().__init__(ctx)
         self.config = config
 
-        from datahub.cli.datapack.loader import check_trust, download_pack
+        from datahub.cli.datapack.loader import (
+            check_trust,
+            download_pack,
+            ingest_datapack_file_entries,
+        )
         from datahub.cli.datapack.models import DataPackInfo, TrustTier
-        from datahub.cli.datapack.time_shift import time_shift_file
 
         # Resolve the pack
         if config.pack_url:
@@ -106,49 +111,37 @@ class DemoDataSource(Source):
         else:
             raise ValueError("Either 'pack_name' or 'pack_url' must be specified.")
 
-        # Trust check
         check_trust(
             pack,
             trust_community=config.trust_community,
             trust_custom=config.trust_custom,
         )
 
-        # Download (combine all index entries into one file for GenericFileSource)
         file_entries = download_pack(pack, no_cache=config.no_cache)
-        if len(file_entries) == 1:
-            effective_path = file_entries[0].path
-        else:
-            import json as _json
-            import tempfile as _tempfile
 
-            all_mcps: list = []
-            for entry in file_entries:
-                with open(entry.path) as _f:
-                    mcps = _json.load(_f)
-                if isinstance(mcps, list):
-                    all_mcps.extend(mcps)
-            combined = _tempfile.NamedTemporaryFile(
-                suffix=".json", delete=False, prefix="demo-data-combined-", mode="w"
-            )
-            _json.dump(all_mcps, combined)
-            combined.close()
-            effective_path = pathlib.Path(combined.name)
-        if not config.no_time_shift and pack.reference_timestamp:
-            target_ts = None
-            if config.as_of:
-                as_of_dt = datetime.fromisoformat(config.as_of)
-                if as_of_dt.tzinfo is None:
-                    as_of_dt = as_of_dt.replace(tzinfo=timezone.utc)
-                target_ts = int(as_of_dt.timestamp() * 1000)
+        as_of_dt: Optional[datetime] = None
+        if config.as_of:
+            as_of_dt = datetime.fromisoformat(config.as_of)
+            if as_of_dt.tzinfo is None:
+                as_of_dt = as_of_dt.replace(tzinfo=timezone.utc)
 
-            effective_path = time_shift_file(
-                input_path=effective_path,
-                reference_timestamp=pack.reference_timestamp,
-                target_timestamp=target_ts,
-            )
+        run_id = ctx.run_id or f"demo-data-{uuid.uuid4()}"
+        ingest_datapack_file_entries(
+            pack,
+            file_entries,
+            run_id,
+            no_time_shift=config.no_time_shift,
+            as_of=as_of_dt,
+            log_progress=False,
+        )
 
-        # Delegate to GenericFileSource
-        file_config = FileSourceConfig(path=str(effective_path))
+        # Outer pipeline sink is unused; datapack ingest already completed above.
+        empty_pack = tempfile.NamedTemporaryFile(
+            suffix=".json", delete=False, prefix="demo-data-empty-", mode="w"
+        )
+        json.dump([], empty_pack)
+        empty_pack.close()
+        file_config = FileSourceConfig(path=empty_pack.name)
         self.file_source = GenericFileSource(ctx, file_config)
 
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:

--- a/metadata-ingestion/tests/unit/api/test_pipeline.py
+++ b/metadata-ingestion/tests/unit/api/test_pipeline.py
@@ -1,6 +1,9 @@
+import json
 import pathlib
+import tempfile
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
+from pathlib import Path
 from typing import Iterable, List, Optional, cast
 from unittest.mock import MagicMock, patch
 
@@ -688,22 +691,45 @@ class TestSinkReportTimingOnClose:
     def _create_real_pipeline_with_realistic_sink(self):
         """Create a real Pipeline instance with a realistic sink using Pipeline.create()"""
 
+        from datahub.cli.datapack.loader import IndexFileEntry
+        from datahub.cli.datapack.models import DataPackInfo, TrustTier
         from datahub.ingestion.run.pipeline import Pipeline
 
         # Create realistic sink
         sink = RealisticDatahubRestSink()
 
-        # Create pipeline using Pipeline.create() like the existing tests do
-        # Use demo data source which is simpler and doesn't require external dependencies
-        pipeline = Pipeline.create(
-            {
-                "source": {
-                    "type": "demo-data",
-                    "config": {},
-                },
-                "sink": {"type": "console"},  # Use console sink to avoid network issues
-            }
+        mock_pack = DataPackInfo(
+            name="bootstrap",
+            description="test",
+            url="https://example.com/bootstrap.json",
+            trust=TrustTier.VERIFIED,
         )
+
+        # demo-data now pre-ingests via datapack loader; avoid network and ~/.datahubenv
+        with (
+            patch("datahub.cli.datapack.loader.check_trust"),
+            patch("datahub.cli.datapack.registry.get_pack", return_value=mock_pack),
+            patch("datahub.cli.datapack.loader.ingest_datapack_file_entries"),
+            patch("datahub.cli.datapack.loader.download_pack") as mock_download,
+            tempfile.NamedTemporaryFile(suffix=".json", mode="w") as pack_file,
+        ):
+            json.dump([], pack_file)
+            pack_file.flush()
+            mock_download.return_value = [IndexFileEntry(path=Path(pack_file.name))]
+
+            # Create pipeline using Pipeline.create() like the existing tests do
+            # Use demo data source which is simpler and doesn't require external dependencies
+            pipeline = Pipeline.create(
+                {
+                    "source": {
+                        "type": "demo-data",
+                        "config": {},
+                    },
+                    "sink": {
+                        "type": "console"
+                    },  # Use console sink to avoid network issues
+                }
+            )
 
         # Replace the sink with our realistic sink and register it with the exit_stack
         # This ensures the context manager calls close() on our realistic sink

--- a/metadata-ingestion/tests/unit/cli/datapack/test_loader.py
+++ b/metadata-ingestion/tests/unit/cli/datapack/test_loader.py
@@ -2,23 +2,401 @@
 
 import hashlib
 import json
+import os
 import pathlib
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import click
 import pytest
 
 from datahub.cli.datapack.loader import (
+    EMIT_MODE_ENV,
+    IndexFileEntry,
     _apply_schema_filter,
+    _build_datapack_sink_config,
     _cache_key,
+    _cached_path,
+    _datapack_emit_mode,
+    _run_pipeline_for_file,
     _sha256_file,
     check_trust,
     download_pack,
     get_load_record,
+    ingest_datapack_file_entries,
+    is_cached,
+    load_pack_into_datahub,
     remove_load_record,
     save_load_record,
 )
 from datahub.cli.datapack.models import DataPackInfo, TrustTier
+from datahub.ingestion.graph.config import DatahubClientConfig
+
+
+class TestDatapackSinkConfig:
+    def test_build_datapack_sink_config_openapi_async_batch(self) -> None:
+        config = DatahubClientConfig(server="http://localhost:8080", token="tok")
+        sink = _build_datapack_sink_config(config)
+        assert sink == {
+            "server": "http://localhost:8080",
+            "token": "tok",
+            "endpoint": "openapi",
+            "mode": "async_batch",
+        }
+
+    def test_build_datapack_sink_config_no_token(self) -> None:
+        config = DatahubClientConfig(server="http://localhost:8080")
+        sink = _build_datapack_sink_config(config)
+        assert "token" not in sink
+        assert sink["endpoint"] == "openapi"
+        assert sink["mode"] == "async_batch"
+
+    def test_datapack_emit_mode_async_wait(self) -> None:
+        prior = os.environ.get(EMIT_MODE_ENV)
+        try:
+            with _datapack_emit_mode(True) as mode:
+                assert mode == "async_wait"
+                assert os.environ[EMIT_MODE_ENV] == "async_wait"
+            assert os.environ.get(EMIT_MODE_ENV) == prior
+        finally:
+            if prior is None:
+                os.environ.pop(EMIT_MODE_ENV, None)
+            else:
+                os.environ[EMIT_MODE_ENV] = prior
+
+    def test_datapack_emit_mode_async(self) -> None:
+        with _datapack_emit_mode(False) as mode:
+            assert mode == "async"
+            assert os.environ[EMIT_MODE_ENV] == "async"
+
+    def test_datapack_emit_mode_restores_prior_value(self) -> None:
+        os.environ[EMIT_MODE_ENV] = "sync"
+        try:
+            with _datapack_emit_mode(True) as mode:
+                assert mode == "async_wait"
+                assert os.environ[EMIT_MODE_ENV] == "async_wait"
+            assert os.environ[EMIT_MODE_ENV] == "sync"
+        finally:
+            os.environ.pop(EMIT_MODE_ENV, None)
+
+    @patch("datahub.ingestion.run.pipeline.Pipeline")
+    def test_run_pipeline_for_file_passes_wait_flag(
+        self, mock_pipeline_cls: MagicMock, tmp_path: pathlib.Path
+    ) -> None:
+        data_file = tmp_path / "data.json"
+        data_file.write_text("[]")
+        mock_pipeline = MagicMock()
+        mock_pipeline_cls.create.return_value = mock_pipeline
+
+        sink_config = {
+            "server": "http://localhost:8080",
+            "endpoint": "openapi",
+            "mode": "async_batch",
+        }
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(EMIT_MODE_ENV, None)
+            _run_pipeline_for_file(
+                data_file, "run-1", sink_config, wait_for_completion=True
+            )
+            assert os.environ.get(EMIT_MODE_ENV) is None
+
+        mock_pipeline_cls.create.assert_called_once()
+        mock_pipeline.run.assert_called_once()
+        mock_pipeline.raise_from_status.assert_called_once()
+
+    @patch("datahub.ingestion.run.pipeline.Pipeline")
+    def test_run_pipeline_for_file_logs_emit_mode_when_waiting(
+        self,
+        mock_pipeline_cls: MagicMock,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        data_file = tmp_path / "data.json"
+        data_file.write_text("[]")
+        mock_pipeline_cls.create.return_value = MagicMock()
+
+        sink_config = {
+            "server": "http://localhost:8080",
+            "endpoint": "openapi",
+            "mode": "async_batch",
+        }
+        _run_pipeline_for_file(
+            data_file, "run-1", sink_config, wait_for_completion=True
+        )
+        assert "async_wait" in capsys.readouterr().out
+
+
+class TestIngestDatapackFileEntries:
+    @patch("datahub.cli.datapack.loader._run_pipeline_for_file")
+    @patch("datahub.cli.datapack.loader._check_referential_integrity")
+    @patch("datahub.cli.datapack.loader._apply_schema_filter")
+    def test_ingest_runs_pipeline_per_entry(
+        self,
+        mock_filter: MagicMock,
+        mock_ref: MagicMock,
+        mock_run: MagicMock,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        mock_filter.side_effect = lambda path, **_: path
+        first = tmp_path / "defs.json"
+        second = tmp_path / "data.json"
+        first.write_text("[]")
+        second.write_text("[]")
+        pack = DataPackInfo(
+            name="test-pack",
+            description="test",
+            url="https://example.com/index.json",
+            trust=TrustTier.VERIFIED,
+        )
+        entries = [
+            IndexFileEntry(first, wait_for_completion=True),
+            IndexFileEntry(second),
+        ]
+        client_config = DatahubClientConfig(server="http://localhost:8080", token="tok")
+
+        ingest_datapack_file_entries(
+            pack,
+            entries,
+            "run-abc",
+            client_config=client_config,
+            log_progress=False,
+        )
+
+        assert mock_run.call_count == 2
+        mock_run.assert_any_call(
+            first,
+            "run-abc",
+            {
+                "server": "http://localhost:8080",
+                "token": "tok",
+                "endpoint": "openapi",
+                "mode": "async_batch",
+            },
+            wait_for_completion=True,
+        )
+        mock_ref.assert_called_once_with(second, client_config=client_config)
+
+    @patch("datahub.cli.datapack.loader._run_pipeline_for_file")
+    @patch("datahub.cli.datapack.loader._check_referential_integrity")
+    @patch("datahub.cli.datapack.loader._apply_schema_filter")
+    @patch("datahub.cli.datapack.loader.time_shift_file")
+    def test_ingest_time_shifts_with_as_of(
+        self,
+        mock_shift: MagicMock,
+        mock_filter: MagicMock,
+        mock_ref: MagicMock,
+        mock_run: MagicMock,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        data_file = tmp_path / "data.json"
+        data_file.write_text("[]")
+        shifted = tmp_path / "shifted.json"
+        shifted.write_text("[]")
+        mock_filter.side_effect = lambda path, **_: path
+        mock_shift.return_value = shifted
+
+        pack = DataPackInfo(
+            name="test-pack",
+            description="test",
+            url="https://example.com/data.json",
+            trust=TrustTier.VERIFIED,
+            reference_timestamp=1700000000000,
+        )
+        as_of = datetime(2024, 6, 1, 12, 0, tzinfo=timezone.utc)
+        client_config = DatahubClientConfig(server="http://localhost:8080")
+
+        ingest_datapack_file_entries(
+            pack,
+            [IndexFileEntry(data_file)],
+            "run-abc",
+            client_config=client_config,
+            no_time_shift=False,
+            as_of=as_of,
+            log_progress=False,
+        )
+
+        mock_shift.assert_called_once_with(
+            input_path=data_file,
+            reference_timestamp=1700000000000,
+            target_timestamp=int(as_of.timestamp() * 1000),
+        )
+        mock_run.assert_called_once_with(
+            shifted,
+            "run-abc",
+            {
+                "server": "http://localhost:8080",
+                "endpoint": "openapi",
+                "mode": "async_batch",
+            },
+            wait_for_completion=False,
+        )
+
+    @patch("datahub.cli.datapack.loader._run_pipeline_for_file")
+    @patch("datahub.cli.datapack.loader._check_referential_integrity")
+    @patch("datahub.cli.datapack.loader._apply_schema_filter")
+    def test_ingest_logs_progress_when_enabled(
+        self,
+        mock_filter: MagicMock,
+        mock_ref: MagicMock,
+        mock_run: MagicMock,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        mock_filter.side_effect = lambda path, **_: path
+        data_file = tmp_path / "data.json"
+        data_file.write_text("[]")
+        client_config = DatahubClientConfig(server="http://localhost:8080")
+
+        ingest_datapack_file_entries(
+            DataPackInfo(
+                name="bootstrap",
+                description="test",
+                url="https://example.com/bootstrap.json",
+                trust=TrustTier.VERIFIED,
+            ),
+            [IndexFileEntry(data_file)],
+            "run-abc",
+            client_config=client_config,
+            log_progress=True,
+        )
+
+        output = capsys.readouterr().out
+        assert "File 1/1" in output
+        assert "data.json" in output
+
+    @patch("datahub.cli.datapack.loader.load_client_config")
+    @patch("datahub.cli.datapack.loader._run_pipeline_for_file")
+    @patch("datahub.cli.datapack.loader._check_referential_integrity")
+    @patch("datahub.cli.datapack.loader._apply_schema_filter")
+    def test_ingest_loads_client_config_when_omitted(
+        self,
+        mock_filter: MagicMock,
+        mock_ref: MagicMock,
+        mock_run: MagicMock,
+        mock_load_config: MagicMock,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        mock_filter.side_effect = lambda path, **_: path
+        data_file = tmp_path / "data.json"
+        data_file.write_text("[]")
+        mock_load_config.return_value = DatahubClientConfig(
+            server="http://gms:8080", token="secret"
+        )
+
+        ingest_datapack_file_entries(
+            DataPackInfo(
+                name="bootstrap",
+                description="test",
+                url="https://example.com/bootstrap.json",
+                trust=TrustTier.VERIFIED,
+            ),
+            [IndexFileEntry(data_file)],
+            "run-xyz",
+            log_progress=False,
+        )
+
+        mock_load_config.assert_called_once()
+        mock_run.assert_called_once()
+        assert mock_run.call_args.args[2]["server"] == "http://gms:8080"
+
+
+class TestLoadPackIntoDatahub:
+    @patch("datahub.cli.datapack.loader.ingest_datapack_file_entries")
+    @patch("datahub.cli.datapack.loader._generate_run_id", return_value="generated-run")
+    @patch("datahub.cli.datapack.loader.load_client_config")
+    def test_dry_run_skips_ingest(
+        self,
+        mock_load_config: MagicMock,
+        mock_run_id: MagicMock,
+        mock_ingest: MagicMock,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        data_file = tmp_path / "data.json"
+        data_file.write_text("[]")
+        pack = DataPackInfo(
+            name="bootstrap",
+            description="test",
+            url="https://example.com/bootstrap.json",
+            trust=TrustTier.VERIFIED,
+        )
+        mock_load_config.return_value = DatahubClientConfig(
+            server="http://localhost:8080"
+        )
+
+        run_id = load_pack_into_datahub(pack, [IndexFileEntry(data_file)], dry_run=True)
+
+        assert run_id == "generated-run"
+        mock_ingest.assert_not_called()
+        output = capsys.readouterr().out
+        assert "Dry run" in output
+        assert "data.json" in output
+
+    @patch("datahub.cli.datapack.loader.save_load_record")
+    @patch("datahub.cli.datapack.loader.ingest_datapack_file_entries")
+    @patch("datahub.cli.datapack.loader._generate_run_id", return_value="generated-run")
+    @patch("datahub.cli.datapack.loader.load_client_config")
+    def test_load_pack_ingests_and_records(
+        self,
+        mock_load_config: MagicMock,
+        mock_run_id: MagicMock,
+        mock_ingest: MagicMock,
+        mock_save: MagicMock,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        data_file = tmp_path / "data.json"
+        data_file.write_text("[]")
+        pack = DataPackInfo(
+            name="bootstrap",
+            description="test",
+            url="https://example.com/bootstrap.json",
+            trust=TrustTier.VERIFIED,
+        )
+        client_config = DatahubClientConfig(server="http://localhost:8080")
+        mock_load_config.return_value = client_config
+        entries = [IndexFileEntry(data_file)]
+
+        run_id = load_pack_into_datahub(pack, entries)
+
+        assert run_id == "generated-run"
+        mock_ingest.assert_called_once_with(
+            pack,
+            entries,
+            "generated-run",
+            client_config=client_config,
+            no_time_shift=False,
+            as_of=None,
+        )
+        mock_save.assert_called_once_with(pack, "generated-run")
+        assert "loaded successfully" in capsys.readouterr().out
+
+
+class TestIsCached:
+    def test_is_cached_when_pack_file_exists(self, tmp_path: pathlib.Path) -> None:
+        pack = DataPackInfo(
+            name="bootstrap",
+            description="test",
+            url="https://example.com/bootstrap.json",
+            trust=TrustTier.VERIFIED,
+        )
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        with patch("datahub.cli.datapack.loader.CACHE_DIR", str(cache_dir)):
+            _cached_path(pack).write_text("[]")
+            assert is_cached(pack) is True
+            assert (
+                is_cached(
+                    DataPackInfo(
+                        name="other",
+                        description="test",
+                        url="https://example.com/other.json",
+                        trust=TrustTier.VERIFIED,
+                    )
+                )
+                is False
+            )
 
 
 class TestCacheKey:

--- a/metadata-ingestion/tests/unit/test_demo_data_source.py
+++ b/metadata-ingestion/tests/unit/test_demo_data_source.py
@@ -38,10 +38,13 @@ class TestDemoDataSource:
         pack_file.write_text(json.dumps([]))
         return pack_file
 
+    @patch("datahub.cli.datapack.loader.ingest_datapack_file_entries")
     @patch("datahub.cli.datapack.registry.get_pack")
     @patch("datahub.cli.datapack.loader.download_pack")
     @patch("datahub.cli.datapack.loader.check_trust")
-    def test_default_loads_bootstrap(self, mock_trust, mock_download, mock_get_pack):
+    def test_default_loads_bootstrap(
+        self, mock_trust, mock_download, mock_get_pack, mock_ingest
+    ):
         """Default config resolves 'bootstrap' pack from registry."""
         from datahub.cli.datapack.models import DataPackInfo, TrustTier
 
@@ -65,11 +68,13 @@ class TestDemoDataSource:
             mock_get_pack.assert_called_once_with("bootstrap")
             mock_trust.assert_called_once()
             mock_download.assert_called_once()
+            mock_ingest.assert_called_once()
             assert source.file_source is not None
 
+    @patch("datahub.cli.datapack.loader.ingest_datapack_file_entries")
     @patch("datahub.cli.datapack.loader.download_pack")
     @patch("datahub.cli.datapack.loader.check_trust")
-    def test_pack_url_creates_custom_pack(self, mock_trust, mock_download):
+    def test_pack_url_creates_custom_pack(self, mock_trust, mock_download, mock_ingest):
         """pack_url creates an ad-hoc custom pack without hitting registry."""
         with tempfile.NamedTemporaryFile(suffix=".json", mode="w") as f:
             json.dump([], f)
@@ -85,13 +90,14 @@ class TestDemoDataSource:
             trust_call_pack = mock_trust.call_args[0][0]
             assert trust_call_pack.name == "custom"
             assert trust_call_pack.trust.value == "custom"
+            mock_ingest.assert_called_once()
 
+    @patch("datahub.cli.datapack.loader.ingest_datapack_file_entries")
     @patch("datahub.cli.datapack.registry.get_pack")
     @patch("datahub.cli.datapack.loader.download_pack")
     @patch("datahub.cli.datapack.loader.check_trust")
-    @patch("datahub.cli.datapack.time_shift.time_shift_file")
     def test_time_shift_when_enabled(
-        self, mock_time_shift, mock_trust, mock_download, mock_get_pack
+        self, mock_trust, mock_download, mock_get_pack, mock_ingest
     ):
         """Time-shifting is invoked when no_time_shift=False and pack has reference_timestamp."""
         from datahub.cli.datapack.models import DataPackInfo, TrustTier
@@ -108,24 +114,22 @@ class TestDemoDataSource:
         with tempfile.NamedTemporaryFile(suffix=".json", mode="w") as f:
             json.dump([], f)
             f.flush()
-            pack_path = Path(f.name)
-            mock_download.return_value = [IndexFileEntry(path=pack_path)]
-
-            shifted_path = Path(f.name)
-            mock_time_shift.return_value = shifted_path
+            mock_download.return_value = [IndexFileEntry(path=Path(f.name))]
 
             ctx = MagicMock()
+            ctx.run_id = "test-run-id"
             config = DemoDataConfig(pack_name="test", no_time_shift=False)
             _source = DemoDataSource(ctx, config)
 
-            mock_time_shift.assert_called_once()
+            mock_ingest.assert_called_once()
+            assert mock_ingest.call_args.kwargs["no_time_shift"] is False
 
+    @patch("datahub.cli.datapack.loader.ingest_datapack_file_entries")
     @patch("datahub.cli.datapack.registry.get_pack")
     @patch("datahub.cli.datapack.loader.download_pack")
     @patch("datahub.cli.datapack.loader.check_trust")
-    @patch("datahub.cli.datapack.time_shift.time_shift_file")
     def test_no_time_shift_by_default(
-        self, mock_time_shift, mock_trust, mock_download, mock_get_pack
+        self, mock_trust, mock_download, mock_get_pack, mock_ingest
     ):
         """Default config (no_time_shift=True) skips time-shifting."""
         from datahub.cli.datapack.models import DataPackInfo, TrustTier
@@ -148,4 +152,64 @@ class TestDemoDataSource:
             config = DemoDataConfig()  # default no_time_shift=True
             _source = DemoDataSource(ctx, config)
 
-            mock_time_shift.assert_not_called()
+            mock_ingest.assert_called_once()
+            assert mock_ingest.call_args.kwargs["no_time_shift"] is True
+
+    @patch("datahub.cli.datapack.loader.ingest_datapack_file_entries")
+    @patch("datahub.cli.datapack.registry.get_pack")
+    @patch("datahub.cli.datapack.loader.download_pack")
+    @patch("datahub.cli.datapack.loader.check_trust")
+    def test_as_of_passed_to_ingest(
+        self, mock_trust, mock_download, mock_get_pack, mock_ingest
+    ):
+        from datahub.cli.datapack.models import DataPackInfo, TrustTier
+
+        mock_get_pack.return_value = DataPackInfo(
+            name="test",
+            description="test",
+            url="https://example.com/test.json",
+            trust=TrustTier.VERIFIED,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".json", mode="w") as f:
+            json.dump([], f)
+            f.flush()
+            mock_download.return_value = [IndexFileEntry(path=Path(f.name))]
+
+            ctx = MagicMock()
+            ctx.run_id = "demo-run"
+            config = DemoDataConfig(as_of="2024-06-01T12:00:00+00:00")
+            DemoDataSource(ctx, config)
+
+            mock_ingest.assert_called_once()
+            as_of = mock_ingest.call_args.kwargs["as_of"]
+            assert as_of is not None
+            assert as_of.year == 2024
+            assert as_of.month == 6
+
+    @patch("datahub.cli.datapack.loader.ingest_datapack_file_entries")
+    @patch("datahub.cli.datapack.registry.get_pack")
+    @patch("datahub.cli.datapack.loader.download_pack")
+    @patch("datahub.cli.datapack.loader.check_trust")
+    def test_get_workunits_and_report(
+        self, mock_trust, mock_download, mock_get_pack, mock_ingest
+    ):
+        from datahub.cli.datapack.models import DataPackInfo, TrustTier
+
+        mock_get_pack.return_value = DataPackInfo(
+            name="bootstrap",
+            description="test",
+            url="https://example.com/bootstrap.json",
+            trust=TrustTier.VERIFIED,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".json", mode="w") as f:
+            json.dump([], f)
+            f.flush()
+            mock_download.return_value = [IndexFileEntry(path=Path(f.name))]
+
+            ctx = MagicMock()
+            source = DemoDataSource(ctx, DemoDataConfig())
+
+            assert list(source.get_workunits()) == []
+            assert source.get_report() is not None

--- a/smoke-test/tests/datapack/test_datapack_smoke.py
+++ b/smoke-test/tests/datapack/test_datapack_smoke.py
@@ -13,12 +13,7 @@ import logging
 
 import pytest
 
-from tests.utils import (
-    execute_graphql,
-    run_datahub_cmd,
-    wait_for_writes_to_sync,
-    with_test_retry,
-)
+from tests.utils import execute_graphql, run_datahub_cmd, with_test_retry
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +50,6 @@ class TestDemoDataBootstrap:
             },
         )
         assert result.exit_code == 0, f"CLI failed: {result.output}"
-        wait_for_writes_to_sync()
 
         @with_test_retry()
         def _check():
@@ -106,12 +100,7 @@ class TestShowcaseData:
                 "DATAHUB_GMS_TOKEN": auth_session.gms_token(),
             },
         )
-        # Allow partial failures — some MCPs may have minor schema mismatches
-        # but the bulk of the data should still be ingested successfully.
-        assert "events_produced" in result.output, (
-            f"Load produced no output: {result.output}"
-        )
-        wait_for_writes_to_sync()
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
         yield
         logger.info("Unloading showcase-ecommerce data pack")
         run_datahub_cmd(
@@ -167,5 +156,28 @@ class TestShowcaseData:
             res = execute_graphql(auth_session, query)
             total = res["data"]["search"]["total"]
             assert total > 0, f"Expected glossary terms from showcase pack, got {total}"
+
+        _check()
+
+    def test_showcase_has_structured_properties(self, auth_session):
+        """Showcase pack should define structured properties before assignments."""
+
+        @with_test_retry()
+        def _check():
+            query = """{
+                search(
+                    input: {
+                        type: STRUCTURED_PROPERTY
+                        query: "showcase"
+                        start: 0
+                        count: 0
+                    }
+                ) {
+                    total
+                }
+            }"""
+            res = execute_graphql(auth_session, query)
+            total = res["data"]["search"]["total"]
+            assert total > 0, f"Expected showcase structured properties, got {total}"
 
         _check()


### PR DESCRIPTION
### The problem

Datapack was not using the OpenAPI ingestion path. The existing implementation relied on a `graph.exists()` polling loop (`_wait_for_entities`) to verify that entities had been persisted before moving to the next file. This approach was flaky — it would poll individual URNs one at a time against the graph, with a timeout and sleep interval, and had no real guarantee that all processing (indexing, search updates, etc.) had actually completed. Critically, this meant structured property *definitions* might not be fully registered before a subsequent file tried to *assign* those properties, causing silent failures. There was also no validation that the data loaded successfully with counts or any confirmation of completeness.

### What changed

The core change is moving datapack ingestion from the default sink to **OpenAPI `async_batch`** mode, and replacing the polling-based wait with **`async_wait`** (trace-level blocking provided by the OpenAPI endpoint itself).

#### 1. New sink configuration (`_build_datapack_sink_config`)

A new helper builds the sink config with `endpoint: "openapi"` and `mode: "async_batch"`, plus token if present. This is the default for all datapack files now.

#### 2. Per-file emit mode via `_datapack_emit_mode` context manager

For each file in the index, the loader sets the `DATAHUB_EMIT_MODE` environment variable to either `async_wait` (if `wait_for_completion: true`) or `async` (otherwise). The context manager cleanly restores the prior env value afterward. This means files that need ordering guarantees (like structured property definitions) block on the OpenAPI trace completing before the next file starts, while files without dependencies fire-and-forget via async.

#### 3. Deleted `_wait_for_entities` and `_extract_urns_from_file`

The entire polling mechanism is removed: no more `graph.exists()` loop, no more URN extraction from files, no more timeout/sleep logic. The server-side `async_wait` trace handles this deterministically instead of the client guessing.

#### 4. `pipeline.raise_from_status()` moved inside per-file execution

Previously only the last pipeline raised on error. Now each file's pipeline run raises immediately if it fails, giving you a hard stop on the first broken file rather than silently continuing.

#### 5. Extracted `ingest_datapack_file_entries`

The actual file-by-file ingestion loop was pulled out of `load_pack_into_datahub` into its own function. This allowed `demo_data.py` to call it directly rather than reimplementing multi-file merging.

#### 6. `demo_data.py` overhaul

The demo data source previously concatenated all index files into a single combined JSON and fed it through `GenericFileSource`. This completely bypassed multi-file ordering and `wait_for_completion` semantics. Now it calls `ingest_datapack_file_entries` directly (respecting per-file ordering), then hands an empty JSON to `GenericFileSource` so the outer pipeline's sink is a no-op.

#### 7. Docs updated

The `datapack.md` doc now describes the OpenAPI `async_batch` / `async_wait` mechanism instead of the old "verifies all entities exist on server" language.

#### 8. Smoke tests

Tests are updated to assert structured properties are actually searchable after load, which would fail under the old approach if the definitions weren't fully persisted before assignments.

### Why it matters

The old polling approach was fundamentally a race condition managed by timeouts. `async_wait` delegates the "is this done?" question to the server, which knows definitively when a trace has been fully processed. This is both more reliable and simpler — you get a deterministic ordering guarantee without client-side polling, timeout tuning, or the graph dependency.