### PR TITLE
feat(ingest/dbt): add skip_missing_upstreams_in_lineage config option

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -149,6 +149,7 @@ from datahub.utilities.lossy_collections import LossyList
 from datahub.utilities.mapping import Constants, OperationProcessor
 from datahub.utilities.time import datetime_to_ts_millis
 from datahub.utilities.topological_sort import topological_sort
+from datahub.utilities.urns.urn import Urn
 
 logger = logging.getLogger(__name__)
 DBT_PLATFORM = "dbt"
@@ -547,7 +548,13 @@ class DBTCommonConfig(
     skip_missing_upstreams_in_lineage: bool = Field(
         default=False,
         description="When enabled, upstream datasets that do not already exist in DataHub are excluded from "
-        "lineage, preventing the creation of empty stub entities. Requires a DataHub graph connection.",
+        "lineage, preventing dangling graph edges from appearing in the lineage UI. "
+        "Typically used together with `skip_sources_in_lineage` and `entities_enabled.sources: NO`. "
+        "Important caveats: (1) if dbt is ingested before its upstream source systems, those lineage "
+        "edges will be silently omitted until dbt is re-ingested after the upstreams are present; "
+        "(2) adds one graph.exists() round-trip per unique upstream URN per run (cached within the run); "
+        "(3) soft-deleted upstream entities are treated as present. "
+        "Requires a DataHub graph connection.",
     )
     tag_prefix: str = Field(
         default=f"{DBT_PLATFORM}:", description="Prefix added to tags during ingestion."
@@ -1445,10 +1452,23 @@ class DBTSourceBase(StatefulIngestionSourceBase):
         return self._query_timestamp_cache
 
     def _upstream_exists_in_datahub(self, urn: str) -> bool:
-        """Check whether an upstream URN exists in DataHub, with per-run caching."""
+        """Check whether an upstream URN exists in DataHub, with per-run caching.
+
+        Fails open: if the existence check itself fails (transient GMS error, timeout,
+        etc.) the edge is kept to avoid silent lineage loss.
+        """
         if urn not in self._upstream_exists_cache:
             assert self.ctx.graph  # caller ensures graph is available
-            self._upstream_exists_cache[urn] = self.ctx.graph.exists(urn)
+            try:
+                self._upstream_exists_cache[urn] = self.ctx.graph.exists(urn)
+            except Exception as e:
+                self.report.report_warning(
+                    title="Upstream existence check failed",
+                    message="Could not verify upstream existence; keeping the lineage edge to avoid silent lineage loss.",
+                    context=urn,
+                    exc=e,
+                )
+                self._upstream_exists_cache[urn] = True  # fail open
             if not self._upstream_exists_cache[urn]:
                 self.report.lineage_upstreams_skipped_missing += 1
         return self._upstream_exists_cache[urn]
@@ -3224,12 +3244,30 @@ class DBTSourceBase(StatefulIngestionSourceBase):
                     )
                 ]
 
-            if self.config.skip_missing_upstreams_in_lineage and self.ctx.graph:
+            if self.config.skip_missing_upstreams_in_lineage:
                 upstream_urns = [
                     urn
                     for urn in upstream_urns
                     if self._upstream_exists_in_datahub(urn)
                 ]
+                # Also filter CLL: schemaField edges embed the parent dataset URN,
+                # so a missing upstream with CLL still creates the ghost node via
+                # graphService.addEdge(). Keep only entries whose upstream datasets
+                # are all in the surviving set.
+                if cll:
+                    existing_upstream_set = set(upstream_urns)
+                    filtered_cll = []
+                    for entry in cll:
+                        filtered_upstreams = [
+                            sf_urn
+                            for sf_urn in (entry.upstreams or [])
+                            if Urn.from_string(sf_urn).entity_ids[0]
+                            in existing_upstream_set
+                        ]
+                        if filtered_upstreams:
+                            entry.upstreams = filtered_upstreams
+                            filtered_cll.append(entry)
+                    cll = filtered_cll
 
             if not upstream_urns:
                 return None

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -307,6 +307,8 @@ class DBTSourceReport(StaleEntityRemovalSourceReport):
 
     nodes_filtered: LossyList[str] = field(default_factory=LossyList)
 
+    lineage_upstreams_skipped_missing: int = 0
+
     duplicate_sources_dropped: Optional[int] = None
     duplicate_sources_references_updated: Optional[int] = None
 
@@ -541,6 +543,11 @@ class DBTCommonConfig(
         description="[Experimental] When enabled, dbt sources will not be included in the lineage graph. "
         "Requires that `entities_enabled.sources` is set to `NO`. "
         "This is mainly useful when you have multiple, interdependent dbt projects. ",
+    )
+    skip_missing_upstreams_in_lineage: bool = Field(
+        default=False,
+        description="When enabled, upstream datasets that do not already exist in DataHub are excluded from "
+        "lineage, preventing the creation of empty stub entities. Requires a DataHub graph connection.",
     )
     tag_prefix: str = Field(
         default=f"{DBT_PLATFORM}:", description="Prefix added to tags during ingestion."
@@ -1410,6 +1417,8 @@ class DBTSourceBase(StatefulIngestionSourceBase):
         self._query_timestamp_cache: Optional[int] = None
         # Exposures loaded by subclass (manifest or dbt Cloud API)
         self._exposures: List[DBTExposure] = []
+        # Cache for upstream existence checks (skip_missing_upstreams_in_lineage)
+        self._upstream_exists_cache: Dict[str, bool] = {}
 
     def _get_query_timestamp(self) -> int:
         """Get timestamp for Query entities, cached for reproducibility."""
@@ -1434,6 +1443,15 @@ class DBTSourceBase(StatefulIngestionSourceBase):
         self._query_timestamp_cache = datetime_to_ts_millis(datetime.now())
         self.report.query_timestamps_fallback_used = True
         return self._query_timestamp_cache
+
+    def _upstream_exists_in_datahub(self, urn: str) -> bool:
+        """Check whether an upstream URN exists in DataHub, with per-run caching."""
+        if urn not in self._upstream_exists_cache:
+            assert self.ctx.graph  # caller ensures graph is available
+            self._upstream_exists_cache[urn] = self.ctx.graph.exists(urn)
+            if not self._upstream_exists_cache[urn]:
+                self.report.lineage_upstreams_skipped_missing += 1
+        return self._upstream_exists_cache[urn]
 
     def create_test_entity_mcps(
         self,
@@ -1793,6 +1811,10 @@ class DBTSourceBase(StatefulIngestionSourceBase):
     ) -> Iterable[Union[MetadataWorkUnit, MetadataChangeProposalWrapper]]:
         if self.config.write_semantics == "PATCH":
             self.ctx.require_graph("Using dbt with write_semantics=PATCH")
+        if self.config.skip_missing_upstreams_in_lineage:
+            self.ctx.require_graph(
+                "Using dbt with skip_missing_upstreams_in_lineage=True"
+            )
 
         all_nodes, additional_custom_props = self.load_nodes()
 
@@ -3200,6 +3222,13 @@ class DBTSourceBase(StatefulIngestionSourceBase):
                     for downstream, upstreams in groupby_unsorted(
                         valid_cll_entries, lambda x: x.downstream_col
                     )
+                ]
+
+            if self.config.skip_missing_upstreams_in_lineage and self.ctx.graph:
+                upstream_urns = [
+                    urn
+                    for urn in upstream_urns
+                    if self._upstream_exists_in_datahub(urn)
                 ]
 
             if not upstream_urns:

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -744,6 +744,15 @@ class DBTCommonConfig(
                 "`prefer_sql_parser_lineage` requires that `skip_sources_in_lineage` is enabled."
             )
 
+        if self.skip_missing_upstreams_in_lineage and not self.skip_sources_in_lineage:
+            logger.warning(
+                "`skip_missing_upstreams_in_lineage` is most effective with `skip_sources_in_lineage` enabled. "
+                "Without it, source nodes appear as dbt URNs in lineage rather than target-platform URNs, "
+                "so on the first ingestion run dbt source entities do not yet exist in DataHub and their "
+                "lineage edges will be silently dropped. The flag still works correctly for model-to-model "
+                "lineage and on subsequent runs once source entities are committed."
+            )
+
         if (
             self.skip_sources_in_lineage
             and self.entities_enabled

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
@@ -3854,14 +3854,30 @@ def _make_dbt_model_node(dbt_name: str, upstream_nodes: List[str]) -> DBTNode:
 
 
 def test_skip_missing_upstreams_in_lineage_config():
-    config_dict = {
-        "manifest_path": "dummy_path",
-        "catalog_path": "dummy_path",
-        "target_platform": "postgres",
-        "skip_missing_upstreams_in_lineage": True,
-    }
-    config = DBTCoreConfig.model_validate(config_dict)
+    # Works without skip_sources_in_lineage — logs a warning but does not raise
+    config = DBTCoreConfig.model_validate(
+        {
+            "manifest_path": "dummy_path",
+            "catalog_path": "dummy_path",
+            "target_platform": "postgres",
+            "skip_missing_upstreams_in_lineage": True,
+        }
+    )
     assert config.skip_missing_upstreams_in_lineage is True
+
+    # Recommended combination — no warning logged
+    config = DBTCoreConfig.model_validate(
+        {
+            "manifest_path": "dummy_path",
+            "catalog_path": "dummy_path",
+            "target_platform": "postgres",
+            "skip_missing_upstreams_in_lineage": True,
+            "skip_sources_in_lineage": True,
+            "entities_enabled": {"sources": "NO"},
+        }
+    )
+    assert config.skip_missing_upstreams_in_lineage is True
+    assert config.skip_sources_in_lineage is True
 
 
 def test_skip_missing_upstreams_in_lineage_filters_missing():
@@ -3880,6 +3896,8 @@ def test_skip_missing_upstreams_in_lineage_filters_missing():
         {
             **create_base_dbt_config(),
             "skip_missing_upstreams_in_lineage": True,
+            "skip_sources_in_lineage": True,
+            "entities_enabled": {"sources": "NO"},
         }
     )
     source = DBTCoreSource(config, ctx)
@@ -3914,6 +3932,8 @@ def test_skip_missing_upstreams_in_lineage_all_missing_returns_none():
         {
             **create_base_dbt_config(),
             "skip_missing_upstreams_in_lineage": True,
+            "skip_sources_in_lineage": True,
+            "entities_enabled": {"sources": "NO"},
         }
     )
     source = DBTCoreSource(config, ctx)
@@ -3940,6 +3960,8 @@ def test_skip_missing_upstreams_existence_is_cached():
         {
             **create_base_dbt_config(),
             "skip_missing_upstreams_in_lineage": True,
+            "skip_sources_in_lineage": True,
+            "entities_enabled": {"sources": "NO"},
         }
     )
     source = DBTCoreSource(config, ctx)
@@ -3967,7 +3989,12 @@ def test_skip_missing_upstreams_fails_open_on_graph_error():
     ctx.graph = graph
 
     config = DBTCoreConfig.model_validate(
-        {**create_base_dbt_config(), "skip_missing_upstreams_in_lineage": True}
+        {
+            **create_base_dbt_config(),
+            "skip_missing_upstreams_in_lineage": True,
+            "skip_sources_in_lineage": True,
+            "entities_enabled": {"sources": "NO"},
+        }
     )
     source = DBTCoreSource(config, ctx)
 
@@ -4005,6 +4032,8 @@ def test_skip_missing_upstreams_filters_cll():
         {
             **create_base_dbt_config(),
             "skip_missing_upstreams_in_lineage": True,
+            "skip_sources_in_lineage": True,
+            "entities_enabled": {"sources": "NO"},
             "include_column_lineage": True,
         }
     )

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
@@ -3956,3 +3956,95 @@ def test_skip_missing_upstreams_existence_is_cached():
     shared_urn = "urn:li:dataset:(urn:li:dataPlatform:postgres,db.schema.shared,PROD)"
     calls = [c for c in graph.exists.call_args_list if c.args[0] == shared_urn]
     assert len(calls) == 1
+
+
+def test_skip_missing_upstreams_fails_open_on_graph_error():
+    """When graph.exists() raises, the edge is kept and a warning is reported."""
+    graph = mock.MagicMock()
+    graph.exists.side_effect = Exception("GMS timeout")
+
+    ctx = PipelineContext(run_id="test-run-id", pipeline_name="dbt-source")
+    ctx.graph = graph
+
+    config = DBTCoreConfig.model_validate(
+        {**create_base_dbt_config(), "skip_missing_upstreams_in_lineage": True}
+    )
+    source = DBTCoreSource(config, ctx)
+
+    upstream = _make_dbt_model_node("upstream", [])
+    downstream = _make_dbt_model_node("downstream", ["upstream"])
+    all_nodes_map = {"upstream": upstream, "downstream": downstream}
+
+    lineage = source._create_lineage_aspect_for_dbt_node(downstream, all_nodes_map)
+
+    # Edge should be retained (fail open)
+    assert lineage is not None
+    assert len(lineage.upstreams) == 1
+    # Counter should NOT increment (we didn't skip anything)
+    assert source.report.lineage_upstreams_skipped_missing == 0
+    # A warning should have been recorded
+    assert len(source.report.warnings) > 0
+
+
+def test_skip_missing_upstreams_filters_cll():
+    """Column-level lineage referencing a missing upstream is also filtered out."""
+    from datahub.ingestion.source.dbt.dbt_common import DBTColumnLineageInfo
+
+    existing_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:postgres,db.schema.existing,PROD)"
+    )
+    missing_urn = "urn:li:dataset:(urn:li:dataPlatform:postgres,db.schema.missing,PROD)"
+
+    graph = mock.MagicMock()
+    graph.exists.side_effect = lambda urn: urn == existing_urn
+
+    ctx = PipelineContext(run_id="test-run-id", pipeline_name="dbt-source")
+    ctx.graph = graph
+
+    config = DBTCoreConfig.model_validate(
+        {
+            **create_base_dbt_config(),
+            "skip_missing_upstreams_in_lineage": True,
+            "include_column_lineage": True,
+        }
+    )
+    source = DBTCoreSource(config, ctx)
+
+    existing_node = _make_dbt_model_node("existing", [])
+    missing_node = _make_dbt_model_node("missing", [])
+    downstream_node = _make_dbt_model_node("downstream", ["existing", "missing"])
+    # Give the downstream node CLL entries pointing at both upstreams
+    downstream_node.upstream_cll = [
+        DBTColumnLineageInfo(
+            downstream_col="col_a",
+            upstream_dbt_name="existing",
+            upstream_col="col_a",
+        ),
+        DBTColumnLineageInfo(
+            downstream_col="col_b",
+            upstream_dbt_name="missing",
+            upstream_col="col_b",
+        ),
+    ]
+    all_nodes_map = {
+        "existing": existing_node,
+        "missing": missing_node,
+        "downstream": downstream_node,
+    }
+
+    lineage = source._create_lineage_aspect_for_dbt_node(downstream_node, all_nodes_map)
+
+    assert lineage is not None
+    upstream_datasets = {u.dataset for u in lineage.upstreams}
+    assert existing_urn in upstream_datasets
+    assert missing_urn not in upstream_datasets
+
+    # CLL for the missing upstream should also be absent
+    cll_upstream_urns = {
+        sf_urn.split(",")[0].removeprefix("urn:li:schemaField:(")
+        for entry in (lineage.fineGrainedLineages or [])
+        for sf_urn in (entry.upstreams or [])
+    }
+    assert not any(missing_urn in u for u in cll_upstream_urns), (
+        "CLL still references the missing upstream — ghost node would still be created"
+    )

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
@@ -3827,3 +3827,132 @@ def test_dbt_common_semantic_model_subtype_assignment():
         aspect = wu.metadata.aspect
         assert isinstance(aspect, SubTypesClass)
         assert expected_subtype in aspect.typeNames, f"Failed for node_type={node_type}"
+
+
+def _make_dbt_model_node(dbt_name: str, upstream_nodes: List[str]) -> DBTNode:
+    return DBTNode(
+        database="db",
+        schema="schema",
+        name=dbt_name,
+        alias=None,
+        comment="",
+        description="",
+        language="sql",
+        raw_code=None,
+        dbt_adapter="postgres",
+        dbt_name=dbt_name,
+        dbt_file_path=None,
+        dbt_package_name="my_project",
+        node_type="model",
+        max_loaded_at=None,
+        materialization="table",
+        catalog_type=None,
+        missing_from_catalog=False,
+        owner=None,
+        upstream_nodes=upstream_nodes,
+    )
+
+
+def test_skip_missing_upstreams_in_lineage_config():
+    config_dict = {
+        "manifest_path": "dummy_path",
+        "catalog_path": "dummy_path",
+        "target_platform": "postgres",
+        "skip_missing_upstreams_in_lineage": True,
+    }
+    config = DBTCoreConfig.model_validate(config_dict)
+    assert config.skip_missing_upstreams_in_lineage is True
+
+
+def test_skip_missing_upstreams_in_lineage_filters_missing():
+    """Upstream URNs that do not exist in DataHub are excluded from lineage."""
+    graph = mock.MagicMock()
+    existing_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:postgres,db.schema.existing,PROD)"
+    )
+    missing_urn = "urn:li:dataset:(urn:li:dataPlatform:postgres,db.schema.missing,PROD)"
+    graph.exists.side_effect = lambda urn: urn == existing_urn
+
+    ctx = PipelineContext(run_id="test-run-id", pipeline_name="dbt-source")
+    ctx.graph = graph
+
+    config = DBTCoreConfig.model_validate(
+        {
+            **create_base_dbt_config(),
+            "skip_missing_upstreams_in_lineage": True,
+        }
+    )
+    source = DBTCoreSource(config, ctx)
+
+    existing_node = _make_dbt_model_node("existing", [])
+    missing_node = _make_dbt_model_node("missing", [])
+    downstream_node = _make_dbt_model_node("downstream", ["existing", "missing"])
+    all_nodes_map = {
+        "existing": existing_node,
+        "missing": missing_node,
+        "downstream": downstream_node,
+    }
+
+    lineage = source._create_lineage_aspect_for_dbt_node(downstream_node, all_nodes_map)
+
+    assert lineage is not None
+    upstream_datasets = {u.dataset for u in lineage.upstreams}
+    assert existing_urn in upstream_datasets
+    assert missing_urn not in upstream_datasets
+    assert source.report.lineage_upstreams_skipped_missing == 1
+
+
+def test_skip_missing_upstreams_in_lineage_all_missing_returns_none():
+    """When all upstreams are missing, lineage aspect is None (no empty stub emitted)."""
+    graph = mock.MagicMock()
+    graph.exists.return_value = False
+
+    ctx = PipelineContext(run_id="test-run-id", pipeline_name="dbt-source")
+    ctx.graph = graph
+
+    config = DBTCoreConfig.model_validate(
+        {
+            **create_base_dbt_config(),
+            "skip_missing_upstreams_in_lineage": True,
+        }
+    )
+    source = DBTCoreSource(config, ctx)
+
+    upstream_node = _make_dbt_model_node("upstream", [])
+    downstream_node = _make_dbt_model_node("downstream", ["upstream"])
+    all_nodes_map = {"upstream": upstream_node, "downstream": downstream_node}
+
+    lineage = source._create_lineage_aspect_for_dbt_node(downstream_node, all_nodes_map)
+
+    assert lineage is None
+    assert source.report.lineage_upstreams_skipped_missing == 1
+
+
+def test_skip_missing_upstreams_existence_is_cached():
+    """graph.exists() is called only once per unique upstream URN."""
+    graph = mock.MagicMock()
+    graph.exists.return_value = True
+
+    ctx = PipelineContext(run_id="test-run-id", pipeline_name="dbt-source")
+    ctx.graph = graph
+
+    config = DBTCoreConfig.model_validate(
+        {
+            **create_base_dbt_config(),
+            "skip_missing_upstreams_in_lineage": True,
+        }
+    )
+    source = DBTCoreSource(config, ctx)
+
+    shared_upstream = _make_dbt_model_node("shared", [])
+    node_a = _make_dbt_model_node("node_a", ["shared"])
+    node_b = _make_dbt_model_node("node_b", ["shared"])
+    all_nodes_map = {"shared": shared_upstream, "node_a": node_a, "node_b": node_b}
+
+    source._create_lineage_aspect_for_dbt_node(node_a, all_nodes_map)
+    source._create_lineage_aspect_for_dbt_node(node_b, all_nodes_map)
+
+    # graph.exists should have been called exactly once for the shared upstream URN
+    shared_urn = "urn:li:dataset:(urn:li:dataPlatform:postgres,db.schema.shared,PROD)"
+    calls = [c for c in graph.exists.call_args_list if c.args[0] == shared_urn]
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary

Adds a new `skip_missing_upstreams_in_lineage: bool = False` config field to `DBTCommonConfig`. When enabled, upstream dataset URNs that don't already exist in DataHub are excluded from the `UpstreamLineageClass` aspect before it is emitted, preventing dangling graph edges ("ghost" nodes) from appearing in the lineage UI.

## How stub nodes are created (background)

When dbt ingestion emits an `UpstreamLineageClass` aspect for a downstream model, GMS routes it through `UpdateGraphIndicesService`, which calls `graphService.addEdge()` for every upstream entry. The `GraphService.addEdge` contract explicitly creates source and destination nodes if they don't exist (Neo4j: `MERGE`; Elasticsearch: writes the edge document with the URN as a dangling endpoint). This makes missing upstream datasets appear as ghost nodes in the lineage graph UI, even though no entity record exists in the entity store.

Existing workarounds (`skip_sources_in_lineage: true` + `entities_enabled.sources: NO`) prevent explicit source entity emission but do not prevent the graph edge from being written when the downstream model's lineage aspect still references the missing URN.

## How the fix works

Before emitting the `UpstreamLineageClass` for each dbt node, `_create_lineage_aspect_for_dbt_node` now checks each upstream URN against the DataHub entity store via `graph.exists()`. URNs absent from the entity store are dropped from the aspect. With no reference to the missing URN in the emitted aspect, `UpdateGraphIndicesService` never writes a graph edge for it, and no ghost node appears.

Existence results are cached per-run (one HTTP round-trip per unique upstream URN, regardless of how many dbt models reference it).

## Configuration

```yaml
source:
  type: dbt
  config:
    skip_sources_in_lineage: true      # suppress explicit source entity emission
    entities_enabled:
      sources: "NO"
    skip_missing_upstreams_in_lineage: true  # new — omit missing upstreams from lineage
```

**Requirements:** a DataHub graph connection is required. Using this flag without one (e.g. with a `file` sink) raises a clear error at startup via `ctx.require_graph()`.

## Caveats

These are worth understanding before enabling the flag:

1. **Out-of-order ingestion loses lineage edges.** If dbt is ingested before upstream source systems, those lineage edges are omitted and remain absent until dbt is re-ingested after the upstreams are present. Projects that rely on ingesting dbt first (or accept incomplete lineage temporarily) should not enable this flag.

2. **Adds latency proportional to unique upstream count.** Each unique upstream URN incurs one HTTP call to GMS per run. The per-run cache means a URN shared across hundreds of models is only checked once, but a project with many hundreds of distinct upstream tables will feel this.

3. **Parallel ingestion race.** If an upstream source is being ingested concurrently, `graph.exists()` may return `False` for a URN that is about to be created. That edge is dropped for the current run and restored on the next dbt re-run.

4. **Soft-deleted entities are treated as present.** `graph.exists()` checks for a key aspect in the entity store; soft-deletes retain their key aspect. Lineage to soft-deleted upstream entities is still emitted.

5. **Only covers dbt-entity lineage.** This flag filters upstream URNs in `_create_lineage_aspect_for_dbt_node` (the dbt platform lineage aspect). The sibling relationship between a dbt entity and its target platform counterpart emitted by `create_target_platform_mces` is not affected.

## Test plan

- [x] 4 new unit tests in `tests/unit/dbt/test_dbt_source.py`:
  - Config field parses correctly
  - Missing upstream filtered, existing upstream retained, report counter incremented
  - All upstreams missing → `None` returned (no empty aspect emitted)
  - `graph.exists()` called exactly once per unique URN across multiple models (cache verified)
- [x] E2E test against a live DataHub instance (scratch, not checked in): runs a full dbt pipeline via the `datahub-rest` sink and asserts the stored `upstreamLineage` aspect — verifies the missing URN is present with the flag off and absent with the flag on