### PR TITLE
fix(ingest): prevent DEBUG log explosion from per-aspect curl logging

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -835,15 +835,6 @@ class DataHubRestEmitter(Closeable, Emitter):
             )
 
         if trace_data:
-            if _DATAHUB_EMITTER_TRACE:
-                try:
-                    logger.info(
-                        f"MCP trace_id={trace_data.trace_id} "
-                        f"timestamp={trace_data.extract_timestamp()} "
-                        f"urn={mcp.entityUrn} aspect={mcp.aspectName}"
-                    )
-                except Exception as e:
-                    logger.debug(f"Failed to log trace data: {e}")
             if self._should_trace(emit_mode):
                 self._await_status(
                     [trace_data],
@@ -947,15 +938,6 @@ class DataHubRestEmitter(Closeable, Emitter):
                     data.trace_id if data else None,
                 )
                 if data is not None:
-                    if _DATAHUB_EMITTER_TRACE:
-                        try:
-                            logger.info(
-                                f"MCP batch trace_id={data.trace_id} "
-                                f"timestamp={data.extract_timestamp()} "
-                                f"urns={list(data.data.keys())}"
-                            )
-                        except Exception as e:
-                            logger.debug(f"Failed to log trace data: {e}")
                     trace_data.append(data)
 
         if trace_data and self._should_trace(emit_mode):
@@ -1042,15 +1024,6 @@ class DataHubRestEmitter(Closeable, Emitter):
                 data.trace_id if data else None,
             )
             if data is not None:
-                if _DATAHUB_EMITTER_TRACE:
-                    try:
-                        logger.info(
-                            f"MCP batch trace_id={data.trace_id} "
-                            f"timestamp={data.extract_timestamp()} "
-                            f"urns={list(data.data.keys())}"
-                        )
-                    except Exception as e:
-                        logger.debug(f"Failed to log trace data: {e}")
                 trace_data.append(data)
 
         return trace_data
@@ -1084,18 +1057,27 @@ class DataHubRestEmitter(Closeable, Emitter):
             logger.warning(
                 f"Apparent payload size exceeded {INGEST_MAX_PAYLOAD_BYTES}, might fail with an exception due to the size"
             )
+        if _DATAHUB_EMITTER_TRACE:
+            logger.debug(
+                "Attempting to emit aspect (size: %s) to DataHub GMS; using curl equivalent to:\n%s",
+                payload_size,
+                make_curl_command(self._session, method, url, payload),
+            )
         try:
             method_func = getattr(self._session, method.lower())
             response = method_func(url, data=payload) if payload else method_func(url)
             response.raise_for_status()
             return response
         except HTTPError as e:
-            logger.debug(
-                "Failed to emit to DataHub GMS (status=%s, payload_size=%d bytes); curl equivalent:\n%s",
-                response.status_code,
-                payload_size,
-                make_curl_command(self._session, method, url, payload),
-            )
+            # When tracing is on the curl equivalent was already logged before the
+            # request, so only log it here to avoid emitting it twice on failure.
+            if not _DATAHUB_EMITTER_TRACE:
+                logger.debug(
+                    "Failed to emit to DataHub GMS (status=%s, payload_size=%d bytes); curl equivalent:\n%s",
+                    response.status_code,
+                    payload_size,
+                    make_curl_command(self._session, method, url, payload),
+                )
             try:
                 info: Dict = response.json()
 
@@ -1121,11 +1103,12 @@ class DataHubRestEmitter(Closeable, Emitter):
                     "Unable to emit metadata to DataHub GMS", {"message": str(e)}
                 ) from e
         except RequestException as e:
-            logger.debug(
-                "Failed to emit to DataHub GMS (no response received, payload_size=%d bytes); curl equivalent:\n%s",
-                payload_size,
-                make_curl_command(self._session, method, url, payload),
-            )
+            if not _DATAHUB_EMITTER_TRACE:
+                logger.debug(
+                    "Failed to emit to DataHub GMS (no response received, payload_size=%d bytes); curl equivalent:\n%s",
+                    payload_size,
+                    make_curl_command(self._session, method, url, payload),
+                )
             raise OperationalError(
                 "Unable to emit metadata to DataHub GMS", {"message": str(e)}
             ) from e

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -841,6 +841,15 @@ class DataHubRestEmitter(Closeable, Emitter):
             )
 
         if trace_data:
+            if _DATAHUB_EMITTER_TRACE:
+                try:
+                    logger.info(
+                        f"MCP trace_id={trace_data.trace_id} "
+                        f"timestamp={trace_data.extract_timestamp()} "
+                        f"urn={mcp.entityUrn} aspect={mcp.aspectName}"
+                    )
+                except Exception as e:
+                    logger.debug(f"Failed to log trace data: {e}")
             if self._should_trace(emit_mode):
                 self._await_status(
                     [trace_data],
@@ -945,6 +954,15 @@ class DataHubRestEmitter(Closeable, Emitter):
                     chunk.urn_aspects,
                 )
                 if data is not None:
+                    if _DATAHUB_EMITTER_TRACE:
+                        try:
+                            logger.info(
+                                f"MCP batch trace_id={data.trace_id} "
+                                f"timestamp={data.extract_timestamp()} "
+                                f"urns={list(data.data.keys())}"
+                            )
+                        except Exception as e:
+                            logger.debug(f"Failed to log trace data: {e}")
                     trace_data.append(data)
 
         if trace_data and self._should_trace(emit_mode):

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -7,7 +7,7 @@ import re
 import socket
 import time
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import auto
 from json.decoder import JSONDecodeError
@@ -441,15 +441,21 @@ class RequestsSessionConfig(ConfigModel):
 class _Chunk:
     items: List[str]
     total_bytes: int = 0
+    # (urn, aspect) for each item, kept parallel to `items` so the batch emit
+    # path can log which entities were sent without re-parsing the serialized
+    # payload.
+    urn_aspects: List[Tuple[Optional[str], Optional[str]]] = field(default_factory=list)
 
-    def add_item(self, item: str) -> bool:
-        item_bytes = len(item.encode())
-        if not self.items:  # Always add at least one item even if over byte limit
-            self.items.append(item)
-            self.total_bytes += item_bytes
-            return True
+    def add_item(
+        self,
+        item: str,
+        urn_aspect: Optional[Tuple[Optional[str], Optional[str]]] = None,
+    ) -> bool:
+        # Always add at least one item even if over byte limit
         self.items.append(item)
-        self.total_bytes += item_bytes
+        self.total_bytes += len(item.encode())
+        if urn_aspect is not None:
+            self.urn_aspects.append(urn_aspect)
         return True
 
     @staticmethod
@@ -908,7 +914,7 @@ class DataHubRestEmitter(Closeable, Emitter):
                     batches[key].append(new_chunk)
                     current_chunk = new_chunk
 
-                current_chunk.add_item(serialized_item)
+                current_chunk.add_item(serialized_item, (mcp.entityUrn, mcp.aspectName))
 
         trace_data: List[TraceData] = []
         # Chunks are grouped by (method, url), so track a global index/total to
@@ -929,13 +935,14 @@ class DataHubRestEmitter(Closeable, Emitter):
                     else None
                 )
                 logger.debug(
-                    "Sent MCP batch chunk=%d/%d method=%s items=%d status=%d trace_id=%s",
+                    "Sent MCP batch chunk=%d/%d method=%s items=%d status=%d trace_id=%s urns=%s",
                     chunk_index,
                     total_chunks,
                     method,
                     len(chunk.items),
                     response.status_code,
                     data.trace_id if data else None,
+                    chunk.urn_aspects,
                 )
                 if data is not None:
                     trace_data.append(data)
@@ -1016,12 +1023,13 @@ class DataHubRestEmitter(Closeable, Emitter):
                 else None
             )
             logger.debug(
-                "Sent MCP batch chunk=%d/%d items=%d status=%d trace_id=%s",
+                "Sent MCP batch chunk=%d/%d items=%d status=%d trace_id=%s urns=%s",
                 chunk_index,
                 len(chunks),
                 len(mcp_chunk),
                 response.status_code,
                 data.trace_id if data else None,
+                [(mcp.entityUrn, mcp.aspectName) for mcp in mcp_chunk],
             )
             if data is not None:
                 trace_data.append(data)

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -938,7 +938,7 @@ class DataHubRestEmitter(Closeable, Emitter):
                     else None
                 )
                 logger.debug(
-                    "Sent MCP batch successfully chunk=%d/%d method=%s items=%d status=%d trace_id=%s",
+                    "Sent MCP batch chunk=%d/%d method=%s items=%d status=%d trace_id=%s",
                     chunk_index,
                     total_chunks,
                     method,
@@ -1034,7 +1034,7 @@ class DataHubRestEmitter(Closeable, Emitter):
                 else None
             )
             logger.debug(
-                "Sent MCP batch successfully chunk=%d/%d items=%d status=%d trace_id=%s",
+                "Sent MCP batch chunk=%d/%d items=%d status=%d trace_id=%s",
                 chunk_index,
                 len(chunks),
                 len(mcp_chunk),

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -438,29 +438,36 @@ class RequestsSessionConfig(ConfigModel):
 
 
 @dataclass
+class _ChunkItem:
+    """A single serialized item in a batch chunk."""
+
+    payload: str
+    urn: Optional[str] = None
+    aspect_name: Optional[str] = None
+
+    @property
+    def byte_size(self) -> int:
+        return len(self.payload.encode())
+
+
+@dataclass
 class _Chunk:
-    items: List[str]
+    items: List[_ChunkItem] = field(default_factory=list)
     total_bytes: int = 0
-    # (urn, aspect) for each item, kept parallel to `items` so the batch emit
-    # path can log which entities were sent without re-parsing the serialized
-    # payload.
-    urn_aspects: List[Tuple[Optional[str], Optional[str]]] = field(default_factory=list)
 
     def add_item(
         self,
-        item: str,
-        urn_aspect: Optional[Tuple[Optional[str], Optional[str]]] = None,
-    ) -> bool:
-        # Always add at least one item even if over byte limit
+        payload: str,
+        urn: Optional[str] = None,
+        aspect_name: Optional[str] = None,
+    ) -> None:
+        item = _ChunkItem(payload=payload, urn=urn, aspect_name=aspect_name)
         self.items.append(item)
-        self.total_bytes += len(item.encode())
-        if urn_aspect is not None:
-            self.urn_aspects.append(urn_aspect)
-        return True
+        self.total_bytes += item.byte_size
 
     @staticmethod
     def join(chunk: "_Chunk") -> str:
-        return "[" + ",".join(chunk.items) + "]"
+        return "[" + ",".join(item.payload for item in chunk.items) + "]"
 
 
 class DataHubRestEmitter(Closeable, Emitter):
@@ -899,7 +906,7 @@ class DataHubRestEmitter(Closeable, Emitter):
         """
         # Group by entity URL and HTTP method
         batches: Dict[Tuple[str, str], List[_Chunk]] = defaultdict(
-            lambda: [_Chunk(items=[])]
+            lambda: [_Chunk()]
         )  # Initialize with one empty Chunk
 
         for mcp in mcps:
@@ -919,11 +926,11 @@ class DataHubRestEmitter(Closeable, Emitter):
                     current_chunk.total_bytes + item_bytes > INGEST_MAX_PAYLOAD_BYTES
                     or len(current_chunk.items) >= BATCH_INGEST_MAX_PAYLOAD_LENGTH
                 ):
-                    new_chunk = _Chunk(items=[])
+                    new_chunk = _Chunk()
                     batches[key].append(new_chunk)
                     current_chunk = new_chunk
 
-                current_chunk.add_item(serialized_item, (mcp.entityUrn, mcp.aspectName))
+                current_chunk.add_item(serialized_item, mcp.entityUrn, mcp.aspectName)
 
         trace_data: List[TraceData] = []
         # Chunks are grouped by (method, url), so track a global index/total to
@@ -951,7 +958,7 @@ class DataHubRestEmitter(Closeable, Emitter):
                     len(chunk.items),
                     response.status_code,
                     data.trace_id if data else None,
-                    chunk.urn_aspects,
+                    [(item.urn, item.aspect_name) for item in chunk.items],
                 )
                 if data is not None:
                     if _DATAHUB_EMITTER_TRACE:

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -739,7 +739,12 @@ class DataHubRestEmitter(Closeable, Emitter):
                 "so this metadata will likely fail to be emitted."
             )
 
-        self._emit_generic(url, payload)
+        response = self._emit_generic(url, payload)
+        logger.debug(
+            "Sent MCE successfully urn=%s status=%d",
+            mce.proposedSnapshot.urn,
+            response.status_code,
+        )
 
     @overload
     @deprecated("Use emit_mode instead of async_flag")
@@ -772,6 +777,7 @@ class DataHubRestEmitter(Closeable, Emitter):
         ensure_has_system_metadata(mcp)
 
         trace_data: Optional[TraceData] = None
+        response: Optional[requests.Response] = None
 
         if self._openapi_ingestion:
             request = self._to_openapi_request(mcp, emit_mode)
@@ -817,6 +823,15 @@ class DataHubRestEmitter(Closeable, Emitter):
                 )
                 if response
                 else None
+            )
+
+        if response is not None:
+            logger.debug(
+                "Sent MCP successfully urn=%s aspect=%s status=%d trace_id=%s",
+                mcp.entityUrn,
+                mcp.aspectName,
+                response.status_code,
+                trace_data.trace_id if trace_data else None,
             )
 
         if trace_data:
@@ -905,8 +920,13 @@ class DataHubRestEmitter(Closeable, Emitter):
                 current_chunk.add_item(serialized_item)
 
         trace_data: List[TraceData] = []
+        # Chunks are grouped by (method, url), so track a global index/total to
+        # keep chunk=i/total truthful across all groups.
+        total_chunks = sum(len(group) for group in batches.values())
+        chunk_index = 0
         for (method, url), chunks in batches.items():
             for chunk in chunks:
+                chunk_index += 1
                 response = self._emit_generic(
                     url, payload=_Chunk.join(chunk), method=method
                 )
@@ -916,6 +936,15 @@ class DataHubRestEmitter(Closeable, Emitter):
                     )
                     if response
                     else None
+                )
+                logger.debug(
+                    "Sent MCP batch successfully chunk=%d/%d method=%s items=%d status=%d trace_id=%s",
+                    chunk_index,
+                    total_chunks,
+                    method,
+                    len(chunk.items),
+                    response.status_code,
+                    data.trace_id if data else None,
                 )
                 if data is not None:
                     if _DATAHUB_EMITTER_TRACE:
@@ -987,7 +1016,7 @@ class DataHubRestEmitter(Closeable, Emitter):
             )
 
         trace_data: List[TraceData] = []
-        for mcp_obj_chunk, mcp_chunk in chunks:
+        for chunk_index, (mcp_obj_chunk, mcp_chunk) in enumerate(chunks, start=1):
             # TODO: We're calling json.dumps on each MCP object twice, once to estimate
             # the size when chunking, and again for the actual request.
             payload_dict: dict = {
@@ -1004,7 +1033,24 @@ class DataHubRestEmitter(Closeable, Emitter):
                 if response
                 else None
             )
+            logger.debug(
+                "Sent MCP batch successfully chunk=%d/%d items=%d status=%d trace_id=%s",
+                chunk_index,
+                len(chunks),
+                len(mcp_chunk),
+                response.status_code,
+                data.trace_id if data else None,
+            )
             if data is not None:
+                if _DATAHUB_EMITTER_TRACE:
+                    try:
+                        logger.info(
+                            f"MCP batch trace_id={data.trace_id} "
+                            f"timestamp={data.extract_timestamp()} "
+                            f"urns={list(data.data.keys())}"
+                        )
+                    except Exception as e:
+                        logger.debug(f"Failed to log trace data: {e}")
                 trace_data.append(data)
 
         return trace_data
@@ -1018,7 +1064,13 @@ class DataHubRestEmitter(Closeable, Emitter):
 
         snapshot = {"buckets": [usage_obj]}
         payload = json.dumps(snapshot)
-        self._emit_generic(url, payload)
+        response = self._emit_generic(url, payload)
+        logger.debug(
+            "Sent usage stats successfully resource=%s bucket=%s status=%d",
+            usageStats.resource,
+            usageStats.bucket,
+            response.status_code,
+        )
 
     def _emit_generic(
         self, url: str, payload: Union[str, Any], method: str = "POST"
@@ -1026,24 +1078,24 @@ class DataHubRestEmitter(Closeable, Emitter):
         if not isinstance(payload, str):
             payload = json.dumps(payload)
 
-        curl_command = make_curl_command(self._session, method, url, payload)
         payload_size = len(payload)
         if payload_size > INGEST_MAX_PAYLOAD_BYTES:
             # since we know total payload size here, we could simply avoid sending such payload at all and report a warning, with current approach we are going to cause whole ingestion to fail
             logger.warning(
                 f"Apparent payload size exceeded {INGEST_MAX_PAYLOAD_BYTES}, might fail with an exception due to the size"
             )
-        logger.debug(
-            "Attempting to emit aspect (size: %s) to DataHub GMS; using curl equivalent to:\n%s",
-            payload_size,
-            curl_command,
-        )
         try:
             method_func = getattr(self._session, method.lower())
             response = method_func(url, data=payload) if payload else method_func(url)
             response.raise_for_status()
             return response
         except HTTPError as e:
+            logger.debug(
+                "Failed to emit to DataHub GMS (status=%s, payload_size=%d bytes); curl equivalent:\n%s",
+                response.status_code,
+                payload_size,
+                make_curl_command(self._session, method, url, payload),
+            )
             try:
                 info: Dict = response.json()
 
@@ -1069,6 +1121,11 @@ class DataHubRestEmitter(Closeable, Emitter):
                     "Unable to emit metadata to DataHub GMS", {"message": str(e)}
                 ) from e
         except RequestException as e:
+            logger.debug(
+                "Failed to emit to DataHub GMS (no response received, payload_size=%d bytes); curl equivalent:\n%s",
+                payload_size,
+                make_curl_command(self._session, method, url, payload),
+            )
             raise OperationalError(
                 "Unable to emit metadata to DataHub GMS", {"message": str(e)}
             ) from e
@@ -1097,6 +1154,11 @@ class DataHubRestEmitter(Closeable, Emitter):
             start_time = datetime.now()
 
             for trace in trace_data:
+                logger.debug(
+                    "awaiting async write trace_id=%s urns=%d",
+                    trace.trace_id,
+                    len(trace.data),
+                )
                 current_backoff = TRACE_INITIAL_BACKOFF
 
                 while trace.data:


### PR DESCRIPTION
## Summary

Enabling `DATAHUB_DEBUG=1` could balloon ingestion logs from MBs to GBs. The root cause was in `DataHubRestEmitter._emit_generic`: for **every** aspect on the **success** path it eagerly built a full `make_curl_command` string (URL + all session headers + the entire serialized payload) and logged it at `DEBUG`. On a large ingestion that is one large multi-line log record per aspect, plus the CPU cost of constructing it.

This PR makes the curl-equivalent string lazy — it is now built **only inside the failure handlers**, where it is genuinely useful for debugging — and takes the opportunity to make the surrounding emit-path logging consistent and actually useful for tracing a write.

## Problem

`_emit_generic` ran this unconditionally, per aspect, at `DEBUG`:

```python
curl_command = make_curl_command(self._session, method, url, payload)
logger.debug(
    "Attempting to emit aspect (size: %s) to DataHub GMS; using curl equivalent to:\n%s",
    payload_size, curl_command,
)
```

Result: `DATAHUB_DEBUG=1` became impractical for real troubleshooting — the signal was buried under per-aspect curl dumps, and the log volume alone made it costly.

## Changes

### Core fix — `_emit_generic`

- Removed the unconditional success-path `make_curl_command` construction and log.
- The curl-equivalent is now built **lazily, only in the `except` handlers**, so the happy path pays neither the CPU nor the log-volume cost.
- When DATAHUB_EMITTER_TRACE is enabled: make_curl_command output is always emitted at TRACE level, regardless of success or failure. This gives a dedicated, opt-in escape hatch for deep per-request debugging without polluting DEBUG logs during normal operation.


### Added post-flight success logging

These paths previously logged nothing on success; each now emits a single concise `DEBUG` line after a successful send:

- `emit_mce` → `Sent MCE successfully urn=… status=…`.
- `emit_mcp` → one `Sent MCP successfully urn=… aspect=… status=… trace_id=…` line shared by both the openapi and restli branches (guarded by `if response is not None`).
- `emit_usage` → `Sent usage stats successfully resource=… bucket=… status=…`.
- For batch emission paths (`_emit_openapi_mcps`, `_emit_restli_mcps`), log a single `DEBUG` line per chunk in the format `Sent MCP batch chunk=<i>/<total> items=<N> status=<status> trace_id=<trace_id> urns=[(<urn>, <aspect>), ...]`, where `chunk=<i>/<total>` helps distinguish split batches (especially in sync mode where logs may otherwise look identical), with OpenAPI computing `total` globally across all `(method, url)` groups to remain accurate, and `urns` enumerating each MCP’s `(entityUrn, aspectName)` so you can precisely verify what was sent and easily grep by URN.

For synchronous paths (MCE, usage, restli) a `2xx` is the commit proof; MCP paths additionally carry `trace_id` for async write correlation.

### `_await_status`

- Added an entry log `awaiting async write trace_id=… urns=N` at the start of verifying each trace, giving visibility into the async write-verification wait (this loop only runs in `ASYNC_WAIT` mode). `urns` is the count of URNs awaiting verification — deliberately not labeled `pending`, since nothing has been polled yet and no GMS write status is known at that point.

## Behavioral impact

- `DATAHUB_DEBUG=1` no longer emits `make_curl_command` output on successful emits. On failures, the curl-equivalent is still logged (at `DEBUG`) — that's where it's actually needed, and failures are rare so volume is a non-issue.
- New success lines are one short line per emit / per chunk at `DEBUG`.
- No public API or return-type changes.