### PR TITLE
docs(snowflake): un-deprecate UDF-based Cortex Agent setup

### DIFF
--- a/docs/dev-guides/agent-context/snowflake.md
+++ b/docs/dev-guides/agent-context/snowflake.md
@@ -63,13 +63,9 @@ Open [Snowflake Intelligence](https://ai.snowflake.com/) and select your agent. 
 
 ---
 
-## Deprecated: UDF-Based Setup
+## UDF-Based Setup
 
-:::warning Deprecated
-The UDF-based integration below is deprecated in favor of the External MCP Server flow above. It is preserved here for users on DataHub Cloud versions prior to v1.0.2 or for existing UDF deployments. New integrations should use the External MCP Server.
-:::
-
-The legacy integration works through UDFs created by the DataHub CLI. Once set up, your Cortex Agent calls DataHub tools alongside your Snowflake tables.
+This integration works through UDFs created by the DataHub CLI. Once set up, your Cortex Agent calls DataHub tools alongside your Snowflake tables.
 
 ### Prerequisites
 


### PR DESCRIPTION
## Summary

- Removes the "Deprecated" label and warning admonition from the UDF-based Snowflake Cortex Agent setup section in [docs/dev-guides/agent-context/snowflake.md](docs/dev-guides/agent-context/snowflake.md).
- The UDF-based flow remains a supported integration alongside the External MCP Server flow.

## Test plan

- [x] Docs site renders the section without the warning callout

🤖 Generated with [Claude Code](https://claude.com/claude-code)