### PR TITLE
fix(ui): useFilterOptionsBySearchQuery filters by option displayName & collectionName

### DIFF
--- a/datahub-web-react/src/app/searchV2/filters/value/utils.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/utils.tsx
@@ -170,9 +170,20 @@ export const useFilterOptionsBySearchQuery = (
         return options;
     }
     return options.filter((option) => {
-        const optionName = option.entity
-            ? entityRegistry.getDisplayName(option.entity.type, option.entity)
-            : option.displayName || option.value;
+        let optionName: string;
+        if (option.entity) {
+            optionName = entityRegistry.getDisplayName(option.entity.type, option.entity);
+        } else if (option.displayName) {
+            optionName = option.displayName;
+        } else {
+            // For entity type values (e.g., "DATASET", "DATASETS"), get the collection name
+            // which returns the proper plural form for filtering
+            try {
+                optionName = entityRegistry.getCollectionName(option.value.toUpperCase() as EntityType);
+            } catch {
+                optionName = option.value;
+            }
+        }
         return filterOptionsWithSearch(searchQuery, optionName, []);
     });
 };


### PR DESCRIPTION
This PR fixes a bug within the View builder module.
In view creation, the search bar to add a filter is able to find the filter name doing a partial match. But when the full filter name is entered, then the match disappears.

To Recreate:
1. Log into Data Catalog
2. Go to Settings page
3. If My Views tab is not already opened, then click on the My Views tab
4. Click on Create new view button
5. Click on Add filter button and select Entity Type
6. Type in the search bar to search for an entity
7. Observation: The entity names shown in the drop down are plural. The search bar is able to find the entity when the singular entity name is entered but not the plural name

Root Cause:
The useFilterOptionsBySearchQuery function was filtering against the displayName, which might be singular. But wasn't considering the use case where a user types the full collectionName. (e.g. searching "DATASET" returns "DATASETS", but searching "DATASETS" returns nothing).