### PR TITLE
fix(ingest/s3): handle file names with dots in the stem when resolving format extension

### DIFF
--- a/metadata-ingestion/docs/sources/s3/s3_post.md
+++ b/metadata-ingestion/docs/sources/s3/s3_post.md
@@ -254,6 +254,20 @@ Schemas for schemaless formats (CSV, TSV, JSONL, JSON) are inferred. For CSV, TS
 JSON file schemas are inferred on the basis of the entire file (given the difficulty in extracting only the first few objects of the file), which may impact performance.
 We are working on using iterator-based JSON parsers to avoid reading in the entire JSON object.
 
+##### File type detection
+
+The format of a file is detected from its name. The connector first checks the apparent extension (everything after the last dot) and accepts it only if it matches one of the supported file types listed above. For files compressed with `.gz` or `.bz2`, the compression suffix is stripped and the inner extension is checked the same way (so `data.json.gz` is treated as JSON).
+
+This means file names whose stem contains dots — for example `events.account.update-2026-05-27-<hash>.gz` — are **not** misinterpreted as having an extension of `.update-2026-05-27-<hash>`. Such files fall back to `path_spec.default_extension` if it is set, and are skipped otherwise.
+
+If your files have no real format extension (or have only a compression extension like `.gz`), set `default_extension` on the path_spec to tell the connector how to parse them:
+
+```yaml
+path_specs:
+  - include: s3://my-bucket/{table}/
+    default_extension: json
+```
+
 #### S3-specific mapping details
 
 This ingestion source maps the following source system concepts to DataHub concepts:

--- a/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/path_spec.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/path_spec.py
@@ -99,7 +99,7 @@ class PathSpec(ConfigModel):
 
     default_extension: Optional[str] = Field(
         None,
-        description="For files without extension it will assume the specified file type. If it is not set the files without extensions will be skipped.",
+        description="Assume this file type for files where the format cannot be inferred from the file name. This includes files with no extension and files whose apparent extension (the part after the last dot) is not a recognised format (which can happen for file names whose stem contains dots, e.g. ``foo.bar.baz-<hash>.gz``). If unset, such files are skipped.",
     )
 
     table_name: Optional[str] = Field(

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -111,6 +111,52 @@ profiling_flags_to_report = [
 URI_SCHEME_REGEX = re.compile(r"^[a-z0-9]+://")
 
 
+def _resolve_format_extension(
+    full_path: str,
+    enable_compression: bool,
+    default_extension: Optional[str],
+) -> str:
+    """Resolve the format extension (e.g. ``.json``) for a file.
+
+    ``pathlib.Path(...).suffix`` is purely lexical (everything after the last dot),
+    so file names whose stem contains dots (e.g. ``foo.bar.baz-<hash>.gz``) produce
+    a fake extension that is not a real file format. We only keep an extension if
+    it matches one of the supported file types, otherwise we fall back to
+    ``default_extension`` so the inferrer can still be selected correctly.
+
+    Behaviour preserved from the previous implementation:
+
+    * ``data.json``        -> ``.json``
+    * ``data.json.gz``     -> ``.json`` (compression stripped, inner extension kept)
+    * ``data.gz``          -> ``default_extension`` if set, else ``""``
+    * ``data.parquet.gz``  -> ``.parquet``
+
+    New behaviour:
+
+    * ``foo.bar.baz-<hash>.gz`` -> ``default_extension`` (was ``.baz-<hash>``)
+    * ``foo.bar.baz-<hash>``    -> ``default_extension`` (was ``.baz-<hash>``)
+    """
+    # Local import to avoid a circular import at module load time.
+    from datahub.ingestion.source.data_lake_common.path_spec import (
+        SUPPORTED_COMPRESSIONS,
+        SUPPORTED_FILE_TYPES,
+    )
+
+    extension = pathlib.Path(full_path).suffix
+    if enable_compression and extension[1:] in SUPPORTED_COMPRESSIONS:
+        inner_extension = pathlib.Path(full_path).with_suffix("").suffix
+        extension = (
+            inner_extension if inner_extension[1:] in SUPPORTED_FILE_TYPES else ""
+        )
+    elif extension[1:] not in SUPPORTED_FILE_TYPES:
+        extension = ""
+
+    if extension == "" and default_extension:
+        extension = f".{default_extension}"
+
+    return extension
+
+
 def partitioned_folder_comparator(folder1: str, folder2: str) -> int:
     # Try to convert to number and compare if the folder name is a number
     try:
@@ -328,16 +374,11 @@ class S3Source(StatefulIngestionSourceBase):
             # capabilities of smart_open.
             file = smart_open(table_data.full_path, "rb")
 
-        extension = pathlib.Path(table_data.full_path).suffix
-        from datahub.ingestion.source.data_lake_common.path_spec import (
-            SUPPORTED_COMPRESSIONS,
+        extension = _resolve_format_extension(
+            table_data.full_path,
+            enable_compression=path_spec.enable_compression,
+            default_extension=path_spec.default_extension,
         )
-
-        if path_spec.enable_compression and (extension[1:] in SUPPORTED_COMPRESSIONS):
-            # Removing the compression extension and using the one before that like .json.gz -> .json
-            extension = pathlib.Path(table_data.full_path).with_suffix("").suffix
-        if extension == "" and path_spec.default_extension:
-            extension = f".{path_spec.default_extension}"
 
         fields = []
         inferrer = self._get_inferrer(extension, table_data.content_type)

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -107,6 +107,52 @@ profiling_flags_to_report = [
 URI_SCHEME_REGEX = re.compile(r"^[a-z0-9]+://")
 
 
+def _resolve_format_extension(
+    full_path: str,
+    enable_compression: bool,
+    default_extension: Optional[str],
+) -> str:
+    """Resolve the format extension (e.g. ``.json``) for a file.
+
+    ``pathlib.Path(...).suffix`` is purely lexical (everything after the last dot),
+    so file names whose stem contains dots (e.g. ``foo.bar.baz-<hash>.gz``) produce
+    a fake extension that is not a real file format. We only keep an extension if
+    it matches one of the supported file types, otherwise we fall back to
+    ``default_extension`` so the inferrer can still be selected correctly.
+
+    Behaviour preserved from the previous implementation:
+
+    * ``data.json``        -> ``.json``
+    * ``data.json.gz``     -> ``.json`` (compression stripped, inner extension kept)
+    * ``data.gz``          -> ``default_extension`` if set, else ``""``
+    * ``data.parquet.gz``  -> ``.parquet``
+
+    New behaviour:
+
+    * ``foo.bar.baz-<hash>.gz`` -> ``default_extension`` (was ``.baz-<hash>``)
+    * ``foo.bar.baz-<hash>``    -> ``default_extension`` (was ``.baz-<hash>``)
+    """
+    # Local import to avoid a circular import at module load time.
+    from datahub.ingestion.source.data_lake_common.path_spec import (
+        SUPPORTED_COMPRESSIONS,
+        SUPPORTED_FILE_TYPES,
+    )
+
+    extension = pathlib.Path(full_path).suffix
+    if enable_compression and extension[1:] in SUPPORTED_COMPRESSIONS:
+        inner_extension = pathlib.Path(full_path).with_suffix("").suffix
+        extension = (
+            inner_extension if inner_extension[1:] in SUPPORTED_FILE_TYPES else ""
+        )
+    elif extension[1:] not in SUPPORTED_FILE_TYPES:
+        extension = ""
+
+    if extension == "" and default_extension:
+        extension = f".{default_extension}"
+
+    return extension
+
+
 def partitioned_folder_comparator(folder1: str, folder2: str) -> int:
     # Try to convert to number and compare if the folder name is a number
     try:
@@ -322,16 +368,11 @@ class S3Source(StatefulIngestionSourceBase):
             # capabilities of smart_open.
             file = smart_open(table_data.full_path, "rb")
 
-        extension = pathlib.Path(table_data.full_path).suffix
-        from datahub.ingestion.source.data_lake_common.path_spec import (
-            SUPPORTED_COMPRESSIONS,
+        extension = _resolve_format_extension(
+            table_data.full_path,
+            enable_compression=path_spec.enable_compression,
+            default_extension=path_spec.default_extension,
         )
-
-        if path_spec.enable_compression and (extension[1:] in SUPPORTED_COMPRESSIONS):
-            # Removing the compression extension and using the one before that like .json.gz -> .json
-            extension = pathlib.Path(table_data.full_path).with_suffix("").suffix
-        if extension == "" and path_spec.default_extension:
-            extension = f".{path_spec.default_extension}"
 
         fields = []
         inferrer = self._get_inferrer(extension, table_data.content_type)

--- a/metadata-ingestion/tests/unit/s3/test_s3_source.py
+++ b/metadata-ingestion/tests/unit/s3/test_s3_source.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime, timezone
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 from unittest.mock import MagicMock, Mock, call, patch
 
 import boto3
@@ -23,6 +23,7 @@ from datahub.ingestion.source.data_lake_common.path_spec import PathSpec
 from datahub.ingestion.source.s3.source import (
     Folder,
     S3Source,
+    _resolve_format_extension,
     partitioned_folder_comparator,
 )
 
@@ -760,3 +761,67 @@ def test_list_objects_recursive_paginates_with_continuation_token(s3_client):
     assert all(obj.bucket_name == "bucket" for obj in results)
     assert all(obj.key.startswith(prefix) for obj in results)
     assert all(obj.size == 1 for obj in results)
+
+
+@pytest.mark.parametrize(
+    "full_path,enable_compression,default_extension,expected",
+    [
+        # Plain supported extension is kept as-is.
+        pytest.param("s3://b/data.json", True, None, ".json", id="plain_json"),
+        pytest.param("s3://b/data.parquet", True, None, ".parquet", id="plain_parquet"),
+        # Compression with a supported inner extension is unwrapped.
+        pytest.param("s3://b/data.json.gz", True, None, ".json", id="json_gz"),
+        pytest.param("s3://b/data.parquet.gz", True, None, ".parquet", id="parquet_gz"),
+        # Compression-only files fall through to default_extension.
+        pytest.param(
+            "s3://b/data.gz", True, "json", ".json", id="gz_only_with_default"
+        ),
+        pytest.param("s3://b/data.gz", True, None, "", id="gz_only_no_default"),
+        # File names with dots in the stem must not produce a fake extension.
+        pytest.param(
+            "s3://b/foo.bar.baz-2026-05-27-11-abc.gz",
+            True,
+            "json",
+            ".json",
+            id="dotted_stem_compressed_falls_back_to_default",
+        ),
+        pytest.param(
+            "s3://b/foo.bar.baz-2026-05-27-11-abc",
+            True,
+            "json",
+            ".json",
+            id="dotted_stem_uncompressed_falls_back_to_default",
+        ),
+        # No default_extension and a fake suffix -> empty (no inferrer).
+        pytest.param(
+            "s3://b/foo.bar.baz-abc.gz",
+            True,
+            None,
+            "",
+            id="dotted_stem_compressed_no_default",
+        ),
+        # enable_compression=False keeps the .gz suffix as the apparent extension,
+        # which is not a supported file type, so it falls back to default_extension.
+        pytest.param(
+            "s3://b/data.json.gz",
+            False,
+            "json",
+            ".json",
+            id="compression_disabled_falls_back",
+        ),
+    ],
+)
+def test_resolve_format_extension(
+    full_path: str,
+    enable_compression: bool,
+    default_extension: Optional[str],
+    expected: str,
+) -> None:
+    assert (
+        _resolve_format_extension(
+            full_path,
+            enable_compression=enable_compression,
+            default_extension=default_extension,
+        )
+        == expected
+    )

--- a/metadata-ingestion/tests/unit/s3/test_s3_source.py
+++ b/metadata-ingestion/tests/unit/s3/test_s3_source.py
@@ -2,7 +2,7 @@ import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 from unittest.mock import MagicMock, Mock, call, patch
 
 import boto3
@@ -29,6 +29,7 @@ from datahub.ingestion.source.s3.source import (
     Folder,
     S3Source,
     TableData,
+    _resolve_format_extension,
     partitioned_folder_comparator,
 )
 from datahub.metadata.schema_classes import ContainerPropertiesClass
@@ -1105,3 +1106,65 @@ def test_data_lake_s3_calls(seeded_local_system_bucket, calls_test_tuple):
         calls.append(c)
 
     assert calls == expected_calls
+@pytest.mark.parametrize(
+    "full_path,enable_compression,default_extension,expected",
+    [
+        # Plain supported extension is kept as-is.
+        pytest.param("s3://b/data.json", True, None, ".json", id="plain_json"),
+        pytest.param("s3://b/data.parquet", True, None, ".parquet", id="plain_parquet"),
+        # Compression with a supported inner extension is unwrapped.
+        pytest.param("s3://b/data.json.gz", True, None, ".json", id="json_gz"),
+        pytest.param("s3://b/data.parquet.gz", True, None, ".parquet", id="parquet_gz"),
+        # Compression-only files fall through to default_extension.
+        pytest.param(
+            "s3://b/data.gz", True, "json", ".json", id="gz_only_with_default"
+        ),
+        pytest.param("s3://b/data.gz", True, None, "", id="gz_only_no_default"),
+        # File names with dots in the stem must not produce a fake extension.
+        pytest.param(
+            "s3://b/foo.bar.baz-2026-05-27-11-abc.gz",
+            True,
+            "json",
+            ".json",
+            id="dotted_stem_compressed_falls_back_to_default",
+        ),
+        pytest.param(
+            "s3://b/foo.bar.baz-2026-05-27-11-abc",
+            True,
+            "json",
+            ".json",
+            id="dotted_stem_uncompressed_falls_back_to_default",
+        ),
+        # No default_extension and a fake suffix -> empty (no inferrer).
+        pytest.param(
+            "s3://b/foo.bar.baz-abc.gz",
+            True,
+            None,
+            "",
+            id="dotted_stem_compressed_no_default",
+        ),
+        # enable_compression=False keeps the .gz suffix as the apparent extension,
+        # which is not a supported file type, so it falls back to default_extension.
+        pytest.param(
+            "s3://b/data.json.gz",
+            False,
+            "json",
+            ".json",
+            id="compression_disabled_falls_back",
+        ),
+    ],
+)
+def test_resolve_format_extension(
+    full_path: str,
+    enable_compression: bool,
+    default_extension: Optional[str],
+    expected: str,
+) -> None:
+    assert (
+        _resolve_format_extension(
+            full_path,
+            enable_compression=enable_compression,
+            default_extension=default_extension,
+        )
+        == expected
+    )

--- a/metadata-ingestion/tests/unit/s3/test_s3_source.py
+++ b/metadata-ingestion/tests/unit/s3/test_s3_source.py
@@ -1106,6 +1106,8 @@ def test_data_lake_s3_calls(seeded_local_system_bucket, calls_test_tuple):
         calls.append(c)
 
     assert calls == expected_calls
+
+
 @pytest.mark.parametrize(
     "full_path,enable_compression,default_extension,expected",
     [


### PR DESCRIPTION
Fixes #19690

## Summary

`pathlib.Path(...).suffix` is purely lexical — it returns everything after the last dot. For S3 files like `events.account.update-2026-05-27-<hash>.gz` this means stripping the `.gz` compression suffix leaves `.update-2026-05-27-<hash>` as the apparent format extension, which is not a real file format. The inferrer then receives a meaningless extension and emits an `"unsupported extension"` warning even when `default_extension` is set on the path_spec.

This PR makes `S3Source.get_fields` only keep an extension after compression stripping (and for uncompressed files) if it matches one of the supported file types (`csv`, `tsv`, `json`, `parquet`, `avro`). Otherwise it falls through to `default_extension` so the inferrer can still be selected correctly.

## Why

We hit this on a real bucket where event names contain dots in their file names, e.g.

`s3://.../event=events.account.update/legalEntity=.../events.account.update-2026-05-27-11-<hash>.gz
`

Even with `default_extension: json` set on the path_spec, every one of these files emitted an `"unsupported extension"` warning because `pathlib.suffix` returned `.update-2026-05-27-11-<hash>` after the `.gz` was stripped — a non-empty value, so the `default_extension` fallback was never reached.

## Behaviour

### Preserved

| Input | Result |
|---|---|
| `data.json` | `.json` |
| `data.json.gz` | `.json` (compression stripped, inner extension kept) |
| `data.parquet` | `.parquet` |
| `data.parquet.gz` | `.parquet` |
| `data.gz` (default=json) | `.json` |
| `data.gz` (no default) | `""` → warn (unchanged) |
| `data` (no extension, default=json) | `.json` |
| `data` (no extension, no default) | `""` → warn (unchanged) |

### New

| Input | Old | New |
|---|---|---|
| `foo.bar.baz-<hash>.gz` (default=json) | `.baz-<hash>` → warn | `.json` ✓ |
| `foo.bar.baz-<hash>` (default=json) | `.baz-<hash>` → warn | `.json` ✓ |
| `data.txt` (default=json) | `.txt` → warn | `.json` ✓ |
| `data.JSON` (uppercase, default=json) | `.JSON` → warn | `.json` ✓ |

The behaviour change is one-directional and gated by `default_extension`: when a user sets it, it now applies to **any** file whose name does not have a recognised format extension, not just files with no dot at all. Without `default_extension`, behaviour is unchanged. There is no panic or data-loss risk — the worst case is a `"could not infer schema"` warning instead of the previous `"unsupported extension"` warning when `default_extension` is set and a stray file's actual content does not match the chosen format.

## Changes

- New `_resolve_format_extension` helper in `s3/source.py` extracted from `S3Source.get_fields` so the resolution logic can be unit-tested directly.
- `S3Source.get_fields` now delegates to the helper.
- `PathSpec.default_extension` field description updated to reflect that it applies to any file whose format cannot be inferred from the file name.
- New "File type detection" section in `metadata-ingestion/docs/sources/s3/s3_post.md` documenting how extensions are resolved and when `default_extension` kicks in.
- Parametrized unit tests in `tests/unit/s3/test_s3_source.py` covering preserved behaviour (plain `.json`, `.json.gz`, `.parquet.gz`, `.gz`-only with/without default, compression disabled) and new behaviour (dotted-stem compressed/uncompressed, with/without default).

## Checklist

- [x] PR title follows the conventional commit format
- [x] Tests added (10 parametrized cases on the new helper)
- [x] Docs updated (S3 connector docs + `PathSpec.default_extension` description)
- [x] No breaking change — see behaviour table above

## Notes for reviewers

- The pre-existing `test_get_folder_info_returns_expected_folder` failure on master (1-hour timezone offset between `tzutc()` and `datetime.timezone.utc`) is unrelated to this change.
