### PR TITLE
fix(ingest): size nested LossyList contexts from sample-size env vars

### DIFF
--- a/metadata-ingestion/src/datahub/api/entities/assertion/compiler_interface.py
+++ b/metadata-ingestion/src/datahub/api/entities/assertion/compiler_interface.py
@@ -4,6 +4,10 @@ from pathlib import Path
 from typing import Dict, List, Literal
 
 from datahub.api.entities.assertion.assertion_config_spec import AssertionsConfigSpec
+from datahub.configuration.env_vars import (
+    get_report_failure_sample_size,
+    get_report_warning_sample_size,
+)
 from datahub.ingestion.api.report import Report
 from datahub.utilities.lossy_collections import LossyDict, LossyList
 from datahub.utilities.str_enum import StrEnum
@@ -36,12 +40,16 @@ class AssertionCompilationReport(Report):
     artifacts: List[Path] = field(default_factory=list)
 
     def report_warning(self, key: str, reason: str) -> None:
-        warnings = self.warnings.get(key, LossyList())
+        warnings = self.warnings.get(
+            key, LossyList(max_elements=get_report_warning_sample_size())
+        )
         warnings.append(reason)
         self.warnings[key] = warnings
 
     def report_failure(self, key: str, reason: str) -> None:
-        failures = self.failures.get(key, LossyList())
+        failures = self.failures.get(
+            key, LossyList(max_elements=get_report_failure_sample_size())
+        )
         failures.append(reason)
         self.failures[key] = failures
 

--- a/metadata-ingestion/src/datahub/ingestion/api/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/source.py
@@ -189,7 +189,7 @@ class StructuredLogs(Report):
             # Size the per-entry context list to match the level's configured
             # sample size, so DATAHUB_REPORT_*_SAMPLE_SIZE controls both the
             # number of distinct entries and the number of grouped contexts
-            # under each entry (see ticket #6656).
+            # under each entry.
             context_list: LossyList[str] = LossyList(max_elements=entries.max_elements)
             if context is not None:
                 context_list.append(context)

--- a/metadata-ingestion/src/datahub/ingestion/api/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/source.py
@@ -186,7 +186,11 @@ class StructuredLogs(Report):
             logger.log(level=level.value, msg=log_content, stacklevel=stacklevel)
 
         if log_key not in entries:
-            context_list: LossyList[str] = LossyList()
+            # Size the per-entry context list to match the level's configured
+            # sample size, so DATAHUB_REPORT_*_SAMPLE_SIZE controls both the
+            # number of distinct entries and the number of grouped contexts
+            # under each entry (see ticket #6656).
+            context_list: LossyList[str] = LossyList(max_elements=entries.max_elements)
             if context is not None:
                 context_list.append(context)
             entries[log_key] = StructuredLogEntry(
@@ -211,12 +215,20 @@ class StructuredLogs(Report):
         log warnings/errors during __init__, so existing entries are pruned
         if they exceed the new limit.
         """
-        if failure_size is not None:
-            self._entries[StructuredLogLevel.ERROR].resize(failure_size)
-        if warning_size is not None:
-            self._entries[StructuredLogLevel.WARN].resize(warning_size)
-        if info_size is not None:
-            self._entries[StructuredLogLevel.INFO].resize(info_size)
+        for level, size in (
+            (StructuredLogLevel.ERROR, failure_size),
+            (StructuredLogLevel.WARN, warning_size),
+            (StructuredLogLevel.INFO, info_size),
+        ):
+            if size is None:
+                continue
+            entries = self._entries[level]
+            entries.resize(size)
+            # Also resize the nested context list on any entries that were
+            # already recorded (e.g. during source __init__ before pipeline
+            # applied the configured sample size).
+            for entry in entries.values():
+                entry.context.resize(size)
 
     def _get_of_type(self, level: StructuredLogLevel) -> LossyList[StructuredLogEntry]:
         entries = self._entries[level]

--- a/metadata-ingestion/src/datahub/ingestion/glossary/classification_mixin.py
+++ b/metadata-ingestion/src/datahub/ingestion/glossary/classification_mixin.py
@@ -10,6 +10,7 @@ from datahub_classify.helper_classes import ColumnInfo, Metadata
 from pydantic import Field
 
 from datahub.configuration.common import ConfigModel, ConfigurationError
+from datahub.configuration.env_vars import get_report_info_sample_size
 from datahub.emitter.mce_builder import get_sys_time, make_term_urn, make_user_urn
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.workunit import MetadataWorkUnit
@@ -243,7 +244,8 @@ class ClassificationHandler:
             col_info.infotype_proposals, key=lambda p: p.confidence_level
         )
         self.report.info_types_detected.setdefault(
-            infotype_proposal.infotype, LossyList()
+            infotype_proposal.infotype,
+            LossyList(max_elements=get_report_info_sample_size()),
         ).append(f"{col_info.metadata.dataset_name}.{col_info.metadata.name}")
         term = self.config.classification.info_type_to_term.get(
             infotype_proposal.infotype, infotype_proposal.infotype

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_database_reader.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_database_reader.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Generic, Iterable, List, Optional, Tuple, TypeVar
 
 from sqlalchemy import create_engine, text
 
+from datahub.configuration.env_vars import get_report_failure_sample_size
 from datahub.emitter.aspect import ASPECT_MAP
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.emitter.serialization_helper import post_json_transform
@@ -396,7 +397,10 @@ class DataHubDatabaseReader:
                 f"Failed to parse metadata for {row['urn']}: {e}", exc_info=True
             )
             self.report.num_database_parse_errors += 1
+            failure_size = get_report_failure_sample_size()
             self.report.database_parse_errors.setdefault(
-                str(e), LossyDict()
-            ).setdefault(row["aspect"], LossyList()).append(row["urn"])
+                str(e), LossyDict(max_elements=failure_size)
+            ).setdefault(row["aspect"], LossyList(max_elements=failure_size)).append(
+                row["urn"]
+            )
             return None

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/dataprocess_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/dataprocess_cleanup.py
@@ -10,6 +10,7 @@ from typing import Dict, Iterable, List, Optional
 from pydantic import Field
 
 from datahub.configuration import ConfigModel
+from datahub.configuration.env_vars import get_report_info_sample_size
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.source import MetadataWorkUnitProcessor, SourceReport
 from datahub.ingestion.api.source_helpers import auto_workunit_reporter
@@ -287,7 +288,9 @@ class DataProcessCleanup:
             self.report.num_aspect_removed_by_type.get(type, 0) + 1
         )
         if type not in self.report.sample_soft_deleted_aspects_by_type:
-            self.report.sample_soft_deleted_aspects_by_type[type] = LossyList()
+            self.report.sample_soft_deleted_aspects_by_type[type] = LossyList(
+                max_elements=get_report_info_sample_size()
+            )
         self.report.sample_soft_deleted_aspects_by_type[type].append(urn)
 
         if self.dry_run:

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/soft_deleted_entity_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/soft_deleted_entity_cleanup.py
@@ -9,6 +9,7 @@ from typing import Dict, Iterable, List, Optional
 from pydantic import Field
 
 from datahub.configuration import ConfigModel
+from datahub.configuration.env_vars import get_report_info_sample_size
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.source import SourceReport
 from datahub.ingestion.graph.client import DataHubGraph
@@ -177,7 +178,7 @@ class SoftDeletedEntitiesCleanup:
             self.report.num_hard_deleted_by_type[entity_type] = current_count + 1
             if entity_type not in self.report.sample_hard_deleted_aspects_by_type:
                 self.report.sample_hard_deleted_aspects_by_type[entity_type] = (
-                    LossyList()
+                    LossyList(max_elements=get_report_info_sample_size())
                 )
             self.report.sample_hard_deleted_aspects_by_type[entity_type].append(urn)
 

--- a/metadata-ingestion/src/datahub/ingestion/source/informatica/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/informatica/models.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Literal, NewType, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from datahub.configuration.env_vars import get_report_info_sample_size
 from datahub.ingestion.source.state.stale_entity_removal_handler import (
     StaleEntityRemovalSourceReport,
 )
@@ -473,7 +474,9 @@ class InformaticaSourceReport(StaleEntityRemovalSourceReport):
             self.raw_objects_by_type.get(object_type, 0) + 1
         )
         if object_type not in self.sample_paths_by_type:
-            self.sample_paths_by_type[object_type] = LossyList()
+            self.sample_paths_by_type[object_type] = LossyList(
+                max_elements=get_report_info_sample_size()
+            )
         self.sample_paths_by_type[object_type].append(path or "<empty path>")
 
     def report_filtered(self, reason: str, object_type: str, detail: str = "") -> None:

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/proxy_profiling.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/proxy_profiling.py
@@ -13,6 +13,7 @@ from databricks.sdk.service.sql import (
     StatementStatus,
 )
 
+from datahub.configuration.env_vars import get_report_failure_sample_size
 from datahub.ingestion.source.unity.hive_metastore_proxy import (
     HIVE_METASTORE,
     HiveMetastoreProxy,
@@ -89,9 +90,9 @@ class UnityCatalogProxyProfilingMixin:
             msg = str(e)
             idx = (str(msg).find("`") + 1) or (str(msg).find("'") + 1) or len(str(msg))
             base_msg = msg[:idx]
-            self.report.profile_table_errors.setdefault(base_msg, LossyList()).append(
-                (str(ref), msg)
-            )
+            self.report.profile_table_errors.setdefault(
+                base_msg, LossyList(max_elements=get_report_failure_sample_size())
+            ).append((str(ref), msg))
             logger.warning(
                 f"Failure during profiling {ref}, {e.kwargs}: ({e.error_code}) {e}",
                 exc_info=True,

--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
@@ -13,7 +13,11 @@ from typing import Callable, Dict, Iterable, List, Optional, Set, Union, cast
 
 import datahub.emitter.mce_builder as builder
 import datahub.metadata.schema_classes as models
-from datahub.configuration.env_vars import get_sql_agg_query_log, get_sql_agg_skip_joins
+from datahub.configuration.env_vars import (
+    get_report_info_sample_size,
+    get_sql_agg_query_log,
+    get_sql_agg_skip_joins,
+)
 from datahub.configuration.time_window_config import get_time_bucket
 from datahub.emitter.mce_builder import get_sys_time, make_ts_millis
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
@@ -1856,7 +1860,9 @@ class SqlParsingAggregator(Closeable):
         composite_query_id = self._composite_query_id(
             [q.query_id for q in ordered_queries]
         )
-        composed_of_queries_truncated: LossyList[str] = LossyList()
+        composed_of_queries_truncated: LossyList[str] = LossyList(
+            max_elements=get_report_info_sample_size()
+        )
         for query_id in composed_of_queries:
             composed_of_queries_truncated.append(query_id)
         self.report.queries_with_temp_upstreams[composite_query_id] = (

--- a/metadata-ingestion/src/datahub/utilities/lossy_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/lossy_collections.py
@@ -120,14 +120,22 @@ class LossyList(List[T], Generic[T]):
 
         Growing is lossless. Shrinking drops random entries (consistent with
         the reservoir-sampling behavior used elsewhere in this class) and
-        marks the list as sampled.
+        marks the list as sampled. Once sampled, the flag is never cleared —
+        dropped entries cannot be recovered by a subsequent grow.
+
+        Note: total_elements (and therefore len()) is not adjusted — it always
+        reflects the count of all ever-appended items, not the current retained
+        count.
         """
+        if max_elements < 1:
+            raise ValueError(f"max_elements must be >= 1, got {max_elements}")
         if max_elements == self.max_elements:
             return
         self.max_elements = max_elements
-        if super().__len__() > max_elements:
+        current_len = super().__len__()
+        if current_len > max_elements:
             indices_to_drop = random.sample(
-                range(super().__len__()), super().__len__() - max_elements
+                range(current_len), current_len - max_elements
             )
             for i in sorted(indices_to_drop, reverse=True):
                 super().__delitem__(i)
@@ -220,6 +228,8 @@ class LossyDict(Dict[_KT, _VT], Generic[_KT, _VT]):
 
     def resize(self, max_elements: int) -> None:
         """Change max_elements, pruning excess entries if needed."""
+        if max_elements < 1:
+            raise ValueError(f"max_elements must be >= 1, got {max_elements}")
         self.max_elements = max_elements
         excess = super().__len__() - max_elements
         if excess > 0:

--- a/metadata-ingestion/src/datahub/utilities/lossy_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/lossy_collections.py
@@ -115,6 +115,24 @@ class LossyList(List[T], Generic[T]):
         self.total_elements = total
         self.sampled = self.total_elements > self.max_elements
 
+    def resize(self, max_elements: int) -> None:
+        """Change max_elements, pruning excess entries if shrinking.
+
+        Growing is lossless. Shrinking drops random entries (consistent with
+        the reservoir-sampling behavior used elsewhere in this class) and
+        marks the list as sampled.
+        """
+        if max_elements == self.max_elements:
+            return
+        self.max_elements = max_elements
+        if super().__len__() > max_elements:
+            indices_to_drop = random.sample(
+                range(super().__len__()), super().__len__() - max_elements
+            )
+            for i in sorted(indices_to_drop, reverse=True):
+                super().__delitem__(i)
+            self.sampled = True
+
 
 class LossySet(Set[T], Generic[T]):
     """A set that only preserves a sample of elements in a set. Currently this is a very simple greedy sampling set"""

--- a/metadata-ingestion/tests/unit/api/test_report_sample_size.py
+++ b/metadata-ingestion/tests/unit/api/test_report_sample_size.py
@@ -31,3 +31,59 @@ class TestReportSampleSizeFromEnvVars:
         assert (
             report._structured_logs._entries[StructuredLogLevel.WARN].max_elements == 75
         )
+
+    def test_per_entry_context_respects_sample_size(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression test for ticket #6656.
+
+        When many items are grouped under one error key (same title+message),
+        every context line must be retained up to the configured sample size,
+        not silently truncated to the LossyList default of 10.
+        """
+        monkeypatch.setenv("DATAHUB_REPORT_FAILURE_SAMPLE_SIZE", "50")
+
+        report = SourceReport()
+        for i in range(24):
+            report.failure(
+                message="Error processing table",
+                context=f"table_{i}",
+                log=False,
+            )
+
+        failures = report.failures
+        assert len(failures) == 1
+        (entry,) = list(failures)
+        assert entry.context.max_elements == 50
+        assert not entry.context.sampled
+        assert len(list(entry.context)) == 24
+
+    def test_set_sample_sizes_resizes_existing_context(self) -> None:
+        """set_sample_sizes must grow context lists on already-recorded entries.
+
+        Sources can call report_warning/report_failure during __init__, before
+        the pipeline applies the configured sample size. Those entries' nested
+        context lists must be resized too, otherwise they remain capped at the
+        default of 10.
+        """
+        report = SourceReport()
+        for i in range(5):
+            report.failure(
+                message="Error processing table",
+                context=f"table_{i}",
+                log=False,
+            )
+
+        report.set_sample_sizes(failure_size=200, warning_size=200, info_size=200)
+
+        for i in range(5, 30):
+            report.failure(
+                message="Error processing table",
+                context=f"table_{i}",
+                log=False,
+            )
+
+        (entry,) = list(report.failures)
+        assert entry.context.max_elements == 200
+        assert not entry.context.sampled
+        assert len(list(entry.context)) == 30

--- a/metadata-ingestion/tests/unit/api/test_report_sample_size.py
+++ b/metadata-ingestion/tests/unit/api/test_report_sample_size.py
@@ -35,9 +35,7 @@ class TestReportSampleSizeFromEnvVars:
     def test_per_entry_context_respects_sample_size(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Regression test for ticket #6656.
-
-        When many items are grouped under one error key (same title+message),
+        """When many items are grouped under one error key (same title+message),
         every context line must be retained up to the configured sample size,
         not silently truncated to the LossyList default of 10.
         """
@@ -87,3 +85,29 @@ class TestReportSampleSizeFromEnvVars:
         assert entry.context.max_elements == 200
         assert not entry.context.sampled
         assert len(list(entry.context)) == 30
+
+    def test_set_sample_sizes_shrinks_existing_context(self) -> None:
+        """set_sample_sizes must prune context lists when shrinking.
+
+        If a source logs many context items at the default sample size, then
+        the pipeline applies a smaller configured limit, excess contexts must
+        be sampled down to the new limit.
+        """
+        report = SourceReport()
+        for i in range(20):
+            report.failure(
+                message="Error processing table",
+                context=f"table_{i}",
+                log=False,
+            )
+
+        report.set_sample_sizes(failure_size=5, warning_size=5, info_size=5)
+
+        (entry,) = list(report.failures)
+        assert entry.context.max_elements == 5
+        assert entry.context.sampled
+        retained = list(entry.context)
+        assert len(retained) == 5
+        # All retained items must come from the original set.
+        original = {f"table_{i}" for i in range(20)}
+        assert set(retained) <= original

--- a/metadata-ingestion/tests/unit/utilities/test_lossy_collections.py
+++ b/metadata-ingestion/tests/unit/utilities/test_lossy_collections.py
@@ -154,16 +154,28 @@ def test_lossylist_resize_grow_is_lossless():
 
 def test_lossylist_resize_shrink_drops_entries():
     """Shrinking below current size drops entries and marks as sampled."""
+    original = list(range(20))
     lst: LossyList[int] = LossyList(max_elements=100)
-    for i in range(20):
+    for i in original:
         lst.append(i)
     lst.resize(5)
     assert lst.max_elements == 5
     assert lst.sampled
     # __len__ reports total_elements seen, not retained count.
     assert lst.total_elements == 20
-    # underlying retained set is capped.
-    assert len(list(lst)) == 5
+    retained = list(lst)
+    # Exactly 5 entries are kept, all drawn from the original set.
+    assert len(retained) == 5
+    assert set(retained) <= set(original)
+
+
+def test_lossylist_resize_rejects_invalid_max_elements():
+    """resize() must reject non-positive max_elements to prevent silent data loss."""
+    lst: LossyList[int] = LossyList(max_elements=10)
+    with pytest.raises(ValueError, match="max_elements must be >= 1"):
+        lst.resize(0)
+    with pytest.raises(ValueError, match="max_elements must be >= 1"):
+        lst.resize(-5)
 
 
 def test_lossylist_resize_to_same_size_is_noop():

--- a/metadata-ingestion/tests/unit/utilities/test_lossy_collections.py
+++ b/metadata-ingestion/tests/unit/utilities/test_lossy_collections.py
@@ -137,6 +137,45 @@ def test_lossydict_resize_respects_new_limit_on_insert():
     assert d.sampled
 
 
+def test_lossylist_resize_grow_is_lossless():
+    """Growing the limit keeps all existing entries and accepts more."""
+    lst: LossyList[int] = LossyList(max_elements=3)
+    for i in range(3):
+        lst.append(i)
+    assert not lst.sampled
+    lst.resize(10)
+    assert lst.max_elements == 10
+    assert not lst.sampled
+    for i in range(3, 10):
+        lst.append(i)
+    assert list(lst) == list(range(10))
+    assert not lst.sampled
+
+
+def test_lossylist_resize_shrink_drops_entries():
+    """Shrinking below current size drops entries and marks as sampled."""
+    lst: LossyList[int] = LossyList(max_elements=100)
+    for i in range(20):
+        lst.append(i)
+    lst.resize(5)
+    assert lst.max_elements == 5
+    assert lst.sampled
+    # __len__ reports total_elements seen, not retained count.
+    assert lst.total_elements == 20
+    # underlying retained set is capped.
+    assert len(list(lst)) == 5
+
+
+def test_lossylist_resize_to_same_size_is_noop():
+    lst: LossyList[int] = LossyList(max_elements=5)
+    for i in range(3):
+        lst.append(i)
+    lst.resize(5)
+    assert lst.max_elements == 5
+    assert not lst.sampled
+    assert list(lst) == [0, 1, 2]
+
+
 def test_lossylist_getitem_direct_indexing():
     """Test that direct indexing returns unwrapped items, not tuples.
 


### PR DESCRIPTION
## Summary

- Per-entry `context: LossyList[str]` inside `StructuredLogEntry` was constructed with the default `max_elements=10`, so `DATAHUB_REPORT_FAILURE_SAMPLE_SIZE` / `_WARNING_` / `_INFO_` only affected the number of distinct entries, not the number of grouped contexts under each entry. When many items got grouped under one error key (e.g. `"Error processing table"` with many failing tables), the customer-visible context was capped at 10 with a `"... sampled of N total elements"` note even when the env var was set to 100,000.
- Fix the root cause in `StructuredLogs.report_log` (size the per-entry context list from the level's configured `max_elements`) and in `set_sample_sizes` (also resize context lists on already-recorded entries, so `__init__`-time logs are not stuck at the default).
- Add `LossyList.resize()` parallel to the existing `LossyDict.resize`.
- Apply the same fix to seven other nested-`LossyList` defaults found by audit: unity `profile_table_errors`, datahub `database_parse_errors`, gc `sample_(soft|hard)_deleted_aspects_by_type`, informatica `sample_paths_by_type`, classification `info_types_detected`, sql_parsing `queries_with_temp_upstreams`, assertion compiler per-key warnings/failures.
- Backward-compatible at defaults: env vars default to `"10"`, matching the prior `LossyList()` default, so existing reports are unchanged.

Builds on the earlier sample-size work in #16165 and #17027.

## Test plan

- [x] Added unit tests for `LossyList.resize` (grow / shrink / no-op).
- [x] Added regression tests for the bug:
  - Per-entry context grows with `DATAHUB_REPORT_FAILURE_SAMPLE_SIZE` for entries created after the env var is set.
  - `set_sample_sizes()` also resizes the nested context on entries created *before* it ran (covers source `__init__`-time logs).
- [x] `./gradlew :metadata-ingestion:lintFix` and `:lint` clean (ruff, format check, mypy).
- [x] `./gradlew :metadata-ingestion:testQuick` — 12,493 pass. The 23 failures are all pre-existing on clean master (timezone drift, env-specific pyodbc, dataproduct golden files) and none touch the modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)