### PR TITLE
fix(ownership): materialize ownerTypes on CREATE_ENTITY writes

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypes.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypes.java
@@ -58,8 +58,13 @@ public class OwnershipOwnerTypes extends MutationHook {
 
       UrnArrayMap materialized = new UrnArrayMap(typeOwners);
       Ownership ownership = item.getAspect(Ownership.class);
-      UrnArrayMap existing = ownership.getOwnerTypes();
-      DataMap existingData = existing != null ? existing.data() : new DataMap();
+      if (ownership.getOwners().isEmpty()) {
+        results.add(Pair.of(item, false));
+        continue;
+      }
+
+      DataMap existingData =
+          ownership.hasOwnerTypes() ? ownership.getOwnerTypes().data() : new DataMap();
       if (existingData.equals(materialized.data())) {
         results.add(Pair.of(item, false));
       } else {

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypeTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypeTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -111,6 +112,71 @@ public class OwnershipOwnerTypeTest {
         resulted.getFirst().getAspect(Ownership.class).getOwnerTypes(),
         originalOwnership.getOwnerTypes());
     assertEquals(resulted.getSecond(), false);
+  }
+
+  @Test
+  public void testWriteMutationSkipsWhenOwnersEmpty() {
+    Ownership ownership = new Ownership();
+    ownership.setOwners(new OwnerArray());
+    TestMCP mcp = getTestMcpBuilder().recordTemplate(ownership).build();
+
+    List<Pair<ChangeMCP, Boolean>> result =
+        test.writeMutation(Set.of(mcp), retrieverContext).toList();
+
+    assertEquals(result.size(), 1);
+    assertFalse(result.get(0).getSecond());
+    assertFalse(ownership.hasOwnerTypes());
+  }
+
+  /**
+   * OpenAPI createEntityIfNotExists uses CREATE_ENTITY. The hook must run on that change type so
+   * the first ownership write materializes ownerTypes, not only subsequent UPSERTs.
+   */
+  @Test
+  public void testCreateEntityMaterializesOwnerTypesWhenProposalOmitsThem()
+      throws URISyntaxException {
+    Ownership proposal = getOwnership(true, false, false);
+    TestMCP mcp =
+        getTestMcpBuilder().changeType(ChangeType.CREATE_ENTITY).recordTemplate(proposal).build();
+
+    List<Pair<ChangeMCP, Boolean>> result =
+        test.writeMutation(Set.of(mcp), retrieverContext).toList();
+
+    assertEquals(result.size(), 1);
+    assertTrue(
+        result.get(0).getSecond(),
+        "CREATE_ENTITY writes must materialize ownerTypes when the proposal omits them.");
+    assertEquals(
+        proposal.getOwnerTypes().get("urn:li:ownershipType:__system__business_owner").get(0),
+        getBusinessOwner());
+  }
+
+  @Test
+  public void testApplyWriteMutationIncludesCreateEntityChangeType() throws URISyntaxException {
+    test.setConfig(
+        AspectPluginConfig.builder()
+            .className(OwnershipOwnerTypes.class.getName())
+            .enabled(true)
+            .supportedOperations(List.of("CREATE", "CREATE_ENTITY", "UPSERT", "UPDATE", "RESTATE"))
+            .supportedEntityAspectNames(
+                List.of(
+                    AspectPluginConfig.EntityAspectName.builder()
+                        .entityName("*")
+                        .aspectName(OWNERSHIP_ASPECT_NAME)
+                        .build()))
+            .build());
+
+    Ownership proposal = getOwnership(true, false, false);
+    TestMCP mcp =
+        getTestMcpBuilder().changeType(ChangeType.CREATE_ENTITY).recordTemplate(proposal).build();
+
+    List<Pair<ChangeMCP, Boolean>> result =
+        test.applyWriteMutation(Set.of(mcp), retrieverContext).toList();
+
+    assertEquals(result.size(), 1);
+    assertTrue(
+        result.get(0).getSecond(),
+        "Hook must apply on CREATE_ENTITY when that change type is configured.");
   }
 
   /**

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
@@ -567,7 +567,7 @@ public class SpringStandardPluginConfiguration {
             AspectPluginConfig.builder()
                 .className(OwnershipOwnerTypes.class.getName())
                 .enabled(true)
-                .supportedOperations(List.of(CREATE, UPSERT, UPDATE, RESTATE, PATCH))
+                .supportedOperations(List.of(CREATE, CREATE_ENTITY, UPSERT, UPDATE, RESTATE, PATCH))
                 .supportedEntityAspectNames(
                     List.of(
                         AspectPluginConfig.EntityAspectName.builder()

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/plugins/StandardPluginConfigurationTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/plugins/StandardPluginConfigurationTest.java
@@ -302,7 +302,7 @@ public class StandardPluginConfigurationTest extends AbstractTestNGSpringContext
     assertEquals(mutator.getConfig().getClassName(), OwnershipOwnerTypes.class.getName());
     assertEquals(
         mutator.getConfig().getSupportedOperations(),
-        List.of("CREATE", "UPSERT", "UPDATE", "RESTATE", "PATCH"));
+        List.of("CREATE", "CREATE_ENTITY", "UPSERT", "UPDATE", "RESTATE", "PATCH"));
   }
 
   @Test


### PR DESCRIPTION
OpenAPI createEntityIfNotExists uses CREATE_ENTITY, but OwnershipOwnerTypes only ran for CREATE/UPSERT, so the first ownership write skipped the hook and ownerTypes were missing until a later UPSERT.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
