### PR TITLE
fix(ingest): treat Hive `list<>` as a synonym for `array<>`

### DIFF
--- a/metadata-ingestion/src/datahub/utilities/hive_schema_to_avro.py
+++ b/metadata-ingestion/src/datahub/utilities/hive_schema_to_avro.py
@@ -45,7 +45,7 @@ class HiveColumnToAvroConverter:
         "byteint": "int",
     }
 
-    _COMPLEX_TYPE = re.compile("^(struct|map|array|uniontype)")
+    _COMPLEX_TYPE = re.compile("^(struct|map|array|list|uniontype)")
 
     _FIXED_DECIMAL = re.compile(r"(decimal|numeric)(\(\s*(\d+)\s*,\s*(\d+)\s*\))?")
 
@@ -58,12 +58,18 @@ class HiveColumnToAvroConverter:
         s: str, **kwargs: Any
     ) -> Union[object, Dict[str, object]]:
         s = s.strip()
-        if s.startswith("array<"):
+        # Iceberg (and some Glue/Athena clients) emit `list<T>` for the same shape Hive
+        # emits as `array<T>`. Treat them as synonyms; without this, `list<...>` falls
+        # through to the unknown-type path and the column's schema collapses to NullType,
+        # which downstream presents as missing or empty column names for complex fields.
+        if s.startswith("array<") or s.startswith("list<"):
             if s[-1] != ">":
                 raise ValueError("'>' should be the last char, but got: %s" % s)
             return {
                 "type": "array",
-                "items": HiveColumnToAvroConverter._parse_datatype_string(s[6:-1]),
+                "items": HiveColumnToAvroConverter._parse_datatype_string(
+                    s[s.index("<") + 1 : -1]
+                ),
                 "native_data_type": s,
             }
         elif s.startswith("map<"):

--- a/metadata-ingestion/tests/unit/utilities/test_hive_schema_to_avro.py
+++ b/metadata-ingestion/tests/unit/utilities/test_hive_schema_to_avro.py
@@ -1,4 +1,5 @@
 from datahub.metadata.schema_classes import (
+    ArrayTypeClass,
     NullTypeClass,
     NumberTypeClass,
     RecordTypeClass,
@@ -43,3 +44,23 @@ def test_get_avro_schema_for_null_type_hive_column():
     )
     assert schema_fields[0].type.type == NullTypeClass()
     assert len(schema_fields) == 1
+
+
+def test_list_type_treated_as_array():
+    # Iceberg and some Athena/Glue clients emit `list<T>` as a synonym for `array<T>`.
+    schema_fields = get_schema_fields_for_hive_column("engines", "list<string>")
+    assert isinstance(schema_fields[0].type.type, ArrayTypeClass)
+
+
+def test_list_of_structs_inside_struct_does_not_collapse_to_null():
+    # Repro for the Iceberg-on-Glue-via-Athena case: a struct field whose value type
+    # is `list<struct<...>>`. Before the `list<>` synonym was added, the inner type
+    # was unrecognised and the whole column collapsed to NullType, presenting as a
+    # missing / empty column name in DataHub.
+    schema_fields = get_schema_fields_for_hive_column(
+        "col", "struct<items:list<struct<name:string,value:int>>>"
+    )
+    assert isinstance(schema_fields[0].type.type, RecordTypeClass)
+    assert not any(isinstance(f.type.type, NullTypeClass) for f in schema_fields), (
+        "no field should fall back to NullType"
+    )


### PR DESCRIPTION
## Summary

The `HiveColumnToAvroConverter` only recognised `array<T>` as the Hive
array shape. Iceberg, and several Athena / Glue clients exposing Iceberg
tables, emit `list<T>` instead — semantically the same.

When the converter hit `list<...>` it fell through to the
unknown-type path and the entire column collapsed to `NullType`. This
showed up downstream as missing or empty column names for any complex
field with a nested list, which broke schema visibility and column-level
lineage extraction for those columns.

### Change

- Add `list` to `_COMPLEX_TYPE` and accept `list<T>` alongside `array<T>` in `_parse_datatype_string`.
- Read the inner type using `s.index("<") + 1` so the same code path handles both prefix lengths.
- Add two unit tests:
  - `test_list_type_treated_as_array` — direct synonym.
  - `test_list_of_structs_inside_struct_does_not_collapse_to_null` — the Iceberg-on-Glue-via-Athena shape that motivated the change.

### Refs

ING-2085

## Checklist

- [x] PR conforms to the Contributing Guideline (especially PR Title Format)
- [x] Tests added
- [x] No breaking changes

Made with [Cursor](https://cursor.com)