### PR TITLE
perf(graphql): eliminate N+1 exists() calls in EntityAssertionsResolver

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/EntityAssertionsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/EntityAssertionsResolver.java
@@ -19,7 +19,6 @@ import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -80,18 +79,15 @@ public class EntityAssertionsResolver
                     new HashSet<>(assertionUrns),
                     null);
 
-            // Step 3: Map GMS assertion model to GraphQL model.
+            // Step 3: Map GMS assertion model to GraphQL model, preserving graph-store order.
             // The status aspect is already in each EntityResponse from step 2 (batchGetV2 was
             // called with null aspect names = fetch all). AssertionMapper surfaces it onto
             // assertion.status.removed, so the soft-delete filter can run in-memory rather than
             // issuing one entityClient.exists() call per assertion (avoids an N+1 against
             // metadata_aspect_v2).
-            final List<EntityResponse> gmsResults = new ArrayList<>();
-            for (Urn urn : assertionUrns) {
-              gmsResults.add(entities.getOrDefault(urn, null));
-            }
             final List<Assertion> assertions =
-                gmsResults.stream()
+                assertionUrns.stream()
+                    .map(entities::get) // null for hard-deleted urns
                     .filter(Objects::nonNull)
                     .map(r -> AssertionMapper.map(context, r))
                     .filter(assertion -> includeSoftDeleted || !isSoftDeleted(assertion))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/EntityAssertionsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/EntityAssertionsResolver.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.EntityRelationship;
 import com.linkedin.common.EntityRelationships;
 import com.linkedin.common.urn.Urn;
-import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.generated.Assertion;
@@ -81,7 +80,12 @@ public class EntityAssertionsResolver
                     new HashSet<>(assertionUrns),
                     null);
 
-            // Step 3: Map GMS assertion model to GraphQL model
+            // Step 3: Map GMS assertion model to GraphQL model.
+            // The status aspect is already in each EntityResponse from step 2 (batchGetV2 was
+            // called with null aspect names = fetch all). AssertionMapper surfaces it onto
+            // assertion.status.removed, so the soft-delete filter can run in-memory rather than
+            // issuing one entityClient.exists() call per assertion (avoids an N+1 against
+            // metadata_aspect_v2).
             final List<EntityResponse> gmsResults = new ArrayList<>();
             for (Urn urn : assertionUrns) {
               gmsResults.add(entities.getOrDefault(urn, null));
@@ -90,7 +94,7 @@ public class EntityAssertionsResolver
                 gmsResults.stream()
                     .filter(Objects::nonNull)
                     .map(r -> AssertionMapper.map(context, r))
-                    .filter(assertion -> assertionExists(assertion, includeSoftDeleted, context))
+                    .filter(assertion -> includeSoftDeleted || !isSoftDeleted(assertion))
                     .collect(Collectors.toList());
 
             // Step 4: Package and return result
@@ -108,16 +112,7 @@ public class EntityAssertionsResolver
         "get");
   }
 
-  private boolean assertionExists(
-      Assertion assertion, Boolean includeSoftDeleted, QueryContext context) {
-    try {
-      return _entityClient.exists(
-          context.getOperationContext(), UrnUtils.getUrn(assertion.getUrn()), includeSoftDeleted);
-    } catch (RemoteInvocationException e) {
-      log.error(
-          String.format("Unable to check if assertion %s exists, ignoring it", assertion.getUrn()),
-          e);
-      return false;
-    }
+  private static boolean isSoftDeleted(final Assertion assertion) {
+    return assertion.getStatus() != null && Boolean.TRUE.equals(assertion.getStatus().getRemoved());
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/EntityAssertionsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/EntityAssertionsResolverTest.java
@@ -120,9 +120,6 @@ public class EntityAssertionsResolverTest {
                     .setUrn(assertionUrn)
                     .setAspects(new EnvelopedAspectMap(assertionAspects))));
 
-    Mockito.when(mockClient.exists(any(), Mockito.any(Urn.class), Mockito.eq(false)))
-        .thenReturn(true);
-
     EntityAssertionsResolver resolver = new EntityAssertionsResolver(mockClient, graphClient);
 
     // Execute resolver
@@ -154,8 +151,10 @@ public class EntityAssertionsResolverTest {
     Mockito.verify(mockClient, Mockito.times(1))
         .batchGetV2(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
 
-    Mockito.verify(mockClient, Mockito.times(1))
-        .exists(Mockito.any(), Mockito.any(), Mockito.any());
+    // Regression guard: the per-URN exists() call was the N+1 source. The resolver must now read
+    // soft-delete state from the already-loaded status aspect instead.
+    Mockito.verify(mockClient, Mockito.never())
+        .exists(Mockito.any(), Mockito.any(Urn.class), Mockito.any());
 
     // Assert that GraphQL assertion run event matches expectations
     assertEquals(result.getStart(), 0);
@@ -185,5 +184,250 @@ public class EntityAssertionsResolverTest {
         com.linkedin.datahub.graphql.generated.AssertionStdParameterType.NUMBER);
     assertEquals(
         assertion.getInfo().getDatasetAssertion().getParameters().getValue().getValue(), "10");
+  }
+
+  /**
+   * Two assertions are returned by the graph store. One has {@code status.removed = true}. With
+   * {@code includeSoftDeleted=false} (the default), it must be filtered out and only the
+   * non-removed assertion should appear in the result. Critically, no per-URN {@code exists} call
+   * is made — the soft-delete state is read from the {@code status} aspect already returned by the
+   * single {@code batchGetV2} call.
+   */
+  @Test
+  public void testSoftDeletedAssertionFilteredOut() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    GraphClient graphClient = Mockito.mock(GraphClient.class);
+
+    Urn datasetUrn = Urn.createFromString("urn:li:dataset:(test,test,test)");
+    Urn liveAssertionUrn = Urn.createFromString("urn:li:assertion:live");
+    Urn removedAssertionUrn = Urn.createFromString("urn:li:assertion:removed");
+
+    Mockito.when(
+            graphClient.getRelatedEntities(
+                Mockito.eq(datasetUrn.toString()),
+                Mockito.eq(ImmutableSet.of("Asserts")),
+                Mockito.eq(RelationshipDirection.INCOMING),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any()))
+        .thenReturn(
+            new EntityRelationships()
+                .setStart(0)
+                .setCount(2)
+                .setTotal(2)
+                .setRelationships(
+                    new EntityRelationshipArray(
+                        ImmutableList.of(
+                            new EntityRelationship().setEntity(liveAssertionUrn).setType("Asserts"),
+                            new EntityRelationship()
+                                .setEntity(removedAssertionUrn)
+                                .setType("Asserts")))));
+
+    Mockito.when(
+            mockClient.batchGetV2(
+                any(),
+                Mockito.eq(Constants.ASSERTION_ENTITY_NAME),
+                Mockito.eq(ImmutableSet.of(liveAssertionUrn, removedAssertionUrn)),
+                Mockito.eq(null)))
+        .thenReturn(
+            ImmutableMap.of(
+                liveAssertionUrn,
+                assertionResponse(liveAssertionUrn, datasetUrn, "live-guid", false),
+                removedAssertionUrn,
+                assertionResponse(removedAssertionUrn, datasetUrn, "removed-guid", true)));
+
+    EntityAssertionsResolver resolver = new EntityAssertionsResolver(mockClient, graphClient);
+
+    EntityAssertionsResult result =
+        resolver.get(mockEnv(datasetUrn, false /* includeSoftDeleted */)).get();
+
+    // The removed assertion must be excluded.
+    assertEquals(result.getAssertions().size(), 1);
+    assertEquals(result.getAssertions().get(0).getUrn(), liveAssertionUrn.toString());
+
+    // The N+1 source must remain gone.
+    Mockito.verify(mockClient, Mockito.never())
+        .exists(Mockito.any(), Mockito.any(Urn.class), Mockito.any());
+  }
+
+  /**
+   * When {@code includeSoftDeleted=true}, soft-deleted assertions must be retained alongside live
+   * ones, matching the legacy semantics of {@code exists(urn, true)}.
+   */
+  @Test
+  public void testIncludeSoftDeletedReturnsRemovedAssertions() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    GraphClient graphClient = Mockito.mock(GraphClient.class);
+
+    Urn datasetUrn = Urn.createFromString("urn:li:dataset:(test,test,test)");
+    Urn liveUrn = Urn.createFromString("urn:li:assertion:live");
+    Urn removedUrn = Urn.createFromString("urn:li:assertion:removed");
+
+    Mockito.when(
+            graphClient.getRelatedEntities(
+                Mockito.eq(datasetUrn.toString()),
+                Mockito.eq(ImmutableSet.of("Asserts")),
+                Mockito.eq(RelationshipDirection.INCOMING),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any()))
+        .thenReturn(
+            new EntityRelationships()
+                .setStart(0)
+                .setCount(2)
+                .setTotal(2)
+                .setRelationships(
+                    new EntityRelationshipArray(
+                        ImmutableList.of(
+                            new EntityRelationship().setEntity(liveUrn).setType("Asserts"),
+                            new EntityRelationship().setEntity(removedUrn).setType("Asserts")))));
+
+    Mockito.when(
+            mockClient.batchGetV2(
+                any(),
+                Mockito.eq(Constants.ASSERTION_ENTITY_NAME),
+                Mockito.eq(ImmutableSet.of(liveUrn, removedUrn)),
+                Mockito.eq(null)))
+        .thenReturn(
+            ImmutableMap.of(
+                liveUrn,
+                assertionResponse(liveUrn, datasetUrn, "live-guid", false),
+                removedUrn,
+                assertionResponse(removedUrn, datasetUrn, "removed-guid", true)));
+
+    EntityAssertionsResolver resolver = new EntityAssertionsResolver(mockClient, graphClient);
+
+    EntityAssertionsResult result =
+        resolver.get(mockEnv(datasetUrn, true /* includeSoftDeleted */)).get();
+
+    assertEquals(result.getAssertions().size(), 2);
+    Mockito.verify(mockClient, Mockito.never())
+        .exists(Mockito.any(), Mockito.any(Urn.class), Mockito.any());
+  }
+
+  /**
+   * When the {@code status} aspect is entirely absent (e.g. older entities ingested before the
+   * status aspect existed), the assertion must default to being included — matching the legacy
+   * {@code EntityServiceImpl.exists(urn, false)} behavior, which treats "no status aspect" as "not
+   * removed".
+   */
+  @Test
+  public void testAssertionWithoutStatusAspectDefaultsToIncluded() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    GraphClient graphClient = Mockito.mock(GraphClient.class);
+
+    Urn datasetUrn = Urn.createFromString("urn:li:dataset:(test,test,test)");
+    Urn urn = Urn.createFromString("urn:li:assertion:no-status");
+
+    Mockito.when(
+            graphClient.getRelatedEntities(
+                Mockito.eq(datasetUrn.toString()),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any()))
+        .thenReturn(
+            new EntityRelationships()
+                .setStart(0)
+                .setCount(1)
+                .setTotal(1)
+                .setRelationships(
+                    new EntityRelationshipArray(
+                        ImmutableList.of(
+                            new EntityRelationship().setEntity(urn).setType("Asserts")))));
+
+    Mockito.when(
+            mockClient.batchGetV2(
+                any(),
+                Mockito.eq(Constants.ASSERTION_ENTITY_NAME),
+                Mockito.eq(ImmutableSet.of(urn)),
+                Mockito.eq(null)))
+        .thenReturn(ImmutableMap.of(urn, buildResponseNoStatus(urn, datasetUrn, "guid")));
+
+    EntityAssertionsResolver resolver = new EntityAssertionsResolver(mockClient, graphClient);
+
+    EntityAssertionsResult result =
+        resolver.get(mockEnv(datasetUrn, false /* includeSoftDeleted */)).get();
+
+    assertEquals(result.getAssertions().size(), 1);
+    Mockito.verify(mockClient, Mockito.never())
+        .exists(Mockito.any(), Mockito.any(Urn.class), Mockito.any());
+  }
+
+  // ---------- Helpers ----------
+
+  private static DataFetchingEnvironment mockEnv(Urn datasetUrn, boolean includeSoftDeleted) {
+    QueryContext mockContext = Mockito.mock(QueryContext.class);
+    Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    DataFetchingEnvironment env = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(env.getArgumentOrDefault(Mockito.eq("start"), Mockito.eq(0))).thenReturn(0);
+    Mockito.when(env.getArgumentOrDefault(Mockito.eq("count"), Mockito.eq(200))).thenReturn(10);
+    Mockito.when(env.getArgumentOrDefault(Mockito.eq("includeSoftDeleted"), Mockito.eq(false)))
+        .thenReturn(includeSoftDeleted);
+    Mockito.when(env.getContext()).thenReturn(mockContext);
+    Dataset parent = new Dataset();
+    parent.setUrn(datasetUrn.toString());
+    Mockito.when(env.getSource()).thenReturn(parent);
+    return env;
+  }
+
+  private static EntityResponse assertionResponse(
+      Urn assertionUrn, Urn datasetUrn, String guid, boolean removed) throws Exception {
+    Map<String, com.linkedin.entity.EnvelopedAspect> aspects = new HashMap<>();
+    aspects.put(
+        Constants.ASSERTION_KEY_ASPECT_NAME,
+        new com.linkedin.entity.EnvelopedAspect()
+            .setValue(new Aspect(new AssertionKey().setAssertionId(guid).data())));
+    aspects.put(
+        Constants.ASSERTION_INFO_ASPECT_NAME,
+        new com.linkedin.entity.EnvelopedAspect()
+            .setValue(
+                new Aspect(
+                    new AssertionInfo()
+                        .setType(AssertionType.DATASET)
+                        .setDatasetAssertion(
+                            new DatasetAssertionInfo()
+                                .setDataset(datasetUrn)
+                                .setScope(DatasetAssertionScope.DATASET_COLUMN)
+                                .setAggregation(AssertionStdAggregation.MAX)
+                                .setOperator(AssertionStdOperator.EQUAL_TO))
+                        .data())));
+    aspects.put(
+        Constants.STATUS_ASPECT_NAME,
+        new com.linkedin.entity.EnvelopedAspect()
+            .setValue(new Aspect(new com.linkedin.common.Status().setRemoved(removed).data())));
+    return new EntityResponse()
+        .setEntityName(Constants.ASSERTION_ENTITY_NAME)
+        .setUrn(assertionUrn)
+        .setAspects(new EnvelopedAspectMap(aspects));
+  }
+
+  private static EntityResponse buildResponseNoStatus(Urn assertionUrn, Urn datasetUrn, String guid)
+      throws Exception {
+    Map<String, com.linkedin.entity.EnvelopedAspect> aspects = new HashMap<>();
+    aspects.put(
+        Constants.ASSERTION_KEY_ASPECT_NAME,
+        new com.linkedin.entity.EnvelopedAspect()
+            .setValue(new Aspect(new AssertionKey().setAssertionId(guid).data())));
+    aspects.put(
+        Constants.ASSERTION_INFO_ASPECT_NAME,
+        new com.linkedin.entity.EnvelopedAspect()
+            .setValue(
+                new Aspect(
+                    new AssertionInfo()
+                        .setType(AssertionType.DATASET)
+                        .setDatasetAssertion(
+                            new DatasetAssertionInfo()
+                                .setDataset(datasetUrn)
+                                .setScope(DatasetAssertionScope.DATASET_COLUMN)
+                                .setAggregation(AssertionStdAggregation.MAX)
+                                .setOperator(AssertionStdOperator.EQUAL_TO))
+                        .data())));
+    // Intentionally no status aspect.
+    return new EntityResponse()
+        .setEntityName(Constants.ASSERTION_ENTITY_NAME)
+        .setUrn(assertionUrn)
+        .setAspects(new EnvelopedAspectMap(aspects));
   }
 }


### PR DESCRIPTION
## Summary

`EntityAssertionsResolver` was issuing one `entityClient.exists(urn, includeSoftDeleted)` call per assertion just to filter out soft-deleted ones. For an entity with N assertions this produced N extra single-row DB round-trips on top of the already-batched `batchGetV2`.

The status aspect needed for the soft-delete check is already returned inline by step 2's `batchGetV2` (called with `null` aspectNames → fetches all aspects), and `AssertionMapper` surfaces it onto `assertion.status.removed`. The filter can run in-memory against data already on hand.

```
before: 1 graph + 1 batchGetV2 + N exists  = N+2 calls
after:  1 graph + 1 batchGetV2             = 2 calls
```

For a typical dataset page (50 assertions, no siblings): **52 → 2 calls**.

## Two commits

1. **`perf(graphql)`** — The N+1 fix. Replaces the per-urn `exists()` filter with an in-memory `isSoftDeleted(assertion)` check that reads the already-fetched status aspect.
2. **`refactor(graphql)`** — Mechanical cleanup. Collapses the intermediate `List<EntityResponse> gmsResults` and the imperative `for` loop into a single declarative stream pipeline. Saves one ArrayList allocation per request; behavior identical.

## Behavioral guarantees

Verified the in-memory filter matches the old `exists()` semantics in every case:

| Scenario | `entityClient.exists(urn, false)` | In-memory `isSoftDeleted(a)` | Match |
|---|---|---|---|
| Live assertion (status.removed=false) | true (KEPT) | false (KEPT) | ✓ |
| Live assertion (no status aspect) | true (KEPT) | false (KEPT) | ✓ |
| Soft-deleted (status.removed=true) | false (DROPPED) | true (DROPPED) | ✓ |
| Hard-deleted (no aspects) | false (already pre-filtered by `Objects::nonNull`) | (already pre-filtered) | ✓ |
| `includeSoftDeleted=true` | true (KEPT) | short-circuits to KEPT | ✓ |

Also strictly more robust in one edge case: previously, a transient `RemoteInvocationException` from the per-urn `exists()` call silently dropped that assertion from the result. There is no remote call now, so transient backend hiccups can no longer cause phantom missing assertions.

API surface is unchanged (GraphQL schema, argument names, return shape, resolver constructor).

## Test plan

- [x] Existing `testGetSuccess` updated with `verify(mockClient, never()).exists(...)` regression guard
- [x] New `testSoftDeletedAssertionFilteredOut` — soft-deleted assertion is excluded when `includeSoftDeleted=false`
- [x] New `testIncludeSoftDeletedReturnsRemovedAssertions` — soft-deleted assertions retained when `includeSoftDeleted=true`
- [x] New `testAssertionWithoutStatusAspectDefaultsToIncluded` — legacy entities without a status aspect default to "not removed", matching the prior `EntityServiceImpl.exists(urn, false)` semantics
- [x] All 4 tests passing locally: `./gradlew :datahub-graphql-core:test --tests EntityAssertionsResolverTest` (4 tests, 0 failures, 0 errors)
