### PR TITLE
fix(ingest/looker): handle glue platform in LookML hive-style lineage

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/view_upstream.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/view_upstream.py
@@ -152,14 +152,20 @@ def _platform_names_have_2_parts(platform: str) -> bool:
 
 def _drop_hive_dot(urn: str) -> str:
     """
-    This is special handling for hive platform where "hive." is coming in urn's id because of the way SQL
-    is written in lookml.
+    This is special handling for hive and glue platforms where "hive." is coming in urn's id because of the way SQL
+    is written in lookml. Glue tables queried via Presto/Athena use the same `hive.<db>.<table>` syntax.
 
     Example: urn:li:dataset:(urn:li:dataPlatform:hive,hive.my_database.my_table,PROD)
+    Example: urn:li:dataset:(urn:li:dataPlatform:glue,hive.my_database.my_table,PROD)
 
     Here we need to transform hive.my_database.my_table to my_database.my_table
     """
-    if urn.startswith("urn:li:dataset:(urn:li:dataPlatform:hive"):
+    if urn.startswith(
+        (
+            "urn:li:dataset:(urn:li:dataPlatform:hive",
+            "urn:li:dataset:(urn:li:dataPlatform:glue",
+        )
+    ):
         return re.sub(r"hive\.", "", urn)
 
     return urn

--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_common.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_common.py
@@ -25,7 +25,9 @@ def get_dialect_str(platform: str) -> str:
     """
     platform_lower = platform.lower()
 
-    if platform_lower == "presto-on-hive":
+    if platform_lower in {"presto-on-hive", "glue"}:
+        # Glue Data Catalog is typically queried via Athena/Presto using hive-style SQL,
+        # and sqlglot has no dedicated `glue` dialect.
         return "hive"
     elif platform_lower == "mssql":
         return "tsql"

--- a/metadata-ingestion/tests/integration/looker/lookml/drop_hive_dot_glue/data.model.lkml
+++ b/metadata-ingestion/tests/integration/looker/lookml/drop_hive_dot_glue/data.model.lkml
@@ -1,0 +1,6 @@
+connection: "my_connection"
+
+include: "top_10_employee_income_source.view.lkml"
+
+explore: top_10_employee_income_source {
+}

--- a/metadata-ingestion/tests/integration/looker/lookml/drop_hive_dot_glue/top_10_employee_income_source.view.lkml
+++ b/metadata-ingestion/tests/integration/looker/lookml/drop_hive_dot_glue/top_10_employee_income_source.view.lkml
@@ -1,0 +1,26 @@
+view: top_10_employee_income_source {
+  derived_table: {
+    sql: SELECT id,
+                name,
+                source
+         FROM hive.employee_db.income_source
+         ORDER BY source desc
+         LIMIT 10
+  ;;
+  }
+
+  dimension: id {
+    type: number
+    sql: ${TABLE}.id ;;
+  }
+
+  dimension: name {
+    type: string
+    sql: ${TABLE}.name ;;
+  }
+
+  dimension: source {
+    type: string
+    sql: ${TABLE}.source ;;
+  }
+}

--- a/metadata-ingestion/tests/integration/looker/lookml/drop_hive_dot_glue_golden.json
+++ b/metadata-ingestion/tests/integration/looker/lookml/drop_hive_dot_glue_golden.json
@@ -1,0 +1,360 @@
+[
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:78f22c19304954b15e8adb1d9809975e",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "looker",
+                "env": "PROD",
+                "project_name": "lkml_samples"
+            },
+            "name": "lkml_samples",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586827800000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:78f22c19304954b15e8adb1d9809975e",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:looker"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586827800000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:78f22c19304954b15e8adb1d9809975e",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "LookML Project"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586827800000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:78f22c19304954b15e8adb1d9809975e",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "Folders"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586827800000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.top_10_employee_income_source,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586827800000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.top_10_employee_income_source,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "json": {
+            "materialized": false,
+            "viewLogic": "SELECT id,\n                name,\n                source\n         FROM hive.employee_db.income_source\n         ORDER BY source desc\n         LIMIT 10",
+            "viewLanguage": "sql"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586827800000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.top_10_employee_income_source,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:looker"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586827800000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.top_10_employee_income_source,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "top_10_employee_income_source",
+            "platform": "urn:li:dataPlatform:looker",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "id",
+                    "nullable": false,
+                    "description": "Dimension. ",
+                    "label": "",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "number",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "name",
+                    "nullable": false,
+                    "description": "Dimension. ",
+                    "label": "",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "source",
+                    "nullable": false,
+                    "description": "Dimension. ",
+                    "label": "",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ],
+            "primaryKeys": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586827800000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.top_10_employee_income_source,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 1586827800000,
+                        "actor": "urn:li:corpuser:datahub"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:glue,employee_db.income_source,PROD)",
+                    "type": "VIEW"
+                }
+            ],
+            "fineGrainedLineages": [
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,employee_db.income_source,PROD),id)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.top_10_employee_income_source,PROD),id)"
+                    ],
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,employee_db.income_source,PROD),name)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.top_10_employee_income_source,PROD),name)"
+                    ],
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,employee_db.income_source,PROD),source)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.top_10_employee_income_source,PROD),source)"
+                    ],
+                    "confidenceScore": 1.0
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586827800000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.top_10_employee_income_source,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "looker.file.path": "top_10_employee_income_source.view.lkml",
+                "looker.model": "data"
+            },
+            "name": "top_10_employee_income_source",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586827800000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.top_10_employee_income_source,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:78f22c19304954b15e8adb1d9809975e"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586827800000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.top_10_employee_income_source,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "View"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586827800000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.top_10_employee_income_source,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "Develop"
+                },
+                {
+                    "id": "urn:li:container:78f22c19304954b15e8adb1d9809975e",
+                    "urn": "urn:li:container:78f22c19304954b15e8adb1d9809975e"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586827800000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:78f22c19304954b15e8adb1d9809975e",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586827800000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/looker/lookml/test_lookml.py
+++ b/metadata-ingestion/tests/integration/looker/lookml/test_lookml.py
@@ -1271,6 +1271,35 @@ def test_drop_hive(pytestconfig, tmp_path, mock_time):
 
 
 @time_machine.travel(FROZEN_TIME, tick=False)
+def test_drop_hive_glue(pytestconfig, tmp_path, mock_time):
+    # Glue tables queried via Athena/Presto use `hive.<db>.<table>` syntax in LookML,
+    # so the same prefix-stripping must apply when the connection maps to the glue platform.
+    test_resources_dir = pytestconfig.rootpath / "tests/integration/looker/lookml"
+    mce_out_file = "drop_hive_dot_glue.json"
+
+    new_recipe = get_default_recipe(
+        f"{tmp_path}/{mce_out_file}",
+        f"{test_resources_dir}/drop_hive_dot_glue",
+    )
+
+    new_recipe["source"]["config"]["connection_to_platform_map"] = {
+        "my_connection": "glue"
+    }
+
+    pipeline = Pipeline.create(new_recipe)
+    pipeline.run()
+    pipeline.pretty_print_summary()
+    pipeline.raise_from_status(raise_warnings=False)
+
+    golden_path = test_resources_dir / "drop_hive_dot_glue_golden.json"
+    mce_helpers.check_golden_file(
+        pytestconfig,
+        output_path=tmp_path / mce_out_file,
+        golden_path=golden_path,
+    )
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
 def test_gms_schema_resolution(pytestconfig, tmp_path, mock_time):
     test_resources_dir = pytestconfig.rootpath / "tests/integration/looker/lookml"
     mce_out_file = "drop_hive_dot.json"

--- a/metadata-ingestion/tests/unit/looker/test_view_upstream.py
+++ b/metadata-ingestion/tests/unit/looker/test_view_upstream.py
@@ -1,0 +1,37 @@
+import pytest
+
+from datahub.ingestion.source.looker.view_upstream import _drop_hive_dot
+
+
+@pytest.mark.parametrize(
+    "urn,expected",
+    [
+        # Hive: hive. prefix stripped from the dataset id.
+        (
+            "urn:li:dataset:(urn:li:dataPlatform:hive,hive.my_database.my_table,PROD)",
+            "urn:li:dataset:(urn:li:dataPlatform:hive,my_database.my_table,PROD)",
+        ),
+        # Glue queried via Athena/Presto uses the same hive.<db>.<table> syntax — strip it too.
+        (
+            "urn:li:dataset:(urn:li:dataPlatform:glue,hive.analytics.my_table,PROD)",
+            "urn:li:dataset:(urn:li:dataPlatform:glue,analytics.my_table,PROD)",
+        ),
+        # Glue URN without a hive. prefix passes through unchanged.
+        (
+            "urn:li:dataset:(urn:li:dataPlatform:glue,analytics.my_table,PROD)",
+            "urn:li:dataset:(urn:li:dataPlatform:glue,analytics.my_table,PROD)",
+        ),
+        # Other platforms are not touched even if they contain "hive." literally.
+        (
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,hive.db.t,PROD)",
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,hive.db.t,PROD)",
+        ),
+        # Hive URN without a hive. prefix is a no-op.
+        (
+            "urn:li:dataset:(urn:li:dataPlatform:hive,my_database.my_table,PROD)",
+            "urn:li:dataset:(urn:li:dataPlatform:hive,my_database.my_table,PROD)",
+        ),
+    ],
+)
+def test_drop_hive_dot(urn: str, expected: str) -> None:
+    assert _drop_hive_dot(urn) == expected

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_utils.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_utils.py
@@ -38,6 +38,11 @@ def test_is_dialect_instance():
     assert is_dialect_instance(redshift, ["postgres", "snowflake"])
 
 
+def test_glue_resolves_to_hive_dialect():
+    # sqlglot has no `glue` dialect; ingestion treats Glue (Athena/Presto) as hive.
+    assert is_dialect_instance(get_dialect("glue"), "hive")
+
+
 def test_query_types():
     assert get_query_type_of_sql(
         sqlglot.parse_one(


### PR DESCRIPTION
## Summary

Fixes broken lineage and column-level lineage for LookML views that reference Glue Data Catalog tables. In LookML, Glue tables queried via Athena/Presto use the same `hive.<db>.<table>` 3-part naming as Hive, but the ingestion code only special-cased the `hive` platform — Glue URNs ended up with the `hive.` prefix baked into the dataset id, and sqlglot failed to parse hive-flavored SQL because there is no `glue` dialect.

Two small changes, both mirroring existing Hive behaviour:

- `sql_parsing_common.get_dialect_str`: map `glue` → `hive` (sqlglot has no dedicated glue dialect; Glue via Athena/Presto is hive-dialect SQL).
- `looker.view_upstream._drop_hive_dot`: also strip the `hive.` prefix from dataset URNs whose platform is `glue`, so upstream and fine-grained lineage point at `urn:li:dataset:(urn:li:dataPlatform:glue,<db>.<table>,...)` instead of `...,hive.<db>.<table>,...`.

Other platforms are untouched.

## Test plan

- [x] Unit test for `_drop_hive_dot` covering glue (with and without `hive.` prefix), hive, snowflake, and a no-op case — `metadata-ingestion/tests/unit/looker/test_view_upstream.py`
- [x] Unit test confirming `get_dialect("glue")` resolves to the hive dialect — `metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_utils.py::test_glue_resolves_to_hive_dialect`
- [x] Integration test `test_drop_hive_glue` mirroring the existing `test_drop_hive`, with a golden file (`drop_hive_dot_glue_golden.json`) that asserts:
  - upstream URN is `urn:li:dataPlatform:glue,employee_db.income_source,PROD` (glue platform, no `hive.` prefix)
  - fine-grained column lineage edges land on the glue dataset's schema fields
- [x] Re-ran existing `test_drop_hive` — no regression
- [x] `./gradlew :metadata-ingestion:lintFix` clean