### PR TITLE
fix(ingestion): respect sample size env var for per-entry context LossyList

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/source.py
@@ -186,18 +186,14 @@ class StructuredLogs(Report):
             logger.log(level=level.value, msg=log_content, stacklevel=stacklevel)
 
         if log_key not in entries:
-            context_list: LossyList[str] = LossyList()
-            if context is not None:
-                context_list.append(context)
             entries[log_key] = StructuredLogEntry(
                 title=title,
                 message=message,
-                context=context_list,
+                context=LossyList(max_elements=entries.max_elements),
                 log_category=log_category,
             )
-        else:
-            if context is not None:
-                entries[log_key].context.append(context)
+        if context is not None:
+            entries[log_key].context.append(context)
 
     def set_sample_sizes(
         self,

--- a/metadata-ingestion/tests/unit/api/test_report_sample_size.py
+++ b/metadata-ingestion/tests/unit/api/test_report_sample_size.py
@@ -31,3 +31,54 @@ class TestReportSampleSizeFromEnvVars:
         assert (
             report._structured_logs._entries[StructuredLogLevel.WARN].max_elements == 75
         )
+
+    def test_context_list_respects_sample_size(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that the per-entry context LossyList respects the sample size env var.
+
+        When multiple datasets share the same error message they are grouped into one
+        StructuredLogEntry. The context list within that entry must honour
+        DATAHUB_REPORT_FAILURE_SAMPLE_SIZE so all affected datasets are visible.
+        """
+        monkeypatch.setenv("DATAHUB_REPORT_FAILURE_SAMPLE_SIZE", "50")
+
+        report = SourceReport()
+        for i in range(30):
+            report.report_failure(
+                message="Error processing table", context=f"table_{i}"
+            )
+
+        failures = report._structured_logs._entries[StructuredLogLevel.ERROR]
+        entry = next(iter(failures.values()))
+        assert entry.context.max_elements == 50, (
+            "context LossyList max_elements should match DATAHUB_REPORT_FAILURE_SAMPLE_SIZE"
+        )
+        assert list(entry.context) == [f"table_{i}" for i in range(30)], (
+            "all 30 context items should be retained (30 < max_elements=50, no sampling)"
+        )
+
+    def test_context_list_truncates_at_configured_limit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that context items are sampled when count exceeds the configured limit.
+
+        This directly reproduces the original bug: before the fix, the context LossyList
+        was hardcoded to max_elements=10, so setting DATAHUB_REPORT_FAILURE_SAMPLE_SIZE=5
+        would still retain 10 items instead of 5, and entry.context.max_elements would be
+        10 rather than the configured 5.
+        """
+        monkeypatch.setenv("DATAHUB_REPORT_FAILURE_SAMPLE_SIZE", "5")
+
+        report = SourceReport()
+        for i in range(20):
+            report.report_failure(message="Permission denied", context=f"table_{i}")
+
+        failures = report._structured_logs._entries[StructuredLogLevel.ERROR]
+        entry = next(iter(failures.values()))
+        assert entry.context.max_elements == 5, (
+            "context LossyList max_elements should match DATAHUB_REPORT_FAILURE_SAMPLE_SIZE"
+        )
+        assert entry.context.sampled, (
+            "context should be sampled when entries (20) exceed max_elements (5)"
+        )


### PR DESCRIPTION
## Summary

- **Bug**: `LossyList` used for per-entry context inside `SourceReport.report_log()` was hardcoded to `max_elements=10`, ignoring the `DATAHUB_REPORT_*_SAMPLE_SIZE` env vars that users configure to control report sampling.
- **Fix**: Pass `max_elements=entries.max_elements` so the inner context list inherits the same limit as the outer `LossyDict`.
- **Cleanup**: Simplified `report_log()` — removed the duplicated `context.append` in both branches; now a single unconditional append after the entry is guaranteed to exist.

## Test plan

- [ ] `test_context_list_respects_sample_size` — verifies `max_elements` is wired through end-to-end and all entries are retained when count is below the limit
- [ ] `test_context_list_truncates_at_configured_limit` — directly reproduces the original bug: with `max_elements=5`, 20 logged entries trigger sampling (would fail on the unfixed code where `max_elements` was hardcoded to 10)