### PR TITLE
feat(docker): symlink bundled venvs for ingestion source aliases

### DIFF
--- a/docker/snippets/ingestion/README.md
+++ b/docker/snippets/ingestion/README.md
@@ -28,6 +28,8 @@ If **no** `BUNDLED_VENV_PLUGINS_*` variables are set, each plugin in `BUNDLED_VE
 
 `BUNDLED_VENV_PLUGINS` remains the **authoritative full list** of plugins that must receive a `{plugin}-bundled` path; every member of every group must appear in that list, and each plugin appears in **at most one** group (or as a singleton).
 
+**Source aliases:** When a plugin is built, the builder also creates `{alias}-bundled` symlinks for known alias pairs in `bundled_venv_config.py` (e.g. list only `unity-catalog` and both `unity-catalog-bundled` and `databricks-bundled` are created). Do not list both names in `BUNDLED_VENV_PLUGINS`.
+
 ## Slim mode and PySpark
 
 When **`BUNDLED_VENV_SLIM_MODE`** is `true`, extras for plugins in `PLUGINS_WITH_SLIM_VARIANT` use the corresponding **`-slim`** extra (e.g. `s3-slim` instead of `s3`) so PySpark is not pulled for data-lake stacks that support it.

--- a/docker/snippets/ingestion/build_bundled_venvs_unified.py
+++ b/docker/snippets/ingestion/build_bundled_venvs_unified.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from bundled_venv_config import (
     BundledVenvGroupPlan,
     build_group_plans,
+    bundled_venv_symlink_names,
     extras_to_install_string,
     groups_config_from_plugin_group_env,
 )
@@ -196,14 +197,14 @@ def ensure_plugin_symlinks(
     venv_base_path: str,
 ) -> None:
     """
-    For groups with multiple members, or a single member whose canonical dir name
-    differs from `{plugin}-bundled`, create relative symlinks so each plugin path exists.
+    Create relative symlinks so each required ``{plugin}-bundled`` path exists,
+    including ingestion source aliases (e.g. ``databricks-bundled`` when only
+    ``unity-catalog`` was built).
     """
     canonical = group_plan.canonical_dir_name
     canonical_path = os.path.join(venv_base_path, canonical)
 
-    for plugin in group_plan.members:
-        alias_name = f"{plugin}-bundled"
+    for alias_name in bundled_venv_symlink_names(group_plan):
         if alias_name == canonical:
             continue
 

--- a/docker/snippets/ingestion/bundled_venv_config.py
+++ b/docker/snippets/ingestion/bundled_venv_config.py
@@ -39,10 +39,40 @@ PLUGIN_ADDITIONAL_EXTRAS: Dict[str, List[str]] = {
     "file": ["s3"],
 }
 
+# Ingestion source aliases (alias -> canonical pip extra). Keep in sync with
+# source_registry.py pairs that share the same setup.py / pyproject optional deps.
+PLUGIN_SOURCE_ALIASES: Dict[str, str] = {
+    "databricks": "unity-catalog",
+    "presto-on-hive": "hive-metastore",
+}
+
+
+def canonical_plugin(plugin: str) -> str:
+    """Resolve alias plugin names to the canonical pip extra / source key."""
+    return PLUGIN_SOURCE_ALIASES.get(plugin, plugin)
+
+
+def alias_cluster(plugin: str) -> frozenset[str]:
+    """All ingestion type names that share one bundled venv install."""
+    canonical = canonical_plugin(plugin)
+    names = {canonical, plugin}
+    for alias, canon in PLUGIN_SOURCE_ALIASES.items():
+        if canon == canonical:
+            names.add(alias)
+    return frozenset(names)
+
+
+def bundled_venv_symlink_names(group_plan: BundledVenvGroupPlan) -> Tuple[str, ...]:
+    """Every ``{name}-bundled`` path that must exist for this install plan."""
+    names: Set[str] = set()
+    for plugin in group_plan.members:
+        names.update(alias_cluster(plugin))
+    return tuple(sorted(f"{name}-bundled" for name in names))
+
 
 def _default_plugin_extras_for_plugin(plugin: str, slim_mode: bool) -> List[str]:
     """OSS default: standard ingestion extras per plugin (no vendor-specific branches)."""
-    plugin_extra = plugin
+    plugin_extra = canonical_plugin(plugin)
     if slim_mode and plugin in PLUGINS_WITH_SLIM_VARIANT:
         plugin_extra = f"{plugin}-slim"
 
@@ -203,6 +233,18 @@ def build_group_plans(
     if len(plugin_set) != len(plugins):
         dupes = [p for p in plugins if plugins.count(p) > 1]
         raise ValueError(f"BUNDLED_VENV_PLUGINS contains duplicates: {set(dupes)}")
+
+    canonical_seen: Dict[str, str] = {}
+    for plugin in plugins:
+        canonical = canonical_plugin(plugin)
+        prior = canonical_seen.get(canonical)
+        if prior is not None and prior != plugin:
+            cluster = sorted(alias_cluster(plugin))
+            raise ValueError(
+                f"BUNDLED_VENV_PLUGINS lists aliases {prior!r} and {plugin!r}; "
+                f"include only one of {cluster}"
+            )
+        canonical_seen[canonical] = plugin
 
     assigned: Set[str] = set()
     plans: List[BundledVenvGroupPlan] = []

--- a/metadata-ingestion/tests/unit/test_bundled_venv_config.py
+++ b/metadata-ingestion/tests/unit/test_bundled_venv_config.py
@@ -9,12 +9,68 @@ _SNIPPETS = _REPO_ROOT / "docker" / "snippets" / "ingestion"
 sys.path.insert(0, str(_SNIPPETS))
 
 from bundled_venv_config import (  # noqa: E402
+    BundledVenvGroupPlan,
+    alias_cluster,
     build_group_plans,
+    bundled_venv_symlink_names,
+    canonical_plugin,
     extras_to_install_string,
     groups_config_from_plugin_group_env,
     plugin_extras_for_plugin,
     sorted_union_extras,
 )
+
+
+def test_canonical_plugin_resolves_databricks_alias() -> None:
+    assert canonical_plugin("databricks") == "unity-catalog"
+    assert canonical_plugin("unity-catalog") == "unity-catalog"
+
+
+def test_alias_cluster_unity_catalog_and_databricks() -> None:
+    assert alias_cluster("unity-catalog") == frozenset({"unity-catalog", "databricks"})
+
+
+def test_alias_cluster_hive_metastore_and_presto_on_hive() -> None:
+    assert alias_cluster("hive-metastore") == frozenset(
+        {"hive-metastore", "presto-on-hive"}
+    )
+
+
+def test_plugin_extras_databricks_uses_unity_catalog_extra() -> None:
+    assert plugin_extras_for_plugin(
+        "databricks", slim_mode=False
+    ) == plugin_extras_for_plugin("unity-catalog", slim_mode=False)
+
+
+def test_bundled_venv_symlink_names_includes_aliases_for_singleton() -> None:
+    plan = BundledVenvGroupPlan(
+        label="unity-catalog",
+        members=("unity-catalog",),
+        extras=("unity-catalog",),
+        canonical_dir_name="unity-catalog-bundled",
+    )
+    assert bundled_venv_symlink_names(plan) == (
+        "databricks-bundled",
+        "unity-catalog-bundled",
+    )
+
+
+def test_bundled_venv_symlink_names_includes_aliases_for_group_member() -> None:
+    plan = BundledVenvGroupPlan(
+        label="common",
+        members=("s3", "unity-catalog"),
+        extras=("s3", "unity-catalog"),
+        canonical_dir_name="common-venv",
+    )
+    names = bundled_venv_symlink_names(plan)
+    assert "databricks-bundled" in names
+    assert "unity-catalog-bundled" in names
+    assert "s3-bundled" in names
+
+
+def test_build_group_plans_rejects_alias_duplicates_in_plugin_list() -> None:
+    with pytest.raises(ValueError, match="lists aliases"):
+        build_group_plans(["unity-catalog", "databricks"], None, slim_mode=False)
 
 
 def test_plugin_extras_dedupes_file_plugin_extra() -> None:


### PR DESCRIPTION
Create {alias}-bundled paths for known alias pairs (e.g. unity-catalog and databricks) when only the canonical plugin is listed in BUNDLED_VENV_PLUGINS.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
