### PR TITLE
fix(ingest/mssql): consolidate to single SqlParsingAggregator

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/mssql/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/mssql/source.py
@@ -72,7 +72,6 @@ from datahub.metadata.schema_classes import (
 )
 from datahub.sql_parsing.sql_parsing_aggregator import SqlParsingAggregator
 from datahub.utilities.file_backed_collections import FileBackedList
-from datahub.utilities.perf_timer import PerfTimer
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -425,7 +424,6 @@ class SQLServerSource(SQLAlchemySource):
                 message="Lineage may not resolve accurately because 'convert_column_urns_to_lowercase' is False. To ensure correct lineage, set 'convert_column_urns_to_lowercase' to True.",
             )
 
-        self.sql_aggregator: Optional[SqlParsingAggregator] = None
         self.lineage_extractor: Optional[MSSQLLineageExtractor] = None
         if self.config.include_query_lineage:
             if self.config.include_usage_statistics and self.ctx.graph is None:
@@ -434,8 +432,20 @@ class SQLServerSource(SQLAlchemySource):
                     "You have enabled 'include_usage_statistics: true' but no graph connection is available. "
                     "Please provide a graph connection in your pipeline configuration or disable usage statistics."
                 )
+            logger.info("Query-based lineage enabled for mssql source")
 
-            self.sql_aggregator = SqlParsingAggregator(
+        if self.config.include_descriptions:
+            for inspector in self.get_inspectors():
+                db_name: str = self.get_db_name(inspector)
+                with inspector.engine.connect() as conn:
+                    if self._is_odbc:
+                        self._add_output_converters(conn)
+                    self._populate_table_descriptions(conn, db_name)
+                    self._populate_column_descriptions(conn, db_name)
+
+    def _create_aggregator(self) -> SqlParsingAggregator:
+        if self.config.include_query_lineage:
+            return SqlParsingAggregator(
                 platform=self.platform,
                 platform_instance=self.config.platform_instance,
                 env=self.config.env,
@@ -446,17 +456,9 @@ class SQLServerSource(SQLAlchemySource):
                 usage_config=self.config
                 if self.config.include_usage_statistics
                 else None,
+                eager_graph_load=False,
             )
-            logger.info("SQL parsing aggregator initialized for query-based lineage")
-
-        if self.config.include_descriptions:
-            for inspector in self.get_inspectors():
-                db_name: str = self.get_db_name(inspector)
-                with inspector.engine.connect() as conn:
-                    if self._is_odbc:
-                        self._add_output_converters(conn)
-                    self._populate_table_descriptions(conn, db_name)
-                    self._populate_column_descriptions(conn, db_name)
+        return super()._create_aggregator()
 
     @staticmethod
     def _add_output_converters(conn: Connection) -> None:
@@ -1374,37 +1376,25 @@ class SQLServerSource(SQLAlchemySource):
         )
 
     def _get_query_based_lineage_workunits(self) -> Iterable[MetadataWorkUnit]:
-        """
-        Extract and emit query-based lineage from Query Store or DMVs.
+        """Populate the shared aggregator with query-history lineage.
 
-        This supplements view and stored procedure lineage with lineage extracted
-        from executed queries (INSERT INTO SELECT, CTAS, etc.).
+        Returns an empty iterable - MCPs are emitted by the parent's single
+        _generate_aggregator_workunits pass after this populate step runs.
+        Splitting view-DDL lineage and query-history lineage across two
+        aggregators caused double-emit of upstreamLineage where the second
+        SET-overwrote v0 with a partial payload (introduced by #16084).
         """
         logger.info(
             "Starting query-based lineage extraction from SQL Server query history"
         )
 
         for inspector in self.get_inspectors():
-            if self.sql_aggregator is None:
-                logger.warning(
-                    "SQL aggregator not initialized, skipping query-based lineage extraction. "
-                    "Check initialization errors above."
-                )
-                self.report.report_warning(
-                    message=(
-                        "Query-based lineage was enabled but SQL aggregator failed to initialize. "
-                        "No query-based lineage will be extracted. Check earlier error messages."
-                    ),
-                    context="query_lineage_skipped",
-                )
-                return
-
             with inspector.engine.connect() as connection:
                 self.lineage_extractor = MSSQLLineageExtractor(
                     config=self.config,
                     connection=connection,
                     report=self.report,
-                    sql_aggregator=self.sql_aggregator,
+                    sql_aggregator=self.aggregator,
                     default_schema="dbo",
                 )
 
@@ -1426,33 +1416,15 @@ class SQLServerSource(SQLAlchemySource):
                         context="query_lineage_extraction_failed",
                     )
 
-        with PerfTimer() as timer:
-            mcp_count = 0
-            if self.sql_aggregator:
-                try:
-                    mcp: MetadataChangeProposalWrapper
-                    for mcp in self.sql_aggregator.gen_metadata():
-                        yield mcp.as_workunit()
-                        mcp_count += 1
-                except Exception as e:
-                    logger.error(
-                        "Failed to generate metadata from SQL aggregator: %s",
-                        e,
-                    )
-                    self.report.report_failure(
-                        message=(
-                            f"Lineage metadata generation failed: {e}. "
-                            "This may indicate issues with the DataHub graph connection or schema resolution. "
-                            "Check your graph configuration and ensure all required schemas are accessible."
-                        ),
-                        context="lineage_metadata_generation_failed",
-                    )
+        return ()
 
-        logger.info(
-            "Generated %d lineage workunits from queries in %.2f seconds",
-            mcp_count,
-            timer.elapsed_seconds(),
-        )
+    def _generate_aggregator_workunits(self) -> Iterable[MetadataWorkUnit]:
+        if self.config.include_query_lineage:
+            # Populate shared aggregator with query history before generating MCPs
+            # so view lineage (from view definitions) and query lineage merge into
+            # a single upstreamLineage MCP per downstream URN.
+            list(self._get_query_based_lineage_workunits())
+        yield from super()._generate_aggregator_workunits()
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         yield from super().get_workunits_internal()
@@ -1490,9 +1462,6 @@ class SQLServerSource(SQLAlchemySource):
                         )
                     ):
                         yield workunit
-
-        if self.config.include_query_lineage and self.sql_aggregator:
-            yield from self._get_query_based_lineage_workunits()
 
     def _report_procedure_failure(self, procedure_name: str) -> None:
         """Report a stored procedure lineage extraction failure to the aggregator."""
@@ -1628,6 +1597,5 @@ class SQLServerSource(SQLAlchemySource):
             ) from e
 
     def close(self) -> None:
-        if self.sql_aggregator:
-            self.sql_aggregator.close()
+        self.aggregator.close()
         super().close()

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/mssql/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/mssql/source.py
@@ -450,6 +450,8 @@ class SQLServerSource(SQLAlchemySource):
                 platform_instance=self.config.platform_instance,
                 env=self.config.env,
                 graph=self.ctx.graph,
+                # Always True here: query lineage requires lineage generation regardless
+                # of the stored-procedure include_lineage flag on the parent class.
                 generate_lineage=True,
                 generate_queries=True,
                 generate_usage_statistics=self.config.include_usage_statistics,
@@ -1375,14 +1377,14 @@ class SQLServerSource(SQLAlchemySource):
             mcps, procedure_name
         )
 
-    def _get_query_based_lineage_workunits(self) -> Iterable[MetadataWorkUnit]:
+    def _populate_aggregator_with_query_history(self) -> None:
         """Populate the shared aggregator with query-history lineage.
 
-        Returns an empty iterable - MCPs are emitted by the parent's single
-        _generate_aggregator_workunits pass after this populate step runs.
-        Splitting view-DDL lineage and query-history lineage across two
-        aggregators caused double-emit of upstreamLineage where the second
-        SET-overwrote v0 with a partial payload (introduced by #16084).
+        Feeds query-history entries into self.aggregator so they merge with
+        view-DDL lineage. MCPs are emitted later by the parent's single
+        _generate_aggregator_workunits pass. Keeping all lineage in one
+        aggregator prevents double-emit of upstreamLineage (the bug introduced
+        by #16084, where a second aggregator SET-overwrote v0 with a partial payload).
         """
         logger.info(
             "Starting query-based lineage extraction from SQL Server query history"
@@ -1416,14 +1418,12 @@ class SQLServerSource(SQLAlchemySource):
                         context="query_lineage_extraction_failed",
                     )
 
-        return ()
-
     def _generate_aggregator_workunits(self) -> Iterable[MetadataWorkUnit]:
         if self.config.include_query_lineage:
             # Populate shared aggregator with query history before generating MCPs
             # so view lineage (from view definitions) and query lineage merge into
             # a single upstreamLineage MCP per downstream URN.
-            list(self._get_query_based_lineage_workunits())
+            self._populate_aggregator_with_query_history()
         yield from super()._generate_aggregator_workunits()
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/mssql/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/mssql/source.py
@@ -424,7 +424,6 @@ class SQLServerSource(SQLAlchemySource):
                 message="Lineage may not resolve accurately because 'convert_column_urns_to_lowercase' is False. To ensure correct lineage, set 'convert_column_urns_to_lowercase' to True.",
             )
 
-        self.lineage_extractor: Optional[MSSQLLineageExtractor] = None
         if self.config.include_query_lineage:
             if self.config.include_usage_statistics and self.ctx.graph is None:
                 raise ValueError(
@@ -1391,8 +1390,9 @@ class SQLServerSource(SQLAlchemySource):
         )
 
         for inspector in self.get_inspectors():
+            db_name = self.get_db_name(inspector)
             with inspector.engine.connect() as connection:
-                self.lineage_extractor = MSSQLLineageExtractor(
+                lineage_extractor = MSSQLLineageExtractor(
                     config=self.config,
                     connection=connection,
                     report=self.report,
@@ -1401,21 +1401,23 @@ class SQLServerSource(SQLAlchemySource):
                 )
 
                 try:
-                    self.lineage_extractor.populate_lineage_from_queries()
+                    lineage_extractor.populate_lineage_from_queries()
                 except Exception as e:
                     logger.error(
-                        "Unexpected error during query lineage extraction: %s. "
+                        "Unexpected error during query lineage extraction for database '%s': %s. "
                         "Continuing with other lineage sources.",
+                        db_name,
                         e,
                     )
                     self.report.report_failure(
                         message=(
-                            f"Query lineage extraction failed with unexpected error: {e}. "
+                            f"Query lineage extraction failed for database '{db_name}' "
+                            f"with unexpected error: {e}. "
                             "Check that Query Store is enabled or VIEW SERVER STATE permission is granted. "
                             "See documentation for setup instructions: "
                             "https://datahubproject.io/docs/generated/ingestion/sources/mssql"
                         ),
-                        context="query_lineage_extraction_failed",
+                        context=f"query_lineage_extraction_failed: {db_name}",
                     )
 
     def _generate_aggregator_workunits(self) -> Iterable[MetadataWorkUnit]:

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -378,16 +378,7 @@ class SQLAlchemySource(StatefulIngestionSourceBase, TestableSource):
         self.views_failed_parsing: Set[str] = set()
 
         self.discovered_datasets: Set[str] = set()
-        self.aggregator = SqlParsingAggregator(
-            platform=self.platform,
-            platform_instance=self.config.platform_instance,
-            env=self.config.env,
-            graph=self.ctx.graph,
-            generate_lineage=self.include_lineage,
-            generate_usage_statistics=False,
-            generate_operations=False,
-            eager_graph_load=False,
-        )
+        self.aggregator = self._create_aggregator()
         self.report.sql_aggregator = self.aggregator.report
 
     def _add_default_options(self, sql_config: SQLCommonConfig) -> None:
@@ -643,6 +634,25 @@ class SQLAlchemySource(StatefulIngestionSourceBase, TestableSource):
                 yield from self.loop_profiler(
                     profile_requests, profiler, platform=self.platform
                 )
+
+    def _create_aggregator(self) -> SqlParsingAggregator:
+        """Construct the SqlParsingAggregator used for lineage extraction.
+
+        Subclasses may override to enable query-history processing or usage
+        stats. All upstreamLineage MCPs MUST flow through this single
+        aggregator; spinning up a second aggregator alongside it causes
+        duplicate emits that SET-overwrite v0 with a partial payload.
+        """
+        return SqlParsingAggregator(
+            platform=self.platform,
+            platform_instance=self.config.platform_instance,
+            env=self.config.env,
+            graph=self.ctx.graph,
+            generate_lineage=self.include_lineage,
+            generate_usage_statistics=False,
+            generate_operations=False,
+            eager_graph_load=False,
+        )
 
     def _generate_aggregator_workunits(self) -> Iterable[MetadataWorkUnit]:
         """Generate work units from SQL parsing aggregator. Can be overridden by subclasses."""

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -642,6 +642,10 @@ class SQLAlchemySource(StatefulIngestionSourceBase, TestableSource):
         stats. All upstreamLineage MCPs MUST flow through this single
         aggregator; spinning up a second aggregator alongside it causes
         duplicate emits that SET-overwrite v0 with a partial payload.
+
+        Called from ``__init__`` before the subclass ``__init__`` body runs, so
+        overrides may only read attributes set by this point: ``self.config``,
+        ``self.platform`` and ``self.ctx``.
         """
         return SqlParsingAggregator(
             platform=self.platform,
@@ -656,8 +660,20 @@ class SQLAlchemySource(StatefulIngestionSourceBase, TestableSource):
 
     def _generate_aggregator_workunits(self) -> Iterable[MetadataWorkUnit]:
         """Generate work units from SQL parsing aggregator. Can be overridden by subclasses."""
-        for mcp in self.aggregator.gen_metadata():
-            yield mcp.as_workunit()
+        # gen_metadata() runs the deferred SQL parsing, schema resolution and
+        # (with eager_graph_load=False) lazy graph lookups, any of which can raise.
+        # This is the single funnel for all lineage/usage, so a failure here must
+        # be reported rather than aborting the run after tables/views were emitted.
+        try:
+            for mcp in self.aggregator.gen_metadata():
+                yield mcp.as_workunit()
+        except Exception as e:
+            self.report.failure(
+                title="Failed to generate lineage/usage from SQL parsing",
+                message="Could not emit aggregated SQL parsing results. "
+                "Other ingested metadata is unaffected.",
+                exc=e,
+            )
 
     def get_identifier(
         self, *, schema: str, entity: str, inspector: Inspector, **kwargs: Any

--- a/metadata-ingestion/tests/unit/test_mssql_query_lineage.py
+++ b/metadata-ingestion/tests/unit/test_mssql_query_lineage.py
@@ -129,9 +129,10 @@ def test_mssql_no_duplicate_upstream_lineage_mcps(create_engine_mock):
     fake_wu.id = view_urn
     fake_mcp.as_workunit.return_value = fake_wu
 
-    with patch.object(
-        source.aggregator, "gen_metadata", return_value=iter([fake_mcp])
-    ), patch.object(source, "_populate_aggregator_with_query_history"):
+    with (
+        patch.object(source.aggregator, "gen_metadata", return_value=iter([fake_mcp])),
+        patch.object(source, "_populate_aggregator_with_query_history"),
+    ):
         workunits = list(source._generate_aggregator_workunits())
 
     count = sum(1 for wu in workunits if wu.id == view_urn)

--- a/metadata-ingestion/tests/unit/test_mssql_query_lineage.py
+++ b/metadata-ingestion/tests/unit/test_mssql_query_lineage.py
@@ -110,25 +110,35 @@ def test_mssql_sql_aggregator_initialization_failure(create_engine_mock):
 
 
 @patch("datahub.ingestion.source.sql.mssql.source.create_engine")
-def test_mssql_single_aggregator_with_query_lineage(create_engine_mock):
-    """Regression: views must not get two UpstreamLineage MCPs.
+def test_mssql_no_duplicate_upstream_lineage_mcps(create_engine_mock):
+    """Regression: each downstream URN must appear exactly once in the workunit stream.
 
-    Before this was fixed, SQLServerSource kept a second SqlParsingAggregator
-    (self.sql_aggregator) alongside the inherited self.aggregator. Both called
-    gen_metadata() and both emitted upstreamLineage MCPs for the same view URN
-    when the view's DDL was also in Query Store, causing the second emit to
-    SET-overwrite v0 with a partial payload (only fineGrainedLineages).
-    See PR #16084 (introducer) and the follow-up fix.
+    Before the fix (PR #16084), SQLServerSource kept a second SqlParsingAggregator
+    that also called gen_metadata(), so views in Query Store received two
+    upstreamLineage MCPs — the second SET-overwrote v0 with a partial payload
+    containing only fineGrainedLineages and no table-level upstreams.
     """
     config = SQLServerConfig.model_validate(
         {**_base_config(), "include_query_lineage": True}
     )
     source = SQLServerSource(config, PipelineContext(run_id="test"))
 
-    extra_aggregator = getattr(source, "sql_aggregator", None)
-    assert extra_aggregator is None or extra_aggregator is source.aggregator, (
-        "SQLServerSource must use a single SqlParsingAggregator. A separate "
-        "self.sql_aggregator causes duplicate upstreamLineage MCPs that overwrite v0."
+    view_urn = "urn:li:dataset:(urn:li:dataPlatform:mssql,TestDB.dbo.my_view,PROD)"
+    fake_mcp = Mock()
+    fake_wu = Mock()
+    fake_wu.id = view_urn
+    fake_mcp.as_workunit.return_value = fake_wu
+
+    source.aggregator.gen_metadata = Mock(return_value=iter([fake_mcp]))
+    source._populate_aggregator_with_query_history = Mock()
+
+    workunits = list(source._generate_aggregator_workunits())
+    count = sum(1 for wu in workunits if wu.id == view_urn)
+
+    assert count == 1, (
+        f"Expected exactly one workunit for {view_urn!r}, got {count}. "
+        "Multiple gen_metadata() calls produce duplicate upstreamLineage MCPs "
+        "that SET-overwrite v0 with a partial payload."
     )
 
 
@@ -155,7 +165,7 @@ def test_mssql_query_extraction_failure_reports_error(create_engine_mock):
         )
 
         with patch.object(source, "get_inspectors", return_value=[inspector_mock]):
-            list(source._get_query_based_lineage_workunits())
+            source._populate_aggregator_with_query_history()
 
     assert len(source.report.failures) > 0
     failure_messages = [f.message for f in source.report.failures]

--- a/metadata-ingestion/tests/unit/test_mssql_query_lineage.py
+++ b/metadata-ingestion/tests/unit/test_mssql_query_lineage.py
@@ -129,10 +129,11 @@ def test_mssql_no_duplicate_upstream_lineage_mcps(create_engine_mock):
     fake_wu.id = view_urn
     fake_mcp.as_workunit.return_value = fake_wu
 
-    source.aggregator.gen_metadata = Mock(return_value=iter([fake_mcp]))
-    source._populate_aggregator_with_query_history = Mock()
+    with patch.object(
+        source.aggregator, "gen_metadata", return_value=iter([fake_mcp])
+    ), patch.object(source, "_populate_aggregator_with_query_history"):
+        workunits = list(source._generate_aggregator_workunits())
 
-    workunits = list(source._generate_aggregator_workunits())
     count = sum(1 for wu in workunits if wu.id == view_urn)
 
     assert count == 1, (

--- a/metadata-ingestion/tests/unit/test_mssql_query_lineage.py
+++ b/metadata-ingestion/tests/unit/test_mssql_query_lineage.py
@@ -13,6 +13,8 @@ from datahub.ingestion.source.sql.mssql.query_lineage_extractor import (
 )
 from datahub.ingestion.source.sql.mssql.source import SQLServerConfig, SQLServerSource
 from datahub.ingestion.source.sql.sql_common import SQLSourceReport
+from datahub.metadata.schema_classes import UpstreamLineageClass
+from datahub.metadata.urns import DatasetUrn
 from datahub.sql_parsing.sql_parsing_aggregator import ObservedQuery
 from datahub.sql_parsing.sqlglot_lineage import SqlUnderstandingError
 
@@ -110,38 +112,104 @@ def test_mssql_sql_aggregator_initialization_failure(create_engine_mock):
 
 
 @patch("datahub.ingestion.source.sql.mssql.source.create_engine")
-def test_mssql_no_duplicate_upstream_lineage_mcps(create_engine_mock):
-    """Regression: each downstream URN must appear exactly once in the workunit stream.
+def test_mssql_view_and_query_history_merge_into_single_upstream_lineage(
+    create_engine_mock,
+):
+    """Regression for the double-emit bug fixed by this PR (originally introduced by #16084).
 
-    Before the fix (PR #16084), SQLServerSource kept a second SqlParsingAggregator
-    that also called gen_metadata(), so views in Query Store received two
-    upstreamLineage MCPs — the second SET-overwrote v0 with a partial payload
-    containing only fineGrainedLineages and no table-level upstreams.
+    A view whose CREATE/ALTER DDL also shows up in Query Store gets lineage from
+    two sources: the view-definition path and the query-history path. When those
+    fed two separate aggregators, each emitted its own ``upstreamLineage`` MCP for
+    the view; the second SET-overwrote v0 with a partial payload (only
+    ``fineGrainedLineages``, empty ``upstreams``), wiping table-level lineage.
+
+    This drives the REAL shared aggregator with BOTH sources for the same view URN
+    and asserts the merged output is a single ``upstreamLineage`` aspect that still
+    carries table-level upstreams. With the pre-fix two-aggregator design this would
+    produce two aspects for the view; with the fix it produces exactly one.
     """
     config = SQLServerConfig.model_validate(
         {**_base_config(), "include_query_lineage": True}
     )
     source = SQLServerSource(config, PipelineContext(run_id="test"))
 
-    view_urn = "urn:li:dataset:(urn:li:dataPlatform:mssql,TestDB.dbo.my_view,PROD)"
-    fake_mcp = Mock()
-    fake_wu = Mock()
-    fake_wu.id = view_urn
-    fake_mcp.as_workunit.return_value = fake_wu
+    # mssql lowercases URNs by default (convert_urns_to_lowercase=True), so the
+    # parser resolves table refs to lowercase URNs — register/assert in lowercase.
+    view_urn = DatasetUrn("mssql", "testdb.dbo.my_view")
+    source_urn = DatasetUrn("mssql", "testdb.dbo.source_table")
 
-    with (
-        patch.object(source.aggregator, "gen_metadata", return_value=iter([fake_mcp])),
-        patch.object(source, "_populate_aggregator_with_query_history"),
-    ):
+    # Schema info lets the parser resolve table- and column-level lineage.
+    for urn in (view_urn, source_urn):
+        source.aggregator._schema_resolver.add_raw_schema_info(
+            urn=urn.urn(), schema_info={"id": "int", "name": "varchar"}
+        )
+
+    view_definition = "create view my_view as select id, name from source_table"
+    # Source 1: view-definition lineage.
+    source.aggregator.add_view_definition(
+        view_urn=view_urn,
+        view_definition=view_definition,
+        default_db="TestDB",
+        default_schema="dbo",
+    )
+    # Source 2: the same view's DDL observed in Query Store.
+    source.aggregator.add_observed_query(
+        ObservedQuery(
+            query=view_definition,
+            default_db="TestDB",
+            default_schema="dbo",
+            override_dialect="mssql",
+        )
+    )
+
+    # Query history is fed manually above, so skip the DB round-trip.
+    with patch.object(source, "_populate_aggregator_with_query_history"):
         workunits = list(source._generate_aggregator_workunits())
 
-    count = sum(1 for wu in workunits if wu.id == view_urn)
+    upstream_aspects = []
+    for wu in workunits:
+        if wu.get_urn() != view_urn.urn():
+            continue
+        aspect = wu.get_aspect_of_type(UpstreamLineageClass)
+        if aspect is not None:
+            upstream_aspects.append(aspect)
 
-    assert count == 1, (
-        f"Expected exactly one workunit for {view_urn!r}, got {count}. "
-        "Multiple gen_metadata() calls produce duplicate upstreamLineage MCPs "
-        "that SET-overwrite v0 with a partial payload."
+    assert len(upstream_aspects) == 1, (
+        f"Expected exactly one upstreamLineage aspect for {view_urn.urn()!r}, "
+        f"got {len(upstream_aspects)}. Two aspects mean the view received a "
+        "duplicate emit that SET-overwrites v0 with a partial payload."
     )
+    # Table-level upstreams must survive the merge (the bug wiped them).
+    upstreams = {u.dataset for u in upstream_aspects[0].upstreams}
+    assert source_urn.urn() in upstreams
+
+
+@patch("datahub.ingestion.source.sql.mssql.source.create_engine")
+def test_mssql_query_history_feeds_shared_aggregator(create_engine_mock):
+    """Query history must flow into the inherited ``self.aggregator``, not a second one.
+
+    The double-emit bug came from a separate ``self.sql_aggregator`` that also called
+    ``gen_metadata()``. This guards against reintroducing a second aggregator by
+    asserting the lineage extractor is wired to the single shared aggregator.
+    """
+    config = SQLServerConfig.model_validate(
+        {**_base_config(), "include_query_lineage": True}
+    )
+    source = SQLServerSource(config, PipelineContext(run_id="test"))
+
+    inspector = Mock()
+    inspector.engine.connect.return_value.__enter__ = Mock(return_value=Mock())
+    inspector.engine.connect.return_value.__exit__ = Mock(return_value=False)
+
+    with (
+        patch.object(source, "get_inspectors", return_value=[inspector]),
+        patch(
+            "datahub.ingestion.source.sql.mssql.source.MSSQLLineageExtractor"
+        ) as extractor_cls,
+    ):
+        source._populate_aggregator_with_query_history()
+
+    assert extractor_cls.call_args.kwargs["sql_aggregator"] is source.aggregator
 
 
 @patch("datahub.ingestion.source.sql.mssql.source.create_engine")

--- a/metadata-ingestion/tests/unit/test_mssql_query_lineage.py
+++ b/metadata-ingestion/tests/unit/test_mssql_query_lineage.py
@@ -110,6 +110,29 @@ def test_mssql_sql_aggregator_initialization_failure(create_engine_mock):
 
 
 @patch("datahub.ingestion.source.sql.mssql.source.create_engine")
+def test_mssql_single_aggregator_with_query_lineage(create_engine_mock):
+    """Regression: views must not get two UpstreamLineage MCPs.
+
+    Before this was fixed, SQLServerSource kept a second SqlParsingAggregator
+    (self.sql_aggregator) alongside the inherited self.aggregator. Both called
+    gen_metadata() and both emitted upstreamLineage MCPs for the same view URN
+    when the view's DDL was also in Query Store, causing the second emit to
+    SET-overwrite v0 with a partial payload (only fineGrainedLineages).
+    See PR #16084 (introducer) and the follow-up fix.
+    """
+    config = SQLServerConfig.model_validate(
+        {**_base_config(), "include_query_lineage": True}
+    )
+    source = SQLServerSource(config, PipelineContext(run_id="test"))
+
+    extra_aggregator = getattr(source, "sql_aggregator", None)
+    assert extra_aggregator is None or extra_aggregator is source.aggregator, (
+        "SQLServerSource must use a single SqlParsingAggregator. A separate "
+        "self.sql_aggregator causes duplicate upstreamLineage MCPs that overwrite v0."
+    )
+
+
+@patch("datahub.ingestion.source.sql.mssql.source.create_engine")
 def test_mssql_query_extraction_failure_reports_error(create_engine_mock):
     """Test that query extraction failures are reported but don't stop ingestion."""
     config = SQLServerConfig.model_validate(


### PR DESCRIPTION
## Summary

mssql kept two `SqlParsingAggregator` instances when `include_query_lineage=True` — the inherited `self.aggregator` (view DDL lineage) and a separate `self.sql_aggregator` (query history lineage). Both called `gen_metadata()`, so views whose CREATE/ALTER DDL also appeared in Query Store got two `upstreamLineage` MCPs per run. The second SET overwrote v0 with a partial payload (`fineGrainedLineages` only, empty `upstreams`), wiping table-level lineage from the UI's Upstreams panel.

## Fix

- Add `_create_aggregator()` hook on `SQLAlchemySource`.
- `SQLServerSource` overrides it to return a query-history-aware aggregator when `include_query_lineage=True`; otherwise falls through to parent.
- `MSSQLLineageExtractor` now feeds the shared `self.aggregator`; the separate `self.sql_aggregator` and its `gen_metadata()` call site are gone.
- Matches the single-aggregator pattern in `snowflake_v2.py`.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
