### PR TITLE
fix(ingest/ldap): Fix manager lookup failures during LDAP user ingestion

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/ldap.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ldap.py
@@ -347,7 +347,10 @@ class LDAPSource(StatefulIngestionSourceBase):
                     m_cn,
                     ldap.SCOPE_BASE,
                     manager_filter,
-                    serverctrls=[self.lc] if self.lc else [],
+                    # SCOPE_BASE resolves a single DN entry, so RFC2696 pagination
+                    # controls are unnecessary here and can be rejected by AD.
+                    # Keep pagination controls only on the main SCOPE_SUBTREE search.
+                    serverctrls=[],
                 )
                 result = self.ldap_client.result3(manager_msgid)
                 if result[1]:

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_lineage.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_lineage.py
@@ -1343,7 +1343,7 @@ class TestLineageMapKeyCollision:
             )
         )
 
-        assert queried_fqns == [
+        assert set(queried_fqns) == [
             "bigquery:test-project.analytics.customers",
             "bigquery:test-project.sales.customers",
         ]

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_lineage.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_lineage.py
@@ -1343,10 +1343,10 @@ class TestLineageMapKeyCollision:
             )
         )
 
-        assert set(queried_fqns) == [
+        assert set(queried_fqns) == {
             "bigquery:test-project.analytics.customers",
             "bigquery:test-project.sales.customers",
-        ]
+        }
         assert len(workunits) == 1
         entity_urn = workunits[0].metadata.entityUrn  # type: ignore[union-attr]
         assert isinstance(entity_urn, str)


### PR DESCRIPTION
**Summary**
This change fixes manager lookup failures during LDAP user ingestion when pagination is enabled. Manager resolution was intermittently failing with LDAP error result 12 (Critical extension is unavailable / UNAVAIL_EXTENSION), which left manager data unpopulated for affected users.

**Root Cause**

The main ingestion query uses paged LDAP controls (RFC 2696), which is correct for SCOPE_SUBTREE searches that return many entries.
Manager lookup uses SCOPE_BASE, which targets a single named entry and cannot produce a multi-page result set.
The manager lookup was incorrectly reusing the paged control object from the main query.
Active Directory rejects RFC 2696 paged controls on SCOPE_BASE requests, causing manager lookup failures.

**Code Change**

1. In manager lookup, changed server controls from conditional paged controls to an empty control list.
2. This ensures manager SCOPE_BASE lookup does not send pagination controls.
3. Main paginated SCOPE_SUBTREE ingestion path is unchanged.

**Changed location**

ldap.py

**Behavior Before**

1. With pagination enabled globally, manager lookup inherited paged control.
2. LDAP server could reject manager lookup with UNAVAIL_EXTENSION.
3. managerUrn could remain null even when manager attribute existed.

**Behavior After**

1. Manager lookup always runs without paged controls.
2. Main user/group ingestion still uses pagination.
3. Manager resolution succeeds when manager DN is valid and readable.

**Impact Assessment**

1. Scope is narrow: only manager lookup control handling changed.
2. No changes to schema, aspect structure, stateful ingestion, or sink behavior.
3. No expected regressions for providers that previously tolerated paged controls on base lookups.
4. Improves compatibility with servers that enforce stricter control usage on SCOPE_BASE.

**Validation**

1. Re-ran LDAP ingestion with pagination enabled.
2. Confirmed manager lookup warnings related to Critical extension is unavailable no longer occur for this path.
3. Verified manager field population in ingested corp user data for affected cases.

**Risk**

1. Low risk.
2. Change is limited to one search call argument in manager lookup path.
3. Semantically aligned with LDAP usage: paging for multi-entry searches, not single-entry base lookups.

**Rollback**

Revert this single-line control change in manager lookup if needed.


Update (June 9, 2026): Applied a minor fix to address a test failure caused by non-deterministic ordering in the assertion.