### PR TITLE
fix(ingest): give NullType columns a unique fieldPath suffix

### DIFF
--- a/metadata-ingestion/src/datahub/utilities/sqlalchemy_type_converter.py
+++ b/metadata-ingestion/src/datahub/utilities/sqlalchemy_type_converter.py
@@ -226,12 +226,19 @@ def get_schema_fields_for_sqlalchemy_column(
             )
         ]
 
-    # for all non-nested data types an additional modification of the `fieldPath` property is required
+    # For all non-nested data types we additionally suffix `fieldPath` with the column name
+    # so each column has a unique path. NullType is included for two reasons:
+    #   1. It is the fallback for any column whose type SqlAlchemy can't reflect (rare dialect
+    #      gaps, complex nested types the dialect doesn't expose), and
+    #   2. Without it, every such column would share the path `[version=2.0].[type=null]`,
+    #      which collapses them into a single entry downstream — observable as missing or
+    #      duplicate column names for affected tables.
     if type(column_type) in (
         *SqlAlchemyColumnToAvroConverter.PRIMITIVE_SQL_ALCHEMY_TYPE_TO_AVRO_TYPE.keys(),
         types.TIMESTAMP,
         types.DATE,
         types.DECIMAL,
+        types.NullType,
     ):
         schema_fields[0].fieldPath += f".{column_name}"
 

--- a/metadata-ingestion/tests/unit/utilities/test_sqlalchemy_type_converter.py
+++ b/metadata-ingestion/tests/unit/utilities/test_sqlalchemy_type_converter.py
@@ -118,3 +118,27 @@ def test_get_avro_schema_for_sqlalchemy_unknown_column():
     assert schema_fields[0].type.type == NullTypeClass()
     assert schema_fields[0].fieldPath == "[version=2.0].[type=null]"
     assert schema_fields[0].nativeDataType == "test"
+
+
+def test_null_type_columns_get_unique_field_paths():
+    # When the dialect can't reflect a column type (rare gaps in SqlAlchemy dialects, or
+    # complex nested types not exposed by the dialect), SqlAlchemy hands back a real
+    # NullType instance. Each such column must get its column name appended so they don't
+    # collide on the shared `[version=2.0].[type=null]` path, which previously caused
+    # multiple columns to be reported as a single entry.
+    inspector_magic_mock = MagicMock()
+    inspector_magic_mock.dialect = DefaultDialect()
+
+    field_a = get_schema_fields_for_sqlalchemy_column(
+        column_name="col_a",
+        column_type=types.NullType(),
+        inspector=inspector_magic_mock,
+    )
+    field_b = get_schema_fields_for_sqlalchemy_column(
+        column_name="col_b",
+        column_type=types.NullType(),
+        inspector=inspector_magic_mock,
+    )
+    assert field_a[0].fieldPath == "[version=2.0].[type=null].col_a"
+    assert field_b[0].fieldPath == "[version=2.0].[type=null].col_b"
+    assert field_a[0].fieldPath != field_b[0].fieldPath


### PR DESCRIPTION
## Summary

Defence-in-depth complement to #17627 (the `list<>` Hive synonym).

When SqlAlchemy can't reflect a column type — either because the dialect
lacks a mapping or because the engine returns a shape the dialect doesn't
expose — it surfaces the column as a real `types.NullType()` instance.
Each such column was suffixed only with `[version=2.0].[type=null]` (no
column name), so two unmapped columns on the same table collided on a
single path and presented downstream as missing or duplicate columns.

### Change

- Add `types.NullType` to the set of types that get the column name
  appended to their `fieldPath` in `get_schema_fields_for_sqlalchemy_column`.
- Add `test_null_type_columns_get_unique_field_paths` covering the
  collision scenario directly.

Existing behaviour for the unknown-string fallback (which passes a `str`
through `get_schema_fields_for_sqlalchemy_column`) is preserved — that
path doesn't hit the new branch because `type("foo") is str`, not
`NullType`.

### Stack

1. [#17627](https://github.com/datahub-project/datahub/pull/17627) — `list<>` Hive synonym
2. **this PR** — NullType fieldPath uniqueness
3. (next) Pandas nullable dtype handling in the Athena dialect

### Refs

ING-2085

## Checklist

- [x] PR conforms to the Contributing Guideline
- [x] Tests added
- [x] No breaking changes (existing assertions retained)

Made with [Cursor](https://cursor.com)