### PR TITLE
feat(s3/abs/gcs): add infer_schema config flag to skip schema inference

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/abs/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/abs/config.py
@@ -97,6 +97,17 @@ class DataLakeSourceConfig(
         description="Number of files to list to sample for schema inference. This will be ignored if sample_files is set to False in the pathspec.",
     )
 
+    infer_schema: bool = Field(
+        default=True,
+        description=(
+            "Whether to infer schema from sampled files and emit a `schemaMetadata` aspect. "
+            "When set to `False`, the source will skip schema inference entirely and not emit "
+            "a `schemaMetadata` aspect for any dataset, leaving any existing schema (e.g. "
+            "written by a separate, schema-aware pipeline) untouched. All other aspects "
+            "(properties, partitions, containers, lineage, profiling, tags) are still emitted."
+        ),
+    )
+
     _rename_path_spec_to_plural = pydantic_renamed_field(
         "path_spec", "path_specs", lambda path_spec: [path_spec]
     )

--- a/metadata-ingestion/src/datahub/ingestion/source/abs/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/abs/config.py
@@ -89,6 +89,17 @@ class DataLakeSourceConfig(
         description="Number of files to list to sample for schema inference. This will be ignored if sample_files is set to False in the pathspec.",
     )
 
+    infer_schema: bool = Field(
+        default=True,
+        description=(
+            "Whether to infer schema from sampled files and emit a `schemaMetadata` aspect. "
+            "When set to `False`, the source will skip schema inference entirely and not emit "
+            "a `schemaMetadata` aspect for any dataset, leaving any existing schema (e.g. "
+            "written by a separate, schema-aware pipeline) untouched. All other aspects "
+            "(properties, partitions, containers, lineage, profiling, tags) are still emitted."
+        ),
+    )
+
     _rename_path_spec_to_plural = pydantic_renamed_field(
         "path_spec", "path_specs", lambda path_spec: [path_spec]
     )

--- a/metadata-ingestion/src/datahub/ingestion/source/abs/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/abs/source.py
@@ -308,7 +308,12 @@ class ABSSource(StatefulIngestionSourceBase):
             customProperties=custom_properties,
         )
         aspects.append(dataset_properties)
-        if table_data.size_in_bytes > 0:
+        if not self.source_config.infer_schema:
+            logger.debug(
+                f"Skipping schema inference for {table_data.display_name} "
+                "because infer_schema is set to False"
+            )
+        elif table_data.size_in_bytes > 0:
             try:
                 fields = self.get_fields(table_data, path_spec)
                 schema_metadata = SchemaMetadata(

--- a/metadata-ingestion/src/datahub/ingestion/source/abs/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/abs/source.py
@@ -330,7 +330,12 @@ class ABSSource(StatefulIngestionSourceBase):
             customProperties=custom_properties,
         )
         aspects.append(dataset_properties)
-        if table_data.size_in_bytes > 0:
+        if not self.source_config.infer_schema:
+            logger.debug(
+                f"Skipping schema inference for {table_data.display_name} "
+                "because infer_schema is set to False"
+            )
+        elif table_data.size_in_bytes > 0:
             try:
                 fields = self.get_fields(table_data, path_spec)
                 schema_metadata = SchemaMetadata(

--- a/metadata-ingestion/src/datahub/ingestion/source/gcs/gcs_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gcs/gcs_source.py
@@ -159,6 +159,17 @@ class GCSSourceConfig(
         description="Number of files to list to sample for schema inference. This will be ignored if sample_files is set to False in the pathspec.",
     )
 
+    infer_schema: bool = Field(
+        default=True,
+        description=(
+            "Whether to infer schema from sampled files and emit a `schemaMetadata` aspect. "
+            "When set to `False`, the source will skip schema inference entirely and not emit "
+            "a `schemaMetadata` aspect for any dataset, leaving any existing schema (e.g. "
+            "written by a separate, schema-aware pipeline) untouched. All other aspects "
+            "(properties, partitions, containers, lineage, profiling, tags) are still emitted."
+        ),
+    )
+
     stateful_ingestion: Optional[StatefulStaleMetadataRemovalConfig] = None
 
     @model_validator(mode="before")
@@ -260,6 +271,7 @@ class GCSSource(StatefulIngestionSourceBase):
                 convert_urns_to_lowercase=self.config.convert_urns_to_lowercase,
                 max_rows=self.config.max_rows,
                 number_of_files_to_sample=self.config.number_of_files_to_sample,
+                infer_schema=self.config.infer_schema,
                 platform=PLATFORM_GCS,
                 platform_instance=self.config.platform_instance,
             )
@@ -284,6 +296,7 @@ class GCSSource(StatefulIngestionSourceBase):
                 convert_urns_to_lowercase=self.config.convert_urns_to_lowercase,
                 max_rows=self.config.max_rows,
                 number_of_files_to_sample=self.config.number_of_files_to_sample,
+                infer_schema=self.config.infer_schema,
                 platform=PLATFORM_GCS,
                 platform_instance=self.config.platform_instance,
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/gcs/gcs_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gcs/gcs_source.py
@@ -167,6 +167,17 @@ class GCSSourceConfig(
         default=DataLakeProfilerConfig(), description="Data profiling configuration"
     )
 
+    infer_schema: bool = Field(
+        default=True,
+        description=(
+            "Whether to infer schema from sampled files and emit a `schemaMetadata` aspect. "
+            "When set to `False`, the source will skip schema inference entirely and not emit "
+            "a `schemaMetadata` aspect for any dataset, leaving any existing schema (e.g. "
+            "written by a separate, schema-aware pipeline) untouched. All other aspects "
+            "(properties, partitions, containers, lineage, profiling, tags) are still emitted."
+        ),
+    )
+
     stateful_ingestion: Optional[StatefulStaleMetadataRemovalConfig] = None
 
     @model_validator(mode="before")
@@ -305,6 +316,7 @@ class GCSSource(StatefulIngestionSourceBase):
             convert_urns_to_lowercase=self.config.convert_urns_to_lowercase,
             max_rows=self.config.max_rows,
             number_of_files_to_sample=self.config.number_of_files_to_sample,
+            infer_schema=self.config.infer_schema,
             platform=PLATFORM_GCS,
             platform_instance=self.config.platform_instance,
             profile_patterns=self.config.profile_patterns,

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/config.py
@@ -101,6 +101,19 @@ class DataLakeSourceConfig(
         description="Number of files to list to sample for schema inference. This will be ignored if sample_files is set to False in the pathspec.",
     )
 
+    infer_schema: bool = Field(
+        default=True,
+        description=(
+            "Whether to infer schema from sampled files and emit a `schemaMetadata` aspect. "
+            "When set to `False`, the source will skip schema inference entirely and not emit "
+            "a `schemaMetadata` aspect for any dataset, leaving any existing schema (e.g. "
+            "written by a separate, schema-aware pipeline) untouched. All other aspects "
+            "(properties, partitions, containers, lineage, profiling, tags) are still emitted. "
+            "Useful when an authoritative schema source already populates the schema and you "
+            "want to avoid having it overwritten by data-driven inference."
+        ),
+    )
+
     _rename_path_spec_to_plural = pydantic_renamed_field(
         "path_spec", "path_specs", lambda path_spec: [path_spec]
     )

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/config.py
@@ -102,6 +102,19 @@ class DataLakeSourceConfig(
         description="Number of files to list to sample for schema inference. This will be ignored if sample_files is set to False in the pathspec.",
     )
 
+    infer_schema: bool = Field(
+        default=True,
+        description=(
+            "Whether to infer schema from sampled files and emit a `schemaMetadata` aspect. "
+            "When set to `False`, the source will skip schema inference entirely and not emit "
+            "a `schemaMetadata` aspect for any dataset, leaving any existing schema (e.g. "
+            "written by a separate, schema-aware pipeline) untouched. All other aspects "
+            "(properties, partitions, containers, lineage, profiling, tags) are still emitted. "
+            "Useful when an authoritative schema source already populates the schema and you "
+            "want to avoid having it overwritten by data-driven inference."
+        ),
+    )
+
     _rename_path_spec_to_plural = pydantic_renamed_field(
         "path_spec", "path_specs", lambda path_spec: [path_spec]
     )

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -528,7 +528,12 @@ class S3Source(StatefulIngestionSourceBase):
             externalUrl=self.get_external_url(table_data),
         )
         aspects.append(dataset_properties)
-        if table_data.size_in_bytes > 0:
+        if not self.source_config.infer_schema:
+            logger.debug(
+                f"Skipping schema inference for {table_data.display_name} "
+                "because infer_schema is set to False"
+            )
+        elif table_data.size_in_bytes > 0:
             try:
                 fields = self.get_fields(table_data, path_spec)
                 schema_metadata = SchemaMetadata(

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -525,7 +525,12 @@ class S3Source(StatefulIngestionSourceBase):
             externalUrl=self.get_external_url(table_data),
         )
         aspects.append(dataset_properties)
-        if table_data.size_in_bytes > 0:
+        if not self.source_config.infer_schema:
+            logger.debug(
+                f"Skipping schema inference for {table_data.display_name} "
+                "because infer_schema is set to False"
+            )
+        elif table_data.size_in_bytes > 0:
             try:
                 with PerfTimer() as schema_timer:
                     fields = self.get_fields(table_data, path_spec)

--- a/metadata-ingestion/tests/integration/s3/test_s3_slim_no_pyspark.py
+++ b/metadata-ingestion/tests/integration/s3/test_s3_slim_no_pyspark.py
@@ -10,9 +10,21 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import Iterable, Set
 from unittest.mock import patch
 
 import pytest
+
+
+def _collect_aspect_names(workunits: Iterable) -> Set[str]:
+    """Extract the set of aspect names emitted by an ingestion run."""
+    aspect_names: Set[str] = set()
+    for wu in workunits:
+        metadata = getattr(wu, "metadata", None)
+        aspect_name = getattr(metadata, "aspectName", None)
+        if aspect_name:
+            aspect_names.add(aspect_name)
+    return aspect_names
 
 
 @pytest.mark.integration
@@ -119,6 +131,47 @@ class TestS3SlimNoPySpark:
 
         workunits = list(source.get_workunits())
         assert len(workunits) > 0
+
+    def test_infer_schema_true_emits_schema_metadata(self, tmp_path: Path) -> None:
+        from datahub.ingestion.api.common import PipelineContext
+        from datahub.ingestion.source.s3.source import S3Source
+
+        test_file = tmp_path / "test.csv"
+        test_file.write_text("id,name,value\n1,test,100\n2,sample,200\n")
+
+        ctx = PipelineContext(run_id="test-s3-infer-schema-on")
+        source = S3Source.create(
+            {
+                "path_specs": [{"include": f"{tmp_path}/*.csv"}],
+                "profiling": {"enabled": False},
+            },
+            ctx,
+        )
+
+        aspect_names = _collect_aspect_names(source.get_workunits())
+        assert "schemaMetadata" in aspect_names
+
+    def test_infer_schema_false_skips_schema_metadata(self, tmp_path: Path) -> None:
+        from datahub.ingestion.api.common import PipelineContext
+        from datahub.ingestion.source.s3.source import S3Source
+
+        test_file = tmp_path / "test.csv"
+        test_file.write_text("id,name,value\n1,test,100\n2,sample,200\n")
+
+        ctx = PipelineContext(run_id="test-s3-infer-schema-off")
+        source = S3Source.create(
+            {
+                "path_specs": [{"include": f"{tmp_path}/*.csv"}],
+                "profiling": {"enabled": False},
+                "infer_schema": False,
+            },
+            ctx,
+        )
+
+        aspect_names = _collect_aspect_names(source.get_workunits())
+        # Schema must not be emitted, but the rest of the dataset metadata still is.
+        assert "schemaMetadata" not in aspect_names
+        assert "datasetProperties" in aspect_names
 
 
 @pytest.mark.integration

--- a/metadata-ingestion/tests/integration/s3/test_s3_slim_no_pyspark.py
+++ b/metadata-ingestion/tests/integration/s3/test_s3_slim_no_pyspark.py
@@ -12,9 +12,21 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import Iterable, Set
 from unittest.mock import patch
 
 import pytest
+
+
+def _collect_aspect_names(workunits: Iterable) -> Set[str]:
+    """Extract the set of aspect names emitted by an ingestion run."""
+    aspect_names: Set[str] = set()
+    for wu in workunits:
+        metadata = getattr(wu, "metadata", None)
+        aspect_name = getattr(metadata, "aspectName", None)
+        if aspect_name:
+            aspect_names.add(aspect_name)
+    return aspect_names
 
 
 @pytest.mark.integration
@@ -125,6 +137,47 @@ class TestS3SlimNoPySpark:
 
         workunits = list(source.get_workunits())
         assert len(workunits) > 0
+
+    def test_infer_schema_true_emits_schema_metadata(self, tmp_path: Path) -> None:
+        from datahub.ingestion.api.common import PipelineContext
+        from datahub.ingestion.source.s3.source import S3Source
+
+        test_file = tmp_path / "test.csv"
+        test_file.write_text("id,name,value\n1,test,100\n2,sample,200\n")
+
+        ctx = PipelineContext(run_id="test-s3-infer-schema-on")
+        source = S3Source.create(
+            {
+                "path_specs": [{"include": f"{tmp_path}/*.csv"}],
+                "profiling": {"enabled": False},
+            },
+            ctx,
+        )
+
+        aspect_names = _collect_aspect_names(source.get_workunits())
+        assert "schemaMetadata" in aspect_names
+
+    def test_infer_schema_false_skips_schema_metadata(self, tmp_path: Path) -> None:
+        from datahub.ingestion.api.common import PipelineContext
+        from datahub.ingestion.source.s3.source import S3Source
+
+        test_file = tmp_path / "test.csv"
+        test_file.write_text("id,name,value\n1,test,100\n2,sample,200\n")
+
+        ctx = PipelineContext(run_id="test-s3-infer-schema-off")
+        source = S3Source.create(
+            {
+                "path_specs": [{"include": f"{tmp_path}/*.csv"}],
+                "profiling": {"enabled": False},
+                "infer_schema": False,
+            },
+            ctx,
+        )
+
+        aspect_names = _collect_aspect_names(source.get_workunits())
+        # Schema must not be emitted, but the rest of the dataset metadata still is.
+        assert "schemaMetadata" not in aspect_names
+        assert "datasetProperties" in aspect_names
 
 
 @pytest.mark.integration

--- a/metadata-ingestion/tests/unit/abs/test_abs_config.py
+++ b/metadata-ingestion/tests/unit/abs/test_abs_config.py
@@ -140,3 +140,32 @@ def test_abs_config_rejects_empty_path_specs():
         match="path_specs must not be empty",
     ):
         DataLakeSourceConfig.model_validate(config_dict)
+
+
+def test_abs_infer_schema_defaults_to_true():
+    config = DataLakeSourceConfig.model_validate(
+        {
+            "path_specs": [
+                {
+                    "include": "/var/lib/data/{table}/*.parquet",
+                    "file_types": ["parquet"],
+                }
+            ]
+        }
+    )
+    assert config.infer_schema is True
+
+
+def test_abs_infer_schema_can_be_disabled():
+    config = DataLakeSourceConfig.model_validate(
+        {
+            "path_specs": [
+                {
+                    "include": "/var/lib/data/{table}/*.parquet",
+                    "file_types": ["parquet"],
+                }
+            ],
+            "infer_schema": False,
+        }
+    )
+    assert config.infer_schema is False

--- a/metadata-ingestion/tests/unit/s3/test_s3_config.py
+++ b/metadata-ingestion/tests/unit/s3/test_s3_config.py
@@ -53,3 +53,18 @@ class TestS3Config:
 
         error_msg = str(exc_info.value).lower()
         assert "s3 bucket tags" in error_msg and "platform is not s3" in error_msg
+
+    def test_infer_schema_defaults_to_true(self):
+        config = DataLakeSourceConfig.parse_obj(
+            {"path_specs": [{"include": "s3://bucket/data/*.parquet"}]}
+        )
+        assert config.infer_schema is True
+
+    def test_infer_schema_can_be_disabled(self):
+        config = DataLakeSourceConfig.parse_obj(
+            {
+                "path_specs": [{"include": "s3://bucket/data/*.parquet"}],
+                "infer_schema": False,
+            }
+        )
+        assert config.infer_schema is False

--- a/metadata-ingestion/tests/unit/s3/test_s3_config.py
+++ b/metadata-ingestion/tests/unit/s3/test_s3_config.py
@@ -94,3 +94,18 @@ class TestS3Config:
 
         error_msg = str(exc_info.value).lower()
         assert "s3 bucket tags" in error_msg and "platform is not s3" in error_msg
+
+    def test_infer_schema_defaults_to_true(self):
+        config = DataLakeSourceConfig.parse_obj(
+            {"path_specs": [{"include": "s3://bucket/data/*.parquet"}]}
+        )
+        assert config.infer_schema is True
+
+    def test_infer_schema_can_be_disabled(self):
+        config = DataLakeSourceConfig.parse_obj(
+            {
+                "path_specs": [{"include": "s3://bucket/data/*.parquet"}],
+                "infer_schema": False,
+            }
+        )
+        assert config.infer_schema is False

--- a/metadata-ingestion/tests/unit/test_gcs_source.py
+++ b/metadata-ingestion/tests/unit/test_gcs_source.py
@@ -624,3 +624,27 @@ def test_gcs_oauth_aws_config_no_hooks_without_creds():
         client = cast(mock.MagicMock, config.get_s3_client())
 
         client.meta.events.register.assert_not_called()
+
+
+def test_gcs_infer_schema_defaults_to_true():
+    config = GCSSourceConfig.model_validate(
+        {
+            "path_specs": [{"include": "gs://bucket/{table}/*.parquet"}],
+            "credential": {"hmac_access_id": "id", "hmac_access_secret": "secret"},
+        }
+    )
+    assert config.infer_schema is True
+
+
+def test_gcs_infer_schema_forwarded_to_s3_config():
+    """infer_schema=False must be forwarded to the underlying S3 config."""
+    graph = mock.MagicMock(spec=DataHubGraph)
+    ctx = PipelineContext(run_id="test-gcs", graph=graph, pipeline_name="test-gcs")
+
+    source = {
+        "path_specs": [{"include": "gs://bucket/{table}/*.parquet"}],
+        "credential": {"hmac_access_id": "id", "hmac_access_secret": "secret"},
+        "infer_schema": False,
+    }
+    gcs_source = GCSSource.create(source, ctx)
+    assert gcs_source.s3_source.source_config.infer_schema is False

--- a/metadata-ingestion/tests/unit/test_gcs_source.py
+++ b/metadata-ingestion/tests/unit/test_gcs_source.py
@@ -747,3 +747,27 @@ def test_gcs_oauth_aws_config_raises_without_creds():
 
         with pytest.raises(RuntimeError, match="_gcs_oauth_credentials must be set"):
             config.get_s3_client()
+
+
+def test_gcs_infer_schema_defaults_to_true():
+    config = GCSSourceConfig.model_validate(
+        {
+            "path_specs": [{"include": "gs://bucket/{table}/*.parquet"}],
+            "credential": {"hmac_access_id": "id", "hmac_access_secret": "secret"},
+        }
+    )
+    assert config.infer_schema is True
+
+
+def test_gcs_infer_schema_forwarded_to_s3_config():
+    """infer_schema=False must be forwarded to the underlying S3 config."""
+    graph = mock.MagicMock(spec=DataHubGraph)
+    ctx = PipelineContext(run_id="test-gcs", graph=graph, pipeline_name="test-gcs")
+
+    source = {
+        "path_specs": [{"include": "gs://bucket/{table}/*.parquet"}],
+        "credential": {"hmac_access_id": "id", "hmac_access_secret": "secret"},
+        "infer_schema": False,
+    }
+    gcs_source = GCSSource.create(source, ctx)
+    assert gcs_source.s3_source.source_config.infer_schema is False


### PR DESCRIPTION
Add an `infer_schema` boolean field (default: `True`) to the S3, ABS, and GCS source configs. When set to `False`, the source skips schema inference entirely and does not emit a `schemaMetadata` aspect for any dataset.

This is useful when an authoritative schema pipeline (e.g. a JSON Schema registry ingestion) already owns the schema aspect and the file-based source should not overwrite it with data-driven inference. All other aspects (datasetProperties, partitions, containers, lineage, tags) are still emitted normally.

- S3: flag added to `DataLakeSourceConfig`, guarded in `S3Source.ingest_table`
- ABS: same change in ABS's own `DataLakeSourceConfig` and `ABSSource.ingest_table`
- GCS: flag added to `GCSSourceConfig` and forwarded to the underlying `DataLakeSourceConfig` in both HMAC and WIF auth paths

Docs are auto-generated from the pydantic Field description annotation.