### PR TITLE
fix(ingestion/unity): emit partner/datahub user-agent for Databricks telemetry

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/unity/connection.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/connection.py
@@ -1,10 +1,11 @@
 """Databricks Unity Catalog connection configuration."""
 
+import re
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
 import pydantic
-from databricks.sdk import WorkspaceClient
+from databricks.sdk import WorkspaceClient, useragent
 from pydantic import Field, model_validator
 
 from datahub._version import nice_version_name
@@ -16,6 +17,30 @@ DATABRICKS = "databricks"
 # User agent entry for Databricks connections.
 # Keep this stable to avoid needing to coordinate version bumps across internal components.
 DATABRICKS_USER_AGENT_ENTRY = "datahub"
+
+_SEMVER_3_PART = re.compile(r"^(\d+)\.(\d+)\.(\d+)")
+
+
+def _sanitize_semver(raw_version: str) -> str:
+    """Coerce a DataHub version string into a SemVer string accepted by the Databricks SDK.
+
+    The Databricks SDK validates product_version against a strict major.minor.patch
+    regex when registered via useragent.with_product(). Although the WorkspaceClient
+    constructor path skips that validation, downstream Databricks telemetry parsers
+    can still drop or mis-attribute invalid versions, so we normalize here.
+
+    DataHub release versions can have a 4th segment (e.g. "1.5.0.19") and the dev
+    sentinel is a human-readable phrase. Both are stripped down to a SemVer-shaped
+    string; unrecognized inputs fall back to a marked dev version.
+    """
+    match = _SEMVER_3_PART.match(raw_version)
+    if match:
+        return f"{match.group(1)}.{match.group(2)}.{match.group(3)}"
+    return "0.0.0-dev"
+
+
+_SANITIZED_PRODUCT_VERSION = _sanitize_semver(nice_version_name())
+_SQL_USER_AGENT_ENTRY = f"{DATABRICKS_USER_AGENT_ENTRY}/{_SANITIZED_PRODUCT_VERSION}"
 
 
 class UnityCatalogConnectionConfig(ConfigModel):
@@ -92,10 +117,15 @@ class UnityCatalogConnectionConfig(ConfigModel):
 
 
 def create_workspace_client(config: UnityCatalogConnectionConfig) -> WorkspaceClient:
+    # Register DataHub as a Databricks partner so requests are attributed in the
+    # `partner/datahub` slot of the User-Agent header — this is the token Databricks's
+    # partner-usage telemetry keys on. with_partner mutates SDK-global state but
+    # appending the same partner twice is harmless.
+    useragent.with_partner(DATABRICKS_USER_AGENT_ENTRY)
     workspace_client = WorkspaceClient(
         host=config.workspace_url,
         product=DATABRICKS_USER_AGENT_ENTRY,
-        product_version=nice_version_name(),
+        product_version=_SANITIZED_PRODUCT_VERSION,
         token=config.token.get_secret_value() if config.token else None,
         azure_tenant_id=config.azure_auth.tenant_id if config.azure_auth else None,
         azure_client_id=config.azure_auth.client_id if config.azure_auth else None,
@@ -120,7 +150,7 @@ def create_workspace_client(config: UnityCatalogConnectionConfig) -> WorkspaceCl
 def get_sql_connection_params(workspace_client: WorkspaceClient) -> dict[str, Any]:
     return {
         "server_hostname": workspace_client.config.host.replace("https://", ""),
-        "user_agent_entry": DATABRICKS_USER_AGENT_ENTRY,
+        "user_agent_entry": _SQL_USER_AGENT_ENTRY,
         # Don't use workspace_client.config.sql_http_path because it adds
         # `sdk-feature/sql-http-path` to the user-agent, which causes errors from the
         # Databricks endpoint: `{user_agent} is not supported for SQL warehouses`.

--- a/metadata-ingestion/tests/unit/test_unity_catalog_connection.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_connection.py
@@ -1,0 +1,90 @@
+"""Tests for Unity Catalog connection helpers — focused on Databricks
+User-Agent attribution so Databricks's partner-usage telemetry can identify
+DataHub traffic."""
+
+import pytest
+
+from datahub.ingestion.source.unity.connection import (
+    DATABRICKS_USER_AGENT_ENTRY,
+    UnityCatalogConnectionConfig,
+    _sanitize_semver,
+    create_workspace_client,
+    get_sql_connection_params,
+)
+
+
+class TestSanitizeSemver:
+    def test_three_segment_passes_through(self) -> None:
+        assert _sanitize_semver("1.6.0") == "1.6.0"
+
+    def test_four_segment_truncates(self) -> None:
+        # acryl-datahub releases use a 4-segment PEP-440 version like 1.5.0.19.
+        # The Databricks SDK SemVer regex only accepts 3 segments.
+        assert _sanitize_semver("1.5.0.19") == "1.5.0"
+
+    def test_dev_sentinel_falls_back(self) -> None:
+        # nice_version_name() returns this literal phrase in develop installs.
+        assert (
+            _sanitize_semver("unavailable (installed in develop mode)") == "0.0.0-dev"
+        )
+
+    def test_pep440_epoch_falls_back(self) -> None:
+        # The in-repo __version__ literal is "1!0.0.0.dev0" — PEP 440 epoch
+        # syntax does not match the SemVer regex.
+        assert _sanitize_semver("1!0.0.0.dev0") == "0.0.0-dev"
+
+    def test_empty_string_falls_back(self) -> None:
+        assert _sanitize_semver("") == "0.0.0-dev"
+
+    def test_pre_release_suffix_stripped(self) -> None:
+        # Only the leading 3 numeric segments matter; suffixes are dropped to
+        # keep the value unambiguous for downstream parsers.
+        assert _sanitize_semver("1.6.0rc1") == "1.6.0"
+
+
+class TestUserAgentAssembly:
+    def test_workspace_client_registers_partner_tag(self) -> None:
+        # Exercises create_workspace_client and verifies the assembled UA
+        # contains both `partner/datahub` (the partner-telemetry token) and a
+        # well-formed `datahub/<semver>` product token. The product/version
+        # slot lives on the per-client Config; the partner tag lives in
+        # SDK-global extras and is appended by to_string().
+        config = UnityCatalogConnectionConfig(
+            workspace_url="https://example.cloud.databricks.com",
+            token="dapi-fake-token-for-test",
+        )
+
+        client = create_workspace_client(config)
+
+        ua = client.config.user_agent
+        assert "partner/datahub" in ua, f"Expected partner tag in UA, got: {ua}"
+        assert ua.startswith(f"{DATABRICKS_USER_AGENT_ENTRY}/"), (
+            f"Expected UA to lead with {DATABRICKS_USER_AGENT_ENTRY}/<ver>, got: {ua}"
+        )
+
+    @pytest.mark.parametrize(
+        "warehouse_id",
+        ["abc-123-warehouse", "0123456789abcdef"],
+    )
+    def test_sql_connection_params_carry_versioned_user_agent(
+        self, warehouse_id: str
+    ) -> None:
+        # The databricks-sql-connector uses its own user_agent_entry field,
+        # separate from the SDK's UA assembly. Confirm we send the versioned
+        # form there too.
+        config = UnityCatalogConnectionConfig(
+            workspace_url="https://example.cloud.databricks.com",
+            token="dapi-fake-token-for-test",
+            warehouse_id=warehouse_id,
+        )
+        client = create_workspace_client(config)
+
+        params = get_sql_connection_params(client)
+
+        entry = params["user_agent_entry"]
+        assert entry.startswith(f"{DATABRICKS_USER_AGENT_ENTRY}/"), entry
+        # Whatever sanitization produced, the version slot must be non-empty
+        # and must not contain whitespace (would corrupt the UA header).
+        _, _, version = entry.partition("/")
+        assert version, "version slot must be populated"
+        assert " " not in version, "version must not contain whitespace"


### PR DESCRIPTION
## Summary

Databricks reported they cannot see DataHub usage on their side. Root cause: the SDK and SQL-connector calls were sending DataHub only in the *product* slot of the User-Agent header, not in the *partner* slot that Databricks's partner-usage telemetry filters on.

Specifically:

- `WorkspaceClient(product="datahub", product_version=…)` lands in the leading `<name>/<ver>` slot of the UA. That slot is for "products built on top of the SDK" — generic, not partner-attributed.
- Databricks's partner dashboards key on the `partner/<name>` token, which is only emitted when `useragent.with_partner("name")` is called. We never called it.

Secondary issues fixed as part of the same change:

- `product_version` was being set from `nice_version_name()`, which can return:
  - 4-segment PyPI strings like `1.5.0.19` (not valid SemVer per Databricks's regex)
  - a PEP-440 dev epoch like `1!0.0.0.dev0`
  - the dev sentinel `"unavailable (installed in develop mode)"` — spaces and parens corrupt the UA
- The `databricks-sql-connector` path was sending bare `"datahub"` rather than the partner-style `"datahub/<ver>"`.

## Changes

- `metadata-ingestion/src/datahub/ingestion/source/unity/connection.py`
  - New `_sanitize_semver()` helper coerces version strings to a SemVer shape (`major.minor.patch`) or falls back to `0.0.0-dev`.
  - `create_workspace_client()` now calls `useragent.with_partner("datahub")` before constructing the client.
  - Sanitized version is passed to both `WorkspaceClient(product_version=…)` and the SQL connector's `user_agent_entry`.
- `metadata-ingestion/tests/unit/test_unity_catalog_connection.py` (new)
  - Unit tests for `_sanitize_semver` covering 3-segment, 4-segment, dev sentinel, PEP-440 epoch, empty, and pre-release inputs.
  - Integration-style tests verifying the assembled `WorkspaceClient.config.user_agent` contains `partner/datahub` and leads with `datahub/<ver>`; SQL connector `user_agent_entry` is non-empty and whitespace-free.

## Wire effect

Before:
```
datahub/unavailable (installed in develop mode) databricks-sdk-py/0.97.0 python/3.10 os/darwin auth/pat
```
(or in production: `datahub/1.5.0.19 …` — invalid SemVer)

After:
```
datahub/0.0.0-dev databricks-sdk-py/0.97.0 python/3.10 os/darwin auth/pat partner/datahub
```
(or in production: `datahub/1.5.0 … partner/datahub`)

## Test plan

- [x] `./gradlew :metadata-ingestion:lintFix` — passes
- [x] 9 new unit tests pass
- [x] Existing unity unit tests (92 tests) still pass
- [ ] After merge, verify with Databricks team that `partner/datahub` now appears in their partner-usage telemetry