### PR TITLE
fix(utilities): make LossyList.__contains__ unwrap stored tuples

### DIFF
--- a/metadata-ingestion/src/datahub/utilities/lossy_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/lossy_collections.py
@@ -83,13 +83,9 @@ class LossyList(List[T], Generic[T]):
         yield from [elem[1] for elem in sorted(super().__iter__())]  # type: ignore
 
     def __contains__(self, item: object) -> bool:
-        """Membership test against unwrapped items.
-
-        Internally items are stored as (index, item) tuples for reservoir
-        sampling, so the inherited list.__contains__ would only match against
-        those tuples. Iterate via __iter__ (which unwraps) so callers can use
-        natural `x in lossy_list` semantics.
-        """
+        # Items are stored as (index, item) tuples for reservoir sampling, so
+        # the inherited list.__contains__ would only match against the tuples.
+        # Reuse __iter__ which unwraps, so callers get natural `x in list` semantics.
         return any(elem == item for elem in self.__iter__())
 
     def __repr__(self) -> str:

--- a/metadata-ingestion/src/datahub/utilities/lossy_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/lossy_collections.py
@@ -83,10 +83,8 @@ class LossyList(List[T], Generic[T]):
         yield from [elem[1] for elem in sorted(super().__iter__())]  # type: ignore
 
     def __contains__(self, item: object) -> bool:
-        # Items are stored as (index, item) tuples for reservoir sampling, so
-        # the inherited list.__contains__ would only match against the tuples.
-        # Iterating `self` goes through our __iter__ which unwraps, giving
-        # callers natural `x in list` semantics.
+        # list.__contains__ would compare against the (index, item) tuples
+        # used for reservoir sampling; iterate self to unwrap via __iter__.
         return any(elem == item for elem in self)
 
     def __repr__(self) -> str:

--- a/metadata-ingestion/src/datahub/utilities/lossy_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/lossy_collections.py
@@ -85,8 +85,9 @@ class LossyList(List[T], Generic[T]):
     def __contains__(self, item: object) -> bool:
         # Items are stored as (index, item) tuples for reservoir sampling, so
         # the inherited list.__contains__ would only match against the tuples.
-        # Reuse __iter__ which unwraps, so callers get natural `x in list` semantics.
-        return any(elem == item for elem in self.__iter__())
+        # Iterating `self` goes through our __iter__ which unwraps, giving
+        # callers natural `x in list` semantics.
+        return any(elem == item for elem in self)
 
     def __repr__(self) -> str:
         return repr(self.as_obj())

--- a/metadata-ingestion/src/datahub/utilities/lossy_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/lossy_collections.py
@@ -82,6 +82,16 @@ class LossyList(List[T], Generic[T]):
     def __iter__(self) -> Iterator[T]:
         yield from [elem[1] for elem in sorted(super().__iter__())]  # type: ignore
 
+    def __contains__(self, item: object) -> bool:
+        """Membership test against unwrapped items.
+
+        Internally items are stored as (index, item) tuples for reservoir
+        sampling, so the inherited list.__contains__ would only match against
+        those tuples. Iterate via __iter__ (which unwraps) so callers can use
+        natural `x in lossy_list` semantics.
+        """
+        return any(elem == item for elem in self.__iter__())
+
     def __repr__(self) -> str:
         return repr(self.as_obj())
 

--- a/metadata-ingestion/tests/unit/utilities/test_lossy_collections.py
+++ b/metadata-ingestion/tests/unit/utilities/test_lossy_collections.py
@@ -283,3 +283,40 @@ def test_lossylist_getitem_with_structured_log_entries():
     assert all(isinstance(item, StructuredLogEntry) for item in slice_result)
     assert slice_result[0].title == "Error 1"
     assert slice_result[1].title == "Error 2"
+
+
+def test_lossylist_contains_unwraps_items():
+    """`x in lossy_list` should match unwrapped items.
+
+    Regression test: items are stored internally as (index, item) tuples for
+    reservoir sampling, so without a custom __contains__ the inherited
+    list.__contains__ would only match against those tuples and `item in
+    lossy_list` would always be False — silently breaking membership tests
+    in every caller of report.filtered et al.
+    """
+    lossy_list: LossyList[str] = LossyList(max_elements=10)
+    lossy_list.append("alpha")
+    lossy_list.append("beta")
+    lossy_list.append("gamma")
+
+    assert "alpha" in lossy_list
+    assert "beta" in lossy_list
+    assert "gamma" in lossy_list
+    assert "delta" not in lossy_list
+
+    # Tuple form should NOT match (the internal representation must not leak).
+    assert (0, "alpha") not in lossy_list
+
+
+def test_lossylist_contains_with_reservoir_sampling():
+    """__contains__ still works after reservoir sampling kicks in."""
+    lossy_list: LossyList[str] = LossyList(max_elements=5)
+    for i in range(20):
+        lossy_list.append(f"item_{i}")
+
+    assert lossy_list.sampled is True
+    # Every survivor should be findable via membership test.
+    for survivor in list(lossy_list):
+        assert survivor in lossy_list
+
+    assert "definitely_not_there" not in lossy_list

--- a/metadata-ingestion/tests/unit/utilities/test_lossy_collections.py
+++ b/metadata-ingestion/tests/unit/utilities/test_lossy_collections.py
@@ -286,14 +286,6 @@ def test_lossylist_getitem_with_structured_log_entries():
 
 
 def test_lossylist_contains_unwraps_items():
-    """`x in lossy_list` should match unwrapped items.
-
-    Regression test: items are stored internally as (index, item) tuples for
-    reservoir sampling, so without a custom __contains__ the inherited
-    list.__contains__ would only match against those tuples and `item in
-    lossy_list` would always be False — silently breaking membership tests
-    in every caller of report.filtered et al.
-    """
     lossy_list: LossyList[str] = LossyList(max_elements=10)
     lossy_list.append("alpha")
     lossy_list.append("beta")
@@ -304,18 +296,16 @@ def test_lossylist_contains_unwraps_items():
     assert "gamma" in lossy_list
     assert "delta" not in lossy_list
 
-    # Tuple form should NOT match (the internal representation must not leak).
+    # The internal (index, item) representation must not leak.
     assert (0, "alpha") not in lossy_list
 
 
 def test_lossylist_contains_with_reservoir_sampling():
-    """__contains__ still works after reservoir sampling kicks in."""
     lossy_list: LossyList[str] = LossyList(max_elements=5)
     for i in range(20):
         lossy_list.append(f"item_{i}")
 
     assert lossy_list.sampled is True
-    # Every survivor should be findable via membership test.
     for survivor in list(lossy_list):
         assert survivor in lossy_list
 


### PR DESCRIPTION
## Summary

`LossyList` stores items internally as `(index, item)` tuples for reservoir sampling and overrides `__getitem__` / `__iter__` to hide that detail. But it never overrode `__contains__`, so the inherited `list.__contains__` compared against the raw tuples — making `x in lossy_list` always `False` for the un-tupled item that callers actually have a reference to.

This silently breaks membership tests across every caller, most visibly anything inspecting `report.filtered` to decide whether an entity was already reported on.

## Changes

- Override `LossyList.__contains__` to iterate via the existing unwrap path (`__iter__`) so there is a single source of truth for the tuple → item projection.
- Add two regression tests:
  - positive/negative membership coverage on the small-list path (pre-reservoir-sampling),
  - survivors-must-be-findable check after enough appends to trigger reservoir sampling.

## Checklist

- [x] PR conforms to the Contributing Guideline (especially PR Title Format)
- [x] Tests added/updated