### PR TITLE
feat(i18n): extract keys from other entity tabs

### DIFF
--- a/datahub-web-react/.eslintrc.js
+++ b/datahub-web-react/.eslintrc.js
@@ -308,6 +308,7 @@ module.exports = {
                                   words: {
                                       exclude: [
                                           '^_blank$',
+                                          '^noopener noreferrer$',
                                           '^\\*$',
                                           '^-$',
                                           '^[A-Z0-9_]+$',

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Embed/EmbedTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Embed/EmbedTab.tsx
@@ -1,5 +1,6 @@
 import { Empty } from 'antd';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { useEntityData } from '@app/entity/shared/EntityContext';
@@ -22,11 +23,12 @@ const StyledEmpty = styled(Empty)`
 
 export const EmbedTab = () => {
     const { entityData } = useEntityData();
+    const { t } = useTranslation('entity.profile.tabs');
     const embedRenderUrl = entityData?.embed?.renderUrl;
     return (
         <EmbedContainer>
             {(embedRenderUrl && <StyledIframe src={embedRenderUrl} title={entityData?.urn} frameBorder={0} />) || (
-                <StyledEmpty description="No preview was found." />
+                <StyledEmpty description={t('embed.noPreview')} />
             )}
         </EmbedContainer>
     );

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Entity/ChartDashboardsTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Entity/ChartDashboardsTab.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { useBaseEntity } from '@app/entity/shared/EntityContext';
 import { EntityList } from '@app/entityV2/shared/tabs/Entity/components/EntityList';
@@ -7,15 +8,16 @@ import { useEntityRegistry } from '@app/useEntityRegistry';
 import { EntityType } from '@types';
 
 export const ChartDashboardsTab = () => {
+    const { t } = useTranslation('entity.profile.tabs');
     const entity = useBaseEntity() as any;
     const chart = entity && entity.chart;
     const dashboards = chart?.dashboards?.relationships?.map((relationship) => relationship.entity);
     const entityRegistry = useEntityRegistry();
     const totalDashboards = chart?.dashboards?.total || 0;
-    const title = `Found in ${totalDashboards} ${
+    const entityName =
         totalDashboards === 1
             ? entityRegistry.getEntityName(EntityType.Dashboard)
-            : entityRegistry.getCollectionName(EntityType.Dashboard)
-    }`;
+            : entityRegistry.getCollectionName(EntityType.Dashboard);
+    const title = t('entity.foundInCount', { count: totalDashboards, entityName });
     return <EntityList title={title} type={EntityType.Dashboard} entities={dashboards || []} />;
 };

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Entity/DashboardChartsTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Entity/DashboardChartsTab.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { useBaseEntity } from '@app/entity/shared/EntityContext';
 import { EntityList } from '@app/entityV2/shared/tabs/Entity/components/EntityList';
@@ -6,10 +7,11 @@ import { EntityList } from '@app/entityV2/shared/tabs/Entity/components/EntityLi
 import { EntityType } from '@types';
 
 export const DashboardChartsTab = () => {
+    const { t } = useTranslation('entity.profile.tabs');
     const entity = useBaseEntity() as any;
     const dashboard = entity && entity.dashboard;
     const charts = dashboard?.charts?.relationships?.map((relationship) => relationship.entity);
     const totalCharts = dashboard?.charts?.total || 0;
-    const title = `Contains ${totalCharts} assets`;
+    const title = t('entity.containsAssets', { count: totalCharts });
     return <EntityList title={title} type={EntityType.Chart} entities={charts || []} />;
 };

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Entity/DashboardDatasetsTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Entity/DashboardDatasetsTab.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { useBaseEntity } from '@app/entity/shared/EntityContext';
 import { EntityList } from '@app/entityV2/shared/tabs/Entity/components/EntityList';
@@ -7,15 +8,16 @@ import { useEntityRegistry } from '@app/useEntityRegistry';
 import { EntityType } from '@types';
 
 export const DashboardDatasetsTab = () => {
+    const { t } = useTranslation('entity.profile.tabs');
     const entity = useBaseEntity() as any;
     const dashboard = entity && entity.dashboard;
     const datasets = dashboard?.datasets?.relationships?.map((relationship) => relationship.entity);
     const entityRegistry = useEntityRegistry();
     const totalDatasets = dashboard?.datasets?.total || 0;
-    const title = `Consumes ${totalDatasets} ${
+    const entityName =
         totalDatasets === 1
             ? entityRegistry.getEntityName(EntityType.Dataset)
-            : entityRegistry.getCollectionName(EntityType.Dataset)
-    }`;
+            : entityRegistry.getCollectionName(EntityType.Dataset);
+    const title = t('entity.consumesCount', { count: totalDatasets, entityName });
     return <EntityList title={title} type={EntityType.Dataset} entities={datasets || []} />;
 };

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Entity/DataFlowJobsTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Entity/DataFlowJobsTab.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { EntityList } from '@app/entityV2/shared/tabs/Entity/components/EntityList';
 import { useEntityRegistry } from '@app/useEntityRegistry';
@@ -14,6 +15,7 @@ interface Props {
 }
 
 export const DataFlowJobsTab = ({ properties = { urn: '' } }: Props) => {
+    const { t } = useTranslation('entity.profile.tabs');
     const [page, setPage] = useState(1);
     const [numResultsPerPage, setNumResultsPerPage] = useState(SearchCfg.RESULTS_PER_PAGE);
 
@@ -38,11 +40,11 @@ export const DataFlowJobsTab = ({ properties = { urn: '' } }: Props) => {
     const pageSize = data?.dataFlow?.childJobs?.count || 0;
     const pageStart = data?.dataFlow?.childJobs?.start || 0;
     const lastResultIndex = pageStart + pageSize > totalJobs ? totalJobs : pageStart + pageSize;
-    const title = `Contains ${totalJobs} ${
+    const entityName =
         totalJobs === 1
             ? entityRegistry.getEntityName(EntityType.DataJob)
-            : entityRegistry.getCollectionName(EntityType.DataJob)
-    }`;
+            : entityRegistry.getCollectionName(EntityType.DataJob);
+    const title = t('entity.containsCount', { count: totalJobs, entityName });
     return (
         <EntityList
             title={title}

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Entity/DataJobFlowTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Entity/DataJobFlowTab.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { useBaseEntity } from '@app/entity/shared/EntityContext';
 import { EntityList } from '@app/entityV2/shared/tabs/Entity/components/EntityList';
@@ -7,10 +8,11 @@ import { useEntityRegistry } from '@app/useEntityRegistry';
 import { EntityType } from '@types';
 
 export const DataJobFlowTab = () => {
+    const { t } = useTranslation('entity.profile.tabs');
     const entity = useBaseEntity() as any;
     const dataJob = entity && entity.dataJob;
     const dataFlow = dataJob?.dataFlow;
     const entityRegistry = useEntityRegistry();
-    const title = `Part of ${entityRegistry.getEntityName(EntityType.DataFlow)}`;
+    const title = t('entity.partOf', { entityName: entityRegistry.getEntityName(EntityType.DataFlow) });
     return <EntityList title={title} type={EntityType.DataFlow} entities={dataFlow ? [dataFlow] : []} />;
 };

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Entity/components/EntityList.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Entity/components/EntityList.tsx
@@ -1,5 +1,6 @@
 import { List, Pagination, Typography } from 'antd';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { PreviewType } from '@app/entityV2/Entity';
@@ -8,6 +9,8 @@ import { useEntityRegistry } from '@app/useEntityRegistry';
 import { SearchCfg } from '@src/conf';
 
 import { EntityType } from '@types';
+
+const LOADING_MARGIN_TOP = '10%';
 
 const ScrollWrapper = styled.div`
     overflow: auto;
@@ -101,6 +104,8 @@ export const EntityList = ({
     setNumResultsPerPage,
 }: EntityListProps) => {
     const entityRegistry = useEntityRegistry();
+    const { t } = useTranslation('entity.profile.tabs');
+    const { t: tc } = useTranslation('common.feedback');
 
     return (
         <>
@@ -113,15 +118,16 @@ export const EntityList = ({
                     )}
                 />
             </ScrollWrapper>
-            {loading && <Message type="loading" content="Loading..." style={{ marginTop: '10%' }} />}
-            {error && <Message type="error" content="Failed to load results! An unexpected error occurred." />}
+            {loading && <Message type="loading" content={tc('loading')} style={{ marginTop: LOADING_MARGIN_TOP }} />}
+            {error && <Message type="error" content={t('entity.list.loadError')} />}
             {showPagination && (
                 <PaginationInfoContainer>
                     <PaginationInfo>
-                        <b>
-                            {lastResultIndex > 0 ? ((page as number) - 1) * pageSize + 1 : 0} - {lastResultIndex}
-                        </b>{' '}
-                        of <b>{totalAssets}</b>
+                        {t('entity.paginationRange', {
+                            start: lastResultIndex > 0 ? ((page as number) - 1) * pageSize + 1 : 0,
+                            end: lastResultIndex,
+                            total: totalAssets,
+                        })}
                     </PaginationInfo>
                     <StyledPagination
                         current={page}

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Entity/components/EntityList.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Entity/components/EntityList.tsx
@@ -1,6 +1,6 @@
 import { List, Pagination, Typography } from 'antd';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { PreviewType } from '@app/entityV2/Entity';
@@ -123,11 +123,15 @@ export const EntityList = ({
             {showPagination && (
                 <PaginationInfoContainer>
                     <PaginationInfo>
-                        {t('entity.paginationRange', {
-                            start: lastResultIndex > 0 ? ((page as number) - 1) * pageSize + 1 : 0,
-                            end: lastResultIndex,
-                            total: totalAssets,
-                        })}
+                        <Trans
+                            i18nKey="entity.paginationRange"
+                            values={{
+                                start: lastResultIndex > 0 ? ((page as number) - 1) * pageSize + 1 : 0,
+                                end: lastResultIndex,
+                                total: totalAssets,
+                            }}
+                            components={{ b: <b /> }}
+                        />
                     </PaginationInfo>
                     <StyledPagination
                         current={page}

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Entity/weaklyTypedAspects/DynamicPropertiesTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Entity/weaklyTypedAspects/DynamicPropertiesTab.tsx
@@ -1,5 +1,6 @@
 import { Typography } from 'antd';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { StyledTable } from '@app/entityV2/shared/components/styled/StyledTable';
@@ -16,20 +17,21 @@ const NameText = styled(Typography.Text)`
 `;
 
 export default function DynamicTabularTab({ payload: rawPayload }: Props) {
+    const { t: tc } = useTranslation('common.labels');
     const aspectData = JSON.parse(rawPayload || '{}');
     const transformedRowData = Object.keys(aspectData).map((key) => ({ key, value: aspectData[key] }));
 
     const propertyTableColumns = [
         {
             width: 210,
-            title: 'Name',
+            title: tc('name'),
             dataIndex: 'key',
             sorter: (a, b) => a?.key?.localeCompare(b?.key || '') || 0,
             defaultSortOrder: 'ascend',
             render: (name: string) => <NameText>{name}</NameText>,
         },
         {
-            title: 'Value',
+            title: tc('value'),
             dataIndex: 'value',
             render: (value: string) => <TableValueElement value={value} />,
         },

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Entity/weaklyTypedAspects/DynamicTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Entity/weaklyTypedAspects/DynamicTab.tsx
@@ -22,6 +22,9 @@ const QueryText = styled(Typography.Paragraph)`
     }
 `;
 
+const SYNTAX_LANGUAGE_JSON = 'json';
+const EMPTY_JSON_OBJECT = '{}';
+
 // NOTE: Yes, using `!important` is a shame. However, the SyntaxHighlighter is applying styles directly
 // to the component, so there's no way around this
 const NestedSyntax = styled(StyledSyntaxHighlighter)`
@@ -42,7 +45,9 @@ export default function DynamicTab({ renderSpec, payload, type }: Props) {
         <>
             <QueryText>
                 <pre>
-                    <NestedSyntax language="json">{JSON.stringify(JSON.parse(payload || '{}'), null, 2)}</NestedSyntax>
+                    <NestedSyntax language={SYNTAX_LANGUAGE_JSON}>
+                        {JSON.stringify(JSON.parse(payload || EMPTY_JSON_OBJECT), null, 2)}
+                    </NestedSyntax>
                 </pre>
             </QueryText>
         </>

--- a/datahub-web-react/src/app/entityV2/shared/tabs/ML/MlFeatureFeatureTableTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/ML/MlFeatureFeatureTableTab.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { useBaseEntity } from '@app/entity/shared/EntityContext';
 import { EntityList } from '@app/entityV2/shared/tabs/Entity/components/EntityList';
@@ -10,10 +11,11 @@ import { EntityType } from '@types';
 export const FeatureTableTab = () => {
     const entity = useBaseEntity() as GetMlFeatureQuery;
     const entityRegistry = useEntityRegistry();
+    const { t } = useTranslation('entity.profile.tabs');
 
     const feature = entity && entity.mlFeature;
     const featureTables = feature?.featureTables?.relationships?.map((relationship) => relationship.entity);
 
-    const title = `Part of ${entityRegistry.getEntityName(EntityType.MlfeatureTable)}`;
+    const title = t('entity.partOf', { entityName: entityRegistry.getEntityName(EntityType.MlfeatureTable) });
     return <EntityList title={title} type={EntityType.MlfeatureTable} entities={featureTables || []} />;
 };

--- a/datahub-web-react/src/app/entityV2/shared/tabs/ML/MlPrimaryKeyFeatureTableTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/ML/MlPrimaryKeyFeatureTableTab.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { useBaseEntity } from '@app/entity/shared/EntityContext';
 import { EntityList } from '@app/entityV2/shared/tabs/Entity/components/EntityList';
@@ -10,10 +11,11 @@ import { EntityType } from '@types';
 export const FeatureTableTab = () => {
     const entity = useBaseEntity() as GetMlPrimaryKeyQuery;
     const entityRegistry = useEntityRegistry();
+    const { t } = useTranslation('entity.profile.tabs');
 
     const feature = entity && entity.mlPrimaryKey;
     const featureTables = feature?.featureTables?.relationships?.map((relationship) => relationship.entity);
 
-    const title = `Part of ${entityRegistry.getEntityName(EntityType.MlfeatureTable)}`;
+    const title = t('entity.partOf', { entityName: entityRegistry.getEntityName(EntityType.MlfeatureTable) });
     return <EntityList title={title} type={EntityType.MlfeatureTable} entities={featureTables || []} />;
 };

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Properties/CardinalityLabel.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Properties/CardinalityLabel.tsx
@@ -1,5 +1,6 @@
 import { Tooltip } from '@components';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import styled, { useTheme } from 'styled-components';
 
 import { PropertyTypeBadge } from '@app/entity/shared/tabs/Dataset/Schema/components/PropertyTypeLabel';
@@ -23,15 +24,18 @@ interface Props {
 
 export default function CardinalityLabel({ structuredProperty }: Props) {
     const theme = useTheme();
+    const { t } = useTranslation('entity.profile.tabs');
     const labelText =
-        structuredProperty.definition.cardinality === PropertyCardinality.Single ? 'Single-Select' : 'Multi-Select';
+        structuredProperty.definition.cardinality === PropertyCardinality.Single
+            ? t('properties.cardinality.singleSelect')
+            : t('properties.cardinality.multiSelect');
 
     return (
         <Tooltip
             color={theme.colors.bgTooltip}
             title={
                 <>
-                    <Header>Property Options</Header>
+                    <Header>{t('properties.optionsTooltip.title')}</Header>
                     <List>
                         {structuredProperty.definition.allowedValues?.map((value) => (
                             <li>{getStructuredPropertyValue(value.value)}</li>

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Properties/NameColumn.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Properties/NameColumn.tsx
@@ -7,6 +7,8 @@ import styled, { useTheme } from 'styled-components';
 import StructuredPropertyTooltip from '@app/entityV2/shared/tabs/Properties/StructuredPropertyTooltip';
 import { PropertyRow } from '@app/entityV2/shared/tabs/Properties/types';
 
+const MIN_CONTENT = 'min-content' as const;
+
 const ParentNameText = styled(Typography.Text)`
     color: ${(props) => props.theme.colors.text};
     font-size: 14px;
@@ -73,7 +75,7 @@ export default function NameColumn({ propertyRow, filterText }: Props) {
                     <Tooltip
                         color={theme.colors.bgTooltip}
                         placement="topRight"
-                        overlayStyle={{ minWidth: 'min-content' }}
+                        overlayStyle={{ minWidth: MIN_CONTENT }}
                         title={structuredProperty ? <StructuredPropertyTooltip propertyRow={propertyRow} /> : ''}
                     >
                         <ChildNameText>

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Properties/PropertiesTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Properties/PropertiesTab.tsx
@@ -1,5 +1,6 @@
 import { Empty, Table } from 'antd';
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { useEntityData } from '@app/entity/shared/EntityContext';
@@ -19,6 +20,8 @@ import { TabRenderType } from '@app/entityV2/shared/types';
 import { useEntityRegistryV2 } from '@app/useEntityRegistry';
 import { EditColumn } from '@src/app/entity/shared/tabs/Properties/Edit/EditColumn';
 import { Maybe, StructuredProperties } from '@src/types.generated';
+
+const PROPERTY_ROW_KEY = 'qualifiedName';
 
 const StyledTable = styled(Table)`
     &&& .ant-table-cell-with-append {
@@ -49,6 +52,8 @@ interface Props {
 }
 
 export const PropertiesTab = ({ renderType = TabRenderType.DEFAULT, properties }: Props) => {
+    const { t } = useTranslation('entity.profile.tabs');
+    const { t: tc } = useTranslation('common.labels');
     const fieldPath = properties?.fieldPath;
     const fieldUrn = properties?.fieldUrn;
     const fieldProperties = properties?.fieldProperties;
@@ -83,11 +88,11 @@ export const PropertiesTab = ({ renderType = TabRenderType.DEFAULT, properties }
     const propertyTableColumns = [
         {
             width: '40%',
-            title: 'Name',
+            title: tc('name'),
             render: (propertyRow: PropertyRow) => <NameColumn propertyRow={propertyRow} filterText={filterText} />,
         },
         {
-            title: 'Value',
+            title: tc('value'),
             ellipsis: true,
             render: (propertyRow: PropertyRow) => (
                 <ValuesColumn
@@ -138,9 +143,9 @@ export const PropertiesTab = ({ renderType = TabRenderType.DEFAULT, properties }
                     columns={propertyTableColumns}
                     dataSource={dataSource}
                     locale={{
-                        emptyText: <EmptyText description="No properties found" image={Empty.PRESENTED_IMAGE_SIMPLE} />,
+                        emptyText: <EmptyText description={t('properties.empty')} image={Empty.PRESENTED_IMAGE_SIMPLE} />,
                     }}
-                    rowKey="qualifiedName"
+                    rowKey={PROPERTY_ROW_KEY}
                     expandable={{
                         expandedRowKeys: [...Array.from(expandedRows)],
                         defaultExpandAllRows: false,

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Properties/PropertiesTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Properties/PropertiesTab.tsx
@@ -143,7 +143,9 @@ export const PropertiesTab = ({ renderType = TabRenderType.DEFAULT, properties }
                     columns={propertyTableColumns}
                     dataSource={dataSource}
                     locale={{
-                        emptyText: <EmptyText description={t('properties.empty')} image={Empty.PRESENTED_IMAGE_SIMPLE} />,
+                        emptyText: (
+                            <EmptyText description={t('properties.empty')} image={Empty.PRESENTED_IMAGE_SIMPLE} />
+                        ),
                     }}
                     rowKey={PROPERTY_ROW_KEY}
                     expandable={{

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Properties/StructuredPropertyTooltip.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Properties/StructuredPropertyTooltip.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import PropertyTypeLabel from '@app/entity/shared/tabs/Dataset/Schema/components/PropertyTypeLabel';
@@ -33,13 +34,14 @@ interface Props {
 }
 
 export default function StructuredPropertyTooltip({ propertyRow }: Props) {
+    const { t } = useTranslation('entity.profile.tabs');
     const { structuredProperty } = propertyRow;
 
     if (!structuredProperty) return null;
 
     return (
         <ContentWrapper>
-            <Header>Structured Property</Header>
+            <Header>{t('properties.structuredProperty.title')}</Header>
             <NameLabelWrapper>
                 <NameWrapper>
                     {structuredProperty.definition.displayName || structuredProperty.definition.qualifiedName}{' '}

--- a/datahub-web-react/src/i18n/i18n.ts
+++ b/datahub-web-react/src/i18n/i18n.ts
@@ -11,6 +11,7 @@ export const NAMESPACES = [
     'entity.ownership',
     'entity.profile.documentation',
     'entity.profile.incident',
+    'entity.profile.tabs',
     'entity.profile.validations',
     'entity.profile.access',
     'entity.profile.queries',

--- a/datahub-web-react/src/i18n/locales/en/common.labels.json
+++ b/datahub-web-react/src/i18n/locales/en/common.labels.json
@@ -13,5 +13,6 @@
     "tags": "Tags",
     "title": "Title",
     "type": "Type",
-    "usage": "Usage"
+    "usage": "Usage",
+    "value": "Value"
 }

--- a/datahub-web-react/src/i18n/locales/en/entity.profile.tabs.json
+++ b/datahub-web-react/src/i18n/locales/en/entity.profile.tabs.json
@@ -1,0 +1,16 @@
+{
+    "embed.noPreview": "No preview was found.",
+    "entity.consumesCount": "Consumes {{count}} {{entityName}}",
+    "entity.containsAssets_one": "Contains {{count}} asset",
+    "entity.containsAssets_other": "Contains {{count}} assets",
+    "entity.containsCount": "Contains {{count}} {{entityName}}",
+    "entity.foundInCount": "Found in {{count}} {{entityName}}",
+    "entity.list.loadError": "Failed to load results! An unexpected error occurred.",
+    "entity.paginationRange": "{{start}} - {{end}} of {{total}}",
+    "entity.partOf": "Part of {{entityName}}",
+    "properties.cardinality.multiSelect": "Multi-Select",
+    "properties.cardinality.singleSelect": "Single-Select",
+    "properties.empty": "No properties found",
+    "properties.optionsTooltip.title": "Property Options",
+    "properties.structuredProperty.title": "Structured Property"
+}

--- a/datahub-web-react/src/i18n/locales/en/entity.profile.tabs.json
+++ b/datahub-web-react/src/i18n/locales/en/entity.profile.tabs.json
@@ -6,7 +6,7 @@
     "entity.containsCount": "Contains {{count}} {{entityName}}",
     "entity.foundInCount": "Found in {{count}} {{entityName}}",
     "entity.list.loadError": "Failed to load results! An unexpected error occurred.",
-    "entity.paginationRange": "{{start}} - {{end}} of {{total}}",
+    "entity.paginationRange": "<b>{{start}} - {{end}}</b> of <b>{{total}}</b>",
     "entity.partOf": "Part of {{entityName}}",
     "properties.cardinality.multiSelect": "Multi-Select",
     "properties.cardinality.singleSelect": "Single-Select",

--- a/datahub-web-react/src/setupTests.ts
+++ b/datahub-web-react/src/setupTests.ts
@@ -17,6 +17,7 @@ import enEntityProfileIncident from '@src/i18n/locales/en/entity.profile.inciden
 import enEntityProfileQueries from '@src/i18n/locales/en/entity.profile.queries.json';
 import enEntityProfileSchema from '@src/i18n/locales/en/entity.profile.schema.json';
 import enEntityProfileStats from '@src/i18n/locales/en/entity.profile.stats.json';
+import enEntityProfileTabs from '@src/i18n/locales/en/entity.profile.tabs.json';
 import enEntityProfileValidations from '@src/i18n/locales/en/entity.profile.validations.json';
 import enEntityProfileView from '@src/i18n/locales/en/entity.profile.view.json';
 import enEntitySharedContainers from '@src/i18n/locales/en/entity.shared.containers.json';
@@ -49,6 +50,7 @@ i18n.use(initReactI18next).init({
         'entity.profile.documentation',
         'entity.ownership',
         'entity.profile.incident',
+        'entity.profile.tabs',
         'entity.profile.validations',
         'entity.profile.access',
         'entity.profile.queries',
@@ -81,6 +83,7 @@ i18n.use(initReactI18next).init({
             'entity.profile.documentation': enEntityProfileDocumentation,
             'entity.ownership': enEntityOwnership,
             'entity.profile.incident': enEntityProfileIncident,
+            'entity.profile.tabs': enEntityProfileTabs,
             'entity.profile.validations': enEntityProfileValidations,
             'entity.profile.access': enEntityProfileAccess,
             'entity.profile.queries': enEntityProfileQueries,

--- a/datahub-web-react/translated-files.txt
+++ b/datahub-web-react/translated-files.txt
@@ -1,6 +1,10 @@
 src/app/domain/**/*.{ts,tsx}
 src/app/domainV2/**/*.{ts,tsx}
 src/app/entityV2/ownership/ManageOwnership.tsx
+src/app/entityV2/shared/tabs/Embed/**/*.{ts,tsx}
+src/app/entityV2/shared/tabs/Entity/**/*.{ts,tsx}
+src/app/entityV2/shared/tabs/ML/**/*.{ts,tsx}
+src/app/entityV2/shared/tabs/Properties/**/*.{ts,tsx}
 src/app/entityV2/ownership/OwnershipBuilderModal.tsx
 src/app/entityV2/ownership/OwnershipList.tsx
 src/app/entityV2/ownership/table/ActionsColumn.tsx


### PR DESCRIPTION
This PR extracts i18n keys from 
src/app/entityV2/shared/tabs/Embed/**/*.{ts,tsx}
src/app/entityV2/shared/tabs/Entity/**/*.{ts,tsx}
src/app/entityV2/shared/tabs/ML/**/*.{ts,tsx}
src/app/entityV2/shared/tabs/Properties/**/*.{ts,tsx}

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
