### PR TITLE
feat(precommit): skip comment-only PDL changes and enforce schema bumps in CI

### DIFF
--- a/.github/path-filters/lint-jobs-filters.yml
+++ b/.github/path-filters/lint-jobs-filters.yml
@@ -21,6 +21,9 @@ code-check-sources:
   - "**/build.gradle.kts"
   - "**/gradle.lockfile"
   - ".github/scripts/check_*.py"
+pdl:
+  - added|modified: "**/*.pdl"
+  - ".github/scripts/bump_schema_versions.py"
 smoke-test-python:
   - added|modified: "smoke-test/**/*.py"
   - "smoke-test/pyproject.toml"

--- a/.github/scripts/bump_schema_versions.py
+++ b/.github/scripts/bump_schema_versions.py
@@ -25,6 +25,7 @@ Usage:
     python3 scripts/bump_schema_versions.py
     python3 scripts/bump_schema_versions.py --base-branch master
     python3 scripts/bump_schema_versions.py --dry-run --verbose
+    python3 scripts/bump_schema_versions.py --check   # CI: fail if a bump is missing
     PDL_ROOTS="metadata-models/src/main/pegasus:other/src/main/pegasus" python3 scripts/bump_schema_versions.py
 """
 
@@ -659,6 +660,12 @@ def main() -> int:
         help="Print what would change without writing files",
     )
     parser.add_argument(
+        "--check",
+        action="store_true",
+        help="CI enforcement mode: write nothing and exit non-zero if any "
+        "changed aspect still needs a schemaVersion bump",
+    )
+    parser.add_argument(
         "--verbose",
         "-v",
         action="store_true",
@@ -770,7 +777,13 @@ def main() -> int:
             errors.append(filepath)
             continue
 
-        if args.dry_run:
+        if args.check:
+            print(
+                f"NEEDS BUMP  {filepath}  v{current_version} → v{new_version}"
+                f"  [{reason}]"
+            )
+            bumped.append(filepath)
+        elif args.dry_run:
             print(
                 f"BUMP  {filepath}  v{base_version} → v{new_version}"
                 f"  [{reason}]  [dry-run]"
@@ -781,9 +794,23 @@ def main() -> int:
             print(f"BUMP  {filepath}  v{base_version} → v{new_version}  [{reason}]")
             bumped.append(filepath)
 
+    verb = "need bump" if args.check else "bumped"
     print(
-        f"\nSummary: {len(bumped)} bumped, {len(skipped)} skipped, {len(errors)} errors"
+        f"\nSummary: {len(bumped)} {verb}, {len(skipped)} skipped, {len(errors)} errors"
     )
+
+    if args.check and bumped:
+        print(
+            "\nERROR: The following aspect(s) changed but their schemaVersion was "
+            "not bumped:\n"
+            + "\n".join(f"  {f}" for f in bumped)
+            + "\n\nRun the bump hook locally and commit the result:\n"
+            "  pre-commit run bump-schema-versions --all-files\n"
+            "or run the script directly:\n"
+            "  python .github/scripts/bump_schema_versions.py",
+            file=sys.stderr,
+        )
+        return 1
 
     return 1 if errors else 0
 

--- a/.github/scripts/bump_schema_versions.py
+++ b/.github/scripts/bump_schema_versions.py
@@ -149,6 +149,30 @@ def get_file_at_branch(filepath: str, branch: str) -> str | None:
     return result.stdout if result.returncode == 0 else None
 
 
+def is_comment_only_change(filepath: str, base_ref: str) -> bool:
+    """Return True if filepath's only diff vs base_ref is comments/whitespace.
+
+    PDL doc comments (`/** */`) and line comments (`//`) carry no schema
+    semantics, so a doc-only clarification must not trigger a schemaVersion
+    bump — nor cascade a bump into every aspect that references the edited
+    record. Compares the working-tree file against base_ref with comments
+    removed and whitespace collapsed.
+
+    New files (absent on base_ref) and unreadable files are treated as real
+    changes (returns False) so they are never silently dropped.
+    """
+    base_content = get_file_at_branch(filepath, base_ref)
+    if base_content is None:
+        return False
+    try:
+        current_content = Path(filepath).read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return normalize_pdl_for_compare(base_content) == normalize_pdl_for_compare(
+        current_content
+    )
+
+
 # ---------------------------------------------------------------------------
 # PDL parsing
 # ---------------------------------------------------------------------------
@@ -275,6 +299,54 @@ def _strip_strings_and_comments(content: str) -> str:
     content = _BLOCK_COMMENT_RE.sub(" ", content)
     content = _LINE_COMMENT_RE.sub(" ", content)
     return content
+
+
+def strip_pdl_comments(content: str) -> str:
+    """Remove PDL block (`/* */`) and line (`//`) comments.
+
+    Unlike `_strip_strings_and_comments`, this preserves the *contents* of
+    string literals — it only drops comments. That distinction matters for
+    semantic comparison: masking strings to `""` would hide a real change to a
+    string value (e.g. an annotation `"name"`) and mis-classify it as
+    comment-only. A single linear scan tracks string state so comment markers
+    appearing inside a string literal are not treated as comments.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(content)
+    while i < n:
+        ch = content[i]
+        if ch == '"':
+            # Copy the string literal verbatim, honoring backslash escapes.
+            j = i + 1
+            while j < n:
+                if content[j] == "\\":
+                    j += 2
+                    continue
+                if content[j] == '"':
+                    j += 1
+                    break
+                j += 1
+            out.append(content[i:j])
+            i = j
+        elif ch == "/" and i + 1 < n and content[i + 1] == "*":
+            end = content.find("*/", i + 2)
+            i = end + 2 if end != -1 else n
+        elif ch == "/" and i + 1 < n and content[i + 1] == "/":
+            end = content.find("\n", i + 2)
+            i = end if end != -1 else n
+        else:
+            out.append(ch)
+            i += 1
+    return "".join(out)
+
+
+def normalize_pdl_for_compare(content: str) -> str:
+    """Canonical form for semantic comparison: comments removed and runs of
+    whitespace collapsed to single spaces. Two PDL files with identical
+    canonical forms differ only in comments and/or formatting.
+    """
+    return " ".join(strip_pdl_comments(content).split())
 
 
 def _strip_annotation_blocks(content: str) -> str:
@@ -598,6 +670,20 @@ def main() -> int:
     merge_base = get_merge_base(remote_ref)
 
     directly_changed = get_changed_pdl_files(merge_base)
+
+    # Drop files whose only diff vs the merge-base is comments/whitespace. A
+    # doc-comment clarification carries no schema semantics, so it must neither
+    # bump the edited file nor cascade a bump into aspects that reference it.
+    comment_only = [
+        f for f in directly_changed if is_comment_only_change(f, merge_base)
+    ]
+    if comment_only:
+        directly_changed = [f for f in directly_changed if f not in set(comment_only)]
+        if args.verbose:
+            print(f"Ignoring {len(comment_only)} comment-only PDL change(s):")
+            for f in comment_only:
+                print(f"  {f}")
+            print()
 
     if not directly_changed:
         print("No changed PDL files found.")

--- a/.github/scripts/test/test_bump_schema_versions.py
+++ b/.github/scripts/test/test_bump_schema_versions.py
@@ -932,3 +932,53 @@ def test_version_bump_dry_run_does_not_write(tmp_path, monkeypatch):
 
     assert rc == 0
     assert aspect.read_text() == original  # file untouched
+
+
+def _run_check(tmp_path, monkeypatch, changed_files, base_content_by_path):
+    """Run main() in --check mode with git/filesystem calls mocked out."""
+    monkeypatch.setenv("PDL_ROOTS", str(tmp_path))
+    monkeypatch.setattr(sys, "argv",
+                        ["bump_schema_versions.py", "--base-branch", "master", "--check"])
+    monkeypatch.setattr(bsv, "get_merge_base", lambda _ref: "deadbeef")
+    monkeypatch.setattr(bsv, "get_base_pdl_changes", lambda _base, _ref: [])
+    monkeypatch.setattr(bsv, "get_changed_pdl_files",
+                        lambda _ref: [str(f) for f in changed_files])
+    monkeypatch.setattr(bsv, "get_file_at_branch",
+                        lambda path, _branch: base_content_by_path.get(path))
+    return bsv.main()
+
+
+def test_check_mode_fails_when_bump_missing(tmp_path, monkeypatch):
+    # Aspect changed but schemaVersion left at base value → CI should fail (rc=1)
+    # and the file must not be modified.
+    base_content = aspect_pdl("myAspect", schema_version=3)
+    aspect = write_pdl(tmp_path, "com/linkedin/dataset/MyAspect.pdl",
+                       _with_added_field(base_content))
+    original = aspect.read_text()
+
+    rc = _run_check(tmp_path, monkeypatch, [aspect], {str(aspect): base_content})
+
+    assert rc == 1
+    assert aspect.read_text() == original  # check mode writes nothing
+
+
+def test_check_mode_passes_when_bump_present(tmp_path, monkeypatch):
+    # Aspect changed AND already bumped to base+1 → CI should pass (rc=0).
+    base_content = aspect_pdl("myAspect", schema_version=3)
+    current_content = _with_added_field(aspect_pdl("myAspect", schema_version=4))
+    aspect = write_pdl(tmp_path, "com/linkedin/dataset/MyAspect.pdl", current_content)
+
+    rc = _run_check(tmp_path, monkeypatch, [aspect], {str(aspect): base_content})
+
+    assert rc == 0
+
+
+def test_check_mode_passes_for_comment_only_change(tmp_path, monkeypatch):
+    # A doc-only edit needs no bump, so --check must not fail it.
+    enum_base = "namespace com.linkedin.a\nenum Op {\n  /** old */\n  A\n}"
+    enum_current = "namespace com.linkedin.a\nenum Op {\n  /** clarified */\n  A\n}"
+    enum_file = write_pdl(tmp_path, "com/linkedin/a/Op.pdl", enum_current)
+
+    rc = _run_check(tmp_path, monkeypatch, [enum_file], {str(enum_file): enum_base})
+
+    assert rc == 0

--- a/.github/scripts/test/test_bump_schema_versions.py
+++ b/.github/scripts/test/test_bump_schema_versions.py
@@ -629,6 +629,88 @@ def test_unrelated_same_namespace_record_is_not_a_dependency(tmp_path, monkeypat
 
 
 # ---------------------------------------------------------------------------
+# strip_pdl_comments / normalize_pdl_for_compare
+# ---------------------------------------------------------------------------
+
+
+def test_strip_pdl_comments_removes_block_and_line_comments():
+    content = (
+        "record Foo {\n"
+        "  /** doc comment */\n"
+        "  field: string  // trailing note\n"
+        "}"
+    )
+    stripped = bsv.strip_pdl_comments(content)
+    assert "doc comment" not in stripped
+    assert "trailing note" not in stripped
+    assert "field: string" in stripped
+
+
+def test_strip_pdl_comments_preserves_string_literals():
+    # Comment markers inside a string literal must survive — they are data,
+    # not comments. (This is what distinguishes it from _strip_strings_and_comments.)
+    content = 'record Foo { @x = { "v": "a // b /* c */ d" } }'
+    stripped = bsv.strip_pdl_comments(content)
+    assert "a // b /* c */ d" in stripped
+
+
+def test_normalize_pdl_collapses_whitespace_and_comments():
+    a = '@Aspect = {\n  "name": "foo"\n}\nrecord Foo { f: string }'
+    b = '/** added doc */\n@Aspect = {\n    "name":   "foo"\n}\n\nrecord Foo { f: string }'
+    assert bsv.normalize_pdl_for_compare(a) == bsv.normalize_pdl_for_compare(b)
+
+
+def test_normalize_pdl_detects_real_schema_change():
+    a = '@Aspect = { "name": "foo" }\nrecord Foo { f: string }'
+    b = '@Aspect = { "name": "foo" }\nrecord Foo { f: string, g: int }'
+    assert bsv.normalize_pdl_for_compare(a) != bsv.normalize_pdl_for_compare(b)
+
+
+def test_normalize_pdl_detects_string_value_change():
+    # A changed annotation value is a real change, even though it's a string.
+    a = '@Aspect = { "name": "foo" }\nrecord Foo { f: string }'
+    b = '@Aspect = { "name": "bar" }\nrecord Foo { f: string }'
+    assert bsv.normalize_pdl_for_compare(a) != bsv.normalize_pdl_for_compare(b)
+
+
+# ---------------------------------------------------------------------------
+# is_comment_only_change
+# ---------------------------------------------------------------------------
+
+
+def test_is_comment_only_change_true_for_doc_edit(tmp_path, monkeypatch):
+    base = 'enum Op {\n  /** old */\n  A\n}'
+    current = 'enum Op {\n  /** a much longer clarified doc comment */\n  A\n}'
+    p = write_pdl(tmp_path, "com/linkedin/x/Op.pdl", current)
+    monkeypatch.setattr(bsv, "get_file_at_branch", lambda _f, _b: base)
+    assert bsv.is_comment_only_change(str(p), "deadbeef") is True
+
+
+def test_is_comment_only_change_false_for_real_edit(tmp_path, monkeypatch):
+    base = "enum Op {\n  A\n}"
+    current = "enum Op {\n  A\n  B\n}"  # new enum value — real change
+    p = write_pdl(tmp_path, "com/linkedin/x/Op.pdl", current)
+    monkeypatch.setattr(bsv, "get_file_at_branch", lambda _f, _b: base)
+    assert bsv.is_comment_only_change(str(p), "deadbeef") is False
+
+
+def test_is_comment_only_change_false_for_new_file(tmp_path, monkeypatch):
+    p = write_pdl(tmp_path, "com/linkedin/x/Op.pdl", "enum Op { A }")
+    monkeypatch.setattr(bsv, "get_file_at_branch", lambda _f, _b: None)  # absent on base
+    assert bsv.is_comment_only_change(str(p), "deadbeef") is False
+
+
+def test_is_comment_only_change_false_for_mixed_edit(tmp_path, monkeypatch):
+    # A real schema change accompanied by a doc-comment edit must NOT be skipped —
+    # the structural change still has to bump. This is the key safety property.
+    base = "record Foo {\n  /** old */\n  a: string\n}"
+    current = "record Foo {\n  /** new clarified doc */\n  a: string\n  b: int\n}"  # added field
+    p = write_pdl(tmp_path, "com/linkedin/x/Foo.pdl", current)
+    monkeypatch.setattr(bsv, "get_file_at_branch", lambda _f, _b: base)
+    assert bsv.is_comment_only_change(str(p), "deadbeef") is False
+
+
+# ---------------------------------------------------------------------------
 # detect_default_branch / get_merge_base / get_base_pdl_changes
 # ---------------------------------------------------------------------------
 
@@ -719,10 +801,16 @@ def _run_main(tmp_path, monkeypatch, changed_files, base_content_by_path, *,
     return bsv.main()
 
 
+def _with_added_field(content: str) -> str:
+    """Return a real (non-comment) schema change of an aspect_pdl() body."""
+    return content.replace("{ field: string }", "{ field: string, added: int }")
+
+
 def test_version_bump_existing_aspect_no_schema_version(tmp_path, monkeypatch):
     # Base has @Aspect with no schemaVersion (defaults to 1) → should bump to 2
     base_content = aspect_pdl("myAspect")  # no schemaVersion
-    aspect = write_pdl(tmp_path, "com/linkedin/dataset/MyAspect.pdl", base_content)
+    aspect = write_pdl(tmp_path, "com/linkedin/dataset/MyAspect.pdl",
+                       _with_added_field(base_content))
 
     rc = _run_main(tmp_path, monkeypatch, [aspect], {str(aspect): base_content})
 
@@ -733,7 +821,8 @@ def test_version_bump_existing_aspect_no_schema_version(tmp_path, monkeypatch):
 def test_version_bump_existing_aspect_with_schema_version(tmp_path, monkeypatch):
     # Base has schemaVersion=3 → should bump to 4
     base_content = aspect_pdl("myAspect", schema_version=3)
-    aspect = write_pdl(tmp_path, "com/linkedin/dataset/MyAspect.pdl", base_content)
+    aspect = write_pdl(tmp_path, "com/linkedin/dataset/MyAspect.pdl",
+                       _with_added_field(base_content))
 
     rc = _run_main(tmp_path, monkeypatch, [aspect], {str(aspect): base_content})
 
@@ -768,7 +857,8 @@ def test_version_bump_new_file_stays_at_1(tmp_path, monkeypatch):
 def test_conflicting_pdl_on_base_branch_exits_with_error(tmp_path, monkeypatch):
     # Base ref is current AND the same PDL changed on both branches → block at stage 2
     base_content = aspect_pdl("myAspect")
-    aspect = write_pdl(tmp_path, "com/linkedin/dataset/MyAspect.pdl", base_content)
+    aspect = write_pdl(tmp_path, "com/linkedin/dataset/MyAspect.pdl",
+                       _with_added_field(base_content))
 
     rc = _run_main(
         tmp_path, monkeypatch,
@@ -784,7 +874,8 @@ def test_conflicting_pdl_on_base_branch_exits_with_error(tmp_path, monkeypatch):
 def test_unrelated_base_pdl_changes_do_not_block(tmp_path, monkeypatch):
     # A different PDL changed on the base branch — should not block this branch's bump
     base_content = aspect_pdl("myAspect")
-    aspect = write_pdl(tmp_path, "com/linkedin/dataset/MyAspect.pdl", base_content)
+    aspect = write_pdl(tmp_path, "com/linkedin/dataset/MyAspect.pdl",
+                       _with_added_field(base_content))
 
     rc = _run_main(
         tmp_path, monkeypatch,
@@ -797,9 +888,37 @@ def test_unrelated_base_pdl_changes_do_not_block(tmp_path, monkeypatch):
     assert bsv.get_schema_version(aspect.read_text()) == 2  # bumped normally
 
 
+def test_comment_only_change_does_not_bump_or_cascade(tmp_path, monkeypatch):
+    # Mirrors the reported case: an enum's doc comment changes, and an aspect
+    # references that enum as a field type. The doc-only edit must NOT bump the
+    # aspect. The enum file on disk differs from base only by a comment.
+    enum_base = "namespace com.linkedin.a\nenum Op {\n  /** old */\n  A\n}"
+    enum_current = "namespace com.linkedin.a\nenum Op {\n  /** clarified longer doc */\n  A\n}"
+    enum_file = write_pdl(tmp_path, "com/linkedin/a/Op.pdl", enum_current)
+
+    aspect_content = (
+        "namespace com.linkedin.a\n"
+        + aspect_pdl("ruleInfo", schema_version=3).replace(
+            "{ field: string }", '{ op: Op = "A" }'
+        )
+    )
+    aspect = write_pdl(tmp_path, "com/linkedin/a/RuleInfo.pdl", aspect_content)
+
+    rc = _run_main(
+        tmp_path,
+        monkeypatch,
+        changed_files=[enum_file],
+        base_content_by_path={str(enum_file): enum_base, str(aspect): aspect_content},
+    )
+
+    assert rc == 0
+    assert bsv.get_schema_version(aspect.read_text()) == 3  # unchanged, no cascade
+
+
 def test_version_bump_dry_run_does_not_write(tmp_path, monkeypatch):
     base_content = aspect_pdl("myAspect")
-    aspect = write_pdl(tmp_path, "com/linkedin/dataset/MyAspect.pdl", base_content)
+    aspect = write_pdl(tmp_path, "com/linkedin/dataset/MyAspect.pdl",
+                       _with_added_field(base_content))
     original = aspect.read_text()
 
     monkeypatch.setenv("PDL_ROOTS", str(tmp_path))

--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -23,6 +23,7 @@ jobs:
       workflow-files: ${{ steps.filter.outputs.workflow-files == 'true' || steps.filter.outputs.lint-job == 'true' }}
       workflow-validation: ${{ steps.filter.outputs.workflow-validation == 'true' || steps.filter.outputs.lint-job == 'true' }}
       code-check-sources: ${{ steps.filter.outputs.code-check-sources == 'true' || steps.filter.outputs.lint-job == 'true' }}
+      pdl: ${{ steps.filter.outputs.pdl == 'true' || steps.filter.outputs.lint-job == 'true' }}
       datahub-web-react: ${{ steps.filter.outputs.datahub-web-react == 'true' || steps.filter.outputs.lint-job == 'true' }}
       smoke-test-python: ${{ steps.filter.outputs.smoke-test-python == 'true' || steps.filter.outputs.lint-job == 'true' }}
       smoke-test-cypress: ${{ steps.filter.outputs.smoke-test-cypress == 'true' || steps.filter.outputs.lint-job == 'true' }}
@@ -148,6 +149,25 @@ jobs:
           python-version: "3.10"
       - name: run check
         run: python .github/scripts/check_gradle_lockfiles.py
+
+  check-schema-versions:
+    name: check-schema-versions
+    runs-on: ${{ needs.setup.outputs.default-gh-runner }}
+    needs: setup
+    if: needs.setup.outputs.pdl == 'true'
+    steps:
+      # Full history so the script can compute the merge-base against the PR's
+      # base branch and diff the changed PDL aspects against it.
+      - uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.10"
+      - name: Verify schemaVersion is bumped for changed PDL aspects
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: python .github/scripts/bump_schema_versions.py --check --base-branch "$BASE_REF"
 
   smoke-test-lint:
     name: Lint on smoke tests

--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Verify schemaVersion is bumped for changed PDL aspects
         env:
           BASE_REF: ${{ github.base_ref }}


### PR DESCRIPTION
## Summary

Two related changes to the PDL schema-version tooling:

1. **Fix false-positive bumps** — the `bump-schema-versions` pre-commit hook treated **any** textual diff to a PDL file as a schema change, so a doc-comment-only edit bumped `schemaVersion` on the edited file **and cascaded into every aspect that references it**.
2. **Enforce bumps in CI** — add a merge-gating `check-schema-versions` job so a contributor who changes a PDL aspect without running the hook (or without pre-commit installed) is caught, instead of merging a stale `schemaVersion`.

---

## Part 1 — Skip comment-only PDL changes (fix)

Clarifying the `AssertionStdOperator._NATIVE_` doc comment (#17567) caused four unrelated aspects to be bumped on an unrelated commit:

- `AssertionInfo` v4 → v5
- `AssertionRunEvent` v5 → v6
- `AssertionAnalyticsRunEvent` v5 → v6
- `MonitorInfo` v5 → v6

all flagged `[implicit (depends on changed record)]`. Doc comments carry no wire-schema semantics, so these bumps are false positives.

**Fix** — filter comment-only PDL changes out of the changed-file set before computing bumps:

- **`strip_pdl_comments`** — removes `/* */` and `//` comments while **preserving string-literal contents** (unlike the existing `_strip_strings_and_comments`, which masks strings to `""` and would hide a real change to a string value such as an annotation `"name"`).
- **`normalize_pdl_for_compare`** — canonical form (comments stripped, whitespace collapsed) for semantic comparison.
- **`is_comment_only_change`** — compares the working-tree file vs the base ref in canonical form. New and unreadable files are treated as real changes (never silently dropped).
- **`main()`** — drops comment-only files (with verbose logging) so they neither bump themselves nor cascade into dependent aspects.

### Does this affect real PDL changes?

No. The filter skips a file **only** when its entire diff reduces to comments/whitespace. Any structural change — fields, types, enum values, annotations, string/default values, `includes` — keeps the file in scope and bumps normally. A real change **bundled with** a comment edit still differs in canonical form and is kept (covered by a dedicated test).

---

## Part 2 — CI enforcement (`check-schema-versions`)

The pre-commit hook bumps versions locally, but nothing failed CI when the hook wasn't run. This adds a check that reuses the **same `main()` detection logic** so its behavior can never drift from the bump tool:

- **`bump_schema_versions.py` — new `--check` mode.** Like `--dry-run` it writes nothing, but exits non-zero if any changed aspect still needs a bump, printing the offending files plus remediation. Because it shares `main()`, comment-only edits (Part 1) are correctly treated as needing no bump.
- **`lint-jobs.yml` — new `check-schema-versions` job**, gated by a new `pdl` path filter, checked out with `fetch-depth: 0` so the merge-base against the PR's base branch is available. The base branch is passed through an `env:` var (repo convention for `github.*` context in `run` steps). Runs the script with `--check`.
- **`lint-jobs-filters.yml` — new `pdl` filter** on `**/*.pdl` and the script itself, so the job only runs when a PDL (or the script) changes and is skipped otherwise.

> **Note:** a failing check only *blocks* merge once a repo admin marks `check-schema-versions` as a **required status check** in branch protection. Until then it runs and reports red as an advisory signal.

---

## Verification

**Part 1** — same baseline, same working tree, only the script differs:

- Without fix: bumps 4 aspects.
- With fix: `Ignoring 1 comment-only PDL change(s)` → 0 bumps.

**Part 2** — validated live against real aspects (each restored afterward):

| Scenario | Result |
| --- | --- |
| No PDL change | `No changed PDL files` → exit 0 |
| Aspect struct change, no bump | `NEEDS BUMP … v2→v3` → exit 1 |
| Aspect struct change + bump | exit 0 |
| Comment-only edit | filtered → exit 0 |
| Enum symbol added, no bump (cascade) | dependent aspect flagged `[implicit]` → exit 1 |
| New aspect file | defaults to v1 → exit 0 |
| `--check` vs `--dry-run` closure | **identical** (no reporting drift) |

**Tests:** all pass — new `--check` unit tests plus the existing unit + end-to-end coverage.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated


  # live: edit any real aspect's body, then:
  python .github/scripts/bump_schema_versions.py --check --base-branch master ; echo "exit=$?"