### PR TITLE
perf(ingest): back UsageAggregator with FileBackedDict to bound memory

### DIFF
--- a/metadata-ingestion/src/datahub/configuration/env_vars.py
+++ b/metadata-ingestion/src/datahub/configuration/env_vars.py
@@ -1,8 +1,11 @@
 # ABOUTME: Central registry for all environment variables used in metadata-ingestion.
 # ABOUTME: All environment variable reads should go through this module for discoverability and maintainability.
 
+import logging
 import os
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 # ============================================================================
 # Core DataHub Configuration
@@ -252,6 +255,35 @@ def get_sql_parse_cache_size() -> int:
 def get_dataset_urn_to_lower() -> str:
     """Convert dataset URNs to lowercase."""
     return os.getenv("DATAHUB_DATASET_URN_TO_LOWER", "false")
+
+
+# Default in-memory LRU cache size (number of GenericAggregatedDataset objects) for the
+# SQLite-backed usage aggregation store. Larger than FileBackedDict's library default (900)
+# because usage events for many resources interleave, so a bigger cache reduces
+# deserialize/re-pickle churn on the hot path. Override via env var for heavy workloads.
+DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE = 2000
+
+
+def get_usage_aggregator_cache_size() -> int:
+    """In-memory LRU cache size for the SQLite-backed usage aggregation store."""
+    raw = os.environ.get("DATAHUB_USAGE_AGGREGATOR_CACHE_SIZE")
+    if raw is None:
+        return DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE
+    # A non-integer or non-positive override is treated as invalid: FileBackedDict
+    # requires a positive cache size (for_mutation asserts > 0), so falling back to the
+    # default avoids crashing on every event from a misconfigured env var.
+    try:
+        value = int(raw)
+    except ValueError:
+        value = 0
+    if value <= 0:
+        logger.warning(
+            "Ignoring invalid DATAHUB_USAGE_AGGREGATOR_CACHE_SIZE=%r; using default %d",
+            raw,
+            DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE,
+        )
+        return DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE
+    return value
 
 
 # ============================================================================

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
@@ -77,6 +77,14 @@ class UnityCatalogUsageExtractor:
         except Exception as e:
             logger.error("Error processing usage", exc_info=True)
             self.report.report_warning("usage-extraction", str(e))
+        finally:
+            # Release the aggregator's temp SQLite database once usage emission is done.
+            # Guard the cleanup so a close() failure can't mask an exception propagating
+            # out of the generator body.
+            try:
+                self.usage_aggregator.close()
+            except Exception:
+                logger.warning("Failed to close usage aggregator", exc_info=True)
 
     def _get_workunits_internal(
         self, table_refs: Set[TableReference]

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
@@ -1,6 +1,5 @@
 import dataclasses
 import logging
-import os
 from datetime import datetime
 from typing import (
     Callable,
@@ -19,6 +18,7 @@ from pydantic.fields import Field
 
 import datahub.emitter.mce_builder as builder
 from datahub.configuration.common import AllowDenyPattern, HiddenFromDocs
+from datahub.configuration.env_vars import get_usage_aggregator_cache_size
 from datahub.configuration.time_window_config import (
     BaseTimeWindowConfig,
     BucketDuration,
@@ -46,35 +46,7 @@ ResourceType = TypeVar("ResourceType")
 # The total number of characters allowed across all queries in a single workunit.
 DEFAULT_QUERIES_CHARACTER_LIMIT = 24000
 
-# Default in-memory LRU cache size (number of GenericAggregatedDataset objects) for the
-# SQLite-backed usage aggregation store. Larger than FileBackedDict's library default (900)
-# because usage events for many resources interleave, so a bigger cache reduces
-# deserialize/re-pickle churn on the hot path. Override via env var for heavy workloads.
-DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE = 2000
-
-
-def _get_usage_aggregator_cache_size() -> int:
-    raw = os.environ.get("DATAHUB_USAGE_AGGREGATOR_CACHE_SIZE")
-    if raw is None:
-        return DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE
-    # A non-integer or non-positive override is treated as invalid: FileBackedDict
-    # requires a positive cache size (for_mutation asserts > 0), so falling back to the
-    # default avoids crashing on every event from a misconfigured env var.
-    try:
-        value = int(raw)
-    except ValueError:
-        value = 0
-    if value <= 0:
-        logger.warning(
-            "Ignoring invalid DATAHUB_USAGE_AGGREGATOR_CACHE_SIZE=%r; using default %d",
-            raw,
-            DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE,
-        )
-        return DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE
-    return value
-
-
-USAGE_AGGREGATOR_CACHE_SIZE = _get_usage_aggregator_cache_size()
+USAGE_AGGREGATOR_CACHE_SIZE = get_usage_aggregator_cache_size()
 
 
 def default_user_urn_builder(email: str) -> str:
@@ -308,7 +280,9 @@ class UsageAggregator(Generic[ResourceType], Closeable):
         # UrnStr (identity) and for usage-path TableReference (str() omits last_updated,
         # which the usage flow never sets — see TableReference.__str__). A ResourceType
         # whose str() is lossy w.r.t. its __eq__ would silently merge distinct resources.
-        return f"{int(floored_ts.timestamp() * 1000)}@{resource}"
+        # FileBackedDict keys must be str (it is a MutableMapping[str, _VT] over a SQLite
+        # TEXT column), so we encode the (bucket_millis, resource) identity as a string.
+        return f"{builder.make_ts_millis(floored_ts)}@{resource}"
 
     def aggregate_event(
         self,

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
@@ -1,11 +1,10 @@
 import dataclasses
 import logging
-from collections import defaultdict
+import os
 from datetime import datetime
 from typing import (
     Callable,
     Counter,
-    Dict,
     Generic,
     Iterable,
     List,
@@ -26,12 +25,17 @@ from datahub.configuration.time_window_config import (
     get_time_bucket,
 )
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.closeable import Closeable
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import (
     DatasetFieldUsageCountsClass,
     DatasetUsageStatisticsClass,
     DatasetUserUsageCountsClass,
     TimeWindowSizeClass,
+)
+from datahub.utilities.file_backed_collections import (
+    ConnectionWrapper,
+    FileBackedDict,
 )
 from datahub.utilities.sql_formatter import format_sql_query, trim_query
 
@@ -41,6 +45,36 @@ ResourceType = TypeVar("ResourceType")
 
 # The total number of characters allowed across all queries in a single workunit.
 DEFAULT_QUERIES_CHARACTER_LIMIT = 24000
+
+# Default in-memory LRU cache size (number of GenericAggregatedDataset objects) for the
+# SQLite-backed usage aggregation store. Larger than FileBackedDict's library default (900)
+# because usage events for many resources interleave, so a bigger cache reduces
+# deserialize/re-pickle churn on the hot path. Override via env var for heavy workloads.
+DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE = 2000
+
+
+def _get_usage_aggregator_cache_size() -> int:
+    raw = os.environ.get("DATAHUB_USAGE_AGGREGATOR_CACHE_SIZE")
+    if raw is None:
+        return DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE
+    # A non-integer or non-positive override is treated as invalid: FileBackedDict
+    # requires a positive cache size (for_mutation asserts > 0), so falling back to the
+    # default avoids crashing on every event from a misconfigured env var.
+    try:
+        value = int(raw)
+    except ValueError:
+        value = 0
+    if value <= 0:
+        logger.warning(
+            "Ignoring invalid DATAHUB_USAGE_AGGREGATOR_CACHE_SIZE=%r; using default %d",
+            raw,
+            DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE,
+        )
+        return DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE
+    return value
+
+
+USAGE_AGGREGATOR_CACHE_SIZE = _get_usage_aggregator_cache_size()
 
 
 def default_user_urn_builder(email: str) -> str:
@@ -240,14 +274,41 @@ class BaseUsageConfig(BaseTimeWindowConfig):
         return v
 
 
-class UsageAggregator(Generic[ResourceType]):
+class UsageAggregator(Generic[ResourceType], Closeable):
     # TODO: Move over other connectors to use this class
 
-    def __init__(self, config: BaseUsageConfig):
+    def __init__(
+        self,
+        config: BaseUsageConfig,
+        *,
+        shared_connection: Optional[ConnectionWrapper] = None,
+        cache_max_size: int = USAGE_AGGREGATOR_CACHE_SIZE,
+    ) -> None:
+        # FileBackedDict.for_mutation asserts cache_max_size > 0; fail fast with a clear
+        # message instead of crashing on the first aggregate_event.
+        if cache_max_size <= 0:
+            raise ValueError(f"cache_max_size must be positive, got {cache_max_size}")
         self.config = config
-        self.aggregation: Dict[
-            datetime, Dict[ResourceType, GenericAggregatedDataset[ResourceType]]
-        ] = defaultdict(dict)
+        # Map of "<bucket_millis>@<resource>" -> GenericAggregatedDataset.
+        # Backed by SQLite so high-cardinality query/user/column counters spill to disk
+        # instead of growing unbounded in memory.
+        self._aggregation: FileBackedDict[GenericAggregatedDataset[ResourceType]] = (
+            FileBackedDict(
+                shared_connection=shared_connection,
+                tablename="usage_aggregation",
+                cache_max_size=cache_max_size,
+            )
+        )
+
+    @staticmethod
+    def _make_key(floored_ts: datetime, resource: ResourceType) -> str:
+        # The (time_bucket, str(resource)) pair IS the aggregation identity: resources
+        # whose str() are equal are intentionally aggregated together. ResourceType must
+        # therefore have a str() that stably and uniquely identifies it. This holds for
+        # UrnStr (identity) and for usage-path TableReference (str() omits last_updated,
+        # which the usage flow never sets — see TableReference.__str__). A ResourceType
+        # whose str() is lossy w.r.t. its __eq__ would silently merge distinct resources.
+        return f"{int(floored_ts.timestamp() * 1000)}@{resource}"
 
     def aggregate_event(
         self,
@@ -260,13 +321,17 @@ class UsageAggregator(Generic[ResourceType]):
         count: int = 1,
     ) -> None:
         floored_ts: datetime = get_time_bucket(start_time, self.config.bucket_duration)
-        self.aggregation[floored_ts].setdefault(
-            resource,
+        key = self._make_key(floored_ts, resource)
+        # for_mutation loads-or-creates and marks the value dirty so the in-place
+        # counter update below survives cache eviction back to SQLite.
+        agg = self._aggregation.for_mutation(
+            key,
             GenericAggregatedDataset[ResourceType](
                 bucket_start_time=floored_ts,
                 resource=resource,
             ),
-        ).add_read_entry(
+        )
+        agg.add_read_entry(
             user,
             query,
             fields,
@@ -279,14 +344,16 @@ class UsageAggregator(Generic[ResourceType]):
         resource_urn_builder: Callable[[ResourceType], str],
         user_urn_builder: Optional[Callable[[str], str]] = None,
     ) -> Iterable[MetadataWorkUnit]:
-        for time_bucket in self.aggregation.values():
-            for aggregate in time_bucket.values():
-                yield aggregate.make_usage_workunit(
-                    bucket_duration=self.config.bucket_duration,
-                    top_n_queries=self.config.top_n_queries,
-                    format_sql_queries=self.config.format_sql_queries,
-                    include_top_n_queries=self.config.include_top_n_queries,
-                    resource_urn_builder=resource_urn_builder,
-                    user_urn_builder=user_urn_builder,
-                    queries_character_limit=self.config.queries_character_limit,
-                )
+        for aggregate in self._aggregation.values():
+            yield aggregate.make_usage_workunit(
+                bucket_duration=self.config.bucket_duration,
+                top_n_queries=self.config.top_n_queries,
+                format_sql_queries=self.config.format_sql_queries,
+                include_top_n_queries=self.config.include_top_n_queries,
+                resource_urn_builder=resource_urn_builder,
+                user_urn_builder=user_urn_builder,
+                queries_character_limit=self.config.queries_character_limit,
+            )
+
+    def close(self) -> None:
+        self._aggregation.close()

--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
@@ -582,7 +582,11 @@ class SqlParsingAggregator(Closeable):
         self._usage_aggregator: Optional[UsageAggregator[UrnStr]] = None
         if self.generate_usage_statistics:
             assert self.usage_config is not None
-            self._usage_aggregator = UsageAggregator(config=self.usage_config)
+            self._usage_aggregator = UsageAggregator(
+                config=self.usage_config,
+                shared_connection=self._shared_connection,
+            )
+            self._exit_stack.push(self._usage_aggregator)
 
         # Query usage aggregator.
         # Map of query ID -> { bucket -> count }

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sql_aggregator.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sql_aggregator.py
@@ -1651,3 +1651,26 @@ def test_lineage_consistency_multiple_missing_tables() -> None:
     # Verify metrics: 3 tables were added (2, 3, 4)
     assert aggregator.report.num_tables_added_from_column_lineage == 3
     assert aggregator.report.num_queries_with_lineage_inconsistencies_fixed == 1
+
+
+def test_usage_aggregator_uses_shared_connection() -> None:
+    # The shared SQLite connection only exists when the query log is enabled.
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=False,
+        generate_usage_statistics=True,
+        generate_operations=False,
+        usage_config=BaseUsageConfig(),
+        query_log=QueryLogSetting.STORE_ALL,
+    )
+    try:
+        assert aggregator._usage_aggregator is not None
+        assert aggregator._shared_connection is not None
+        # The usage store must reuse the aggregator's shared SQLite connection,
+        # not open a second database file.
+        assert (
+            aggregator._usage_aggregator._aggregation._conn
+            is aggregator._shared_connection
+        )
+    finally:
+        aggregator.close()

--- a/metadata-ingestion/tests/unit/test_usage_common.py
+++ b/metadata-ingestion/tests/unit/test_usage_common.py
@@ -6,17 +6,19 @@ from pydantic import ValidationError
 
 import datahub.ingestion.source.usage.usage_common
 from datahub.configuration.common import AllowDenyPattern
+from datahub.configuration.env_vars import (
+    DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE,
+    get_usage_aggregator_cache_size,
+)
 from datahub.configuration.time_window_config import BucketDuration, get_time_bucket
 from datahub.emitter.mce_builder import make_dataset_urn_with_platform_instance
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.usage.usage_common import (
     DEFAULT_QUERIES_CHARACTER_LIMIT,
-    DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE,
     BaseUsageConfig,
     GenericAggregatedDataset,
     UsageAggregator,
-    _get_usage_aggregator_cache_size,
 )
 from datahub.metadata.schema_classes import (
     DatasetUsageStatisticsClass,
@@ -530,12 +532,12 @@ def test_get_usage_aggregator_cache_size(monkeypatch):
     env = "DATAHUB_USAGE_AGGREGATOR_CACHE_SIZE"
 
     monkeypatch.delenv(env, raising=False)
-    assert _get_usage_aggregator_cache_size() == DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE
+    assert get_usage_aggregator_cache_size() == DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE
 
     monkeypatch.setenv(env, "500")
-    assert _get_usage_aggregator_cache_size() == 500
+    assert get_usage_aggregator_cache_size() == 500
 
     # Non-integer and non-positive overrides fall back to the default rather than crash.
     for bad in ("notanint", "0", "-5"):
         monkeypatch.setenv(env, bad)
-        assert _get_usage_aggregator_cache_size() == DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE
+        assert get_usage_aggregator_cache_size() == DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE

--- a/metadata-ingestion/tests/unit/test_usage_common.py
+++ b/metadata-ingestion/tests/unit/test_usage_common.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime
 
 import pytest
@@ -11,14 +12,17 @@ from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.usage.usage_common import (
     DEFAULT_QUERIES_CHARACTER_LIMIT,
+    DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE,
     BaseUsageConfig,
     GenericAggregatedDataset,
     UsageAggregator,
+    _get_usage_aggregator_cache_size,
 )
 from datahub.metadata.schema_classes import (
     DatasetUsageStatisticsClass,
 )
 from datahub.testing.doctest import assert_doctest
+from datahub.utilities.file_backed_collections import ConnectionWrapper
 
 _TestTableRef = str
 
@@ -322,8 +326,216 @@ def test_usage_aggregator_passes_user_email_pattern():
         fields=[],
     )
 
-    floored_ts = get_time_bucket(event_time, BucketDuration.DAY)
-    aggregated_dataset = aggregator.aggregation[floored_ts][resource]
+    # The denied user is filtered out, so the resource's aggregate records no
+    # queries or users (matching the pre-FileBackedDict behavior, which kept an
+    # empty aggregate for the resource).
+    workunits = list(
+        aggregator.generate_workunits(resource_urn_builder=_simple_urn_builder)
+    )
+    assert len(workunits) == 1
+    aspect = workunits[0].metadata.aspect  # type: ignore[union-attr]
+    assert isinstance(aspect, DatasetUsageStatisticsClass)
+    assert aspect.totalSqlQueries == 0
+    assert aspect.userCounts == []
+    aggregator.close()
 
-    assert aggregated_dataset.queryCount == 0
-    assert aggregated_dataset.userFreq[test_email] == 0
+
+def test_usage_aggregator_persists_across_eviction():
+    # cache_max_size=1 forces every other key out of the in-memory cache,
+    # proving dirty values are flushed to SQLite and re-merged correctly.
+    config = BaseUsageConfig()
+    aggregator: UsageAggregator[str] = UsageAggregator(config, cache_max_size=1)
+
+    event_time = datetime(2020, 1, 1)
+    resource_a = "db.schema.table_a"
+    resource_b = "db.schema.table_b"
+
+    # Interleave events across two resources so each access evicts the other.
+    aggregator.aggregate_event(
+        resource=resource_a,
+        start_time=event_time,
+        query="select 1",
+        user="u1@test.com",
+        fields=[],
+    )
+    aggregator.aggregate_event(
+        resource=resource_b,
+        start_time=event_time,
+        query="select 2",
+        user="u2@test.com",
+        fields=[],
+    )
+    aggregator.aggregate_event(
+        resource=resource_a,
+        start_time=event_time,
+        query="select 1",
+        user="u1@test.com",
+        fields=[],
+    )
+
+    workunits = list(
+        aggregator.generate_workunits(resource_urn_builder=_simple_urn_builder)
+    )
+    counts_by_urn = {
+        wu.get_urn(): wu.metadata.aspect.totalSqlQueries  # type: ignore[union-attr]
+        for wu in workunits
+    }
+    # resource_a saw 2 reads of "select 1"; resource_b saw 1 read of "select 2".
+    assert counts_by_urn == {
+        _simple_urn_builder(resource_a): 2,
+        _simple_urn_builder(resource_b): 1,
+    }
+    aggregator.close()
+
+
+@dataclass(frozen=True)
+class _FrozenResource:
+    db: str
+    table: str
+
+    def __str__(self) -> str:
+        return f"{self.db}.{self.table}"
+
+
+def test_usage_aggregator_with_non_str_resource_survives_eviction():
+    # A frozen-dataclass resource (like Unity's TableReference) must pickle round-trip
+    # and key correctly through SQLite under forced eviction.
+    config = BaseUsageConfig()
+    aggregator: UsageAggregator[_FrozenResource] = UsageAggregator(
+        config, cache_max_size=1
+    )
+    res_a = _FrozenResource("db", "table_a")
+    res_b = _FrozenResource("db", "table_b")
+    event_time = datetime(2020, 1, 1)
+
+    aggregator.aggregate_event(
+        resource=res_a,
+        start_time=event_time,
+        query="select 1",
+        user="u@test.com",
+        fields=[],
+    )
+    aggregator.aggregate_event(
+        resource=res_b,
+        start_time=event_time,
+        query="select 2",
+        user="u@test.com",
+        fields=[],
+    )
+    aggregator.aggregate_event(
+        resource=res_a,
+        start_time=event_time,
+        query="select 1",
+        user="u@test.com",
+        fields=[],
+    )
+
+    def _urn_builder(r: _FrozenResource) -> str:
+        return f"urn:li:dataset:(urn:li:dataPlatform:test,{r},PROD)"
+
+    actual = {
+        wu.get_urn(): wu.metadata.aspect.totalSqlQueries  # type: ignore[union-attr]
+        for wu in aggregator.generate_workunits(resource_urn_builder=_urn_builder)
+    }
+    assert actual == {_urn_builder(res_a): 2, _urn_builder(res_b): 1}
+    aggregator.close()
+
+
+def test_usage_aggregator_close_is_idempotent():
+    aggregator: UsageAggregator[str] = UsageAggregator(BaseUsageConfig())
+    aggregator.aggregate_event(
+        resource="db.s.t",
+        start_time=datetime(2020, 1, 1),
+        query="select 1",
+        user="u@test.com",
+        fields=[],
+    )
+    aggregator.close()
+    aggregator.close()  # must not raise
+
+
+def test_usage_aggregator_shared_connection_not_closed_on_aggregator_close():
+    conn = ConnectionWrapper()
+    try:
+        aggregator: UsageAggregator[str] = UsageAggregator(
+            BaseUsageConfig(), shared_connection=conn
+        )
+        aggregator.aggregate_event(
+            resource="db.s.t",
+            start_time=datetime(2020, 1, 1),
+            query="select 1",
+            user="u@test.com",
+            fields=[],
+        )
+        workunits = list(
+            aggregator.generate_workunits(resource_urn_builder=_simple_urn_builder)
+        )
+        assert len(workunits) == 1
+        aggregator.close()
+        # Shared connection must remain usable after the aggregator closes.
+        conn.execute("SELECT 1").fetchone()
+    finally:
+        conn.close()
+
+
+@dataclass(frozen=True)
+class _LossyStrResource:
+    table: str
+    # Part of __eq__/__hash__ but intentionally omitted from __str__, mirroring
+    # TableReference's last_updated field.
+    version: int
+
+    def __str__(self) -> str:
+        return self.table
+
+
+def test_usage_aggregator_merges_resources_with_equal_str():
+    # Pins the intended key contract: the (bucket, str(resource)) pair is the aggregation
+    # identity, so two resources that are != but share str() are merged into one aspect.
+    # This mirrors usage-path TableReference (str() omits last_updated). A change to the
+    # key contract that re-split these would flip the count from 2 to 1.
+    aggregator: UsageAggregator[_LossyStrResource] = UsageAggregator(BaseUsageConfig())
+    event_time = datetime(2020, 1, 1)
+    res_v1 = _LossyStrResource("db.t", 1)
+    res_v2 = _LossyStrResource("db.t", 2)
+    assert res_v1 != res_v2
+    assert str(res_v1) == str(res_v2)
+
+    for res in (res_v1, res_v2):
+        aggregator.aggregate_event(
+            resource=res,
+            start_time=event_time,
+            query="select 1",
+            user="u@test.com",
+            fields=[],
+        )
+
+    def _urn_builder(r: _LossyStrResource) -> str:
+        return f"urn:li:dataset:(urn:li:dataPlatform:test,{r},PROD)"
+
+    workunits = list(aggregator.generate_workunits(resource_urn_builder=_urn_builder))
+    assert len(workunits) == 1
+    assert workunits[0].metadata.aspect.totalSqlQueries == 2  # type: ignore[union-attr]
+    aggregator.close()
+
+
+def test_usage_aggregator_rejects_non_positive_cache_size():
+    # The ctor guard prevents a downstream crash in FileBackedDict.for_mutation, which
+    # would otherwise fail on every event rather than at construction.
+    with pytest.raises(ValueError):
+        UsageAggregator(BaseUsageConfig(), cache_max_size=0)
+
+
+def test_get_usage_aggregator_cache_size(monkeypatch):
+    env = "DATAHUB_USAGE_AGGREGATOR_CACHE_SIZE"
+
+    monkeypatch.delenv(env, raising=False)
+    assert _get_usage_aggregator_cache_size() == DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE
+
+    monkeypatch.setenv(env, "500")
+    assert _get_usage_aggregator_cache_size() == 500
+
+    # Non-integer and non-positive overrides fall back to the default rather than crash.
+    for bad in ("notanint", "0", "-5"):
+        monkeypatch.setenv(env, bad)
+        assert _get_usage_aggregator_cache_size() == DEFAULT_USAGE_AGGREGATOR_CACHE_SIZE


### PR DESCRIPTION
## Summary

`UsageAggregator` accumulated usage statistics entirely in memory
(`Dict[datetime, Dict[ResourceType, GenericAggregatedDataset]]`). Each
`GenericAggregatedDataset` holds three `Counter`s, and `queryFreq` is keyed by full
SQL query text — so for high-cardinality workloads this grows unbounded and is a
dominant driver of remote-executor OOMs (ING-2749). This actions the long-standing
`# TODO: Replace with FileBackedDict` on that class.

This change backs the aggregation with a SQLite-backed `FileBackedDict` so values spill
to disk, bounding RAM. **Emitted workunits are unchanged** (verified by the existing
golden/aggregator tests).

### What changed
- **`usage_common.py`**: `UsageAggregator` stores aggregates in a `FileBackedDict` keyed
  by `"<bucket_millis>@<resource>"`. `aggregate_event` uses `for_mutation` (load-or-create
  + dirty bit) so in-place counter updates survive cache eviction. The class is now
  `Closeable`. In-memory cache size is tunable via `DATAHUB_USAGE_AGGREGATOR_CACHE_SIZE`
  (default 2000), validated positive.
- **`sql_parsing_aggregator.py`**: shares its existing SQLite connection with the usage
  aggregator and closes it via the exit stack (single DB file).
- **`unity/usage.py`**: closes its own temp DB in a `finally` (guarded so cleanup can't
  mask an in-flight exception).

### Behavior / scope notes
- The `(time bucket, str(resource))` pair is the aggregation identity; resources whose
  `str()` are equal are intentionally merged. This contract is documented and pinned by a
  regression test. Safe for the current callers (`UrnStr`; usage-path `TableReference`,
  whose `last_updated` is unset).
- Memory is bounded ≤ the previous behavior. Trade-off: under very high cardinality with
  poor access locality there is a serialization cost on cache misses — tune the cache size
  env var if needed.
- Scope: this fixes usage paths that flow through `SqlParsingAggregator` (e.g. Snowflake
  `use_queries_v2`, the default) and Unity. Bespoke per-source usage aggregators
  (redshift/usage, clickhouse_usage, starburst_trino_usage) still use the in-memory pattern
  and are not migrated here.

## Test Plan
- [x] `pytest tests/unit/test_usage_common.py` — 18 passed (incl. eviction-persistence,
  non-str resource round-trip, equal-`str` merge contract, idempotent close,
  shared-connection-not-closed, env-var parser, non-positive cache-size guard)
- [x] `pytest tests/unit/sql_parsing/test_sql_aggregator.py` — passes (shared-connection
  wiring + unchanged usage goldens)
- [x] `pytest tests/unit -k unity` — 281 passed
- [x] `./gradlew :metadata-ingestion:lintFix` clean; mypy clean on changed files

## Checklist
- [x] PR conforms to the Contributing Guideline (PR title format)
- [x] Links to related issues — ING-2749
- [x] Tests added/updated
- [ ] Docs added/updated — n/a (no user-facing config beyond an internal tuning env var)
- [ ] Breaking changes — none