### PR TITLE
fix(ingestion/PowerBi): Improves comment and CTE handling for PowerBI parser

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/native_sql_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/native_sql_parser.py
@@ -288,7 +288,7 @@ def parse_custom_sql(
         # separators only at depth-0 positions that are not the closing SELECT
         # of a CTE query, then decide which parser to use.
         normalized = _insert_statement_separators(query)
-        if ";" in normalized:
+        if _has_real_semicolons(normalized):
             result = create_lineage_from_sql_statements(
                 queries=normalized,
                 default_schema=schema,

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/native_sql_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/native_sql_parser.py
@@ -182,11 +182,17 @@ def _insert_statement_separators(query: str) -> str:
         if blank_count >= 1 and paren_depth == 0:
             if re.match(r"SELECT\b", stripped, re.IGNORECASE):
                 if in_cte_query:
-                    # This SELECT closes the open WITH clause — it is part of
-                    # the same statement, so do NOT insert a separator.
+                    # This SELECT is the final query of the WITH clause.
+                    # Inserting a separator here would detach it from the CTE
+                    # definitions, causing sqlglot to treat CTE aliases as real
+                    # tables and generate spurious upstream URNs.
                     in_cte_query = False
                 else:
-                    result.append(";")
+                    # Append to the last non-blank line for conventional SQL style.
+                    for i in range(len(result) - 1, -1, -1):
+                        if result[i].strip():
+                            result[i] += ";"
+                            break
         elif paren_depth == 0 and in_cte_query:
             # CTE closing SELECT with no preceding blank line — the blank_count
             # gate above never fires, so reset the flag here.  Without this,

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/native_sql_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/native_sql_parser.py
@@ -132,6 +132,92 @@ def remove_drop_statement(query: str) -> str:
     return remove_tsql_control_statements(query)
 
 
+def _has_real_semicolons(query: str) -> bool:
+    """Return True if the query contains semicolons outside of SQL comments.
+
+    Prevents comment content (e.g. '-- already done; continue') from
+    incorrectly triggering the multi-statement parsing path.
+    """
+    no_line_comments = re.sub(r"--[^\n]*", "", query)
+    no_comments = re.sub(r"/\*.*?\*/", "", no_line_comments, flags=re.DOTALL)
+    return ";" in no_comments
+
+
+def _insert_statement_separators(query: str) -> str:
+    """Insert semicolons before top-level SELECT statements preceded by blank lines.
+
+    After remove_tsql_control_statements strips DDL between SELECT statements,
+    they may be separated only by blank lines without any semicolons.  This
+    function inserts the missing separators so the multi-statement parser can
+    handle each statement independently.
+
+    Unlike a simple regex, this function tracks parenthesis depth so it never
+    inserts a separator inside a CTE body or subquery.  It also tracks whether
+    a WITH clause is open at depth 0; the SELECT that closes a CTE belongs to
+    the same statement and must not be separated from its WITH clause.
+    """
+    lines = query.split("\n")
+    result: List[str] = []
+    paren_depth = 0
+    blank_count = 0
+    in_cte_query = False  # True while a WITH clause is open at depth 0
+
+    for line in lines:
+        stripped = line.strip()
+
+        if not stripped:
+            blank_count += 1
+            result.append(line)
+            continue
+
+        # Detect the opening of a CTE query (WITH keyword at depth 0).
+        # Must be checked before the SELECT-separator logic so a WITH on the
+        # same "paragraph" as preceding blank lines is recognised as a CTE
+        # start rather than a potential new-statement boundary.
+        if paren_depth == 0 and not in_cte_query:
+            if re.match(r"WITH\b", stripped, re.IGNORECASE):
+                in_cte_query = True
+
+        # Consider inserting a statement separator before this line.
+        if blank_count >= 1 and paren_depth == 0:
+            if re.match(r"SELECT\b", stripped, re.IGNORECASE):
+                if in_cte_query:
+                    # This SELECT closes the open WITH clause — it is part of
+                    # the same statement, so do NOT insert a separator.
+                    in_cte_query = False
+                else:
+                    result.append(";")
+
+        blank_count = 0
+        result.append(line)
+
+        # Update paren depth, respecting line comments and single-quoted
+        # strings so that parentheses inside them are not counted.
+        in_line_comment = False
+        in_string = False
+        quote_char = ""
+        idx = 0
+        while idx < len(line):
+            c = line[idx]
+            if in_line_comment:
+                break
+            if in_string:
+                if c == quote_char:
+                    in_string = False
+            elif c == "-" and idx + 1 < len(line) and line[idx + 1] == "-":
+                in_line_comment = True
+            elif c in ("'", '"'):
+                in_string = True
+                quote_char = c
+            elif c == "(":
+                paren_depth += 1
+            elif c == ")":
+                paren_depth = max(0, paren_depth - 1)
+            idx += 1
+
+    return "\n".join(result)
+
+
 def parse_custom_sql(
     ctx: PipelineContext,
     query: str,
@@ -144,14 +230,13 @@ def parse_custom_sql(
     logger.debug("Using sqlglot_lineage to parse custom sql")
     logger.debug(f"Processing native query using DataHub Sql Parser = {query}")
 
-    # Blank-line-separated SELECTs appear after DROP TABLE stripping removes the DDL
-    # between statements, leaving no semicolons. Insert them so the multi-statement
-    # check below treats them correctly.
-    normalized = re.sub(r"\n{2,}(\s*SELECT\b)", r";\n\n\1", query, flags=re.IGNORECASE)
-
-    if ";" in normalized:
+    if _has_real_semicolons(query):
+        # The query already has real statement separators — use multi-statement
+        # parsing directly with the original query.  We avoid the blank-line
+        # normalisation here because it can incorrectly insert semicolons inside
+        # CTE bodies that happen to have blank lines before their SELECT clause.
         result = create_lineage_from_sql_statements(
-            queries=normalized,
+            queries=query,
             default_schema=schema,
             default_db=database,
             platform=platform,
@@ -160,14 +245,30 @@ def parse_custom_sql(
             graph=ctx.graph,
         )
     else:
-        result = create_lineage_sql_parsed_result(
-            query=query,
-            default_schema=schema,
-            default_db=database,
-            platform=platform,
-            platform_instance=platform_instance,
-            env=env,
-            graph=ctx.graph,
-        )
+        # No real semicolons.  Blank-line-separated SELECTs can appear after
+        # remove_tsql_control_statements strips the DDL between them.  Insert
+        # separators only at depth-0 positions that are not the closing SELECT
+        # of a CTE query, then decide which parser to use.
+        normalized = _insert_statement_separators(query)
+        if ";" in normalized:
+            result = create_lineage_from_sql_statements(
+                queries=normalized,
+                default_schema=schema,
+                default_db=database,
+                platform=platform,
+                platform_instance=platform_instance,
+                env=env,
+                graph=ctx.graph,
+            )
+        else:
+            result = create_lineage_sql_parsed_result(
+                query=query,
+                default_schema=schema,
+                default_db=database,
+                platform=platform,
+                platform_instance=platform_instance,
+                env=env,
+                graph=ctx.graph,
+            )
 
     return result

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/native_sql_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/native_sql_parser.py
@@ -187,6 +187,13 @@ def _insert_statement_separators(query: str) -> str:
                     in_cte_query = False
                 else:
                     result.append(";")
+        elif paren_depth == 0 and in_cte_query:
+            # CTE closing SELECT with no preceding blank line — the blank_count
+            # gate above never fires, so reset the flag here.  Without this,
+            # the flag stays True and the next blank-line-separated SELECT is
+            # incorrectly swallowed as the CTE closing SELECT.
+            if re.match(r"SELECT\b", stripped, re.IGNORECASE):
+                in_cte_query = False
 
         blank_count = 0
         result.append(line)

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/native_sql_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/native_sql_parser.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import sqlparse
 
@@ -133,14 +133,58 @@ def remove_drop_statement(query: str) -> str:
 
 
 def _has_real_semicolons(query: str) -> bool:
-    """Return True if the query contains semicolons outside of SQL comments.
+    """Return True if the query contains semicolons outside comments and string literals.
 
-    Prevents comment content (e.g. '-- already done; continue') from
-    incorrectly triggering the multi-statement parsing path.
+    Prevents comment content (e.g. '-- already done; continue') and string
+    literals (e.g. SELECT 'status; pending') from incorrectly triggering the
+    multi-statement parsing path.
     """
     no_line_comments = re.sub(r"--[^\n]*", "", query)
     no_comments = re.sub(r"/\*.*?\*/", "", no_line_comments, flags=re.DOTALL)
-    return ";" in no_comments
+    # Strip single-quoted string literals; '' is the SQL escape for a literal quote.
+    no_strings = re.sub(r"'(?:[^']|'')*'", "", no_comments, flags=re.DOTALL)
+    return ";" in no_strings
+
+
+def _scan_line_depth(
+    line: str, paren_depth: int, in_block_comment: bool
+) -> Tuple[int, bool]:
+    """Return updated (paren_depth, in_block_comment) after scanning one SQL line.
+
+    Skips characters inside line comments (--), block comments (/* ... */), and
+    quoted strings so their parentheses are not counted.
+    """
+    in_line_comment = False
+    in_string = False
+    quote_char = ""
+    idx = 0
+    while idx < len(line):
+        c = line[idx]
+        if in_block_comment:
+            if c == "*" and idx + 1 < len(line) and line[idx + 1] == "/":
+                in_block_comment = False
+                idx += 2
+                continue
+        elif in_line_comment:
+            break
+        elif in_string:
+            if c == quote_char:
+                in_string = False
+        elif c == "/" and idx + 1 < len(line) and line[idx + 1] == "*":
+            in_block_comment = True
+            idx += 2
+            continue
+        elif c == "-" and idx + 1 < len(line) and line[idx + 1] == "-":
+            in_line_comment = True
+        elif c in ("'", '"'):
+            in_string = True
+            quote_char = c
+        elif c == "(":
+            paren_depth += 1
+        elif c == ")":
+            paren_depth = max(0, paren_depth - 1)
+        idx += 1
+    return paren_depth, in_block_comment
 
 
 def _insert_statement_separators(query: str) -> str:
@@ -161,6 +205,7 @@ def _insert_statement_separators(query: str) -> str:
     paren_depth = 0
     blank_count = 0
     in_cte_query = False  # True while a WITH clause is open at depth 0
+    in_block_comment = False  # /* ... */ can span lines; persisted across iterations
 
     for line in lines:
         stripped = line.strip()
@@ -204,29 +249,9 @@ def _insert_statement_separators(query: str) -> str:
         blank_count = 0
         result.append(line)
 
-        # Update paren depth, respecting line comments and single-quoted
-        # strings so that parentheses inside them are not counted.
-        in_line_comment = False
-        in_string = False
-        quote_char = ""
-        idx = 0
-        while idx < len(line):
-            c = line[idx]
-            if in_line_comment:
-                break
-            if in_string:
-                if c == quote_char:
-                    in_string = False
-            elif c == "-" and idx + 1 < len(line) and line[idx + 1] == "-":
-                in_line_comment = True
-            elif c in ("'", '"'):
-                in_string = True
-                quote_char = c
-            elif c == "(":
-                paren_depth += 1
-            elif c == ")":
-                paren_depth = max(0, paren_depth - 1)
-            idx += 1
+        paren_depth, in_block_comment = _scan_line_depth(
+            line, paren_depth, in_block_comment
+        )
 
     return "\n".join(result)
 

--- a/metadata-ingestion/tests/unit/powerbi/test_native_sql_parser.py
+++ b/metadata-ingestion/tests/unit/powerbi/test_native_sql_parser.py
@@ -5,7 +5,109 @@ from datahub.ingestion.source.powerbi.m_query.native_sql_parser import (
     _has_real_semicolons,
     _insert_statement_separators,
     parse_custom_sql,
+    remove_drop_statement,
+    remove_special_characters,
 )
+
+# ---------------------------------------------------------------------------
+# Shared SQL fixture used by both the _insert_statement_separators structural
+# test and the end-to-end parse_custom_sql regression test.
+#
+# Key structural properties exercised:
+#   - Nested WITH (a WITH clause inside the body of an outer CTE)
+#   - Blank lines before every SELECT, including those inside CTE bodies
+#   - Semicolon inside a SQL comment (must not trigger multi-statement parsing)
+#   - Multiple blank lines before the final depth-0 SELECT
+#
+# These properties combine to produce the bug where the outer CTE alias was
+# mistakenly emitted as a real upstream table: blank-line SELECT detection
+# split the query, leaving the final SELECT without its CTE definitions.
+# ---------------------------------------------------------------------------
+
+_NESTED_CTE_SQL = """\
+-- Find merged records; see ticket #42
+
+With outer_cte as (
+with inner_cte_a as
+(
+
+SELECT
+      a.id as record_id
+      , count(a.grp) as grp_count
+
+FROM
+
+    db_a.schema_a.table_a a
+
+group by
+    a.id
+
+),
+inner_cte_b as
+(
+
+SELECT
+      b.id as record_id
+      , count(b.grp) as grp_count_b
+
+FROM
+
+    db_b.schema_b.table_b b
+
+group by
+    b.id
+
+)
+SELECT
+    a.record_id
+    , a.grp_count
+    , b.grp_count_b
+FROM
+    inner_cte_a a
+      left join inner_cte_b b
+        on a.record_id = b.record_id
+GROUP BY
+    a.record_id
+    , a.grp_count
+    , b.grp_count_b
+HAVING a.grp_count = b.grp_count_b
+)
+,
+cte_c as
+(
+  SELECT distinct
+     c.id as record_id
+    , c.val
+FROM
+    db_a.schema_a.table_a c
+)
+,
+cte_d as
+(
+    SELECT
+     d.record_id
+FROM
+    cte_c d
+group by
+      d.record_id
+having count(d.record_id) = 1
+)
+
+
+
+SELECT
+    e.id
+    , f.val
+
+FROM
+
+    outer_cte oc
+      left join cte_d d
+        on oc.record_id = d.record_id
+      left join db_c.schema_c.table_c e
+        on d.record_id = e.id
+
+where e.is_active = 'TRUE'"""
 
 # ---------------------------------------------------------------------------
 # _has_real_semicolons
@@ -72,98 +174,18 @@ def test_insert_separators_adds_between_standalone_selects():
 
 
 def test_insert_separators_nested_cte_with_comment_semicolon():
+    """No separator should be inserted anywhere — the whole query is one statement.
+
+    Uses _NESTED_CTE_SQL which contains all three properties that previously
+    triggered incorrect splitting: nested CTEs, blank lines before SELECTs, and
+    a comment semicolon.
     """
-    Nested CTE (WITH inside a CTE body), blank lines before every SELECT,
-    and a semicolon inside a comment.
-
-    No separator should be inserted anywhere — the whole query is one statement.
-    """
-    sql = """\
--- Find merged records; see ticket #42
-
-With outer_cte as (
-with inner_cte_a as
-(
-
-SELECT
-      a.id as record_id
-      , count(a.grp) as grp_count
-
-FROM
-    db_a.schema_a.table_a a
-
-group by
-    a.id
-
-),
-inner_cte_b as
-(
-
-SELECT
-      b.id as record_id
-      , count(b.grp) as grp_count_b
-
-FROM
-    db_b.schema_b.table_b b
-
-group by
-    b.id
-
-)
-SELECT
-    a.record_id
-    , a.grp_count
-    , b.grp_count_b
-FROM
-    inner_cte_a a
-      left join inner_cte_b b
-        on a.record_id = b.record_id
-GROUP BY
-    a.record_id
-    , a.grp_count
-    , b.grp_count_b
-HAVING a.grp_count = b.grp_count_b
-)
-,
-cte_c as
-(
-  SELECT distinct
-     c.id as record_id
-    , c.val
-FROM
-    db_a.schema_a.table_a c
-)
-,
-cte_d as
-(
-    SELECT
-     d.record_id
-FROM
-    cte_c d
-group by
-      d.record_id
-having count(d.record_id) = 1
-)
-
-
-
-SELECT
-    e.id
-    , f.val
-
-FROM
-    outer_cte oc
-      left join cte_d d
-        on oc.record_id = d.record_id
-      left join db_c.schema_c.table_c e
-        on d.record_id = e.id
-
-where e.is_active = 'TRUE'"""
-
-    result = _insert_statement_separators(sql)
+    result = _insert_statement_separators(_NESTED_CTE_SQL)
     # The function must not have inserted any new statement separators.
     # (The original SQL has a ";" inside the comment, which must be preserved unchanged.)
-    assert result == sql, f"Query should be returned unchanged, but got:\n{result}"
+    assert result == _NESTED_CTE_SQL, (
+        f"Query should be returned unchanged, but got:\n{result}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -177,98 +199,15 @@ def pipeline_ctx() -> PipelineContext:
 
 
 def test_parse_nested_cte_no_cte_alias_in_upstreams(pipeline_ctx: PipelineContext):
+    """Regression test: CTE aliases must NOT appear in upstream URNs.
+
+    Runs _NESTED_CTE_SQL through the full production pre-processing sequence
+    (remove_special_characters → remove_drop_statement → parse_custom_sql) to
+    guard against the bug where the outer CTE alias leaked into upstream URNs.
     """
-    Regression test: CTE aliases must NOT appear in upstream URNs, and the
-    real source tables must appear.
-
-    Tests a query with a nested WITH (WITH inside a CTE body), blank lines
-    before SELECT statements, and a semicolon inside a SQL comment — the
-    combination that previously caused the outer CTE alias to leak into upstreams.
-    """
-    sql = """\
--- Find merged records; see ticket #42
-
-With outer_cte as (
-with inner_cte_a as
-(
-
-SELECT
-      a.id as record_id
-      , count(a.grp) as grp_count
-
-FROM
-
-    db_a.schema_a.table_a a
-
-group by
-    a.id
-
-),
-inner_cte_b as
-(
-
-SELECT
-      b.id as record_id
-      , count(b.grp) as grp_count_b
-
-FROM
-
-    db_b.schema_b.table_b b
-
-group by
-    b.id
-
-)
-SELECT
-    a.record_id
-    , a.grp_count
-    , b.grp_count_b
-FROM
-    inner_cte_a a
-      left join inner_cte_b b
-        on a.record_id = b.record_id
-GROUP BY
-    a.record_id
-    , a.grp_count
-    , b.grp_count_b
-HAVING a.grp_count = b.grp_count_b
-)
-,
-cte_c as
-(
-  SELECT distinct
-     c.id as record_id
-    , c.val
-FROM
-    db_a.schema_a.table_a c
-)
-,
-cte_d as
-(
-    SELECT
-     d.record_id
-FROM
-    cte_c d
-group by
-      d.record_id
-having count(d.record_id) = 1
-)
-
-
-
-SELECT
-    e.id
-    , f.val
-
-FROM
-
-    outer_cte oc
-      left join cte_d d
-        on oc.record_id = d.record_id
-      left join db_c.schema_c.table_c e
-        on d.record_id = e.id
-
-where e.is_active = 'TRUE'"""
+    # Mirror the production call sequence in OdbcLineage.query_lineage
+    sql = remove_special_characters(_NESTED_CTE_SQL)
+    sql = remove_drop_statement(sql)
 
     result = parse_custom_sql(
         ctx=pipeline_ctx,

--- a/metadata-ingestion/tests/unit/powerbi/test_native_sql_parser.py
+++ b/metadata-ingestion/tests/unit/powerbi/test_native_sql_parser.py
@@ -227,6 +227,43 @@ def pipeline_ctx() -> PipelineContext:
     return PipelineContext(run_id="test")
 
 
+def test_parse_real_semicolons_path(pipeline_ctx: PipelineContext):
+    """Query with real semicolons takes the _has_real_semicolons=True path."""
+    sql = "SELECT id FROM db_a.schema_a.table_a;\nSELECT val FROM db_b.schema_b.table_b"
+    result = parse_custom_sql(
+        ctx=pipeline_ctx,
+        query=sql,
+        schema=None,
+        database="test_db",
+        platform="redshift",
+        env="PROD",
+        platform_instance=None,
+    )
+    assert result is not None
+    in_tables = set(result.in_tables)
+    assert any("table_a" in urn for urn in in_tables)
+    assert any("table_b" in urn for urn in in_tables)
+
+
+def test_parse_blank_line_separated_statements(pipeline_ctx: PipelineContext):
+    """Blank-line-separated SELECTs (no real semicolons) get separators inserted
+    and are parsed via create_lineage_from_sql_statements."""
+    sql = "SELECT id FROM db_a.schema_a.table_a\n\n\nSELECT val FROM db_b.schema_b.table_b"
+    result = parse_custom_sql(
+        ctx=pipeline_ctx,
+        query=sql,
+        schema=None,
+        database="test_db",
+        platform="redshift",
+        env="PROD",
+        platform_instance=None,
+    )
+    assert result is not None
+    in_tables = set(result.in_tables)
+    assert any("table_a" in urn for urn in in_tables)
+    assert any("table_b" in urn for urn in in_tables)
+
+
 def test_parse_nested_cte_no_cte_alias_in_upstreams(pipeline_ctx: PipelineContext):
     """Regression test: CTE aliases must NOT appear in upstream URNs.
 

--- a/metadata-ingestion/tests/unit/powerbi/test_native_sql_parser.py
+++ b/metadata-ingestion/tests/unit/powerbi/test_native_sql_parser.py
@@ -227,7 +227,7 @@ def pipeline_ctx() -> PipelineContext:
     return PipelineContext(run_id="test")
 
 
-def test_parse_real_semicolons_path(pipeline_ctx: PipelineContext):
+def test_parse_real_semicolons_path(pipeline_ctx: PipelineContext) -> None:
     """Query with real semicolons takes the _has_real_semicolons=True path."""
     sql = "SELECT id FROM db_a.schema_a.table_a;\nSELECT val FROM db_b.schema_b.table_b"
     result = parse_custom_sql(
@@ -245,7 +245,7 @@ def test_parse_real_semicolons_path(pipeline_ctx: PipelineContext):
     assert any("table_b" in urn for urn in in_tables)
 
 
-def test_parse_blank_line_separated_statements(pipeline_ctx: PipelineContext):
+def test_parse_blank_line_separated_statements(pipeline_ctx: PipelineContext) -> None:
     """Blank-line-separated SELECTs (no real semicolons) get separators inserted
     and are parsed via create_lineage_from_sql_statements."""
     sql = "SELECT id FROM db_a.schema_a.table_a\n\n\nSELECT val FROM db_b.schema_b.table_b"
@@ -264,7 +264,9 @@ def test_parse_blank_line_separated_statements(pipeline_ctx: PipelineContext):
     assert any("table_b" in urn for urn in in_tables)
 
 
-def test_parse_nested_cte_no_cte_alias_in_upstreams(pipeline_ctx: PipelineContext):
+def test_parse_nested_cte_no_cte_alias_in_upstreams(
+    pipeline_ctx: PipelineContext,
+) -> None:
     """Regression test: CTE aliases must NOT appear in upstream URNs.
 
     Runs _NESTED_CTE_SQL through the full production pre-processing sequence

--- a/metadata-ingestion/tests/unit/powerbi/test_native_sql_parser.py
+++ b/metadata-ingestion/tests/unit/powerbi/test_native_sql_parser.py
@@ -1,0 +1,296 @@
+import pytest
+
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.powerbi.m_query.native_sql_parser import (
+    _has_real_semicolons,
+    _insert_statement_separators,
+    parse_custom_sql,
+)
+
+# ---------------------------------------------------------------------------
+# _has_real_semicolons
+# ---------------------------------------------------------------------------
+
+
+def test_has_real_semicolons_false_for_comment_only():
+    sql = "-- This query is done; next step\nSELECT 1"
+    assert _has_real_semicolons(sql) is False
+
+
+def test_has_real_semicolons_false_for_block_comment():
+    sql = "/* done; continue */ SELECT 1"
+    assert _has_real_semicolons(sql) is False
+
+
+def test_has_real_semicolons_true_for_real_semicolon():
+    sql = "SELECT 1;\nSELECT 2"
+    assert _has_real_semicolons(sql) is True
+
+
+def test_has_real_semicolons_true_when_mixed():
+    # Real semicolon present even though a comment also has one
+    sql = "-- comment; info\nSELECT 1;\nSELECT 2"
+    assert _has_real_semicolons(sql) is True
+
+
+# ---------------------------------------------------------------------------
+# _insert_statement_separators
+# ---------------------------------------------------------------------------
+
+
+def test_insert_separators_does_not_add_inside_cte_body():
+    """Blank lines before SELECT inside a CTE body must not produce a separator."""
+    sql = "WITH cte AS (\n\nSELECT 1 AS x FROM source\n)\nSELECT * FROM cte"
+    result = _insert_statement_separators(sql)
+    assert ";" not in result
+
+
+def test_insert_separators_does_not_split_cte_final_select():
+    """The final SELECT of a CTE query must not be separated from the WITH clause."""
+    sql = "WITH cte AS (SELECT 1 AS x FROM source)\n\n\nSELECT * FROM cte"
+    result = _insert_statement_separators(sql)
+    assert ";" not in result
+
+
+def test_insert_separators_adds_between_standalone_selects():
+    """Two blank-line-separated standalone SELECTs should get a separator."""
+    sql = "SELECT 1 AS x FROM t1\n\n\nSELECT 2 AS y FROM t2"
+    result = _insert_statement_separators(sql)
+    assert ";" in result
+    stmts = [s.strip() for s in result.split(";") if s.strip()]
+    assert len(stmts) == 2
+
+
+def test_insert_separators_nested_cte_with_comment_semicolon():
+    """
+    Nested CTE (WITH inside a CTE body), blank lines before every SELECT,
+    and a semicolon inside a comment.
+
+    No separator should be inserted anywhere — the whole query is one statement.
+    """
+    sql = """\
+-- Find merged records; see ticket #42
+
+With outer_cte as (
+with inner_cte_a as
+(
+
+SELECT
+      a.id as record_id
+      , count(a.grp) as grp_count
+
+FROM
+    db_a.schema_a.table_a a
+
+group by
+    a.id
+
+),
+inner_cte_b as
+(
+
+SELECT
+      b.id as record_id
+      , count(b.grp) as grp_count_b
+
+FROM
+    db_b.schema_b.table_b b
+
+group by
+    b.id
+
+)
+SELECT
+    a.record_id
+    , a.grp_count
+    , b.grp_count_b
+FROM
+    inner_cte_a a
+      left join inner_cte_b b
+        on a.record_id = b.record_id
+GROUP BY
+    a.record_id
+    , a.grp_count
+    , b.grp_count_b
+HAVING a.grp_count = b.grp_count_b
+)
+,
+cte_c as
+(
+  SELECT distinct
+     c.id as record_id
+    , c.val
+FROM
+    db_a.schema_a.table_a c
+)
+,
+cte_d as
+(
+    SELECT
+     d.record_id
+FROM
+    cte_c d
+group by
+      d.record_id
+having count(d.record_id) = 1
+)
+
+
+
+SELECT
+    e.id
+    , f.val
+
+FROM
+    outer_cte oc
+      left join cte_d d
+        on oc.record_id = d.record_id
+      left join db_c.schema_c.table_c e
+        on d.record_id = e.id
+
+where e.is_active = 'TRUE'"""
+
+    result = _insert_statement_separators(sql)
+    # The function must not have inserted any new statement separators.
+    # (The original SQL has a ";" inside the comment, which must be preserved unchanged.)
+    assert result == sql, f"Query should be returned unchanged, but got:\n{result}"
+
+
+# ---------------------------------------------------------------------------
+# parse_custom_sql – end-to-end correctness
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pipeline_ctx() -> PipelineContext:
+    return PipelineContext(run_id="test")
+
+
+def test_parse_nested_cte_no_cte_alias_in_upstreams(pipeline_ctx: PipelineContext):
+    """
+    Regression test: CTE aliases must NOT appear in upstream URNs, and the
+    real source tables must appear.
+
+    Tests a query with a nested WITH (WITH inside a CTE body), blank lines
+    before SELECT statements, and a semicolon inside a SQL comment — the
+    combination that previously caused the outer CTE alias to leak into upstreams.
+    """
+    sql = """\
+-- Find merged records; see ticket #42
+
+With outer_cte as (
+with inner_cte_a as
+(
+
+SELECT
+      a.id as record_id
+      , count(a.grp) as grp_count
+
+FROM
+
+    db_a.schema_a.table_a a
+
+group by
+    a.id
+
+),
+inner_cte_b as
+(
+
+SELECT
+      b.id as record_id
+      , count(b.grp) as grp_count_b
+
+FROM
+
+    db_b.schema_b.table_b b
+
+group by
+    b.id
+
+)
+SELECT
+    a.record_id
+    , a.grp_count
+    , b.grp_count_b
+FROM
+    inner_cte_a a
+      left join inner_cte_b b
+        on a.record_id = b.record_id
+GROUP BY
+    a.record_id
+    , a.grp_count
+    , b.grp_count_b
+HAVING a.grp_count = b.grp_count_b
+)
+,
+cte_c as
+(
+  SELECT distinct
+     c.id as record_id
+    , c.val
+FROM
+    db_a.schema_a.table_a c
+)
+,
+cte_d as
+(
+    SELECT
+     d.record_id
+FROM
+    cte_c d
+group by
+      d.record_id
+having count(d.record_id) = 1
+)
+
+
+
+SELECT
+    e.id
+    , f.val
+
+FROM
+
+    outer_cte oc
+      left join cte_d d
+        on oc.record_id = d.record_id
+      left join db_c.schema_c.table_c e
+        on d.record_id = e.id
+
+where e.is_active = 'TRUE'"""
+
+    result = parse_custom_sql(
+        ctx=pipeline_ctx,
+        query=sql,
+        schema=None,
+        database="test_db",
+        platform="redshift",
+        env="PROD",
+        platform_instance=None,
+    )
+
+    assert result is not None
+    in_tables = set(result.in_tables)
+
+    # CTE aliases must NOT appear as upstreams
+    assert not any("outer_cte" in urn for urn in in_tables), (
+        f"CTE alias leaked into upstreams: {in_tables}"
+    )
+    assert not any("cte_d" in urn for urn in in_tables), (
+        f"CTE alias leaked into upstreams: {in_tables}"
+    )
+    assert not any("inner_cte_a" in urn for urn in in_tables), (
+        f"CTE alias leaked into upstreams: {in_tables}"
+    )
+
+    # Real source tables must appear
+    assert any("table_a" in urn for urn in in_tables), (
+        f"Real table missing from upstreams: {in_tables}"
+    )
+    assert any("table_b" in urn for urn in in_tables), (
+        f"Real table missing from upstreams: {in_tables}"
+    )
+    assert any("table_c" in urn for urn in in_tables), (
+        f"Real table missing from upstreams: {in_tables}"
+    )

--- a/metadata-ingestion/tests/unit/powerbi/test_native_sql_parser.py
+++ b/metadata-ingestion/tests/unit/powerbi/test_native_sql_parser.py
@@ -129,6 +129,11 @@ def test_has_real_semicolons_true_for_real_semicolon():
     assert _has_real_semicolons(sql) is True
 
 
+def test_has_real_semicolons_false_for_string_literal():
+    sql = "SELECT 'status; pending' AS status FROM t"
+    assert _has_real_semicolons(sql) is False
+
+
 def test_has_real_semicolons_true_when_mixed():
     # Real semicolon present even though a comment also has one
     sql = "-- comment; info\nSELECT 1;\nSELECT 2"
@@ -167,6 +172,30 @@ def test_insert_separators_cte_no_blank_before_final_select():
 def test_insert_separators_adds_between_standalone_selects():
     """Two blank-line-separated standalone SELECTs should get a separator."""
     sql = "SELECT 1 AS x FROM t1\n\n\nSELECT 2 AS y FROM t2"
+    result = _insert_statement_separators(sql)
+    assert ";" in result
+    stmts = [s.strip() for s in result.split(";") if s.strip()]
+    assert len(stmts) == 2
+
+
+def test_insert_separators_block_comment_unbalanced_paren_same_line():
+    """Block comment with unbalanced '(' on the same line must not corrupt depth."""
+    sql = "/* setup (config */ SELECT 1 AS x FROM t1\n\n\nSELECT 2 AS y FROM t2"
+    result = _insert_statement_separators(sql)
+    assert ";" in result
+    stmts = [s.strip() for s in result.split(";") if s.strip()]
+    assert len(stmts) == 2
+
+
+def test_insert_separators_block_comment_unbalanced_paren_multi_line():
+    """Block comment spanning multiple lines with unbalanced parens must not
+    corrupt depth tracking — the in_block_comment flag persists across lines."""
+    sql = (
+        "/* multi-line\n"
+        "   comment (with paren\n"
+        "   still in comment */\n"
+        "SELECT 1 AS x FROM t1\n\n\nSELECT 2 AS y FROM t2"
+    )
     result = _insert_statement_separators(sql)
     assert ";" in result
     stmts = [s.strip() for s in result.split(";") if s.strip()]

--- a/metadata-ingestion/tests/unit/powerbi/test_native_sql_parser.py
+++ b/metadata-ingestion/tests/unit/powerbi/test_native_sql_parser.py
@@ -52,6 +52,16 @@ def test_insert_separators_does_not_split_cte_final_select():
     assert ";" not in result
 
 
+def test_insert_separators_cte_no_blank_before_final_select():
+    """CTE closing SELECT with no blank line — flag must reset so the next
+    blank-line-separated SELECT still gets a separator."""
+    sql = "WITH cte AS (SELECT 1 AS x FROM t1)\nSELECT * FROM cte\n\n\nSELECT id FROM other"
+    result = _insert_statement_separators(sql)
+    assert ";" in result
+    stmts = [s.strip() for s in result.split(";") if s.strip()]
+    assert len(stmts) == 2
+
+
 def test_insert_separators_adds_between_standalone_selects():
     """Two blank-line-separated standalone SELECTs should get a separator."""
     sql = "SELECT 1 AS x FROM t1\n\n\nSELECT 2 AS y FROM t2"


### PR DESCRIPTION
## Summary

- **Bug**: PowerBI `Odbc.Query` ingestion produced wrong upstream URNs when the custom SQL was a single CTE query containing blank lines before `SELECT` keywords and a semicolon inside a SQL comment. A CTE alias (e.g. `my_cte`) was emitted as a real upstream table instead of the actual source tables referenced inside the CTE bodies.

- **Root cause**: Two interacting bugs in `parse_custom_sql` (`native_sql_parser.py`):
  1. The old normalization regex (`re.sub(r"\n{2,}(\s*SELECT\b)", ...)`) blindly inserted `;` before any `SELECT` preceded by blank lines — including `SELECT`s inside CTE bodies and the closing `SELECT` of a `WITH` clause. This fragmented single-statement CTE queries into multiple pieces.
  2. The check `if ";" in normalized` fired on semicolons inside SQL comments (e.g. `-- done; continue`), sending single-statement queries down the multi-statement parsing path. With the query fragmented, the final fragment had no CTE definitions, so the outer CTE alias resolved as a real table against the default database.

- **Fix**: Replaced both mechanisms with two new helper functions:
  - `_has_real_semicolons(query)` — strips `--` line comments and `/* */` block comments before checking for `;`, so comment content never triggers multi-statement parsing.
  - `_insert_statement_separators(query)` — replaces the naive regex with a line-by-line parser that tracks parenthesis depth and an `in_cte_query` flag. Separators are only inserted before `SELECT` at depth 0 when no `WITH` clause is open, ensuring CTE bodies and the closing `SELECT` of a `WITH` query are never split.

- **Tests**: Added `tests/unit/powerbi/test_native_sql_parser.py` covering `_has_real_semicolons` (comment vs. real semicolons), `_insert_statement_separators` (CTE body, CTE final SELECT, standalone SELECTs, nested CTE with comment semicolon), and an end-to-end regression test verifying CTE aliases do not leak into upstream URNs.