### PR TITLE
fix(search): prevent ES8 reindex loops and normalize legacy range queries

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -170,9 +170,11 @@ Requirements:
 
 ### Known Issues
 
+- **(Operations / Elasticsearch 8) Spurious mappings reindex on every Helm upgrade.** Deployments backed by **Elasticsearch 8.x** may trigger a full index mappings reindex on **every** system-update run (including each Helm upgrade), even when no authored mapping change was shipped. ES8 persists mappings differently than DataHub's authored definitions (for example injecting `type: object` on nested object fields), so the index builder detects spurious drift and schedules reindex work repeatedly. This is most likely when **`ELASTICSEARCH_INDEX_BUILDER_MAPPINGS_REINDEX=true`** (including Docker quickstart, which enables it for initial index builds). **Workaround:** Let the **first** system-update after install or upgrade finish so indices are created, then set **`ELASTICSEARCH_INDEX_BUILDER_MAPPINGS_REINDEX=false`** on **`datahub-gms`** and **`datahub-upgrade`** before later Helm upgrades until a fixed release is available.
+
 ### Potential Downtime
 
-- **System-update / Elasticsearch:** Upgrades that trigger reindexing, incremental index migration, or optional Elasticsearch ZDU (#16887) can run for an extended period depending on catalog size. Reindex duration was improved (#16949) and a perpetual ES8 reindex loop fix was included (#17402). Helm upgrades without `--atomic` may report failure while background reindex jobs continue — allow system-update to finish before retrying. See **Helm Notes** under the [0.10.0](#0100) section below for timeout guidance patterns.
+- **System-update / Elasticsearch:** Upgrades that trigger reindexing, incremental index migration, or optional Elasticsearch ZDU (#16887) can run for an extended period depending on catalog size. Reindex duration was improved (#16949). Elasticsearch 8 deployments with mappings reindex enabled may repeat unnecessary reindex work on every Helm upgrade — see **Known Issues** above. Helm upgrades without `--atomic` may report failure while background reindex jobs continue — allow system-update to finish before retrying. See **Helm Notes** under the [0.10.0](#0100) section below for timeout guidance patterns.
 - **First deploy after bootstrap moves:** Entity Types ingestion moved to system-update (see Breaking Changes). Expect additional system-update work on the first upgrade after this release.
 - **Aspect schema version sweep (#16930):** Large deployments may observe background migration activity during upgrade; plan maintenance windows accordingly.
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/Es8SearchClientShim.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/Es8SearchClientShim.java
@@ -90,6 +90,7 @@ import com.linkedin.metadata.search.elasticsearch.client.shim.builder.es8.Es8Sem
 import com.linkedin.metadata.search.elasticsearch.client.shim.builder.es8.Es8SemanticIndexSettingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.client.shim.impl.v8.CustomQuery;
 import com.linkedin.metadata.search.elasticsearch.client.shim.impl.v8.Es8BulkListener;
+import com.linkedin.metadata.search.elasticsearch.client.shim.impl.v8.LegacyRangeQueryNormalizer;
 import com.linkedin.metadata.utils.elasticsearch.responses.GetIndexResponse;
 import com.linkedin.metadata.utils.elasticsearch.responses.RawResponse;
 import com.linkedin.metadata.utils.elasticsearch.shim.EmbeddingBatch;
@@ -105,6 +106,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -241,6 +243,22 @@ import org.opensearch.search.suggest.SuggestionBuilder;
 @Slf4j
 public class Es8SearchClientShim extends AbstractBulkProcessorShim<BulkIngester<?>>
     implements ElasticSearchClientShim<ElasticsearchClient> {
+
+  /**
+   * ES8+ silently strips {@code doc_values: false} from {@code search_as_you_type} fields on
+   * round-trip. Including it in the authored mapping creates a permanent diff against what the
+   * cluster returns and triggers a reindex on every system update cycle, so we omit it here.
+   */
+  public static final Map<String, String> PARTIAL_NGRAM_CONFIG =
+      ImmutableMap.of(
+          "type", "search_as_you_type",
+          "max_shingle_size", "4");
+
+  /**
+   * ES8 injects {@code type: custom} on custom analyzers when settings are persisted, but authored
+   * V2 index settings omit {@code type} on analyzer definitions.
+   */
+  public static final String INJECTED_CUSTOM_ANALYZER_TYPE = "custom";
 
   @Getter private final ShimConfiguration shimConfiguration;
   private final SearchEngineType engineType;
@@ -1424,20 +1442,52 @@ public class Es8SearchClientShim extends AbstractBulkProcessorShim<BulkIngester<
     return engineType;
   }
 
-  /**
-   * ES8+ silently strips {@code doc_values: false} from {@code search_as_you_type} fields on
-   * round-trip. Including it in the authored mapping creates a permanent diff against what the
-   * cluster returns and triggers a reindex on every system update cycle, so we omit it here.
-   */
-  public static final Map<String, String> PARTIAL_NGRAM_CONFIG =
-      ImmutableMap.of(
-          "type", "search_as_you_type",
-          "max_shingle_size", "4");
+  /** ES8-specific index analysis settings comparison rules for reindex detection. */
+  public static final class IndexSettingsComparison {
+    private IndexSettingsComparison() {}
+
+    @Nonnull
+    public static Set<String> storedNamesForComparison(
+        @Nonnull Map<String, Object> targetSettings, @Nonnull Settings storedSettings) {
+      Set<String> names = new HashSet<>(storedSettings.names());
+      if (!targetSettings.containsKey("type") && names.remove("type")) {
+        String typeValue = storedSettings.get("type");
+        if (typeValue == null || !INJECTED_CUSTOM_ANALYZER_TYPE.equalsIgnoreCase(typeValue)) {
+          names.add("type");
+        }
+      }
+      return names;
+    }
+
+    public static boolean valuesEqual(@Nullable Object targetValue, @Nullable String storedValue) {
+      if (com.linkedin.metadata.utils.elasticsearch.IndexSettingsComparison.Strict.INSTANCE
+          .indexSettingValuesEqual(targetValue, storedValue)) {
+        return true;
+      }
+      if (targetValue == null || storedValue == null) {
+        return false;
+      }
+      return targetValue.toString().equalsIgnoreCase(storedValue);
+    }
+  }
 
   @Nonnull
   @Override
   public Map<String, String> partialNgramConfig() {
     return PARTIAL_NGRAM_CONFIG;
+  }
+
+  @Nonnull
+  @Override
+  public Set<String> indexSettingNamesForComparison(
+      @Nonnull Map<String, Object> targetSettings, @Nonnull Settings storedSettings) {
+    return IndexSettingsComparison.storedNamesForComparison(targetSettings, storedSettings);
+  }
+
+  @Override
+  public boolean indexSettingValuesEqual(
+      @Nullable Object targetValue, @Nullable String storedValue) {
+    return IndexSettingsComparison.valuesEqual(targetValue, storedValue);
   }
 
   @Nonnull
@@ -1808,7 +1858,7 @@ public class Es8SearchClientShim extends AbstractBulkProcessorShim<BulkIngester<
     if (osQuery == null) {
       return null;
     }
-    String jsonString = osQuery.toString();
+    String jsonString = normalizeQueryJson(osQuery.toString());
     return Query.of(
         q ->
             q.withJson(
@@ -1817,12 +1867,20 @@ public class Es8SearchClientShim extends AbstractBulkProcessorShim<BulkIngester<
   }
 
   private Rescore convertRescore(RescorerBuilder<?> rescorerBuilder) {
-    String jsonString = rescorerBuilder.toString();
+    String jsonString = normalizeQueryJson(rescorerBuilder.toString());
     return Rescore.of(
         q ->
             q.withJson(
                 jacksonJsonpMapper.jsonProvider().createParser(new StringReader(jsonString)),
                 jacksonJsonpMapper));
+  }
+
+  private String normalizeQueryJson(String jsonString) {
+    try {
+      return LegacyRangeQueryNormalizer.normalize(jsonString, objectMapper);
+    } catch (JsonProcessingException e) {
+      return jsonString;
+    }
   }
 
   private FieldSuggester convertSuggestion(SuggestionBuilder<?> suggestionBuilder) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/v8/LegacyRangeQueryNormalizer.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/v8/LegacyRangeQueryNormalizer.java
@@ -1,0 +1,72 @@
+package com.linkedin.metadata.search.elasticsearch.client.shim.impl.v8;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import javax.annotation.Nonnull;
+
+/**
+ * Rewrites legacy OpenSearch {@code RangeQueryBuilder} JSON ({@code from}/{@code to} with {@code
+ * include_lower}/{@code include_upper}) into ES 8-compatible bounds ({@code gte}/{@code gt}/{@code
+ * lte}/{@code lt}). OpenSearch HLRC {@code QueryBuilder#toString()} still emits the legacy shape,
+ * which Elasticsearch 8.18+ deprecates.
+ */
+public final class LegacyRangeQueryNormalizer {
+
+  private LegacyRangeQueryNormalizer() {}
+
+  @Nonnull
+  public static String normalize(@Nonnull String queryJson, @Nonnull ObjectMapper objectMapper)
+      throws JsonProcessingException {
+    JsonNode root = objectMapper.readTree(queryJson);
+    normalizeRangeNodes(root);
+    return objectMapper.writeValueAsString(root);
+  }
+
+  private static void normalizeRangeNodes(JsonNode node) {
+    if (node == null) {
+      return;
+    }
+    if (node.isObject()) {
+      ObjectNode objectNode = (ObjectNode) node;
+      if (objectNode.has("range") && objectNode.get("range").isObject()) {
+        ObjectNode rangeNode = (ObjectNode) objectNode.get("range");
+        rangeNode
+            .properties()
+            .forEach(
+                entry -> {
+                  if (entry.getValue().isObject()) {
+                    normalizeRangeSpec((ObjectNode) entry.getValue());
+                  }
+                });
+      }
+      objectNode.properties().forEach(entry -> normalizeRangeNodes(entry.getValue()));
+    } else if (node.isArray()) {
+      node.forEach(LegacyRangeQueryNormalizer::normalizeRangeNodes);
+    }
+  }
+
+  private static void normalizeRangeSpec(ObjectNode spec) {
+    if (!spec.has("from") && !spec.has("to")) {
+      return;
+    }
+
+    JsonNode from = spec.get("from");
+    JsonNode to = spec.get("to");
+    boolean includeLower = !spec.has("include_lower") || spec.get("include_lower").asBoolean(true);
+    boolean includeUpper = !spec.has("include_upper") || spec.get("include_upper").asBoolean(true);
+
+    if (from != null && !from.isNull()) {
+      spec.set(includeLower ? "gte" : "gt", from);
+    }
+    if (to != null && !to.isNull()) {
+      spec.set(includeUpper ? "lte" : "lt", to);
+    }
+
+    spec.remove("from");
+    spec.remove("to");
+    spec.remove("include_lower");
+    spec.remove("include_upper");
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
@@ -381,7 +381,8 @@ public class ESIndexBuilder {
                 structPropConfig.isEnabled()
                     && structPropConfig.isSystemUpdateEnabled()
                     && !copyStructuredPropertyMappings)
-            .version(gitVersion.getVersion());
+            .version(gitVersion.getVersion())
+            .settingsComparisonShim(searchClient);
 
     Map<String, Object> baseSettings = new HashMap<>(settings);
     baseSettings.put(NUMBER_OF_SHARDS, indexConfig.getNumShards());

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ReindexConfig.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ReindexConfig.java
@@ -10,10 +10,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
+import com.linkedin.metadata.utils.elasticsearch.IndexSettingsComparison;
+import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import com.linkedin.util.Pair;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.Accessors;
@@ -140,6 +143,15 @@ public class ReindexConfig {
     }
 
     private ReindexConfigBuilder hasRemovedStructuredProperty(boolean ignored) {
+      return this;
+    }
+
+    @Nonnull
+    private IndexSettingsComparison settingsComparison = IndexSettingsComparison.Strict.INSTANCE;
+
+    public ReindexConfigBuilder settingsComparisonShim(
+        @Nonnull SearchClientShim<?> settingsComparisonShim) {
+      this.settingsComparison = settingsComparisonShim;
       return this;
     }
 
@@ -446,7 +458,7 @@ public class ReindexConfig {
       // Compare analysis section
       Map<String, Object> newAnalysis = (Map<String, Object>) indexSettings.get("analysis");
       Settings oldAnalysis = super.currentSettings.getByPrefix("index.analysis.");
-      return equalsGroup(newAnalysis, oldAnalysis);
+      return equalsGroup(newAnalysis, oldAnalysis, super.settingsComparison);
     }
 
     private boolean isSettingsEqual() {
@@ -504,7 +516,8 @@ public class ReindexConfig {
       return (indexSettings.containsKey("analysis")
           && !equalsGroup(
               (Map<String, Object>) indexSettings.get("analysis"),
-              super.currentSettings.getByPrefix("index.analysis.")));
+              super.currentSettings.getByPrefix("index.analysis."),
+              super.settingsComparison));
     }
 
     /**
@@ -690,8 +703,13 @@ public class ReindexConfig {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  private static boolean equalsGroup(Map<String, Object> newSettings, Settings oldSettings) {
-    if (!newSettings.keySet().equals(oldSettings.names())) {
+  private static boolean equalsGroup(
+      Map<String, Object> newSettings,
+      Settings oldSettings,
+      IndexSettingsComparison settingsComparison) {
+    Set<String> oldNames =
+        settingsComparison.indexSettingNamesForComparison(newSettings, oldSettings);
+    if (!newSettings.keySet().equals(oldNames)) {
       return false;
     }
 
@@ -703,7 +721,9 @@ public class ReindexConfig {
       }
       if (newSettings.get(key) instanceof Map) {
         if (!equalsGroup(
-            (Map<String, Object>) newSettings.get(key), oldSettings.getByPrefix(key + "."))) {
+            (Map<String, Object>) newSettings.get(key),
+            oldSettings.getByPrefix(key + "."),
+            settingsComparison)) {
           return false;
         }
       } else if (newSettings.get(key) instanceof List) {
@@ -713,14 +733,7 @@ public class ReindexConfig {
       } else {
         String oldValue = oldSettings.get(key);
         Object newValue = newSettings.get(key);
-        // Handle null values properly
-        if (newValue == null && oldValue == null) {
-          continue;
-        }
-        if (newValue == null || oldValue == null) {
-          return false;
-        }
-        if (!newValue.toString().equals(oldValue)) {
+        if (!settingsComparison.indexSettingValuesEqual(newValue, oldValue)) {
           return false;
         }
       }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/client/shim/Es8SearchClientShimConversionTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/client/shim/Es8SearchClientShimConversionTest.java
@@ -5,10 +5,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import co.elastic.clients.elasticsearch._helpers.bulk.BulkIngester;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import co.elastic.clients.elasticsearch.core.search.FieldSuggester;
 import co.elastic.clients.elasticsearch.indices.update_aliases.Action;
@@ -25,6 +27,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.suggest.Suggest;
@@ -351,6 +354,34 @@ public class Es8SearchClientShimConversionTest {
                 json)) {
       return SearchResponse.fromXContent(parser);
     }
+  }
+
+  /** convertQuery rewrites legacy range bounds before sending to Elasticsearch 8. */
+  @Test
+  public void testConvertQueryNormalizesLegacyRangeBounds() throws Exception {
+    Method normalizeQueryJsonMethod =
+        Es8SearchClientShim.class.getDeclaredMethod("normalizeQueryJson", String.class);
+    normalizeQueryJsonMethod.setAccessible(true);
+
+    String legacy = QueryBuilders.rangeQuery("timestamp").gte(100L).lt(200L).toString();
+    String normalized = (String) normalizeQueryJsonMethod.invoke(shim, legacy);
+
+    assertFalse(normalized.contains("\"from\""));
+    assertFalse(normalized.contains("\"to\""));
+    assertTrue(normalized.contains("\"gte\":100"));
+    assertTrue(normalized.contains("\"lt\":200"));
+
+    Query result = invokeConvertQuery(QueryBuilders.rangeQuery("timestamp").gte(100L).lt(200L));
+    assertNotNull(result);
+  }
+
+  /** Helper method to invoke the private convertQuery method via reflection. */
+  private Query invokeConvertQuery(QueryBuilder queryBuilder) throws Exception {
+    Method convertQueryMethod =
+        Es8SearchClientShim.class.getDeclaredMethod(
+            "convertQuery", org.opensearch.index.query.QueryBuilder.class);
+    convertQueryMethod.setAccessible(true);
+    return (Query) convertQueryMethod.invoke(shim, queryBuilder);
   }
 
   /** Helper method to invoke the private convertSuggestion method via reflection. */

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/Es8SearchClientShimIndexSettingsComparisonTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/Es8SearchClientShimIndexSettingsComparisonTest.java
@@ -1,0 +1,63 @@
+package com.linkedin.metadata.search.elasticsearch.client.shim.impl;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.metadata.search.elasticsearch.client.shim.impl.Es8SearchClientShim.IndexSettingsComparison;
+import java.util.Set;
+import org.opensearch.common.settings.Settings;
+import org.testng.annotations.Test;
+
+public class Es8SearchClientShimIndexSettingsComparisonTest {
+
+  @Test
+  public void testStoredNamesForComparisonIgnoresInjectedCustomTypeWhenTargetOmitsType() {
+    Settings stored =
+        Settings.builder().put("type", "custom").put("tokenizer", "path_hierarchy").build();
+
+    Set<String> names =
+        IndexSettingsComparison.storedNamesForComparison(
+            ImmutableMap.of("tokenizer", "path_hierarchy"), stored);
+
+    assertFalse(names.contains("type"));
+    assertTrue(names.contains("tokenizer"));
+  }
+
+  @Test
+  public void testStoredNamesForComparisonKeepsNonCustomTypeWhenTargetOmitsType() {
+    Settings stored =
+        Settings.builder().put("type", "standard").put("tokenizer", "standard").build();
+
+    Set<String> names =
+        IndexSettingsComparison.storedNamesForComparison(
+            ImmutableMap.of("tokenizer", "standard"), stored);
+
+    assertTrue(names.contains("type"));
+  }
+
+  @Test
+  public void testStoredNamesForComparisonKeepsTypeWhenTargetIncludesType() {
+    Settings stored =
+        Settings.builder().put("type", "custom").put("tokenizer", "path_hierarchy").build();
+
+    Set<String> names =
+        IndexSettingsComparison.storedNamesForComparison(
+            ImmutableMap.of("type", "custom", "tokenizer", "path_hierarchy"), stored);
+
+    assertTrue(names.contains("type"));
+  }
+
+  @Test
+  public void testValuesEqualIsCaseInsensitiveAfterStrictMatchFails() {
+    assertTrue(IndexSettingsComparison.valuesEqual("True", "true"));
+    assertTrue(IndexSettingsComparison.valuesEqual("CUSTOM", "custom"));
+    assertFalse(IndexSettingsComparison.valuesEqual("keyword", "standard"));
+  }
+
+  @Test
+  public void testValuesEqualStrictMatchPreferred() {
+    assertTrue(IndexSettingsComparison.valuesEqual("exact", "exact"));
+    assertFalse(IndexSettingsComparison.valuesEqual(null, "x"));
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/v8/LegacyRangeQueryNormalizerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/v8/LegacyRangeQueryNormalizerTest.java
@@ -1,0 +1,108 @@
+package com.linkedin.metadata.search.elasticsearch.client.shim.impl.v8;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opensearch.index.query.QueryBuilders;
+import org.testng.annotations.Test;
+
+public class LegacyRangeQueryNormalizerTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  public void testNormalizeBetweenRange() throws Exception {
+    String legacy =
+        QueryBuilders.rangeQuery("age")
+            .from(18)
+            .to(65)
+            .includeLower(true)
+            .includeUpper(true)
+            .toString();
+
+    String normalized = LegacyRangeQueryNormalizer.normalize(legacy, objectMapper);
+
+    assertFalse(normalized.contains("\"from\""));
+    assertFalse(normalized.contains("\"to\""));
+    assertTrue(normalized.contains("\"gte\":18"));
+    assertTrue(normalized.contains("\"lte\":65"));
+  }
+
+  @Test
+  public void testNormalizeGteLtRange() throws Exception {
+    String legacy = QueryBuilders.rangeQuery("timestamp").gte(100L).lt(200L).toString();
+
+    String normalized = LegacyRangeQueryNormalizer.normalize(legacy, objectMapper);
+
+    assertFalse(normalized.contains("\"from\""));
+    assertFalse(normalized.contains("\"to\""));
+    assertTrue(normalized.contains("\"gte\":100"));
+    assertTrue(normalized.contains("\"lt\":200"));
+  }
+
+  @Test
+  public void testNormalizeGreaterThanRange() throws Exception {
+    String legacy = QueryBuilders.rangeQuery("timestamp").gt(1731974400000L).toString();
+
+    String normalized = LegacyRangeQueryNormalizer.normalize(legacy, objectMapper);
+
+    assertFalse(normalized.contains("\"from\""));
+    assertTrue(normalized.contains("\"gt\":1731974400000"));
+  }
+
+  @Test
+  public void testNormalizeNestedBoolRange() throws Exception {
+    String legacy =
+        QueryBuilders.boolQuery()
+            .must(QueryBuilders.rangeQuery("timestamp").gte(1L).lt(2L))
+            .toString();
+
+    String normalized = LegacyRangeQueryNormalizer.normalize(legacy, objectMapper);
+
+    assertFalse(normalized.contains("\"from\""));
+    assertFalse(normalized.contains("\"to\""));
+    assertTrue(normalized.contains("\"gte\":1"));
+    assertTrue(normalized.contains("\"lt\":2"));
+  }
+
+  @Test
+  public void testNormalizeLessThanOrEqualRange() throws Exception {
+    String legacy = QueryBuilders.rangeQuery("timestamp").lte(500L).toString();
+
+    String normalized = LegacyRangeQueryNormalizer.normalize(legacy, objectMapper);
+
+    assertFalse(normalized.contains("\"to\""));
+    assertTrue(normalized.contains("\"lte\":500"));
+  }
+
+  @Test
+  public void testNormalizeAlreadyModernRangeUnchanged() throws Exception {
+    String modern = "{\"range\":{\"timestamp\":{\"gte\":1,\"lt\":2,\"boost\":1.0}}}";
+
+    String normalized = LegacyRangeQueryNormalizer.normalize(modern, objectMapper);
+
+    assertEquals(objectMapper.readTree(modern), objectMapper.readTree(normalized));
+  }
+
+  @Test
+  public void testNormalizeNullFromWithUpperBound() throws Exception {
+    String legacy =
+        QueryBuilders.rangeQuery("score").to(10).includeLower(true).includeUpper(true).toString();
+
+    String normalized = LegacyRangeQueryNormalizer.normalize(legacy, objectMapper);
+
+    assertFalse(normalized.contains("\"from\""));
+    assertTrue(normalized.contains("\"lte\":10"));
+  }
+
+  @Test
+  public void testLeavesNonRangeQueryUnchanged() throws Exception {
+    String legacy = QueryBuilders.termQuery("status", "active").toString();
+
+    String normalized = LegacyRangeQueryNormalizer.normalize(legacy, objectMapper);
+
+    assertEquals(objectMapper.readTree(legacy), objectMapper.readTree(normalized));
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/IndexBuilderTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/IndexBuilderTestBase.java
@@ -61,6 +61,7 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.rest.RestStatus;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.springframework.util.CollectionUtils;
+import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -190,7 +191,9 @@ public abstract class IndexBuilderTestBase extends AbstractTestNGSpringContextTe
     }
 
     // Clean up all test indices
-    String[] testIndices = {TEST_V2_INDEX_NAME, TEST_V3_INDEX_NAME};
+    String[] testIndices = {
+      TEST_V2_INDEX_NAME, TEST_V3_INDEX_NAME, TEST_V2_INDEX_NAME + "_object_roundtrip"
+    };
 
     for (String indexName : testIndices) {
       try {
@@ -868,6 +871,83 @@ public abstract class IndexBuilderTestBase extends AbstractTestNGSpringContextTe
     assertFalse(
         indexConvention.isV3EntityIndex(TEST_V2_INDEX_NAME),
         "IndexConvention should not identify dataset v2 index as v3");
+  }
+
+  /**
+   * Guards against ES8 settings reindex loops: after creating an index with analysis settings, a
+   * second {@link ESIndexBuilder#buildReindexState} pass must not detect spurious analysis drift
+   * (e.g. ES8-injected {@code type=custom} on analyzers).
+   */
+  @Test
+  public void testNoSettingsReindexLoopAfterAnalysisIndexCreationOnES8() throws Exception {
+    if (getSearchClient().getEngineType() != SearchClientShim.SearchEngineType.ELASTICSEARCH_8) {
+      throw new SkipException("ES8 engine round-trip reindex loop test");
+    }
+
+    Map<String, Object> minimalMappings =
+        ImmutableMap.of("properties", ImmutableMap.of("name", ImmutableMap.of("type", "keyword")));
+    Map<String, Object> v2Settings =
+        delegatingSettingsBuilder.getSettings(testDefaultConfig.getIndex(), TEST_V2_INDEX_NAME);
+
+    ReindexConfig createConfig =
+        testDefaultBuilder.buildReindexState(TEST_V2_INDEX_NAME, minimalMappings, v2Settings);
+    assertEquals(testDefaultBuilder.buildIndex(createConfig), ReindexResult.CREATED_NEW);
+
+    GetIndexResponse v2Index = getV2TestIndex();
+    String concreteIndex = v2Index.getIndices()[0];
+    assertEquals(
+        v2Index.getSetting(concreteIndex, "index.analysis.analyzer.browse_path_hierarchy.type"),
+        "custom",
+        "ES8 should persist type=custom for custom analyzers");
+
+    ReindexConfig secondPass =
+        testDefaultBuilder.buildReindexState(TEST_V2_INDEX_NAME, minimalMappings, v2Settings);
+
+    assertTrue(secondPass.exists(), "Index should exist for round-trip comparison");
+    assertFalse(
+        secondPass.requiresApplySettings(),
+        "ES8 round-trip must not detect spurious analysis settings drift");
+    assertFalse(
+        secondPass.requiresReindex(),
+        "Second system-update pass must not enter a settings reindex loop on ES8");
+  }
+
+  /**
+   * Guards against ES8 mapping reindex loops: nested object mappings gain {@code type: object} on
+   * persistence; a second pass must treat authored implicit-object mappings as equal.
+   */
+  @Test
+  public void testNoMappingsReindexLoopAfterObjectMappingCreationOnES8() throws Exception {
+    if (getSearchClient().getEngineType() != SearchClientShim.SearchEngineType.ELASTICSEARCH_8) {
+      throw new SkipException("ES8 mapping round-trip reindex loop test");
+    }
+
+    String indexName = TEST_V2_INDEX_NAME + "_object_roundtrip";
+    Map<String, Object> implicitObjectMappings =
+        ImmutableMap.of(
+            "properties",
+            ImmutableMap.of(
+                "partitionSpec",
+                ImmutableMap.of(
+                    "properties",
+                    ImmutableMap.of(
+                        "partition", ImmutableMap.of("type", "keyword"),
+                        "timePartition", ImmutableMap.of("type", "keyword")))));
+
+    ReindexConfig createConfig =
+        testDefaultBuilder.buildReindexState(indexName, implicitObjectMappings, Map.of());
+    assertEquals(testDefaultBuilder.buildIndex(createConfig), ReindexResult.CREATED_NEW);
+
+    ReindexConfig secondPass =
+        testDefaultBuilder.buildReindexState(indexName, implicitObjectMappings, Map.of());
+
+    assertTrue(secondPass.exists());
+    assertFalse(
+        secondPass.requiresApplyMappings(),
+        "ES8 object mapping round-trip must not produce a synthetic mapping diff");
+    assertFalse(
+        secondPass.requiresReindex(),
+        "Second system-update pass must not enter a mapping reindex loop on ES8");
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ReindexConfigTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ReindexConfigTest.java
@@ -1,11 +1,14 @@
 package com.linkedin.metadata.search.indexbuilder;
 
 import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
+import com.linkedin.metadata.search.elasticsearch.client.shim.impl.Es8SearchClientShim;
 import com.linkedin.metadata.search.elasticsearch.indexbuilder.ReindexConfig;
+import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import java.util.*;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -20,6 +23,21 @@ public class ReindexConfigTest {
   private static final String TEST_INDEX_NAME = "test_index";
   private static final String PROPERTIES_KEY = "properties";
   private static final String TYPE_KEY = "type";
+
+  private static SearchClientShim<?> es8SettingsComparisonShim() {
+    SearchClientShim<?> shim = mock(SearchClientShim.class);
+    when(shim.indexSettingNamesForComparison(any(), any()))
+        .thenAnswer(
+            invocation ->
+                Es8SearchClientShim.IndexSettingsComparison.storedNamesForComparison(
+                    invocation.getArgument(0), invocation.getArgument(1)));
+    when(shim.indexSettingValuesEqual(any(), any()))
+        .thenAnswer(
+            invocation ->
+                Es8SearchClientShim.IndexSettingsComparison.valuesEqual(
+                    invocation.getArgument(0), invocation.getArgument(1)));
+    return shim;
+  }
 
   @BeforeMethod
   void setUp() {
@@ -1380,6 +1398,177 @@ public class ReindexConfigTest {
 
     // Should detect that settings are equal
     Assert.assertFalse(config.requiresApplySettings());
+  }
+
+  @Test
+  void testEngineRoundTrip_ES8_AnalyzerTypeCustom_IgnoredWhenTargetOmitsType() {
+    // V2LegacySettingsBuilder emits analyzers without "type"; ES8 persists type=custom.
+    Settings currentSettings =
+        Settings.builder()
+            .put("index.analysis.analyzer.browse_path_hierarchy.type", "custom")
+            .put("index.analysis.analyzer.browse_path_hierarchy.tokenizer", "path_hierarchy")
+            .put("index.analysis.analyzer.partial.type", "custom")
+            .put("index.analysis.analyzer.partial.tokenizer", "main_tokenizer")
+            .put("index.analysis.analyzer.partial.filter.0", "asciifolding")
+            .put("index.analysis.analyzer.partial.filter.1", "autocomplete_custom_delimiter")
+            .put("index.analysis.analyzer.partial.filter.2", "lowercase")
+            .put("index.analysis.filter.autocomplete_custom_delimiter.type", "word_delimiter")
+            .put("index.analysis.filter.autocomplete_custom_delimiter.preserve_original", "true")
+            .put("index.analysis.filter.autocomplete_custom_delimiter.split_on_numerics", "false")
+            .put(
+                "index.analysis.filter.autocomplete_custom_delimiter.split_on_case_change", "false")
+            .build();
+
+    Map<String, Object> targetSettings =
+        ImmutableMap.of(
+            "index",
+            ImmutableMap.of(
+                "analysis",
+                ImmutableMap.of(
+                    "analyzer",
+                    ImmutableMap.of(
+                        "browse_path_hierarchy",
+                        ImmutableMap.of("tokenizer", "path_hierarchy"),
+                        "partial",
+                        ImmutableMap.of(
+                            "tokenizer",
+                            "main_tokenizer",
+                            "filter",
+                            Arrays.asList(
+                                "asciifolding", "autocomplete_custom_delimiter", "lowercase"))),
+                    "filter",
+                    ImmutableMap.of(
+                        "autocomplete_custom_delimiter",
+                        ImmutableMap.of(
+                            "type",
+                            "word_delimiter",
+                            "preserve_original",
+                            true,
+                            "split_on_numerics",
+                            false,
+                            "split_on_case_change",
+                            false)))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(new HashMap<>())
+            .targetMappings(new HashMap<>())
+            .currentSettings(currentSettings)
+            .targetSettings(targetSettings)
+            .enableIndexSettingsReindex(true)
+            .settingsComparisonShim(es8SettingsComparisonShim())
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplySettings(),
+        "ES8-injected analyzer type=custom must not force analysis settings reindex");
+    Assert.assertFalse(config.requiresReindex());
+  }
+
+  @Test
+  void testEngineRoundTrip_ES8_AnalyzerTypeCustom_TriggersReindexWithoutShim() {
+    Settings currentSettings =
+        Settings.builder()
+            .put("index.analysis.analyzer.browse_path_hierarchy.type", "custom")
+            .put("index.analysis.analyzer.browse_path_hierarchy.tokenizer", "path_hierarchy")
+            .build();
+
+    Map<String, Object> targetSettings =
+        ImmutableMap.of(
+            "index",
+            ImmutableMap.of(
+                "analysis",
+                ImmutableMap.of(
+                    "analyzer",
+                    ImmutableMap.of(
+                        "browse_path_hierarchy", ImmutableMap.of("tokenizer", "path_hierarchy")))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(new HashMap<>())
+            .targetMappings(new HashMap<>())
+            .currentSettings(currentSettings)
+            .targetSettings(targetSettings)
+            .enableIndexSettingsReindex(true)
+            .build();
+
+    Assert.assertTrue(
+        config.requiresApplySettings(),
+        "Without ES8 shim, injected type=custom must be treated as a settings drift");
+  }
+
+  @Test
+  void testEngineRoundTrip_ES8_AnalyzerRealChangeStillDetected() {
+    Settings currentSettings =
+        Settings.builder()
+            .put("index.analysis.analyzer.partial.type", "custom")
+            .put("index.analysis.analyzer.partial.tokenizer", "main_tokenizer")
+            .build();
+
+    Map<String, Object> targetSettings =
+        ImmutableMap.of(
+            "index",
+            ImmutableMap.of(
+                "analysis",
+                ImmutableMap.of(
+                    "analyzer",
+                    ImmutableMap.of("partial", ImmutableMap.of("tokenizer", "keyword")))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(new HashMap<>())
+            .targetMappings(new HashMap<>())
+            .currentSettings(currentSettings)
+            .targetSettings(targetSettings)
+            .enableIndexSettingsReindex(true)
+            .settingsComparisonShim(es8SettingsComparisonShim())
+            .build();
+
+    Assert.assertTrue(
+        config.requiresApplySettings(), "Real analyzer tokenizer change must still be detected");
+    Assert.assertTrue(config.requiresReindex());
+  }
+
+  @Test
+  void testEngineRoundTrip_ES8_CaseInsensitiveBooleanValuesEqual() {
+    Settings currentSettings =
+        Settings.builder()
+            .put("index.analysis.filter.autocomplete_custom_delimiter.preserve_original", "True")
+            .build();
+
+    Map<String, Object> targetSettings =
+        ImmutableMap.of(
+            "index",
+            ImmutableMap.of(
+                "analysis",
+                ImmutableMap.of(
+                    "filter",
+                    ImmutableMap.of(
+                        "autocomplete_custom_delimiter",
+                        ImmutableMap.of("preserve_original", true)))));
+
+    ReindexConfig config =
+        ReindexConfig.builder()
+            .name(TEST_INDEX_NAME)
+            .exists(true)
+            .currentMappings(new HashMap<>())
+            .targetMappings(new HashMap<>())
+            .currentSettings(currentSettings)
+            .targetSettings(targetSettings)
+            .enableIndexSettingsReindex(true)
+            .settingsComparisonShim(es8SettingsComparisonShim())
+            .build();
+
+    Assert.assertFalse(
+        config.requiresApplySettings(),
+        "ES8 shim should treat True/true as equal for boolean settings");
+    Assert.assertFalse(config.requiresReindex());
   }
 
   @Test

--- a/metadata-io/src/test/java/io/datahubproject/test/search/FaultInjectingSearchClientShim.java
+++ b/metadata-io/src/test/java/io/datahubproject/test/search/FaultInjectingSearchClientShim.java
@@ -11,8 +11,10 @@ import com.linkedin.metadata.utils.metrics.MetricUtils;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -66,6 +68,7 @@ import org.opensearch.client.indices.ResizeRequest;
 import org.opensearch.client.indices.ResizeResponse;
 import org.opensearch.client.tasks.GetTaskRequest;
 import org.opensearch.client.tasks.GetTaskResponse;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.DeleteByQueryRequest;
 import org.opensearch.index.reindex.ReindexRequest;
@@ -344,6 +347,19 @@ public class FaultInjectingSearchClientShim implements SearchClientShim<Object> 
   @Nonnull
   public Map<String, String> partialNgramConfig() {
     return delegate.partialNgramConfig();
+  }
+
+  @Override
+  @Nonnull
+  public Set<String> indexSettingNamesForComparison(
+      @Nonnull Map<String, Object> targetSettings, @Nonnull Settings storedSettings) {
+    return delegate.indexSettingNamesForComparison(targetSettings, storedSettings);
+  }
+
+  @Override
+  public boolean indexSettingValuesEqual(
+      @Nullable Object targetValue, @Nullable String storedValue) {
+    return delegate.indexSettingValuesEqual(targetValue, storedValue);
   }
 
   @Override

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/elasticsearch/IndexSettingsComparison.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/elasticsearch/IndexSettingsComparison.java
@@ -1,0 +1,45 @@
+package com.linkedin.metadata.utils.elasticsearch;
+
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.opensearch.common.settings.Settings;
+
+/**
+ * Compares authored index analysis settings against values persisted in Elasticsearch/OpenSearch.
+ * Engine-specific shims implement this to normalize round-trip representation differences.
+ */
+public interface IndexSettingsComparison {
+
+  /**
+   * Stored setting keys to compare against the authored target at one nesting level of index
+   * analysis settings. Engine-specific shims may ignore keys injected on persistence round-trip.
+   */
+  @Nonnull
+  default Set<String> indexSettingNamesForComparison(
+      @Nonnull Map<String, Object> targetSettings, @Nonnull Settings storedSettings) {
+    return storedSettings.names();
+  }
+
+  /**
+   * Compare scalar values from authored target settings with stored index settings strings.
+   *
+   * <p>Engine-specific shims may normalize values that differ only by representation on round-trip.
+   */
+  default boolean indexSettingValuesEqual(
+      @Nullable Object targetValue, @Nullable String storedValue) {
+    if (targetValue == null && storedValue == null) {
+      return true;
+    }
+    if (targetValue == null || storedValue == null) {
+      return false;
+    }
+    return targetValue.toString().equals(storedValue);
+  }
+
+  /** Strict comparison with no engine-specific normalization. */
+  enum Strict implements IndexSettingsComparison {
+    INSTANCE
+  }
+}

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/elasticsearch/SearchClientShim.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/elasticsearch/SearchClientShim.java
@@ -76,7 +76,7 @@ import org.opensearch.index.reindex.UpdateByQueryRequest;
  * allows DataHub to support ES 7.17 (with API compatibility), ES 8.x, ES 9.x and OpenSearch 2.x.,
  * through a common interface.
  */
-public interface SearchClientShim<T> extends Closeable {
+public interface SearchClientShim<T> extends Closeable, IndexSettingsComparison {
 
   /** Enum representing the different search engine types supported by the shim */
   enum SearchEngineType {

--- a/metadata-utils/src/test/java/com/linkedin/metadata/utils/elasticsearch/IndexSettingsComparisonTest.java
+++ b/metadata-utils/src/test/java/com/linkedin/metadata/utils/elasticsearch/IndexSettingsComparisonTest.java
@@ -1,0 +1,43 @@
+package com.linkedin.metadata.utils.elasticsearch;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Set;
+import org.opensearch.common.settings.Settings;
+import org.testng.annotations.Test;
+
+public class IndexSettingsComparisonTest {
+
+  @Test
+  public void testStrictIndexSettingNamesForComparisonUsesStoredNames() {
+    Settings stored =
+        Settings.builder().put("tokenizer", "standard").put("filter", "lowercase").build();
+    Set<String> names =
+        IndexSettingsComparison.Strict.INSTANCE.indexSettingNamesForComparison(
+            ImmutableMap.of("tokenizer", "standard"), stored);
+
+    assertTrue(names.contains("tokenizer"));
+    assertTrue(names.contains("filter"));
+  }
+
+  @Test
+  public void testStrictIndexSettingValuesEqualMatchesStrings() {
+    assertTrue(IndexSettingsComparison.Strict.INSTANCE.indexSettingValuesEqual("true", "true"));
+    assertFalse(IndexSettingsComparison.Strict.INSTANCE.indexSettingValuesEqual("true", "false"));
+  }
+
+  @Test
+  public void testStrictIndexSettingValuesEqualHandlesNulls() {
+    assertTrue(IndexSettingsComparison.Strict.INSTANCE.indexSettingValuesEqual(null, null));
+    assertFalse(IndexSettingsComparison.Strict.INSTANCE.indexSettingValuesEqual("x", null));
+    assertFalse(IndexSettingsComparison.Strict.INSTANCE.indexSettingValuesEqual(null, "x"));
+  }
+
+  @Test
+  public void testStrictIndexSettingValuesEqualUsesToString() {
+    assertTrue(IndexSettingsComparison.Strict.INSTANCE.indexSettingValuesEqual(2, "2"));
+    assertFalse(IndexSettingsComparison.Strict.INSTANCE.indexSettingValuesEqual(2, "3"));
+  }
+}


### PR DESCRIPTION
## Summary
- Add engine-specific index settings comparison via `IndexSettingsComparison` so ES8-injected `type=custom` on analyzers and case-only boolean diffs no longer trigger spurious reindex cycles
- Normalize legacy OpenSearch `RangeQueryBuilder` JSON (`from`/`to` with `include_lower`/`include_upper`) to ES8-compatible bounds (`gte`/`gt`/`lte`/`lt`) before query conversion
- Wire the ES8 shim into `ReindexConfig` through `ESIndexBuilder` and add unit/integration tests covering round-trip settings and mapping stability



Made with [Cursor](https://cursor.com)