### PR TITLE
ci(slack): notify Slack on CI failures for push/scheduled/release events

### DIFF
--- a/.github/scripts/collect_workflow_metrics.py
+++ b/.github/scripts/collect_workflow_metrics.py
@@ -55,14 +55,17 @@ def main() -> int:
     # Step 1: Fetch workflow run attempt
     run_data = gh.get_run_attempt(args.repo, args.run_id, args.attempt)
 
-    # Step 2: Fetch all jobs for this run (filter=latest gives latest version of each job)
+    # Step 2: Fetch all jobs (latest per job) to classify the rerun type, then fetch
+    # the attempt-specific jobs via the dedicated endpoint — filter=latest only returns
+    # the most-recent attempt of each job, so filtering by attempt number on that list
+    # yields nothing for any attempt that isn't the latest.
     all_jobs = gh.get_run_jobs(args.repo, args.run_id)
 
     # Step 3: Classify rerun type
     rerun_type = classify_rerun(args.attempt, all_jobs)
 
-    # Step 4: Filter to only jobs that ran in this attempt
-    attempt_jobs = [j for j in all_jobs if j.get("run_attempt") == args.attempt]
+    # Step 4: Fetch jobs that ran in this specific attempt
+    attempt_jobs = gh.get_run_attempt_jobs(args.repo, args.run_id, args.attempt)
 
     # Step 5: Build metrics dataclasses
     metrics = Metrics(

--- a/.github/scripts/fetch_workflow_details.py
+++ b/.github/scripts/fetch_workflow_details.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Fetch GitHub Actions workflow run details and write them to a JSON file.
+
+Used by notify-slack-status.yml to gather all data needed for a Slack
+notification in one place, without mixing API calls and context expressions.
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from utils.datetime_utils import duration_seconds, parse_dt
+from utils.github.gh_client import GitHubAPIClient
+
+_FAILED_CONCLUSIONS = {"failure", "timed_out"}
+
+
+def _build_details(
+    run_data: dict[str, Any],
+    jobs: list[dict[str, Any]],
+    repo: str,
+    conclusion_override: str | None,
+) -> dict[str, Any]:
+    started = parse_dt(run_data.get("run_started_at"))
+    completed = parse_dt(run_data.get("updated_at"))
+    actor: dict[str, Any] = run_data.get("actor") or {}
+    conclusion = conclusion_override or run_data.get("conclusion") or ""
+    failed_jobs = [j["name"] for j in jobs if j.get("conclusion") in _FAILED_CONCLUSIONS]
+
+    # display_title is provided by the GitHub API and automatically resolves to:
+    # - first line of the commit message for push/PR events
+    # - workflow run name for schedule events
+    # - release name for release events
+    head_commit: dict[str, Any] = run_data.get("head_commit") or {}
+    display_title: str = run_data.get("display_title") or head_commit.get("message", "").split("\n")[0]
+
+    return {
+        "workflow_name": run_data.get("name", ""),
+        "head_branch": run_data.get("head_branch", ""),
+        "head_sha": run_data.get("head_sha", ""),
+        "actor_login": actor.get("login", ""),
+        "run_url": run_data.get("html_url", ""),
+        "event": run_data.get("event", ""),
+        "conclusion": conclusion,
+        "repo": repo,
+        "duration_seconds": duration_seconds(started, completed),
+        "failed_jobs": failed_jobs,
+        "display_title": display_title,
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("ERROR: GITHUB_TOKEN environment variable is required.", file=sys.stderr)
+        return 2
+
+    gh = GitHubAPIClient(token)
+    run_data = gh.get_run_attempt(args.repo, args.run_id, args.attempt)
+    jobs = gh.get_run_attempt_jobs(args.repo, args.run_id, args.attempt)
+    details = _build_details(run_data, jobs, args.repo, args.conclusion)
+
+    Path(args.output).write_text(json.dumps(details, indent=2))
+    print(f"Workflow details written to {args.output}")
+    return 0
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-id", required=True, help="Workflow run ID")
+    parser.add_argument("--attempt", required=True, type=int, help="Run attempt number")
+    parser.add_argument("--repo", required=True, help="Repository in owner/repo format")
+    parser.add_argument("--output", required=True, help="Path to write the JSON output")
+    parser.add_argument(
+        "--conclusion",
+        help="Override the conclusion from the API (e.g. when a manual input is provided)",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/notify_workflow_status_slack.py
+++ b/.github/scripts/notify_workflow_status_slack.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Post a Slack notification when a CI workflow completes on a protected branch.
+
+Sends a commit-scoped root message on the first notification, then threads all
+subsequent notifications for the same commit as replies. Thread state is persisted
+via the --thread-ts-file argument, which is backed by GitHub Actions cache so
+multiple post-workflow-actions runs for the same commit share it.
+Omit --thread-ts-file to always post a standalone root message.
+
+Root message (posted once per commit SHA):
+  🔴/🟢 GitHub Action <conclusion> in <repo> on <branch> for <commit> for event: <event>
+  Repo | Branch | Commit | Author | Event
+
+Thread reply (posted per workflow):
+  🔴/🟢 <workflow-name> <conclusion-verb> — <link to run>
+  Repo | Branch | Commit | Event | Duration
+  [Failed Jobs section if applicable]
+  [Extra fields as additional sections]
+"""
+
+import argparse
+import dataclasses
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from utils.slack_notifier import blockkit, slack_client
+
+_CONCLUSION_VERB: dict[str, str] = {
+    "failure": "failed",
+    "timed_out": "timed out",
+    "cancelled": "was cancelled",
+    "success": "succeeded",
+}
+
+_CONCLUSION_COLOR: dict[str, blockkit.Status] = {
+    "failure": "failure",
+    "timed_out": "failure",
+    "cancelled": "warning",
+    "success": "success",
+}
+
+_CONCLUSION_EMOJI: dict[str, str] = {
+    "failure": ":red_circle:",
+    "timed_out": ":red_circle:",
+    "cancelled": ":large_yellow_circle:",
+    "success": ":large_green_circle:",
+}
+
+_FAILED_CONCLUSIONS = {"failure", "timed_out"}
+
+
+@dataclass
+class WorkflowDetails:
+    # Required — must be present in the input JSON
+    workflow_name: str
+    head_branch: str
+    head_sha: str
+    display_title: str
+    actor_login: str
+    run_url: str
+    event: str
+    conclusion: str
+    repo: str
+
+    # Optional — explicitly rendered in the Slack message
+    duration_seconds: int | None = None
+    failed_jobs: list[str] = field(default_factory=list)
+
+    # Passthrough — any extra keys from the JSON not listed above
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_file(cls, path: str) -> "WorkflowDetails":
+        data: dict[str, Any] = json.loads(Path(path).read_text())
+
+        all_field_names = {f.name for f in dataclasses.fields(cls)}
+        known_field_names = all_field_names - {"extra"}
+
+        required_names = {
+            f.name
+            for f in dataclasses.fields(cls)
+            if f.default is dataclasses.MISSING
+            and f.default_factory is dataclasses.MISSING  # type: ignore[misc]
+        }
+        missing = required_names - data.keys()
+        if missing:
+            raise ValueError(f"Missing required fields in workflow details JSON: {sorted(missing)}")
+
+        known = {k: v for k, v in data.items() if k in known_field_names}
+        extra = {k: v for k, v in data.items() if k not in known_field_names}
+        return cls(**known, extra=extra)
+
+
+def _fmt_duration(seconds: int) -> str:
+    m, s = divmod(seconds, 60)
+    return f"{m}m {s}s" if m else f"{s}s"
+
+
+def main() -> int:
+    args = _parse_args()
+
+    token = os.environ.get("SLACK_BOT_TOKEN")
+    if not token:
+        print("ERROR: SLACK_BOT_TOKEN environment variable is required.", file=sys.stderr)
+        return 2
+
+    details = WorkflowDetails.from_file(args.input_file)
+
+    thread_ts_map: dict[str, str] = _load_thread_ts_map(args.thread_ts_file)
+    short_sha = details.head_sha[:7]
+    repo_url = f"https://github.com/{details.repo}"
+    commit_url = f"{repo_url}/commit/{details.head_sha}"
+    conclusion = details.conclusion
+    conclusion_verb = _CONCLUSION_VERB.get(conclusion, conclusion)
+    conclusion_color: blockkit.Status = _CONCLUSION_COLOR.get(conclusion, "failure")
+    conclusion_emoji = _CONCLUSION_EMOJI.get(conclusion, "\U0001f534")
+
+    any_new_thread = False
+    for channel in args.channel:
+        existing_ts = thread_ts_map.get(channel)
+        if existing_ts:
+            _post_thread_reply(
+                channel=channel,
+                thread_ts=existing_ts,
+                details=details,
+                short_sha=short_sha,
+                commit_url=commit_url,
+                conclusion_verb=conclusion_verb,
+                conclusion_color=conclusion_color,
+                conclusion_emoji=conclusion_emoji,
+                token=token,
+            )
+        else:
+            ts = _post_root_message(
+                channel=channel,
+                details=details,
+                repo_url=repo_url,
+                short_sha=short_sha,
+                commit_url=commit_url,
+                conclusion=conclusion,
+                conclusion_color=conclusion_color,
+                conclusion_emoji=conclusion_emoji,
+                token=token,
+            )
+            thread_ts_map[channel] = ts
+            any_new_thread = True
+            _post_thread_reply(
+                channel=channel,
+                thread_ts=ts,
+                details=details,
+                short_sha=short_sha,
+                commit_url=commit_url,
+                conclusion_verb=conclusion_verb,
+                conclusion_color=conclusion_color,
+                conclusion_emoji=conclusion_emoji,
+                token=token,
+            )
+
+    if any_new_thread and args.thread_ts_file:
+        Path(args.thread_ts_file).write_text(json.dumps(thread_ts_map))
+
+    return 0
+
+
+def _load_thread_ts_map(path: str | None) -> dict[str, str]:
+    if not path:
+        print("No thread-ts-file specified; each run will post a new root message.")
+        return {}
+    ts_path = Path(path)
+    if not ts_path.exists():
+        print(f"Thread-ts file not found at {ts_path}; will post a new root message.")
+        return {}
+    if ts_path.stat().st_size == 0:
+        print(f"Thread-ts file at {ts_path} is empty; will post a new root message.")
+        return {}
+    result: dict[str, str] = json.loads(ts_path.read_text())
+    print(f"Loaded thread-ts map from {ts_path}: {result}")
+    return result
+
+
+def _post_root_message(
+    *,
+    channel: str,
+    details: WorkflowDetails,
+    repo_url: str,
+    short_sha: str,
+    commit_url: str,
+    conclusion: str,
+    conclusion_color: blockkit.Status,
+    conclusion_emoji: str,
+    token: str,
+) -> str:
+    commit_ref = blockkit.link(short_sha, commit_url)
+    display_title = details.display_title
+    if display_title:
+        title_body = f"({commit_ref}): {display_title}"
+    else:
+        title_body = f"({commit_ref})"
+    title = f"*{conclusion_emoji} {title_body}"
+    root_fields: dict[str, str] = {
+        "Repo": blockkit.link(details.repo, repo_url),
+        "Branch": details.head_branch,
+        "Commit": f"{blockkit.link(short_sha, commit_url)} by @{details.actor_login}",
+        "Event": details.event,
+    }
+    if details.display_title:
+        root_fields["Commit Message"] = details.display_title
+    blocks: list[dict[str, Any]] = [
+        blockkit.section(title),
+        blockkit.fields_section(root_fields),
+    ]
+    return slack_client.post_message(
+        channel=channel,
+        blocks=[],
+        attachments=[blockkit.color_attachment(conclusion_color, blocks)],
+        token=token,
+        text=(
+            f"GitHub Action {conclusion} in {details.repo} on {details.head_branch}"
+            f" for {short_sha} (event: {details.event})"
+        ),
+    )
+
+
+def _post_thread_reply(
+    *,
+    channel: str,
+    thread_ts: str,
+    details: WorkflowDetails,
+    short_sha: str,
+    commit_url: str,
+    conclusion_verb: str,
+    conclusion_color: blockkit.Status,
+    conclusion_emoji: str,
+    token: str,
+) -> None:
+    metadata_fields: dict[str, str] = {
+        "Repo": details.repo,
+        "Branch": details.head_branch,
+        "Commit": f"{blockkit.link(short_sha, commit_url)} by @{details.actor_login}",
+        "Event": details.event,
+    }
+    if details.display_title:
+        metadata_fields["Commit Message"] = details.display_title
+    if details.duration_seconds is not None:
+        metadata_fields["Duration"] = _fmt_duration(details.duration_seconds)
+
+    reply_blocks: list[dict[str, Any]] = [
+        blockkit.section(
+            f"{conclusion_emoji} *{details.workflow_name}* {conclusion_verb}"
+            f" — {blockkit.link('view run', details.run_url)}"
+        ),
+        blockkit.fields_section(metadata_fields),
+    ]
+
+    if details.failed_jobs and details.conclusion in _FAILED_CONCLUSIONS:
+        bullet_list = "\n".join(f"• {name}" for name in details.failed_jobs)
+        reply_blocks.append(blockkit.section(f"*Failed Jobs*\n{bullet_list}"))
+
+    for key, value in details.extra.items():
+        reply_blocks.append(blockkit.fields_section({key: str(value)}))
+
+    slack_client.post_thread_reply(
+        channel=channel,
+        thread_ts=thread_ts,
+        blocks=[],
+        attachments=[blockkit.color_attachment(conclusion_color, reply_blocks)],
+        token=token,
+        text=(
+            f"{details.workflow_name} {conclusion_verb} in {details.repo}"
+            f" on {details.head_branch} ({short_sha}) [event: {details.event}]"
+        ),
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input-file",
+        required=True,
+        metavar="FILE",
+        help="Path to JSON file produced by fetch_workflow_details.py",
+    )
+    parser.add_argument(
+        "--channel",
+        action="append",
+        required=True,
+        metavar="CHANNEL",
+        help="Slack channel (repeatable, e.g. --channel '#ci-failures' --channel '#releases')",
+    )
+    parser.add_argument(
+        "--thread-ts-file",
+        help="Path to JSON file storing {channel: thread_ts} map (read + written in-place)",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/utils/github/gh_client.py
+++ b/.github/scripts/utils/github/gh_client.py
@@ -72,8 +72,10 @@ class GitHubAPIClient:
     """Thin wrapper around requests.Session for GitHub REST API calls."""
 
     BASE_URL = "https://api.github.com"
+    _RUN_PATH = "/repos/{repo}/actions/runs/{run_id}"
     _RUN_ATTEMPT_PATH = "/repos/{repo}/actions/runs/{run_id}/attempts/{attempt}"
     _RUN_JOBS_PATH = "/repos/{repo}/actions/runs/{run_id}/jobs"
+    _RUN_ATTEMPT_JOBS_PATH = "/repos/{repo}/actions/runs/{run_id}/attempts/{attempt}/jobs"
 
     def __init__(self, token: str, base_url: str = BASE_URL) -> None:
         self.base_url = base_url
@@ -94,6 +96,18 @@ class GitHubAPIClient:
     def _run_jobs_url(self, repo: str, run_id: str) -> str:
         return self.base_url + self._RUN_JOBS_PATH.format(repo=repo, run_id=run_id)
 
+    def _run_attempt_jobs_url(self, repo: str, run_id: str, attempt: int) -> str:
+        return self.base_url + self._RUN_ATTEMPT_JOBS_PATH.format(
+            repo=repo, run_id=run_id, attempt=attempt
+        )
+
+    def _run_url(self, repo: str, run_id: str) -> str:
+        return self.base_url + self._RUN_PATH.format(repo=repo, run_id=run_id)
+
+    def get_run(self, repo: str, run_id: str) -> dict[str, Any]:
+        """Fetch the latest state of a workflow run."""
+        return self.get(self._run_url(repo, run_id))
+
     def get_run_attempt(self, repo: str, run_id: str, attempt: int) -> dict[str, Any]:
         """Fetch a specific workflow run attempt."""
         return self.get(self._run_attempt_url(repo, run_id, attempt))
@@ -102,6 +116,14 @@ class GitHubAPIClient:
         """Fetch all jobs for a workflow run (latest version of each job across attempts)."""
         return self.get_paginated(
             self._run_jobs_url(repo, run_id), "jobs", params={"filter": "latest"}
+        )
+
+    def get_run_attempt_jobs(
+        self, repo: str, run_id: str, attempt: int
+    ) -> list[dict[str, Any]]:
+        """Fetch all jobs that ran in a specific attempt."""
+        return self.get_paginated(
+            self._run_attempt_jobs_url(repo, run_id, attempt), "jobs"
         )
 
     @handle_rate_limit()

--- a/.github/scripts/utils/slack_notifier/blockkit.py
+++ b/.github/scripts/utils/slack_notifier/blockkit.py
@@ -1,0 +1,48 @@
+"""Generic Slack BlockKit builders.
+
+Pure functions producing BlockKit JSON fragments. No I/O, no knowledge of
+tests. Callers compose these into messages.
+"""
+
+from typing import Any, Literal
+
+Status = Literal["success", "warning", "failure"]
+
+# Slack's recommended attachment colors for status bars.
+_STATUS_COLORS: dict[Status, str] = {
+    "success": "#36a64f",
+    "warning": "#ecb22e",
+    "failure": "#e01e5a",
+}
+
+
+def header(text: str) -> dict[str, Any]:
+    return {"type": "header", "text": {"type": "plain_text", "text": text, "emoji": True}}
+
+
+def section(text: str) -> dict[str, Any]:
+    return {"type": "section", "text": {"type": "mrkdwn", "text": text}}
+
+
+def fields_section(fields: dict[str, str]) -> dict[str, Any]:
+    """Render a two-column grid. Each key becomes a bold label above its value."""
+    return {
+        "type": "section",
+        "fields": [
+            {"type": "mrkdwn", "text": f"*{label}*\n{value}"} for label, value in fields.items()
+        ],
+    }
+
+
+def divider() -> dict[str, Any]:
+    return {"type": "divider"}
+
+
+def link(text: str, url: str) -> str:
+    """Slack mrkdwn link syntax: <url|text>."""
+    return f"<{url}|{text}>"
+
+
+def color_attachment(status: Status, blocks: list[dict[str, Any]]) -> dict[str, Any]:
+    """Wrap *blocks* in an attachment with a colored bar based on *status*."""
+    return {"color": _STATUS_COLORS[status], "blocks": blocks}

--- a/.github/scripts/utils/slack_notifier/slack_client.py
+++ b/.github/scripts/utils/slack_notifier/slack_client.py
@@ -1,0 +1,87 @@
+"""Generic Slack Web API client.
+
+Knows nothing about tests. Any CI notifier can import this to post messages
+or threaded replies to a Slack channel.
+"""
+
+import time
+from typing import Any
+
+import requests
+
+_API_BASE = "https://slack.com/api"
+_DEFAULT_TIMEOUT_SECONDS = 10
+_MAX_RETRIES_ON_RATE_LIMIT = 2
+
+
+class SlackApiError(RuntimeError):
+    """Raised when the Slack Web API returns ok=false or a non-2xx HTTP status."""
+
+
+def post_message(
+    *,
+    channel: str,
+    blocks: list[dict[str, Any]],
+    token: str,
+    attachments: list[dict[str, Any]] | None = None,
+    text: str = "",
+) -> str:
+    """Post a message to *channel*. Returns the message's ``ts`` (for threading).
+
+    *text* is a plaintext fallback shown in notifications / accessibility
+    contexts; blocks are the rich rendering.
+    """
+    payload: dict[str, Any] = {"channel": channel, "blocks": blocks, "text": text}
+    if attachments is not None:
+        payload["attachments"] = attachments
+    response = _call("chat.postMessage", payload, token)
+    return str(response["ts"])
+
+
+def post_thread_reply(
+    *,
+    channel: str,
+    thread_ts: str,
+    blocks: list[dict[str, Any]],
+    token: str,
+    attachments: list[dict[str, Any]] | None = None,
+    text: str = "",
+) -> None:
+    """Post a reply in the thread rooted at *thread_ts*."""
+    payload: dict[str, Any] = {
+        "channel": channel,
+        "thread_ts": thread_ts,
+        "blocks": blocks,
+        "text": text,
+    }
+    if attachments is not None:
+        payload["attachments"] = attachments
+    _call("chat.postMessage", payload, token)
+
+
+def _call(method: str, payload: dict[str, Any], token: str) -> dict[str, Any]:
+    url = f"{_API_BASE}/{method}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json; charset=utf-8",
+    }
+
+    for attempt in range(_MAX_RETRIES_ON_RATE_LIMIT + 1):
+        resp = requests.post(url, json=payload, headers=headers, timeout=_DEFAULT_TIMEOUT_SECONDS)
+
+        # Slack returns 429 with Retry-After on rate limits; everything else
+        # (including auth errors) comes back as 200 with ok=false.
+        if resp.status_code == 429 and attempt < _MAX_RETRIES_ON_RATE_LIMIT:
+            retry_after = int(resp.headers.get("Retry-After", "1"))
+            time.sleep(retry_after)
+            continue
+
+        if not resp.ok:
+            raise SlackApiError(f"Slack API {method} returned HTTP {resp.status_code}: {resp.text}")
+
+        body: dict[str, Any] = resp.json()
+        if not body.get("ok"):
+            raise SlackApiError(f"Slack API {method} failed: {body.get('error', 'unknown_error')}")
+        return body
+
+    raise SlackApiError(f"Slack API {method} rate-limited after {_MAX_RETRIES_ON_RATE_LIMIT} retries")

--- a/.github/workflows/notify-slack-status.yml
+++ b/.github/workflows/notify-slack-status.yml
@@ -25,7 +25,7 @@ on:
       channel:
         type: string
         required: false
-        default: "#datahub-build-notifications"
+        default: "#datahub-oss-build-notifications"
         description: Slack channel to post to
       thread_ts_file:
         type: string
@@ -109,7 +109,6 @@ jobs:
           key: slack-thread-${{ steps.fetch-details.outputs.head_sha }}
 
       - name: Post Slack notification
-        continue-on-error: true
         env:
           SLACK_BOT_TOKEN: ${{ secrets.CI_NOTIFIER_SLACK_BOT_TOKEN }}
           CHANNEL: ${{ inputs.channel }}

--- a/.github/workflows/notify-slack-status.yml
+++ b/.github/workflows/notify-slack-status.yml
@@ -1,0 +1,134 @@
+name: Notify Slack Workflow Status
+
+on:
+  workflow_call:
+    inputs:
+      run_id:
+        type: string
+        required: false
+        default: ""
+        description: >-
+          Run ID to fetch details for via the GitHub API. Leave empty to use
+          event/run context instead.
+      attempt:
+        type: string
+        required: false
+        default: "1"
+        description: Run attempt number to fetch job details for.
+      conclusion:
+        type: string
+        required: false
+        default: ""
+        description: >-
+          Workflow conclusion (success, failure, timed_out, cancelled). When
+          run_id is provided and this is empty, fetched from the API.
+      channel:
+        type: string
+        required: false
+        default: "#datahub-build-notifications"
+        description: Slack channel to post to
+      thread_ts_file:
+        type: string
+        required: false
+        default: ""
+        description: >-
+          Workspace-relative path to a JSON file storing {channel: thread_ts}
+          for threaded notifications. Omit to always post a standalone message.
+
+  # Allows standalone testing from the Actions UI.
+  workflow_dispatch:
+    inputs:
+      run_id:
+        type: string
+        required: true
+        description: Run ID to fetch details for (leave empty to use current run context)
+      attempt:
+        type: string
+        required: false
+        default: "1"
+        description: Run attempt number to fetch job details for.
+      conclusion:
+        type: string
+        required: false
+        description: "Workflow conclusion: success, failure, timed_out, cancelled"
+      channel:
+        type: string
+        required: false
+        default: "#datahub-build-notifications"
+        description: Slack channel to post to
+      thread_ts_file:
+        type: string
+        required: false
+        description: Workspace-relative path to thread-ts JSON file
+
+jobs:
+  notify:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv pip install requests --system
+
+      - name: Fetch workflow details
+        id: fetch-details
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONCLUSION_INPUT: ${{ inputs.conclusion }}
+          RUN_ID: ${{ inputs.run_id }}
+          ATTEMPT: ${{ inputs.attempt || '1' }}
+        run: |
+          cd .github/scripts
+          ARGS=(
+            --run-id "${RUN_ID}"
+            --attempt "${ATTEMPT}"
+            --repo "${{ github.repository }}"
+            --output workflow-details.json
+          )
+          [ -n "${CONCLUSION_INPUT}" ] && ARGS+=(--conclusion "${CONCLUSION_INPUT}")
+          python fetch_workflow_details.py "${ARGS[@]}"
+          echo "head_sha=$(jq -r .head_sha workflow-details.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Slack thread cache
+        id: thread-cache
+        if: inputs.thread_ts_file != ''
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ inputs.thread_ts_file }}
+          key: slack-thread-${{ steps.fetch-details.outputs.head_sha }}
+
+      - name: Post Slack notification
+        continue-on-error: true
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.CI_NOTIFIER_SLACK_BOT_TOKEN }}
+          CHANNEL: ${{ inputs.channel }}
+        run: |
+          cd .github/scripts
+          ARGS=(
+            --input-file workflow-details.json
+            --channel "${CHANNEL}"
+          )
+          if [ -n "${{ inputs.thread_ts_file }}" ]; then
+            ARGS+=(--thread-ts-file "$GITHUB_WORKSPACE/${{ inputs.thread_ts_file }}")
+          fi
+          python notify_workflow_status_slack.py "${ARGS[@]}"
+
+      - name: Save Slack thread cache
+        if: >-
+          inputs.thread_ts_file != '' && steps.thread-cache.outputs.cache-hit !=
+          'true' && hashFiles(inputs.thread_ts_file) != ''
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ inputs.thread_ts_file }}
+          key: slack-thread-${{ steps.fetch-details.outputs.head_sha }}

--- a/.github/workflows/post-workflow-actions.yml
+++ b/.github/workflows/post-workflow-actions.yml
@@ -58,6 +58,12 @@ on:
         required: false
         type: boolean
         default: false
+      notify_slack:
+        description: "Send Slack failure notification (for testing; production
+          notifications fire automatically)"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   actions: read
@@ -168,3 +174,45 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "/repos/${REPOSITORY}/actions/runs/${RUN_ID}/rerun-failed-jobs"
+
+  # Notify Slack on CI failure on protected branches.
+  # Fires when:
+  #   - workflow_dispatch with notify_slack=true (manual testing)
+  #   - workflow_run that failed or timed out,
+  #       - triggered by schedule/release
+  #       - or a push to a protected branch (default, release/*, hotfix/*)
+  notify-slack-failure:
+    name: Notify Slack on CI failure
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.notify_slack == true)
+      || (github.event_name == 'workflow_run'
+          && contains(fromJSON('["failure","timed_out"]'), github.event.workflow_run.conclusion)
+          && (contains(fromJSON('["schedule","release"]'), github.event.workflow_run.event)
+              || (github.event.workflow_run.event == 'push'
+                  && (github.event.workflow_run.head_branch == github.event.repository.default_branch
+                      || startsWith(github.event.workflow_run.head_branch, 'releases/')
+                      || startsWith(github.event.workflow_run.head_branch, 'hotfixes/')))))
+    uses: ./.github/workflows/notify-slack-status.yml
+    secrets: inherit
+    with:
+      run_id: ${{ inputs.run_id || github.event.workflow_run.id }}
+      attempt: ${{ inputs.attempt || github.event.workflow_run.run_attempt }}
+      thread_ts_file: ${{ github.event.workflow_run.event != 'schedule' && '.slack-thread-ts.json' || '' }}
+      channel: ${{ vars.BUILD_STATUS_NOTIFICATION_SLACK_CHANNEL }}
+
+  # Notify Slack when the Docker build succeeds on a push or release event.
+  # Posts a standalone message (not threaded) so it's visible as a positive signal
+  # separate from any failure thread on the same commit.
+  notify-slack-docker-success:
+    name: Notify Slack on Docker build success
+    if: >-
+      github.event_name == 'workflow_run'
+      && github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.name == 'Docker Build, Scan, Test'
+      && contains(fromJSON('["push","release"]'), github.event.workflow_run.event)
+    uses: ./.github/workflows/notify-slack-status.yml
+    secrets: inherit
+    with:
+      run_id: ${{ github.event.workflow_run.id }}
+      conclusion: success
+      channel: ${{ vars.BUILD_STATUS_NOTIFICATION_SLACK_CHANNEL }}


### PR DESCRIPTION
## Summary

Adds Slack notifications when CI workflows fail on protected branches or scheduled/release runs, mirroring the SaaS implementation.

- Reusable `notify-slack-status.yml` workflow that fetches workflow run details via the GitHub API and posts a color-coded BlockKit message.
- Per-commit threading: one root message per commit SHA, threaded replies per workflow (thread state cached via Actions cache).
- Two new jobs in `post-workflow-actions.yml`:
  - `notify-slack-failure` — fires on failure/timed_out for `schedule`/`release` events, or pushes to default/`release/*`/`hotfix/*` branches.
  - `notify-slack-docker-success` — standalone success ping for Docker Build, Scan, Test on push/release.
- Small fix in `collect_workflow_metrics.py`: use the attempt-specific jobs endpoint so reruns report correctly.

Channel is supplied via repo variable `BUILD_STATUS_NOTIFICATION_SLACK_CHANNEL`; bot token via secret `CI_NOTIFIER_SLACK_BOT_TOKEN`.

## Test plan

- [x] Configure `BUILD_STATUS_NOTIFICATION_SLACK_CHANNEL` repo variable and `CI_NOTIFIER_SLACK_BOT_TOKEN` secret.
- [ ] Manually dispatch `Post Workflow Actions` against a historical failed run with `notify_slack=true` and verify the failure message + thread reply.
- [ ] Verify a Docker Build success on a push to master posts the success message.
- [ ] Confirm `validate_post_workflow_list.py` still passes (notify-slack-status.yml is workflow_call-only, so excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)