### PR TITLE
ci: skip Linear ticket creation for internal PRs

### DIFF
--- a/.github/workflows/pr-to-linear.yml
+++ b/.github/workflows/pr-to-linear.yml
@@ -138,8 +138,12 @@ jobs:
           if [ -z "$TEAM_MEMBERS" ]; then
             echo "⚠️  DATAHUB_TEAM_MEMBERS variable is not set — defaulting to Internal"
             echo "contributor_type=Internal" >> "$GITHUB_OUTPUT"
+            echo "should_skip=true" >> "$GITHUB_OUTPUT"
+            echo "⏭️  Skipping - Internal contributor"
           elif echo "$TEAM_MEMBERS" | jq -e --arg actor "$PR_AUTHOR" '[.[].github] | map(ascii_downcase) | contains([($actor | ascii_downcase)])' > /dev/null 2>&1; then
             echo "contributor_type=Internal" >> "$GITHUB_OUTPUT"
+            echo "should_skip=true" >> "$GITHUB_OUTPUT"
+            echo "⏭️  Skipping - Internal contributor"
           else
             echo "contributor_type=External" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary
- Internal PRs (authors in `DATAHUB_TEAM_MEMBERS`) no longer create Linear tickets
- If `DATAHUB_TEAM_MEMBERS` is unset, also skips (was already defaulting to Internal)
- External PRs and issue tracking are unaffected

## Test plan
- [ ] Open a PR from an internal team member — no Linear ticket should be created
- [ ] Open a PR from an external contributor — Linear ticket should still be created

🤖 Generated with [Claude Code](https://claude.com/claude-code)