### PR TITLE
fix(graphql): always register semantic-search schema; stub resolver when disabled

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/plugins/SemanticSearchPlugin.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/plugins/SemanticSearchPlugin.java
@@ -8,9 +8,11 @@ import com.linkedin.datahub.graphql.resolvers.semantic.SemanticSearchResolver;
 import com.linkedin.datahub.graphql.types.EntityType;
 import com.linkedin.datahub.graphql.types.LoadableType;
 import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.search.SemanticSearchDisabledException;
 import com.linkedin.metadata.search.SemanticSearchService;
 import com.linkedin.metadata.service.FormService;
 import com.linkedin.metadata.service.ViewService;
+import graphql.schema.DataFetcher;
 import graphql.schema.idl.RuntimeWiring;
 import java.util.Collection;
 import java.util.Collections;
@@ -69,11 +71,11 @@ public class SemanticSearchPlugin implements GmsGraphQLPlugin {
 
   @Override
   public List<String> getSchemaFiles() {
-    // Only load the schema if semantic search is available
-    if (semanticSearchService != null) {
-      return List.of(SEMANTIC_SEARCH_SCHEMA_FILE);
-    }
-    return Collections.emptyList();
+    // Always load the schema so the field is defined for clients. When the
+    // service is unavailable, the resolver throws SemanticSearchDisabledException
+    // which surfaces as a clear runtime GraphQL error instead of FieldUndefined
+    // — giving clients a stable contract for feature detection.
+    return List.of(SEMANTIC_SEARCH_SCHEMA_FILE);
   }
 
   @Override
@@ -90,10 +92,24 @@ public class SemanticSearchPlugin implements GmsGraphQLPlugin {
 
   @Override
   public void configureExtraResolvers(RuntimeWiring.Builder builder, GmsGraphQLEngine baseEngine) {
-    // Only register resolvers if semantic search is available
     if (semanticSearchService == null) {
-      log.debug(
-          "Skipping semantic search resolver registration - SemanticSearchService not available");
+      // Register stub resolvers that throw SemanticSearchDisabledException so
+      // clients see a stable runtime error ("Semantic search is disabled in
+      // this environment") instead of a schema-level FieldUndefined error.
+      // This lets clients (e.g. the integrations service) reliably detect
+      // unavailability and fall back to keyword search.
+      log.info(
+          "SemanticSearchService not available — registering disabled stubs for semantic search resolvers");
+      final DataFetcher<Object> disabledStub =
+          env -> {
+            throw new SemanticSearchDisabledException();
+          };
+      builder.type(
+          "Query",
+          typeWiring ->
+              typeWiring
+                  .dataFetcher("semanticSearch", disabledStub)
+                  .dataFetcher("semanticSearchAcrossEntities", disabledStub));
       return;
     }
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/plugins/SemanticSearchPluginTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/plugins/SemanticSearchPluginTest.java
@@ -4,16 +4,17 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.datahub.graphql.GmsGraphQLEngine;
 import com.linkedin.datahub.graphql.GmsGraphQLEngineArgs;
 import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.search.SemanticSearchDisabledException;
 import com.linkedin.metadata.search.SemanticSearchService;
 import com.linkedin.metadata.service.FormService;
 import com.linkedin.metadata.service.ViewService;
@@ -80,9 +81,11 @@ public class SemanticSearchPluginTest {
     // When
     plugin.init(args);
 
-    // Then: Plugin should initialize gracefully without throwing
+    // Then: Schema is always loaded so clients see a defined field; the
+    // resolver itself throws SemanticSearchDisabledException at runtime.
     List<String> schemaFiles = plugin.getSchemaFiles();
-    assertTrue(schemaFiles.isEmpty());
+    assertEquals(schemaFiles.size(), 1);
+    assertEquals(schemaFiles.get(0), "semantic-search.graphql");
   }
 
   @Test
@@ -117,9 +120,11 @@ public class SemanticSearchPluginTest {
     // When
     List<String> schemaFiles = plugin.getSchemaFiles();
 
-    // Then
+    // Then: Schema must always be loaded so the field is defined; the
+    // stub resolver surfaces SemanticSearchDisabledException at call time.
     assertNotNull(schemaFiles);
-    assertTrue(schemaFiles.isEmpty());
+    assertEquals(schemaFiles.size(), 1);
+    assertEquals(schemaFiles.get(0), "semantic-search.graphql");
   }
 
   @Test
@@ -201,12 +206,34 @@ public class SemanticSearchPluginTest {
     plugin.init(args);
 
     RuntimeWiring.Builder mockBuilder = mock(RuntimeWiring.Builder.class);
+    TypeRuntimeWiring.Builder mockTypeBuilder = mock(TypeRuntimeWiring.Builder.class);
+    when(mockBuilder.type(eq("Query"), any()))
+        .thenAnswer(
+            invocation -> {
+              java.util.function.UnaryOperator<TypeRuntimeWiring.Builder> configurator =
+                  invocation.getArgument(1);
+              configurator.apply(mockTypeBuilder);
+              return mockBuilder;
+            });
+    when(mockTypeBuilder.dataFetcher(anyString(), any(DataFetcher.class)))
+        .thenReturn(mockTypeBuilder);
+
+    ArgumentCaptor<DataFetcher<?>> fetcherCaptor = ArgumentCaptor.forClass(DataFetcher.class);
 
     // When
     plugin.configureExtraResolvers(mockBuilder, mockEngine);
 
-    // Then: Should NOT register any resolvers
-    verify(mockBuilder, never()).type(anyString(), any());
+    // Then: Stub fetchers are registered for both fields so the schema is
+    // always satisfied. Invoking either fetcher must throw
+    // SemanticSearchDisabledException — giving clients a stable runtime
+    // error instead of FieldUndefined.
+    verify(mockTypeBuilder).dataFetcher(eq("semanticSearch"), fetcherCaptor.capture());
+    verify(mockTypeBuilder)
+        .dataFetcher(eq("semanticSearchAcrossEntities"), fetcherCaptor.capture());
+
+    for (DataFetcher<?> fetcher : fetcherCaptor.getAllValues()) {
+      assertThrows(SemanticSearchDisabledException.class, () -> fetcher.get(null));
+    }
   }
 
   @Test
@@ -221,8 +248,8 @@ public class SemanticSearchPluginTest {
     // When
     plugin.init(args);
 
-    // Then: Should initialize without error
-    assertTrue(plugin.getSchemaFiles().isEmpty());
+    // Then: Schema is always loaded (stub resolver handles unavailability)
+    assertEquals(plugin.getSchemaFiles().size(), 1);
     assertTrue(plugin.getLoadableTypes().isEmpty());
     assertTrue(plugin.getEntityTypes().isEmpty());
   }


### PR DESCRIPTION
## Summary

When `SemanticSearchService` is null (the default in OSS / local dev with `ELASTICSEARCH_SEMANTIC_SEARCH_ENABLED=false`), `SemanticSearchPlugin` was registering neither the GraphQL schema nor the resolvers. Clients calling `semanticSearchAcrossEntities` got a `FieldUndefined` validation error — a schema-level error that varies by GMS configuration and is indistinguishable from a typo on the client side.

This makes the schema always-defined and registers stub `DataFetcher`s that throw `SemanticSearchDisabledException` when the service is unavailable. Clients now see a stable runtime error (`"Semantic search is disabled in this environment"`) and can reliably detect the disabled state to fall back to keyword search.

Discovered while debugging silent zero-hit failures in Ask DataHub on OSS quickstart environments (see internal report; the integrations service couldn't tell apart "semantic search is off" from "field is misspelled" and swallowed both as empty results).

## Changes

- `SemanticSearchPlugin.getSchemaFiles()` unconditionally returns `semantic-search.graphql`.
- `SemanticSearchPlugin.configureExtraResolvers()` registers stub fetchers (lambda → throws `SemanticSearchDisabledException`) for both `semanticSearch` and `semanticSearchAcrossEntities` when the service is null.
- Updated `SemanticSearchPluginTest` to reflect the new contract — schema is always loaded; invoking either stub fetcher throws `SemanticSearchDisabledException`.

The "happy path" (service available) is unchanged.

## Test plan

- [x] `./gradlew :datahub-graphql-core:test --tests SemanticSearchPluginTest` — 10 passing
- [ ] Verify against a GMS with semantic search enabled — existing semantic search behavior unchanged
- [ ] Verify against a GMS with semantic search disabled — calling `semanticSearchAcrossEntities` returns a clear runtime error mentioning "disabled", not `FieldUndefined`