### PR TITLE
feat(ingestion/dremio): map RESTCATALOG / Polaris / Unity / BigQuery / HANA source types

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -60,6 +60,8 @@ Requirements:
 
 - **(Ingestion / dbt)** dbt test assertion entities now emit an `ownership` aspect when the dbt test node has explicit owner metadata (`meta.owner` / `config.meta.owner`).
 
+- **(Ingestion / Dremio)** Added DataHub platform mappings for several Dremio source types that previously fell through to a lowercased default: `BIGQUERY → bigquery`, `RESTCATALOG → iceberg` (Apache Polaris OSS, Nessie with Iceberg REST, AWS Glue Iceberg REST, S3 Tables, Confluent Tableflow, Microsoft OneLake), `SAPHANA → hana`, `SNOWFLAKEOPENCATALOG → iceberg` (Snowflake's hosted Polaris), and `UNITY → databricks` (Databricks Unity Catalog). Existing Dremio recipes that previously produced lineage URNs like `urn:li:dataPlatform:restcatalog` will now produce `urn:li:dataPlatform:iceberg` (etc.); update any URN-based lineage / dashboards that depend on the old values.
+
 ## v1.6.0
 
 Requirements:

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -60,7 +60,7 @@ Requirements:
 
 - **(Ingestion / dbt)** dbt test assertion entities now emit an `ownership` aspect when the dbt test node has explicit owner metadata (`meta.owner` / `config.meta.owner`).
 
-- **(Ingestion / Dremio)** Added DataHub platform mappings for several Dremio source types that previously fell through to a lowercased default: `BIGQUERY → bigquery`, `RESTCATALOG → iceberg` (Apache Polaris OSS, Nessie with Iceberg REST, AWS Glue Iceberg REST, S3 Tables, Confluent Tableflow, Microsoft OneLake), `SAPHANA → hana`, `SNOWFLAKEOPENCATALOG → iceberg` (Snowflake's hosted Polaris), and `UNITY → databricks` (Databricks Unity Catalog). Existing Dremio recipes that previously produced lineage URNs like `urn:li:dataPlatform:restcatalog` will now produce `urn:li:dataPlatform:iceberg` (etc.); update any URN-based lineage / dashboards that depend on the old values.
+- #17648 **(Ingestion / Dremio)** Added DataHub platform mappings for several Dremio source types that previously fell through to a lowercased default: `BIGQUERY → bigquery`, `RESTCATALOG → iceberg` (Apache Polaris OSS, Nessie with Iceberg REST, AWS Glue Iceberg REST, S3 Tables, Confluent Tableflow, Microsoft OneLake), `SAPHANA → hana`, `SNOWFLAKEOPENCATALOG → iceberg` (Snowflake's hosted Polaris), and `UNITY → databricks` (Databricks Unity Catalog). Existing Dremio recipes that previously produced lineage URNs like `urn:li:dataPlatform:restcatalog` will now produce `urn:li:dataPlatform:iceberg` (etc.); update any URN-based lineage / dashboards that depend on the old values.
 
 ## v1.6.0
 

--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_datahub_source_mapping.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_datahub_source_mapping.py
@@ -79,6 +79,12 @@ class DremioToDataHubSourceTypeMapping:
 
     FILE_OBJECT_STORAGE_TYPES = {
         "ADL",
+        # AZURE_STORAGE is also listed in DATABASE_SOURCE_TYPES above.
+        # get_category checks DATABASE_SOURCE_TYPES first, so AZURE_STORAGE
+        # always resolves to "database" — which is the dot-notation path
+        # users hit in practice with Dremio's Azure Storage source
+        # (container/database/table). It's kept in this set so any future
+        # call site that asks "is this object storage?" still says yes.
         "AZURE_STORAGE",
         "GCS",
         "HDFS",
@@ -120,6 +126,15 @@ class DremioToDataHubSourceTypeMapping:
     ) -> None:
         """
         Add a new source type if not in the map (e.g., Dremio ARP).
+
+        `category` controls categorization for `get_category` / URN dispatch:
+        - "file_object_storage": registers as slash-notation file storage.
+        - any other truthy value (e.g. "database"): registers as dot-notation
+          database storage.
+        - None (default): only `SOURCE_TYPE_MAPPING` is updated; `get_category`
+          will return "unknown" for this type, which means URN building falls
+          back to its generic path. Pass an explicit `category` if you want
+          container-aware URN dispatch for this source.
         """
         dremio_source_type = dremio_source_type.upper()
         DremioToDataHubSourceTypeMapping.SOURCE_TYPE_MAPPING[dremio_source_type] = (

--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_datahub_source_mapping.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_datahub_source_mapping.py
@@ -6,12 +6,9 @@ class DremioToDataHubSourceTypeMapping:
     Dremio source type to the Datahub source type mapping.
     """
 
+    # Keys are the `type` field returned by Dremio's Catalog API
+    # (https://docs.dremio.com/current/reference/api/catalog/source/).
     SOURCE_TYPE_MAPPING = {
-        # Dremio source types -> DataHub platform names.
-        # Source type strings come from Dremio's Catalog API (the `type`
-        # field on a source object). See
-        # https://docs.dremio.com/current/reference/api/catalog/source/ and
-        # https://docs.dremio.com/dremio-cloud/api/catalog/source/.
         "ADL": "abfs",
         "AMAZONELASTIC": "elasticsearch",
         "AWSGLUE": "glue",
@@ -32,20 +29,16 @@ class DremioToDataHubSourceTypeMapping:
         "ORACLE": "oracle",
         "POSTGRES": "postgres",
         "REDSHIFT": "redshift",
-        # Iceberg REST Catalog source: covers Apache Polaris OSS, Nessie
-        # with Iceberg REST, AWS Glue Iceberg REST, S3 Tables, Confluent
-        # Tableflow, and Microsoft OneLake (all served as Iceberg tables).
+        # Polaris OSS, Nessie+REST, Glue Iceberg REST, S3 Tables,
+        # Tableflow, OneLake — all surface as Iceberg tables.
         "RESTCATALOG": "iceberg",
         "S3": "s3",
         "SAPHANA": "hana",
         "SNOWFLAKE": "snowflake",
-        # Snowflake Open Catalog (managed Polaris): also serves Iceberg
-        # tables, so map to the iceberg platform rather than snowflake to
-        # match how the data is physically materialised.
+        # Snowflake Open Catalog (managed Polaris) serves Iceberg, not Snowflake tables.
         "SNOWFLAKEOPENCATALOG": "iceberg",
         "SYNAPSE": "mssql",
         "TERADATA": "teradata",
-        # Databricks Unity Catalog source.
         "UNITY": "databricks",
         "VERTICA": "vertica",
     }
@@ -79,12 +72,9 @@ class DremioToDataHubSourceTypeMapping:
 
     FILE_OBJECT_STORAGE_TYPES = {
         "ADL",
-        # AZURE_STORAGE is also listed in DATABASE_SOURCE_TYPES above.
-        # get_category checks DATABASE_SOURCE_TYPES first, so AZURE_STORAGE
-        # always resolves to "database" — which is the dot-notation path
-        # users hit in practice with Dremio's Azure Storage source
-        # (container/database/table). It's kept in this set so any future
-        # call site that asks "is this object storage?" still says yes.
+        # AZURE_STORAGE also lives in DATABASE_SOURCE_TYPES. get_category
+        # picks "database" first (matching the dot-notation path users
+        # actually hit); membership here keeps "is object storage?" honest.
         "AZURE_STORAGE",
         "GCS",
         "HDFS",
@@ -124,18 +114,10 @@ class DremioToDataHubSourceTypeMapping:
         datahub_source_type: str,
         category: Optional[str] = None,
     ) -> None:
-        """
-        Add a new source type if not in the map (e.g., Dremio ARP).
-
-        `category` controls categorization for `get_category` / URN dispatch:
-        - "file_object_storage": registers as slash-notation file storage.
-        - any other truthy value (e.g. "database"): registers as dot-notation
-          database storage.
-        - None (default): only `SOURCE_TYPE_MAPPING` is updated; `get_category`
-          will return "unknown" for this type, which means URN building falls
-          back to its generic path. Pass an explicit `category` if you want
-          container-aware URN dispatch for this source.
-        """
+        """Register a Dremio source type (e.g. an ARP). Pass `category` =
+        "database" or "file_object_storage" to control URN dispatch; with
+        `category=None` the platform name resolves but `get_category`
+        returns "unknown", so URN building falls back to the generic path."""
         dremio_source_type = dremio_source_type.upper()
         DremioToDataHubSourceTypeMapping.SOURCE_TYPE_MAPPING[dremio_source_type] = (
             datahub_source_type

--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_datahub_source_mapping.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_datahub_source_mapping.py
@@ -7,11 +7,16 @@ class DremioToDataHubSourceTypeMapping:
     """
 
     SOURCE_TYPE_MAPPING = {
-        # Dremio source types
+        # Dremio source types -> DataHub platform names.
+        # Source type strings come from Dremio's Catalog API (the `type`
+        # field on a source object). See
+        # https://docs.dremio.com/current/reference/api/catalog/source/ and
+        # https://docs.dremio.com/dremio-cloud/api/catalog/source/.
         "ADL": "abfs",
         "AMAZONELASTIC": "elasticsearch",
         "AWSGLUE": "glue",
         "AZURE_STORAGE": "abfs",
+        "BIGQUERY": "bigquery",
         "DB2": "db2",
         "DREMIOTODREMIO": "dremio",
         "ELASTIC": "elasticsearch",
@@ -27,10 +32,21 @@ class DremioToDataHubSourceTypeMapping:
         "ORACLE": "oracle",
         "POSTGRES": "postgres",
         "REDSHIFT": "redshift",
+        # Iceberg REST Catalog source: covers Apache Polaris OSS, Nessie
+        # with Iceberg REST, AWS Glue Iceberg REST, S3 Tables, Confluent
+        # Tableflow, and Microsoft OneLake (all served as Iceberg tables).
+        "RESTCATALOG": "iceberg",
         "S3": "s3",
+        "SAPHANA": "hana",
         "SNOWFLAKE": "snowflake",
+        # Snowflake Open Catalog (managed Polaris): also serves Iceberg
+        # tables, so map to the iceberg platform rather than snowflake to
+        # match how the data is physically materialised.
+        "SNOWFLAKEOPENCATALOG": "iceberg",
         "SYNAPSE": "mssql",
         "TERADATA": "teradata",
+        # Databricks Unity Catalog source.
+        "UNITY": "databricks",
         "VERTICA": "vertica",
     }
 
@@ -38,6 +54,7 @@ class DremioToDataHubSourceTypeMapping:
         "AMAZONELASTIC",
         "AWSGLUE",
         "AZURE_STORAGE",
+        "BIGQUERY",
         "DB2",
         "DREMIOTODREMIO",
         "ELASTIC",
@@ -50,9 +67,13 @@ class DremioToDataHubSourceTypeMapping:
         "ORACLE",
         "POSTGRES",
         "REDSHIFT",
+        "RESTCATALOG",
+        "SAPHANA",
         "SNOWFLAKE",
+        "SNOWFLAKEOPENCATALOG",
         "SYNAPSE",
         "TERADATA",
+        "UNITY",
         "VERTICA",
     }
 

--- a/metadata-ingestion/tests/unit/dremio/test_dremio_source_type_mapping.py
+++ b/metadata-ingestion/tests/unit/dremio/test_dremio_source_type_mapping.py
@@ -64,3 +64,52 @@ def test_unknown_source_type_falls_back_to_lowercase_name() -> None:
         == "future_source"
     )
     assert DremioToDataHubSourceTypeMapping.get_category("FUTURE_SOURCE") == "unknown"
+
+
+def test_azure_storage_resolves_to_database_despite_dual_membership() -> None:
+    # AZURE_STORAGE is intentionally in both DATABASE_SOURCE_TYPES and
+    # FILE_OBJECT_STORAGE_TYPES; the check order in get_category makes
+    # "database" win. Pin that so accidental reordering trips the test.
+    assert DremioToDataHubSourceTypeMapping.get_category("AZURE_STORAGE") == "database"
+
+
+@pytest.fixture
+def restore_mapping_state():
+    # add_mapping mutates class-level state; snapshot and restore so tests
+    # don't leak into each other.
+    snapshot_map = dict(DremioToDataHubSourceTypeMapping.SOURCE_TYPE_MAPPING)
+    snapshot_db = set(DremioToDataHubSourceTypeMapping.DATABASE_SOURCE_TYPES)
+    snapshot_fs = set(DremioToDataHubSourceTypeMapping.FILE_OBJECT_STORAGE_TYPES)
+    yield
+    DremioToDataHubSourceTypeMapping.SOURCE_TYPE_MAPPING.clear()
+    DremioToDataHubSourceTypeMapping.SOURCE_TYPE_MAPPING.update(snapshot_map)
+    DremioToDataHubSourceTypeMapping.DATABASE_SOURCE_TYPES.clear()
+    DremioToDataHubSourceTypeMapping.DATABASE_SOURCE_TYPES.update(snapshot_db)
+    DremioToDataHubSourceTypeMapping.FILE_OBJECT_STORAGE_TYPES.clear()
+    DremioToDataHubSourceTypeMapping.FILE_OBJECT_STORAGE_TYPES.update(snapshot_fs)
+
+
+class TestAddMapping:
+    def test_database_category_registers_for_dot_dispatch(self, restore_mapping_state):
+        DremioToDataHubSourceTypeMapping.add_mapping("MYDB", "mydb", "database")
+        assert DremioToDataHubSourceTypeMapping.get_datahub_platform("MYDB") == "mydb"
+        assert DremioToDataHubSourceTypeMapping.get_category("MYDB") == "database"
+
+    def test_file_object_storage_category_registers_for_slash_dispatch(
+        self, restore_mapping_state
+    ):
+        DremioToDataHubSourceTypeMapping.add_mapping(
+            "MYSTORE", "mystore", "file_object_storage"
+        )
+        assert (
+            DremioToDataHubSourceTypeMapping.get_category("MYSTORE")
+            == "file_object_storage"
+        )
+
+    def test_none_category_leaves_type_uncategorized(self, restore_mapping_state):
+        # Documented surprise: without an explicit category the new mapping
+        # works for get_datahub_platform but not get_category. Callers that
+        # need container-aware URN dispatch must pass an explicit category.
+        DremioToDataHubSourceTypeMapping.add_mapping("MYARP", "myarp")
+        assert DremioToDataHubSourceTypeMapping.get_datahub_platform("MYARP") == "myarp"
+        assert DremioToDataHubSourceTypeMapping.get_category("MYARP") == "unknown"

--- a/metadata-ingestion/tests/unit/dremio/test_dremio_source_type_mapping.py
+++ b/metadata-ingestion/tests/unit/dremio/test_dremio_source_type_mapping.py
@@ -1,12 +1,5 @@
-"""
-Tests for `DremioToDataHubSourceTypeMapping`.
-
-These cover the table-driven mapping/category behavior that downstream
-URN construction depends on. The intent is to lock in canonical Dremio
-source-type strings (as documented in Dremio's Catalog API reference)
-against their DataHub platform names — so adding a new entry can't
-silently break categorization (database vs. file_object_storage).
-"""
+"""Pin canonical Dremio source-type strings against DataHub platform names
+and categories that URN construction depends on."""
 
 import pytest
 
@@ -19,8 +12,6 @@ from datahub.ingestion.source.dremio.dremio_datahub_source_mapping import (
     "dremio_type,expected_platform",
     [
         ("BIGQUERY", "bigquery"),
-        # Covers Polaris OSS, Nessie+REST, AWS Glue Iceberg REST, S3 Tables,
-        # Confluent Tableflow, Microsoft OneLake.
         ("RESTCATALOG", "iceberg"),
         ("SAPHANA", "hana"),
         ("SNOWFLAKEOPENCATALOG", "iceberg"),
@@ -41,14 +32,11 @@ def test_new_source_types_map_to_expected_platforms(
     ["BIGQUERY", "RESTCATALOG", "SAPHANA", "SNOWFLAKEOPENCATALOG", "UNITY"],
 )
 def test_new_source_types_categorized_as_database(dremio_type: str) -> None:
-    # These all use dot-notation database/schema/table paths in Dremio,
-    # not slash-notation file paths.
+    # Dot-notation path sources, not slash-notation file paths.
     assert DremioToDataHubSourceTypeMapping.get_category(dremio_type) == "database"
 
 
 def test_case_insensitive_lookup() -> None:
-    # Dremio returns SOURCE TYPES uppercase, but recipes / user input may
-    # not. Already covered by the implementation but worth pinning.
     assert (
         DremioToDataHubSourceTypeMapping.get_datahub_platform("restcatalog")
         == "iceberg"
@@ -57,8 +45,7 @@ def test_case_insensitive_lookup() -> None:
 
 
 def test_unknown_source_type_falls_back_to_lowercase_name() -> None:
-    # Behavior contract: unknown types pass through as the lowercased
-    # Dremio name with an unknown category — used by ARP / custom sources.
+    # ARP / custom sources rely on this lowercase+unknown fallback.
     assert (
         DremioToDataHubSourceTypeMapping.get_datahub_platform("FUTURE_SOURCE")
         == "future_source"
@@ -67,16 +54,13 @@ def test_unknown_source_type_falls_back_to_lowercase_name() -> None:
 
 
 def test_azure_storage_resolves_to_database_despite_dual_membership() -> None:
-    # AZURE_STORAGE is intentionally in both DATABASE_SOURCE_TYPES and
-    # FILE_OBJECT_STORAGE_TYPES; the check order in get_category makes
-    # "database" win. Pin that so accidental reordering trips the test.
+    # AZURE_STORAGE is in both sets; "database" wins via get_category check order.
     assert DremioToDataHubSourceTypeMapping.get_category("AZURE_STORAGE") == "database"
 
 
 @pytest.fixture
 def restore_mapping_state():
-    # add_mapping mutates class-level state; snapshot and restore so tests
-    # don't leak into each other.
+    # add_mapping mutates class state — snapshot/restore to isolate tests.
     snapshot_map = dict(DremioToDataHubSourceTypeMapping.SOURCE_TYPE_MAPPING)
     snapshot_db = set(DremioToDataHubSourceTypeMapping.DATABASE_SOURCE_TYPES)
     snapshot_fs = set(DremioToDataHubSourceTypeMapping.FILE_OBJECT_STORAGE_TYPES)
@@ -107,9 +91,7 @@ class TestAddMapping:
         )
 
     def test_none_category_leaves_type_uncategorized(self, restore_mapping_state):
-        # Documented surprise: without an explicit category the new mapping
-        # works for get_datahub_platform but not get_category. Callers that
-        # need container-aware URN dispatch must pass an explicit category.
+        # category=None: platform resolves, get_category returns "unknown".
         DremioToDataHubSourceTypeMapping.add_mapping("MYARP", "myarp")
         assert DremioToDataHubSourceTypeMapping.get_datahub_platform("MYARP") == "myarp"
         assert DremioToDataHubSourceTypeMapping.get_category("MYARP") == "unknown"

--- a/metadata-ingestion/tests/unit/dremio/test_dremio_source_type_mapping.py
+++ b/metadata-ingestion/tests/unit/dremio/test_dremio_source_type_mapping.py
@@ -1,0 +1,66 @@
+"""
+Tests for `DremioToDataHubSourceTypeMapping`.
+
+These cover the table-driven mapping/category behavior that downstream
+URN construction depends on. The intent is to lock in canonical Dremio
+source-type strings (as documented in Dremio's Catalog API reference)
+against their DataHub platform names — so adding a new entry can't
+silently break categorization (database vs. file_object_storage).
+"""
+
+import pytest
+
+from datahub.ingestion.source.dremio.dremio_datahub_source_mapping import (
+    DremioToDataHubSourceTypeMapping,
+)
+
+
+@pytest.mark.parametrize(
+    "dremio_type,expected_platform",
+    [
+        ("BIGQUERY", "bigquery"),
+        # Covers Polaris OSS, Nessie+REST, AWS Glue Iceberg REST, S3 Tables,
+        # Confluent Tableflow, Microsoft OneLake.
+        ("RESTCATALOG", "iceberg"),
+        ("SAPHANA", "hana"),
+        ("SNOWFLAKEOPENCATALOG", "iceberg"),
+        ("UNITY", "databricks"),
+    ],
+)
+def test_new_source_types_map_to_expected_platforms(
+    dremio_type: str, expected_platform: str
+) -> None:
+    assert (
+        DremioToDataHubSourceTypeMapping.get_datahub_platform(dremio_type)
+        == expected_platform
+    )
+
+
+@pytest.mark.parametrize(
+    "dremio_type",
+    ["BIGQUERY", "RESTCATALOG", "SAPHANA", "SNOWFLAKEOPENCATALOG", "UNITY"],
+)
+def test_new_source_types_categorized_as_database(dremio_type: str) -> None:
+    # These all use dot-notation database/schema/table paths in Dremio,
+    # not slash-notation file paths.
+    assert DremioToDataHubSourceTypeMapping.get_category(dremio_type) == "database"
+
+
+def test_case_insensitive_lookup() -> None:
+    # Dremio returns SOURCE TYPES uppercase, but recipes / user input may
+    # not. Already covered by the implementation but worth pinning.
+    assert (
+        DremioToDataHubSourceTypeMapping.get_datahub_platform("restcatalog")
+        == "iceberg"
+    )
+    assert DremioToDataHubSourceTypeMapping.get_category("restcatalog") == "database"
+
+
+def test_unknown_source_type_falls_back_to_lowercase_name() -> None:
+    # Behavior contract: unknown types pass through as the lowercased
+    # Dremio name with an unknown category — used by ARP / custom sources.
+    assert (
+        DremioToDataHubSourceTypeMapping.get_datahub_platform("FUTURE_SOURCE")
+        == "future_source"
+    )
+    assert DremioToDataHubSourceTypeMapping.get_category("FUTURE_SOURCE") == "unknown"


### PR DESCRIPTION
## Summary

Dremio's [Catalog API](https://docs.dremio.com/dremio-cloud/api/catalog/source/) publishes a fixed enum of supported source types. Several of those — notably the unified `RESTCATALOG` connector (Apache Polaris OSS, Nessie+REST, AWS Glue Iceberg REST, S3 Tables, Confluent Tableflow, Microsoft OneLake), plus `BIGQUERY`, `SAPHANA`, `SNOWFLAKEOPENCATALOG`, and `UNITY` — were missing from the Dremio → DataHub platform map.

Without explicit entries, `get_datahub_platform` lowercased the unknown source type (so a Polaris source became `urn:li:dataPlatform:restcatalog`, Unity Catalog became `unity`, etc.), and `get_category` returned `"unknown"`, which silently disables the container-vs-file dispatch used by URN building and cross-platform lineage.

## Changes

Add the documented mappings to `DremioToDataHubSourceTypeMapping`:

| Dremio source type | DataHub platform | Category | Notes |
|---|---|---|---|
| `BIGQUERY` | `bigquery` | database | Dremio Cloud only |
| `RESTCATALOG` | `iceberg` | database | Polaris OSS, Nessie+REST, Glue Iceberg REST, S3 Tables, Tableflow, OneLake |
| `SAPHANA` | `hana` | database | EE only |
| `SNOWFLAKEOPENCATALOG` | `iceberg` | database | Snowflake-hosted Polaris (Iceberg REST) |
| `UNITY` | `databricks` | database | Databricks Unity Catalog |

## Behavior change

Existing deployments that ingested any of these sources will see their dataset URNs migrate to the correct `urn:li:dataPlatform:<correct>` value. Previously these sources lived under URN platforms like `restcatalog` and `unity` which don't exist in DataHub's `DataPlatformInfo` registry — so cross-platform lineage was not working anyway.

To avoid orphaned entities post-upgrade, enable stateful ingestion with stale entity removal on the next run, or perform a one-time URN rewrite for the affected datasets.

## Tests

- `tests/unit/dremio/test_dremio_source_type_mapping.py`:
  - `test_new_source_types_map_to_expected_platforms` — each new type returns its target platform.
  - `test_new_source_types_categorized_as_database` — each is classified as `database` for URN/path dispatch.
  - `test_case_insensitive_lookup` — mixed-case inputs still resolve.
  - `test_unknown_source_type_falls_back_to_lowercase_name` — pinning the historical fallback so regressions break the build.

## Docs

- Added an "Other Notable Changes" entry to `docs/how/updating-datahub.md`.

## Checklist

- [x] PR conforms to the Contributing Guideline (especially PR Title Format)
- [x] Tests added
- [x] Docs added (`updating-datahub.md`)
- [x] Behavior-change entry in `updating-datahub.md`

Made with [Cursor](https://cursor.com)