### PR TITLE
fix(ui): darken UserProfileInfoCard GradientContainer background

### DIFF
--- a/datahub-web-react/src/app/entityV2/user/UserProfileInfoCard.tsx
+++ b/datahub-web-react/src/app/entityV2/user/UserProfileInfoCard.tsx
@@ -1,4 +1,4 @@
-import { Avatar } from '@components';
+import { Avatar, colors } from '@components';
 import { Col } from 'antd';
 import React, { useState } from 'react';
 import styled from 'styled-components';
@@ -65,7 +65,7 @@ export const UserProfileInfoCard = ({ sidebarData, refetch, dataHubRoleName, isP
     return (
         <>
             <CustomAvatarContainer>
-                <GradientContainer />
+                <GradientContainer gradient={colors.primary[900]} />
                 <UserInfo>
                     <Col xxl={8} xl={10} lg={24} md={24} sm={24} xs={24}>
                         <ProfileAvatarWrapper>


### PR DESCRIPTION
The UserProfileInfoCard background color is not dark enough behind the white text in order to meet accessibility contrast ratio 4:5:1

<img width="377" height="385" alt="Screenshot 2026-05-27 at 10 44 50 AM" src="https://github.com/user-attachments/assets/886f170d-4204-4fae-8b88-a5fc4ac11764" />

This PR just adjusts that color to be darker.
