### PR TITLE
ci(docker): pin PR image tags to head sha and comment them on the PR

### DIFF
--- a/.github/scripts/docker_helpers.sh
+++ b/.github/scripts/docker_helpers.sh
@@ -15,7 +15,14 @@ export QUICKSTART_TAG="quickstart"
 export SHA_TAG_PREFIX="sha-"
 
 function get_short_sha {
-    echo $(git rev-parse --short "$GITHUB_SHA"|head -c7)
+    # On pull_request events GITHUB_SHA is the ephemeral merge commit, which isn't a useful
+    # reference. Prefer the PR branch HEAD sha (passed explicitly by the workflow) so tags
+    # pin to the actual reviewed commit.
+    if [ -n "${GITHUB_PR_HEAD_SHA:-}" ]; then
+        echo "${GITHUB_PR_HEAD_SHA}" | head -c7
+    else
+        echo $(git rev-parse --short "$GITHUB_SHA"|head -c7)
+    fi
 }
 
 export SHORT_SHA=$(get_short_sha)
@@ -24,15 +31,15 @@ echo "SHORT_SHA: $SHORT_SHA"
 echo "SHA_TAG: $SHA_TAG"
 
 function get_tag {
-    echo $(echo ${REF} | sed -e "s,refs/heads/${MAIN_BRANCH},${SHA_TAG},g" -e 's,refs/tags/,,g' -e 's,refs/heads/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g'  -e 's,/,-,g')
+    echo $(echo ${REF} | sed -e "s,refs/heads/${MAIN_BRANCH},${SHA_TAG},g" -e 's,refs/tags/,,g' -e 's,refs/heads/,,g' -e "s,refs/pull/\([0-9]*\).*,pr\1-${SHORT_SHA},g"  -e 's,/,-,g')
 }
 
 function get_tag_slim {
-    echo $(echo ${REF} | sed -e "s,refs/heads/${MAIN_BRANCH},${SHA_TAG}-slim,g" -e 's,refs/tags/\(.*\),\1-slim,g' -e 's,refs/heads/\(.*\),\1-slim,g' -e 's,refs/pull/\([0-9]*\).*,pr\1-slim,g'  -e 's,/,-,g')
+    echo $(echo ${REF} | sed -e "s,refs/heads/${MAIN_BRANCH},${SHA_TAG}-slim,g" -e 's,refs/tags/\(.*\),\1-slim,g' -e 's,refs/heads/\(.*\),\1-slim,g' -e "s,refs/pull/\([0-9]*\).*,pr\1-${SHORT_SHA}-slim,g"  -e 's,/,-,g')
 }
 
 function get_tag_full {
-    echo $(echo ${REF} | sed -e "s,refs/heads/${MAIN_BRANCH},${SHA_TAG}-full,g" -e 's,refs/tags/\(.*\),\1-full,g' -e 's,refs/heads/\(.*\),\1-full,g' -e 's,refs/pull/\([0-9]*\).*,pr\1-full,g'  -e 's,/,-,g')
+    echo $(echo ${REF} | sed -e "s,refs/heads/${MAIN_BRANCH},${SHA_TAG}-full,g" -e 's,refs/tags/\(.*\),\1-full,g' -e 's,refs/heads/\(.*\),\1-full,g' -e "s,refs/pull/\([0-9]*\).*,pr\1-${SHORT_SHA}-full,g"  -e 's,/,-,g')
 }
 
 function get_python_docker_release_v() {
@@ -57,9 +64,9 @@ if [ ${TEST_DOCKER_HELPERS:-0} -eq 1 ]; then
     REF="refs/tags/v0.1.2rc1"    get_tag_slim # 'v0.1.2rc1-slim'
     REF="refs/tags/v0.1.2rc1"    get_tag_full # 'v0.1.2rc1-full'
 
-    REF="refs/pull/4788/merge"    get_tag # 'pr4788'
-    REF="refs/pull/4788/merge"    get_tag_slim # 'pr4788-slim'
-    REF="refs/pull/4788/merge"    get_tag_full # 'pr4788-full'
+    REF="refs/pull/4788/merge"    get_tag # 'pr4788-<short_sha>'
+    REF="refs/pull/4788/merge"    get_tag_slim # 'pr4788-<short_sha>-slim'
+    REF="refs/pull/4788/merge"    get_tag_full # 'pr4788-<short_sha>-full'
 
     REF="refs/heads/branch-name" get_tag # 'branch-name'
     REF="refs/heads/branch-name" get_tag_slim # 'branch-name-slim'
@@ -73,15 +80,15 @@ if [ ${TEST_DOCKER_HELPERS:-0} -eq 1 ]; then
 fi
 
 function get_unique_tag {
-    echo $(echo ${REF} | sed -e "s,refs/heads/${MAIN_BRANCH},${SHA_TAG},g" -e 's,refs/tags/,,g' -e "s,refs/heads/.*,${SHA_TAG},g"  -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
+    echo $(echo ${REF} | sed -e "s,refs/heads/${MAIN_BRANCH},${SHA_TAG},g" -e 's,refs/tags/,,g' -e "s,refs/heads/.*,${SHA_TAG},g"  -e "s,refs/pull/\([0-9]*\).*,pr\1-${SHORT_SHA},g")
 }
 
 function get_unique_tag_slim {
-    echo $(echo ${REF} | sed -e "s,refs/heads/${MAIN_BRANCH},${SHA_TAG}-slim,g" -e 's,refs/tags/\(.*\),\1-slim,g' -e "s,refs/heads/.*,${SHA_TAG}-slim,g" -e 's,refs/pull/\([0-9]*\).*,pr\1-slim,g')
+    echo $(echo ${REF} | sed -e "s,refs/heads/${MAIN_BRANCH},${SHA_TAG}-slim,g" -e 's,refs/tags/\(.*\),\1-slim,g' -e "s,refs/heads/.*,${SHA_TAG}-slim,g" -e "s,refs/pull/\([0-9]*\).*,pr\1-${SHORT_SHA}-slim,g")
 }
 
 function get_unique_tag_full {
-    echo $(echo ${REF} | sed -e "s,refs/heads/${MAIN_BRANCH},${SHA_TAG}-full,g" -e 's,refs/tags/\(.*\),\1-full,g' -e "s,refs/heads/.*,${SHA_TAG}-full,g" -e 's,refs/pull/\([0-9]*\).*,pr\1-full,g')
+    echo $(echo ${REF} | sed -e "s,refs/heads/${MAIN_BRANCH},${SHA_TAG}-full,g" -e 's,refs/tags/\(.*\),\1-full,g' -e "s,refs/heads/.*,${SHA_TAG}-full,g" -e "s,refs/pull/\([0-9]*\).*,pr\1-${SHORT_SHA}-full,g")
 }
 
 function get_platforms_based_on_branch {

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -115,6 +115,7 @@ jobs:
         env:
           GITHUB_REF_FALLBACK: ${{ github.event_name == 'release' && format('refs/tags/{0}', github.event.release.tag_name) || github.ref}}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           source .github/scripts/docker_helpers.sh
           {
@@ -362,6 +363,61 @@ jobs:
             ~/.gradle/caches/jars-*
             ~/.gradle/caches/transforms-*
           key: gradle-plugins-cache
+
+  comment_pr_images:
+    name: Comment PR image tags
+    runs-on: ubuntu-latest
+    needs: [setup, base_build]
+    if: ${{ github.event_name == 'pull_request' && needs.setup.outputs.pr-publish == 'true' }}
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Upsert PR image comment
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          PR_TAG: ${{ needs.setup.outputs.tag }}
+          SHORT_SHA: ${{ needs.setup.outputs.short_sha }}
+          REGISTRY: ${{ env.DOCKER_REGISTRY }}
+        with:
+          script: |
+            const marker = '<!-- pr-docker-images -->';
+            const { PR_TAG, SHORT_SHA, REGISTRY } = process.env;
+            const body = [
+              marker,
+              '## 🐳 Docker Images Published for Testing',
+              '',
+              `Images for this PR have been published to the [\`${REGISTRY}\`](https://hub.docker.com/u/${REGISTRY}) Docker Hub registry, tagged \`${PR_TAG}\`.`,
+              '',
+              'Run DataHub quickstart with these images:',
+              '',
+              '```bash',
+              `DATAHUB_VERSION=${PR_TAG} datahub docker quickstart`,
+              '```',
+              '',
+              'Or pull an individual image, e.g.:',
+              '',
+              '```bash',
+              `docker pull ${REGISTRY}/datahub-gms:${PR_TAG}`,
+              '```',
+              '',
+              `Pinned to commit \`${SHORT_SHA}\`.`,
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+            });
+            const existing = comments.find(
+              (c) => c.user?.type === 'Bot' && c.body?.includes(marker),
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
 
   smoke_test_matrix:
     runs-on: ${{ needs.setup.outputs.test_runner_type_small }}


### PR DESCRIPTION
## Summary

Two related improvements to the PR docker image workflow (`docker-unified.yml`):

### 1. PR image tags now pin to the branch HEAD commit

PR tags change from `pr<N>` to `pr<N>-<short_sha>`, so each tag references a specific commit instead of floating across pushes to the PR branch. The short sha is sourced from the **PR branch HEAD** (`github.event.pull_request.head.sha`, threaded in via `GITHUB_PR_HEAD_SHA`) rather than `GITHUB_SHA`, which on `pull_request` events is the ephemeral merge commit and isn't a useful reference.

Applied consistently across `get_tag`, `get_tag_slim`, `get_tag_full`, and the `get_unique_tag*` variants in `docker_helpers.sh`. `master` (`sha-<sha>`) and release (`v*`) tags are unchanged.

### 2. New `comment_pr_images` job

When PR image publishing is enabled (the PR carries the `publish`/`publish-docker` label, on a non-fork PR), this job upserts a single PR comment with the published tag and a ready-to-run quickstart command so contributors can test the changes:

```bash
DATAHUB_VERSION=pr<N>-<sha> datahub docker quickstart
```

The comment is keyed by a hidden marker and updated in place on subsequent runs (no spam). It uses `actions/github-script` — matching the existing `contributor-open-pr-comment.yml` pattern — and a job-scoped `pull-requests: write` permission. Fork PRs publish nothing, so no misleading comment is posted.

## Notes

- The `comment_pr_images` job is gated on `pr-publish == 'true'`, so it only runs when images were actually pushed.
- Tag-computation logic was verified against the inline test cases in `docker_helpers.sh`; the embedded github-script passes `node --check` and the workflow passes `actionlint` + prettier.