### PR TITLE
feat(glue): add simplify_nested_field_paths config flag

### DIFF
--- a/metadata-ingestion/docs/sources/glue/glue_post.md
+++ b/metadata-ingestion/docs/sources/glue/glue_post.md
@@ -110,6 +110,23 @@ source:
 
 When this is configured, dataset URNs produced by the Glue connector will include the same `platform_instance` and `env` as the target platform's connector, ensuring entities merge correctly in DataHub. If the target platform connector does not use a `platform_instance`, no configuration is needed — URNs will match by default.
 
+#### Aligning Field Paths with v1-Emitting Sources
+
+By default the Glue connector emits v2 schemaField paths (`[version=2.0].[type=string].email`), while sources like dbt emit v1 paths (`email`). The URN mismatch blocks column-level lineage and term/tag propagation across the boundary.
+
+Set `simplify_nested_field_paths: true` to emit v1 paths for every column type — scalars, arrays, maps, structs, and nested combinations:
+
+```yaml
+source:
+  type: glue
+  config:
+    simplify_nested_field_paths: true
+```
+
+**Union types are not supported.** Columns with type `uniontype<...>` continue to emit v2 paths because v1 cannot disambiguate union variants — downgrading them would collapse the SchemaField entries into the same path and one would be dropped.
+
+Flipping this flag on an existing ingestion changes every schemaField URN on the affected datasets. Annotations attached to the old v2 URNs (tags, terms, descriptions, column-level lineage edges) become orphaned until the tables are re-ingested.
+
 #### Column Parameters as Structured Properties
 
 When `extract_column_parameters` is enabled, column-level `Parameters` from the Glue catalog are

--- a/metadata-ingestion/docs/sources/glue/glue_pre.md
+++ b/metadata-ingestion/docs/sources/glue/glue_pre.md
@@ -10,6 +10,8 @@ This plugin extracts the following:
 - Jobs and their component transformations, data sources, and data sinks
 - Upstream lineage from JDBC sources (e.g. PostgreSQL, MySQL, Redshift) referenced by Glue jobs
 
+Optional: enable `simplify_nested_field_paths` to emit v1 (simple) schemaField paths for cross-source URN alignment with v1-emitting connectors like dbt. Union types are not supported. See [Aligning Field Paths with v1-Emitting Sources](#aligning-field-paths-with-v1-emitting-sources) for details.
+
 ### Prerequisites
 
 Before running ingestion, ensure network connectivity to the source, valid authentication credentials, and read permissions for metadata APIs required by this module.

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -173,13 +173,14 @@ GLUE_NATIVE_CONNECTION_TYPE_MAP: Dict[str, str] = {
 JDBC_PREFIX = "jdbc:"
 
 
-# Union variants share a column name with different types; stripping the [type=...]
+# Hive complex types that must keep v2 field paths. Only `uniontype` qualifies:
+# its variants share a column name with different types, so stripping the [type=...]
 # qualifiers collapses them into the same v1 path and GMS dedups one of the entries.
-_HIVE_UNION_TYPE_RE = re.compile(r"^\s*uniontype\s*<", re.IGNORECASE)
+_COMPLEX_HIVE_TYPE_RE = re.compile(r"^\s*uniontype\s*<", re.IGNORECASE)
 
 
-def _hive_type_requires_v2_paths(hive_type: str) -> bool:
-    return bool(_HIVE_UNION_TYPE_RE.match(hive_type))
+def _is_complex_hive_type(hive_type: str) -> bool:
+    return bool(_COMPLEX_HIVE_TYPE_RE.match(hive_type))
 
 
 def _sanitize_jdbc_url(jdbc_url: str) -> str:
@@ -300,10 +301,12 @@ class GlueSourceConfig(
     simplify_nested_field_paths: bool = Field(
         default=False,
         description=(
-            "Emit v1 (simple) field paths for every column except `uniontype` — "
-            "`column` instead of `[version=2.0].[type=string].column`. "
-            "Aligns schemaField URNs with v1-emitting sources (e.g. dbt) for "
-            "column-level lineage and term/tag propagation."
+            "Emit v1 (simple) field paths — `column` instead of "
+            "`[version=2.0].[type=string].column`. Aligns schemaField URNs with "
+            "v1-emitting sources (e.g. dbt) for column-level lineage and term/tag "
+            "propagation. **Union types are not supported**: `uniontype<...>` "
+            "columns continue to emit v2 paths because v1 cannot disambiguate "
+            "union variants."
         ),
     )
 
@@ -1935,9 +1938,8 @@ class GlueSource(StatefulIngestionSourceBase):
             description=description,
             default_nullable=default_nullable,
         )
-        if (
-            self.source_config.simplify_nested_field_paths
-            and not _hive_type_requires_v2_paths(hive_column_type)
+        if self.source_config.simplify_nested_field_paths and not _is_complex_hive_type(
+            hive_column_type
         ):
             for f in fields:
                 f.fieldPath = get_simple_field_path_from_v2_field_path(f.fieldPath)

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -139,6 +139,7 @@ from datahub.utilities.delta import delta_type_to_hive_type
 from datahub.utilities.hive_schema_to_avro import get_schema_fields_for_hive_column
 from datahub.utilities.lossy_collections import LossyList
 from datahub.utilities.urns.error import InvalidUrnError
+from datahub.utilities.urns.field_paths import get_simple_field_path_from_v2_field_path
 
 logger = logging.getLogger(__name__)
 
@@ -170,6 +171,15 @@ GLUE_NATIVE_CONNECTION_TYPE_MAP: Dict[str, str] = {
 }
 
 JDBC_PREFIX = "jdbc:"
+
+
+# Union variants share a column name with different types; stripping the [type=...]
+# qualifiers collapses them into the same v1 path and GMS dedups one of the entries.
+_HIVE_UNION_TYPE_RE = re.compile(r"^\s*uniontype\s*<", re.IGNORECASE)
+
+
+def _hive_type_requires_v2_paths(hive_type: str) -> bool:
+    return bool(_HIVE_UNION_TYPE_RE.match(hive_type))
 
 
 def _sanitize_jdbc_url(jdbc_url: str) -> str:
@@ -284,6 +294,16 @@ class GlueSourceConfig(
             "When enabled, column-level Parameters from Glue are ingested as structured properties "
             "on each schemaField entity. A StructuredPropertyDefinition is upserted once per unique "
             "parameter key per recipe run; subsequent columns reuse the cached definition."
+        ),
+    )
+
+    simplify_nested_field_paths: bool = Field(
+        default=False,
+        description=(
+            "Emit v1 (simple) field paths for every column except `uniontype` — "
+            "`column` instead of `[version=2.0].[type=string].column`. "
+            "Aligns schemaField URNs with v1-emitting sources (e.g. dbt) for "
+            "column-level lineage and term/tag propagation."
         ),
     )
 
@@ -1901,6 +1921,28 @@ class GlueSource(StatefulIngestionSourceBase):
             and columns[0].get("Type", "") == "array<string>"
         )
 
+    def _build_schema_fields(
+        self,
+        *,
+        hive_column_name: str,
+        hive_column_type: str,
+        description: Optional[str],
+        default_nullable: bool,
+    ) -> List[SchemaField]:
+        fields = get_schema_fields_for_hive_column(
+            hive_column_name=hive_column_name,
+            hive_column_type=hive_column_type,
+            description=description,
+            default_nullable=default_nullable,
+        )
+        if (
+            self.source_config.simplify_nested_field_paths
+            and not _hive_type_requires_v2_paths(hive_column_type)
+        ):
+            for f in fields:
+                f.fieldPath = get_simple_field_path_from_v2_field_path(f.fieldPath)
+        return fields
+
     def _get_glue_schema_metadata(
         self, table: Dict, table_name: str
     ) -> Optional[SchemaMetadata]:
@@ -1910,7 +1952,7 @@ class GlueSource(StatefulIngestionSourceBase):
 
         # Process regular columns
         for field in schema:
-            schema_fields = get_schema_fields_for_hive_column(
+            schema_fields = self._build_schema_fields(
                 hive_column_name=field["Name"],
                 hive_column_type=field["Type"],
                 description=field.get("Comment"),
@@ -1922,7 +1964,7 @@ class GlueSource(StatefulIngestionSourceBase):
         # Process partition keys
         partition_keys = table.get("PartitionKeys", [])
         for partition_key in partition_keys:
-            schema_fields = get_schema_fields_for_hive_column(
+            schema_fields = self._build_schema_fields(
                 hive_column_name=partition_key["Name"],
                 hive_column_type=partition_key.get("Type", "unknown"),
                 description=partition_key.get("Comment"),
@@ -1956,7 +1998,7 @@ class GlueSource(StatefulIngestionSourceBase):
             fields: List[SchemaField] = []
             for field in schema_json["fields"]:
                 field_type = delta_type_to_hive_type(field.get("type", "unknown"))
-                schema_fields = get_schema_fields_for_hive_column(
+                schema_fields = self._build_schema_fields(
                     hive_column_name=field["name"],
                     hive_column_type=field_type,
                     description=field.get("description"),
@@ -2028,7 +2070,7 @@ class GlueSource(StatefulIngestionSourceBase):
                 params = column.get("Parameters")
                 if not params:
                     continue
-                schema_fields = get_schema_fields_for_hive_column(
+                schema_fields = self._build_schema_fields(
                     hive_column_name=column["Name"],
                     hive_column_type=column.get("Type", "string"),
                     description=column.get("Comment"),

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -176,11 +176,14 @@ JDBC_PREFIX = "jdbc:"
 # Hive complex types that must keep v2 field paths. Only `uniontype` qualifies:
 # its variants share a column name with different types, so stripping the [type=...]
 # qualifiers collapses them into the same v1 path and GMS dedups one of the entries.
-_COMPLEX_HIVE_TYPE_RE = re.compile(r"^\s*uniontype\s*<", re.IGNORECASE)
+# Matches anywhere in the type string (not just at the top level) so columns like
+# `struct<payload:uniontype<int,string>>` correctly keep v2 paths for their nested
+# union variants — otherwise those variants silently dedup on ingest.
+_COMPLEX_HIVE_TYPE_RE = re.compile(r"uniontype\s*<", re.IGNORECASE)
 
 
 def _is_complex_hive_type(hive_type: str) -> bool:
-    return bool(_COMPLEX_HIVE_TYPE_RE.match(hive_type))
+    return bool(_COMPLEX_HIVE_TYPE_RE.search(hive_type))
 
 
 def _sanitize_jdbc_url(jdbc_url: str) -> str:
@@ -1942,7 +1945,16 @@ class GlueSource(StatefulIngestionSourceBase):
             hive_column_type
         ):
             for f in fields:
-                f.fieldPath = get_simple_field_path_from_v2_field_path(f.fieldPath)
+                simplified = get_simple_field_path_from_v2_field_path(f.fieldPath)
+                if simplified:
+                    f.fieldPath = simplified
+                else:
+                    logger.warning(
+                        "simplify_nested_field_paths produced empty path for column "
+                        "%r (v2 path: %r); keeping v2 path to avoid malformed URN",
+                        hive_column_name,
+                        f.fieldPath,
+                    )
         return fields
 
     def _get_glue_schema_metadata(

--- a/metadata-ingestion/tests/unit/glue/test_glue_simplify_field_paths.py
+++ b/metadata-ingestion/tests/unit/glue/test_glue_simplify_field_paths.py
@@ -4,7 +4,7 @@ from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.source.aws.glue import (
     GlueSource,
     GlueSourceConfig,
-    _hive_type_requires_v2_paths,
+    _is_complex_hive_type,
 )
 
 
@@ -36,8 +36,8 @@ def _build_glue_source(*, simplify: bool) -> GlueSource:
         ("  UNIONTYPE<int,string>  ", True),  # leading whitespace + uppercase
     ],
 )
-def test_hive_type_requires_v2_paths(hive_type: str, expected: bool) -> None:
-    assert _hive_type_requires_v2_paths(hive_type) is expected
+def test_is_complex_hive_type(hive_type: str, expected: bool) -> None:
+    assert _is_complex_hive_type(hive_type) is expected
 
 
 def test_flag_off_keeps_v2_for_scalar() -> None:

--- a/metadata-ingestion/tests/unit/glue/test_glue_simplify_field_paths.py
+++ b/metadata-ingestion/tests/unit/glue/test_glue_simplify_field_paths.py
@@ -1,0 +1,169 @@
+import pytest
+
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.aws.glue import (
+    GlueSource,
+    GlueSourceConfig,
+    _hive_type_requires_v2_paths,
+)
+
+
+def _build_glue_source(*, simplify: bool) -> GlueSource:
+    return GlueSource(
+        ctx=PipelineContext(run_id="glue-simplify-test"),
+        config=GlueSourceConfig(
+            aws_region="us-west-2",
+            extract_transforms=False,
+            simplify_nested_field_paths=simplify,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "hive_type, expected",
+    [
+        # Only uniontype requires v2 paths; every other shape downgrades safely.
+        ("string", False),
+        ("int", False),
+        ("bigint", False),
+        ("decimal(10,2)", False),
+        ("varchar(255)", False),
+        ("map<string,int>", False),
+        ("array<string>", False),
+        ("array<struct<id:int,name:string>>", False),
+        ("struct<id:int,name:string>", False),
+        ("uniontype<int,string>", True),
+        ("  UNIONTYPE<int,string>  ", True),  # leading whitespace + uppercase
+    ],
+)
+def test_hive_type_requires_v2_paths(hive_type: str, expected: bool) -> None:
+    assert _hive_type_requires_v2_paths(hive_type) is expected
+
+
+def test_flag_off_keeps_v2_for_scalar() -> None:
+    source = _build_glue_source(simplify=False)
+    fields = source._build_schema_fields(
+        hive_column_name="email",
+        hive_column_type="string",
+        description=None,
+        default_nullable=True,
+    )
+    assert len(fields) == 1
+    assert fields[0].fieldPath == "[version=2.0].[type=string].email"
+
+
+def test_flag_on_downgrades_scalar_to_v1() -> None:
+    source = _build_glue_source(simplify=True)
+    fields = source._build_schema_fields(
+        hive_column_name="email",
+        hive_column_type="string",
+        description=None,
+        default_nullable=True,
+    )
+    assert len(fields) == 1
+    assert fields[0].fieldPath == "email"
+
+
+def test_flag_on_preserves_v2_for_uniontype() -> None:
+    source = _build_glue_source(simplify=True)
+    fields = source._build_schema_fields(
+        hive_column_name="payload",
+        hive_column_type="uniontype<int,string>",
+        description=None,
+        default_nullable=True,
+    )
+    assert fields, "expected at least one SchemaField for uniontype"
+    for f in fields:
+        assert f.fieldPath.startswith("[version=2.0]"), (
+            f"uniontype produced non-v2 fieldPath: {f.fieldPath}"
+        )
+
+
+@pytest.mark.parametrize(
+    "hive_type, expected_paths",
+    [
+        (
+            "struct<id:int,name:string>",
+            {"person", "person.id", "person.name"},
+        ),
+        # Nested struct still produces unique dotted paths after downgrade.
+        (
+            "struct<inner:struct<id:int>,name:string>",
+            {"person", "person.inner", "person.inner.id", "person.name"},
+        ),
+    ],
+)
+def test_flag_on_downgrades_struct_to_v1(hive_type: str, expected_paths: set) -> None:
+    source = _build_glue_source(simplify=True)
+    fields = source._build_schema_fields(
+        hive_column_name="person",
+        hive_column_type=hive_type,
+        description=None,
+        default_nullable=True,
+    )
+    paths = {f.fieldPath for f in fields}
+    assert paths == expected_paths
+    for f in fields:
+        assert not f.fieldPath.startswith("[version=2.0]")
+
+
+@pytest.mark.parametrize(
+    "hive_type, expected_paths",
+    [
+        ("array<string>", {"tags"}),
+        # Array-of-struct: container + leaf struct fields all downgrade.
+        ("array<struct<id:int,name:string>>", {"tags", "tags.id", "tags.name"}),
+        # Deeply nested arrays still produce unique paths after downgrade.
+        (
+            "array<struct<nested:array<struct<x:int>>>>",
+            {"tags", "tags.nested", "tags.nested.x"},
+        ),
+    ],
+)
+def test_flag_on_downgrades_array_to_v1(hive_type: str, expected_paths: set) -> None:
+    source = _build_glue_source(simplify=True)
+    fields = source._build_schema_fields(
+        hive_column_name="tags",
+        hive_column_type=hive_type,
+        description=None,
+        default_nullable=True,
+    )
+    paths = {f.fieldPath for f in fields}
+    assert paths == expected_paths
+    for f in fields:
+        assert not f.fieldPath.startswith("[version=2.0]")
+
+
+@pytest.mark.parametrize(
+    "hive_type, expected_paths",
+    [
+        ("map<string,int>", {"counts"}),
+        # Map value-side struct fields downgrade to flat dotted paths too.
+        ("map<string,struct<a:int,b:string>>", {"counts", "counts.a", "counts.b"}),
+    ],
+)
+def test_flag_on_downgrades_map_to_v1(hive_type: str, expected_paths: set) -> None:
+    source = _build_glue_source(simplify=True)
+    fields = source._build_schema_fields(
+        hive_column_name="counts",
+        hive_column_type=hive_type,
+        description=None,
+        default_nullable=True,
+    )
+    paths = {f.fieldPath for f in fields}
+    assert paths == expected_paths
+    for f in fields:
+        assert not f.fieldPath.startswith("[version=2.0]")
+
+
+def test_flag_on_preserves_description_on_downgrade() -> None:
+    source = _build_glue_source(simplify=True)
+    fields = source._build_schema_fields(
+        hive_column_name="event_id",
+        hive_column_type="int",
+        description="primary event identifier",
+        default_nullable=True,
+    )
+    assert len(fields) == 1
+    assert fields[0].fieldPath == "event_id"
+    assert fields[0].description == "primary event identifier"

--- a/metadata-ingestion/tests/unit/glue/test_glue_simplify_field_paths.py
+++ b/metadata-ingestion/tests/unit/glue/test_glue_simplify_field_paths.py
@@ -34,6 +34,12 @@ def _build_glue_source(*, simplify: bool) -> GlueSource:
         ("struct<id:int,name:string>", False),
         ("uniontype<int,string>", True),
         ("  UNIONTYPE<int,string>  ", True),  # leading whitespace + uppercase
+        # Uniontype nested inside other complex types must also be detected,
+        # otherwise its variants collide on v1 downgrade and GMS dedups one.
+        ("struct<payload:uniontype<int,string>>", True),
+        ("array<uniontype<int,string>>", True),
+        ("map<string,uniontype<int,string>>", True),
+        ("struct<a:array<struct<b:uniontype<int,string>>>>", True),
     ],
 )
 def test_is_complex_hive_type(hive_type: str, expected: bool) -> None:
@@ -64,19 +70,36 @@ def test_flag_on_downgrades_scalar_to_v1() -> None:
     assert fields[0].fieldPath == "email"
 
 
-def test_flag_on_preserves_v2_for_uniontype() -> None:
+@pytest.mark.parametrize(
+    "hive_type",
+    [
+        "uniontype<int,string>",
+        # Nested unions must also be detected — otherwise the variant SchemaField
+        # entries collapse to the same v1 path and one is silently dropped by GMS.
+        "struct<payload:uniontype<int,string>>",
+        "array<uniontype<int,string>>",
+        "map<string,uniontype<int,string>>",
+    ],
+)
+def test_flag_on_preserves_v2_for_uniontype(hive_type: str) -> None:
     source = _build_glue_source(simplify=True)
     fields = source._build_schema_fields(
         hive_column_name="payload",
-        hive_column_type="uniontype<int,string>",
+        hive_column_type=hive_type,
         description=None,
         default_nullable=True,
     )
-    assert fields, "expected at least one SchemaField for uniontype"
+    assert fields, f"expected at least one SchemaField for {hive_type}"
     for f in fields:
         assert f.fieldPath.startswith("[version=2.0]"), (
-            f"uniontype produced non-v2 fieldPath: {f.fieldPath}"
+            f"{hive_type!r} produced non-v2 fieldPath: {f.fieldPath}"
         )
+    # And critically: no collisions in the path set (the very property the helper
+    # exists to protect).
+    paths = [f.fieldPath for f in fields]
+    assert len(set(paths)) == len(paths), (
+        f"{hive_type!r} produced duplicate fieldPaths: {paths}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -154,6 +177,28 @@ def test_flag_on_downgrades_map_to_v1(hive_type: str, expected_paths: set) -> No
     assert paths == expected_paths
     for f in fields:
         assert not f.fieldPath.startswith("[version=2.0]")
+
+
+def test_flag_on_keeps_v2_when_downgrade_would_produce_empty_path(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Column names ending with `]` are stripped to an empty path by the v2->v1
+    # converter. The empty path would yield a malformed schemaField URN that
+    # silently dedups across columns, so we must fall back to the v2 path and warn.
+    source = _build_glue_source(simplify=True)
+    with caplog.at_level("WARNING"):
+        fields = source._build_schema_fields(
+            hive_column_name="arr[idx]",
+            hive_column_type="string",
+            description=None,
+            default_nullable=True,
+        )
+    assert len(fields) == 1
+    assert fields[0].fieldPath == "[version=2.0].[type=string].arr[idx]"
+    assert any(
+        "produced empty path" in r.message and "arr[idx]" in r.message
+        for r in caplog.records
+    )
 
 
 def test_flag_on_preserves_description_on_downgrade() -> None:


### PR DESCRIPTION
## Summary

- Adds opt-in `simplify_nested_field_paths` config flag (default `False`) to the Glue source. When enabled, emits v1 (simple) schemaField paths — `email` instead of `[version=2.0].[type=string].email` — for every Hive type except `uniontype`.
- Aligns Glue schemaField URNs with v1-emitting sources (dbt, native SQL connectors) so column-level lineage and term/tag propagation can traverse the Glue↔dbt boundary.
- `uniontype` is the only exception: v1 paths can't disambiguate union variants — they'd collapse to the same path and GMS dedups one of the SchemaField entries (silent data loss).

**Caveat for operators enabling the flag:** flipping it changes every schemaField URN on the affected datasets, orphaning existing annotations (tags, terms, descriptions, column-level lineage edges) attached to the old v2 URNs. One-way in practice — stateful ingestion will mark the v2 URNs as stale on the first run after the flip.

## Implementation notes

- New module helper `_hive_type_requires_v2_paths()` — matches only `uniontype<...>` via `re.IGNORECASE`.
- New method `GlueSource._build_schema_fields()` — runs the Avro converter, then conditionally rewrites each `fieldPath` via `get_simple_field_path_from_v2_field_path` from `datahub.utilities.urns.field_paths` (the non-deprecated free function, not the deprecated `DatasetUrn` static method).
- Four existing `get_schema_fields_for_hive_column()` call sites updated to route through the helper: `_get_glue_schema_metadata` (regular columns + partition keys), `_get_delta_schema_metadata`, `_get_column_param_workunits`.
