### PR TITLE
feat(ci): forward sha-XXXXXXX tag to OSS deploy pipelines via SQS

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -1211,4 +1211,4 @@ jobs:
         if: ${{ needs.setup.outputs.publish != 'false' && github.repository_owner == 'datahub-project' && needs.setup.outputs.repository_name == 'datahub' }}
         with:
           sqs-url: ${{ secrets.DATAHUB_HEAD_SYNC_QUEUE }}
-          message: '{ "command": "git-sync", "args" : {"repoName": "${{ needs.setup.outputs.repository_name }}", "repoOrg": "${{ github.repository_owner }}", "repoBranch": "${{ needs.setup.outputs.branch_name }}", "repoShaShort": "${{ needs.setup.outputs.short_sha }}" }}'
+          message: '{ "command": "git-sync", "args" : {"repoName": "${{ needs.setup.outputs.repository_name }}", "repoOrg": "${{ github.repository_owner }}", "repoBranch": "${{ needs.setup.outputs.branch_name }}", "repoShaShort": "${{ needs.setup.outputs.short_sha }}", "repoShaTag": "${{ needs.setup.outputs.tag }}" }}'


### PR DESCRIPTION
## Summary
- Include `repoShaTag` in the git-sync SQS message from `docker-unified.yml` so cd-pipeline can pin oss-head to the immutable `sha-XXXXXXX` tag

Companion to acryldata/dev-ops#758 and acryldata/datahub-apps#6411.

## Test plan
- [ ] Confirm SQS message includes `repoShaTag` after a master docker-unified publish

Made with [Cursor](https://cursor.com)