### PR TITLE
fix(ingest/teradata): correct nullable and autoincrement hydration for CHAR(N)-padded values

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
@@ -651,43 +651,22 @@ def optimized_get_pk_constraint(
     return {"constrained_columns": index_columns, "name": index_name}
 
 
-def _apply_nullable_override(row: Any, col_info: Dict[str, Any]) -> None:
-    """Override col_info['nullable'] with a defensive parse of the raw Nullable field.
+def _strip_padded_nullable(row: Any, col_info: Dict[str, Any]) -> None:
+    """Re-derive col_info['nullable'] by stripping CHAR(1) padding from row.Nullable.
 
-    teradatasqlalchemy's _get_column_info computes nullable via the strict check
-    ``row['Nullable'] == 'Y'``. Teradata's `Nullable` column in dbc.ColumnsV (and
-    HELP COLUMN output) is CHAR(1), which Teradata returns space-padded over the
-    wire as ``'Y '`` / ``'N '``. The strict check then evaluates False for every
-    column, so genuinely nullable fields incorrectly hydrate as nullable=False.
-
-    Re-derive nullable from the raw field, normalizing whitespace/case/bytes.
-    When the raw value is None or unparseable, leave the existing value alone —
-    the most common cause is a view column without QVCI enabled, where the
-    metadata genuinely isn't available and guessing would just be wrong in the
-    opposite direction.
-    """
-    raw: Any = None
-    if hasattr(row, "Nullable"):
-        raw = row.Nullable
-    elif isinstance(row, dict) and "Nullable" in row:
-        raw = row["Nullable"]
-    else:
-        mapping = getattr(row, "_mapping", None)
-        if mapping is not None and "Nullable" in mapping:
-            raw = mapping["Nullable"]
-
-    if isinstance(raw, bytes):
-        try:
-            raw = raw.decode("utf-8")
-        except UnicodeDecodeError:
-            return
-
+    teradatasqlalchemy does a strict `row['Nullable'] == 'Y'` check, but
+    Teradata returns CHAR(1) values space-padded ('Y '/'N '), so the check
+    evaluates False for every nullable column. No-op when the row's Nullable
+    isn't a string (e.g. None for view columns without QVCI enabled)."""
+    raw = (
+        row.Nullable
+        if hasattr(row, "Nullable")
+        else row.get("Nullable")
+        if isinstance(row, dict)
+        else None
+    )
     if isinstance(raw, str):
-        normalized = raw.strip().upper()
-        if normalized == "Y":
-            col_info["nullable"] = True
-        elif normalized == "N":
-            col_info["nullable"] = False
+        col_info["nullable"] = raw.strip() == "Y"
 
 
 def optimized_get_columns(
@@ -788,7 +767,7 @@ def optimized_get_columns(
     for row in res:
         try:
             col_info = self._get_column_info(row)
-            _apply_nullable_override(row, col_info)
+            _strip_padded_nullable(row, col_info)
 
             # Add CommentString as comment field for column description
             if hasattr(row, "CommentString") and row.CommentString:

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
@@ -651,6 +651,45 @@ def optimized_get_pk_constraint(
     return {"constrained_columns": index_columns, "name": index_name}
 
 
+def _apply_nullable_override(row: Any, col_info: Dict[str, Any]) -> None:
+    """Override col_info['nullable'] with a defensive parse of the raw Nullable field.
+
+    teradatasqlalchemy's _get_column_info computes nullable via the strict check
+    ``row['Nullable'] == 'Y'``. Teradata's `Nullable` column in dbc.ColumnsV (and
+    HELP COLUMN output) is CHAR(1), which Teradata returns space-padded over the
+    wire as ``'Y '`` / ``'N '``. The strict check then evaluates False for every
+    column, so genuinely nullable fields incorrectly hydrate as nullable=False.
+
+    Re-derive nullable from the raw field, normalizing whitespace/case/bytes.
+    When the raw value is None or unparseable, leave the existing value alone —
+    the most common cause is a view column without QVCI enabled, where the
+    metadata genuinely isn't available and guessing would just be wrong in the
+    opposite direction.
+    """
+    raw: Any = None
+    if hasattr(row, "Nullable"):
+        raw = row.Nullable
+    elif isinstance(row, dict) and "Nullable" in row:
+        raw = row["Nullable"]
+    else:
+        mapping = getattr(row, "_mapping", None)
+        if mapping is not None and "Nullable" in mapping:
+            raw = mapping["Nullable"]
+
+    if isinstance(raw, bytes):
+        try:
+            raw = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return
+
+    if isinstance(raw, str):
+        normalized = raw.strip().upper()
+        if normalized == "Y":
+            col_info["nullable"] = True
+        elif normalized == "N":
+            col_info["nullable"] = False
+
+
 def optimized_get_columns(
     self: Any,
     connection: Connection,
@@ -749,6 +788,7 @@ def optimized_get_columns(
     for row in res:
         try:
             col_info = self._get_column_info(row)
+            _apply_nullable_override(row, col_info)
 
             # Add CommentString as comment field for column description
             if hasattr(row, "CommentString") and row.CommentString:

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
@@ -651,6 +651,15 @@ def optimized_get_pk_constraint(
     return {"constrained_columns": index_columns, "name": index_name}
 
 
+def _read_padded_char_field(row: Any, field: str) -> Optional[str]:
+    """Read a CHAR(N) field that Teradata returns space-padded, return it stripped.
+
+    Returns None when the field is missing or not a string — callers should
+    leave any existing value alone in that case."""
+    raw = getattr(row, field, None) if not isinstance(row, dict) else row.get(field)
+    return raw.strip() if isinstance(raw, str) else None
+
+
 def _strip_padded_nullable(row: Any, col_info: Dict[str, Any]) -> None:
     """Re-derive col_info['nullable'] by stripping CHAR(1) padding from row.Nullable.
 
@@ -658,15 +667,21 @@ def _strip_padded_nullable(row: Any, col_info: Dict[str, Any]) -> None:
     Teradata returns CHAR(1) values space-padded ('Y '/'N '), so the check
     evaluates False for every nullable column. No-op when the row's Nullable
     isn't a string (e.g. None for view columns without QVCI enabled)."""
-    raw = (
-        row.Nullable
-        if hasattr(row, "Nullable")
-        else row.get("Nullable")
-        if isinstance(row, dict)
-        else None
-    )
-    if isinstance(raw, str):
-        col_info["nullable"] = raw.strip() == "Y"
+    val = _read_padded_char_field(row, "Nullable")
+    if val is not None:
+        col_info["nullable"] = val == "Y"
+
+
+def _strip_padded_autoincrement(row: Any, col_info: Dict[str, Any]) -> None:
+    """Re-derive col_info['autoincrement'] by stripping padding from row.IdColType.
+
+    Same root cause as _strip_padded_nullable: teradatasqlalchemy checks
+    `row['IdColType'] in ('GA', 'GD')` strictly, but Teradata returns IdColType
+    space-padded ('GA  '), so the check evaluates False for every identity
+    column. No-op when the raw value isn't a string."""
+    val = _read_padded_char_field(row, "IdColType")
+    if val is not None:
+        col_info["autoincrement"] = val in ("GA", "GD")
 
 
 def optimized_get_columns(
@@ -768,6 +783,7 @@ def optimized_get_columns(
         try:
             col_info = self._get_column_info(row)
             _strip_padded_nullable(row, col_info)
+            _strip_padded_autoincrement(row, col_info)
 
             # Add CommentString as comment field for column description
             if hasattr(row, "CommentString") and row.CommentString:

--- a/metadata-ingestion/tests/unit/test_teradata_source.py
+++ b/metadata-ingestion/tests/unit/test_teradata_source.py
@@ -25,7 +25,6 @@ from datahub.ingestion.source.sql.teradata import (
     TeradataReport,
     TeradataSource,
     TeradataTable,
-    _apply_nullable_override,
     _engine_connect_with_retry,
     _execute_with_retry,
     _fetchmany_with_retry,
@@ -4111,76 +4110,82 @@ class TestExecuteWithCursorFallback:
         assert result is expected
 
 
-class TestApplyNullableOverride:
-    """Tests for the defensive Nullable parser used to work around CHAR(1)
-    space-padding in Teradata's dbc.ColumnsV and HELP COLUMN output.
+class TestNullableCharPadding:
+    """Teradata returns dbc.ColumnsV.Nullable space-padded as 'Y '/'N ' (CHAR(1)).
+    The library's strict `row['Nullable'] == 'Y'` then evaluates False for every
+    column, so genuinely nullable columns hydrate as nullable=False until we
+    re-check after stripping. Exercise this through optimized_get_columns so we
+    catch a regression at the actual code path."""
 
-    See _apply_nullable_override docstring for the underlying issue."""
+    def _make_dialect_with_row(self, raw_nullable):
+        """Build a mock dialect that returns a single row with the given
+        raw Nullable value, mimicking the buggy library output."""
 
-    @pytest.mark.parametrize(
-        "raw, expected",
-        [
-            # Bare values
-            ("Y", True),
-            ("N", False),
-            # CHAR(1) space-padded — the bug we're actually fixing
-            ("Y ", True),
-            ("N ", False),
-            ("  Y  ", True),
-            ("  N  ", False),
-            # Case insensitivity (defensive, low real-world risk)
-            ("y", True),
-            ("n", False),
-            ("y ", True),
-            # Bytes (defensive)
-            (b"Y", True),
-            (b"N", False),
-            (b"Y ", True),
-        ],
-    )
-    def test_parses_padded_and_variant_inputs(self, raw, expected):
-        row = {"Nullable": raw}
-        col_info: Dict[str, Any] = {"nullable": not expected}  # opposite of expected
-        _apply_nullable_override(row, col_info)
-        assert col_info["nullable"] is expected
+        # Library produces False for any non-bare-'Y' value, including padded.
+        library_nullable = raw_nullable == "Y"
 
-    @pytest.mark.parametrize("raw", [None, "", "   ", "?", "unknown", 1, 0, object()])
-    def test_leaves_value_alone_when_unparseable(self, raw):
-        """When the raw Nullable can't be confidently parsed, we must NOT
-        overwrite — most often this means a view column without QVCI, and
-        defaulting either direction would be wrong."""
-        for original in (True, False):
-            col_info: Dict[str, Any] = {"nullable": original}
-            _apply_nullable_override({"Nullable": raw}, col_info)
-            assert col_info["nullable"] is original
+        mock_dialect = MagicMock()
+        mock_dialect.default_schema_name = "mydb"
+        mock_dialect._get_column_info.return_value = {
+            "name": "col1",
+            "nullable": library_nullable,
+        }
 
-    def test_handles_row_object_with_attribute(self):
-        """Library passes SQLAlchemy Row-like objects; attribute access path."""
+        # Row with attribute access (matches SQLAlchemy Row from dbc.ColumnsV).
+        row = MagicMock(spec=["Nullable", "CommentString"])
+        row.Nullable = raw_nullable
+        row.CommentString = None
+        mock_dialect.get_schema_columns.return_value = {"my_table": [row]}
+        return mock_dialect
 
-        class FakeRow:
-            Nullable = "Y "
+    def _call(self, mock_dialect):
+        tables_cache: Dict[str, List[TeradataTable]] = {
+            "mydb": [
+                TeradataTable(
+                    database="mydb",
+                    name="my_table",
+                    description=None,
+                    object_type="Table",
+                    create_timestamp=datetime.now(),
+                    last_alter_name=None,
+                    last_alter_timestamp=None,
+                    request_text=None,
+                )
+            ]
+        }
+        return optimized_get_columns(
+            mock_dialect,
+            MagicMock(),
+            "my_table",
+            "mydb",
+            tables_cache=tables_cache,
+        )
 
-        col_info: Dict[str, Any] = {"nullable": False}
-        _apply_nullable_override(FakeRow(), col_info)
-        assert col_info["nullable"] is True
+    def test_padded_y_hydrates_as_nullable_true(self):
+        """The real-world bug: 'Y ' (padded) must produce nullable=True."""
+        cols = self._call(self._make_dialect_with_row("Y "))
+        assert cols[0]["nullable"] is True
 
-    def test_handles_row_object_with_mapping(self):
-        """Some Row objects expose `_mapping` instead of attributes."""
+    def test_padded_n_hydrates_as_nullable_false(self):
+        cols = self._call(self._make_dialect_with_row("N "))
+        assert cols[0]["nullable"] is False
 
-        class FakeRow:
-            _mapping = {"Nullable": "N "}
+    def test_clean_y_still_works(self):
+        """Bare 'Y' (no padding) is unchanged behavior."""
+        cols = self._call(self._make_dialect_with_row("Y"))
+        assert cols[0]["nullable"] is True
 
-        col_info: Dict[str, Any] = {"nullable": True}
-        _apply_nullable_override(FakeRow(), col_info)
-        assert col_info["nullable"] is False
-
-    def test_missing_nullable_key_is_noop(self):
-        col_info: Dict[str, Any] = {"nullable": True}
-        _apply_nullable_override({"OtherKey": "Y"}, col_info)
-        assert col_info["nullable"] is True
-
-    def test_invalid_utf8_bytes_does_not_raise(self):
-        col_info: Dict[str, Any] = {"nullable": False}
-        # Should not raise; should leave value untouched.
-        _apply_nullable_override({"Nullable": b"\xff\xfe"}, col_info)
-        assert col_info["nullable"] is False
+    def test_dict_row_with_padded_nullable(self):
+        """HELP path produces dict rows via _update_column_help_info; both
+        SQLAlchemy Row attribute access and dict access must work."""
+        mock_dialect = MagicMock()
+        mock_dialect.default_schema_name = "mydb"
+        mock_dialect._get_column_info.return_value = {
+            "name": "col1",
+            "nullable": False,
+        }
+        mock_dialect.get_schema_columns.return_value = {
+            "my_table": [{"Nullable": "Y ", "ColumnName": "col1"}]
+        }
+        cols = self._call(mock_dialect)
+        assert cols[0]["nullable"] is True

--- a/metadata-ingestion/tests/unit/test_teradata_source.py
+++ b/metadata-ingestion/tests/unit/test_teradata_source.py
@@ -4110,35 +4110,28 @@ class TestExecuteWithCursorFallback:
         assert result is expected
 
 
-class TestNullableCharPadding:
-    """Teradata returns dbc.ColumnsV.Nullable space-padded as 'Y '/'N ' (CHAR(1)).
-    The library's strict `row['Nullable'] == 'Y'` then evaluates False for every
-    column, so genuinely nullable columns hydrate as nullable=False until we
-    re-check after stripping. Exercise this through optimized_get_columns so we
+class TestCharPaddingFixes:
+    """Teradata returns CHAR(N) values space-padded over the wire. The library's
+    strict comparisons (`row['Nullable'] == 'Y'`, `row['IdColType'] in ('GA',
+    'GD')`) then evaluate False for every column, so genuinely nullable columns
+    hydrate as nullable=False and identity columns hydrate as
+    autoincrement=False. Exercise the fix through optimized_get_columns so we
     catch a regression at the actual code path."""
 
-    def _make_dialect_with_row(self, raw_nullable):
-        """Build a mock dialect that returns a single row with the given
-        raw Nullable value, mimicking the buggy library output."""
+    def _call_with_row(self, row, library_col_info=None):
+        """Drive optimized_get_columns with a single mocked row.
 
-        # Library produces False for any non-bare-'Y' value, including padded.
-        library_nullable = raw_nullable == "Y"
-
+        library_col_info simulates what teradatasqlalchemy's _get_column_info
+        would return; the test then asserts our padding fixes override it."""
         mock_dialect = MagicMock()
         mock_dialect.default_schema_name = "mydb"
-        mock_dialect._get_column_info.return_value = {
+        mock_dialect._get_column_info.return_value = library_col_info or {
             "name": "col1",
-            "nullable": library_nullable,
+            "nullable": False,
+            "autoincrement": False,
         }
-
-        # Row with attribute access (matches SQLAlchemy Row from dbc.ColumnsV).
-        row = MagicMock(spec=["Nullable", "CommentString"])
-        row.Nullable = raw_nullable
-        row.CommentString = None
         mock_dialect.get_schema_columns.return_value = {"my_table": [row]}
-        return mock_dialect
 
-    def _call(self, mock_dialect):
         tables_cache: Dict[str, List[TeradataTable]] = {
             "mydb": [
                 TeradataTable(
@@ -4161,31 +4154,54 @@ class TestNullableCharPadding:
             tables_cache=tables_cache,
         )
 
-    def test_padded_y_hydrates_as_nullable_true(self):
-        """The real-world bug: 'Y ' (padded) must produce nullable=True."""
-        cols = self._call(self._make_dialect_with_row("Y "))
+    @staticmethod
+    def _row(**fields):
+        """SQLAlchemy Row-like object with attribute access for given fields."""
+        row = MagicMock(spec=list(fields.keys()) + ["CommentString"])
+        for k, v in fields.items():
+            setattr(row, k, v)
+        row.CommentString = None
+        return row
+
+    # Nullable: customer-reported bug
+    def test_padded_nullable_y_hydrates_as_true(self):
+        cols = self._call_with_row(self._row(Nullable="Y "))
         assert cols[0]["nullable"] is True
 
-    def test_padded_n_hydrates_as_nullable_false(self):
-        cols = self._call(self._make_dialect_with_row("N "))
+    def test_padded_nullable_n_hydrates_as_false(self):
+        cols = self._call_with_row(self._row(Nullable="N "))
         assert cols[0]["nullable"] is False
 
-    def test_clean_y_still_works(self):
-        """Bare 'Y' (no padding) is unchanged behavior."""
-        cols = self._call(self._make_dialect_with_row("Y"))
+    def test_clean_nullable_y_unchanged(self):
+        cols = self._call_with_row(self._row(Nullable="Y"))
         assert cols[0]["nullable"] is True
 
-    def test_dict_row_with_padded_nullable(self):
-        """HELP path produces dict rows via _update_column_help_info; both
-        SQLAlchemy Row attribute access and dict access must work."""
-        mock_dialect = MagicMock()
-        mock_dialect.default_schema_name = "mydb"
-        mock_dialect._get_column_info.return_value = {
-            "name": "col1",
-            "nullable": False,
-        }
-        mock_dialect.get_schema_columns.return_value = {
-            "my_table": [{"Nullable": "Y ", "ColumnName": "col1"}]
-        }
-        cols = self._call(mock_dialect)
+    def test_dict_row_padded_nullable(self):
+        """HELP-derived dict rows must work alongside SQLAlchemy Row objects."""
+        cols = self._call_with_row({"Nullable": "Y ", "ColumnName": "col1"})
         assert cols[0]["nullable"] is True
+
+    # IdColType: latent sibling bug, same root cause
+    def test_padded_idcoltype_hydrates_as_autoincrement_true(self):
+        """The library does `row['IdColType'] in ('GA','GD')`; Teradata returns
+        'GA  ' padded, so the check fails for every identity column."""
+        cols = self._call_with_row(
+            self._row(Nullable="Y", IdColType="GA  "),
+            library_col_info={"name": "col1", "nullable": True, "autoincrement": False},
+        )
+        assert cols[0]["autoincrement"] is True
+
+    def test_padded_idcoltype_gd_hydrates_as_autoincrement_true(self):
+        cols = self._call_with_row(
+            self._row(Nullable="Y", IdColType="GD  "),
+            library_col_info={"name": "col1", "nullable": True, "autoincrement": False},
+        )
+        assert cols[0]["autoincrement"] is True
+
+    def test_no_idcoltype_leaves_autoincrement_alone(self):
+        """Non-identity columns have IdColType=None; we must not overwrite."""
+        cols = self._call_with_row(
+            self._row(Nullable="Y", IdColType=None),
+            library_col_info={"name": "col1", "nullable": True, "autoincrement": False},
+        )
+        assert cols[0]["autoincrement"] is False

--- a/metadata-ingestion/tests/unit/test_teradata_source.py
+++ b/metadata-ingestion/tests/unit/test_teradata_source.py
@@ -25,6 +25,7 @@ from datahub.ingestion.source.sql.teradata import (
     TeradataReport,
     TeradataSource,
     TeradataTable,
+    _apply_nullable_override,
     _engine_connect_with_retry,
     _execute_with_retry,
     _fetchmany_with_retry,
@@ -4108,3 +4109,78 @@ class TestExecuteWithCursorFallback:
 
         conn.execution_options.assert_not_called()
         assert result is expected
+
+
+class TestApplyNullableOverride:
+    """Tests for the defensive Nullable parser used to work around CHAR(1)
+    space-padding in Teradata's dbc.ColumnsV and HELP COLUMN output.
+
+    See _apply_nullable_override docstring for the underlying issue."""
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            # Bare values
+            ("Y", True),
+            ("N", False),
+            # CHAR(1) space-padded — the bug we're actually fixing
+            ("Y ", True),
+            ("N ", False),
+            ("  Y  ", True),
+            ("  N  ", False),
+            # Case insensitivity (defensive, low real-world risk)
+            ("y", True),
+            ("n", False),
+            ("y ", True),
+            # Bytes (defensive)
+            (b"Y", True),
+            (b"N", False),
+            (b"Y ", True),
+        ],
+    )
+    def test_parses_padded_and_variant_inputs(self, raw, expected):
+        row = {"Nullable": raw}
+        col_info: Dict[str, Any] = {"nullable": not expected}  # opposite of expected
+        _apply_nullable_override(row, col_info)
+        assert col_info["nullable"] is expected
+
+    @pytest.mark.parametrize("raw", [None, "", "   ", "?", "unknown", 1, 0, object()])
+    def test_leaves_value_alone_when_unparseable(self, raw):
+        """When the raw Nullable can't be confidently parsed, we must NOT
+        overwrite — most often this means a view column without QVCI, and
+        defaulting either direction would be wrong."""
+        for original in (True, False):
+            col_info: Dict[str, Any] = {"nullable": original}
+            _apply_nullable_override({"Nullable": raw}, col_info)
+            assert col_info["nullable"] is original
+
+    def test_handles_row_object_with_attribute(self):
+        """Library passes SQLAlchemy Row-like objects; attribute access path."""
+
+        class FakeRow:
+            Nullable = "Y "
+
+        col_info: Dict[str, Any] = {"nullable": False}
+        _apply_nullable_override(FakeRow(), col_info)
+        assert col_info["nullable"] is True
+
+    def test_handles_row_object_with_mapping(self):
+        """Some Row objects expose `_mapping` instead of attributes."""
+
+        class FakeRow:
+            _mapping = {"Nullable": "N "}
+
+        col_info: Dict[str, Any] = {"nullable": True}
+        _apply_nullable_override(FakeRow(), col_info)
+        assert col_info["nullable"] is False
+
+    def test_missing_nullable_key_is_noop(self):
+        col_info: Dict[str, Any] = {"nullable": True}
+        _apply_nullable_override({"OtherKey": "Y"}, col_info)
+        assert col_info["nullable"] is True
+
+    def test_invalid_utf8_bytes_does_not_raise(self):
+        col_info: Dict[str, Any] = {"nullable": False}
+        # Should not raise; should leave value untouched.
+        _apply_nullable_override({"Nullable": b"\xff\xfe"}, col_info)
+        assert col_info["nullable"] is False


### PR DESCRIPTION
## Summary

`teradatasqlalchemy._get_column_info` uses strict equality / membership checks that don't tolerate CHAR(N) space-padding:

- `'nullable': row['Nullable'] == 'Y'` — Teradata returns `'Y '` / `'N '` (CHAR(1) padded), so the check evaluates `False` for every column. Genuinely nullable columns hydrate as `nullable: false` everywhere.
- `autoinc = row['IdColType'] in ('GA', 'GD')` — Teradata returns `'GA  '` / `'GD  '` (CHAR(4) padded), so the check evaluates `False` for every identity column. Identity columns hydrate as `autoincrement: false`.

Both bugs reproduce on a stock Teradata install with `teradatasqlalchemy==20.0.0.2`, no special configuration. The nullable bug is what surfaced the report (customer ticket: every column appears non-nullable); the IdColType bug is a latent sibling found by auditing other CHAR field accesses in the same code path.

## Fix

After `self._get_column_info(row)` in `optimized_get_columns`, re-derive `nullable` and `autoincrement` from the raw row fields with whitespace-stripping. Shared `_read_padded_char_field` helper handles SQLAlchemy Row attribute access and dict access. Both helpers are no-ops when the raw value isn't a string (e.g. NULL — most often a view column without QVCI, where the metadata is genuinely unknown and guessing either direction would be wrong).

## Test plan

- [x] Unit: new `TestCharPaddingFixes` class with 7 focused tests covering padded `'Y '`/`'N '`, clean `'Y'`, dict-row vs Row-attr access, padded `'GA  '` and `'GD  '`, and `IdColType=None` no-op.
- [x] Full `tests/unit/test_teradata_source.py`: 112 passing.
- [x] `./gradlew :metadata-ingestion:lintFix`: clean.
- [x] End-to-end against a real local Teradata: padded `'Y '` now hydrates as `nullable=True`; padded `'GA  '` now hydrates as `autoincrement=True`.

## What this does and doesn't cover

✅ Padded `'Y '` / `'N '` for `Nullable` (the primary customer-reported bug)
✅ Padded `'GA  '` / `'GD  '` for `IdColType` (autoincrement detection)
❌ View columns where `Nullable` is genuinely `None` (e.g., views without QVCI enabled on Teradata) — the metadata isn't available, and the helper correctly does not guess. Addressed customer-side via QVCI on Teradata.

## Out of scope

Other padded CHAR fields the library handles internally (`ColumnType`, `ColumnName`, etc.) — these flow through `normalize_name` or `_resolve_type` in the library, which already strip. Audited and confirmed no user-visible breakage from those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)