### PR TITLE
perf(lineage): viewport virtualization + perf benchmark infra

### DIFF
--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -112,7 +112,11 @@ play.filters {
       style-src = "'unsafe-inline' https: http:"
       style-src = ${?DATAHUB_CSP_STYLE_SRC}
 
-      img-src = "*"
+      # `data:` is required because `html-to-image` (used by the lineage
+      # screenshot button) inlines its serialised SVG as a `data:` URI
+      # before rasterising to canvas. Without it the screenshot feature
+      # is silently broken (capture fails inside the button's catch).
+      img-src = "* data:"
       img-src = ${?DATAHUB_CSP_IMG_SRC}
 
       font-src = "* data:"

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -277,6 +277,8 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
             .setShowHomePageRedesign(_featureFlags.isShowHomePageRedesign())
             .setShowProductUpdates(_featureFlags.isShowProductUpdates())
             .setLineageGraphV3(_featureFlags.isLineageGraphV3())
+            .setLineageGraphPerfVirtEnabled(_featureFlags.isLineageGraphPerfVirtEnabled())
+            .setLineageGraphPerfOverscanEnabled(_featureFlags.isLineageGraphPerfOverscanEnabled())
             .setLogicalModelsEnabled(_featureFlags.isLogicalModelsEnabled())
             .setShowHomepageUserRole(_featureFlags.isShowHomepageUserRole())
             .setAssetSummaryPageV1(_featureFlags.isAssetSummaryPageV1())

--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -820,6 +820,25 @@ type FeatureFlagsConfig {
   lineageGraphV3: Boolean!
 
   """
+  Enables viewport-based DOM virtualization in the V2 lineage graph.
+  When true (the default), the frontend auto-enables virtualization above
+  ~50 rendered nodes. The `?lineagePerf=` URL param and
+  `datahub.lineagePerfFlags` localStorage entry can still override this
+  per session for diagnostics.
+  """
+  lineageGraphPerfVirtEnabled: Boolean!
+
+  """
+  Enables the overscan-buffered virtualization path in the V2 lineage graph.
+  When true, the frontend auto-enables the wider viewport above ~200 nodes
+  (only when `lineageGraphPerfVirtEnabled` is also true). Defaults to false
+  because the wider bounds calculation trades a small pan-cost regression
+  for fewer pop-in artefacts; turn it on for deployments where pop-in is
+  the louder complaint.
+  """
+  lineageGraphPerfOverscanEnabled: Boolean!
+
+  """
   Enables logical models feature
   """
   logicalModelsEnabled: Boolean!

--- a/datahub-web-react/src/app/lineageV2/LineageVisualization.tsx
+++ b/datahub-web-react/src/app/lineageV2/LineageVisualization.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import ReactFlow, { Background, BackgroundVariant, Edge, EdgeTypes, MiniMap, NodeTypes, useReactFlow } from 'reactflow';
 import 'reactflow/dist/style.css';
@@ -20,6 +20,14 @@ import LineageControls from '@app/lineageV2/controls/LineageControls';
 import SearchControl from '@app/lineageV2/controls/SearchControl';
 import ZoomControls from '@app/lineageV2/controls/ZoomControls';
 import { getLineageUrl } from '@app/lineageV2/lineageUtils';
+import {
+    OVERSCAN_AUTO_THRESHOLD,
+    getLineagePerfFlags,
+    resolveTriMode,
+    resolveVirtEnabled,
+} from '@app/lineageV2/perfFlags';
+import { useOverscanVirt } from '@app/lineageV2/useOverscanVirt';
+import { useAppConfig } from '@app/useAppConfig';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 const StyledReactFlow = styled(ReactFlow)<{ $edgesOnTop: boolean }>`
@@ -58,18 +66,53 @@ function LineageVisualization({ initialNodes, initialEdges }: Props) {
     const [searchQuery, setSearchQuery] = useState('');
     const [isFocused, setIsFocused] = useState(false);
     const [searchedEntity, setSearchedEntity] = useState<string | null>(null);
+    const [forceMountAll, setForceMountAll] = useState(false);
     const { highlightedEdges, setSelectedColumn, setDisplayedMenuNode } = useContext(LineageDisplayContext);
     const theme = useTheme();
     const entityRegistry = useEntityRegistry();
     const history = useHistory();
     const location = useLocation();
+    const { config } = useAppConfig();
+    // Resolved once per mount: rendering modes are a stable property of the
+    // initial graph, so expand/contract churn doesn't flip them mid-session
+    // (which would break screenshot capture and column-edge geometry).
+    // Defaults come from the server feature flags; URL/localStorage still
+    // override per-session for diagnostics.
+    const perfFlags = useMemo(
+        () =>
+            getLineagePerfFlags({
+                virtEnabled: config?.featureFlags?.lineageGraphPerfVirtEnabled,
+                overscanEnabled: config?.featureFlags?.lineageGraphPerfOverscanEnabled,
+            }),
+        [config?.featureFlags?.lineageGraphPerfVirtEnabled, config?.featureFlags?.lineageGraphPerfOverscanEnabled],
+    );
+    const baseVirt = useMemo(
+        () => resolveVirtEnabled(perfFlags.virtMode, initialNodes.length),
+        [perfFlags.virtMode, initialNodes.length],
+    );
+    const overscanRaw = useMemo(
+        () => resolveTriMode(perfFlags.overscanMode, initialNodes.length, OVERSCAN_AUTO_THRESHOLD),
+        [perfFlags.overscanMode, initialNodes.length],
+    );
+    // `forceMountAll` is the screenshot escape hatch — suspends virt for the
+    // capture window so html-to-image walks a fully-mounted DOM.
+    const virtEnabled = baseVirt && !forceMountAll;
+    const overscanEnabled = virtEnabled && overscanRaw;
 
     useFitView(searchedEntity);
     useHandleKeyboardDeselect(setSelectedColumn);
 
     return (
         <LineageVisualizationContext.Provider
-            value={{ searchQuery, setSearchQuery, searchedEntity, setSearchedEntity, isFocused }}
+            value={{
+                searchQuery,
+                setSearchQuery,
+                searchedEntity,
+                setSearchedEntity,
+                isFocused,
+                forceMountAll,
+                setForceMountAll,
+            }}
         >
             <StyledReactFlow
                 defaultNodes={initialNodes}
@@ -97,12 +140,16 @@ function LineageVisualization({ initialNodes, initialEdges }: Props) {
                 maxZoom={5}
                 fitView
                 fitViewOptions={{ maxZoom: 1, duration: 0 }}
+                // Overscan drives virt via `<OverscanVirt>` below, so disable
+                // the built-in filter to avoid double-filtering thrash.
+                onlyRenderVisibleElements={virtEnabled && !overscanEnabled}
                 $edgesOnTop={!!highlightedEdges.size}
                 tabIndex={0} // Allow focus for keyboard shortcuts
                 onFocus={() => setIsFocused(true)}
                 onBlur={() => setIsFocused(false)}
             >
                 <Background variant={BackgroundVariant.Lines} />
+                {overscanEnabled && <OverscanVirt />}
                 <ZoomControls />
                 <SearchControl />
                 <LineageControls />
@@ -118,6 +165,14 @@ function LineageVisualization({ initialNodes, initialEdges }: Props) {
             </StyledReactFlow>
         </LineageVisualizationContext.Provider>
     );
+}
+
+// Isolated so its `useStore` subscriptions on viewport state don't re-render
+// the parent (which would cascade into every memoised node). Parent guards
+// the mount on `overscanEnabled` so overscan-off configurations pay nothing.
+function OverscanVirt() {
+    useOverscanVirt(true);
+    return null;
 }
 
 function useFitView(searchedEntity: string | null) {

--- a/datahub-web-react/src/app/lineageV2/LineageVisualizationContext.tsx
+++ b/datahub-web-react/src/app/lineageV2/LineageVisualizationContext.tsx
@@ -8,6 +8,13 @@ interface VisualizationContext {
     searchedEntity: Urn | null;
     setSearchedEntity: (entity: Urn | null) => void;
     isFocused: boolean;
+    /**
+     * Ephemeral pulse — set to suspend virt for the duration of a screenshot
+     * capture so html-to-image walks a fully-mounted DOM. Always restore to
+     * `false` after the capture; leaving it on defeats virt at scale.
+     */
+    forceMountAll: boolean;
+    setForceMountAll: (value: boolean) => void;
 }
 
 const LineageVisualizationContext = React.createContext<VisualizationContext>({
@@ -16,6 +23,8 @@ const LineageVisualizationContext = React.createContext<VisualizationContext>({
     searchedEntity: null,
     setSearchedEntity: () => {},
     isFocused: false,
+    forceMountAll: false,
+    setForceMountAll: () => {},
 });
 
 export default LineageVisualizationContext;

--- a/datahub-web-react/src/app/lineageV2/__tests__/perfFlags.test.ts
+++ b/datahub-web-react/src/app/lineageV2/__tests__/perfFlags.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    OVERSCAN_AUTO_THRESHOLD,
+    VIRT_AUTO_THRESHOLD,
+    getLineagePerfFlags,
+    resolveTriMode,
+    resolveVirtEnabled,
+} from '@app/lineageV2/perfFlags';
+
+const STORAGE_KEY = 'datahub.lineagePerfFlags';
+
+describe('resolveVirtEnabled', () => {
+    it('honours explicit on/off regardless of node count', () => {
+        expect(resolveVirtEnabled('on', 0)).toBe(true);
+        expect(resolveVirtEnabled('on', VIRT_AUTO_THRESHOLD + 1000)).toBe(true);
+        expect(resolveVirtEnabled('off', 0)).toBe(false);
+        expect(resolveVirtEnabled('off', VIRT_AUTO_THRESHOLD + 1000)).toBe(false);
+    });
+
+    it('auto returns true only above the threshold', () => {
+        expect(resolveVirtEnabled('auto', 0)).toBe(false);
+        expect(resolveVirtEnabled('auto', VIRT_AUTO_THRESHOLD)).toBe(false);
+        expect(resolveVirtEnabled('auto', VIRT_AUTO_THRESHOLD + 1)).toBe(true);
+    });
+});
+
+describe('resolveTriMode', () => {
+    it('on/off ignore the node count and threshold', () => {
+        expect(resolveTriMode('on', 0, OVERSCAN_AUTO_THRESHOLD)).toBe(true);
+        expect(resolveTriMode('off', 99999, OVERSCAN_AUTO_THRESHOLD)).toBe(false);
+    });
+
+    it('auto flips at the per-flag threshold (overscan)', () => {
+        expect(resolveTriMode('auto', OVERSCAN_AUTO_THRESHOLD, OVERSCAN_AUTO_THRESHOLD)).toBe(false);
+        expect(resolveTriMode('auto', OVERSCAN_AUTO_THRESHOLD + 1, OVERSCAN_AUTO_THRESHOLD)).toBe(true);
+    });
+
+    // Overscan kicks in well above virt so graphs just past VIRT_AUTO_THRESHOLD
+    // don't pay the wider viewport bounds calculation.
+    it('overscan threshold is higher than the virt threshold', () => {
+        expect(OVERSCAN_AUTO_THRESHOLD).toBeGreaterThan(VIRT_AUTO_THRESHOLD);
+    });
+});
+
+describe('getLineagePerfFlags', () => {
+    const originalSearch = window.location.search;
+
+    beforeEach(() => {
+        window.localStorage.clear();
+        Object.defineProperty(window, 'location', { value: { search: '' }, writable: true });
+    });
+
+    afterEach(() => {
+        Object.defineProperty(window, 'location', {
+            value: { search: originalSearch },
+            writable: true,
+        });
+        vi.unstubAllGlobals();
+    });
+
+    // Overscan stays `'off'` by default — measured pan cost outweighs the
+    // pop-in win at synthetic-100 scale.
+    it('falls back to defaults when no source provides a value', () => {
+        const flags = getLineagePerfFlags();
+        expect(flags.virtMode).toBe('auto');
+        expect(flags.overscanMode).toBe('off');
+    });
+
+    describe('server feature flag defaults', () => {
+        it('virtEnabled=false flips the virt default to "off"', () => {
+            const flags = getLineagePerfFlags({ virtEnabled: false, overscanEnabled: false });
+            expect(flags.virtMode).toBe('off');
+            expect(flags.overscanMode).toBe('off');
+        });
+
+        it('overscanEnabled=true flips the overscan default to "auto"', () => {
+            const flags = getLineagePerfFlags({ virtEnabled: true, overscanEnabled: true });
+            expect(flags.virtMode).toBe('auto');
+            expect(flags.overscanMode).toBe('auto');
+        });
+
+        it('URL overrides win over server flag defaults', () => {
+            Object.defineProperty(window, 'location', {
+                value: { search: '?lineagePerf=virt-on,overscan-off' },
+                writable: true,
+            });
+            const flags = getLineagePerfFlags({ virtEnabled: false, overscanEnabled: true });
+            expect(flags.virtMode).toBe('on');
+            expect(flags.overscanMode).toBe('off');
+        });
+
+        it('localStorage overrides win over server flag defaults', () => {
+            window.localStorage.setItem(STORAGE_KEY, 'virt-on');
+            const flags = getLineagePerfFlags({ virtEnabled: false });
+            expect(flags.virtMode).toBe('on');
+        });
+
+        // Frequency-of-use case: server flag flips overscan on by default but
+        // an operator pins it off mid-session via URL for an investigation.
+        it('honours partial URL patches against server-driven defaults', () => {
+            Object.defineProperty(window, 'location', {
+                value: { search: '?lineagePerf=overscan-off' },
+                writable: true,
+            });
+            const flags = getLineagePerfFlags({ virtEnabled: true, overscanEnabled: true });
+            expect(flags.virtMode).toBe('auto');
+            expect(flags.overscanMode).toBe('off');
+        });
+    });
+
+    it('parses the legacy `virt` token as `virtMode: "on"`', () => {
+        window.localStorage.setItem(STORAGE_KEY, 'virt');
+        expect(getLineagePerfFlags().virtMode).toBe('on');
+    });
+
+    it.each([
+        ['virt-on', 'on'],
+        ['virt-off', 'off'],
+        ['virt-auto', 'auto'],
+    ] as const)('parses the `%s` token as `virtMode: "%s"`', (token, mode) => {
+        window.localStorage.setItem(STORAGE_KEY, token);
+        expect(getLineagePerfFlags().virtMode).toBe(mode);
+    });
+
+    // Old harness strings often carried `defer-minimap` / `no-transition`
+    // tokens — they're silently ignored (rather than throwing) so saved
+    // localStorage / URL values from earlier branches stay functional.
+    it('silently drops removed flag tokens while honouring the rest', () => {
+        window.localStorage.setItem(STORAGE_KEY, 'virt defer-minimap no-transition-auto');
+        const flags = getLineagePerfFlags();
+        expect(flags.virtMode).toBe('on');
+        // Unknown / removed tokens must not contaminate other modes.
+        expect(flags.overscanMode).toBe('off');
+    });
+
+    it.each([
+        ['overscan', 'on'],
+        ['overscan-on', 'on'],
+        ['overscan-off', 'off'],
+        ['overscan-auto', 'auto'],
+    ] as const)('parses `%s` as `overscanMode: "%s"`', (token, mode) => {
+        window.localStorage.setItem(STORAGE_KEY, token);
+        expect(getLineagePerfFlags().overscanMode).toBe(mode);
+    });
+
+    it('URL params take precedence over localStorage', () => {
+        window.localStorage.setItem(STORAGE_KEY, 'virt-off');
+        Object.defineProperty(window, 'location', {
+            value: { search: '?lineagePerf=virt-on' },
+            writable: true,
+        });
+        expect(getLineagePerfFlags().virtMode).toBe('on');
+    });
+
+    it('ignores unknown tokens, leaving defaults intact', () => {
+        window.localStorage.setItem(STORAGE_KEY, 'definitely-not-a-flag');
+        expect(getLineagePerfFlags().virtMode).toBe('auto');
+    });
+});

--- a/datahub-web-react/src/app/lineageV2/controls/DownloadLineageScreenshotButton.tsx
+++ b/datahub-web-react/src/app/lineageV2/controls/DownloadLineageScreenshotButton.tsx
@@ -1,9 +1,11 @@
 import { CameraOutlined } from '@ant-design/icons';
+import { message } from 'antd';
 import { toPng } from 'html-to-image';
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { getRectOfNodes, getTransformForBounds, useReactFlow } from 'reactflow';
 import { useTheme } from 'styled-components';
 
+import LineageVisualizationContext from '@app/lineageV2/LineageVisualizationContext';
 import { LineageNodesContext } from '@app/lineageV2/common';
 import { StyledPanelButton } from '@app/lineageV2/controls/StyledPanelButton';
 
@@ -30,42 +32,69 @@ function downloadImage(dataUrl: string, name?: string) {
     a.click();
 }
 
+// Two RAFs + a layout-flush tail. First RAF runs after the render commit,
+// second after React Flow's post-commit measurement pass. RAFs (not setTimeout)
+// pace correctly when the tab is unfocused.
+function nextTwoFrames(): Promise<void> {
+    return new Promise((resolve) => {
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                setTimeout(resolve, 50);
+            });
+        });
+    });
+}
+
 export default function DownloadLineageScreenshotButton({ showExpandedText }: Props) {
     const themeConfig = useTheme();
     const { getNodes } = useReactFlow();
     const { rootUrn, nodes } = useContext(LineageNodesContext);
+    const { setForceMountAll } = useContext(LineageVisualizationContext);
+    const [isCapturing, setIsCapturing] = useState(false);
 
-    const getPreviewImage = () => {
-        const nodesBounds = getRectOfNodes(getNodes());
-        const imageWidth = nodesBounds.width + 200;
-        const imageHeight = nodesBounds.height + 200;
-        const transform = getTransformForBounds(nodesBounds, imageWidth, imageHeight, 0.5, 2);
+    const getPreviewImage = async () => {
+        if (isCapturing) return;
+        setIsCapturing(true);
+        // Suspend virt for the capture: html-to-image walks the live DOM, so
+        // with virt on it would only see the on-screen subset.
+        setForceMountAll(true);
+        try {
+            await nextTwoFrames();
 
-        // Get the entity name for the screenshot filename
-        const rootEntity = nodes.get(rootUrn);
-        const entityName = rootEntity?.entity?.name || 'lineage';
-        // Clean the entity name to be safe for filename use
-        const cleanEntityName = entityName.replace(/[^a-zA-Z0-9_-]/g, '_');
+            const nodesBounds = getRectOfNodes(getNodes());
+            const imageWidth = nodesBounds.width + 200;
+            const imageHeight = nodesBounds.height + 200;
+            const transform = getTransformForBounds(nodesBounds, imageWidth, imageHeight, 0.5, 2);
 
-        toPng(document.querySelector('.react-flow__viewport') as HTMLElement, {
-            backgroundColor: themeConfig.colors.bgSurface,
-            width: imageWidth,
-            height: imageHeight,
-            style: {
-                width: String(imageWidth),
-                height: String(imageHeight),
-                transform: `translate(${transform[0]}px, ${transform[1]}px) scale(${transform[2]})`,
-            },
-        }).then((dataUrl) => {
+            const rootEntity = nodes.get(rootUrn);
+            const entityName = rootEntity?.entity?.name || 'lineage';
+            const cleanEntityName = entityName.replace(/[^a-zA-Z0-9_-]/g, '_');
+
+            const dataUrl = await toPng(document.querySelector('.react-flow__viewport') as HTMLElement, {
+                backgroundColor: themeConfig.colors.bgSurface,
+                width: imageWidth,
+                height: imageHeight,
+                style: {
+                    width: String(imageWidth),
+                    height: String(imageHeight),
+                    transform: `translate(${transform[0]}px, ${transform[1]}px) scale(${transform[2]})`,
+                },
+            });
             downloadImage(dataUrl, cleanEntityName);
-        });
+        } finally {
+            setForceMountAll(false);
+            setIsCapturing(false);
+        }
     };
 
     return (
         <StyledPanelButton
             type="text"
+            disabled={isCapturing}
             onClick={() => {
-                getPreviewImage();
+                getPreviewImage().catch(() => {
+                    message.error('Failed to capture lineage screenshot.');
+                });
             }}
         >
             <CameraOutlined />

--- a/datahub-web-react/src/app/lineageV2/controls/__tests__/DownloadLineageScreenshotButton.test.tsx
+++ b/datahub-web-react/src/app/lineageV2/controls/__tests__/DownloadLineageScreenshotButton.test.tsx
@@ -1,3 +1,32 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { toPng } from 'html-to-image';
+import React from 'react';
+import { ReactFlowProvider } from 'reactflow';
+import { ThemeProvider } from 'styled-components';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import LineageVisualizationContext from '@app/lineageV2/LineageVisualizationContext';
+import { LineageNodesContext } from '@app/lineageV2/common';
+import DownloadLineageScreenshotButton from '@app/lineageV2/controls/DownloadLineageScreenshotButton';
+
+import { EntityType, LineageDirection } from '@types';
+
+// Control toPng resolution so we can assert state DURING the capture window
+// vs after it resolves.
+vi.mock('html-to-image', () => ({ toPng: vi.fn() }));
+
+// Stub the React Flow geometry helpers — out of scope for the screenshot
+// wiring assertions, and we don't want to mount a real lineage graph in jsdom.
+vi.mock('reactflow', async () => {
+    const actual = await vi.importActual<typeof import('reactflow')>('reactflow');
+    return {
+        ...actual,
+        useReactFlow: () => ({ getNodes: () => [] }),
+        getRectOfNodes: () => ({ x: 0, y: 0, width: 800, height: 600 }),
+        getTransformForBounds: () => [0, 0, 1] as const,
+    };
+});
+
 describe('Entity name cleaning', () => {
     it('should clean special characters', () => {
         const cleanName = (name: string) => name.replace(/[^a-zA-Z0-9_-]/g, '_');
@@ -6,5 +35,99 @@ describe('Entity name cleaning', () => {
         expect(cleanName('user.transactions')).toBe('user_transactions');
         expect(cleanName('normal_name')).toBe('normal_name');
         expect(cleanName('123-valid_name')).toBe('123-valid_name');
+    });
+});
+
+describe('DownloadLineageScreenshotButton — virtualisation interop', () => {
+    const setForceMountAll = vi.fn();
+    const baseVisualizationContext = {
+        searchQuery: '',
+        setSearchQuery: () => {},
+        searchedEntity: null,
+        setSearchedEntity: () => {},
+        isFocused: false,
+        forceMountAll: false,
+        setForceMountAll,
+    };
+    // Cast through unknown — the real context has 15+ unrelated state/setter
+    // pairs the button never touches.
+    const baseNodesContext = {
+        rootUrn: 'urn:li:dataset:(urn:li:dataPlatform:perf,sample,PROD)',
+        rootType: EntityType.Dataset,
+        nodes: new Map(),
+        edges: new Map(),
+        adjacencyList: {
+            [LineageDirection.Upstream]: new Map(),
+            [LineageDirection.Downstream]: new Map(),
+        },
+    } as unknown as React.ContextType<typeof LineageNodesContext>;
+
+    const theme = { colors: { bgSurface: '#fff' } } as React.ComponentProps<typeof ThemeProvider>['theme'];
+
+    function renderButton() {
+        return render(
+            <ThemeProvider theme={theme}>
+                <ReactFlowProvider>
+                    <LineageNodesContext.Provider value={baseNodesContext}>
+                        <LineageVisualizationContext.Provider value={baseVisualizationContext}>
+                            <DownloadLineageScreenshotButton showExpandedText />
+                        </LineageVisualizationContext.Provider>
+                    </LineageNodesContext.Provider>
+                </ReactFlowProvider>
+            </ThemeProvider>,
+        );
+    }
+
+    beforeEach(() => {
+        setForceMountAll.mockClear();
+        // jsdom doesn't ship a real rAF; drive it from setTimeout so the
+        // component's "two frames + tail" wait resolves inside `waitFor`.
+        vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+            setTimeout(() => cb(performance.now()), 0);
+            return 0;
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.mocked(toPng).mockReset();
+    });
+
+    it('toggles forceMountAll on before capture and off after toPng resolves', async () => {
+        let resolveCapture: (value: string) => void = () => {};
+        const capturePromise = new Promise<string>((resolve) => {
+            resolveCapture = resolve;
+        });
+        vi.mocked(toPng).mockReturnValue(capturePromise);
+
+        const { getByRole } = renderButton();
+        fireEvent.click(getByRole('button'));
+
+        await waitFor(() => {
+            expect(setForceMountAll).toHaveBeenCalledWith(true);
+        });
+        expect(setForceMountAll).not.toHaveBeenCalledWith(false);
+
+        resolveCapture('data:image/png;base64,abc');
+        await waitFor(() => {
+            expect(setForceMountAll).toHaveBeenCalledWith(false);
+        });
+
+        const calls = setForceMountAll.mock.calls.map((args) => args[0]);
+        expect(calls).toEqual([true, false]);
+    });
+
+    // A failed capture must still restore the flag — otherwise virt stays
+    // disabled for the rest of the session.
+    it('still restores forceMountAll if toPng rejects', async () => {
+        vi.mocked(toPng).mockRejectedValue(new Error('canvas tainted'));
+
+        const { getByRole } = renderButton();
+        fireEvent.click(getByRole('button'));
+
+        await waitFor(() => {
+            expect(setForceMountAll).toHaveBeenCalledWith(true);
+            expect(setForceMountAll).toHaveBeenCalledWith(false);
+        });
     });
 });

--- a/datahub-web-react/src/app/lineageV2/perfFlags.ts
+++ b/datahub-web-react/src/app/lineageV2/perfFlags.ts
@@ -1,0 +1,142 @@
+/**
+ * Lineage rendering perf flags.
+ *
+ * The runtime defaults come from the server-side `featureFlags` block on
+ * `AppConfig` — `lineageGraphPerfVirtEnabled` and
+ * `lineageGraphPerfOverscanEnabled`. When a server flag is on, the
+ * corresponding mode defaults to `'auto'` (apply above the node-count
+ * threshold); when off, it defaults to `'off'`.
+ *
+ * The `?lineagePerf=` URL param and `datahub.lineagePerfFlags` localStorage
+ * entry remain as per-session overrides (URL wins over localStorage, which
+ * wins over the server default). They exist for diagnostics and customer
+ * dogfood; the source of truth for the rollout is the server flag.
+ */
+
+export type LineageVirtMode = 'on' | 'off' | 'auto';
+export type LineagePerfTriMode = 'on' | 'off' | 'auto';
+
+/** Above this node count, `'auto'` enables `onlyRenderVisibleElements`. */
+export const VIRT_AUTO_THRESHOLD = 50;
+/** Above this node count, `'auto'` enables the overscan-buffered virt. */
+export const OVERSCAN_AUTO_THRESHOLD = 200;
+
+/**
+ * Viewport inflation factor when the overscan buffer is active. Conservative
+ * because larger values regress pan worst-frame: synthetic_100 measures ~1.5×
+ * the strict-viewport pan cost at 0.15.
+ */
+export const DEFAULT_OVERSCAN_FACTOR = 0.15;
+
+export interface LineagePerfFlags {
+    virtMode: LineageVirtMode;
+    /** Overscan-buffered virt. Off by default — see {@link DEFAULT_OVERSCAN_FACTOR}. */
+    overscanMode: LineagePerfTriMode;
+}
+
+/**
+ * Server-driven defaults pulled from `AppConfig.featureFlags`. Optional so
+ * call sites that pre-date `useAppConfig` wiring keep the legacy hardcoded
+ * defaults; production callers should always pass the resolved values.
+ */
+export interface LineagePerfFeatureFlags {
+    virtEnabled?: boolean;
+    overscanEnabled?: boolean;
+}
+
+const STORAGE_KEY = 'datahub.lineagePerfFlags';
+const URL_PARAM = 'lineagePerf';
+
+/**
+ * Fallback when no server flags are available — matches the pre-feature-flag
+ * behaviour: virt on (auto-thresholded), overscan off.
+ */
+const HARDCODED_DEFAULTS: LineagePerfFlags = {
+    virtMode: 'auto',
+    overscanMode: 'off',
+};
+
+function resolveDefaults(featureFlags?: LineagePerfFeatureFlags): LineagePerfFlags {
+    if (!featureFlags) return HARDCODED_DEFAULTS;
+    return {
+        virtMode: featureFlags.virtEnabled === false ? 'off' : 'auto',
+        overscanMode: featureFlags.overscanEnabled ? 'auto' : 'off',
+    };
+}
+
+type FlagPatch = Partial<LineagePerfFlags>;
+
+// Bare tokens (no `-on/-off/-auto` suffix) alias to `'on'` for back-compat
+// with the original boolean grammar. `defer-minimap` / `no-transition` were
+// removed after an N=5 sweep showed p50 within ~5 % of baseline and p95
+// spread 3–5× wider; they're accepted as silent no-ops so saved harness
+// strings from earlier branches stay functional.
+const NO_OP_TOKENS = new Set([
+    'defer-minimap',
+    'defer-minimap-on',
+    'defer-minimap-off',
+    'defer-minimap-auto',
+    'no-transition',
+    'no-transition-on',
+    'no-transition-off',
+    'no-transition-auto',
+]);
+const TOKEN_PATCHES: Record<string, FlagPatch> = {
+    virt: { virtMode: 'on' },
+    'virt-on': { virtMode: 'on' },
+    'virt-off': { virtMode: 'off' },
+    'virt-auto': { virtMode: 'auto' },
+    overscan: { overscanMode: 'on' },
+    'overscan-on': { overscanMode: 'on' },
+    'overscan-off': { overscanMode: 'off' },
+    'overscan-auto': { overscanMode: 'auto' },
+};
+
+function parseFlagString(value: string): FlagPatch {
+    const out: FlagPatch = {};
+    value
+        .split(/[,\s+]+/)
+        .map((t) => t.trim().toLowerCase())
+        .filter(Boolean)
+        .forEach((token) => {
+            if (NO_OP_TOKENS.has(token)) return;
+            const patch = TOKEN_PATCHES[token];
+            if (patch) Object.assign(out, patch);
+        });
+    return out;
+}
+
+export function getLineagePerfFlags(featureFlags?: LineagePerfFeatureFlags): LineagePerfFlags {
+    const defaults = resolveDefaults(featureFlags);
+    if (typeof window === 'undefined') return defaults;
+    try {
+        const fromUrl = new URLSearchParams(window.location.search).get(URL_PARAM);
+        if (fromUrl) return { ...defaults, ...parseFlagString(fromUrl) };
+    } catch {
+        // window.location can be unavailable in embedded contexts.
+    }
+    try {
+        const fromStorage = window.localStorage.getItem(STORAGE_KEY);
+        if (fromStorage) return { ...defaults, ...parseFlagString(fromStorage) };
+    } catch {
+        // localStorage throws in private-browsing / sandboxed contexts.
+    }
+    return defaults;
+}
+
+/**
+ * Resolved against `initialNodes.length` (not a live store sub) so virt is a
+ * stable property of the mount — flickering would break screenshot capture
+ * and column-edge geometry mid-session.
+ */
+export function resolveVirtEnabled(mode: LineageVirtMode, nodeCount: number): boolean {
+    if (mode === 'on') return true;
+    if (mode === 'off') return false;
+    return nodeCount > VIRT_AUTO_THRESHOLD;
+}
+
+export function resolveTriMode(mode: LineagePerfTriMode, nodeCount: number, autoThreshold: number): boolean {
+    if (mode === 'on') return true;
+    if (mode === 'off') return false;
+    return nodeCount > autoThreshold;
+}

--- a/datahub-web-react/src/app/lineageV2/useOverscanVirt.ts
+++ b/datahub-web-react/src/app/lineageV2/useOverscanVirt.ts
@@ -1,0 +1,97 @@
+/**
+ * Overscan-aware DOM virtualisation for lineage graphs.
+ *
+ * React Flow's `onlyRenderVisibleElements` filters against the exact viewport,
+ * so nodes pop in at the trailing edge during a pan. This hook reproduces the
+ * filter but inflates the viewport by {@link DEFAULT_OVERSCAN_FACTOR} on each
+ * side, eliminating pop-in within one buffer's worth of drag at the cost of
+ * mounting more DOM.
+ *
+ * Must be called inside the `<ReactFlow>` subtree (uses `useStore`). The hook
+ * never re-renders parents on viewport changes — it writes `hidden` flags
+ * directly via `setNodes`, and preserves object identity for unchanged nodes
+ * so `React.memo` on `LineageEntityNode` still skips re-renders.
+ */
+import { useEffect, useRef } from 'react';
+import { useReactFlow, useStore } from 'reactflow';
+
+import type { LineageVisualizationNode } from '@app/lineageV2/NodeBuilder';
+import { DEFAULT_OVERSCAN_FACTOR } from '@app/lineageV2/perfFlags';
+
+// Conservative fallbacks for nodes React Flow hasn't measured yet — wider /
+// taller than real nodes so a late-arriving measurement can't accidentally
+// exclude a node from the overscan rect.
+const FALLBACK_NODE_WIDTH = 320;
+const FALLBACK_NODE_HEIGHT = 200;
+
+export function useOverscanVirt(enabled: boolean, overscanFactor: number = DEFAULT_OVERSCAN_FACTOR): void {
+    const reactFlow = useReactFlow();
+    const transform = useStore((s) => s.transform);
+    const width = useStore((s) => s.width);
+    const height = useStore((s) => s.height);
+    // Short-circuit consecutive viewport events that resolve to the same rect
+    // (d3 emits sub-pixel transform updates during inertia scroll).
+    const lastRectKeyRef = useRef<string>('');
+    const everEnabledRef = useRef<boolean>(false);
+
+    useEffect(() => {
+        if (!enabled) {
+            if (everEnabledRef.current) {
+                reactFlow.setNodes((nodes) => nodes.map((n) => (n.hidden ? { ...n, hidden: false } : n)));
+                everEnabledRef.current = false;
+                lastRectKeyRef.current = '';
+            }
+            return;
+        }
+        everEnabledRef.current = true;
+
+        const [tx, ty, zoom] = transform;
+        if (!zoom || zoom <= 0 || !width || !height) return;
+
+        // Screen → flow coords; `node.position` lives in flow coords.
+        const flowViewportWidth = width / zoom;
+        const flowViewportHeight = height / zoom;
+        const flowViewportX = -tx / zoom;
+        const flowViewportY = -ty / zoom;
+
+        const overscanX = flowViewportX - flowViewportWidth * overscanFactor;
+        const overscanY = flowViewportY - flowViewportHeight * overscanFactor;
+        const overscanWidth = flowViewportWidth * (1 + 2 * overscanFactor);
+        const overscanHeight = flowViewportHeight * (1 + 2 * overscanFactor);
+
+        const rectKey =
+            `${Math.floor(overscanX)}|${Math.floor(overscanY)}|` +
+            `${Math.floor(overscanWidth)}|${Math.floor(overscanHeight)}`;
+        if (rectKey === lastRectKeyRef.current) return;
+        lastRectKeyRef.current = rectKey;
+
+        reactFlow.setNodes((nodes) => {
+            let mutated = false;
+            const next = nodes.map((node) => {
+                const n = node as LineageVisualizationNode & { hidden?: boolean };
+                const w = n.width ?? FALLBACK_NODE_WIDTH;
+                const h = n.height ?? FALLBACK_NODE_HEIGHT;
+                const nx = n.position?.x ?? 0;
+                const ny = n.position?.y ?? 0;
+                const intersects =
+                    nx < overscanX + overscanWidth &&
+                    nx + w > overscanX &&
+                    ny < overscanY + overscanHeight &&
+                    ny + h > overscanY;
+                const shouldHide = !intersects;
+                if (Boolean(n.hidden) === shouldHide) return node;
+                mutated = true;
+                return { ...node, hidden: shouldHide };
+            });
+            return mutated ? next : nodes;
+        });
+    }, [enabled, overscanFactor, transform, width, height, reactFlow]);
+
+    // Restore `hidden` flags on unmount so toggling overscan off mid-session
+    // doesn't leave nodes permanently invisible.
+    useEffect(() => {
+        return () => {
+            reactFlow.setNodes((nodes) => nodes.map((n) => (n.hidden ? { ...n, hidden: false } : n)));
+        };
+    }, [reactFlow]);
+}

--- a/datahub-web-react/src/app/lineageV3/LineageVisualization.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageVisualization.tsx
@@ -76,6 +76,7 @@ function LineageVisualization({ initialNodes, initialEdges }: Props) {
     const [searchQuery, setSearchQuery] = useState('');
     const [isFocused, setIsFocused] = useState(false);
     const [isDraggingBoundingBox, setIsDraggingBoundingBox] = useState(false);
+    const [forceMountAll, setForceMountAll] = useState(false);
     const [searchedEntity, setSearchedEntity] = useState<string | null>(null);
     const { highlightedEdges, setSelectedColumn, setDisplayedMenuNode } = useContext(LineageDisplayContext);
     useFitView(searchedEntity);
@@ -92,6 +93,8 @@ function LineageVisualization({ initialNodes, initialEdges }: Props) {
                 isFocused,
                 isDraggingBoundingBox,
                 setIsDraggingBoundingBox,
+                forceMountAll,
+                setForceMountAll,
             }}
         >
             <LineageSVGs />

--- a/datahub-web-react/src/app/lineageV3/LineageVisualizationContext.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageVisualizationContext.tsx
@@ -10,6 +10,13 @@ interface VisualizationContext {
     isFocused: boolean;
     isDraggingBoundingBox: boolean; // Used to prevent transition when dragging bounding boxes
     setIsDraggingBoundingBox: (dragging: boolean) => void;
+    /**
+     * Temporary escape hatch for code paths that need every node mounted
+     * (e.g. screenshot export). When `true`, virtualisation should treat
+     * every node as visible. Mirrors V2's `forceMountAll`.
+     */
+    forceMountAll: boolean;
+    setForceMountAll: (force: boolean) => void;
 }
 
 const LineageVisualizationContext = React.createContext<VisualizationContext>({
@@ -20,6 +27,8 @@ const LineageVisualizationContext = React.createContext<VisualizationContext>({
     isFocused: false,
     isDraggingBoundingBox: false,
     setIsDraggingBoundingBox: () => {},
+    forceMountAll: false,
+    setForceMountAll: () => {},
 });
 
 export default LineageVisualizationContext;

--- a/datahub-web-react/src/app/lineageV3/__perf__/stubNodeTypes.tsx
+++ b/datahub-web-react/src/app/lineageV3/__perf__/stubNodeTypes.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { NodeProps, NodeTypes } from 'reactflow';
+import styled from 'styled-components';
+
+import { PERF_STUB_NODE_TYPE } from '@app/lineageV3/__perf__/syntheticGraph';
+
+/**
+ * Two node-component variants used by the rendering perf harness:
+ *
+ *  - `Light` is a minimal styled div, representative of pure ReactFlow + a
+ *    React.memo'd component with cheap renders. Establishes a lower bound on
+ *    per-node cost.
+ *
+ *  - `Heavy` mirrors the structural shape of the real `LineageEntityNode`
+ *    (multiple nested styled-components, conditional sub-renders driven by
+ *    props, a couple of hooks). It does NOT pull in Apollo / EntityRegistry /
+ *    the entire lineage context, so it under-counts the real component, but
+ *    it's a reasonable proxy for "how does a chunkier node react under load".
+ */
+
+const Wrapper = styled.div<{ $heavy?: boolean }>`
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+    background: ${({ theme }) => theme?.colors?.bg ?? '#fff'};
+    border: 1px solid #d9d9d9;
+    border-radius: 8px;
+    padding: 8px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-family: 'Roboto', sans-serif;
+    font-size: 12px;
+    box-shadow: ${({ $heavy }) => ($heavy ? '0 1px 3px rgba(0,0,0,0.08)' : 'none')};
+`;
+
+const Title = styled.div`
+    font-weight: 600;
+    color: #262626;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+`;
+
+const Subtitle = styled.div`
+    color: #8c8c8c;
+    font-size: 11px;
+`;
+
+const TagRow = styled.div`
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+`;
+
+const Tag = styled.span<{ $idx: number }>`
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: ${({ $idx }) => ['#e6f4ff', '#f6ffed', '#fffbe6', '#fff1f0'][$idx % 4]};
+    color: #595959;
+    font-size: 10px;
+`;
+
+type PerfNodeProps = NodeProps<{ urn: string; label: string }>;
+
+const LightStubBase = ({ data }: PerfNodeProps) => (
+    <Wrapper>
+        <Title>{data.label}</Title>
+        <Subtitle>{data.urn}</Subtitle>
+    </Wrapper>
+);
+const LightStub = React.memo(LightStubBase);
+
+const HeavyStubBase = ({ data, selected, dragging }: PerfNodeProps) => {
+    const [open, setOpen] = React.useState(false);
+    const onClick = React.useCallback(() => setOpen((v) => !v), []);
+    const tags = React.useMemo(
+        () => ['Owners', 'Tags', 'Domain', 'Glossary'].slice(0, (data.label.length % 4) + 1),
+        [data.label],
+    );
+    return (
+        <Wrapper $heavy onClick={onClick} aria-pressed={selected || dragging}>
+            <Title>{data.label}</Title>
+            <Subtitle>{data.urn}</Subtitle>
+            <TagRow>
+                {tags.map((tag, idx) => (
+                    <Tag key={tag} $idx={idx}>
+                        {tag}
+                    </Tag>
+                ))}
+            </TagRow>
+            {open && <Subtitle>Expanded · {data.urn}</Subtitle>}
+        </Wrapper>
+    );
+};
+const HeavyStub = React.memo(HeavyStubBase);
+
+export const lightNodeTypes: NodeTypes = {
+    [PERF_STUB_NODE_TYPE]: LightStub,
+};
+
+export const heavyNodeTypes: NodeTypes = {
+    [PERF_STUB_NODE_TYPE]: HeavyStub,
+};

--- a/datahub-web-react/src/app/lineageV3/__perf__/syntheticGraph.ts
+++ b/datahub-web-react/src/app/lineageV3/__perf__/syntheticGraph.ts
@@ -1,0 +1,174 @@
+import { Edge, Node } from 'reactflow';
+
+/**
+ * Lightweight synthetic-graph generators for the lineage rendering perf survey.
+ *
+ * These deliberately produce plain ReactFlow Node / Edge shapes (not full
+ * LineageEntity / FetchedEntityV2 stubs) so the harness measures the cost of
+ * mounting the React Flow tree + a representative node component, isolated
+ * from upstream concerns like Apollo, the entity registry, or compute-graph
+ * layout. Real-world numbers will be larger than what we report here — the
+ * goal is to surface scaling behaviour and the relative effect of toggles
+ * like `onlyRenderVisibleElements`, not to predict production frame time.
+ */
+
+export interface SyntheticGraph {
+    nodes: Node<{ urn: string; label: string }>[];
+    edges: Edge[];
+    /** Roughly the bounding box the layout occupies — useful for tuning viewport tests. */
+    bounds: { width: number; height: number };
+}
+
+const NODE_W = 320;
+const NODE_H = 96;
+const GAP_X = 80;
+const GAP_Y = 32;
+
+const STUB_NODE_TYPE = 'stub-entity';
+
+/**
+ * `flat`: N nodes arranged in a single column. Edges chain consecutive nodes
+ * so we always have at least one edge per node (closer to lineage shapes than
+ * an empty edge set). No nesting.
+ */
+export function makeFlatGraph(n: number): SyntheticGraph {
+    const nodes: SyntheticGraph['nodes'] = [];
+    const edges: SyntheticGraph['edges'] = [];
+    for (let i = 0; i < n; i += 1) {
+        const urn = `urn:li:dataset:(urn:li:dataPlatform:perf,table_${i},PROD)`;
+        nodes.push({
+            id: urn,
+            type: STUB_NODE_TYPE,
+            position: { x: 0, y: i * (NODE_H + GAP_Y) },
+            data: { urn, label: `table_${i}` },
+            width: NODE_W,
+            height: NODE_H,
+        });
+        if (i > 0) {
+            const prevUrn = `urn:li:dataset:(urn:li:dataPlatform:perf,table_${i - 1},PROD)`;
+            edges.push({ id: `e_${i - 1}_${i}`, source: prevUrn, target: urn });
+        }
+    }
+    return {
+        nodes,
+        edges,
+        bounds: { width: NODE_W, height: n * (NODE_H + GAP_Y) },
+    };
+}
+
+/**
+ * `nested`: Domain bbox → P member DP bboxes → A assets per DP. Approximates
+ * the Domain lineage view's worst-case shape. Each asset has an upstream edge
+ * to the previous asset in the same DP, and each DP has a cross-DP edge to
+ * the next DP so we exercise inter-bbox edges too.
+ */
+export function makeNestedGraph(domainCount: number, dpsPerDomain: number, assetsPerDp: number): SyntheticGraph {
+    const nodes: SyntheticGraph['nodes'] = [];
+    const edges: SyntheticGraph['edges'] = [];
+
+    let cursorY = 0;
+    const dpBoxW = NODE_W + 80;
+    const dpBoxAssetGap = NODE_H + 16;
+
+    for (let d = 0; d < domainCount; d += 1) {
+        const domainUrn = `urn:li:domain:perf_${d}`;
+        const dpsHeight = dpsPerDomain * (assetsPerDp * dpBoxAssetGap + 120);
+        nodes.push({
+            id: domainUrn,
+            type: STUB_NODE_TYPE,
+            position: { x: 0, y: cursorY },
+            data: { urn: domainUrn, label: `Domain ${d}` },
+            width: dpBoxW + 64,
+            height: dpsHeight + 80,
+            style: { width: dpBoxW + 64, height: dpsHeight + 80 },
+        });
+        let dpY = 40;
+        let prevDpUrn: string | null = null;
+        for (let p = 0; p < dpsPerDomain; p += 1) {
+            const dpUrn = `urn:li:dataProduct:perf_${d}_${p}`;
+            const dpBoxHeight = assetsPerDp * dpBoxAssetGap + 56;
+            nodes.push({
+                id: dpUrn,
+                type: STUB_NODE_TYPE,
+                position: { x: 32, y: dpY },
+                data: { urn: dpUrn, label: `DP ${d}.${p}` },
+                width: dpBoxW,
+                height: dpBoxHeight,
+                style: { width: dpBoxW, height: dpBoxHeight },
+                parentNode: domainUrn,
+                extent: 'parent',
+            });
+            if (prevDpUrn) {
+                edges.push({ id: `dp_${prevDpUrn}_${dpUrn}`, source: prevDpUrn, target: dpUrn });
+            }
+            let prevAssetUrn: string | null = null;
+            for (let a = 0; a < assetsPerDp; a += 1) {
+                const assetUrn = `urn:li:dataset:(urn:li:dataPlatform:perf,d${d}_p${p}_t${a},PROD)`;
+                nodes.push({
+                    id: assetUrn,
+                    type: STUB_NODE_TYPE,
+                    position: { x: 16, y: 32 + a * dpBoxAssetGap },
+                    data: { urn: assetUrn, label: `t${a}` },
+                    width: NODE_W,
+                    height: NODE_H,
+                    parentNode: dpUrn,
+                    extent: 'parent',
+                });
+                if (prevAssetUrn) {
+                    edges.push({ id: `a_${prevAssetUrn}_${assetUrn}`, source: prevAssetUrn, target: assetUrn });
+                }
+                prevAssetUrn = assetUrn;
+            }
+            prevDpUrn = dpUrn;
+            dpY += dpBoxHeight + 24;
+        }
+        cursorY += dpsHeight + 120;
+    }
+    return {
+        nodes,
+        edges,
+        bounds: { width: dpBoxW + 64, height: cursorY },
+    };
+}
+
+/**
+ * `dense`: N nodes laid out in a grid, with every node connected to up to
+ * `edgesPerNode` arbitrary other nodes. Exercises the edge-rendering path
+ * specifically — SVG paths are usually the second-largest render cost after
+ * node DOM, so this surfaces edge scaling separately from node scaling.
+ */
+export function makeDenseGraph(n: number, edgesPerNode: number): SyntheticGraph {
+    const nodes: SyntheticGraph['nodes'] = [];
+    const edges: SyntheticGraph['edges'] = [];
+    const cols = Math.max(1, Math.ceil(Math.sqrt(n)));
+    for (let i = 0; i < n; i += 1) {
+        const urn = `urn:li:dataset:(urn:li:dataPlatform:perf,dense_${i},PROD)`;
+        const row = Math.floor(i / cols);
+        const col = i % cols;
+        nodes.push({
+            id: urn,
+            type: STUB_NODE_TYPE,
+            position: { x: col * (NODE_W + GAP_X), y: row * (NODE_H + GAP_Y) },
+            data: { urn, label: `dense_${i}` },
+            width: NODE_W,
+            height: NODE_H,
+        });
+    }
+    for (let i = 0; i < n; i += 1) {
+        for (let k = 1; k <= edgesPerNode; k += 1) {
+            const targetIdx = (i + k) % n;
+            if (targetIdx !== i) {
+                const sourceUrn = `urn:li:dataset:(urn:li:dataPlatform:perf,dense_${i},PROD)`;
+                const targetUrn = `urn:li:dataset:(urn:li:dataPlatform:perf,dense_${targetIdx},PROD)`;
+                edges.push({ id: `e_${i}_${targetIdx}`, source: sourceUrn, target: targetUrn });
+            }
+        }
+    }
+    return {
+        nodes,
+        edges,
+        bounds: { width: cols * (NODE_W + GAP_X), height: Math.ceil(n / cols) * (NODE_H + GAP_Y) },
+    };
+}
+
+export const PERF_STUB_NODE_TYPE = STUB_NODE_TYPE;

--- a/datahub-web-react/src/app/lineageV3/__perf__/virtualization.sanity.test.tsx
+++ b/datahub-web-react/src/app/lineageV3/__perf__/virtualization.sanity.test.tsx
@@ -1,0 +1,63 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import ReactFlow, { ReactFlowProvider } from 'reactflow';
+import 'reactflow/dist/style.css';
+import { describe, expect, it } from 'vitest';
+
+import { lightNodeTypes } from '@app/lineageV3/__perf__/stubNodeTypes';
+import { makeFlatGraph } from '@app/lineageV3/__perf__/syntheticGraph';
+
+/**
+ * Sanity check on the perf survey's `onlyRenderVisibleElements` measurement.
+ *
+ * In jsdom, `getBoundingClientRect` typically returns zeros, which can cause
+ * React Flow's viewport-intersection check to skip ALL nodes — making
+ * `virt=true` look artificially fast because it's not rendering anything,
+ * not because virtualisation is working. This test asserts that virt-off
+ * mounts at least one DOM node per synthetic node and virt-on mounts
+ * strictly fewer (potentially zero).
+ */
+
+function countMountedNodes(container: HTMLElement): number {
+    return container.querySelectorAll('.react-flow__node').length;
+}
+
+describe('Virtualisation sanity check (interpret perf numbers carefully)', () => {
+    const N = 100;
+
+    it('virt=false mounts every node', () => {
+        const { nodes, edges } = makeFlatGraph(N);
+        const { container } = render(
+            <div style={{ width: 1280, height: 720 }}>
+                <ReactFlowProvider>
+                    <ReactFlow
+                        defaultNodes={nodes}
+                        defaultEdges={edges}
+                        nodeTypes={lightNodeTypes}
+                        onlyRenderVisibleElements={false}
+                        proOptions={{ hideAttribution: true }}
+                    />
+                </ReactFlowProvider>
+            </div>,
+        );
+        expect(countMountedNodes(container)).toBeGreaterThan(0);
+    });
+
+    it('virt=true mounts strictly fewer (or zero) nodes', () => {
+        const { nodes, edges } = makeFlatGraph(N);
+        const { container } = render(
+            <div style={{ width: 1280, height: 720 }}>
+                <ReactFlowProvider>
+                    <ReactFlow
+                        defaultNodes={nodes}
+                        defaultEdges={edges}
+                        nodeTypes={lightNodeTypes}
+                        onlyRenderVisibleElements
+                        proOptions={{ hideAttribution: true }}
+                    />
+                </ReactFlowProvider>
+            </div>,
+        );
+        expect(countMountedNodes(container)).toBeLessThan(N);
+    });
+});

--- a/datahub-web-react/src/app/lineageV3/controls/DownloadLineageScreenshotButton.tsx
+++ b/datahub-web-react/src/app/lineageV3/controls/DownloadLineageScreenshotButton.tsx
@@ -1,9 +1,11 @@
 import { CameraOutlined } from '@ant-design/icons';
+import { message } from 'antd';
 import { toPng } from 'html-to-image';
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { getRectOfNodes, getTransformForBounds, useReactFlow } from 'reactflow';
 import { useTheme } from 'styled-components';
 
+import LineageVisualizationContext from '@app/lineageV3/LineageVisualizationContext';
 import { LineageNodesContext } from '@app/lineageV3/common';
 import { StyledPanelButton } from '@app/lineageV3/controls/StyledPanelButton';
 import { downloadImage } from '@app/lineageV3/utils/lineageUtils';
@@ -12,42 +14,69 @@ type Props = {
     showExpandedText: boolean;
 };
 
+// Two RAFs + a layout-flush tail. First RAF runs after the render commit,
+// second after React Flow's post-commit measurement pass. RAFs (not
+// setTimeout) pace correctly when the tab is unfocused.
+function nextTwoFrames(): Promise<void> {
+    return new Promise((resolve) => {
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                setTimeout(resolve, 50);
+            });
+        });
+    });
+}
+
 export default function DownloadLineageScreenshotButton({ showExpandedText }: Props) {
     const themeConfig = useTheme();
     const { getNodes } = useReactFlow();
     const { rootUrn, nodes } = useContext(LineageNodesContext);
+    const { setForceMountAll } = useContext(LineageVisualizationContext);
+    const [isCapturing, setIsCapturing] = useState(false);
 
-    const getPreviewImage = () => {
-        const nodesBounds = getRectOfNodes(getNodes());
-        const imageWidth = nodesBounds.width + 200;
-        const imageHeight = nodesBounds.height + 200;
-        const transform = getTransformForBounds(nodesBounds, imageWidth, imageHeight, 0.5, 2);
+    const getPreviewImage = async () => {
+        if (isCapturing) return;
+        setIsCapturing(true);
+        // Suspend virt for the capture: html-to-image walks the live DOM, so
+        // with virt on it would only see the on-screen subset.
+        setForceMountAll(true);
+        try {
+            await nextTwoFrames();
 
-        // Get the entity name for the screenshot filename
-        const rootEntity = nodes.get(rootUrn);
-        const entityName = rootEntity?.entity?.name || 'lineage';
-        // Clean the entity name to be safe for filename use
-        const cleanEntityName = entityName.replace(/[^a-zA-Z0-9_-]/g, '_');
+            const nodesBounds = getRectOfNodes(getNodes());
+            const imageWidth = nodesBounds.width + 200;
+            const imageHeight = nodesBounds.height + 200;
+            const transform = getTransformForBounds(nodesBounds, imageWidth, imageHeight, 0.5, 2);
 
-        toPng(document.querySelector('.react-flow__viewport') as HTMLElement, {
-            backgroundColor: themeConfig.colors.bgSurface,
-            width: imageWidth,
-            height: imageHeight,
-            style: {
-                width: String(imageWidth),
-                height: String(imageHeight),
-                transform: `translate(${transform[0]}px, ${transform[1]}px) scale(${transform[2]})`,
-            },
-        }).then((dataUrl) => {
+            const rootEntity = nodes.get(rootUrn);
+            const entityName = rootEntity?.entity?.name || 'lineage';
+            const cleanEntityName = entityName.replace(/[^a-zA-Z0-9_-]/g, '_');
+
+            const dataUrl = await toPng(document.querySelector('.react-flow__viewport') as HTMLElement, {
+                backgroundColor: themeConfig.colors.bgSurface,
+                width: imageWidth,
+                height: imageHeight,
+                style: {
+                    width: String(imageWidth),
+                    height: String(imageHeight),
+                    transform: `translate(${transform[0]}px, ${transform[1]}px) scale(${transform[2]})`,
+                },
+            });
             downloadImage(dataUrl, cleanEntityName);
-        });
+        } finally {
+            setForceMountAll(false);
+            setIsCapturing(false);
+        }
     };
 
     return (
         <StyledPanelButton
             type="text"
+            disabled={isCapturing}
             onClick={() => {
-                getPreviewImage();
+                getPreviewImage().catch(() => {
+                    message.error('Failed to capture lineage screenshot.');
+                });
             }}
         >
             <CameraOutlined />

--- a/datahub-web-react/src/appConfigContext.tsx
+++ b/datahub-web-react/src/appConfigContext.tsx
@@ -92,6 +92,8 @@ export const DEFAULT_APP_CONFIG = {
         showHomePageRedesign: false,
         showProductUpdates: false,
         lineageGraphV3: false,
+        lineageGraphPerfVirtEnabled: true,
+        lineageGraphPerfOverscanEnabled: false,
         logicalModelsEnabled: false,
         showHomepageUserRole: false,
         assetSummaryPageV1: false,

--- a/datahub-web-react/src/graphql/app.graphql
+++ b/datahub-web-react/src/graphql/app.graphql
@@ -114,6 +114,8 @@ query appConfig {
             showDefaultExternalLinks
             showProductUpdates
             lineageGraphV3
+            lineageGraphPerfVirtEnabled
+            lineageGraphPerfOverscanEnabled
             logicalModelsEnabled
             showHomepageUserRole
             assetSummaryPageV1

--- a/e2e-test/ui/playwright/README.md
+++ b/e2e-test/ui/playwright/README.md
@@ -334,3 +334,54 @@ deletion of all entities of a type.
 - JUnit report written to `test-results/junit.xml`.
 - Screenshots and traces captured on failure.
 - Single worker (`workers: 1`) in CI for stable ordering.
+
+## Performance Benchmarks
+
+Lineage rendering benchmarks live under `tests/lineage-perf/`. They are opt-in
+(skipped unless `LINEAGE_PERF=1`) and use `playwright.no-webserver.config.ts`
+so they run against an already-running DataHub instance.
+
+### Run
+
+```bash
+# Default scenarios + 100/500-node synthetic stress matrix
+yarn perf
+
+# Pass through to playwright (filter, repeat, etc.)
+yarn perf tests/lineage-perf/lineage-perf.spec.ts -g "synthetic"
+
+# N-sample variance sweep — each (scenario, variant) replays N times
+LINEAGE_PERF_REPEAT=5 yarn perf
+```
+
+Useful env vars (see `tests/lineage-perf/lineage-perf.spec.ts` for the full
+list):
+
+| Var                             | Effect                                                                                    |
+| ------------------------------- | ----------------------------------------------------------------------------------------- |
+| `LINEAGE_PERF=1`                | Required to opt into the suite. The `yarn perf` script sets this for you.                 |
+| `LINEAGE_PERF_REPEAT=N`         | Replay each (scenario, variant) N times; rows tagged with `iteration` for variance bands. |
+| `LINEAGE_PERF_SYNTHETIC_SCALES` | Comma-separated total-node sizes for the synthetic stress matrix (default `100,500`).     |
+| `LINEAGE_PERF_CLL_MATRIX`       | Column-level lineage matrix tokens like `100x50` (datasets × columns); off by default.    |
+| `LINEAGE_PERF_MIXED_MATRIX`     | Mixed-entity matrix like `label:ds=20,dj=10,df=5,ch=10,db=5`; off by default.             |
+
+Each run appends rows to `test-results/lineage-perf.json` keyed by
+`(scenario, variant, iteration)`. With repeat enabled, aggregate them into
+p50 / p95 / max bands:
+
+```bash
+yarn perf:aggregate                       # ASCII table on stdout
+yarn perf:aggregate:json                  # machine-readable JSON
+yarn perf:aggregate --scenario synthetic  # filter to one scenario substring
+yarn perf:aggregate --variant overscan    # filter to one variant substring
+```
+
+Bands cover `wallMs`, `longTaskTotalMs`, `longTaskMaxMs`, `requestsDuring`,
+`graphqlRequestsDuring`, and `requestBytesDuring`, plus `timedOut` counts.
+
+Adjacent specs in the same directory:
+
+- `lineage-screenshot-stress.spec.ts` — stress test for the screenshot export
+  path under virtualization (emits a `.tsv` artifact alongside the JSON).
+- `lineage-a11y-audit.spec.ts` — axe-core accessibility audit on small and
+  large lineage graphs.

--- a/e2e-test/ui/playwright/helpers/lineage-perf-helper.ts
+++ b/e2e-test/ui/playwright/helpers/lineage-perf-helper.ts
@@ -1,0 +1,230 @@
+/**
+ * LineagePerfRecorder — `measure(label, fn)` around UI interactions.
+ *
+ * Records wall time, long-task delta (only tasks fired during the action),
+ * and optional FPS sample (`measureWithFps` for pan/zoom). Output written
+ * to `e2e-test/ui/playwright/test-results/lineage-perf.json`.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import path from 'path';
+import type { Page } from '@playwright/test';
+
+import {
+  collectRaw,
+  installInPage,
+  startFpsSample,
+  stopFpsSample,
+  summarise,
+  type FpsSample,
+  type LongTaskEntry,
+  type PerfSummary,
+} from '../utils/lineage-perf-collector';
+
+export interface MeasuredAction {
+  label: string;
+  wallMs: number;
+  longTasksDuring: LongTaskEntry[];
+  longTaskTotalMs: number;
+  longTaskMaxMs: number;
+  fpsDuringAction?: FpsSample;
+  /** True when a `timeoutMs` cap was hit; `wallMs` reflects the cap, not completion. */
+  timedOut?: boolean;
+  /** Total resource entries (fetch/xhr/script/css/img/...) that fired
+   *  during the action. */
+  requestsDuring: number;
+  /** Subset of `requestsDuring` that hit `/api/v2/graphql` — useful for
+   *  spotting variants that quietly fan out more GMS calls. */
+  graphqlRequestsDuring: number;
+  /** Sum of `encodedBodySize` across requests fired during the action. */
+  requestBytesDuring: number;
+}
+
+export interface ScenarioRecording {
+  scenario: string;
+  /** Flag combination active during the recording. Consumers slice by `(scenario, variant)`. */
+  variant: string;
+  /**
+   * 1-indexed run number when `LINEAGE_PERF_REPEAT > 1`. Aggregators key
+   * (scenario, variant, action) → samples by `iteration` to compute
+   * percentile bands; absent / `1` for single-shot runs.
+   */
+  iteration?: number;
+  url: string;
+  actions: MeasuredAction[];
+  summary: PerfSummary;
+}
+
+export class LineagePerfRecorder {
+  private readonly page: Page;
+  private readonly actions: MeasuredAction[] = [];
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  /** Must run BEFORE any navigation so PerformanceObserver catches the first frame. */
+  async install(): Promise<void> {
+    await installInPage(this.page);
+  }
+
+  /**
+   * Bake any settle wait into `fn` itself — long tasks fired after `fn`
+   * resolves are not attributed. Pass `timeoutMs` to cap with `Promise.race`;
+   * a timed-out action records `timedOut: true` and `wallMs = cap`.
+   */
+  async measure<T>(
+    label: string,
+    fn: () => Promise<T>,
+    { timeoutMs }: { timeoutMs?: number } = {},
+  ): Promise<MeasuredAction> {
+    const longTasksBefore = await this.longTaskCount();
+    const resourcesBefore = await this.resourceCount();
+    const start = Date.now();
+    const timedOut = await this.runWithTimeout(fn, timeoutMs);
+    const wallMs = Date.now() - start;
+    const tasks = await this.longTasksSince(longTasksBefore);
+    const resourceDelta = await this.resourcesSince(resourcesBefore);
+    const action: MeasuredAction = {
+      label,
+      wallMs,
+      longTasksDuring: tasks,
+      longTaskTotalMs: tasks.reduce((s, t) => s + t.duration, 0),
+      longTaskMaxMs: tasks.reduce((m, t) => Math.max(m, t.duration), 0),
+      requestsDuring: resourceDelta.total,
+      graphqlRequestsDuring: resourceDelta.graphql,
+      requestBytesDuring: resourceDelta.bytes,
+      ...(timedOut ? { timedOut: true } : {}),
+    };
+    this.actions.push(action);
+    return action;
+  }
+
+  /** Like {@link measure}, plus an FPS sample. Use for sustained animation. */
+  async measureWithFps<T>(
+    label: string,
+    fn: () => Promise<T>,
+    { timeoutMs }: { timeoutMs?: number } = {},
+  ): Promise<MeasuredAction> {
+    const longTasksBefore = await this.longTaskCount();
+    const resourcesBefore = await this.resourceCount();
+    await startFpsSample(this.page);
+    const start = Date.now();
+    const timedOut = await this.runWithTimeout(fn, timeoutMs);
+    const wallMs = Date.now() - start;
+    const fps = await stopFpsSample(this.page);
+    const tasks = await this.longTasksSince(longTasksBefore);
+    const resourceDelta = await this.resourcesSince(resourcesBefore);
+    const action: MeasuredAction = {
+      label,
+      wallMs,
+      longTasksDuring: tasks,
+      longTaskTotalMs: tasks.reduce((s, t) => s + t.duration, 0),
+      longTaskMaxMs: tasks.reduce((m, t) => Math.max(m, t.duration), 0),
+      fpsDuringAction: fps ?? undefined,
+      requestsDuring: resourceDelta.total,
+      graphqlRequestsDuring: resourceDelta.graphql,
+      requestBytesDuring: resourceDelta.bytes,
+      ...(timedOut ? { timedOut: true } : {}),
+    };
+    this.actions.push(action);
+    return action;
+  }
+
+  private async runWithTimeout<T>(fn: () => Promise<T>, timeoutMs?: number): Promise<boolean> {
+    if (!timeoutMs) {
+      try {
+        await fn();
+        return false;
+      } catch {
+        // Swallow — long-task / wall data is still useful even if the gesture failed.
+        return false;
+      }
+    }
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const timeoutPromise = new Promise<'timeout'>((resolve) => {
+      timer = setTimeout(() => resolve('timeout'), timeoutMs);
+    });
+    try {
+      const result = await Promise.race<'timeout' | T>([fn(), timeoutPromise]);
+      return result === 'timeout';
+    } catch {
+      return false;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  /** Snapshot the final per-page summary (node/edge count, paint, CLS, …). */
+  async summarise(): Promise<PerfSummary> {
+    return summarise(this.page);
+  }
+
+  /** All measured actions in capture order. */
+  recordedActions(): MeasuredAction[] {
+    return this.actions.slice();
+  }
+
+  private async longTaskCount(): Promise<number> {
+    const raw = await collectRaw(this.page);
+    return raw.longTasks.length;
+  }
+
+  private async longTasksSince(previousCount: number): Promise<LongTaskEntry[]> {
+    const raw = await collectRaw(this.page);
+    return raw.longTasks.slice(previousCount);
+  }
+
+  private async resourceCount(): Promise<number> {
+    const raw = await collectRaw(this.page);
+    return raw.resources.length;
+  }
+
+  private async resourcesSince(previousCount: number): Promise<{ total: number; graphql: number; bytes: number }> {
+    const raw = await collectRaw(this.page);
+    const slice = raw.resources.slice(previousCount);
+    return {
+      total: slice.length,
+      graphql: slice.reduce((s, r) => s + (r.isGraphql ? 1 : 0), 0),
+      bytes: slice.reduce((s, r) => s + r.encodedBodySize, 0),
+    };
+  }
+}
+
+/**
+ * Append a recording to the perf results file. Reads + rewrites the whole
+ * array each call (inefficient, but Playwright worker respawns wipe module
+ * state so we can't accumulate in memory). Call {@link resetRecordingFile}
+ * once per worker boot to clear stale results.
+ */
+export function emitRecording(recording: ScenarioRecording, outFile = 'lineage-perf.json'): void {
+  const outDir = path.resolve(__dirname, '../test-results');
+  try {
+    mkdirSync(outDir, { recursive: true });
+  } catch {
+    // Best-effort.
+  }
+  const out = path.join(outDir, outFile);
+  let existing: ScenarioRecording[] = [];
+  if (existsSync(out)) {
+    try {
+      const raw = readFileSync(out, 'utf8');
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) existing = parsed as ScenarioRecording[];
+    } catch {
+      // Treat unreadable file as empty.
+    }
+  }
+  existing.push(recording);
+  writeFileSync(out, JSON.stringify(existing, null, 2));
+}
+
+export function resetRecordingFile(outFile = 'lineage-perf.json'): void {
+  const outDir = path.resolve(__dirname, '../test-results');
+  try {
+    mkdirSync(outDir, { recursive: true });
+  } catch {
+    // Best-effort.
+  }
+  writeFileSync(path.join(outDir, outFile), '[]');
+}

--- a/e2e-test/ui/playwright/helpers/seeders/lineage-perf-seeder.ts
+++ b/e2e-test/ui/playwright/helpers/seeders/lineage-perf-seeder.ts
@@ -1,0 +1,645 @@
+/**
+ * Synthetic lineage seeders for the perf benchmark.
+ *
+ * - {@link seedSyntheticLineage}: dataset-only fanout (root + N up + M down)
+ *   with optional `schemaMetadata` + per-column `fineGrainedLineages` when
+ *   `columnCount > 0`. Drives the dataset and CLL stress matrices.
+ * - {@link seedMixedFanoutLineage}: heterogeneous entities (Dataset, DataJob,
+ *   DataFlow, Chart, Dashboard) so virt is measured against every edge shape
+ *   the renderer supports.
+ *
+ * Both are idempotent on URN (UPSERT via `/aspects?action=ingestProposal`)
+ * and each `scale` gets its own URN namespace, so corpora can coexist.
+ * URNs use the dedicated `perfTest` / `airflow` / `looker` platforms for
+ * easy identification.
+ */
+
+import type { APIRequestContext } from '@playwright/test';
+
+import { gmsUrl } from '../../utils/constants';
+import type { DataHubLogger } from '../../utils/logger';
+
+export interface SyntheticLineageOptions {
+  /** Short token embedded in every URN — lets multiple corpora coexist. */
+  scale: string;
+  upstreamCount: number;
+  downstreamCount: number;
+  /**
+   * Columns per dataset. Every dataset gets a `schemaMetadata` aspect with
+   * `col_001 … col_NNN`, and each `upstreamLineage` gets matching
+   * `fineGrainedLineages` (same-named column on each upstream).
+   *
+   * Defaults to {@link DEFAULT_SYNTHETIC_COLUMN_COUNT} so the rendered graph
+   * actually carries column rows + column edges — without schemas the
+   * perf measurement misses the entire CLL render path. Pass `0` to
+   * explicitly opt out (dataset-edge cost in isolation).
+   */
+  columnCount?: number;
+  /** Defaults to `perfTest`. */
+  platform?: string;
+}
+
+/**
+ * Modest column count that exercises the column-row + column-edge render
+ * machinery without ballooning seed time. The dedicated
+ * `LINEAGE_PERF_CLL_MATRIX` covers higher-cardinality stress.
+ */
+export const DEFAULT_SYNTHETIC_COLUMN_COUNT = 10;
+
+export interface SyntheticLineageHandles {
+  rootUrn: string;
+  upstreamUrns: string[];
+  downstreamUrns: string[];
+  /** Column names actually seeded (empty if `columnCount` was 0). */
+  columnNames: string[];
+}
+
+const DEFAULT_PLATFORM = 'perfTest';
+const DEFAULT_FLOW_PLATFORM = 'airflow';
+const DEFAULT_BI_PLATFORM = 'looker';
+const ACTOR = 'urn:li:corpuser:datahub';
+
+function datasetUrn(platform: string, name: string): string {
+  return `urn:li:dataset:(urn:li:dataPlatform:${platform},${name},PROD)`;
+}
+
+function dataFlowUrn(orchestrator: string, flowId: string): string {
+  return `urn:li:dataFlow:(${orchestrator},${flowId},PROD)`;
+}
+
+function dataJobUrn(orchestrator: string, flowId: string, taskId: string): string {
+  return `urn:li:dataJob:(${dataFlowUrn(orchestrator, flowId)},${taskId})`;
+}
+
+function chartUrn(platform: string, id: string): string {
+  return `urn:li:chart:(${platform},${id})`;
+}
+
+function dashboardUrn(platform: string, id: string): string {
+  return `urn:li:dashboard:(${platform},${id})`;
+}
+
+function pad(n: number, width = 4): string {
+  return n.toString().padStart(width, '0');
+}
+
+async function ingestProposal(
+  request: APIRequestContext,
+  gmsToken: string,
+  entityType: string,
+  entityUrn: string,
+  aspectName: string,
+  aspectValue: unknown,
+  logger?: DataHubLogger,
+): Promise<void> {
+  const url = `${gmsUrl()}/aspects?action=ingestProposal`;
+  const payload = {
+    proposal: {
+      entityType,
+      entityUrn,
+      changeType: 'UPSERT',
+      aspectName,
+      aspect: {
+        contentType: 'application/json',
+        value: JSON.stringify(aspectValue),
+      },
+    },
+  };
+  const response = await request.post(url, {
+    data: payload,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${gmsToken}`,
+    },
+    failOnStatusCode: false,
+  });
+  if (!response.ok()) {
+    const body = await response.text();
+    logger?.warn('lineage-perf-seeder: ingest failed', {
+      entityUrn,
+      aspectName,
+      status: response.status(),
+      body: body.slice(0, 200),
+    });
+  }
+}
+
+async function seedDatasetStub(
+  request: APIRequestContext,
+  gmsToken: string,
+  urn: string,
+  description: string,
+  logger?: DataHubLogger,
+): Promise<void> {
+  await ingestProposal(request, gmsToken, 'dataset', urn, 'datasetProperties', { description }, logger);
+}
+
+/**
+ * Write a numeric-only `schemaMetadata` aspect with `columnNames` as the
+ * fields list. Uses `OtherSchema` for `platformSchema` to avoid the
+ * Avro-union types (`SqlSchema`, `KafkaSchema`) that the legacy MCP
+ * ingestion endpoint rejects.
+ */
+async function seedSchemaMetadata(
+  request: APIRequestContext,
+  gmsToken: string,
+  datasetUrn: string,
+  platform: string,
+  schemaName: string,
+  columnNames: string[],
+  logger?: DataHubLogger,
+): Promise<void> {
+  if (columnNames.length === 0) return;
+  const now = Date.now();
+  const fields = columnNames.map((name) => ({
+    fieldPath: name,
+    nativeDataType: 'NUMBER',
+    type: {
+      type: { 'com.linkedin.schema.NumberType': {} },
+    },
+  }));
+  await ingestProposal(
+    request,
+    gmsToken,
+    'dataset',
+    datasetUrn,
+    'schemaMetadata',
+    {
+      schemaName,
+      platform: `urn:li:dataPlatform:${platform}`,
+      version: 0,
+      created: { time: now, actor: ACTOR },
+      lastModified: { time: now, actor: ACTOR },
+      hash: '',
+      platformSchema: {
+        'com.linkedin.schema.OtherSchema': { rawSchema: '' },
+      },
+      fields,
+    },
+    logger,
+  );
+}
+
+function schemaFieldUrn(datasetUrn: string, columnName: string): string {
+  return `urn:li:schemaField:(${datasetUrn},${columnName})`;
+}
+
+/** One FGL entry per column, mapping `col` to the same-named column on every upstream. */
+function buildFineGrainedLineages(
+  downstreamUrn: string,
+  upstreamUrns: string[],
+  columnNames: string[],
+): Array<Record<string, unknown>> {
+  return columnNames.map((col) => ({
+    upstreamType: 'FIELD_SET',
+    downstreamType: 'FIELD_SET',
+    upstreams: upstreamUrns.map((u) => schemaFieldUrn(u, col)),
+    downstreams: [schemaFieldUrn(downstreamUrn, col)],
+    confidenceScore: 1.0,
+    transformOperation: 'identity',
+  }));
+}
+
+/**
+ * Write `upstreamLineage` on `entityUrn`. Each entry needs the deprecated
+ * `type` field — GMS rejects entries without it. When `columnNames` is non-
+ * empty, also emits per-column FGLs (worst-case 1:N fan-in shape).
+ */
+async function seedUpstreamLineage(
+  request: APIRequestContext,
+  gmsToken: string,
+  entityUrn: string,
+  upstreamUrns: string[],
+  columnNames: string[],
+  logger?: DataHubLogger,
+): Promise<void> {
+  if (upstreamUrns.length === 0) return;
+  const now = Date.now();
+  const upstreams = upstreamUrns.map((u) => ({
+    dataset: u,
+    type: 'TRANSFORMED',
+    auditStamp: { time: now, actor: ACTOR },
+    created: { time: now, actor: ACTOR },
+    lastModified: { time: now, actor: ACTOR },
+  }));
+  const aspect: Record<string, unknown> = { upstreams };
+  if (columnNames.length > 0) {
+    aspect.fineGrainedLineages = buildFineGrainedLineages(entityUrn, upstreamUrns, columnNames);
+  }
+  await ingestProposal(request, gmsToken, 'dataset', entityUrn, 'upstreamLineage', aspect, logger);
+}
+
+/**
+ * Order: dataset stubs → schemas → lineage. Stub-first guards against future
+ * dangling-edge validation; schema-before-lineage ensures FGL column URNs are
+ * resolvable when the lineage aspect lands.
+ */
+export async function seedSyntheticLineage(
+  request: APIRequestContext,
+  gmsToken: string,
+  opts: SyntheticLineageOptions,
+  logger?: DataHubLogger,
+): Promise<SyntheticLineageHandles> {
+  const platform = opts.platform ?? DEFAULT_PLATFORM;
+  const columnCount = opts.columnCount ?? DEFAULT_SYNTHETIC_COLUMN_COUNT;
+  const columnNames = Array.from({ length: columnCount }, (_, i) => `col_${pad(i + 1, 3)}`);
+  const rootUrn = datasetUrn(platform, `perf_${opts.scale}_root`);
+  const upstreamUrns = Array.from({ length: opts.upstreamCount }, (_, i) =>
+    datasetUrn(platform, `perf_${opts.scale}_up_${pad(i + 1)}`),
+  );
+  const downstreamUrns = Array.from({ length: opts.downstreamCount }, (_, i) =>
+    datasetUrn(platform, `perf_${opts.scale}_down_${pad(i + 1)}`),
+  );
+
+  const startMs = Date.now();
+  logger?.info('lineage-perf-seeder: seeding synthetic corpus', {
+    scale: opts.scale,
+    upstreams: opts.upstreamCount,
+    downstreams: opts.downstreamCount,
+    columns: columnCount,
+  });
+
+  await seedDatasetStub(request, gmsToken, rootUrn, `perf root @ scale ${opts.scale}`, logger);
+  for (const urn of upstreamUrns) {
+    await seedDatasetStub(request, gmsToken, urn, `perf upstream of scale ${opts.scale}`, logger);
+  }
+  for (const urn of downstreamUrns) {
+    await seedDatasetStub(request, gmsToken, urn, `perf downstream of scale ${opts.scale}`, logger);
+  }
+
+  if (columnNames.length > 0) {
+    await seedSchemaMetadata(request, gmsToken, rootUrn, platform, `perf_${opts.scale}_root`, columnNames, logger);
+    for (const urn of upstreamUrns) {
+      const name = urn.split(',')[1];
+      await seedSchemaMetadata(request, gmsToken, urn, platform, name, columnNames, logger);
+    }
+    for (const urn of downstreamUrns) {
+      const name = urn.split(',')[1];
+      await seedSchemaMetadata(request, gmsToken, urn, platform, name, columnNames, logger);
+    }
+  }
+
+  await seedUpstreamLineage(request, gmsToken, rootUrn, upstreamUrns, columnNames, logger);
+  for (const downstreamUrn of downstreamUrns) {
+    await seedUpstreamLineage(request, gmsToken, downstreamUrn, [rootUrn], columnNames, logger);
+  }
+
+  // OpenSearch indexing is async through MAE/MCE; without this poll, the
+  // first run after a fresh seed sees only the root node.
+  const expectedMin = Math.max(1, Math.floor(opts.upstreamCount * 0.5));
+  await waitForLineageIndexed(request, gmsToken, rootUrn, expectedMin, logger);
+
+  logger?.info('lineage-perf-seeder: done', {
+    scale: opts.scale,
+    totalEntities: 1 + opts.upstreamCount + opts.downstreamCount,
+    columns: columnCount,
+    elapsedMs: Date.now() - startMs,
+  });
+
+  return { rootUrn, upstreamUrns, downstreamUrns, columnNames };
+}
+
+/**
+ * Poll `searchAcrossLineage` (the frontend's query) until the root reports at
+ * least `expectedMin` upstreams. Bails after `timeoutMs` and lets the test
+ * run with whatever is indexed.
+ */
+async function waitForLineageIndexed(
+  request: APIRequestContext,
+  gmsToken: string,
+  rootUrn: string,
+  expectedMin: number,
+  logger?: DataHubLogger,
+  { timeoutMs = 60_000, pollMs = 2_000 }: { timeoutMs?: number; pollMs?: number } = {},
+): Promise<void> {
+  // Plain query — only the total count matters for readiness.
+  const query = `query LineagePerfProbe($urn: String!) {
+    searchAcrossLineage(input: { urn: $urn, direction: UPSTREAM, count: 0, query: "*" }) {
+      total
+    }
+  }`;
+  const url = `${gmsUrl()}/api/graphql`;
+  const deadline = Date.now() + timeoutMs;
+  let lastTotal = -1;
+  while (Date.now() < deadline) {
+    const response = await request.post(url, {
+      data: { query, variables: { urn: rootUrn } },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${gmsToken}`,
+        'X-DataHub-Actor': 'urn:li:corpuser:datahub',
+      },
+      failOnStatusCode: false,
+    });
+    if (response.ok()) {
+      const body = (await response.json()) as {
+        data?: { searchAcrossLineage?: { total?: number } };
+      };
+      const total = body.data?.searchAcrossLineage?.total ?? 0;
+      if (total !== lastTotal) {
+        logger?.info('lineage-perf-seeder: waiting for index', { rootUrn, total, expectedMin });
+        lastTotal = total;
+      }
+      if (total >= expectedMin) return;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, pollMs);
+    });
+  }
+  logger?.warn('lineage-perf-seeder: index poll timed out', {
+    rootUrn,
+    lastTotal,
+    expectedMin,
+    timeoutMs,
+  });
+}
+
+// ── Mixed-entity fanout ────────────────────────────────────────────────────
+//
+// Covers every edge shape the V2 renderer draws: Dataset→Dataset,
+// Dataset→DataJob, DataJob→Dataset, Dataset→Chart, Chart→Dashboard.
+//
+//                          ┌───────────────────────┐
+//   upstream datasets ────▶│         root          │──▶ downstream datasets
+//                          │      (Dataset)        │──▶ downstream charts ─▶ dashboards
+//   jobinput datasets ─▶[DataJob]────────▶          │
+//                          └───────────────────────┘
+//
+// Each DataJob owns its own DataFlow + one input dataset so the
+// orchestrator-edge is present and the job isn't dangling.
+
+export interface MixedFanoutOptions {
+  scale: string;
+  /** Datasets attached to root via root.upstreamLineage. */
+  upstreamDatasets: number;
+  /** DataJobs whose outputDatasets includes root (each gets own DataFlow + input dataset). */
+  upstreamDatajobs: number;
+  /** Datasets with root as their upstream. */
+  downstreamDatasets: number;
+  /** Charts whose chartInfo.inputs includes root. */
+  downstreamCharts: number;
+  /** Dashboards containing the first N charts (capped at downstreamCharts). */
+  downstreamDashboards: number;
+  /**
+   * Columns per dataset (root + upstream/jobinput/downstream datasets).
+   * Defaults to {@link DEFAULT_SYNTHETIC_COLUMN_COUNT} so the rendered graph
+   * exercises the column-row + CLL edge render path. Pass `0` to opt out.
+   * Note: DataJobs / Charts / Dashboards don't carry `schemaMetadata`, so
+   * this only affects dataset nodes.
+   */
+  columnCount?: number;
+  platform?: string;
+  flowPlatform?: string;
+  biPlatform?: string;
+}
+
+export interface MixedFanoutHandles {
+  rootUrn: string;
+  upstreamDatasetUrns: string[];
+  upstreamDatajobUrns: string[];
+  upstreamDataflowUrns: string[];
+  upstreamJobInputDatasetUrns: string[];
+  downstreamDatasetUrns: string[];
+  downstreamChartUrns: string[];
+  downstreamDashboardUrns: string[];
+}
+
+async function seedDataFlow(
+  request: APIRequestContext,
+  gmsToken: string,
+  urn: string,
+  name: string,
+  logger?: DataHubLogger,
+): Promise<void> {
+  await ingestProposal(
+    request,
+    gmsToken,
+    'dataFlow',
+    urn,
+    'dataFlowInfo',
+    { name, description: `perf flow ${name}`, project: null },
+    logger,
+  );
+}
+
+async function seedDataJob(
+  request: APIRequestContext,
+  gmsToken: string,
+  jobUrn: string,
+  flowUrn: string,
+  name: string,
+  inputDatasets: string[],
+  outputDatasets: string[],
+  logger?: DataHubLogger,
+): Promise<void> {
+  await ingestProposal(
+    request,
+    gmsToken,
+    'dataJob',
+    jobUrn,
+    'dataJobInfo',
+    { name, description: `perf job ${name}`, type: 'SQL', flowUrn },
+    logger,
+  );
+  await ingestProposal(
+    request,
+    gmsToken,
+    'dataJob',
+    jobUrn,
+    'dataJobInputOutput',
+    { inputDatasets, outputDatasets },
+    logger,
+  );
+}
+
+async function seedChart(
+  request: APIRequestContext,
+  gmsToken: string,
+  urn: string,
+  title: string,
+  inputs: string[],
+  logger?: DataHubLogger,
+): Promise<void> {
+  const now = Date.now();
+  await ingestProposal(
+    request,
+    gmsToken,
+    'chart',
+    urn,
+    'chartInfo',
+    {
+      title,
+      description: `perf chart ${title}`,
+      lastModified: {
+        created: { time: now, actor: ACTOR },
+        lastModified: { time: now, actor: ACTOR },
+      },
+      inputs,
+    },
+    logger,
+  );
+}
+
+async function seedDashboard(
+  request: APIRequestContext,
+  gmsToken: string,
+  urn: string,
+  title: string,
+  chartUrns: string[],
+  logger?: DataHubLogger,
+): Promise<void> {
+  const now = Date.now();
+  await ingestProposal(
+    request,
+    gmsToken,
+    'dashboard',
+    urn,
+    'dashboardInfo',
+    {
+      title,
+      description: `perf dashboard ${title}`,
+      charts: chartUrns,
+      lastModified: {
+        created: { time: now, actor: ACTOR },
+        lastModified: { time: now, actor: ACTOR },
+      },
+    },
+    logger,
+  );
+}
+
+export async function seedMixedFanoutLineage(
+  request: APIRequestContext,
+  gmsToken: string,
+  opts: MixedFanoutOptions,
+  logger?: DataHubLogger,
+): Promise<MixedFanoutHandles> {
+  const platform = opts.platform ?? DEFAULT_PLATFORM;
+  const flowPlatform = opts.flowPlatform ?? DEFAULT_FLOW_PLATFORM;
+  const biPlatform = opts.biPlatform ?? DEFAULT_BI_PLATFORM;
+  const columnCount = opts.columnCount ?? DEFAULT_SYNTHETIC_COLUMN_COUNT;
+  const columnNames = Array.from({ length: columnCount }, (_, i) => `col_${pad(i + 1, 3)}`);
+  const ns = `perf_mx_${opts.scale}`;
+
+  const rootUrn = datasetUrn(platform, `${ns}_root`);
+  const upstreamDatasetUrns = Array.from({ length: opts.upstreamDatasets }, (_, i) =>
+    datasetUrn(platform, `${ns}_up_ds_${pad(i + 1)}`),
+  );
+  const upstreamDataflowUrns = Array.from({ length: opts.upstreamDatajobs }, (_, i) =>
+    dataFlowUrn(flowPlatform, `${ns}_flow_${pad(i + 1)}`),
+  );
+  const upstreamDatajobUrns = Array.from({ length: opts.upstreamDatajobs }, (_, i) =>
+    dataJobUrn(flowPlatform, `${ns}_flow_${pad(i + 1)}`, `task_${pad(i + 1)}`),
+  );
+  const upstreamJobInputDatasetUrns = Array.from({ length: opts.upstreamDatajobs }, (_, i) =>
+    datasetUrn(platform, `${ns}_jobin_${pad(i + 1)}`),
+  );
+  const downstreamDatasetUrns = Array.from({ length: opts.downstreamDatasets }, (_, i) =>
+    datasetUrn(platform, `${ns}_down_ds_${pad(i + 1)}`),
+  );
+  const downstreamChartUrns = Array.from({ length: opts.downstreamCharts }, (_, i) =>
+    chartUrn(biPlatform, `${ns}_chart_${pad(i + 1)}`),
+  );
+  const downstreamDashboardUrns = Array.from({ length: opts.downstreamDashboards }, (_, i) =>
+    dashboardUrn(biPlatform, `${ns}_dash_${pad(i + 1)}`),
+  );
+
+  const totalEntities =
+    1 +
+    upstreamDatasetUrns.length +
+    upstreamDataflowUrns.length +
+    upstreamDatajobUrns.length +
+    upstreamJobInputDatasetUrns.length +
+    downstreamDatasetUrns.length +
+    downstreamChartUrns.length +
+    downstreamDashboardUrns.length;
+
+  const startMs = Date.now();
+  logger?.info('lineage-perf-seeder: seeding mixed fanout', {
+    scale: opts.scale,
+    upstreamDatasets: opts.upstreamDatasets,
+    upstreamDatajobs: opts.upstreamDatajobs,
+    downstreamDatasets: opts.downstreamDatasets,
+    downstreamCharts: opts.downstreamCharts,
+    downstreamDashboards: opts.downstreamDashboards,
+    columns: columnCount,
+    totalEntities,
+  });
+
+  // ── Entity stubs ────────────────────────────────────────────────────────
+  await seedDatasetStub(request, gmsToken, rootUrn, `mx root @ ${opts.scale}`, logger);
+  for (const urn of upstreamDatasetUrns) {
+    await seedDatasetStub(request, gmsToken, urn, `mx upstream dataset @ ${opts.scale}`, logger);
+  }
+  for (const urn of upstreamJobInputDatasetUrns) {
+    await seedDatasetStub(request, gmsToken, urn, `mx job input @ ${opts.scale}`, logger);
+  }
+  for (const urn of downstreamDatasetUrns) {
+    await seedDatasetStub(request, gmsToken, urn, `mx downstream dataset @ ${opts.scale}`, logger);
+  }
+
+  // Schemas — emitted on every dataset so the rendered graph actually
+  // shows column rows + column edges, matching production lineage.
+  if (columnNames.length > 0) {
+    const allDatasetUrns = [rootUrn, ...upstreamDatasetUrns, ...upstreamJobInputDatasetUrns, ...downstreamDatasetUrns];
+    for (const urn of allDatasetUrns) {
+      const name = urn.split(',')[1];
+      await seedSchemaMetadata(request, gmsToken, urn, platform, name, columnNames, logger);
+    }
+  }
+
+  for (let i = 0; i < upstreamDataflowUrns.length; i += 1) {
+    await seedDataFlow(request, gmsToken, upstreamDataflowUrns[i], `mx_flow_${pad(i + 1)}`, logger);
+  }
+
+  for (let i = 0; i < upstreamDatajobUrns.length; i += 1) {
+    await seedDataJob(
+      request,
+      gmsToken,
+      upstreamDatajobUrns[i],
+      upstreamDataflowUrns[i],
+      `mx_task_${pad(i + 1)}`,
+      [upstreamJobInputDatasetUrns[i]],
+      [rootUrn],
+      logger,
+    );
+  }
+
+  await seedUpstreamLineage(request, gmsToken, rootUrn, upstreamDatasetUrns, columnNames, logger);
+  for (const downstreamUrn of downstreamDatasetUrns) {
+    await seedUpstreamLineage(request, gmsToken, downstreamUrn, [rootUrn], columnNames, logger);
+  }
+
+  for (let i = 0; i < downstreamChartUrns.length; i += 1) {
+    await seedChart(request, gmsToken, downstreamChartUrns[i], `mx_chart_${pad(i + 1)}`, [rootUrn], logger);
+  }
+
+  // Each dashboard claims one chart (mod-cycled) so the chart→dashboard
+  // edge is exercised.
+  for (let i = 0; i < downstreamDashboardUrns.length; i += 1) {
+    const chartsForDash = downstreamChartUrns.length ? [downstreamChartUrns[i % downstreamChartUrns.length]] : [];
+    await seedDashboard(request, gmsToken, downstreamDashboardUrns[i], `mx_dash_${pad(i + 1)}`, chartsForDash, logger);
+  }
+
+  // Wait for OpenSearch to index — both dataset and dataJob upstreams
+  // surface under `searchAcrossLineage(UPSTREAM)`.
+  const expectedMin = Math.max(1, Math.floor((opts.upstreamDatasets + opts.upstreamDatajobs) * 0.5));
+  await waitForLineageIndexed(request, gmsToken, rootUrn, expectedMin, logger);
+
+  logger?.info('lineage-perf-seeder: mixed fanout done', {
+    scale: opts.scale,
+    totalEntities,
+    elapsedMs: Date.now() - startMs,
+  });
+
+  return {
+    rootUrn,
+    upstreamDatasetUrns,
+    upstreamDatajobUrns,
+    upstreamDataflowUrns,
+    upstreamJobInputDatasetUrns,
+    downstreamDatasetUrns,
+    downstreamChartUrns,
+    downstreamDashboardUrns,
+  };
+}

--- a/e2e-test/ui/playwright/package.json
+++ b/e2e-test/ui/playwright/package.json
@@ -13,9 +13,13 @@
     "lint": "tsc --noEmit && eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"**/*.ts\"",
-    "format:check": "prettier --check \"**/*.ts\""
+    "format:check": "prettier --check \"**/*.ts\"",
+    "perf": "LINEAGE_PERF=1 playwright test --config=playwright.no-webserver.config.ts tests/lineage-perf",
+    "perf:aggregate": "node scripts/lineage-perf-aggregate.mjs",
+    "perf:aggregate:json": "node scripts/lineage-perf-aggregate.mjs --json"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@playwright/test": "^1.40.0",
     "@types/node": "^20.19.37",
     "eslint": "^10",

--- a/e2e-test/ui/playwright/pages/lineage-perf.page.ts
+++ b/e2e-test/ui/playwright/pages/lineage-perf.page.ts
@@ -1,0 +1,189 @@
+/**
+ * LineagePerfPage — perf-benchmark extensions to {@link LineageV2Page}.
+ *
+ * Adds mouse-driven pan/zoom (exercising the real React Flow event path),
+ * node-body click, fanout expansion, and a stable-count waiter. Selector
+ * conventions mirror the parent page.
+ */
+
+import type { Page, Locator } from '@playwright/test';
+
+import { LineageV2Page } from './lineage-v2.page';
+import type { DataHubLogger } from '../utils/logger';
+
+export class LineagePerfPage extends LineageV2Page {
+  readonly canvas: Locator;
+  readonly viewport: Locator;
+
+  constructor(page: Page, logger?: DataHubLogger, logDir?: string) {
+    super(page, logger, logDir);
+    // Pan against the outer container, not `.react-flow__viewport` (the inner
+    // transform target), so the drag math accounts for the real hit area.
+    this.canvas = page.locator('.react-flow').first();
+    this.viewport = page.locator('.react-flow__viewport').first();
+  }
+
+  /** Drag right-then-left in ~30 px steps so the RF store emits multiple updates. */
+  async panHorizontal(distance = 240): Promise<void> {
+    const box = await this.canvas.boundingBox();
+    if (!box) return;
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    await this.page.mouse.move(cx, cy);
+    await this.page.mouse.down();
+    for (let dx = 0; dx <= distance; dx += 30) {
+      await this.page.mouse.move(cx - dx, cy);
+    }
+    for (let dx = distance; dx >= 0; dx -= 30) {
+      await this.page.mouse.move(cx - dx, cy);
+    }
+    await this.page.mouse.up();
+  }
+
+  /** Discrete wheel-driven zoom. Positive `steps` zooms in, negative out. */
+  async zoom(steps: number): Promise<void> {
+    const box = await this.canvas.boundingBox();
+    if (!box) return;
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    await this.page.mouse.move(cx, cy);
+    for (let i = 0; i < Math.abs(steps); i += 1) {
+      await this.page.mouse.wheel(0, steps > 0 ? -120 : 120);
+      await this.page.waitForTimeout(50);
+    }
+  }
+
+  async zoomIn(steps = 2): Promise<void> {
+    await this.zoom(steps);
+  }
+
+  async zoomOut(steps = 2): Promise<void> {
+    await this.zoom(-steps);
+  }
+
+  async clickNodeBody(urn: string): Promise<void> {
+    await this.getNode(urn).click({ force: true });
+  }
+
+  /** Best-effort: not every sidebar variant exposes this testid. */
+  async closeSidebar(): Promise<void> {
+    const closeButton = this.page.locator('[data-testid="entity-profile-sidebar-close"]').first();
+    if (await closeButton.count()) await closeButton.click();
+  }
+
+  /**
+   * Poll for an unchanged node count over `stableMs`. Necessary because
+   * `useBulkEntityLineage` fetches in batches of 10 — consecutive samples
+   * can briefly agree while the next batch is in-flight.
+   */
+  async waitForStableNodeCount({
+    pollMs = 250,
+    maxMs = 5_000,
+    stableMs = 1_500,
+  }: { pollMs?: number; maxMs?: number; stableMs?: number } = {}): Promise<number> {
+    const deadline = Date.now() + maxMs;
+    let lastCount = -1;
+    let lastChangeAt = Date.now();
+    let count = 0;
+    while (Date.now() < deadline) {
+      count = await this.page.locator('.react-flow__node').count();
+      if (count !== lastCount) {
+        lastCount = count;
+        lastChangeAt = Date.now();
+      } else if (count > 0 && Date.now() - lastChangeAt >= stableMs) {
+        return count;
+      }
+      await this.page.waitForTimeout(pollMs);
+    }
+    return count;
+  }
+
+  async waitForReactFlowNode(urn: string, timeoutMs = 15_000): Promise<void> {
+    await this.getReactFlowNode(urn).waitFor({ state: 'attached', timeout: timeoutMs });
+  }
+
+  /**
+   * Repeatedly click filter-node expand affordances until the graph stops
+   * growing. Prefers larger steps: `show-max` (+100) > `show-all` > `show-more`
+   * (+4). The non-`show-more` buttons live in a hover-revealed menu, so we
+   * hover the wrapper first to make them interactive.
+   *
+   * Virt-awareness: under virt, expand wrappers may be unmounted after
+   * each round's fitView. Before bailing on "no wrappers" we zoom out
+   * incrementally (up to {@link maxZoomOutTicks}). We also can't trust
+   * the DOM count as a "did the graph grow" signal — virt keeps the DOM
+   * count bounded by viewport even when the store grew by 100. Instead
+   * we use "did this round click any wrappers at all" plus a max round
+   * cap. Without this fallback the perf comparison degenerates into
+   * "11-node-virt vs 211-node-baseline" because virt's helper bailout
+   * happens after one round.
+   *
+   * Returns the total click count.
+   */
+  async expandFanoutFully({
+    maxRounds = 20,
+    settleMaxMs = 8_000,
+    settleStableMs = 1_200,
+    maxZoomOutTicks = 20,
+  }: {
+    maxRounds?: number;
+    settleMaxMs?: number;
+    settleStableMs?: number;
+    maxZoomOutTicks?: number;
+  } = {}): Promise<number> {
+    let total = 0;
+    let zoomOutTicksUsed = 0;
+    for (let round = 0; round < maxRounds; round += 1) {
+      const wrappers = this.page.locator('[data-testid="show-max-wrapper"]');
+      let count = await wrappers.count();
+
+      // Wrappers can be filtered out by virt after the previous round's
+      // fitView. Zoom out aggressively to pull them back into viewport.
+      while (count === 0 && zoomOutTicksUsed < maxZoomOutTicks) {
+        await this.zoomOut(2);
+        zoomOutTicksUsed += 2;
+        await this.page.waitForTimeout(250);
+        count = await wrappers.count();
+      }
+      if (count === 0) break;
+
+      let clickedThisRound = 0;
+      for (let i = 0; i < count; i += 1) {
+        const wrapper = wrappers.nth(i);
+        try {
+          await wrapper.hover({ timeout: 800, force: true });
+        } catch {
+          continue;
+        }
+        const showMax = wrapper.locator('[data-testid="show-max"]');
+        const showAll = wrapper.locator('[data-testid="show-all"]');
+        const showMore = wrapper.locator('[data-testid="show-more"]');
+        let target: typeof showMore;
+        if ((await showMax.count()) > 0) {
+          target = showMax.first();
+        } else if ((await showAll.count()) > 0) {
+          target = showAll.first();
+        } else {
+          target = showMore.first();
+        }
+        try {
+          await target.click({ timeout: 1200, force: true });
+          total += 1;
+          clickedThisRound += 1;
+        } catch {
+          // Re-layout can detach the button mid-click; try other wrappers.
+        }
+      }
+      if (clickedThisRound === 0) break;
+
+      // Wait for the show-max batches (size 10) to settle, but don't
+      // gate on `newCount === lastDomCount` — under virt that's always
+      // true regardless of store growth.
+      await this.waitForStableNodeCount({
+        maxMs: settleMaxMs,
+        stableMs: settleStableMs,
+      });
+    }
+    return total;
+  }
+}

--- a/e2e-test/ui/playwright/pages/lineage-v2.page.ts
+++ b/e2e-test/ui/playwright/pages/lineage-v2.page.ts
@@ -453,4 +453,47 @@ export class LineageV2Page extends BasePage {
     await this.lineageTabDirectionSelect.click();
     await this.lineageTabUpstreamOption.last().click();
   }
+
+  // ── Perf / virtualisation flag plumbing ──────────────────────────────────────
+
+  /**
+   * Set the localStorage key `getLineagePerfFlags()` reads on every lineage
+   * mount. MUST be called before the first navigation — `addInitScript` runs
+   * on document load, not on an in-flight navigation. Empty string clears.
+   */
+  async setPerfFlags(flagString: string): Promise<void> {
+    await this.page.addInitScript((value) => {
+      try {
+        window.localStorage.setItem('datahub.lineagePerfFlags', value);
+      } catch {
+        // localStorage can throw in private-browsing / sandboxed contexts;
+        // tests can fall back to the URL `?lineagePerf=` param if needed.
+      }
+    }, flagString);
+  }
+
+  /**
+   * Drag horizontally and release at the end (no return stroke), leaving the
+   * viewport translated. For regression tests that need a node off-screen.
+   *
+   * React Flow camera convention: `'right'` drags the mouse rightward → camera
+   * moves right → LEFT-side content leaves the viewport. Use `'right'` to
+   * push the upstream node off, `'left'` for downstream.
+   */
+  async sustainedPan(direction: 'left' | 'right', distance = 600): Promise<void> {
+    const canvas = this.page.locator('.react-flow').first();
+    const box = await canvas.boundingBox();
+    if (!box) return;
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    const sign = direction === 'right' ? 1 : -1;
+    await this.page.mouse.move(cx, cy);
+    await this.page.mouse.down();
+    // Step incrementally so the React Flow store emits multiple
+    // viewport-transform updates rather than one jump.
+    for (let dx = 0; dx <= distance; dx += 30) {
+      await this.page.mouse.move(cx + sign * dx, cy);
+    }
+    await this.page.mouse.up();
+  }
 }

--- a/e2e-test/ui/playwright/scripts/lineage-perf-aggregate.mjs
+++ b/e2e-test/ui/playwright/scripts/lineage-perf-aggregate.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+/**
+ * Aggregate `lineage-perf.json` samples produced by the lineage perf
+ * benchmark into variance bands per (scenario, variant, action).
+ *
+ * The perf spec writes one row per (scenario, variant, iteration). With
+ * `LINEAGE_PERF_REPEAT=N` you get N rows per (scenario, variant); this
+ * script groups them and reports {n, min, p50, p95, max, mean, stddev}
+ * for each measured action's `wallMs` and `longTaskTotalMs`.
+ *
+ * Usage:
+ *   node scripts/lineage-perf-aggregate.mjs            # reads test-results/lineage-perf.json
+ *   node scripts/lineage-perf-aggregate.mjs --json     # emit JSON instead of a table
+ *   node scripts/lineage-perf-aggregate.mjs --in path  # custom input
+ *
+ * Bands use linear interpolation (numpy / Excel default). With N=5
+ * samples p95 is effectively max — that is intentional; the band still
+ * exposes outliers even when the cohort is small.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const out = { json: false, input: null, scenario: null, variant: null };
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--json') out.json = true;
+    else if (a === '--in') {
+      out.input = args[i + 1];
+      i += 1;
+    } else if (a === '--scenario') {
+      out.scenario = args[i + 1];
+      i += 1;
+    } else if (a === '--variant') {
+      out.variant = args[i + 1];
+      i += 1;
+    } else if (a === '--help' || a === '-h') {
+      process.stdout.write(
+        [
+          'Usage: lineage-perf-aggregate.mjs [--in path] [--json] [--scenario s] [--variant v]',
+          '',
+          '  --in <path>        path to lineage-perf.json (default: ../test-results/lineage-perf.json)',
+          '  --json             emit JSON instead of an ASCII table',
+          '  --scenario <name>  filter to a single scenario (substring match)',
+          '  --variant <name>   filter to a single variant (substring match)',
+        ].join('\n') + '\n',
+      );
+      process.exit(0);
+    }
+  }
+  return out;
+}
+
+function defaultInputPath() {
+  return path.resolve(__dirname, '..', 'test-results', 'lineage-perf.json');
+}
+
+function percentile(sortedAsc, p) {
+  if (sortedAsc.length === 0) return NaN;
+  if (sortedAsc.length === 1) return sortedAsc[0];
+  const rank = (p / 100) * (sortedAsc.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sortedAsc[lo];
+  const frac = rank - lo;
+  return sortedAsc[lo] + (sortedAsc[hi] - sortedAsc[lo]) * frac;
+}
+
+function stats(values) {
+  if (values.length === 0) {
+    return { n: 0, min: NaN, p50: NaN, p95: NaN, max: NaN, mean: NaN, stddev: NaN };
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+  const mean = sorted.reduce((s, v) => s + v, 0) / n;
+  const variance = n > 1 ? sorted.reduce((s, v) => s + (v - mean) ** 2, 0) / (n - 1) : 0;
+  return {
+    n,
+    min: sorted[0],
+    p50: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    max: sorted[n - 1],
+    mean,
+    stddev: Math.sqrt(variance),
+  };
+}
+
+function fmt(value) {
+  if (!Number.isFinite(value)) return '–';
+  if (value === 0) return '0';
+  if (value < 10) return value.toFixed(2);
+  if (value < 100) return value.toFixed(1);
+  return value.toFixed(0);
+}
+
+function aggregate(recordings, filter) {
+  // Group: scenario → variant → action.label → metric → samples[]
+  const groups = new Map();
+  for (const rec of recordings) {
+    if (filter.scenario && !rec.scenario.includes(filter.scenario)) continue;
+    if (filter.variant && !rec.variant.includes(filter.variant)) continue;
+    for (const action of rec.actions ?? []) {
+      const key = `${rec.scenario}\t${rec.variant}\t${action.label}`;
+      let entry = groups.get(key);
+      if (!entry) {
+        entry = {
+          scenario: rec.scenario,
+          variant: rec.variant,
+          action: action.label,
+          wallMs: [],
+          longTaskTotalMs: [],
+          longTaskMaxMs: [],
+          requestsDuring: [],
+          graphqlRequestsDuring: [],
+          requestBytesDuring: [],
+          timedOutCount: 0,
+        };
+        groups.set(key, entry);
+      }
+      if (typeof action.wallMs === 'number') entry.wallMs.push(action.wallMs);
+      if (typeof action.longTaskTotalMs === 'number') {
+        entry.longTaskTotalMs.push(action.longTaskTotalMs);
+      }
+      if (typeof action.longTaskMaxMs === 'number') {
+        entry.longTaskMaxMs.push(action.longTaskMaxMs);
+      }
+      if (typeof action.requestsDuring === 'number') {
+        entry.requestsDuring.push(action.requestsDuring);
+      }
+      if (typeof action.graphqlRequestsDuring === 'number') {
+        entry.graphqlRequestsDuring.push(action.graphqlRequestsDuring);
+      }
+      if (typeof action.requestBytesDuring === 'number') {
+        entry.requestBytesDuring.push(action.requestBytesDuring);
+      }
+      if (action.timedOut) entry.timedOutCount += 1;
+    }
+  }
+
+  const rows = [];
+  for (const entry of groups.values()) {
+    rows.push({
+      scenario: entry.scenario,
+      variant: entry.variant,
+      action: entry.action,
+      wallMs: stats(entry.wallMs),
+      longTaskTotalMs: stats(entry.longTaskTotalMs),
+      longTaskMaxMs: stats(entry.longTaskMaxMs),
+      requestsDuring: stats(entry.requestsDuring),
+      graphqlRequestsDuring: stats(entry.graphqlRequestsDuring),
+      requestBytesDuring: stats(entry.requestBytesDuring),
+      timedOutCount: entry.timedOutCount,
+    });
+  }
+  rows.sort((a, b) => {
+    if (a.scenario !== b.scenario) return a.scenario.localeCompare(b.scenario);
+    if (a.variant !== b.variant) return a.variant.localeCompare(b.variant);
+    return a.action.localeCompare(b.action);
+  });
+  return rows;
+}
+
+function renderTable(rows) {
+  if (rows.length === 0) {
+    return '(no rows — check input file / filters)';
+  }
+  const lines = [];
+  let currentScenario = null;
+  for (const row of rows) {
+    if (row.scenario !== currentScenario) {
+      lines.push('');
+      lines.push(`=== ${row.scenario} ===`);
+      lines.push(
+        [
+          'variant',
+          'action',
+          'n',
+          'wall_p50',
+          'wall_p95',
+          'wall_max',
+          'longTask_total_p50',
+          'longTask_max_p95',
+          'req_p50',
+          'gql_p50',
+          'kb_p50',
+          'timedOut',
+        ]
+          .map((s) => s.padEnd(20))
+          .join(''),
+      );
+      currentScenario = row.scenario;
+    }
+    const kbP50 =
+      Number.isFinite(row.requestBytesDuring.p50) && row.requestBytesDuring.p50 > 0
+        ? row.requestBytesDuring.p50 / 1024
+        : 0;
+    lines.push(
+      [
+        row.variant,
+        row.action,
+        String(row.wallMs.n),
+        fmt(row.wallMs.p50),
+        fmt(row.wallMs.p95),
+        fmt(row.wallMs.max),
+        fmt(row.longTaskTotalMs.p50),
+        fmt(row.longTaskMaxMs.p95),
+        fmt(row.requestsDuring.p50),
+        fmt(row.graphqlRequestsDuring.p50),
+        fmt(kbP50),
+        row.timedOutCount > 0 ? String(row.timedOutCount) : '',
+      ]
+        .map((s) => String(s).padEnd(20))
+        .join(''),
+    );
+  }
+  return lines.join('\n');
+}
+
+function main() {
+  const args = parseArgs();
+  const inputPath = args.input ?? defaultInputPath();
+  if (!existsSync(inputPath)) {
+    process.stderr.write(`No such file: ${inputPath}\n`);
+    process.exit(1);
+  }
+  const raw = readFileSync(inputPath, 'utf8');
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    process.stderr.write(`Failed to parse ${inputPath}: ${err.message}\n`);
+    process.exit(1);
+  }
+  if (!Array.isArray(parsed)) {
+    process.stderr.write(`Expected ${inputPath} to be a JSON array.\n`);
+    process.exit(1);
+  }
+
+  const rows = aggregate(parsed, args);
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`${renderTable(rows)}\n`);
+}
+
+main();

--- a/e2e-test/ui/playwright/tests/lineage-perf/lineage-a11y-audit.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-perf/lineage-a11y-audit.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * Accessibility audit for lineage V2 under virtualisation.
+ *
+ * Virt unmounts off-screen nodes, which means assistive tech can't
+ * navigate to them via the standard tab order or screen-reader DOM
+ * walk. This spec runs axe-core in a few states to surface:
+ *   - WCAG / best-practice violations on the visible portion of the
+ *     graph (independent of virt — these are pre-existing if any).
+ *   - Whether enabling `virt` introduces any *new* a11y violations
+ *     against the current rules (e.g. orphaned labels, missing
+ *     `aria-hidden` on tentative edges, etc.).
+ *
+ * Surfaces violations as test failures only when `LINEAGE_A11Y_FAIL=1`
+ * is set; otherwise we log them as test attachments so this can
+ * baseline the audit without blocking CI.
+ *
+ * Opt-in via `LINEAGE_A11Y=1`. The spec uses the existing small-graph
+ * fixture so it runs in a few seconds.
+ */
+
+import AxeBuilder from '@axe-core/playwright';
+import { expect, request as playwrightRequest } from '@playwright/test';
+
+import { test } from '../../fixtures/base-test';
+import { readGmsToken } from '../../fixtures/login';
+import { seedSyntheticLineage } from '../../helpers/seeders/lineage-perf-seeder';
+import { LineagePerfPage } from '../../pages/lineage-perf.page';
+import { users } from '../../data/users';
+import { gmsUrl } from '../../utils/constants';
+
+const RUN = process.env.LINEAGE_A11Y === '1';
+const FAIL_ON_VIOLATIONS = process.env.LINEAGE_A11Y_FAIL === '1';
+// Opt in to the large-graph scan separately because it requires the
+// synthetic 100 fixture (~30 s seed on a cold DB).
+const RUN_LARGE = process.env.LINEAGE_A11Y_LARGE === '1';
+
+const SMALL_GRAPH_URN = 'urn:li:dataset:(urn:li:dataPlatform:kafka,SamplePlaywrightKafkaDataset,PROD)';
+const LARGE_GRAPH_SCALE = 100;
+
+interface VariantSpec {
+  name: string;
+  flagString: string;
+}
+const BASELINE_FLAGS = 'virt-off overscan-off';
+const VARIANTS: VariantSpec[] = [
+  { name: 'baseline', flagString: BASELINE_FLAGS },
+  { name: 'virt', flagString: 'virt' },
+];
+
+interface ViolationSummary {
+  id: string;
+  impact: string | null | undefined;
+  help: string;
+  nodes: number;
+  sampleHtml: string;
+}
+
+function summarise(results: Awaited<ReturnType<AxeBuilder['analyze']>>): ViolationSummary[] {
+  return results.violations.map((v) => ({
+    id: v.id,
+    impact: v.impact,
+    help: v.help,
+    nodes: v.nodes.length,
+    sampleHtml: v.nodes[0]?.html?.slice(0, 200) ?? '',
+  }));
+}
+
+async function runAxeAndReport(
+  page: import('@playwright/test').Page,
+  label: string,
+  testInfo: import('@playwright/test').TestInfo,
+): Promise<void> {
+  // Skip the page chrome (header, nav, etc.) — the goal is lineage-
+  // specific issues. Restrict to WCAG A/AA to keep first-pass output
+  // actionable; best-practice rules are opinionated and noisier.
+  const results = await new AxeBuilder({ page })
+    .include('.react-flow')
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .analyze();
+  const summary = summarise(results);
+  const summaryJson = JSON.stringify(
+    { label, totalViolations: results.violations.length, violations: summary },
+    null,
+    2,
+  );
+  await testInfo.attach(`a11y-${label}.json`, {
+    body: summaryJson,
+    contentType: 'application/json',
+  });
+
+  if (FAIL_ON_VIOLATIONS) {
+    expect(results.violations, JSON.stringify(summary, null, 2)).toEqual([]);
+  }
+}
+
+test.describe('lineage a11y audit', () => {
+  test.skip(!RUN, 'Set LINEAGE_A11Y=1 to run.');
+
+  for (const variant of VARIANTS) {
+    test(`small graph axe-core scan [${variant.name}]`, async ({ page, logger, logDir }, testInfo) => {
+      test.setTimeout(60_000);
+      const lp = new LineagePerfPage(page, logger, logDir);
+      await lp.setPerfFlags(variant.flagString);
+      await lp.goToLineageGraph('dataset', SMALL_GRAPH_URN);
+      await lp.waitForReactFlowNode(SMALL_GRAPH_URN);
+      await lp.waitForStableNodeCount({ maxMs: 10_000 });
+
+      await runAxeAndReport(page, `small-${variant.name}`, testInfo);
+    });
+  }
+
+  // Large-graph scan: the only place where virt actually unmounts nodes
+  // (small graph fits in viewport). Compares whether virt regresses on
+  // any axe rule once off-screen nodes leave the DOM.
+  test.describe('large graph axe-core scan', () => {
+    test.skip(!RUN_LARGE, 'Set LINEAGE_A11Y_LARGE=1 to run the synthetic large-graph audit.');
+
+    let rootUrn: string | null = null;
+
+    test.beforeAll(async () => {
+      if (!RUN || !RUN_LARGE) return;
+      test.setTimeout(30 * 60_000);
+      const apiContext = await playwrightRequest.newContext({ baseURL: gmsUrl() });
+      try {
+        const gmsToken = readGmsToken(users.admin.username);
+        const handles = await seedSyntheticLineage(apiContext, gmsToken, {
+          scale: String(LARGE_GRAPH_SCALE),
+          upstreamCount: LARGE_GRAPH_SCALE / 2,
+          downstreamCount: LARGE_GRAPH_SCALE / 2,
+        });
+        rootUrn = handles.rootUrn;
+      } finally {
+        await apiContext.dispose();
+      }
+    });
+
+    for (const variant of VARIANTS) {
+      test(`large graph axe-core scan [${variant.name}]`, async ({ page, logger, logDir }, testInfo) => {
+        test.setTimeout(90_000);
+        if (!rootUrn) throw new Error('Large-graph seed missing.');
+        const lp = new LineagePerfPage(page, logger, logDir);
+        await lp.setPerfFlags(variant.flagString);
+        await lp.goToLineageGraph('dataset', rootUrn);
+        await lp.waitForReactFlowNode(rootUrn);
+        await lp.waitForStableNodeCount({ maxMs: 15_000 });
+        await lp.zoomOut(2);
+        await lp.expandFanoutFully();
+        await lp.waitForStableNodeCount({ maxMs: 30_000 });
+
+        await runAxeAndReport(page, `large-${variant.name}`, testInfo);
+      });
+    }
+  });
+});

--- a/e2e-test/ui/playwright/tests/lineage-perf/lineage-perf.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-perf/lineage-perf.spec.ts
@@ -1,0 +1,683 @@
+/**
+ * Lineage rendering perf — user-journey benchmark across feature-flag variants.
+ *
+ * Three journeys (small graph, chain + column lineage, filtering hub) run once
+ * per variant of the lineage perf flags. Each action records wall time, long
+ * tasks, and pan/zoom FPS. Synthetic stress, CLL, and mixed-entity matrices
+ * are opt-in via env vars.
+ *
+ * Opt-in: `LINEAGE_PERF=1`. Output: `test-results/lineage-perf.json` keyed by
+ * `(scenario, variant)`.
+ *
+ *     LINEAGE_PERF=1 yarn playwright test \
+ *         --config=playwright.no-webserver.config.ts tests/lineage-perf
+ */
+
+import { request as playwrightRequest } from '@playwright/test';
+
+import { test } from '../../fixtures/base-test';
+import { readGmsToken } from '../../fixtures/login';
+import { LineagePerfRecorder, emitRecording, resetRecordingFile } from '../../helpers/lineage-perf-helper';
+import {
+  type MixedFanoutHandles,
+  type SyntheticLineageHandles,
+  seedMixedFanoutLineage,
+  seedSyntheticLineage,
+} from '../../helpers/seeders/lineage-perf-seeder';
+import { LineagePerfPage } from '../../pages/lineage-perf.page';
+import { users } from '../../data/users';
+import { gmsUrl } from '../../utils/constants';
+
+const RUN = process.env.LINEAGE_PERF === '1';
+
+// Number of times to replay each (scenario, variant) pair. Each iteration
+// emits its own row in `lineage-perf.json` tagged with `iteration`; use the
+// aggregator (`scripts/lineage-perf-aggregate.mjs`) to compute p50/p95 bands.
+const REPEAT = (() => {
+  const raw = parseInt(process.env.LINEAGE_PERF_REPEAT ?? '1', 10);
+  if (!Number.isFinite(raw) || raw < 1) return 1;
+  return raw;
+})();
+
+function iterSuffix(iter: number): string {
+  return REPEAT > 1 ? ` [iter ${iter}/${REPEAT}]` : '';
+}
+
+// Comma-separated total-node sizes for the synthetic stress matrix. Each size
+// produces a `size/2 + size/2` upstream/downstream fanout under `perfTest`.
+const SYNTHETIC_SIZES = (process.env.LINEAGE_PERF_SYNTHETIC_SCALES ?? '100,500')
+  .split(',')
+  .map((s) => parseInt(s.trim(), 10))
+  .filter((n) => Number.isFinite(n) && n > 0);
+
+// CLL matrix: `<datasetsPerSide>x<columnsPerDataset>` (e.g. `10x50`). Empty by
+// default since seeding column lineage at scale is expensive.
+interface CllEntry {
+  datasetsPerSide: number;
+  columns: number;
+}
+const CLL_MATRIX: CllEntry[] = (process.env.LINEAGE_PERF_CLL_MATRIX ?? '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean)
+  .map((token) => {
+    const [d, c] = token.split('x').map((v) => parseInt(v, 10));
+    if (!Number.isFinite(d) || !Number.isFinite(c) || d <= 0 || c <= 0) {
+      throw new Error(`Invalid LINEAGE_PERF_CLL_MATRIX entry "${token}"; expected "DxC".`);
+    }
+    return { datasetsPerSide: d, columns: c };
+  });
+
+function cllScale(entry: CllEntry): string {
+  return `cll_${entry.datasetsPerSide}x${entry.columns}`;
+}
+
+// Mixed-entity matrix: `<label>:ds=N,dj=N,dds=N,c=N,dash=N` (semicolon-
+// separated for multiple configs). Empty by default.
+//
+//   ds=upstream datasets, dj=upstream dataJobs (each gets its own dataFlow +
+//   1 input dataset), dds=downstream datasets, c=downstream charts,
+//   dash=downstream dashboards (each owns 1 chart).
+//
+// Example: `small:ds=5,dj=5,dds=5,c=5,dash=3;mid:ds=20,dj=20,dds=20,c=20,dash=10`
+interface MixedEntry {
+  label: string;
+  upstreamDatasets: number;
+  upstreamDatajobs: number;
+  downstreamDatasets: number;
+  downstreamCharts: number;
+  downstreamDashboards: number;
+}
+function parseMixedToken(token: string): MixedEntry {
+  const [label, body] = token.split(':');
+  if (!label || !body) {
+    throw new Error(`Invalid LINEAGE_PERF_MIXED_MATRIX token "${token}"; expected "<label>:ds=<N>,dj=<N>,..."`);
+  }
+  const counts = new Map<string, number>();
+  for (const part of body.split(',')) {
+    const [k, v] = part.split('=');
+    const n = parseInt(v, 10);
+    if (!k || !Number.isFinite(n) || n < 0) {
+      throw new Error(`Invalid mixed matrix part "${part}" in token "${token}".`);
+    }
+    counts.set(k.trim(), n);
+  }
+  return {
+    label: label.trim(),
+    upstreamDatasets: counts.get('ds') ?? 0,
+    upstreamDatajobs: counts.get('dj') ?? 0,
+    downstreamDatasets: counts.get('dds') ?? 0,
+    downstreamCharts: counts.get('c') ?? 0,
+    downstreamDashboards: counts.get('dash') ?? 0,
+  };
+}
+const MIXED_MATRIX: MixedEntry[] = (process.env.LINEAGE_PERF_MIXED_MATRIX ?? '')
+  .split(';')
+  .map((s) => s.trim())
+  .filter(Boolean)
+  .map(parseMixedToken);
+
+function mixedScale(entry: MixedEntry): string {
+  return `mixed_${entry.label}`;
+}
+
+// ── Seeded URN constants (mirror tests/lineage-v2/v2-lineage-graph.spec.ts) ──
+
+const SMALL_GRAPH_URN = 'urn:li:dataset:(urn:li:dataPlatform:kafka,SamplePlaywrightKafkaDataset,PROD)';
+const CHAIN_ROOT_URN = 'urn:li:dataset:(urn:li:dataPlatform:postgres,playwright_lineage.node1_dataset,PROD)';
+const CHAIN_NEIGHBOUR_URN = 'urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage.node2_dataset,PROD)';
+const CHAIN_COLUMN_NAME = 'record_id';
+const FILTERING_HUB_URN = 'urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_filtering.node7,PROD)';
+
+// ── Variant matrix ──────────────────────────────────────────────────────────
+
+interface Variant {
+  name: string;
+  flagString: string;
+}
+
+// `baseline` forces every lever off explicitly — empty string would resolve
+// to the in-app `'auto'` defaults and contaminate the comparison as
+// thresholds move. `defer-minimap` / `no-transition` variants were dropped
+// after N=5 showed no p50 benefit and 3–5× wider p95.
+const BASELINE_FLAGS = 'virt-off overscan-off';
+
+const VARIANTS: Variant[] = [
+  { name: 'baseline', flagString: BASELINE_FLAGS },
+  { name: 'virt', flagString: 'virt' },
+];
+
+// ── Suite ────────────────────────────────────────────────────────────────────
+
+// Per-test writes are append-style; reset once per worker boot so re-runs
+// don't mix historical samples with the current run.
+test.beforeAll(() => {
+  if (!RUN) return;
+  resetRecordingFile();
+});
+
+for (let iter = 1; iter <= REPEAT; iter += 1) {
+  for (const variant of VARIANTS) {
+    test.describe(`lineage perf [${variant.name}]${iterSuffix(iter)}`, () => {
+      test.beforeEach(async ({ apiMock }) => {
+        test.skip(!RUN, 'Lineage perf benchmark — set LINEAGE_PERF=1 to enable.');
+        // Lock V2 lineage so the flags map to a known rendering pipeline.
+        await apiMock.setFeatureFlags({ lineageGraphV3: false });
+      });
+
+      // ── Journey 1: small graph — load + pan + zoom + node click ──────────────
+
+      test('small graph — load, pan, zoom, click node', async ({ page, logger, logDir }) => {
+        test.setTimeout(60_000);
+        const lp = new LineagePerfPage(page, logger, logDir);
+        await lp.setPerfFlags(variant.flagString);
+        const rec = new LineagePerfRecorder(page);
+        await rec.install();
+
+        await rec.measure('navigate', async () => {
+          await lp.goToLineageGraph('dataset', SMALL_GRAPH_URN);
+        });
+        await rec.measure('wait-first-node', async () => {
+          await lp.waitForReactFlowNode(SMALL_GRAPH_URN);
+        });
+        await rec.measure('settle', async () => {
+          await lp.waitForStableNodeCount();
+        });
+        await rec.measureWithFps('pan-horizontal', () => lp.panHorizontal());
+        await rec.measureWithFps('zoom-out', () => lp.zoomOut(3));
+        await rec.measureWithFps('zoom-in', () => lp.zoomIn(3));
+        await rec.measure('click-center-node', () => lp.clickNodeBody(SMALL_GRAPH_URN));
+        await rec.measure('close-sidebar', () => lp.closeSidebar());
+
+        const summary = await rec.summarise();
+        emitRecording({
+          scenario: 'small_graph',
+          variant: variant.name,
+          iteration: iter,
+          url: page.url(),
+          actions: rec.recordedActions(),
+          summary,
+        });
+      });
+
+      // ── Journey 2: chain graph — column lineage flow ─────────────────────────
+
+      test('chain graph — load, expand columns, column lineage', async ({ page, logger, logDir }) => {
+        test.setTimeout(90_000);
+        const lp = new LineagePerfPage(page, logger, logDir);
+        await lp.setPerfFlags(variant.flagString);
+        const rec = new LineagePerfRecorder(page);
+        await rec.install();
+
+        await rec.measure('navigate', async () => {
+          await lp.goToLineageGraph('dataset', CHAIN_ROOT_URN);
+        });
+        await rec.measure('wait-first-node', async () => {
+          await lp.waitForReactFlowNode(CHAIN_ROOT_URN);
+        });
+        await rec.measure('settle', async () => {
+          await lp.waitForStableNodeCount();
+        });
+        // Under `virt`, fitView can leave the neighbour off-screen; the
+        // unmount would time out the later expand/hover. Zoom out once to
+        // keep both nodes mounted. Measured separately to keep pan/zoom clean.
+        await rec.measure('pre-interaction-zoom-out', () => lp.zoomOut(1));
+        await rec.measureWithFps('pan-horizontal', () => lp.panHorizontal());
+        await rec.measureWithFps('zoom-out', () => lp.zoomOut(3));
+        await rec.measureWithFps('zoom-in', () => lp.zoomIn(3));
+        await rec.measure('click-neighbour', () => lp.clickNodeBody(CHAIN_NEIGHBOUR_URN));
+
+        await rec.measure(
+          'expand-columns',
+          async () => {
+            await lp.expandContractColumns(CHAIN_NEIGHBOUR_URN);
+          },
+          { timeoutMs: 5000 },
+        );
+        await rec.measure(
+          'hover-column',
+          async () => {
+            await lp.hoverColumn(CHAIN_NEIGHBOUR_URN, CHAIN_COLUMN_NAME);
+            await page
+              .locator(`[data-testid^="rf__edge-${CHAIN_ROOT_URN}::${CHAIN_COLUMN_NAME}-"]`)
+              .first()
+              .waitFor({ state: 'attached', timeout: 3000 });
+          },
+          { timeoutMs: 5000 },
+        );
+        await rec.measure('unhover-column', () => lp.unhoverColumn(CHAIN_NEIGHBOUR_URN, CHAIN_COLUMN_NAME), {
+          timeoutMs: 3000,
+        });
+        await rec.measure('contract-columns', () => lp.expandContractColumns(CHAIN_NEIGHBOUR_URN), { timeoutMs: 5000 });
+
+        const summary = await rec.summarise();
+        emitRecording({
+          scenario: 'chain_graph',
+          variant: variant.name,
+          iteration: iter,
+          url: page.url(),
+          actions: rec.recordedActions(),
+          summary,
+        });
+      });
+
+      // ── Journey 3: filtering hub — expand/contract neighbours ────────────────
+
+      test('filtering hub — load, expand-one, contract', async ({ page, logger, logDir }) => {
+        test.setTimeout(90_000);
+        const lp = new LineagePerfPage(page, logger, logDir);
+        await lp.setPerfFlags(variant.flagString);
+        const rec = new LineagePerfRecorder(page);
+        await rec.install();
+
+        await rec.measure('navigate', async () => {
+          await lp.goToLineageGraph('dataset', FILTERING_HUB_URN);
+        });
+        await rec.measure('wait-first-node', async () => {
+          await lp.waitForReactFlowNode(FILTERING_HUB_URN);
+        });
+        await rec.measure('settle', async () => {
+          await lp.waitForStableNodeCount();
+        });
+        // See `chain graph` — same fitView+virt off-screen problem.
+        await rec.measure('pre-interaction-zoom-out', () => lp.zoomOut(1));
+        await rec.measureWithFps('pan-horizontal', () => lp.panHorizontal());
+        await rec.measureWithFps('zoom-out', () => lp.zoomOut(3));
+        await rec.measureWithFps('zoom-in', () => lp.zoomIn(3));
+        await rec.measure(
+          'expand-one',
+          async () => {
+            await lp.expandOne(FILTERING_HUB_URN);
+            await lp.waitForStableNodeCount();
+          },
+          { timeoutMs: 6000 },
+        );
+        await rec.measure(
+          'contract',
+          async () => {
+            await lp.contract(FILTERING_HUB_URN);
+            await lp.waitForStableNodeCount();
+          },
+          { timeoutMs: 6000 },
+        );
+
+        const summary = await rec.summarise();
+        emitRecording({
+          scenario: 'filtering_hub',
+          variant: variant.name,
+          iteration: iter,
+          url: page.url(),
+          actions: rec.recordedActions(),
+          summary,
+        });
+      });
+    });
+  }
+}
+
+// ── Synthetic stress matrix ─────────────────────────────────────────────────
+//
+// Same journey at production scale (100/500/1000+ nodes). Reduced variant
+// set: `defer-minimap` / `no-transition` removed (see comment above
+// `VARIANTS`); the remaining levers are strict virt vs overscan-buffered virt.
+
+const SYNTHETIC_VARIANTS: Variant[] = [
+  { name: 'baseline', flagString: BASELINE_FLAGS },
+  { name: 'virt', flagString: 'virt' },
+  // Strict-vs-buffered trade-off: overscan kills pop-in but mounts ~30%
+  // more nodes, so pan worst-frame is slower than `virt` alone.
+  { name: 'virt+overscan', flagString: 'virt overscan' },
+];
+
+// Wrap in a describe so the seeding beforeAll only fires when synthetic
+// tests are actually selected — otherwise the small-scale tests above would
+// pay the 1000-dataset ingest cost on every run.
+test.describe('lineage perf synthetic suite', () => {
+  test.skip(SYNTHETIC_SIZES.length === 0, 'No synthetic scales configured.');
+
+  const seededRoots = new Map<number, string>();
+
+  test.beforeAll(async () => {
+    if (!RUN) return;
+    // Default 60 s is too tight: seeding 1000 datasets × (stub +
+    // schemaMetadata + upstreamLineage w/ per-column FGLs) is ~3000
+    // sequential ingest calls plus OpenSearch index polling. Allow 30 min.
+    test.setTimeout(30 * 60_000);
+    const apiContext = await playwrightRequest.newContext({ baseURL: gmsUrl() });
+    try {
+      const gmsToken = readGmsToken(users.admin.username);
+      for (const size of SYNTHETIC_SIZES) {
+        const half = Math.floor(size / 2);
+        const handles = await seedSyntheticLineage(apiContext, gmsToken, {
+          scale: String(size),
+          upstreamCount: half,
+          downstreamCount: size - half,
+        });
+        seededRoots.set(size, handles.rootUrn);
+      }
+    } finally {
+      await apiContext.dispose();
+    }
+  });
+
+  for (let iter = 1; iter <= REPEAT; iter += 1) {
+    for (const size of SYNTHETIC_SIZES) {
+      for (const variant of SYNTHETIC_VARIANTS) {
+        test.describe(`scale ${size} [${variant.name}]${iterSuffix(iter)}`, () => {
+          test.beforeEach(async ({ apiMock }) => {
+            test.skip(!RUN, 'Lineage perf benchmark — set LINEAGE_PERF=1 to enable.');
+            await apiMock.setFeatureFlags({ lineageGraphV3: false });
+          });
+
+          test(`synthetic ${size} — load, expand all, pan, zoom`, async ({ page, logger, logDir }) => {
+            // At 500 nodes, navigation + fetch + expand can each take seconds.
+            test.setTimeout(180_000);
+            const lp = new LineagePerfPage(page, logger, logDir);
+            await lp.setPerfFlags(variant.flagString);
+            const rec = new LineagePerfRecorder(page);
+            await rec.install();
+
+            const rootUrn = seededRoots.get(size);
+            if (!rootUrn) {
+              throw new Error(`Synthetic root URN missing for size ${size}; beforeAll seed must have failed.`);
+            }
+
+            await rec.measure('navigate', async () => {
+              await lp.goToLineageGraph('dataset', rootUrn);
+            });
+            await rec.measure('wait-first-node', async () => {
+              await lp.waitForReactFlowNode(rootUrn);
+            });
+            await rec.measure('settle-default', async () => {
+              await lp.waitForStableNodeCount({ maxMs: 15_000 });
+            });
+
+            // Under virt + fitView at scale, filter-node wrappers can land off-
+            // screen and make expand-fanout a no-op. Zoom out first to mount them.
+            await rec.measure('pre-expand-zoom-out', () => lp.zoomOut(2));
+
+            // Force-load every neighbour past LINEAGE_FILTER_PAGINATION (4) so
+            // the measurement covers the full corpus, not the default cap.
+            await rec.measure('expand-fanout', async () => {
+              await lp.expandFanoutFully();
+            });
+            await rec.measure('settle-expanded', async () => {
+              await lp.waitForStableNodeCount({ maxMs: 30_000 });
+            });
+
+            await rec.measureWithFps('pan-horizontal', () => lp.panHorizontal());
+            await rec.measureWithFps('zoom-out', () => lp.zoomOut(3));
+            await rec.measureWithFps('zoom-in', () => lp.zoomIn(3));
+
+            // Expand columns on the root so the measurement reflects the
+            // CLL-render cost users see in production (root carries
+            // DEFAULT_SYNTHETIC_COLUMN_COUNT columns + per-column FGLs).
+            // Captures column-row mount + edge-highlight pass on hover.
+            await rec.measure('expand-columns-root', () => lp.expandContractColumns(rootUrn));
+            await rec.measureWithFps('hover-column-root', async () => {
+              await lp.hoverColumn(rootUrn, 'col_001');
+              await page.waitForTimeout(150);
+              await lp.unhoverColumn(rootUrn, 'col_001');
+            });
+
+            await rec.measure('click-root', () => lp.clickNodeBody(rootUrn));
+            await rec.measure('close-sidebar', () => lp.closeSidebar());
+
+            const summary = await rec.summarise();
+            emitRecording({
+              scenario: `synthetic_${size}`,
+              variant: variant.name,
+              iteration: iter,
+              url: page.url(),
+              actions: rec.recordedActions(),
+              summary,
+            });
+          });
+        });
+      }
+    }
+  }
+});
+
+// ── Column-lineage stress matrix ────────────────────────────────────────────
+//
+// Fanout corpora carrying per-column FGLs. Each expand-columns click adds
+// hundreds of SVG paths; each column hover triggers an edge-highlight pass
+// over every incident FGL. Opt-in via `LINEAGE_PERF_CLL_MATRIX` because
+// seeding column lineage is expensive.
+test.describe('lineage perf column-lineage suite', () => {
+  test.skip(CLL_MATRIX.length === 0, 'No CLL matrix configured.');
+
+  const seeded = new Map<string, SyntheticLineageHandles>();
+
+  test.beforeAll(async () => {
+    if (!RUN) return;
+    // Default 60 s is too tight for high-column-count matrices; FGL volume
+    // multiplies sequential ingest cost. Match the synthetic suite budget.
+    test.setTimeout(30 * 60_000);
+    const apiContext = await playwrightRequest.newContext({ baseURL: gmsUrl() });
+    try {
+      const gmsToken = readGmsToken(users.admin.username);
+      for (const entry of CLL_MATRIX) {
+        const handles = await seedSyntheticLineage(apiContext, gmsToken, {
+          scale: cllScale(entry),
+          upstreamCount: entry.datasetsPerSide,
+          downstreamCount: entry.datasetsPerSide,
+          columnCount: entry.columns,
+        });
+        seeded.set(cllScale(entry), handles);
+      }
+    } finally {
+      await apiContext.dispose();
+    }
+  });
+
+  for (let iter = 1; iter <= REPEAT; iter += 1) {
+    for (const entry of CLL_MATRIX) {
+      for (const variant of SYNTHETIC_VARIANTS) {
+        test.describe(`cll ${entry.datasetsPerSide}×${entry.columns} [${variant.name}]${iterSuffix(iter)}`, () => {
+          test.beforeEach(async ({ apiMock }) => {
+            test.skip(!RUN, 'Lineage perf benchmark — set LINEAGE_PERF=1 to enable.');
+            await apiMock.setFeatureFlags({ lineageGraphV3: false });
+          });
+
+          test(`cll ${cllScale(entry)} — load, expand columns, hover, pan`, async ({ page, logger, logDir }) => {
+            // Column expand+hover at 50–100 cols can be slow on baseline.
+            test.setTimeout(240_000);
+            const lp = new LineagePerfPage(page, logger, logDir);
+            await lp.setPerfFlags(variant.flagString);
+            const rec = new LineagePerfRecorder(page);
+            await rec.install();
+
+            const handles = seeded.get(cllScale(entry));
+            if (!handles) {
+              throw new Error(`Synthetic CLL handles missing for ${cllScale(entry)}; beforeAll seed must have failed.`);
+            }
+            const { rootUrn, columnNames, downstreamUrns } = handles;
+            // Column UI paginates at NUM_COLUMNS_PER_PAGE (5) — pick hover
+            // targets from the first page so they're DOM-attached. Total column
+            // count still drives FGL data + edge-highlight cost (what we measure).
+            const hoverCol = columnNames[0];
+            const secondHoverCol = columnNames[Math.min(2, columnNames.length - 1)];
+            const downstreamUrn = downstreamUrns[0];
+
+            await rec.measure('navigate', () => lp.goToLineageGraph('dataset', rootUrn));
+            await rec.measure('wait-first-node', () => lp.waitForReactFlowNode(rootUrn));
+            await rec.measure('settle-default', () => lp.waitForStableNodeCount({ maxMs: 15_000 }));
+
+            await rec.measure('pre-expand-zoom-out', () => lp.zoomOut(2));
+
+            // Expand fanout both ways so column hover hits the worst case:
+            // every root column reaches every upstream/downstream peer.
+            await rec.measure('expand-fanout', () => lp.expandFanoutFully());
+            await rec.measure('settle-expanded', () => lp.waitForStableNodeCount({ maxMs: 30_000 }));
+
+            // Wait for the column-expand affordance to attach — it only renders
+            // once the bulk-lineage fetch populates the node's column count.
+            await page
+              .locator(`[data-testid="lineage-node-${rootUrn}"] [data-testid="expand-contract-columns"]`)
+              .first()
+              .waitFor({ state: 'attached', timeout: 20_000 });
+
+            await rec.measure(
+              'expand-columns-root',
+              async () => {
+                await lp.expandContractColumns(rootUrn);
+                await lp.waitForStableNodeCount({ maxMs: 10_000, stableMs: 600 });
+              },
+              { timeoutMs: 12_000 },
+            );
+            await rec.measure('hover-column-root', () => lp.hoverColumn(rootUrn, hoverCol), { timeoutMs: 6_000 });
+            await rec.measure('unhover-column-root', () => lp.unhoverColumn(rootUrn, hoverCol), { timeoutMs: 3_000 });
+
+            // Large fanouts can leave the downstream entity unfetched long
+            // after the root. Skip gracefully if the affordance never attaches.
+            const downExpandButton = page
+              .locator(`[data-testid="lineage-node-${downstreamUrn}"] [data-testid="expand-contract-columns"]`)
+              .first();
+            const downExpandReady = await downExpandButton
+              .waitFor({ state: 'attached', timeout: 20_000 })
+              .then(() => true)
+              .catch(() => false);
+
+            if (downExpandReady) {
+              await rec.measure(
+                'expand-columns-downstream',
+                async () => {
+                  await lp.expandContractColumns(downstreamUrn);
+                  await lp.waitForStableNodeCount({ maxMs: 10_000, stableMs: 600 });
+                },
+                { timeoutMs: 12_000 },
+              );
+            }
+            await rec.measure('hover-column-after-down-expand', () => lp.hoverColumn(rootUrn, secondHoverCol), {
+              timeoutMs: 6_000,
+            });
+            await rec.measure('unhover-column-after-down-expand', () => lp.unhoverColumn(rootUrn, secondHoverCol), {
+              timeoutMs: 3_000,
+            });
+
+            // ── Pan / zoom under load ───────────────────────────────────
+            await rec.measureWithFps('pan-horizontal', () => lp.panHorizontal());
+            await rec.measureWithFps('zoom-out', () => lp.zoomOut(3));
+            await rec.measureWithFps('zoom-in', () => lp.zoomIn(3));
+
+            // ── Tear down columns; measure contract cost too ───────────
+            await rec.measure('contract-columns-root', () => lp.expandContractColumns(rootUrn), { timeoutMs: 6_000 });
+
+            const summary = await rec.summarise();
+            emitRecording({
+              scenario: cllScale(entry),
+              variant: variant.name,
+              iteration: iter,
+              url: page.url(),
+              actions: rec.recordedActions(),
+              summary,
+            });
+          });
+        });
+      }
+    }
+  }
+});
+
+// ── Mixed-entity stress matrix ──────────────────────────────────────────────
+//
+// Exercises every edge shape between heterogeneous entities (Dataset, DataJob,
+// DataFlow, Chart, Dashboard) so virt is measured against "real" lineage
+// topologies, not just dataset fanouts.
+test.describe('lineage perf mixed-entity suite', () => {
+  test.skip(MIXED_MATRIX.length === 0, 'No mixed-entity matrix configured.');
+
+  const seeded = new Map<string, MixedFanoutHandles>();
+
+  test.beforeAll(async () => {
+    if (!RUN) return;
+    // Default 60 s is too tight: datasets now carry schemas + per-column
+    // FGLs, multiplying sequential ingest cost. Match the other suites.
+    test.setTimeout(30 * 60_000);
+    const apiContext = await playwrightRequest.newContext({ baseURL: gmsUrl() });
+    try {
+      const gmsToken = readGmsToken(users.admin.username);
+      for (const entry of MIXED_MATRIX) {
+        const handles = await seedMixedFanoutLineage(apiContext, gmsToken, {
+          scale: entry.label,
+          upstreamDatasets: entry.upstreamDatasets,
+          upstreamDatajobs: entry.upstreamDatajobs,
+          downstreamDatasets: entry.downstreamDatasets,
+          downstreamCharts: entry.downstreamCharts,
+          downstreamDashboards: entry.downstreamDashboards,
+        });
+        seeded.set(mixedScale(entry), handles);
+      }
+    } finally {
+      await apiContext.dispose();
+    }
+  });
+
+  for (let iter = 1; iter <= REPEAT; iter += 1) {
+    for (const entry of MIXED_MATRIX) {
+      for (const variant of SYNTHETIC_VARIANTS) {
+        test.describe(`mixed ${entry.label} [${variant.name}]${iterSuffix(iter)}`, () => {
+          test.beforeEach(async ({ apiMock }) => {
+            test.skip(!RUN, 'Lineage perf benchmark — set LINEAGE_PERF=1 to enable.');
+            await apiMock.setFeatureFlags({ lineageGraphV3: false });
+          });
+
+          test(`mixed ${entry.label} — load, expand, pan, zoom`, async ({ page, logger, logDir }) => {
+            test.setTimeout(240_000);
+            const lp = new LineagePerfPage(page, logger, logDir);
+            await lp.setPerfFlags(variant.flagString);
+            const rec = new LineagePerfRecorder(page);
+            await rec.install();
+
+            const handles = seeded.get(mixedScale(entry));
+            if (!handles) {
+              throw new Error(`Mixed handles missing for ${mixedScale(entry)}; beforeAll seed must have failed.`);
+            }
+            const { rootUrn } = handles;
+
+            await rec.measure('navigate', () => lp.goToLineageGraph('dataset', rootUrn));
+            await rec.measure('wait-first-node', () => lp.waitForReactFlowNode(rootUrn));
+            await rec.measure('settle-default', () => lp.waitForStableNodeCount({ maxMs: 15_000 }));
+
+            await rec.measure('pre-expand-zoom-out', () => lp.zoomOut(2));
+
+            // expandFanoutFully clicks Show More/All/Max for every entity type,
+            // so DataJobs and Charts mount alongside Datasets.
+            await rec.measure('expand-fanout', () => lp.expandFanoutFully());
+            await rec.measure('settle-expanded', () => lp.waitForStableNodeCount({ maxMs: 30_000 }));
+
+            await rec.measureWithFps('pan-horizontal', () => lp.panHorizontal());
+            await rec.measureWithFps('zoom-out', () => lp.zoomOut(3));
+            await rec.measureWithFps('zoom-in', () => lp.zoomIn(3));
+
+            // Expand columns on the root so the measurement reflects the
+            // CLL-render cost on heterogeneous lineage. Dataset nodes carry
+            // DEFAULT_SYNTHETIC_COLUMN_COUNT columns + per-column FGLs;
+            // DataJob/Chart/Dashboard neighbours simply ignore the action.
+            await rec.measure('expand-columns-root', () => lp.expandContractColumns(rootUrn));
+            await rec.measureWithFps('hover-column-root', async () => {
+              await lp.hoverColumn(rootUrn, 'col_001');
+              await page.waitForTimeout(150);
+              await lp.unhoverColumn(rootUrn, 'col_001');
+            });
+
+            await rec.measure('click-root', () => lp.clickNodeBody(rootUrn));
+            await rec.measure('close-sidebar', () => lp.closeSidebar());
+
+            const summary = await rec.summarise();
+            emitRecording({
+              scenario: mixedScale(entry),
+              variant: variant.name,
+              iteration: iter,
+              url: page.url(),
+              actions: rec.recordedActions(),
+              summary,
+            });
+          });
+        });
+      }
+    }
+  }
+});

--- a/e2e-test/ui/playwright/tests/lineage-perf/lineage-screenshot-stress.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-perf/lineage-screenshot-stress.spec.ts
@@ -1,0 +1,267 @@
+/**
+ * Screenshot-export stress test for lineage V2 under virtualisation.
+ *
+ * Verifies that `forceMountAll` in the screenshot button restores a fully-
+ * mounted DOM for html-to-image even when virt has unmounted off-screen
+ * nodes. For each scale × variant: expand the fanout, snapshot heap,
+ * click the camera button, race the download event against the button
+ * re-enabling, and record click→download wall time + the resulting PNG
+ * byte size (the only reliable ground truth that capture saw the full
+ * graph — a virtualised-viewport screenshot is < ~50 KB).
+ *
+ * Opt-in via `LINEAGE_PERF=1 LINEAGE_PERF_SCREENSHOT=1`.
+ */
+
+import { expect, request as playwrightRequest, type Page } from '@playwright/test';
+
+import { test } from '../../fixtures/base-test';
+import { readGmsToken } from '../../fixtures/login';
+import { seedSyntheticLineage } from '../../helpers/seeders/lineage-perf-seeder';
+import { LineagePerfPage } from '../../pages/lineage-perf.page';
+import { users } from '../../data/users';
+import { gmsUrl } from '../../utils/constants';
+
+const RUN = process.env.LINEAGE_PERF === '1';
+const SCREENSHOT_RUN = process.env.LINEAGE_PERF_SCREENSHOT === '1';
+
+const SCREENSHOT_SCALES: number[] = (process.env.LINEAGE_PERF_SCREENSHOT_SCALES ?? '100,500,1000')
+  .split(',')
+  .map((s) => parseInt(s.trim(), 10))
+  .filter((n) => Number.isFinite(n) && n > 0);
+
+interface ScreenshotVariant {
+  name: string;
+  flagString: string;
+}
+
+// Only baseline + virt — overscan / `all` don't change screenshot
+// behaviour, just the everyday render, so they'd add wall time without
+// new information.
+const BASELINE_FLAGS = 'virt-off overscan-off';
+const SCREENSHOT_VARIANTS: ScreenshotVariant[] = [
+  { name: 'baseline', flagString: BASELINE_FLAGS },
+  { name: 'virt', flagString: 'virt' },
+];
+
+interface ScreenshotMeasurement {
+  scale: number;
+  variant: string;
+  clickToDownloadMs: number;
+  downloadByteCount: number;
+  heapBeforeMb: number | null;
+  heapAfterMb: number | null;
+  heapDeltaMb: number | null;
+  /** Mounted nodes immediately before the click (virt may be filtering). */
+  domNodesBeforeCapture: number;
+  /** Mounted nodes after capture finished (button restored virt). */
+  domNodesAfterCapture: number;
+}
+
+const measurements: ScreenshotMeasurement[] = [];
+
+async function readHeapMb(page: Page): Promise<number | null> {
+  const bytes = await page.evaluate(() => {
+    const mem = (performance as unknown as { memory?: { usedJSHeapSize: number } }).memory;
+    return mem ? mem.usedJSHeapSize : null;
+  });
+  return bytes != null ? Math.round((bytes / 1024 / 1024) * 10) / 10 : null;
+}
+
+test.describe('lineage perf screenshot suite', () => {
+  test.skip(!RUN || !SCREENSHOT_RUN, 'Set LINEAGE_PERF=1 LINEAGE_PERF_SCREENSHOT=1 to run.');
+  test.skip(SCREENSHOT_SCALES.length === 0, 'No screenshot scales configured.');
+
+  const seededRoots = new Map<number, string>();
+
+  test.beforeAll(async () => {
+    if (!RUN || !SCREENSHOT_RUN) return;
+    // Match the synthetic suite seed budget — schemas + per-column FGLs
+    // make seeding three scales non-trivial on a cold DataHub.
+    test.setTimeout(30 * 60_000);
+    const apiContext = await playwrightRequest.newContext({ baseURL: gmsUrl() });
+    try {
+      const gmsToken = readGmsToken(users.admin.username);
+      for (const size of SCREENSHOT_SCALES) {
+        const half = Math.floor(size / 2);
+        const handles = await seedSyntheticLineage(apiContext, gmsToken, {
+          scale: String(size),
+          upstreamCount: half,
+          downstreamCount: size - half,
+        });
+        seededRoots.set(size, handles.rootUrn);
+      }
+    } finally {
+      await apiContext.dispose();
+    }
+  });
+
+  test.afterAll(async () => {
+    if (measurements.length === 0) return;
+    // Emit as a test artifact rather than `console.log` so the summary
+    // survives CI log truncation and can be pasted into the rollout RFC
+    // without re-instrumentation.
+    const columns = [
+      'scale',
+      'variant',
+      'clickToDownloadMs',
+      'downloadByteCount',
+      'heapBeforeMb',
+      'heapAfterMb',
+      'heapDeltaMb',
+      'domNodesBeforeCapture',
+      'domNodesAfterCapture',
+    ] as const;
+    const lines = [columns.join('\t')];
+    for (const m of measurements) {
+      lines.push(
+        [
+          m.scale,
+          m.variant,
+          m.clickToDownloadMs,
+          m.downloadByteCount,
+          m.heapBeforeMb,
+          m.heapAfterMb,
+          m.heapDeltaMb,
+          m.domNodesBeforeCapture,
+          m.domNodesAfterCapture,
+        ].join('\t'),
+      );
+    }
+    const { mkdirSync, writeFileSync } = await import('node:fs');
+    const path = await import('node:path');
+    const outDir = path.resolve(__dirname, '..', '..', 'test-results');
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(path.join(outDir, 'lineage-screenshot-stress.tsv'), `${lines.join('\n')}\n`);
+  });
+
+  for (const size of SCREENSHOT_SCALES) {
+    for (const variant of SCREENSHOT_VARIANTS) {
+      test.describe(`screenshot scale ${size} [${variant.name}]`, () => {
+        test.beforeEach(async ({ apiMock }) => {
+          test.skip(!RUN || !SCREENSHOT_RUN);
+          await apiMock.setFeatureFlags({ lineageGraphV3: false });
+        });
+
+        test(`screenshot ${size} — capture full graph`, async ({ page, logger, logDir }) => {
+          // html-to-image serialises every SVG path + every node — give
+          // it room at 1000.
+          test.setTimeout(180_000);
+          const lp = new LineagePerfPage(page, logger, logDir);
+          await lp.setPerfFlags(variant.flagString);
+
+          const rootUrn = seededRoots.get(size);
+          if (!rootUrn) {
+            throw new Error(`Screenshot seed missing for scale ${size}.`);
+          }
+
+          await lp.goToLineageGraph('dataset', rootUrn);
+          await lp.waitForReactFlowNode(rootUrn);
+          await lp.waitForStableNodeCount({ maxMs: 15_000 });
+
+          // Mount the full neighbour set so capture matches what a user
+          // would see after exploring, not the default-fanout subset.
+          await lp.zoomOut(2);
+          await lp.expandFanoutFully();
+          await lp.waitForStableNodeCount({ maxMs: 30_000 });
+
+          const heapBeforeMb = await readHeapMb(page);
+          const domNodesBeforeCapture = await page.evaluate(
+            () => document.querySelectorAll('.react-flow__node').length,
+          );
+
+          // Capture page errors during the capture window so a silent
+          // html-to-image failure (e.g. tainted canvas) surfaces as an
+          // assertion message instead of a 90 s wait-for-download timeout.
+          const captureSideErrors: string[] = [];
+          const onConsoleError = (msg: import('@playwright/test').ConsoleMessage) => {
+            if (msg.type() === 'error') captureSideErrors.push(`[console.error] ${msg.text()}`);
+          };
+          const onPageError = (err: Error) => {
+            captureSideErrors.push(`[pageerror] ${err.message}`);
+          };
+          page.on('console', onConsoleError);
+          page.on('pageerror', onPageError);
+
+          const screenshotButton = page.locator('.anticon-camera').first().locator('xpath=ancestor::button[1]');
+          await expect(screenshotButton).toBeVisible({ timeout: 10_000 });
+
+          // Race the download event against the button re-enabling: the
+          // V2 button disables itself while capturing and re-enables in
+          // a try/finally. If it re-enables without firing a download,
+          // capture failed (caught by `getPreviewImage`'s `.catch` and
+          // surfaced as an antd `message.error` to the user).
+          const downloadPromise = page.waitForEvent('download', { timeout: 90_000 });
+
+          const captureFinishedPromise = (async () => {
+            const deadline = Date.now() + 90_000;
+            while (Date.now() < deadline) {
+              const isDisabled = await screenshotButton.evaluate((el) => el.hasAttribute('disabled'));
+              if (isDisabled) {
+                while (Date.now() < deadline) {
+                  await page.waitForTimeout(200);
+                  const stillDisabled = await screenshotButton.evaluate((el) => el.hasAttribute('disabled'));
+                  if (!stillDisabled) return 'capture-finished' as const;
+                }
+                return 'capture-finished' as const;
+              }
+              await page.waitForTimeout(50);
+            }
+            return 'capture-finished' as const;
+          })();
+
+          const clickStart = Date.now();
+          await screenshotButton.click();
+          const winner = await Promise.race([
+            downloadPromise.then(() => 'download' as const).catch(() => 'capture-finished' as const),
+            captureFinishedPromise,
+          ]);
+          const clickToDownloadMs = Date.now() - clickStart;
+
+          page.off('console', onConsoleError);
+          page.off('pageerror', onPageError);
+
+          if (winner !== 'download') {
+            const detail =
+              captureSideErrors.length > 0 ? captureSideErrors.join('\n  ') : '(no console / page errors captured)';
+            throw new Error(
+              `Screenshot capture finished without firing a download event after ${clickToDownloadMs} ms. Console / page errors during capture:\n  ${detail}`,
+            );
+          }
+
+          const download = await downloadPromise;
+          const downloadPath = await download.path();
+          if (!downloadPath) {
+            throw new Error('Screenshot download had no path.');
+          }
+          const { statSync } = await import('node:fs');
+          const downloadByteCount = statSync(downloadPath).size;
+
+          const heapAfterMb = await readHeapMb(page);
+          const heapDeltaMb =
+            heapBeforeMb != null && heapAfterMb != null ? Math.round((heapAfterMb - heapBeforeMb) * 10) / 10 : null;
+
+          const domNodesAfterCapture = await page.evaluate(() => document.querySelectorAll('.react-flow__node').length);
+
+          measurements.push({
+            scale: size,
+            variant: variant.name,
+            clickToDownloadMs,
+            downloadByteCount,
+            heapBeforeMb,
+            heapAfterMb,
+            heapDeltaMb,
+            domNodesBeforeCapture,
+            domNodesAfterCapture,
+          });
+
+          // Sanity floor: a virtualised screenshot of just the viewport
+          // would be a small PNG (< ~50 KB at 1280×720 with little
+          // content). A full-graph capture is multi-MB at 500/1000
+          // nodes. We don't assert tighter than a non-trivial floor
+          // because compression is content-dependent.
+          expect(downloadByteCount).toBeGreaterThan(10_000);
+        });
+      });
+    }
+  }
+});

--- a/e2e-test/ui/playwright/tests/lineage-v2/v2-lineage-virt.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-v2/v2-lineage-virt.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * Lineage V2 — virtualisation interop regression tests.
+ *
+ * Two DOM-boundary interactions need explicit coverage as virt becomes the
+ * default at scale:
+ *
+ *   1. Column-edge highlighting — edge geometry comes from the React Flow
+ *      store, not the DOM, so column hover should attach the highlight even
+ *      when the off-screen endpoint is virtualised away.
+ *   2. Screenshot capture — html-to-image walks the live DOM, so the button
+ *      flips `forceMountAll` during capture and reverts afterwards.
+ */
+
+import { expect, test } from '../../fixtures/base-test';
+import { LineageV2Page } from '../../pages/lineage-v2.page';
+
+const NODE1_URN = 'urn:li:dataset:(urn:li:dataPlatform:postgres,playwright_lineage.node1_dataset,PROD)';
+const NODE2_URN = 'urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage.node2_dataset,PROD)';
+const COLUMN_NAME = 'record_id';
+
+test.describe('lineage_graph virtualisation regression', () => {
+  test.beforeEach(async ({ apiMock }) => {
+    await apiMock.setFeatureFlags({ lineageGraphV3: false });
+  });
+
+  test('column-edge highlight renders under virt-on', async ({ page, logger, logDir }) => {
+    // Smoke test only — the 3-node fixture is too tightly packed to
+    // reliably pan one endpoint off-screen without also unmounting the
+    // hover target. Off-screen coverage is in the screenshot test below.
+    test.setTimeout(60_000);
+
+    const lp = new LineageV2Page(page, logger, logDir);
+    await lp.setPerfFlags('virt');
+    await lp.goToLineageGraph('dataset', NODE2_URN);
+
+    await lp.checkNodeExists(NODE2_URN);
+    await lp.checkNodeExists(NODE1_URN);
+    await lp.expandContractColumns(NODE2_URN);
+    await lp.hoverColumn(NODE2_URN, COLUMN_NAME);
+    await lp.checkEdgeBetweenColumnsExists(NODE1_URN, COLUMN_NAME, NODE2_URN, COLUMN_NAME);
+  });
+
+  test('screenshot capture force-mounts every node under virt-on', async ({ page, logger, logDir }) => {
+    test.setTimeout(60_000);
+
+    const lp = new LineageV2Page(page, logger, logDir);
+    await lp.setPerfFlags('virt');
+    await lp.goToLineageGraph('dataset', NODE2_URN);
+    await lp.checkNodeExists(NODE2_URN);
+    await lp.checkNodeExists(NODE1_URN);
+
+    // Pan NODE1 off the left edge so virt unmounts it.
+    await lp.sustainedPan('right', 700);
+    await page.waitForTimeout(200);
+    await expect(page.locator(`[data-testid="rf__node-${NODE1_URN}"]`)).toHaveCount(0);
+
+    // Neuter html-to-image's synthetic download so the test doesn't
+    // trigger a real browser download dialog mid-run.
+    await page.evaluate(() => {
+      const proto = HTMLAnchorElement.prototype as HTMLAnchorElement & { __origClick?: () => void };
+      if (!proto.__origClick) {
+        proto.__origClick = proto.click;
+        proto.click = function noopClick() {
+          /* swallowed by virt regression test */
+        };
+      }
+    });
+
+    // Watch for NODE1 to remount: the screenshot button flips
+    // `forceMountAll=true` before `toPng` walks the DOM.
+    const seenAllMountedPromise = page.waitForFunction(
+      (node1Selector) => document.querySelector(node1Selector) !== null,
+      `[data-testid="rf__node-${NODE1_URN}"]`,
+      { timeout: 10_000 },
+    );
+
+    // The camera icon is the only selector stable across collapsed
+    // / expanded controls panels.
+    const screenshotButton = page.locator('button:has([aria-label="camera"])').first();
+    await screenshotButton.click();
+
+    await seenAllMountedPromise;
+
+    // After capture, forceMountAll flips back and NODE1 unmounts again.
+    await page.waitForTimeout(300);
+    await expect(page.locator(`[data-testid="rf__node-${NODE1_URN}"]`)).toHaveCount(0);
+  });
+});

--- a/e2e-test/ui/playwright/utils/lineage-perf-collector.ts
+++ b/e2e-test/ui/playwright/utils/lineage-perf-collector.ts
@@ -1,0 +1,261 @@
+/**
+ * Lineage rendering perf collector.
+ *
+ * `installInPage(page)` injects an init script before navigation that sets up
+ * `PerformanceObserver` for long tasks, paint, layout-shift, marks, and
+ * measures, plus a RAF-driven FPS sampler. The Node-side helpers
+ * (`collectRaw`, `start/stopFpsSample`, `summarise`) read the buffers back
+ * and roll them into a stable `PerfSummary` shape.
+ */
+
+import type { Page } from '@playwright/test';
+
+export interface LongTaskEntry {
+  startTime: number;
+  duration: number;
+}
+
+export interface PaintEntry {
+  name: string;
+  startTime: number;
+}
+
+export interface LayoutShiftEntry {
+  startTime: number;
+  value: number;
+  hadRecentInput: boolean;
+}
+
+export interface FpsSample {
+  /** Start time of the sample window (DOMHighResTimeStamp). */
+  startedAt: number;
+  /** Duration of the sample window in ms. */
+  durationMs: number;
+  /** Total frames painted during the window. */
+  frames: number;
+  /** Mean frame duration in ms (1000 / fps). */
+  meanFrameMs: number;
+  /** Worst (longest) frame duration in ms. */
+  maxFrameMs: number;
+}
+
+export interface ResourceEntry {
+  name: string;
+  initiatorType: string;
+  startTime: number;
+  duration: number;
+  encodedBodySize: number;
+  /** True if the URL contains `/api/v2/graphql` — used to attribute GMS traffic. */
+  isGraphql: boolean;
+}
+
+export interface RawPerfBuffer {
+  longTasks: LongTaskEntry[];
+  paint: PaintEntry[];
+  layoutShifts: LayoutShiftEntry[];
+  marks: Array<{ name: string; startTime: number }>;
+  measures: Array<{ name: string; startTime: number; duration: number }>;
+  resources: ResourceEntry[];
+}
+
+export interface PerfSummary {
+  url: string;
+  reactFlowNodesInDom: number;
+  reactFlowEdgesInDom: number;
+  longTaskCount: number;
+  longTaskTotalMs: number;
+  longTaskMaxMs: number;
+  firstPaintMs?: number;
+  firstContentfulPaintMs?: number;
+  cumulativeLayoutShift: number;
+  navigationMs?: number;
+  domContentLoadedMs?: number;
+  loadEventMs?: number;
+  /** All resource entries the browser captured for the page (excludes
+   *  data:/blob: which `PerformanceObserver` skips anyway). */
+  totalRequests: number;
+  /** Subset of `totalRequests` that hit `/api/v2/graphql` — proxy for
+   *  GMS round-trips. Lineage fetch + bulk-lineage + expand all flow
+   *  through this endpoint, so the count tracks "how chatty did this
+   *  variant get?" for a synthetic scale. */
+  totalGraphqlRequests: number;
+  /** Sum of `encodedBodySize` across resource entries (bytes the
+   *  browser actually received over the wire — Service Workers / cache
+   *  hits don't inflate it). */
+  totalEncodedBodyBytes: number;
+}
+
+const INIT_SCRIPT = /* js */ `
+(function () {
+  if (window.__lineagePerf) return;
+  const longTasks = [];
+  const paint = [];
+  const layoutShifts = [];
+  const marks = [];
+  const measures = [];
+  const resources = [];
+
+  function safeObserve(type, push) {
+    try {
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) push(entry);
+      });
+      observer.observe({ type, buffered: true });
+    } catch (_err) {
+      // Not all entry types are supported on every Chromium version.
+    }
+  }
+
+  safeObserve('longtask', (e) => longTasks.push({ startTime: e.startTime, duration: e.duration }));
+  safeObserve('paint', (e) => paint.push({ name: e.name, startTime: e.startTime }));
+  safeObserve('layout-shift', (e) => {
+    layoutShifts.push({ startTime: e.startTime, value: e.value, hadRecentInput: e.hadRecentInput });
+  });
+  safeObserve('mark', (e) => marks.push({ name: e.name, startTime: e.startTime }));
+  safeObserve('measure', (e) =>
+    measures.push({ name: e.name, startTime: e.startTime, duration: e.duration }),
+  );
+  // 'resource' covers fetch/xhr/img/script/css; data: and blob: URLs are
+  // not reported by the browser, which is what we want — we're counting
+  // GMS / asset traffic, not in-memory generated images.
+  safeObserve('resource', (e) =>
+    resources.push({
+      name: e.name,
+      initiatorType: e.initiatorType,
+      startTime: e.startTime,
+      duration: e.duration,
+      encodedBodySize: e.encodedBodySize || 0,
+      isGraphql: typeof e.name === 'string' && e.name.indexOf('/api/v2/graphql') !== -1,
+    }),
+  );
+
+  // FPS sampler: accumulate inter-frame deltas; the Node side computes stats.
+  let fpsState = null;
+  function fpsTick(ts) {
+    if (!fpsState) return;
+    if (fpsState.lastTs !== null) {
+      const delta = ts - fpsState.lastTs;
+      fpsState.deltas.push(delta);
+    }
+    fpsState.lastTs = ts;
+    fpsState.handle = requestAnimationFrame(fpsTick);
+  }
+
+  window.__lineagePerf = { longTasks, paint, layoutShifts, marks, measures, resources };
+
+  window.__lineagePerfStartFps = function () {
+    if (fpsState) return;
+    fpsState = { startedAt: performance.now(), lastTs: null, deltas: [], handle: null };
+    fpsState.handle = requestAnimationFrame(fpsTick);
+  };
+
+  window.__lineagePerfStopFps = function () {
+    if (!fpsState) return null;
+    const ended = performance.now();
+    if (fpsState.handle !== null) cancelAnimationFrame(fpsState.handle);
+    const result = {
+      startedAt: fpsState.startedAt,
+      durationMs: ended - fpsState.startedAt,
+      deltas: fpsState.deltas.slice(),
+    };
+    fpsState = null;
+    return result;
+  };
+})();
+`;
+
+export async function installInPage(page: Page): Promise<void> {
+  await page.addInitScript({ content: INIT_SCRIPT });
+}
+
+export async function collectRaw(page: Page): Promise<RawPerfBuffer> {
+  return page.evaluate(() => {
+    type Window = typeof globalThis & { __lineagePerf?: RawPerfBuffer };
+    const w = window as Window;
+    return (
+      w.__lineagePerf ?? {
+        longTasks: [],
+        paint: [],
+        layoutShifts: [],
+        marks: [],
+        measures: [],
+        resources: [],
+      }
+    );
+  });
+}
+
+export async function startFpsSample(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    type W = typeof globalThis & { __lineagePerfStartFps?: () => void };
+    (window as W).__lineagePerfStartFps?.();
+  });
+}
+
+export async function stopFpsSample(page: Page): Promise<FpsSample | null> {
+  const raw = await page.evaluate(() => {
+    type W = typeof globalThis & {
+      __lineagePerfStopFps?: () => { startedAt: number; durationMs: number; deltas: number[] } | null;
+    };
+    return (window as W).__lineagePerfStopFps?.() ?? null;
+  });
+  if (!raw) return null;
+  const frames = raw.deltas.length;
+  const meanFrameMs = frames > 0 ? raw.deltas.reduce((s: number, d: number) => s + d, 0) / frames : 0;
+  const maxFrameMs = frames > 0 ? Math.max(...raw.deltas) : 0;
+  return {
+    startedAt: raw.startedAt,
+    durationMs: raw.durationMs,
+    frames,
+    meanFrameMs,
+    maxFrameMs,
+  };
+}
+
+export async function countReactFlowDomNodes(page: Page): Promise<{ nodes: number; edges: number }> {
+  return page.evaluate(() => ({
+    nodes: document.querySelectorAll('.react-flow__node').length,
+    edges: document.querySelectorAll('.react-flow__edge').length,
+  }));
+}
+
+export async function summarise(page: Page): Promise<PerfSummary> {
+  const raw = await collectRaw(page);
+  const dom = await countReactFlowDomNodes(page);
+  const nav = await page.evaluate(() => {
+    const entry = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
+    if (!entry) return null;
+    return {
+      url: location.href,
+      navigationMs: entry.responseEnd - entry.startTime,
+      domContentLoadedMs: entry.domContentLoadedEventEnd - entry.startTime,
+      loadEventMs: entry.loadEventEnd - entry.startTime,
+    };
+  });
+
+  const firstPaint = raw.paint.find((p) => p.name === 'first-paint')?.startTime;
+  const firstContentfulPaint = raw.paint.find((p) => p.name === 'first-contentful-paint')?.startTime;
+  const cls = raw.layoutShifts.reduce((s, l) => (l.hadRecentInput ? s : s + l.value), 0);
+  const longTaskTotalMs = raw.longTasks.reduce((s, l) => s + l.duration, 0);
+  const longTaskMaxMs = raw.longTasks.reduce((m, l) => Math.max(m, l.duration), 0);
+  const totalGraphqlRequests = raw.resources.reduce((s, r) => s + (r.isGraphql ? 1 : 0), 0);
+  const totalEncodedBodyBytes = raw.resources.reduce((s, r) => s + r.encodedBodySize, 0);
+
+  return {
+    url: nav?.url ?? '',
+    reactFlowNodesInDom: dom.nodes,
+    reactFlowEdgesInDom: dom.edges,
+    longTaskCount: raw.longTasks.length,
+    longTaskTotalMs,
+    longTaskMaxMs,
+    firstPaintMs: firstPaint,
+    firstContentfulPaintMs: firstContentfulPaint,
+    cumulativeLayoutShift: cls,
+    navigationMs: nav?.navigationMs,
+    domContentLoadedMs: nav?.domContentLoadedMs,
+    loadEventMs: nav?.loadEventMs,
+    totalRequests: raw.resources.length,
+    totalGraphqlRequests,
+    totalEncodedBodyBytes,
+  };
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -490,6 +490,8 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "featureFlags.fineGrainedLineageNotAllowedForPlatforms",
           "featureFlags.graphServiceDiffModeEnabled",
           "featureFlags.hideDbtSourceInLineage",
+          "featureFlags.lineageGraphPerfOverscanEnabled",
+          "featureFlags.lineageGraphPerfVirtEnabled",
           "featureFlags.lineageGraphV2",
           "featureFlags.lineageGraphV3",
           "featureFlags.lineageSearchCacheEnabled",

--- a/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
@@ -46,6 +46,11 @@ public class FeatureFlags {
   private boolean showStatsTabRedesign = false;
   private boolean showHomePageRedesign = false;
   private boolean lineageGraphV3 = true;
+  // Server defaults for V2 lineage rendering perf levers. Overridable per-session
+  // by the `?lineagePerf=` URL param and `datahub.lineagePerfFlags` localStorage
+  // entry, but those overrides start from these values rather than hardcoded ones.
+  private boolean lineageGraphPerfVirtEnabled = true;
+  private boolean lineageGraphPerfOverscanEnabled = false;
   private boolean showProductUpdates = false;
   private String productUpdatesJsonUrl;
   private String productUpdatesJsonFallbackResource;

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -1161,6 +1161,8 @@ featureFlags:
   showStatsTabRedesign: ${SHOW_STATS_TAB_REDESIGN:true} # If turned on, show the re-designed Stats tab on the entity page
   showHomePageRedesign: ${SHOW_HOME_PAGE_REDESIGN:true} # If turned on, show the re-designed home page
   lineageGraphV3: ${LINEAGE_GRAPH_V3:true} # Enables the redesign of the lineage v2 graph
+  lineageGraphPerfVirtEnabled: ${LINEAGE_GRAPH_PERF_VIRT_ENABLED:true} # Enables viewport-based DOM virtualization in the V2 lineage graph (auto-applied above ~50 nodes). URL/localStorage overrides still apply per-session.
+  lineageGraphPerfOverscanEnabled: ${LINEAGE_GRAPH_PERF_OVERSCAN_ENABLED:false} # Enables the wider overscan-buffered virt path in the V2 lineage graph (auto-applied above ~200 nodes when virt is on). Trades a small pan-cost regression for fewer pop-in artefacts.
   showProductUpdates: ${SHOW_PRODUCT_UPDATES:true} # Whether to show in-product update popover on new updates.
   # product updates for OSS (master):
   productUpdatesJsonUrl: ${PRODUCT_UPDATES_JSON_URL:https://product.datahub.com/updates/datahub-core/} # URL to fetch product updates JSON from remote source.


### PR DESCRIPTION
## Summary

Adds viewport-based DOM virtualization for the V2 lineage graph plus an opt-in Playwright benchmark suite for measuring and regressing lineage rendering performance at scale.

### Why

The V2 lineage graph renders every node and edge regardless of viewport, which makes large graphs (500+ nodes) very expensive to expand, pan, and click. Synthetic measurements on this branch show single-action stalls of 2.4–4.4 s at 500 nodes (`expand-fanout`, `pan-horizontal`, `click-root`, `hover-column-root`).

### What

**Backend feature flags** (`metadata-service/configuration`, `datahub-graphql-core`)

- `lineageGraphPerfVirtEnabled` (default `true`) — server default for auto-applying ReactFlow's `onlyRenderVisibleElements` above ~50 rendered nodes.
- `lineageGraphPerfOverscanEnabled` (default `false`) — server default for the wider overscan-buffered virt path above ~200 nodes; trades a small pan-cost regression for fewer pop-in artefacts.
- Both surface through `appConfig.featureFlags` and `AppConfigResolver`, and are classified as non-sensitive in `PropertiesCollectorConfigurationTest`. URL (`?lineagePerf=`) and localStorage (`datahub.lineagePerfFlags`) still override per-session for diagnostics.

**Frontend — lineageV2** (`datahub-web-react/src/app/lineageV2`)

- `perfFlags.ts` resolves modes (`virt`, `overscan`) from server defaults, URL, and localStorage with documented precedence; unit-tested in `__tests__/perfFlags.test.ts`.
- `useOverscanVirt.ts` inflates ReactFlow's `nodeExtent`/`viewport` bounds by `DEFAULT_OVERSCAN_FACTOR` so neighbours mount before they scroll into view.
- `LineageVisualization` reads server flags via `useAppConfig()` and threads the resolved modes into ReactFlow.
- `LineageVisualizationContext` adds `forceMountAll` so the screenshot export can temporarily disable virtualization for capture.

**Screenshot export** (V2 + V3)

- `application.conf` CSP: add `data:` to `img-src`. `html-to-image` inlines its serialised SVG as a `data:` URI before rasterising, so the screenshot button was silently broken under the previous policy. Surfaced by the new screenshot-stress spec.
- `DownloadLineageScreenshotButton` (V2 + V3): replace `console.error` with `antd.message.error` for user-visible feedback; new focused test for the failure path.

**E2E perf benchmark suite** (`e2e-test/ui/playwright`)

- New `tests/lineage-perf/` directory, opt-in via `LINEAGE_PERF=1`:
  - Journey benchmark across small / chain+columns / filter-hub graphs.
  - Synthetic scaling matrix (100/500/1000 nodes) × {baseline, virt, virt+overscan}.
  - Opt-in screenshot stress (`LINEAGE_PERF_SCREENSHOT=1`).
  - Opt-in axe-core accessibility audit (`LINEAGE_A11Y=1`, `LINEAGE_A11Y_LARGE=1`).
- `LineagePerfRecorder` (`utils/lineage-perf-collector.ts`) records wall time, long tasks, FPS, network request count + bytes per action.
- `lineage-perf-seeder.ts` programmatically seeds Dataset, column lineage, DataJob/DataFlow, Chart, and Dashboard graphs at arbitrary scale via `ingestProposal`.
- `LineagePerfPage` (`pages/lineage-perf.page.ts`) — virt-aware `expandFanoutFully` helper plus standard navigation steps.
- `LINEAGE_PERF_REPEAT=N` runs each scenario N times for variance.
- `scripts/lineage-perf-aggregate.mjs` computes p50 / p95 / max bands from the JSON output; wired up as `yarn perf:aggregate` and `yarn perf:aggregate:json`. Documented in `e2e-test/ui/playwright/README.md`.
- `v2-lineage-virt.spec.ts` regression test: virt path produces the expected DOM node count for forced-on and forced-off variants.

### Headline measurements

Synthetic 500-node graph, single run, forced-virt vs baseline:

| Action | Baseline | Virt | Δ |
| --- | ---: | ---: | ---: |
| `expand-fanout` | 2446 ms | 65 ms | **−97%** |
| `pan-horizontal` | 4367 ms | 384 ms | **−91%** |
| `click-root` | 2496 ms | 39 ms | **−98%** |
| `hover-column-root` | 2381 ms | 328 ms | **−86%** |

At 100 nodes forced-virt regresses `expand-fanout` (1730 → 9397 ms), which is exactly why the production code's auto thresholds (`VIRT_AUTO_THRESHOLD=50`, `OVERSCAN_AUTO_THRESHOLD=200`) gate virt off at small scales. `virt+overscan` at 100 nodes (1787 ms) confirms the rest of the pipeline isn't penalised.

### Risk and rollout

- Default behaviour for new deployments: virt on (auto-threshold), overscan off. The auto-threshold means small graphs render identically to today.
- Both flags can be overridden via env var (`LINEAGE_GRAPH_PERF_VIRT_ENABLED`, `LINEAGE_GRAPH_PERF_OVERSCAN_ENABLED`) or via URL / localStorage per session.
- Screenshot CSP fix is independently safe: only widens `img-src` to also allow `data:` URIs, which is needed by `html-to-image`.

### Tests

- New Java unit-test coverage: `AppConfigResolverTest`, `PropertiesCollectorConfigurationTest` updated.
- New frontend unit tests: `perfFlags.test.ts`, `virtualization.sanity.test.tsx`, `DownloadLineageScreenshotButton.test.tsx`.
- New Playwright suites under `tests/lineage-perf/` and `tests/lineage-v2/v2-lineage-virt.spec.ts`.
- Verified locally with `LINEAGE_PERF=1 yarn perf` against a running stack — 12 / 12 active tests pass; a11y + screenshot-stress suites are opt-in.

### Checklist

- [x] PR conforms to the Contributing Guideline (PR title format)
- [x] Tests added/updated
- [x] Docs added/updated (`e2e-test/ui/playwright/README.md` — performance benchmark instructions)
- [x] No breaking changes (feature flags default to current behaviour at small scale)

Made with [Cursor](https://cursor.com)