### PR TITLE
fix(ingestion/dremio): auto-detect ARRAY<VARCHAR> queried_datasets on Dremio 26.1.0+

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -60,6 +60,8 @@ Requirements:
 
 - **(Ingestion / dbt)** dbt test assertion entities now emit an `ownership` aspect when the dbt test node has explicit owner metadata (`meta.owner` / `config.meta.owner`).
 
+- **(Ingestion / Dremio)** The Dremio Software connector now auto-detects whether `sys.jobs_recent.queried_datasets` is exposed as `VARCHAR` (pre-26.1.0) or `ARRAY<VARCHAR>` (26.1.0+) by probing the column once per ingestion and selecting an appropriate jobs query. Users upgrading their Dremio cluster to 26.1.0 or newer no longer have to disable usage/lineage extraction to avoid a `Function ARRAY_SIZE not found` error. No recipe changes are required; the probe runs lazily before query extraction.
+
 ## v1.6.0
 
 Requirements:

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -60,8 +60,6 @@ Requirements:
 
 - **(Ingestion / dbt)** dbt test assertion entities now emit an `ownership` aspect when the dbt test node has explicit owner metadata (`meta.owner` / `config.meta.owner`).
 
-- **(Ingestion / Dremio)** The Dremio Software connector now auto-detects whether `sys.jobs_recent.queried_datasets` is exposed as `VARCHAR` (pre-26.1.0) or `ARRAY<VARCHAR>` (26.1.0+) by probing the column once per ingestion and selecting an appropriate jobs query. Users upgrading their Dremio cluster to 26.1.0 or newer no longer have to disable usage/lineage extraction to avoid a `Function ARRAY_SIZE not found` error. No recipe changes are required; the probe runs lazily before query extraction.
-
 ## v1.6.0
 
 Requirements:

--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_api.py
@@ -74,6 +74,8 @@ class DremioAPIOperations:
 
         self.authenticate(connection_args)
         self.edition = self.get_dremio_edition()
+        # Lazily probed on first use; see _supports_array_queried_datasets.
+        self._queried_datasets_is_array: Optional[bool] = None
 
     def get_dremio_edition(self):
         if self.is_dremio_cloud:
@@ -773,6 +775,46 @@ class DremioAPIOperations:
 
         return parents_list
 
+    def _supports_array_queried_datasets(self) -> bool:
+        """
+        Detect whether sys.jobs_recent.queried_datasets is ARRAY<VARCHAR>
+        (Dremio Software 26.1.0+) vs VARCHAR (pre-26.1.0).
+
+        Probes once with a minimal LIMIT 1 query that calls ARRAY_SIZE on the
+        column. ARRAY_SIZE only resolves against array-typed columns, so a
+        successful execution implies the array schema; any execution failure
+        falls back to the legacy VARCHAR query form. The result is cached on
+        the instance so the probe runs at most once per ingestion.
+
+        Cloud always uses the array schema and skips the probe.
+        """
+        if self._queried_datasets_is_array is not None:
+            return self._queried_datasets_is_array
+
+        if self.edition == DremioEdition.CLOUD:
+            self._queried_datasets_is_array = True
+            return True
+
+        probe_query = (
+            "SELECT ARRAY_SIZE(queried_datasets) AS sz FROM SYS.JOBS_RECENT LIMIT 1"
+        )
+        try:
+            list(self.execute_query_iter(query=probe_query))
+            self._queried_datasets_is_array = True
+            logger.info(
+                "Detected ARRAY<VARCHAR> queried_datasets column "
+                "(Dremio Software 26.1.0+); using array-aware jobs query."
+            )
+        except DremioAPIException as exc:
+            self._queried_datasets_is_array = False
+            logger.info(
+                f"queried_datasets probe failed; assuming legacy VARCHAR column "
+                f"(pre-26.1.0 Dremio Software). Falling back to legacy jobs "
+                f"query. Probe error: {exc}"
+            )
+
+        return self._queried_datasets_is_array
+
     def extract_all_queries(self) -> Iterator[Dict[str, Any]]:
         """
         Memory-efficient streaming version for extracting query results.
@@ -788,6 +830,11 @@ class DremioAPIOperations:
 
         if self.edition == DremioEdition.CLOUD:
             jobs_query = DremioSQLQueries.get_query_all_jobs_cloud(
+                start_timestamp_millis=start_timestamp_str,
+                end_timestamp_millis=end_timestamp_str,
+            )
+        elif self._supports_array_queried_datasets():
+            jobs_query = DremioSQLQueries.get_query_all_jobs_array(
                 start_timestamp_millis=start_timestamp_str,
                 end_timestamp_millis=end_timestamp_str,
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_api.py
@@ -806,12 +806,10 @@ class DremioAPIOperations:
                 "(Dremio Software 26.1.0+); using array-aware jobs query."
             )
         except Exception as exc:
-            # Catch broadly: execute_query_iter can raise DremioAPIException
-            # (SQL-level type-mismatch on legacy VARCHAR), RuntimeError (job
-            # FAILED/CANCELED), or network/transport errors. The probe's only
-            # job is "any failure -> assume legacy"; the real jobs query will
-            # raise a meaningful error later if the underlying problem isn't
-            # the schema version.
+            # Probe contract: any failure -> assume legacy. Catch broadly
+            # because execute_query_iter raises DremioAPIException, RuntimeError
+            # (job FAILED/CANCELED), or transport errors. Real problems still
+            # surface later from the actual jobs query.
             self._queried_datasets_is_array = False
             logger.info(
                 f"queried_datasets probe failed; assuming legacy VARCHAR column "

--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_api.py
@@ -74,7 +74,7 @@ class DremioAPIOperations:
 
         self.authenticate(connection_args)
         self.edition = self.get_dremio_edition()
-        # Lazily probed on first use; see _supports_array_queried_datasets.
+        # Lazily probed on first call to _supports_array_queried_datasets.
         self._queried_datasets_is_array: Optional[bool] = None
 
     def get_dremio_edition(self):
@@ -776,18 +776,10 @@ class DremioAPIOperations:
         return parents_list
 
     def _supports_array_queried_datasets(self) -> bool:
-        """
-        Detect whether sys.jobs_recent.queried_datasets is ARRAY<VARCHAR>
-        (Dremio Software 26.1.0+) vs VARCHAR (pre-26.1.0).
-
-        Probes once with a minimal LIMIT 1 query that calls ARRAY_SIZE on the
-        column. ARRAY_SIZE only resolves against array-typed columns, so a
-        successful execution implies the array schema; any execution failure
-        falls back to the legacy VARCHAR query form. The result is cached on
-        the instance so the probe runs at most once per ingestion.
-
-        Cloud always uses the array schema and skips the probe.
-        """
+        """Detect whether sys.jobs_recent.queried_datasets is ARRAY<VARCHAR>
+        (Dremio Software 26.1.0+) vs VARCHAR. Probes once with ARRAY_SIZE —
+        the function only resolves on array columns, so success → array,
+        any failure → legacy form. Cloud is always array."""
         if self._queried_datasets_is_array is not None:
             return self._queried_datasets_is_array
 
@@ -806,15 +798,14 @@ class DremioAPIOperations:
                 "(Dremio Software 26.1.0+); using array-aware jobs query."
             )
         except Exception as exc:
-            # Probe contract: any failure -> assume legacy. Catch broadly
-            # because execute_query_iter raises DremioAPIException, RuntimeError
-            # (job FAILED/CANCELED), or transport errors. Real problems still
-            # surface later from the actual jobs query.
+            # Catch broadly: execute_query_iter can raise DremioAPIException,
+            # RuntimeError (FAILED/CANCELED job), or transport errors — any
+            # of which means we don't have the array column type. Real
+            # problems surface later from the actual jobs query.
             self._queried_datasets_is_array = False
             logger.info(
-                f"queried_datasets probe failed; assuming legacy VARCHAR column "
-                f"(pre-26.1.0 Dremio Software). Falling back to legacy jobs "
-                f"query. Probe error: {exc}"
+                f"queried_datasets probe failed; assuming legacy VARCHAR. "
+                f"Probe error: {exc}"
             )
 
         return self._queried_datasets_is_array

--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_api.py
@@ -805,7 +805,13 @@ class DremioAPIOperations:
                 "Detected ARRAY<VARCHAR> queried_datasets column "
                 "(Dremio Software 26.1.0+); using array-aware jobs query."
             )
-        except DremioAPIException as exc:
+        except Exception as exc:
+            # Catch broadly: execute_query_iter can raise DremioAPIException
+            # (SQL-level type-mismatch on legacy VARCHAR), RuntimeError (job
+            # FAILED/CANCELED), or network/transport errors. The probe's only
+            # job is "any failure -> assume legacy"; the real jobs query will
+            # raise a meaningful error later if the underlying problem isn't
+            # the schema version.
             self._queried_datasets_is_array = False
             logger.info(
                 f"queried_datasets probe failed; assuming legacy VARCHAR column "

--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_sql_queries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_sql_queries.py
@@ -298,20 +298,9 @@ class DremioSQLQueries:
         start_timestamp_millis: Optional[str] = None,
         end_timestamp_millis: Optional[str] = None,
     ) -> str:
-        """
-        Get query for all jobs on Dremio Software 26.1.0+ where
-        sys.jobs_recent.queried_datasets is ARRAY<VARCHAR>.
-
-        The legacy `get_query_all_jobs` form uses LENGTH()/raw selection and
-        breaks at runtime once Dremio Software 26.1.0 changes the column type
-        from VARCHAR to ARRAY<VARCHAR>. We wrap the array as a bracket-string
-        so the downstream parser (DremioQuery._get_queried_datasets) keeps
-        working unchanged.
-
-        Args:
-            start_timestamp_millis: Start timestamp in format 'YYYY-MM-DD HH:MM:SS.mmm' (defaults to 1 day ago)
-            end_timestamp_millis: End timestamp in format 'YYYY-MM-DD HH:MM:SS.mmm' (defaults to now)
-        """
+        """All-jobs query for Dremio Software 26.1.0+ (queried_datasets is
+        ARRAY<VARCHAR>). Renders the array as a bracket-string so the
+        existing DremioQuery._get_queried_datasets parser keeps working."""
         if start_timestamp_millis is None:
             start_timestamp_millis = (
                 DremioSQLQueries._get_default_start_timestamp_millis()

--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_sql_queries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_sql_queries.py
@@ -294,6 +294,50 @@ class DremioSQLQueries:
         """
 
     @staticmethod
+    def get_query_all_jobs_array(
+        start_timestamp_millis: Optional[str] = None,
+        end_timestamp_millis: Optional[str] = None,
+    ) -> str:
+        """
+        Get query for all jobs on Dremio Software 26.1.0+ where
+        sys.jobs_recent.queried_datasets is ARRAY<VARCHAR>.
+
+        The legacy `get_query_all_jobs` form uses LENGTH()/raw selection and
+        breaks at runtime once Dremio Software 26.1.0 changes the column type
+        from VARCHAR to ARRAY<VARCHAR>. We wrap the array as a bracket-string
+        so the downstream parser (DremioQuery._get_queried_datasets) keeps
+        working unchanged.
+
+        Args:
+            start_timestamp_millis: Start timestamp in format 'YYYY-MM-DD HH:MM:SS.mmm' (defaults to 1 day ago)
+            end_timestamp_millis: End timestamp in format 'YYYY-MM-DD HH:MM:SS.mmm' (defaults to now)
+        """
+        if start_timestamp_millis is None:
+            start_timestamp_millis = (
+                DremioSQLQueries._get_default_start_timestamp_millis()
+            )
+        if end_timestamp_millis is None:
+            end_timestamp_millis = DremioSQLQueries._get_default_end_timestamp_millis()
+
+        return f"""
+        SELECT
+            job_id,
+            user_name,
+            submitted_ts,
+            query,
+            CONCAT('[', ARRAY_TO_STRING(queried_datasets, ','), ']') as queried_datasets
+        FROM
+            SYS.JOBS_RECENT
+        WHERE
+            STATUS = 'COMPLETED'
+            AND ARRAY_SIZE(queried_datasets)>0
+            AND user_name != '$dremio$'
+            AND query_type not like '%INTERNAL%'
+            AND submitted_ts >= TIMESTAMP '{start_timestamp_millis}'
+            AND submitted_ts <= TIMESTAMP '{end_timestamp_millis}'
+        """
+
+    @staticmethod
     def get_query_all_jobs_cloud(
         start_timestamp_millis: Optional[str] = None,
         end_timestamp_millis: Optional[str] = None,

--- a/metadata-ingestion/tests/unit/dremio/test_dremio_api_pagination.py
+++ b/metadata-ingestion/tests/unit/dremio/test_dremio_api_pagination.py
@@ -238,6 +238,9 @@ class TestDremioAPIPagination:
         dremio_api.edition = DremioEdition.ENTERPRISE
         dremio_api.start_time = None
         dremio_api.end_time = None
+        # Pin the queried_datasets schema so we skip the runtime probe and
+        # exercise a single SQL execution path.
+        dremio_api._queried_datasets_is_array = True
 
         # Mock streaming query execution
         mock_query_results = [

--- a/metadata-ingestion/tests/unit/dremio/test_dremio_jobs_array.py
+++ b/metadata-ingestion/tests/unit/dremio/test_dremio_jobs_array.py
@@ -132,15 +132,18 @@ class TestExtractAllQueriesDispatch:
         report = DremioSourceReport()
         api = DremioAPIOperations(config, report)
         api.session = mock_session
-        api.start_time = None
-        api.end_time = None
+        api.start_time = None  # type: ignore[assignment]
+        api.end_time = None  # type: ignore[assignment]
         return api
 
     def _captured_query(self, dremio_api):
         sent: list = []
-        dremio_api.execute_query_iter = Mock(
-            side_effect=lambda query: sent.append(query) or iter([])
-        )
+
+        def _capture(query):
+            sent.append(query)
+            return iter([])
+
+        dremio_api.execute_query_iter = Mock(side_effect=_capture)
         list(dremio_api.extract_all_queries())
         return sent[-1]
 

--- a/metadata-ingestion/tests/unit/dremio/test_dremio_jobs_array.py
+++ b/metadata-ingestion/tests/unit/dremio/test_dremio_jobs_array.py
@@ -92,6 +92,16 @@ class TestSupportsArrayQueriedDatasetsProbe:
         )
         assert dremio_api._supports_array_queried_datasets() is False
 
+    def test_probe_falls_back_on_non_dremio_exception(self, dremio_api):
+        # execute_query_iter also raises RuntimeError for FAILED/CANCELED jobs
+        # and may surface transport errors; any failure must fall back to the
+        # legacy form so ingestion continues.
+        dremio_api.edition = DremioEdition.ENTERPRISE
+        dremio_api.execute_query_iter = Mock(
+            side_effect=RuntimeError("Query failed: planner exception")
+        )
+        assert dremio_api._supports_array_queried_datasets() is False
+
     def test_probe_is_cached_after_success(self, dremio_api):
         dremio_api.edition = DremioEdition.ENTERPRISE
         mock = Mock(return_value=iter([{"sz": 0}]))

--- a/metadata-ingestion/tests/unit/dremio/test_dremio_jobs_array.py
+++ b/metadata-ingestion/tests/unit/dremio/test_dremio_jobs_array.py
@@ -18,30 +18,24 @@ from datahub.ingestion.source.dremio.dremio_sql_queries import DremioSQLQueries
 
 
 class TestQueriedDatasetsArrayQuery:
-    """Pure SQL-string assertions for the new array-aware EE/CE jobs query."""
-
     def test_array_query_uses_array_size_predicate(self):
+        # 26.1.0+ array column — LENGTH() no longer applies.
         query = DremioSQLQueries.get_query_all_jobs_array()
-        # Legacy form used LENGTH(queried_datasets); 26.1.0+ exposes the
-        # column as ARRAY<VARCHAR>, so the WHERE clause must use ARRAY_SIZE.
         assert "ARRAY_SIZE(queried_datasets)>0" in query
         assert "LENGTH(queried_datasets)" not in query
 
     def test_array_query_wraps_array_as_bracket_string(self):
+        # Keeps DremioQuery._get_queried_datasets's "[ds1,ds2]" parser stable.
         query = DremioSQLQueries.get_query_all_jobs_array()
-        # DremioQuery._get_queried_datasets parses the SELECTED value as
-        # "[ds1,ds2]" — keep the output stable across schema versions.
         assert "CONCAT('[', ARRAY_TO_STRING(queried_datasets, ','), ']')" in query
 
     def test_array_query_targets_jobs_recent_not_history(self):
-        # The cloud query targets sys.project.history.jobs (different
-        # surface). EE/CE 26.1.0+ keeps sys.jobs_recent.
+        # EE/CE 26.1.0+ stays on sys.jobs_recent (cloud uses history.jobs).
         query = DremioSQLQueries.get_query_all_jobs_array()
         assert "SYS.JOBS_RECENT" in query
         assert "sys.project.history.jobs" not in query
 
     def test_legacy_query_unchanged(self):
-        # Don't regress the legacy path — pre-26.1.0 Dremio still needs it.
         query = DremioSQLQueries.get_query_all_jobs()
         assert "LENGTH(queried_datasets)>0" in query
         assert "ARRAY_SIZE(queried_datasets)" not in query
@@ -70,9 +64,7 @@ class TestSupportsArrayQueriedDatasetsProbe:
 
     def test_cloud_skips_probe_and_returns_true(self, dremio_api):
         dremio_api.edition = DremioEdition.CLOUD
-        # If we accidentally probed against Cloud (which uses a different
-        # jobs table entirely), the call would raise — assert we never get
-        # there.
+        # Probe would target the wrong table on Cloud — must not run.
         dremio_api.execute_query_iter = Mock(
             side_effect=AssertionError("Cloud must not run the EE/CE probe")
         )
@@ -93,8 +85,7 @@ class TestSupportsArrayQueriedDatasetsProbe:
         assert dremio_api._supports_array_queried_datasets() is False
 
     def test_probe_falls_back_on_non_dremio_exception(self, dremio_api):
-        # Covers RuntimeError (FAILED/CANCELED) and transport errors that
-        # execute_query_iter can raise alongside DremioAPIException.
+        # RuntimeError (FAILED/CANCELED) and transport errors must also fall back.
         dremio_api.edition = DremioEdition.ENTERPRISE
         dremio_api.execute_query_iter = Mock(
             side_effect=RuntimeError("Query failed: planner exception")
@@ -163,7 +154,6 @@ class TestExtractAllQueriesDispatch:
 
     def test_enterprise_array_uses_new_query(self, dremio_api):
         dremio_api.edition = DremioEdition.ENTERPRISE
-        # Probe returns True (array schema).
         dremio_api._queried_datasets_is_array = True
         query = self._captured_query(dremio_api)
         assert "SYS.JOBS_RECENT" in query
@@ -172,7 +162,6 @@ class TestExtractAllQueriesDispatch:
 
     def test_enterprise_legacy_uses_legacy_query(self, dremio_api):
         dremio_api.edition = DremioEdition.ENTERPRISE
-        # Probe returns False (legacy VARCHAR schema).
         dremio_api._queried_datasets_is_array = False
         query = self._captured_query(dremio_api)
         assert "SYS.JOBS_RECENT" in query

--- a/metadata-ingestion/tests/unit/dremio/test_dremio_jobs_array.py
+++ b/metadata-ingestion/tests/unit/dremio/test_dremio_jobs_array.py
@@ -93,9 +93,8 @@ class TestSupportsArrayQueriedDatasetsProbe:
         assert dremio_api._supports_array_queried_datasets() is False
 
     def test_probe_falls_back_on_non_dremio_exception(self, dremio_api):
-        # execute_query_iter also raises RuntimeError for FAILED/CANCELED jobs
-        # and may surface transport errors; any failure must fall back to the
-        # legacy form so ingestion continues.
+        # Covers RuntimeError (FAILED/CANCELED) and transport errors that
+        # execute_query_iter can raise alongside DremioAPIException.
         dremio_api.edition = DremioEdition.ENTERPRISE
         dremio_api.execute_query_iter = Mock(
             side_effect=RuntimeError("Query failed: planner exception")

--- a/metadata-ingestion/tests/unit/dremio/test_dremio_jobs_array.py
+++ b/metadata-ingestion/tests/unit/dremio/test_dremio_jobs_array.py
@@ -1,0 +1,174 @@
+"""
+Tests for Dremio Software 26.1.0+ compatibility where
+sys.jobs_recent.queried_datasets changed from VARCHAR to ARRAY<VARCHAR>.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from datahub.ingestion.source.dremio.dremio_api import (
+    DremioAPIException,
+    DremioAPIOperations,
+    DremioEdition,
+)
+from datahub.ingestion.source.dremio.dremio_config import DremioSourceConfig
+from datahub.ingestion.source.dremio.dremio_reporting import DremioSourceReport
+from datahub.ingestion.source.dremio.dremio_sql_queries import DremioSQLQueries
+
+
+class TestQueriedDatasetsArrayQuery:
+    """Pure SQL-string assertions for the new array-aware EE/CE jobs query."""
+
+    def test_array_query_uses_array_size_predicate(self):
+        query = DremioSQLQueries.get_query_all_jobs_array()
+        # Legacy form used LENGTH(queried_datasets); 26.1.0+ exposes the
+        # column as ARRAY<VARCHAR>, so the WHERE clause must use ARRAY_SIZE.
+        assert "ARRAY_SIZE(queried_datasets)>0" in query
+        assert "LENGTH(queried_datasets)" not in query
+
+    def test_array_query_wraps_array_as_bracket_string(self):
+        query = DremioSQLQueries.get_query_all_jobs_array()
+        # DremioQuery._get_queried_datasets parses the SELECTED value as
+        # "[ds1,ds2]" — keep the output stable across schema versions.
+        assert "CONCAT('[', ARRAY_TO_STRING(queried_datasets, ','), ']')" in query
+
+    def test_array_query_targets_jobs_recent_not_history(self):
+        # The cloud query targets sys.project.history.jobs (different
+        # surface). EE/CE 26.1.0+ keeps sys.jobs_recent.
+        query = DremioSQLQueries.get_query_all_jobs_array()
+        assert "SYS.JOBS_RECENT" in query
+        assert "sys.project.history.jobs" not in query
+
+    def test_legacy_query_unchanged(self):
+        # Don't regress the legacy path — pre-26.1.0 Dremio still needs it.
+        query = DremioSQLQueries.get_query_all_jobs()
+        assert "LENGTH(queried_datasets)>0" in query
+        assert "ARRAY_SIZE(queried_datasets)" not in query
+
+
+class TestSupportsArrayQueriedDatasetsProbe:
+    @pytest.fixture
+    def dremio_api(self, monkeypatch):
+        mock_session = Mock()
+        monkeypatch.setattr("requests.Session", Mock(return_value=mock_session))
+        mock_session.post.return_value.json.return_value = {"token": "dummy-token"}
+        mock_session.post.return_value.status_code = 200
+
+        config = DremioSourceConfig(
+            hostname="dummy-host",
+            port=9047,
+            tls=False,
+            authentication_method="password",
+            username="dummy-user",
+            password="dummy-password",
+        )
+        report = DremioSourceReport()
+        api = DremioAPIOperations(config, report)
+        api.session = mock_session
+        return api
+
+    def test_cloud_skips_probe_and_returns_true(self, dremio_api):
+        dremio_api.edition = DremioEdition.CLOUD
+        # If we accidentally probed against Cloud (which uses a different
+        # jobs table entirely), the call would raise — assert we never get
+        # there.
+        dremio_api.execute_query_iter = Mock(
+            side_effect=AssertionError("Cloud must not run the EE/CE probe")
+        )
+        assert dremio_api._supports_array_queried_datasets() is True
+
+    def test_array_column_probe_succeeds(self, dremio_api):
+        dremio_api.edition = DremioEdition.ENTERPRISE
+        dremio_api.execute_query_iter = Mock(return_value=iter([{"sz": 0}]))
+        assert dremio_api._supports_array_queried_datasets() is True
+
+    def test_varchar_column_probe_raises_and_falls_back(self, dremio_api):
+        dremio_api.edition = DremioEdition.ENTERPRISE
+        dremio_api.execute_query_iter = Mock(
+            side_effect=DremioAPIException(
+                "Function ARRAY_SIZE not found with arguments [VARCHAR]"
+            )
+        )
+        assert dremio_api._supports_array_queried_datasets() is False
+
+    def test_probe_is_cached_after_success(self, dremio_api):
+        dremio_api.edition = DremioEdition.ENTERPRISE
+        mock = Mock(return_value=iter([{"sz": 0}]))
+        dremio_api.execute_query_iter = mock
+
+        assert dremio_api._supports_array_queried_datasets() is True
+        assert dremio_api._supports_array_queried_datasets() is True
+        assert mock.call_count == 1
+
+    def test_probe_is_cached_after_failure(self, dremio_api):
+        dremio_api.edition = DremioEdition.ENTERPRISE
+        mock = Mock(side_effect=DremioAPIException("type mismatch"))
+        dremio_api.execute_query_iter = mock
+
+        assert dremio_api._supports_array_queried_datasets() is False
+        assert dremio_api._supports_array_queried_datasets() is False
+        assert mock.call_count == 1
+
+
+class TestExtractAllQueriesDispatch:
+    """Verify the right SQL form is sent to Dremio per edition + probe result."""
+
+    @pytest.fixture
+    def dremio_api(self, monkeypatch):
+        mock_session = Mock()
+        monkeypatch.setattr("requests.Session", Mock(return_value=mock_session))
+        mock_session.post.return_value.json.return_value = {"token": "dummy-token"}
+        mock_session.post.return_value.status_code = 200
+
+        config = DremioSourceConfig(
+            hostname="dummy-host",
+            port=9047,
+            tls=False,
+            authentication_method="password",
+            username="dummy-user",
+            password="dummy-password",
+        )
+        report = DremioSourceReport()
+        api = DremioAPIOperations(config, report)
+        api.session = mock_session
+        api.start_time = None
+        api.end_time = None
+        return api
+
+    def _captured_query(self, dremio_api):
+        sent: list = []
+        dremio_api.execute_query_iter = Mock(
+            side_effect=lambda query: sent.append(query) or iter([])
+        )
+        list(dremio_api.extract_all_queries())
+        return sent[-1]
+
+    def test_cloud_uses_history_jobs_query(self, dremio_api):
+        dremio_api.edition = DremioEdition.CLOUD
+        query = self._captured_query(dremio_api)
+        assert "sys.project.history.jobs" in query
+
+    def test_enterprise_array_uses_new_query(self, dremio_api):
+        dremio_api.edition = DremioEdition.ENTERPRISE
+        # Probe returns True (array schema).
+        dremio_api._queried_datasets_is_array = True
+        query = self._captured_query(dremio_api)
+        assert "SYS.JOBS_RECENT" in query
+        assert "ARRAY_SIZE(queried_datasets)>0" in query
+        assert "CONCAT('[', ARRAY_TO_STRING(queried_datasets, ','), ']')" in query
+
+    def test_enterprise_legacy_uses_legacy_query(self, dremio_api):
+        dremio_api.edition = DremioEdition.ENTERPRISE
+        # Probe returns False (legacy VARCHAR schema).
+        dremio_api._queried_datasets_is_array = False
+        query = self._captured_query(dremio_api)
+        assert "SYS.JOBS_RECENT" in query
+        assert "LENGTH(queried_datasets)>0" in query
+        assert "ARRAY_SIZE(queried_datasets)" not in query
+
+    def test_community_array_uses_new_query(self, dremio_api):
+        dremio_api.edition = DremioEdition.COMMUNITY
+        dremio_api._queried_datasets_is_array = True
+        query = self._captured_query(dremio_api)
+        assert "ARRAY_SIZE(queried_datasets)>0" in query


### PR DESCRIPTION
## Summary

Dremio Software [26.1.0](https://docs.dremio.com/current/release-notes/version-260-release/) changed `sys.jobs_recent.queried_datasets` from `VARCHAR` (a comma-separated bracket string) to `ARRAY<VARCHAR>`. The existing EE/CE jobs query used `LENGTH(queried_datasets)` and selected the column raw, both of which fail at runtime against the array type with errors like:

```
Function ARRAY_SIZE not found with arguments [VARCHAR]
```

This broke usage/lineage ingestion for users upgrading their Dremio cluster to 26.1.0+, with no opt-out short of disabling the extraction entirely.

## Changes

- Add a one-shot runtime probe `_supports_array_queried_datasets` that issues a minimal `SELECT ARRAY_SIZE(queried_datasets) FROM SYS.JOBS_RECENT LIMIT 1` and caches the result on the API client. Probe runs once per ingestion process; subsequent calls hit the cached boolean.
- The probe catches `Exception` broadly: `execute_query_iter` can raise `DremioAPIException` (SQL-level type-mismatch on legacy VARCHAR), `RuntimeError` (job FAILED/CANCELED), or network/transport errors. Any failure -> assume legacy; the real jobs query will raise a meaningful error later if the underlying problem isn't the schema version.
- On probe success, use new `get_query_all_jobs_array` which mirrors the cloud query (`CONCAT('[', ARRAY_TO_STRING(queried_datasets, ','), ']')`) so the downstream parser (`DremioQuery._get_queried_datasets`) consumes a stable bracket-string regardless of server version.
- On probe failure (Dremio < 26.1.0, or no jobs visible), fall back to the existing VARCHAR-shaped query unchanged.
- Cloud Dremio always uses `get_query_all_jobs_cloud` — no probe needed there.

## Tests

- `tests/unit/dremio/test_dremio_jobs_array.py`:
  - `TestQueriedDatasetsArrayQuery` — SQL string assertions on the new array-form query.
  - `TestSupportsArrayQueriedDatasetsProbe` — probe caching, cloud edition short-circuit, the `DremioAPIException` fallback path, and the `RuntimeError` fallback path (covers `execute_query_iter`'s FAILED/CANCELED job-state raises).
  - `TestExtractAllQueriesDispatch` — verifies the right SQL is dispatched for each (edition, probe-result) combination.
- `test_extract_all_queries` in `test_dremio_api_pagination.py` pins `_queried_datasets_is_array=True` so the new probe doesn't consume the mocked iterator under existing tests.

## Docs

No `updating-datahub.md` entry: this is a forward-compat fix that auto-detects the server schema and keeps the externally-observable output (bracket-string `queried_datasets`) identical across Dremio versions. There is no behavior or configuration change for users to act on.

## Checklist

- [x] PR conforms to the Contributing Guideline (especially PR Title Format)
- [x] Tests added
- [ ] Docs added (`updating-datahub.md`) — N/A, see Docs section above
- [ ] Behavior-change entry in `updating-datahub.md` — N/A, no behavior change

Made with [Cursor](https://cursor.com)