### PR TITLE
fix(ui): Allow editing schema from schema module

### DIFF
--- a/datahub-web-react/src/app/entityV2/summary/modules/schemaTable/ColumnsModule.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/modules/schemaTable/ColumnsModule.tsx
@@ -12,7 +12,6 @@ import EmptyContent from '@app/homeV3/module/components/EmptyContent';
 import LargeModule from '@app/homeV3/module/components/LargeModule';
 import { useModuleContext } from '@app/homeV3/module/context/ModuleContext';
 import { ModuleProps, ModuleSize } from '@app/homeV3/module/types';
-import SchemaEditableContext from '@app/shared/SchemaEditableContext';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { GetDatasetQuery, useGetDatasetSchemaQuery } from '@graphql/dataset.generated';
@@ -96,21 +95,19 @@ export default function ColumnsModule(props: ModuleProps) {
                 viewAllText="View in Columns"
             >
                 <Wrapper>
-                    <SchemaEditableContext.Provider value={false}>
-                        <SchemaTable
-                            rows={rows}
-                            schemaMetadata={schemaMetadata}
-                            editableSchemaMetadata={editableSchemaMetadata}
-                            usageStats={usageStats}
-                            expandedRowsFromFilter={expandedRowsFromFilter}
-                            filterText=""
-                            expandedDrawerFieldPath={expandedDrawerFieldPath}
-                            setExpandedDrawerFieldPath={setExpandedDrawerFieldPath}
-                            openTimelineDrawer={false}
-                            refetch={refetch}
-                            visibleColumns={size === ModuleSize.FULL ? undefined : ['fieldPath', 'type', 'description']}
-                        />
-                    </SchemaEditableContext.Provider>
+                    <SchemaTable
+                        rows={rows}
+                        schemaMetadata={schemaMetadata}
+                        editableSchemaMetadata={editableSchemaMetadata}
+                        usageStats={usageStats}
+                        expandedRowsFromFilter={expandedRowsFromFilter}
+                        filterText=""
+                        expandedDrawerFieldPath={expandedDrawerFieldPath}
+                        setExpandedDrawerFieldPath={setExpandedDrawerFieldPath}
+                        openTimelineDrawer={false}
+                        refetch={refetch}
+                        visibleColumns={size === ModuleSize.FULL ? undefined : ['fieldPath', 'type', 'description']}
+                    />
                 </Wrapper>
             </LargeModule>
         </SchemaContext.Provider>


### PR DESCRIPTION
Fixes a small bug where you couldn't edit schema fields from the summary tab on datasets. We previously didn't allow this before when we had a different style on the schema - but now that you click a field in order to edit we can allow edits here.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
