### PR TITLE
fix(ingest): skip empty columns for CLL

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -2227,6 +2227,8 @@ class DBTSourceBase(StatefulIngestionSourceBase):
                         # TODO: Add some telemetry around this - how frequently does it filter stuff out?
                         if target_platform_urn_to_dbt_name.get(upstream_column.table)
                         in node.upstream_nodes
+                        and upstream_column.column
+                        and column_lineage_info.downstream.column
                     ]
 
             # If we didn't fetch the schema from the graph, use the inferred schema.
@@ -3135,6 +3137,8 @@ class DBTSourceBase(StatefulIngestionSourceBase):
 
                     cll = []
                     for column_lineage in sql_parsing_result.column_lineage or []:
+                        if not column_lineage.downstream.column:
+                            continue
                         cll.append(
                             FineGrainedLineage(
                                 upstreamType=FineGrainedLineageUpstreamType.FIELD_SET,
@@ -3144,6 +3148,7 @@ class DBTSourceBase(StatefulIngestionSourceBase):
                                         upstream.table, upstream.column
                                     )
                                     for upstream in column_lineage.upstreams
+                                    if upstream.column
                                 ],
                                 downstreams=[
                                     mce_builder.make_schema_field_urn(

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -3170,6 +3170,11 @@ class DBTSourceBase(StatefulIngestionSourceBase):
                         # SQL parsing failed entirely, which is already reported above.
                         pass
 
+                valid_cll_entries = [
+                    entry
+                    for entry in node.upstream_cll
+                    if entry.upstream_col and entry.downstream_col
+                ]
                 cll = [
                     FineGrainedLineage(
                         upstreamType=FineGrainedLineageUpstreamType.FIELD_SET,
@@ -3193,7 +3198,7 @@ class DBTSourceBase(StatefulIngestionSourceBase):
                         ),
                     )
                     for downstream, upstreams in groupby_unsorted(
-                        node.upstream_cll, lambda x: x.downstream_col
+                        valid_cll_entries, lambda x: x.downstream_col
                     )
                 ]
 

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_source_cll.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_source_cll.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List
+from unittest import mock
 
-from datahub.ingestion.source.dbt.dbt_common import parse_semantic_view_cll
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.dbt.dbt_common import (
+    DBTColumnLineageInfo,
+    DBTNode,
+    parse_semantic_view_cll,
+)
+from datahub.ingestion.source.dbt.dbt_core import DBTCoreConfig, DBTCoreSource
 from tests.unit.dbt.test_helpers import (  # type: ignore[import-untyped]
     create_mock_dbt_node,
 )
@@ -81,3 +88,115 @@ def test_parse_semantic_view_cll_with_various_functions() -> None:
     assert "median_value" in downstream_cols
     assert "value_stddev" in downstream_cols
     assert "total" in downstream_cols
+
+
+def _make_dbt_source() -> DBTCoreSource:
+    ctx = PipelineContext(run_id="test-run-id", pipeline_name="dbt-source")
+    ctx.graph = mock.MagicMock()
+    return DBTCoreSource(
+        DBTCoreConfig(
+            manifest_path="temp/",
+            catalog_path="temp/",
+            target_platform="bigquery",
+            enable_meta_mapping=False,
+        ),
+        ctx,
+    )
+
+
+def _make_model_node(dbt_name: str, upstream_dbt_name: str) -> DBTNode:
+    return DBTNode(
+        database="myproject",
+        schema="mydataset",
+        name="my_model",
+        alias=None,
+        comment="",
+        description="",
+        language="sql",
+        raw_code=None,
+        dbt_adapter="bigquery",
+        dbt_name=dbt_name,
+        dbt_file_path=None,
+        dbt_package_name="mypackage",
+        node_type="model",
+        max_loaded_at=None,
+        materialization="table",
+        catalog_type=None,
+        missing_from_catalog=False,
+        owner=None,
+        upstream_nodes=[upstream_dbt_name],
+    )
+
+
+def _make_upstream_node(dbt_name: str) -> DBTNode:
+    return DBTNode(
+        database="myproject",
+        schema="internal_staging",
+        name="stg_utm_campaigns",
+        alias=None,
+        comment="",
+        description="",
+        language="sql",
+        raw_code=None,
+        dbt_adapter="bigquery",
+        dbt_name=dbt_name,
+        dbt_file_path=None,
+        dbt_package_name="mypackage",
+        node_type="source",
+        max_loaded_at=None,
+        materialization=None,
+        catalog_type=None,
+        missing_from_catalog=False,
+        owner=None,
+    )
+
+
+def test_empty_column_names_filtered_from_fine_grained_lineage() -> None:
+    """Regression: sqlglot v30 can produce empty column names from SQL parsing.
+    These must be dropped before emitting schemaField URNs or GMS rejects them with 422."""
+    upstream_dbt_name = "source.mypackage.mydb.stg_utm_campaigns"
+    model_dbt_name = "model.mypackage.my_model"
+
+    node = _make_model_node(model_dbt_name, upstream_dbt_name)
+    upstream_node = _make_upstream_node(upstream_dbt_name)
+
+    node.upstream_cll = [
+        # valid entry — should be kept
+        DBTColumnLineageInfo(
+            upstream_dbt_name=upstream_dbt_name,
+            upstream_col="campaign_id",
+            downstream_col="campaign_id",
+        ),
+        # empty upstream column — must be dropped
+        DBTColumnLineageInfo(
+            upstream_dbt_name=upstream_dbt_name,
+            upstream_col="",
+            downstream_col="campaign_name",
+        ),
+        # empty downstream column — must be dropped
+        DBTColumnLineageInfo(
+            upstream_dbt_name=upstream_dbt_name,
+            upstream_col="source_col",
+            downstream_col="",
+        ),
+    ]
+
+    source = _make_dbt_source()
+    all_nodes_map = {
+        model_dbt_name: node,
+        upstream_dbt_name: upstream_node,
+    }
+
+    result = source._create_lineage_aspect_for_dbt_node(node, all_nodes_map)
+
+    assert result is not None
+    assert result.fineGrainedLineages is not None
+    assert len(result.fineGrainedLineages) == 1
+
+    fgl = result.fineGrainedLineages[0]
+    assert len(fgl.upstreams) == 1
+    assert len(fgl.downstreams) == 1
+
+    # Neither upstream nor downstream should contain a schemaField URN with an empty field name.
+    for urn in fgl.upstreams + fgl.downstreams:
+        assert not urn.endswith(",)"), f"Empty field name in schemaField URN: {urn}"

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_source_cll.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_source_cll.py
@@ -194,6 +194,8 @@ def test_empty_column_names_filtered_from_fine_grained_lineage() -> None:
     assert len(result.fineGrainedLineages) == 1
 
     fgl = result.fineGrainedLineages[0]
+    assert fgl.upstreams is not None
+    assert fgl.downstreams is not None
     assert len(fgl.upstreams) == 1
     assert len(fgl.downstreams) == 1
 


### PR DESCRIPTION
The sqlglot SQL parser upgrade from v29 to v30 (shipped in 1.5.0.19) changed how certain SQL patterns are analyzed during CLL extraction, causing some upstream column names to be empty strings. These empty strings were being passed directly to make_schema_field_urn(), producing invalid URNs of the form urn:li:schemaField:(urn:li:dataset:(...),) that GMS rejects, causing the entire ingestion to fail. The fix adds guards in two places in dbt_common.py. 
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
