### PR TITLE
fix(ingest/athena): map Pandas nullable dtypes to SQL types

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/athena.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/athena.py
@@ -249,6 +249,32 @@ class CustomAthenaRestDialect(AthenaRestDialect):
             detected_col_type = types.DECIMAL
             precision, scale = type_meta_information.split(",")
             args = [int(precision), int(scale)]
+        elif type_name.endswith("dtype"):
+            # Pandas nullable dtype names (e.g. `Int64Dtype`, `UInt32Dtype`, `BooleanDtype`)
+            # can leak into column type strings via great_expectations profiling on Athena
+            # result sets — they're lowered by the dialect and reach this method as e.g.
+            # `int64dtype`. Map them back to the matching SqlAlchemy type so the column
+            # doesn't fall through to NullType and disappear from the emitted schema.
+            base = type_name[:-5]
+            pandas_dtype_to_sql: Dict[str, Any] = {
+                "int8": types.INTEGER,
+                "int16": types.INTEGER,
+                "int32": types.INTEGER,
+                "uint8": types.INTEGER,
+                "uint16": types.INTEGER,
+                "uint32": types.INTEGER,
+                "int64": types.BIGINT,
+                "uint64": types.BIGINT,
+                "float32": types.FLOAT,
+                "float64": types.FLOAT,
+                "boolean": types.BOOLEAN,
+                "string": types.String,
+                "object": types.String,
+            }
+            mapped = pandas_dtype_to_sql.get(base)
+            if mapped is None:
+                return super()._get_column_type(type_name)
+            detected_col_type = mapped
         else:
             return super()._get_column_type(type_name)
         return detected_col_type(*args)

--- a/metadata-ingestion/tests/unit/test_athena_source.py
+++ b/metadata-ingestion/tests/unit/test_athena_source.py
@@ -883,6 +883,35 @@ def test_column_type_decimal():
     assert result.scale == 2
 
 
+@pytest.mark.parametrize(
+    "type_name,expected_sql_type",
+    [
+        # Pandas nullable dtype names leak through great_expectations profiling on Athena
+        # result sets — they reach the dialect as lowercase `<base>dtype`.
+        ("int8dtype", types.INTEGER),
+        ("int16dtype", types.INTEGER),
+        ("int32dtype", types.INTEGER),
+        ("int64dtype", types.BIGINT),
+        ("uint64dtype", types.BIGINT),
+        ("float32dtype", types.FLOAT),
+        ("float64dtype", types.FLOAT),
+        ("booleandtype", types.BOOLEAN),
+        ("stringdtype", types.String),
+    ],
+)
+def test_get_column_type_pandas_nullable_dtypes(type_name, expected_sql_type):
+    result = CustomAthenaRestDialect()._get_column_type(type_=type_name)
+    assert isinstance(result, expected_sql_type)
+
+
+def test_get_column_type_unknown_dtype_suffix_falls_through():
+    # Unrecognised `*dtype` names must defer to the base class so dialect-level
+    # handling stays the same; this guards against the new branch over-claiming.
+    result = CustomAthenaRestDialect()._get_column_type(type_="mysterydtype")
+    # Base class signals "unknown" via NullType; that's the contract we rely on.
+    assert isinstance(result, types.NullType)
+
+
 def test_column_type_complex_combination():
     result = CustomAthenaRestDialect()._get_column_type(
         type_="struct<id:string,name:string,choices:array<struct<id:string,label:string>>>"


### PR DESCRIPTION
## Summary

Third PR in the stack targeting ING-2085 — Athena schema extraction
failures on columns with non-trivial types.

When great_expectations profiles an Athena result set, columns reflected
through Pandas surface with nullable dtype names (e.g. \`Int64Dtype\`,
\`UInt32Dtype\`, \`BooleanDtype\`). Those names get lowercased by the
dialect and reach \`_get_column_type\` as \`int64dtype\`, \`uint32dtype\`,
etc. The CustomAthenaRestDialect didn't know about them, so the column
fell through to the base class and was recorded as NullType — vanishing
from the emitted schema and causing profiling pipelines to crash on the
missing schema fields.

### Change

- Recognise \`*dtype\` suffixes in \`CustomAthenaRestDialect._get_column_type\` and map them to the appropriate SqlAlchemy type.
- Unknown \`*dtype\` names still defer to the base class (covered by \`test_get_column_type_unknown_dtype_suffix_falls_through\`).
- Parametrised test covering the nine canonical nullable dtype names.

### Stack

1. [#17627](https://github.com/datahub-project/datahub/pull/17627) — \`list<>\` Hive synonym
2. [#17628](https://github.com/datahub-project/datahub/pull/17628) — NullType fieldPath uniqueness
3. **this PR** — Pandas nullable dtype handling

Each commit in the stack is independently mergeable; together they close
the three known schema-collapse paths that ING-2085 reports.

### Refs

ING-2085

## Checklist

- [x] PR conforms to the Contributing Guideline
- [x] Tests added
- [x] No breaking changes

Made with [Cursor](https://cursor.com)