### PR TITLE
fix(masking): mask at handler level and scope secrets per execution

### DIFF
--- a/.cursor/rules/masking-framework.mdc
+++ b/.cursor/rules/masking-framework.mdc
@@ -1,0 +1,147 @@
+---
+description: DataHub secret-masking framework invariants — applies when working in metadata-ingestion/src/datahub/masking or its tests
+globs: metadata-ingestion/src/datahub/masking/**,metadata-ingestion/tests/unit/test_masking*.py,metadata-ingestion/tests/unit/test_secret_registry.py,metadata-ingestion/tests/unit/test_bootstrap.py
+alwaysApply: false
+---
+
+# DataHub Secret-Masking Framework
+
+Source lives in `metadata-ingestion/src/datahub/masking/` (`masking_filter.py`,
+`secret_registry.py`, `bootstrap.py`, `logging_utils.py`). Tests live in
+`metadata-ingestion/tests/unit/test_masking*.py`, `test_secret_registry.py`,
+`test_bootstrap.py`. The autouse `_reset_secret_masking` fixture in
+`metadata-ingestion/tests/conftest.py` tears down state between tests.
+
+## Placement invariants (do not break these)
+
+- **Filter attaches to `logging.Handler` objects, never to the root logger.** Python
+  does not consult logger-level filters for records propagated from child loggers.
+  The root-logger filter is only an install sentinel.
+- **Handler streams are never repointed.** Masking happens in `filter()`, not in a
+  stream wrapper that re-emits. `StreamMaskingWrapper` exists only for the
+  `logging_utils` opt-in path; it does not replace handler streams.
+- **`_is_real_stream()` gates `sys.stdout`/`sys.stderr` wrapping on `fileno()`
+  succeeding.** Celery's `LoggingProxy` defines no `fileno`, so it is never wrapped.
+  Under celery, `LoggingProxy.write` has a thread-local `recurse_protection` flag that
+  returns `0` and drops the write on re-entry — wrapping it would re-enter logging
+  via the proxy and silently drop every masked write. There is **no** infinite
+  recursion, no `RecursionError`, no deadlock. Describe the mechanism this way.
+- **Coverage does not depend on install ordering vs. handler construction.**
+  `_install_handler_init_hook()` patches `logging.Handler.__init__` to auto-attach
+  `_installed_filter` to every newly constructed handler, installed before the
+  one-shot `_add_filter_to_existing_handlers()` scan.
+- **Install/uninstall are identity-based on the single `_installed_filter`.** A
+  foreign `SecretMaskingFilter` is never attached-around or stripped.
+
+## Idempotency and re-entrancy
+
+- **`_MASKED` is a module-level random string token**, compared by value (`==`), not
+  an `object()` sentinel and not `is`. Structured formatters serialize
+  `record.__dict__`; an `object()` sentinel raises `TypeError` and drops the record.
+  Value comparison survives cross-thread `QueueHandler`/`QueueListener` and
+  cross-process pickle, where `is` would fail. Randomness prevents forging
+  `extra={'_datahub_masked': ...}` to disable masking.
+- **`_truncate_message` is independently idempotent** (detects its own suffix
+  marker and returns unchanged). The `_MASKED` guard is a performance
+  optimization, not a correctness dependency. A second masking pass when the
+  guard fails must not re-truncate and corrupt the byte count.
+- **The masking-namespace bypass predicate is shared** between `filter()` and the
+  attach-time skip — do not duplicate the predicate.
+
+## Truncation
+
+- **Mask before truncate.** A raw-length pre-truncate bound would cut a JSON-escaped
+  or repr-escaped secret at the boundary and reintroduce partial disclosure. The
+  pre-truncate bound is `max_message_size + _longest_key_length`, where
+  `_longest_key_length` is the longest *expanded* key (repr/JSON/SQLAlchemy variants
+  can be longer than the raw value).
+- **Pre-truncate only when secrets are registered** (`_longest_key_length > 0`).
+  With no secrets, `mask_text` is a no-op, so there is no performance gain, and
+  skipping preserves single-stage marker semantics.
+- **The marker reports `original_len - max_message_size`**, not the pre-truncated
+  region's overrun. The user sees how much of the original was dropped.
+
+## Registry and scoping
+
+- **Registry reads on the hot path are lock-free** against immutable published
+  snapshots (copy-on-write). Writers hold `_registry_lock` and atomically swap in
+  freshly-built immutable dicts. Registration stays linear in the number of secrets
+  (incremental COW updates, not a full rebuild per add).
+- **A distinct execution scope per `initialize_secret_masking()` call.** The caller
+  owns the returned token; a second call on the same context does not alias onto an
+  earlier scope. `end_execution(token)` returns truthy while other scopes are live;
+  only the last live scope reaches teardown.
+- **`uninstall_masking_filter()` (public) refuses and logs a warning while
+  execution scopes are active.** Internal callers that have already verified scope
+  state use `_uninstall_masking_filter()` (the unguarded primitive).
+  `SecretRegistry.has_active_executions()` is the guard.
+
+## Handler-init hook lifecycle
+
+- On **uninstall-accept** (we own the current `Handler.__init__`): restore the true
+  original and clear `_original_handler_init` / `_patched_handler_init`.
+- On **uninstall-decline** (a third party patched over us): restore nothing and
+  **do not clear the saved globals**. Clearing them would force re-install to
+  capture the third-party wrapper as the new "original" and nest a new patch on
+  every cycle — permanent stack growth in a long-lived worker. The dead patch
+  stays live because it reads `_installed_filter`, which is re-set on re-install.
+- **`_cover_handler()` acquires `_install_lock`** so adds are serialized with the
+  readers in `_remove_filter_from_existing_handlers()` (which snapshots the set
+  under the same lock). `_install_lock` is an `RLock`, so calling from inside
+  `install_masking_filter()` (which already holds the lock) does not self-deadlock.
+
+## Failure posture
+
+- **Fail closed.** Every failure mode emits a placeholder or redaction marker,
+  never an unmasked value. If masking fails, prevent sensitive information from
+  being exposed.
+- **`bootstrap.initialize_secret_masking()` logs `critical` on install failure**
+  and continues without masking rather than crashing the host process.
+- **Teardown is symmetric with install** across: root filter, handler filters,
+  covered handlers, stream wrappers, the `Handler.__init__` hook, and the
+  exception hook.
+
+## Documented residuals (do not redesign; do not re-document the wrong direction)
+
+- **Custom `Formatter.formatException` overrides are bypassed.** `filter()`
+  pre-fills `record.exc_text`, and stdlib `Formatter.format` only calls
+  `formatException` when `exc_text` is falsy. The stock masked traceback is
+  emitted instead. The trade is: pre-filling is what masks printed tracebacks;
+  not pre-filling leaves tracebacks unmasked.
+- **A formatter that re-derives exc text from `exc_info` escapes masking.** This
+  is the opposite direction of the residual above; both are real.
+
+## Comment discipline
+
+- State the invariant the code enforces. Delete alternatives-considered narrative
+  — that belongs in the PR description, where going stale is harmless. A comment
+  long enough to contain its own errata has stopped being documentation.
+- **Do not leave review-thread labels** (D1, D2, S1, …) in shipped source. They
+  identify nothing outside the review that produced them.
+
+## Test organization
+
+- Organize tests by the **behavior they pin**, not by which review round produced
+  them. Class names like `TestStreamWrapperContract`, `TestRegistrySingleton`,
+  `TestInstallLifecycleAndCoverage`, `TestStructuredFormatterAndGuard`,
+  `TestCustomFormatException` — not `TestP1Fixes` / `TestReviewFixes`.
+- The masking suite + `lintFix` must stay green. Run:
+  ```bash
+  ./gradlew :metadata-ingestion:lintFix
+  smoke-test/venv/bin/python -m pytest metadata-ingestion/tests/unit/test_masking_filter.py \
+    metadata-ingestion/tests/unit/test_masking_error_recovery.py \
+    metadata-ingestion/tests/unit/test_secret_registry.py \
+    metadata-ingestion/tests/unit/test_bootstrap.py
+  ```
+
+## Acceptance properties (must hold after any change)
+
+1. A formatter serializing non-standard record attributes emits a valid line; no
+   record is dropped by masking.
+2. Masking a record twice produces byte-identical output to masking it once.
+3. No log line contains a complete or partial registered secret in any of its
+   expanded forms.
+4. Overlapping executions in any thread/context combination: one ending leaves the
+   other's secrets registered and the filter installed.
+5. The celery mechanism is described identically and correctly in the PR body, the
+   commit message, and the code.

--- a/metadata-ingestion/src/datahub/masking/bootstrap.py
+++ b/metadata-ingestion/src/datahub/masking/bootstrap.py
@@ -106,8 +106,14 @@ def initialize_secret_masking(
 
     # The filter + exception hook are installed once for the process lifetime;
     # they are harmless when no secrets are registered. Only secrets are scoped
-    # per execution (begin_execution below). `force` is accepted for backward
+    # per execution (ensure_execution below). `force` is accepted for backward
     # compatibility but no longer gates anything — installation is idempotent.
+    #
+    # The whole install-check + scope registration is done under _bootstrap_lock
+    # (the same lock shutdown holds across its teardown), so a concurrent
+    # shutdown can't decide it is the last execution and uninstall the filter
+    # between our completion-check and our scope registration — which would let
+    # this execution run unmasked.
     with _bootstrap_lock:
         if not _bootstrap_completed:
             try:
@@ -157,10 +163,10 @@ def initialize_secret_masking(
                 logger.error(f"Failed to initialize secret masking: {e}", exc_info=True)
                 return  # Don't raise - graceful degradation
 
-    # Open a secret scope for this execution (idempotent within one context).
-    # Secrets registered after this belong to this execution and are dropped by
-    # the matching shutdown_secret_masking(), without affecting other executions.
-    registry.ensure_execution()
+        # Open a secret scope for this execution (idempotent within one context).
+        # Secrets registered after this belong to this execution and are dropped
+        # by the matching shutdown_secret_masking(), without affecting others.
+        registry.ensure_execution()
 
 
 def shutdown_secret_masking() -> None:
@@ -174,25 +180,31 @@ def shutdown_secret_masking() -> None:
 
     try:
         registry = SecretRegistry.get_instance()
-        # Remove this execution's secrets; bail out if others are still active.
-        if registry.end_execution():
-            return
+        # Hold _bootstrap_lock across the "am I the last execution?" decision and
+        # the teardown, so it is atomic w.r.t. a concurrent initialize that is
+        # checking _bootstrap_completed and registering a new scope. Otherwise an
+        # execution starting in this window would skip re-install and then have
+        # the filter uninstalled out from under it (running unmasked).
+        with _bootstrap_lock:
+            # Remove this execution's secrets; bail out if others are still active.
+            if registry.end_execution():
+                return
 
-        # Last execution finished — fully tear down.
-        uninstall_masking_filter()
+            # Last execution finished — fully tear down.
+            uninstall_masking_filter()
 
-        # Restore original exception hook
-        if _original_excepthook is not None:
-            sys.excepthook = _original_excepthook
-            _original_excepthook = None
+            # Restore original exception hook
+            if _original_excepthook is not None:
+                sys.excepthook = _original_excepthook
+                _original_excepthook = None
 
-        # Reset masking-safe loggers to restore normal logging
-        from datahub.masking.logging_utils import reset_masking_safe_loggers
+            # Reset masking-safe loggers to restore normal logging
+            from datahub.masking.logging_utils import reset_masking_safe_loggers
 
-        reset_masking_safe_loggers()
+            reset_masking_safe_loggers()
 
-        _bootstrap_completed = False
-        _bootstrap_error = None
+            _bootstrap_completed = False
+            _bootstrap_error = None
 
         logger.info("Secret masking shutdown completed")
     except Exception as e:

--- a/metadata-ingestion/src/datahub/masking/bootstrap.py
+++ b/metadata-ingestion/src/datahub/masking/bootstrap.py
@@ -92,7 +92,7 @@ def initialize_secret_masking(
     global _bootstrap_completed, _bootstrap_error
 
     # Check if masking is disabled via environment variable
-    from datahub.masking.secret_registry import is_masking_enabled
+    from datahub.masking.secret_registry import _current_exec, is_masking_enabled
 
     if not is_masking_enabled():
         logger.warning(
@@ -102,80 +102,90 @@ def initialize_secret_masking(
         _bootstrap_completed = True  # Mark as completed to avoid repeated warnings
         return
 
-    # Thread-safe initialization: acquire lock for entire operation
+    registry = SecretRegistry.get_instance()
+
+    # The filter + exception hook are installed once for the process lifetime;
+    # they are harmless when no secrets are registered. Only secrets are scoped
+    # per execution (begin_execution below). `force` is accepted for backward
+    # compatibility but no longer gates anything — installation is idempotent.
     with _bootstrap_lock:
-        # Prevent double initialization
-        if _bootstrap_completed and not force:
-            logger.debug("Secret masking already initialized")
-            return
-
-        try:
-            logger.info("Initializing secret masking infrastructure")
-
-            # Get registry
-            registry = SecretRegistry.get_instance()
-
-            # Install logging filter + stdout wrapper
-            install_masking_filter(
-                secret_registry=registry,
-                max_message_size=max_message_size,
-                install_stdout_wrapper=True,
-            )
-
-            # Install custom exception hook to mask unhandled exceptions
-            _install_exception_hook(registry)
-
-            # Configure warnings to use logging
-            logging.captureWarnings(True)
-
-            # Disable HTTP debug output (prevent deadlock)
+        if not _bootstrap_completed:
             try:
-                import http.client
+                logger.info("Initializing secret masking infrastructure")
 
-                http.client.HTTPConnection.debuglevel = 0
-            except Exception:
-                pass
+                # Install logging filter + stdout wrapper (idempotent)
+                install_masking_filter(
+                    secret_registry=registry,
+                    max_message_size=max_message_size,
+                    install_stdout_wrapper=True,
+                )
 
-            # Set HTTP-related loggers to INFO (not DEBUG)
-            for logger_name in [
-                "urllib3",
-                "urllib3.connectionpool",
-                "urllib3.util.retry",
-                "requests",
-            ]:
+                # Install custom exception hook to mask unhandled exceptions
+                _install_exception_hook(registry)
+
+                # Configure warnings to use logging
+                logging.captureWarnings(True)
+
+                # Disable HTTP debug output (prevent deadlock)
                 try:
-                    logging.getLogger(logger_name).setLevel(logging.INFO)
+                    import http.client
+
+                    http.client.HTTPConnection.debuglevel = 0
                 except Exception:
                     pass
 
-            _bootstrap_completed = True
-            _bootstrap_error = None
-            logger.info(
-                "Secret masking infrastructure initialized successfully. "
-                "Secrets will be registered automatically as they are loaded."
-            )
+                # Set HTTP-related loggers to INFO (not DEBUG)
+                for logger_name in [
+                    "urllib3",
+                    "urllib3.connectionpool",
+                    "urllib3.util.retry",
+                    "requests",
+                ]:
+                    try:
+                        logging.getLogger(logger_name).setLevel(logging.INFO)
+                    except Exception:
+                        pass
 
-        except Exception as e:
-            _bootstrap_error = e
-            logger.error(f"Failed to initialize secret masking: {e}", exc_info=True)
-            # Don't raise - graceful degradation
+                _bootstrap_completed = True
+                _bootstrap_error = None
+                logger.info(
+                    "Secret masking infrastructure initialized successfully. "
+                    "Secrets will be registered automatically as they are loaded."
+                )
+            except Exception as e:
+                _bootstrap_error = e
+                logger.error(f"Failed to initialize secret masking: {e}", exc_info=True)
+                return  # Don't raise - graceful degradation
+
+    # Open a secret scope for this execution (idempotent within one context).
+    # Secrets registered after this belong to this execution and are dropped by
+    # the matching shutdown_secret_masking(), without affecting other executions.
+    if _current_exec.get() is None:
+        registry.begin_execution()
 
 
 def shutdown_secret_masking() -> None:
-    """Shutdown secret masking system."""
+    """End the current execution's masking scope.
+
+    Drops only this execution's secrets. If other executions are still running,
+    masking stays installed (their secrets must keep being masked). Only when the
+    last active execution ends do we fully tear down the filter/exception hook.
+    """
     global _bootstrap_completed, _bootstrap_error, _original_excepthook
 
     try:
+        registry = SecretRegistry.get_instance()
+        # Remove this execution's secrets; bail out if others are still active.
+        if registry.end_execution():
+            return
+
+        # Last execution finished — fully tear down.
         uninstall_masking_filter()
 
         # Restore original exception hook
         if _original_excepthook is not None:
             sys.excepthook = _original_excepthook
             _original_excepthook = None
-
-        # Clear registry
-        registry = SecretRegistry.get_instance()
-        registry.clear()
 
         # Reset masking-safe loggers to restore normal logging
         from datahub.masking.logging_utils import reset_masking_safe_loggers

--- a/metadata-ingestion/src/datahub/masking/bootstrap.py
+++ b/metadata-ingestion/src/datahub/masking/bootstrap.py
@@ -92,7 +92,7 @@ def initialize_secret_masking(
     global _bootstrap_completed, _bootstrap_error
 
     # Check if masking is disabled via environment variable
-    from datahub.masking.secret_registry import _current_exec, is_masking_enabled
+    from datahub.masking.secret_registry import is_masking_enabled
 
     if not is_masking_enabled():
         logger.warning(
@@ -160,8 +160,7 @@ def initialize_secret_masking(
     # Open a secret scope for this execution (idempotent within one context).
     # Secrets registered after this belong to this execution and are dropped by
     # the matching shutdown_secret_masking(), without affecting other executions.
-    if _current_exec.get() is None:
-        registry.begin_execution()
+    registry.ensure_execution()
 
 
 def shutdown_secret_masking() -> None:

--- a/metadata-ingestion/src/datahub/masking/bootstrap.py
+++ b/metadata-ingestion/src/datahub/masking/bootstrap.py
@@ -17,7 +17,6 @@ import logging
 import sys
 import threading
 import traceback
-import warnings
 from typing import Optional
 
 from datahub.masking.logging_utils import get_masking_safe_logger
@@ -97,15 +96,6 @@ def initialize_secret_masking(
         compatibility and will be removed in a future release.
     """
     global _bootstrap_completed, _bootstrap_error
-
-    if force:
-        warnings.warn(
-            "The 'force' argument to initialize_secret_masking() is deprecated "
-            "and ignored: the masking filter is installed once and each call "
-            "opens a per-execution scope.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
     # Check if masking is disabled via environment variable
     from datahub.masking.secret_registry import is_masking_enabled

--- a/metadata-ingestion/src/datahub/masking/bootstrap.py
+++ b/metadata-ingestion/src/datahub/masking/bootstrap.py
@@ -17,6 +17,7 @@ import logging
 import sys
 import threading
 import traceback
+import warnings
 from typing import Optional
 
 from datahub.masking.logging_utils import get_masking_safe_logger
@@ -88,8 +89,23 @@ def initialize_secret_masking(
     Initialize secret masking infrastructure (logging filter + exception hook).
 
     Secrets register automatically at point-of-read.
+
+    .. deprecated::
+        ``force`` is deprecated and ignored. The filter is installed once for the
+        process lifetime and every call opens a per-execution secret scope, so
+        there is nothing to force. The argument is kept only for backward
+        compatibility and will be removed in a future release.
     """
     global _bootstrap_completed, _bootstrap_error
+
+    if force:
+        warnings.warn(
+            "The 'force' argument to initialize_secret_masking() is deprecated "
+            "and ignored: the masking filter is installed once and each call "
+            "opens a per-execution scope.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     # Check if masking is disabled via environment variable
     from datahub.masking.secret_registry import is_masking_enabled

--- a/metadata-ingestion/src/datahub/masking/bootstrap.py
+++ b/metadata-ingestion/src/datahub/masking/bootstrap.py
@@ -22,8 +22,8 @@ from typing import Optional
 from datahub.masking.logging_utils import get_masking_safe_logger
 from datahub.masking.masking_filter import (
     SecretMaskingFilter,
+    _uninstall_masking_filter,
     install_masking_filter,
-    uninstall_masking_filter,
 )
 from datahub.masking.secret_registry import SecretRegistry
 
@@ -214,7 +214,7 @@ def initialize_secret_masking(
                 )
                 raise RuntimeError(f"Secret masking installation failed: {e}") from e
 
-        # Always open a *distinct* scope per call (D1). The caller owns the
+        # Always open a *distinct* scope per call. The caller owns the
         # token; a second call on the same context does NOT alias onto an
         # earlier scope, so ending one execution never drops another's
         # secrets.
@@ -262,7 +262,9 @@ def shutdown_secret_masking(execution_id: Optional[str] = None) -> None:
             # teardown mutation so the seam's contract is "the race window".
             _teardown_hook()
 
-            uninstall_masking_filter()
+            # Internal caller: bypass the public guard (we already verified
+            # via end_execution that no scopes are active).
+            _uninstall_masking_filter()
 
             # Restore original exception hook
             if _original_excepthook is not None:

--- a/metadata-ingestion/src/datahub/masking/bootstrap.py
+++ b/metadata-ingestion/src/datahub/masking/bootstrap.py
@@ -83,11 +83,21 @@ def _install_exception_hook(registry: SecretRegistry) -> None:
 def initialize_secret_masking(
     max_message_size: int = 5000,
     force: bool = False,
-) -> None:
+) -> Optional[str]:
     """
     Initialize secret masking infrastructure (logging filter + exception hook).
 
     Secrets register automatically at point-of-read.
+
+    Returns:
+        The execution token (opaque string) for this scope, or ``None`` if
+        masking is disabled. Pass the token to ``shutdown_secret_masking(token)``
+        when tearing down — this is required when the call site that tears down
+        runs in a different thread/context than the one that initialized (e.g.
+        a dispatcher that starts an execution on one thread and finishes it on
+        another). Without the token, shutdown falls back to the ambient
+        context's scope and is a silent no-op if that context has none
+        (secrets then accumulate for the process lifetime — fails safe).
 
     .. deprecated::
         ``force`` is deprecated and ignored. The filter is installed once for the
@@ -106,7 +116,7 @@ def initialize_secret_masking(
             "Sensitive information will be exposed in logs. Only use this for debugging!"
         )
         _bootstrap_completed = True  # Mark as completed to avoid repeated warnings
-        return
+        return None
 
     registry = SecretRegistry.get_instance()
 
@@ -167,20 +177,34 @@ def initialize_secret_masking(
             except Exception as e:
                 _bootstrap_error = e
                 logger.error(f"Failed to initialize secret masking: {e}", exc_info=True)
-                return  # Don't raise - graceful degradation
+                return None  # Don't raise - graceful degradation
 
         # Open a secret scope for this execution (idempotent within one context).
         # Secrets registered after this belong to this execution and are dropped
         # by the matching shutdown_secret_masking(), without affecting others.
-        registry.ensure_execution()
+        exec_id = registry.ensure_execution()
+        return exec_id
 
 
-def shutdown_secret_masking() -> None:
+def _teardown_hook() -> None:
+    """Test seam: called at a defined point inside shutdown_secret_masking
+    (after the last-execution decision, before teardown). Tests monkeypatch
+    this to gate concurrent threads deterministically. No-op in production."""
+    return None
+
+
+def shutdown_secret_masking(execution_id: Optional[str] = None) -> None:
     """End the current execution's masking scope.
 
     Drops only this execution's secrets. If other executions are still running,
     masking stays installed (their secrets must keep being masked). Only when the
     last active execution ends do we fully tear down the filter/exception hook.
+
+    Args:
+        execution_id: Token returned by ``initialize_secret_masking``. Pass it
+            when the teardown caller runs in a different thread/context than the
+            initializer (e.g. a dispatcher). Without it, the ambient context's
+            scope is ended — a silent no-op if that context has none.
     """
     global _bootstrap_completed, _bootstrap_error, _original_excepthook
 
@@ -193,10 +217,15 @@ def shutdown_secret_masking() -> None:
         # the filter uninstalled out from under it (running unmasked).
         with _bootstrap_lock:
             # Remove this execution's secrets; bail out if others are still active.
-            if registry.end_execution():
+            if registry.end_execution(execution_id):
                 return
 
             # Last execution finished — fully tear down.
+            # Test seam: tests gate concurrent threads on this point. Keep the
+            # call immediately after the last-execution decision and before any
+            # teardown mutation so the seam's contract is "the race window".
+            _teardown_hook()
+
             uninstall_masking_filter()
 
             # Restore original exception hook

--- a/metadata-ingestion/src/datahub/masking/bootstrap.py
+++ b/metadata-ingestion/src/datahub/masking/bootstrap.py
@@ -33,6 +33,11 @@ logger = get_masking_safe_logger(__name__)
 _bootstrap_completed = False
 _bootstrap_error: Optional[Exception] = None
 _original_excepthook = None  # Track original exception hook for restoration
+# True once we've warned about masking being disabled by env var. Separate
+# from ``_bootstrap_completed`` (which means "the filter is installed") so a
+# disabled call does not strand the install latch True — see
+# ``initialize_secret_masking``.
+_disabled_warned = False
 # ``RLock`` so reset_instance can re-enter it if reached from inside a locked
 # region (see SecretRegistry.reset_instance). shutdown_secret_masking takes
 # this first, then SecretRegistry._lock; reset_instance calls
@@ -52,11 +57,14 @@ def reset_bootstrap_state() -> None:
     installed filter) so the flag can't strand True while the filter is gone.
     Without this, the next ``initialize_secret_masking()`` short-circuits on
     the flag and runs with masking off. Safe to call when not bootstrapped.
+    Also clears ``_disabled_warned`` so a transition from disabled to enabled
+    re-warns if the env var is later flipped back off.
     """
-    global _bootstrap_completed, _bootstrap_error
+    global _bootstrap_completed, _bootstrap_error, _disabled_warned
     with _bootstrap_lock:
         _bootstrap_completed = False
         _bootstrap_error = None
+        _disabled_warned = False
 
 
 def get_bootstrap_error() -> Optional[Exception]:
@@ -96,6 +104,57 @@ def _install_exception_hook(registry: SecretRegistry) -> None:
     # Install the custom hook
     sys.excepthook = masking_excepthook
     logger.debug("Installed custom exception hook for secret masking")
+
+
+def _restore_exception_hook() -> None:
+    """Restore the original ``sys.excepthook`` saved at install time.
+
+    Called from both ``shutdown_secret_masking`` (the refcounted lifecycle) and
+    ``SecretRegistry.reset_instance`` (the test teardown path). Without this
+    being called from ``reset_instance`` too, a ``shutdown_secret_masking()``
+    that skipped teardown (peer execution still active on another thread)
+    left ``reset_instance`` to drop the filter but NOT restore the excepthook —
+    leaving a hook bound to a dead registry for the rest of the session.
+    Idempotent: a no-op if no hook was ever installed.
+    """
+    global _original_excepthook
+    if _original_excepthook is not None:
+        sys.excepthook = _original_excepthook
+        _original_excepthook = None
+
+
+def _force_teardown_secret_masking() -> None:
+    """Force-tear down the masking infrastructure regardless of active scopes.
+
+    Test-only (underscore-prefixed): the refcounted ``shutdown_secret_masking``
+    refuses to uninstall the filter while execution scopes are active (fail-
+    safe — masking stays on). Tests need a path that tears down unconditionally
+    so a leaked scope from a buggy test does not strand the filter into the
+    next test. Production code should never call this — tearing down masking
+    while a live execution is still logging is a deliberate fail-open.
+
+    Uninstalls the filter, restores the excepthook, clears the bootstrap latch,
+    and resets masking-safe loggers. Does NOT touch the registry's execution
+    scopes — the caller (``SecretRegistry.reset_instance``) owns those.
+    """
+    global _bootstrap_completed, _bootstrap_error
+    with _bootstrap_lock:
+        try:
+            _uninstall_masking_filter()
+        except Exception as e:
+            logger.debug("_force_teardown: uninstall failed: %r", e)
+        try:
+            _restore_exception_hook()
+        except Exception as e:
+            logger.debug("_force_teardown: restore excepthook failed: %r", e)
+        try:
+            from datahub.masking.logging_utils import reset_masking_safe_loggers
+
+            reset_masking_safe_loggers()
+        except Exception as e:
+            logger.debug("_force_teardown: reset safe loggers failed: %r", e)
+        _bootstrap_completed = False
+        _bootstrap_error = None
 
 
 def initialize_secret_masking(
@@ -139,11 +198,23 @@ def initialize_secret_masking(
     from datahub.masking.secret_registry import is_masking_enabled
 
     if not is_masking_enabled():
-        logger.warning(
-            "Secret masking is DISABLED via DATAHUB_DISABLE_SECRET_MASKING environment variable. "
-            "Sensitive information will be exposed in logs. Only use this for debugging!"
-        )
-        _bootstrap_completed = True  # Mark as completed to avoid repeated warnings
+        # Warn once per disabled episode. Do NOT latch ``_bootstrap_completed``
+        # here: that flag means "the filter is installed", and a disabled call
+        # installs nothing. Latching True on the disabled branch stranded the
+        # flag so a later call with masking enabled short-circuited the
+        # install (the ``if not _bootstrap_completed`` check below saw True)
+        # but still ran ``begin_execution()`` and returned a non-None token —
+        # the caller got the "masking is on" signal with no filter and no
+        # excepthook. ``_disabled_warned`` is a separate warn-once flag that
+        # does not affect the install decision.
+        global _disabled_warned
+        if not _disabled_warned:
+            logger.warning(
+                "Secret masking is DISABLED via DATAHUB_DISABLE_SECRET_MASKING "
+                "environment variable. Sensitive information will be exposed in "
+                "logs. Only use this for debugging!"
+            )
+            _disabled_warned = True
         return None
 
     registry = SecretRegistry.get_instance()
@@ -153,11 +224,15 @@ def initialize_secret_masking(
     # per execution (begin_execution below). `force` is accepted for backward
     # compatibility but no longer gates anything — installation is idempotent.
     #
-    # The install decision uses ``_bootstrap_completed`` as the latch (not
-    # ``masking_filter._installed_filter``) so that test mocks patching
-    # ``install_masking_filter`` still latch correctly. The flag MUST be cleared
-    # wherever the filter is uninstalled, or it strands True while the filter
-    # is gone and the next initialize short-circuits with masking off.
+    # ``_bootstrap_completed`` is a pure "don't redo the expensive install
+    # work" optimization, set only after a real install succeeds and cleared
+    # on teardown. It is NOT the source of truth for "is the filter
+    # installed?" — that is ``masking_filter._installed_filter``. A test mock
+    # patching ``install_masking_filter`` returns a Mock (non-None), so it
+    # latches correctly here without bootstrap reaching into
+    # ``masking_filter._installed_filter``. The flag MUST be cleared wherever
+    # the filter is uninstalled, or it strands True while the filter is gone
+    # and the next initialize short-circuits with masking off.
     # ``reset_bootstrap_state()`` (called by ``SecretRegistry.reset_instance()``,
     # which tears down the filter) clears it.
     #
@@ -244,6 +319,16 @@ def shutdown_secret_masking(execution_id: Optional[str] = None) -> None:
     """
     global _bootstrap_completed, _bootstrap_error, _original_excepthook
 
+    # Teardown swallows errors (failed teardown leaves masking ON, which is
+    # fail-safe; raising from cleanup destroys the original exception) but
+    # clears the bootstrap latch in a ``finally`` around the teardown steps so
+    # a raise from ``_uninstall_masking_filter`` or
+    # ``reset_masking_safe_loggers`` does not strand ``_bootstrap_completed``
+    # True over a partially-torn-down filter — the next initialize would then
+    # short-circuit with masking off. ``_uninstall_masking_filter`` is itself
+    # step-wise tolerant, so a partial teardown is the only failure mode that
+    # reaches this finally. The early-return path (other executions still
+    # active) does NOT clear the latch — masking stays installed there.
     try:
         registry = SecretRegistry.get_instance()
         # Hold _bootstrap_lock across the "am I the last execution?" decision and
@@ -262,23 +347,28 @@ def shutdown_secret_masking(execution_id: Optional[str] = None) -> None:
             # teardown mutation so the seam's contract is "the race window".
             _teardown_hook()
 
-            # Internal caller: bypass the public guard (we already verified
-            # via end_execution that no scopes are active).
-            _uninstall_masking_filter()
+            try:
+                # Internal caller: bypass the public guard (we already
+                # verified via end_execution that no scopes are active).
+                _uninstall_masking_filter()
 
-            # Restore original exception hook
-            if _original_excepthook is not None:
-                sys.excepthook = _original_excepthook
-                _original_excepthook = None
+                # Restore original exception hook
+                _restore_exception_hook()
 
-            # Reset masking-safe loggers to restore normal logging
-            from datahub.masking.logging_utils import reset_masking_safe_loggers
+                # Reset masking-safe loggers to restore normal logging
+                from datahub.masking.logging_utils import reset_masking_safe_loggers
 
-            reset_masking_safe_loggers()
-
-            _bootstrap_completed = False
-            _bootstrap_error = None
+                reset_masking_safe_loggers()
+            finally:
+                # Clear the latch whether the teardown steps succeeded or not.
+                # A stranded ``True`` over a half-torn state would make the
+                # next initialize short-circuit the install and run with
+                # masking off. ``_uninstall`` is step-wise tolerant, so even
+                # a partial teardown leaves the globals consistent enough
+                # for a re-install to rebuild from.
+                _bootstrap_completed = False
+                _bootstrap_error = None
 
         logger.info("Secret masking shutdown completed")
     except Exception as e:
-        logger.error(f"Error during secret masking shutdown: {e}")
+        logger.error(f"Error during secret masking shutdown: {e}", exc_info=True)

--- a/metadata-ingestion/src/datahub/masking/bootstrap.py
+++ b/metadata-ingestion/src/datahub/masking/bootstrap.py
@@ -33,7 +33,11 @@ logger = get_masking_safe_logger(__name__)
 _bootstrap_completed = False
 _bootstrap_error: Optional[Exception] = None
 _original_excepthook = None  # Track original exception hook for restoration
-_bootstrap_lock = threading.Lock()  # Thread safety for concurrent initialization
+# ``RLock`` so reset_instance can re-enter it if reached from inside a locked
+# region (see SecretRegistry.reset_instance). shutdown_secret_masking takes
+# this first, then SecretRegistry._lock; reset_instance calls
+# reset_bootstrap_state (which acquires this) after releasing SecretRegistry._lock.
+_bootstrap_lock = threading.RLock()
 
 
 def is_bootstrapped() -> bool:
@@ -99,19 +103,29 @@ def initialize_secret_masking(
     force: bool = False,
 ) -> Optional[str]:
     """
-    Initialize secret masking infrastructure (logging filter + exception hook).
+    Initialize secret masking infrastructure (logging filter + exception hook)
+    and open a new per-execution secret scope.
 
-    Secrets register automatically at point-of-read.
+    Secrets register automatically at point-of-read. Each call opens a
+    *distinct* scope and returns its token; the caller owns nesting and
+    passes the token to ``shutdown_secret_masking(token)`` when done. Two
+    calls on the same context return different tokens and own different
+    groups, so ending one execution never drops another's secrets or
+    uninstalls the filter while another execution is still live.
 
     Returns:
         The execution token (opaque string) for this scope, or ``None`` if
-        masking is disabled. Pass the token to ``shutdown_secret_masking(token)``
-        when tearing down — this is required when the call site that tears down
-        runs in a different thread/context than the one that initialized (e.g.
-        a dispatcher that starts an execution on one thread and finishes it on
-        another). Without the token, shutdown falls back to the ambient
-        context's scope and is a silent no-op if that context has none
-        (secrets then accumulate for the process lifetime — fails safe).
+        masking is disabled by configuration. A return of ``None`` from a
+        *failed* install is raised as ``RuntimeError`` instead, so a caller
+        can distinguish "off by configuration" from "installation crashed,
+        secrets now reaching logs" — the exact failure shape that made the
+        Python 3.13 ``_acquireLock`` removal silent.
+
+    Raises:
+        RuntimeError: if masking is enabled but installation failed (the
+        filter is not installed and secrets would reach logs unmasked).
+        This is fail-loud for a security control: a silent ``None`` on
+        failure left no signal.
 
     .. deprecated::
         ``force`` is deprecated and ignored. The filter is installed once for the
@@ -136,16 +150,14 @@ def initialize_secret_masking(
 
     # The filter + exception hook are installed once for the process lifetime;
     # they are harmless when no secrets are registered. Only secrets are scoped
-    # per execution (ensure_execution below). `force` is accepted for backward
+    # per execution (begin_execution below). `force` is accepted for backward
     # compatibility but no longer gates anything — installation is idempotent.
     #
     # The install decision uses ``_bootstrap_completed`` as the latch (not
     # ``masking_filter._installed_filter``) so that test mocks patching
-    # ``install_masking_filter`` still latch correctly — deriving purely
-    # from the real installed state would let every concurrent initializer
-    # re-enter when the install is mocked out. The flag MUST be cleared
-    # wherever the filter is uninstalled, or it strands True while the
-    # filter is gone and the next initialize short-circuits with masking off.
+    # ``install_masking_filter`` still latch correctly. The flag MUST be cleared
+    # wherever the filter is uninstalled, or it strands True while the filter
+    # is gone and the next initialize short-circuits with masking off.
     # ``reset_bootstrap_state()`` (called by ``SecretRegistry.reset_instance()``,
     # which tears down the filter) clears it.
     #
@@ -158,29 +170,19 @@ def initialize_secret_masking(
         if not _bootstrap_completed:
             try:
                 logger.info("Initializing secret masking infrastructure")
-
-                # Install logging filter + stdout wrapper (idempotent)
                 install_masking_filter(
                     secret_registry=registry,
                     max_message_size=max_message_size,
                     install_stdout_wrapper=True,
                 )
-
-                # Install custom exception hook to mask unhandled exceptions
                 _install_exception_hook(registry)
-
-                # Configure warnings to use logging
                 logging.captureWarnings(True)
-
-                # Disable HTTP debug output (prevent deadlock)
                 try:
                     import http.client
 
                     http.client.HTTPConnection.debuglevel = 0
                 except Exception:
                     pass
-
-                # Set HTTP-related loggers to INFO (not DEBUG)
                 for logger_name in [
                     "urllib3",
                     "urllib3.connectionpool",
@@ -191,7 +193,6 @@ def initialize_secret_masking(
                         logging.getLogger(logger_name).setLevel(logging.INFO)
                     except Exception:
                         pass
-
                 _bootstrap_completed = True
                 _bootstrap_error = None
                 logger.info(
@@ -200,13 +201,24 @@ def initialize_secret_masking(
                 )
             except Exception as e:
                 _bootstrap_error = e
-                logger.error(f"Failed to initialize secret masking: {e}", exc_info=True)
-                return None  # Don't raise - graceful degradation
+                # D7: fail-loud for a security control. A silent None here left
+                # no signal that masking was off — the exact shape that made
+                # the Python 3.13 _acquireLock removal silent. Log at critical
+                # (the masking-safe logger writes to sys.__stderr__, which
+                # survives celery's stderr proxy) and raise so the caller can
+                # decide whether to proceed unmasked.
+                logger.critical(
+                    f"Failed to initialize secret masking: {e}. "
+                    f"Secrets may reach logs unmasked.",
+                    exc_info=True,
+                )
+                raise RuntimeError(f"Secret masking installation failed: {e}") from e
 
-        # Open a secret scope for this execution (idempotent within one context).
-        # Secrets registered after this belong to this execution and are dropped
-        # by the matching shutdown_secret_masking(), without affecting others.
-        exec_id = registry.ensure_execution()
+        # Always open a *distinct* scope per call (D1). The caller owns the
+        # token; a second call on the same context does NOT alias onto an
+        # earlier scope, so ending one execution never drops another's
+        # secrets.
+        exec_id = registry.begin_execution()
         return exec_id
 
 

--- a/metadata-ingestion/src/datahub/masking/bootstrap.py
+++ b/metadata-ingestion/src/datahub/masking/bootstrap.py
@@ -41,6 +41,20 @@ def is_bootstrapped() -> bool:
     return _bootstrap_completed
 
 
+def reset_bootstrap_state() -> None:
+    """Clear the bootstrap-completed latch.
+
+    Called by ``SecretRegistry.reset_instance()`` (which tears down the
+    installed filter) so the flag can't strand True while the filter is gone.
+    Without this, the next ``initialize_secret_masking()`` short-circuits on
+    the flag and runs with masking off. Safe to call when not bootstrapped.
+    """
+    global _bootstrap_completed, _bootstrap_error
+    with _bootstrap_lock:
+        _bootstrap_completed = False
+        _bootstrap_error = None
+
+
 def get_bootstrap_error() -> Optional[Exception]:
     """Get bootstrap error if bootstrap failed."""
     return _bootstrap_error
@@ -124,6 +138,16 @@ def initialize_secret_masking(
     # they are harmless when no secrets are registered. Only secrets are scoped
     # per execution (ensure_execution below). `force` is accepted for backward
     # compatibility but no longer gates anything — installation is idempotent.
+    #
+    # The install decision uses ``_bootstrap_completed`` as the latch (not
+    # ``masking_filter._installed_filter``) so that test mocks patching
+    # ``install_masking_filter`` still latch correctly — deriving purely
+    # from the real installed state would let every concurrent initializer
+    # re-enter when the install is mocked out. The flag MUST be cleared
+    # wherever the filter is uninstalled, or it strands True while the
+    # filter is gone and the next initialize short-circuits with masking off.
+    # ``reset_bootstrap_state()`` (called by ``SecretRegistry.reset_instance()``,
+    # which tears down the filter) clears it.
     #
     # The whole install-check + scope registration is done under _bootstrap_lock
     # (the same lock shutdown holds across its teardown), so a concurrent

--- a/metadata-ingestion/src/datahub/masking/constants.py
+++ b/metadata-ingestion/src/datahub/masking/constants.py
@@ -1,0 +1,10 @@
+"""Shared constants for the secret-masking framework.
+
+``REDACTED_FORMAT`` lives here so both ``secret_registry`` (validation at
+registration time) and ``masking_filter`` (the masking callback) reference
+one definition. A duplicate would let them drift and re-open the route-A
+hole (a marker-shaped value passing registration because the registry's
+format string differs from the filter's).
+"""
+
+REDACTED_FORMAT = "***REDACTED:{name}***"

--- a/metadata-ingestion/src/datahub/masking/logging_utils.py
+++ b/metadata-ingestion/src/datahub/masking/logging_utils.py
@@ -8,9 +8,13 @@ preventing re-entrancy deadlocks by writing directly to the original stderr.
 import logging
 import sys
 
-# Capture original stderr BEFORE any masking initialization
-# This ensures masking-safe loggers write to unwrapped stderr
-_original_stderr = sys.stderr
+# Capture the *real* stderr (not a proxy). Under celery, ``redirect_stdits_for_logger``
+# replaces ``sys.stderr`` with a ``LoggingProxy`` that re-enters logging; the masking
+# package is typically imported at task time, *after* that redirect has run, so
+# ``sys.stderr`` at import time is already the proxy. ``sys.__stderr__`` is the
+# original stream and is not affected by the redirect. May be ``None`` under
+# pythonw/embedded interpreters; fall back to ``sys.stderr`` then.
+_original_stderr = sys.__stderr__ if sys.__stderr__ is not None else sys.stderr
 
 
 def get_masking_safe_logger(name: str) -> logging.Logger:

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -463,8 +463,8 @@ def _iter_all_loggers() -> list[logging.Logger]:
     return loggers
 
 
-def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> int:
-    """Attach the masking filter to all existing handlers; return how many.
+def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> None:
+    """Attach the masking filter to all existing handlers.
 
     Masking lives on handlers, not the logger: Python skips logger-level filters
     for records propagated from child loggers, so a root-logger filter would miss
@@ -475,7 +475,7 @@ def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> int
     Skip datahub.masking.* loggers: they log to the original stderr by design and
     carry no secrets, so filtering them only risks re-entrancy.
     """
-    added_count = 0
+    added = 0
     for log in _iter_all_loggers():
         if log.name.startswith("datahub.masking"):
             continue
@@ -483,10 +483,9 @@ def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> int
         for handler in list(log.handlers):
             if not any(isinstance(f, SecretMaskingFilter) for f in handler.filters):
                 handler.addFilter(masking_filter)
-                added_count += 1
-    if added_count > 0:
-        logger.debug(f"Installed SecretMaskingFilter on {added_count} handler(s)")
-    return added_count
+                added += 1
+    if added:
+        logger.debug(f"Installed SecretMaskingFilter on {added} handler(s)")
 
 
 def _remove_filter_from_existing_handlers() -> None:

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -453,14 +453,9 @@ class StreamMaskingWrapper:
 
 
 def _iter_all_loggers() -> list[logging.Logger]:
-    """Return the root logger plus every initialized named logger.
-
-    Skips PlaceHolder objects that the logging module stores in loggerDict for
-    not-yet-created intermediate loggers.
-    """
+    """Root logger plus every initialized named logger (skipping PlaceHolders)."""
     loggers: list[logging.Logger] = [logging.getLogger()]
-    # Snapshot the keys, then .get() each — a logger may disappear from the dict
-    # between snapshot and access in a multi-threaded worker.
+    # .get() per snapshotted key: a logger may be removed between snapshot and access.
     for name in list(logging.root.manager.loggerDict.keys()):
         obj = logging.root.manager.loggerDict.get(name)
         if isinstance(obj, logging.Logger):
@@ -469,27 +464,22 @@ def _iter_all_loggers() -> list[logging.Logger]:
 
 
 def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> int:
-    """Attach the masking filter to every existing handler.
+    """Attach the masking filter to all existing handlers; return how many.
 
-    A filter on the root *logger* is only consulted for records logged directly
-    on root; Python does not run it for records propagated up from child loggers.
-    Since virtually all log output comes from named child loggers, masking must
-    happen at the *handler* level, where every record that reaches an output is
-    seen regardless of which logger produced it.
+    Masking lives on handlers, not the logger: Python skips logger-level filters
+    for records propagated from child loggers, so a root-logger filter would miss
+    almost everything. A handler filter sees every record reaching that output and
+    masks it in place, without touching the handler's stream. (Repointing streams
+    instead loops forever under celery -- see install_masking_filter.)
 
-    This masks records in place without touching handler streams. We deliberately
-    do NOT repoint handler streams at a wrapped sys.stdout/stderr: under celery,
-    sys.stderr is a proxy that re-enters logging, and a handler pointed at it
-    forms an infinite recursion cycle that silently drops all output.
-
-    The masking framework's own loggers are skipped — they write to the original
-    stderr by design and carry no secrets, so masking them only adds re-entrancy.
+    Skip datahub.masking.* loggers: they log to the original stderr by design and
+    carry no secrets, so filtering them only risks re-entrancy.
     """
     added_count = 0
     for log in _iter_all_loggers():
         if log.name.startswith("datahub.masking"):
             continue
-        # Iterate a copy: another thread may add/remove handlers concurrently.
+        # Copy: handlers may be added/removed by other threads during iteration.
         for handler in list(log.handlers):
             if not any(isinstance(f, SecretMaskingFilter) for f in handler.filters):
                 handler.addFilter(masking_filter)
@@ -513,63 +503,44 @@ def install_masking_filter(
     max_message_size: int = 5000,
     install_stdout_wrapper: bool = True,
 ) -> SecretMaskingFilter:
-    """Install secret masking filter on root logger and optionally wrap stdout/stderr.
+    """Enable secret masking: install the filter on existing handlers (+ root
+    logger) and, optionally, wrap sys.stdout/stderr for raw writes.
 
-    Masking is applied at the handler level (see _add_filter_to_existing_handlers),
-    so coverage is a snapshot of the handlers that exist when this is called.
-    Install AFTER logging is fully configured. Handlers added later are not
-    masked unless install is called again (which re-scans), except default
-    StreamHandlers bound to sys.stdout/stderr, which the stream wrapper still
-    covers.
+    Masking happens at the handler level (see _add_filter_to_existing_handlers).
+    Coverage is a snapshot of the handlers present now, so call this AFTER logging
+    is configured; handlers added later are covered only by a re-install or, for
+    stdout/stderr, by the stream wrapper.
 
-    Known limitation (fail-open): a handler added to a child logger after
-    install can emit unmasked. callHandlers runs a logger's own handlers before
-    walking up to ancestor handlers, so an unfiltered child handler writes the
-    record before a filtered root handler masks it in place. In the executor
-    this is not a concern — handlers are wired at worker startup, before the
-    per-task install — but a more complete fix (e.g. wrapping Handler.addFilter)
-    would be needed if dynamic post-install handlers ever carry secrets.
+    Fail-open limitation: a handler added to a child logger after install can emit
+    unmasked (a logger's own handlers run before ancestors'). Not a concern in the
+    executor, where handlers exist before masking is installed per task.
     """
-    # Create filter
     masking_filter = SecretMaskingFilter(
         secret_registry=secret_registry, max_message_size=max_message_size
     )
-
-    # Install on root logger (affects all loggers)
     root_logger = logging.getLogger()
 
-    # A SecretMaskingFilter on the root logger is the "already installed?"
-    # sentinel. It also masks records logged directly on root, but is NOT what
-    # masks the bulk of output — Python does not run logger-level filters for
-    # records propagated from child loggers. That is the handler-level filter's
-    # job (_add_filter_to_existing_handlers below).
+    # The root-logger filter is just the "already installed?" sentinel (and masks
+    # records logged directly on root). The real masking is the handler filters
+    # below, since logger-level filters don't see propagated child-logger records.
     existing_filters = [
         f for f in root_logger.filters if isinstance(f, SecretMaskingFilter)
     ]
 
     if existing_filters:
-        # Already installed: re-scan so handlers created since the first install
-        # are covered too (masking is fail-open — a missed handler leaks).
+        # Already installed: re-scan to cover handlers added since (fail-open).
         masking_filter = existing_filters[0]
         _add_filter_to_existing_handlers(masking_filter)
-        logger.debug(
-            "SecretMaskingFilter already installed; refreshed handler coverage"
-        )
+        logger.debug("SecretMaskingFilter already installed; refreshed handlers")
         return masking_filter
 
     root_logger.addFilter(masking_filter)
-
-    # Attach to existing handlers: handler-level filtering masks records in place
-    # for every record that reaches an output, including those propagated from
-    # child loggers, without touching handler streams.
     _add_filter_to_existing_handlers(masking_filter)
     logger.info("Installed SecretMaskingFilter on root logger and existing handlers")
 
-    # Optionally wrap stdout/stderr to also mask raw writes such as print().
-    # NOTE: we intentionally do NOT repoint existing handler streams at the
-    # wrapped streams — masking of log records is handled by the handler-level
-    # filter above, and repointing handlers at sys.stderr deadlocks/recurses
-    # under celery's stderr-to-logging redirection.
+    # Wrap stdout/stderr only to mask raw writes (print(), C-extension output).
+    # We do NOT repoint handler streams here: under celery, sys.stderr re-enters
+    # logging, so a handler pointed at it would recurse infinitely and drop output.
     if install_stdout_wrapper:
         if not isinstance(sys.stdout, StreamMaskingWrapper):
             sys.stdout = StreamMaskingWrapper(sys.stdout, masking_filter)

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -521,6 +521,14 @@ def install_masking_filter(
     masked unless install is called again (which re-scans), except default
     StreamHandlers bound to sys.stdout/stderr, which the stream wrapper still
     covers.
+
+    Known limitation (fail-open): a handler added to a child logger after
+    install can emit unmasked. callHandlers runs a logger's own handlers before
+    walking up to ancestor handlers, so an unfiltered child handler writes the
+    record before a filtered root handler masks it in place. In the executor
+    this is not a concern — handlers are wired at worker startup, before the
+    per-task install — but a more complete fix (e.g. wrapping Handler.addFilter)
+    would be needed if dynamic post-install handlers ever carry secrets.
     """
     # Create filter
     masking_filter = SecretMaskingFilter(

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -459,8 +459,10 @@ def _iter_all_loggers() -> list[logging.Logger]:
     not-yet-created intermediate loggers.
     """
     loggers: list[logging.Logger] = [logging.getLogger()]
+    # Snapshot the keys, then .get() each — a logger may disappear from the dict
+    # between snapshot and access in a multi-threaded worker.
     for name in list(logging.root.manager.loggerDict.keys()):
-        obj = logging.root.manager.loggerDict[name]
+        obj = logging.root.manager.loggerDict.get(name)
         if isinstance(obj, logging.Logger):
             loggers.append(obj)
     return loggers
@@ -487,7 +489,8 @@ def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> int
     for log in _iter_all_loggers():
         if log.name.startswith("datahub.masking"):
             continue
-        for handler in log.handlers:
+        # Iterate a copy: another thread may add/remove handlers concurrently.
+        for handler in list(log.handlers):
             if not any(isinstance(f, SecretMaskingFilter) for f in handler.filters):
                 handler.addFilter(masking_filter)
                 added_count += 1
@@ -499,7 +502,7 @@ def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> int
 def _remove_filter_from_existing_handlers() -> None:
     """Remove the masking filter from every handler it was attached to."""
     for log in _iter_all_loggers():
-        for handler in log.handlers:
+        for handler in list(log.handlers):
             handler.filters = [
                 f for f in handler.filters if not isinstance(f, SecretMaskingFilter)
             ]
@@ -510,7 +513,15 @@ def install_masking_filter(
     max_message_size: int = 5000,
     install_stdout_wrapper: bool = True,
 ) -> SecretMaskingFilter:
-    """Install secret masking filter on root logger and optionally wrap stdout/stderr."""
+    """Install secret masking filter on root logger and optionally wrap stdout/stderr.
+
+    Masking is applied at the handler level (see _add_filter_to_existing_handlers),
+    so coverage is a snapshot of the handlers that exist when this is called.
+    Install AFTER logging is fully configured. Handlers added later are not
+    masked unless install is called again (which re-scans), except default
+    StreamHandlers bound to sys.stdout/stderr, which the stream wrapper still
+    covers.
+    """
     # Create filter
     masking_filter = SecretMaskingFilter(
         secret_registry=secret_registry, max_message_size=max_message_size
@@ -519,21 +530,30 @@ def install_masking_filter(
     # Install on root logger (affects all loggers)
     root_logger = logging.getLogger()
 
-    # Check if already installed (avoid duplicates)
+    # A SecretMaskingFilter on the root logger is the "already installed?"
+    # sentinel. It also masks records logged directly on root, but is NOT what
+    # masks the bulk of output — Python does not run logger-level filters for
+    # records propagated from child loggers. That is the handler-level filter's
+    # job (_add_filter_to_existing_handlers below).
     existing_filters = [
         f for f in root_logger.filters if isinstance(f, SecretMaskingFilter)
     ]
 
     if existing_filters:
-        logger.debug("SecretMaskingFilter already installed on root logger")
-        return existing_filters[0]
+        # Already installed: re-scan so handlers created since the first install
+        # are covered too (masking is fail-open — a missed handler leaks).
+        masking_filter = existing_filters[0]
+        _add_filter_to_existing_handlers(masking_filter)
+        logger.debug(
+            "SecretMaskingFilter already installed; refreshed handler coverage"
+        )
+        return masking_filter
 
     root_logger.addFilter(masking_filter)
 
-    # Attach to existing handlers too: a filter on the root logger does not run
-    # for records propagated from child loggers, so handler-level filtering is
-    # what actually masks the bulk of log output. This masks records in place
-    # and never touches handler streams (see _add_filter_to_existing_handlers).
+    # Attach to existing handlers: handler-level filtering masks records in place
+    # for every record that reaches an output, including those propagated from
+    # child loggers, without touching handler streams.
     _add_filter_to_existing_handlers(masking_filter)
     logger.info("Installed SecretMaskingFilter on root logger and existing handlers")
 

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -452,44 +452,57 @@ class StreamMaskingWrapper:
         return getattr(self._original, name)
 
 
-def _update_existing_handlers() -> None:
-    """Update all existing logging handlers to use wrapped streams."""
-    updated_count = 0
+def _iter_all_loggers() -> list[logging.Logger]:
+    """Return the root logger plus every initialized named logger.
 
-    # Get all loggers (including root and all named loggers)
-    all_loggers = [logging.getLogger()] + [
-        logging.getLogger(name) for name in logging.root.manager.loggerDict
-    ]
+    Skips PlaceHolder objects that the logging module stores in loggerDict for
+    not-yet-created intermediate loggers.
+    """
+    loggers: list[logging.Logger] = [logging.getLogger()]
+    for name in list(logging.root.manager.loggerDict.keys()):
+        obj = logging.root.manager.loggerDict[name]
+        if isinstance(obj, logging.Logger):
+            loggers.append(obj)
+    return loggers
 
-    for log in all_loggers:
-        if not isinstance(log, logging.Logger):
-            # Skip PlaceHolder objects in logger dict
+
+def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> int:
+    """Attach the masking filter to every existing handler.
+
+    A filter on the root *logger* is only consulted for records logged directly
+    on root; Python does not run it for records propagated up from child loggers.
+    Since virtually all log output comes from named child loggers, masking must
+    happen at the *handler* level, where every record that reaches an output is
+    seen regardless of which logger produced it.
+
+    This masks records in place without touching handler streams. We deliberately
+    do NOT repoint handler streams at a wrapped sys.stdout/stderr: under celery,
+    sys.stderr is a proxy that re-enters logging, and a handler pointed at it
+    forms an infinite recursion cycle that silently drops all output.
+
+    The masking framework's own loggers are skipped — they write to the original
+    stderr by design and carry no secrets, so masking them only adds re-entrancy.
+    """
+    added_count = 0
+    for log in _iter_all_loggers():
+        if log.name.startswith("datahub.masking"):
             continue
-
         for handler in log.handlers:
-            if isinstance(handler, logging.StreamHandler):
-                # Check if handler is using an unwrapped stream
-                if hasattr(handler, "stream"):
-                    stream = handler.stream
+            if not any(isinstance(f, SecretMaskingFilter) for f in handler.filters):
+                handler.addFilter(masking_filter)
+                added_count += 1
+    if added_count > 0:
+        logger.debug(f"Installed SecretMaskingFilter on {added_count} handler(s)")
+    return added_count
 
-                    # If handler's stream is the original unwrapped stdout/stderr,
-                    # update it to use our wrapped version
-                    if not isinstance(stream, StreamMaskingWrapper):
-                        # Check if this is stdout or stderr by comparing the underlying file
-                        try:
-                            if hasattr(stream, "name"):
-                                if stream.name == "<stderr>":
-                                    handler.setStream(sys.stderr)
-                                    updated_count += 1
-                                elif stream.name == "<stdout>":
-                                    handler.setStream(sys.stdout)
-                                    updated_count += 1
-                        except Exception:
-                            # If we can't determine the stream, skip it
-                            pass
 
-    if updated_count > 0:
-        logger.debug(f"Updated {updated_count} logging handlers to use wrapped streams")
+def _remove_filter_from_existing_handlers() -> None:
+    """Remove the masking filter from every handler it was attached to."""
+    for log in _iter_all_loggers():
+        for handler in log.handlers:
+            handler.filters = [
+                f for f in handler.filters if not isinstance(f, SecretMaskingFilter)
+            ]
 
 
 def install_masking_filter(
@@ -516,9 +529,19 @@ def install_masking_filter(
         return existing_filters[0]
 
     root_logger.addFilter(masking_filter)
-    logger.info("Installed SecretMaskingFilter on root logger")
 
-    # Optionally install stdout/stderr wrapper as backup
+    # Attach to existing handlers too: a filter on the root logger does not run
+    # for records propagated from child loggers, so handler-level filtering is
+    # what actually masks the bulk of log output. This masks records in place
+    # and never touches handler streams (see _add_filter_to_existing_handlers).
+    _add_filter_to_existing_handlers(masking_filter)
+    logger.info("Installed SecretMaskingFilter on root logger and existing handlers")
+
+    # Optionally wrap stdout/stderr to also mask raw writes such as print().
+    # NOTE: we intentionally do NOT repoint existing handler streams at the
+    # wrapped streams — masking of log records is handled by the handler-level
+    # filter above, and repointing handlers at sys.stderr deadlocks/recurses
+    # under celery's stderr-to-logging redirection.
     if install_stdout_wrapper:
         if not isinstance(sys.stdout, StreamMaskingWrapper):
             sys.stdout = StreamMaskingWrapper(sys.stdout, masking_filter)
@@ -528,11 +551,6 @@ def install_masking_filter(
             sys.stderr = StreamMaskingWrapper(sys.stderr, masking_filter)
             logger.debug("Wrapped sys.stderr with StreamMaskingWrapper")
 
-        # Update all existing logging handlers to use wrapped streams
-        # Handlers created before masking was initialized will have cached
-        # references to the original unwrapped stderr/stdout
-        _update_existing_handlers()
-
     return masking_filter
 
 
@@ -540,10 +558,12 @@ def uninstall_masking_filter() -> None:
     """Remove secret masking filter from root logger."""
     root_logger = logging.getLogger()
 
-    # Remove filters
+    # Remove filter from the root logger and from every handler it was added to
+    # (symmetric with install_masking_filter).
     root_logger.filters = [
         f for f in root_logger.filters if not isinstance(f, SecretMaskingFilter)
     ]
+    _remove_filter_from_existing_handlers()
 
     # Unwrap stdout/stderr
     if isinstance(sys.stdout, StreamMaskingWrapper):

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -21,15 +21,35 @@ Performance:
 
 import io
 import logging
+import os
 import re
 import sys
 import threading
+import weakref
 from typing import Any, Dict, List, Optional, TextIO, Tuple
 
 from datahub.masking.logging_utils import get_masking_safe_logger
-from datahub.masking.secret_registry import SecretRegistry
+from datahub.masking.secret_registry import SecretRegistry, is_masking_enabled
 
 logger = get_masking_safe_logger(__name__)
+
+# Cached is_masking_enabled() result. Refreshed when the env var changes
+# (one os.getenv per call, no .lower() per call) so filter() doesn't
+# re-import is_masking_enabled or re-read the env per record. Tests that
+# toggle DATAHUB_DISABLE_SECRET_MASKING via os.environ/monkeypatch are
+# picked up on the next record (the refresh compares the raw env string).
+_masking_enabled_cached: bool = is_masking_enabled()
+_masking_enabled_env_raw: Optional[str] = os.getenv("DATAHUB_DISABLE_SECRET_MASKING")
+
+
+def _refresh_masking_enabled_cached() -> None:
+    """Recompute the cached is_masking_enabled() if the env var changed."""
+    global _masking_enabled_cached, _masking_enabled_env_raw
+    raw = os.getenv("DATAHUB_DISABLE_SECRET_MASKING")
+    if raw != _masking_enabled_env_raw:
+        _masking_enabled_env_raw = raw
+        _masking_enabled_cached = is_masking_enabled()
+
 
 # The single installed filter instance for this process (identity-based
 # install/uninstall tracking). See install_masking_filter. Forward-annotated
@@ -49,10 +69,48 @@ _original_handler_init: Optional[Any] = None
 # _uninstall_handler_init_hook).
 _patched_handler_init: Optional[Any] = None
 
+# Serializes install/uninstall mutations of the module globals
+# (_installed_filter, _original_handler_init, _patched_handler_init) and the
+# root-logger / handler filter attachments. Bootstrap holds _bootstrap_lock
+# across install/uninstall, but install_masking_filter is also public and
+# called directly by tests; without this lock, two concurrent direct calls
+# attach two filter instances and leak one on teardown (D5). An RLock so a
+# holder can re-enter (e.g. bootstrap's _bootstrap_lock path calling install
+# then uninstall within the same thread).
+_install_lock = threading.RLock()
+
+# Weak set of every handler the filter was attached to (via the one-shot
+# scan or the Handler.__init__ hook). Uninstall iterates this in addition to
+# _snapshot_handler_pairs so handlers not on any logger (held by a
+# QueueListener, or nested inside another handler) still get the filter
+# removed — _snapshot_handler_pairs only sees handlers attached to a
+# logger, so without this set those handlers would retain the filter after
+# uninstall and keep masking records dispatched through them (S7). Weak so
+# a GC'd handler leaves the set without manual cleanup.
+_covered_handlers: "weakref.WeakSet[logging.Handler]" = weakref.WeakSet()
+
 # Constants
 REDACTED_MASKING_NAMESPACE = "datahub.masking."
 REDACTED_FORMAT = "***REDACTED:{name}***"
 MASKING_ERROR_MESSAGE = "[MASKING_ERROR - OUTPUT_SUPPRESSED_FOR_SECURITY]"
+
+
+def _is_masking_namespace_name(name: str) -> bool:
+    """True for loggers in the masking framework's own namespace.
+
+    Single predicate for the two call sites that need to skip masking-internal
+    loggers: ``filter()``'s record-name bypass and
+    ``_add_filter_to_existing_handlers``'s attach-time skip. They must agree,
+    or a record from the exact-name ``datahub.masking`` logger is masked by
+    ``filter()`` (whose ``startswith(REDACTED_MASKING_NAMESPACE)`` check
+    misses the dotless name) while its handler was skipped at attach time —
+    an inconsistency that over-masks internal logs. The trailing dot in
+    ``REDACTED_MASKING_NAMESPACE`` avoids matching a hypothetical
+    "datahub.maskingfoo" logger; the explicit ``== "datahub.masking"`` covers
+    the dotless name itself.
+    """
+    return name == "datahub.masking" or name.startswith(REDACTED_MASKING_NAMESPACE)
+
 
 # Module-private sentinel stamped onto records after masking so the
 # idempotency guard can recognize them with `is` rather than truthiness.
@@ -92,6 +150,11 @@ _STANDARD_RECORD_ATTRS = frozenset(
         "taskName",
         "message",
         "asctime",
+        # The idempotency sentinel stamped by filter() after masking. Without
+        # this, structured formatters that serialize non-standard record
+        # attributes would emit "_datahub_masked": "<object object at 0x...>"
+        # on every line — the sentinel is internal, not user data.
+        "_datahub_masked",
     }
 )
 
@@ -577,31 +640,39 @@ class SecretMaskingFilter(logging.Filter):
         # own loggers bypass masking entirely (their handlers are skipped at
         # install time, but they may propagate to root handlers after
         # reset_masking_safe_loggers flips propagate=True on teardown — see
-        # bootstrap.shutdown_secret_masking). The startswith check is on the
-        # record name, not the logger we attached to, so it catches propagation.
-        if record.name.startswith(REDACTED_MASKING_NAMESPACE):
+        # bootstrap.shutdown_secret_masking). The check is on the record name,
+        # not the logger we attached to, so it catches propagation. Uses the
+        # shared _is_masking_namespace_name predicate so the bypass and the
+        # attach-time skip agree (D3): a record from the exact-name
+        # ``datahub.masking`` logger is bypassed here, not masked.
+        if _is_masking_namespace_name(record.name):
             return True
 
         if getattr(record, "_datahub_masked", None) is _MASKED:
             return True
 
-        # Check if masking is disabled for debugging
-        from datahub.masking.secret_registry import is_masking_enabled
-
-        if not is_masking_enabled():
+        # Check if masking is disabled for debugging. is_masking_enabled is
+        # imported at module load (no per-record import) and the result is
+        # cached, refreshed when the env var changes (one getenv per call).
+        _refresh_masking_enabled_cached()
+        if not _masking_enabled_cached:
             return True  # Skip all masking and truncation for debugging
 
         try:
-            # 1. Truncate large messages BEFORE masking (performance optimization)
-            #    This is intentional: truncating first avoids regex on huge strings
-            #    Security: Truncation removes end of message, so secrets at end
-            #    are removed entirely (not just masked), which is acceptable
-            if isinstance(record.msg, str):
-                record.msg = self._truncate_message(record.msg)
-
-            # 2. Mask the log message (after truncation for performance)
+            # 1. Mask the full message BEFORE truncating. Truncating first
+            #    would leak a partial secret straddling the cut point (the
+            #    regex matches full secrets only, so a partial would survive
+            #    unmasked). Masking first replaces secrets with
+            #    ***REDACTED:X*** tokens, so truncating the masked message
+            #    can only cut tokens, never secret bytes. This trades the
+            #    "regex on huge strings" cost the old ordering avoided for
+            #    correctness — the right trade for a security control.
             if isinstance(record.msg, str):
                 record.msg = self.mask_text(record.msg)
+
+            # 2. Truncate the masked message (performance: bounds output size).
+            if isinstance(record.msg, str):
+                record.msg = self._truncate_message(record.msg)
 
             # 3. Mask arguments (for formatting)
             if record.args:
@@ -688,6 +759,15 @@ class StreamMaskingWrapper:
         except Exception:
             pass
 
+    def writelines(self, lines) -> None:
+        """Mask each line then write. Without this, ``writelines`` falls
+        through ``__getattr__`` to the unwrapped stream and bypasses masking
+        (a ``print(..., file=wrapped_stream)`` path that uses ``writelines``
+        would leak). Mask each line via ``write`` so the masking + graceful-
+        degradation behavior is identical to the single-line path."""
+        for line in lines:
+            self.write(line)
+
     def __getattr__(self, name):
         """Delegate all other attributes to original stream."""
         return getattr(self._original, name)
@@ -757,6 +837,7 @@ def _install_handler_init_hook() -> None:
         f = _installed_filter
         if f is not None and f not in self.filters:
             self.addFilter(f)
+            _cover_handler(self)
 
     _patched_handler_init = patched_handler_init
     logging.Handler.__init__ = patched_handler_init  # type: ignore[assignment]
@@ -772,25 +853,54 @@ def _uninstall_handler_init_hook() -> None:
     patch — the classic monkeypatch stacking hazard. When the current
     attribute is not ours, leave the chain alone and log at debug: we
     cannot safely unwind a patch someone else wrapped, and the residual
-    (their patch stays in place, ours is no longer reachable) is the safe
-    choice. No-op if the hook was never installed.
+    (their patch stays in place, ours is no longer reachable as
+    ``Handler.__init__``) is the safe choice. No-op if the hook was never
+    installed.
+
+    On decline, the saved globals are NOT cleared. This keeps re-install
+    idempotent (``_original_handler_init is not None`` short-circuits
+    ``_install_handler_init_hook``) and prevents wrapper stacking across
+    repeated install/uninstall cycles: the dead ``patched_v1`` stays in
+    lib X's chain, but on re-install it reads the re-set ``_installed_filter``
+    and reactivates, so the hook is live again without stacking a new
+    wrapper. Clearing the globals on decline would force re-install to
+    capture lib X's wrapper as the new "original" and nest a new patch on
+    every cycle — permanent stack growth in a long-lived worker.
     """
     global _original_handler_init, _patched_handler_init
     if _original_handler_init is None:
         return
     if logging.Handler.__init__ is _patched_handler_init:
         logging.Handler.__init__ = _original_handler_init  # type: ignore[assignment]
+        _original_handler_init = None
+        _patched_handler_init = None
     else:
         # Someone wrapped our patch. Restoring the original would clobber
         # their wrapper; leave it in place. Our filter is still attached
         # to handlers constructed while our patch was active, and
-        # _remove_filter_from_existing_handlers cleans those up.
+        # _remove_filter_from_existing_handlers cleans those up. Keep the
+        # saved globals so the next install is idempotent (the dead patch
+        # in lib X's chain reactivates when _installed_filter is set again).
         logger.debug(
             "Skipping Handler.__init__ restore: another library patched "
-            "it after we did; leaving their patch in place"
+            "it after we did; leaving their patch in place and keeping our "
+            "saved globals for idempotent re-install"
         )
-    _original_handler_init = None
-    _patched_handler_init = None
+
+
+def _cover_handler(handler: logging.Handler) -> None:
+    """Track a handler we attached the filter to, for uninstall cleanup.
+
+    Handlers not on any logger (held by a QueueListener, nested inside
+    another handler) are unreachable from _snapshot_handler_pairs; without
+    tracking, uninstall would miss them and they'd retain the filter (S7).
+    The weak set auto-drops GC'd handlers."""
+    try:
+        _covered_handlers.add(handler)
+    except Exception:
+        # WeakSet can raise ReferenceError on a dying ref; not worth failing
+        # the install for.
+        pass
 
 
 def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> None:
@@ -807,22 +917,19 @@ def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> Non
     on install ordering.
 
     Skip datahub.masking.* loggers: they log to the original stderr by design and
-    carry no secrets, so filtering them only risks re-entrancy. The trailing dot
-    in ``REDACTED_MASKING_NAMESPACE`` avoids matching a hypothetical
-    "datahub.maskingfoo" logger. A handler *shared* between a datahub.masking.*
-    logger and another logger still gets the filter via the other logger — that
-    is safe because ``filter()``'s record-name bypass short-circuits masking
-    for records whose name is in the masking namespace, so there is no
-    re-entrancy and no masking of internal logs. The per-logger skip is a
-    best-effort attach-time optimization; the record-name bypass is the real
-    safety net.
+    carry no secrets, so filtering them only risks re-entrancy. A handler
+    *shared* between a datahub.masking.* logger and another logger still gets
+    the filter via the other logger — that is safe because ``filter()``'s
+    record-name bypass (using the same _is_masking_namespace_name predicate)
+    short-circuits masking for records whose name is in the masking
+    namespace, so there is no re-entrancy and no masking of internal logs. The
+    per-logger skip is a best-effort attach-time optimization; the record-name
+    bypass is the real safety net, and the two now agree (D3).
     """
     pairs = _snapshot_handler_pairs()
     added = 0
     for log, handler in pairs:
-        if log.name == "datahub.masking" or log.name.startswith(
-            REDACTED_MASKING_NAMESPACE
-        ):
+        if _is_masking_namespace_name(log.name):
             continue
         # Identity check: don't skip attaching because some OTHER
         # SecretMaskingFilter is present — that would let us miss handlers
@@ -831,6 +938,7 @@ def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> Non
         if masking_filter in handler.filters:
             continue
         handler.addFilter(masking_filter)
+        _cover_handler(handler)
         added += 1
     if added:
         logger.debug(f"Installed SecretMaskingFilter on {added} handler(s)")
@@ -841,12 +949,23 @@ def _remove_filter_from_existing_handlers(masking_filter: SecretMaskingFilter) -
 
     Identity-based (not isinstance) so we never strip a different
     SecretMaskingFilter that someone else installed. Uses removeFilter (the
-    logging API) rather than reassigning handler.filters. Snapshots under
+    logging API) rather than reassigning handler.filters. Iterates
+    _snapshot_handler_pairs (handlers on loggers) AND _covered_handlers
+    (handlers we attached to but which may not be on any logger — held by a
+    QueueListener, nested inside another handler — S7). Snapshots under
     the logging module lock so a concurrent addHandler/removeHandler can't
     mutate the lists under us.
     """
     pairs = _snapshot_handler_pairs()
     for _log, handler in pairs:
+        while masking_filter in handler.filters:
+            handler.removeFilter(masking_filter)
+    # Handlers we covered but that aren't on any logger. Snapshot the weak
+    # set under the install lock so a concurrent add doesn't mutate it; the
+    # handlers themselves are alive (we hold them via the snapshot).
+    with _install_lock:
+        covered = list(_covered_handlers)
+    for handler in covered:
         while masking_filter in handler.filters:
             handler.removeFilter(masking_filter)
 
@@ -909,82 +1028,85 @@ def install_masking_filter(
     """
     global _installed_filter
 
-    root_logger = logging.getLogger()
+    with _install_lock:
+        root_logger = logging.getLogger()
 
-    # Identity-based "already installed?" check. The previous isinstance check
-    # could skip attaching because someone else's SecretMaskingFilter was
-    # present, then strip that filter on teardown. Track our own instance.
-    if _installed_filter is not None:
-        # Already installed: re-scan to cover handlers added since (fail-open).
-        _add_filter_to_existing_handlers(_installed_filter)
+        # Identity-based "already installed?" check. The previous isinstance check
+        # could skip attaching because someone else's SecretMaskingFilter was
+        # present, then strip that filter on teardown. Track our own instance.
+        if _installed_filter is not None:
+            # Already installed: re-scan to cover handlers added since (fail-open).
+            _add_filter_to_existing_handlers(_installed_filter)
 
-        # Re-add the root-logger filter if something removed it (partial
-        # teardown state). Without this, a partially-torn-down state stays
-        # partial: the handler filters are re-scanned but the root-logger
-        # sentinel is gone, so the "already installed?" check on a later call
-        # would re-install from scratch and attach a second filter.
-        if _installed_filter not in root_logger.filters:
-            root_logger.addFilter(_installed_filter)
+            # Re-add the root-logger filter if something removed it (partial
+            # teardown state). Without this, a partially-torn-down state stays
+            # partial: the handler filters are re-scanned but the root-logger
+            # sentinel is gone, so the "already installed?" check on a later call
+            # would re-install from scratch and attach a second filter.
+            if _installed_filter not in root_logger.filters:
+                root_logger.addFilter(_installed_filter)
 
-        # Rebind the registry if the caller passed a different one. Without
-        # this, install(r1) → reset_instance() → install(r2) leaves the
-        # filter masking with r1 (now stale), so r2's secrets leak. The
-        # filter is process-lifetime, but the registry it reads is not —
-        # rebind so the same filter instance reads the new registry, and
-        # reset _last_version to force a pattern rebuild on the next mask.
-        if (
-            secret_registry is not None
-            and secret_registry is not _installed_filter._registry
-        ):
-            logger.warning(
-                "Rebinding SecretMaskingFilter registry on repeat install; "
-                "the previous registry is no longer active. "
-                "Use SecretRegistry.reset_instance() between installs to "
-                "fully tear down first."
-            )
-            _installed_filter.rebind_registry(secret_registry)
+            # Rebind the registry if the caller passed a different one. Without
+            # this, install(r1) → reset_instance() → install(r2) leaves the
+            # filter masking with r1 (now stale), so r2's secrets leak. The
+            # filter is process-lifetime, but the registry it reads is not —
+            # rebind so the same filter instance reads the new registry, and
+            # reset _last_version to force a pattern rebuild on the next mask.
+            if (
+                secret_registry is not None
+                and secret_registry is not _installed_filter._registry
+            ):
+                logger.warning(
+                    "Rebinding SecretMaskingFilter registry on repeat install; "
+                    "the previous registry is no longer active. "
+                    "Use SecretRegistry.reset_instance() between installs to "
+                    "fully tear down first."
+                )
+                _installed_filter.rebind_registry(secret_registry)
 
-        # Honour install_stdout_wrapper on refresh. The wrapper block sits after
-        # this path's early return, so a repeat install with
-        # install_stdout_wrapper=True after an earlier install with False would
-        # silently skip wrapping. The helper is idempotent and guarded by the
-        # fileno() real-stream check, so calling it here is safe. We do NOT
-        # unwrap when False is passed — teardown owns unwrapping.
+            # Honour install_stdout_wrapper on refresh. The wrapper block sits after
+            # this path's early return, so a repeat install with
+            # install_stdout_wrapper=True after an earlier install with False would
+            # silently skip wrapping. The helper is idempotent and guarded by the
+            # fileno() real-stream check, so calling it here is safe. We do NOT
+            # unwrap when False is passed — teardown owns unwrapping.
+            if install_stdout_wrapper:
+                _wrap_std_streams(_installed_filter)
+
+            logger.debug("SecretMaskingFilter already installed; refreshed handlers")
+            return _installed_filter
+
+        masking_filter = SecretMaskingFilter(
+            secret_registry=secret_registry, max_message_size=max_message_size
+        )
+
+        # The root-logger filter is the "already installed?" sentinel (and masks
+        # records logged directly on root). The real masking is the handler
+        # filters below, since logger-level filters don't see propagated
+        # child-logger records.
+        root_logger.addFilter(masking_filter)
+        _installed_filter = masking_filter
+        # Hook Handler.__init__ before the handler scan so a handler
+        # constructed between the two is covered by the hook rather than
+        # missed by both. The scan's identity check prevents a double
+        # attach for handlers the hook has already covered.
+        _install_handler_init_hook()
+        _add_filter_to_existing_handlers(masking_filter)
+        logger.info(
+            "Installed SecretMaskingFilter on root logger and existing handlers"
+        )
+
+        # Wrap stdout/stderr only to mask raw writes (print(), C-extension output).
+        # We do NOT repoint handler streams here: under celery, sys.stderr re-enters
+        # logging, so a handler pointed at it would recurse infinitely and drop output.
+        # Skip wrapping when the stream is not a real OS-backed stream (proxy / pytest
+        # capture / structlog / etc.) — wrapping a proxy re-enters logging. Under a
+        # proxy, raw writes become log records and flow through handlers that carry
+        # the masking filter, so coverage doesn't suffer.
         if install_stdout_wrapper:
-            _wrap_std_streams(_installed_filter)
+            _wrap_std_streams(masking_filter)
 
-        logger.debug("SecretMaskingFilter already installed; refreshed handlers")
-        return _installed_filter
-
-    masking_filter = SecretMaskingFilter(
-        secret_registry=secret_registry, max_message_size=max_message_size
-    )
-
-    # The root-logger filter is the "already installed?" sentinel (and masks
-    # records logged directly on root). The real masking is the handler
-    # filters below, since logger-level filters don't see propagated
-    # child-logger records.
-    root_logger.addFilter(masking_filter)
-    _installed_filter = masking_filter
-    # Hook Handler.__init__ before the handler scan so a handler
-    # constructed between the two is covered by the hook rather than
-    # missed by both. The scan's identity check prevents a double
-    # attach for handlers the hook has already covered.
-    _install_handler_init_hook()
-    _add_filter_to_existing_handlers(masking_filter)
-    logger.info("Installed SecretMaskingFilter on root logger and existing handlers")
-
-    # Wrap stdout/stderr only to mask raw writes (print(), C-extension output).
-    # We do NOT repoint handler streams here: under celery, sys.stderr re-enters
-    # logging, so a handler pointed at it would recurse infinitely and drop output.
-    # Skip wrapping when the stream is not a real OS-backed stream (proxy / pytest
-    # capture / structlog / etc.) — wrapping a proxy re-enters logging. Under a
-    # proxy, raw writes become log records and flow through handlers that carry
-    # the masking filter, so coverage doesn't suffer.
-    if install_stdout_wrapper:
-        _wrap_std_streams(masking_filter)
-
-    return masking_filter
+        return masking_filter
 
 
 def _wrap_std_streams(masking_filter: "SecretMaskingFilter") -> None:
@@ -998,16 +1120,23 @@ def _wrap_std_streams(masking_filter: "SecretMaskingFilter") -> None:
         sys.stdout = StreamMaskingWrapper(sys.stdout, masking_filter)
         logger.debug("Wrapped sys.stdout with StreamMaskingWrapper")
     else:
-        logger.debug(
-            "Skipped wrapping sys.stdout (not a real stream / already wrapped)"
+        # A skipped security control warrants at least info — debug is easy
+        # to miss in production logs, and an operator who sees this knows
+        # raw print()/C-extension output on stdout is not being masked by
+        # the wrapper (it is still masked if it flows through a handler
+        # that carries the filter, e.g. under a proxy).
+        logger.info(
+            "Skipped wrapping sys.stdout (not a real stream / already wrapped); "
+            "raw writes are not masked by the stdout wrapper"
         )
 
     if not isinstance(sys.stderr, StreamMaskingWrapper) and _is_real_stream(sys.stderr):
         sys.stderr = StreamMaskingWrapper(sys.stderr, masking_filter)
         logger.debug("Wrapped sys.stderr with StreamMaskingWrapper")
     else:
-        logger.debug(
-            "Skipped wrapping sys.stderr (not a real stream / already wrapped)"
+        logger.info(
+            "Skipped wrapping sys.stderr (not a real stream / already wrapped); "
+            "raw writes are not masked by the stderr wrapper"
         )
 
 
@@ -1023,25 +1152,29 @@ def uninstall_masking_filter() -> None:
     """
     global _installed_filter
 
-    root_logger = logging.getLogger()
+    with _install_lock:
+        root_logger = logging.getLogger()
 
-    # Remove our instance (identity-based) from the root logger and handlers.
-    if _installed_filter is not None:
-        while _installed_filter in root_logger.filters:
-            root_logger.removeFilter(_installed_filter)
-        _remove_filter_from_existing_handlers(_installed_filter)
-        _installed_filter = None
+        # Remove our instance (identity-based) from the root logger and handlers.
+        if _installed_filter is not None:
+            while _installed_filter in root_logger.filters:
+                root_logger.removeFilter(_installed_filter)
+            _remove_filter_from_existing_handlers(_installed_filter)
+            _installed_filter = None
 
-    # Revert the Handler.__init__ hook so handlers constructed after uninstall
-    # don't auto-attach a (now-None) filter. Done after _installed_filter is
-    # cleared so the hook's pointer read sees None during teardown.
-    _uninstall_handler_init_hook()
+        # Revert the Handler.__init__ hook so handlers constructed after uninstall
+        # don't auto-attach a (now-None) filter. Done after _installed_filter is
+        # cleared so the hook's pointer read sees None during teardown.
+        _uninstall_handler_init_hook()
 
-    # Unwrap stdout/stderr (only if we wrapped them)
-    if isinstance(sys.stdout, StreamMaskingWrapper):
-        sys.stdout = sys.stdout._original
+        # Drop the covered-handler tracking set so a re-install starts clean.
+        _covered_handlers.clear()
 
-    if isinstance(sys.stderr, StreamMaskingWrapper):
-        sys.stderr = sys.stderr._original
+        # Unwrap stdout/stderr (only if we wrapped them)
+        if isinstance(sys.stdout, StreamMaskingWrapper):
+            sys.stdout = sys.stdout._original
 
-    logger.info("Uninstalled SecretMaskingFilter")
+        if isinstance(sys.stderr, StreamMaskingWrapper):
+            sys.stderr = sys.stderr._original
+
+        logger.info("Uninstalled SecretMaskingFilter")

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -39,11 +39,15 @@ _installed_filter: Optional["SecretMaskingFilter"] = None
 # Original ``logging.Handler.__init__`` saved while the __init__ hook is
 # installed, so uninstall can restore it. ``None`` means the hook is not
 # active. The hook auto-attaches the installed filter to every *new* handler
-# (P0-1: a handler created after install — basicConfig, a library's lazy
-# logging config, a per-task FileHandler — otherwise gets no filter, and
-# the deleted stream-repointing accidentally covered this case). Idempotent
+# (a handler created after install — basicConfig, a library's lazy logging
+# config, a per-task FileHandler — otherwise gets no filter). Idempotent
 # (re-install is a no-op) and reversible on uninstall.
 _original_handler_init: Optional[Any] = None
+# The patched ``__init__`` we installed, kept so uninstall can verify the
+# current ``Handler.__init__`` is still ours before restoring. If another
+# library wrapped our patch, we leave the chain alone (see
+# _uninstall_handler_init_hook).
+_patched_handler_init: Optional[Any] = None
 
 # Constants
 REDACTED_MASKING_NAMESPACE = "datahub.masking."
@@ -692,20 +696,23 @@ class StreamMaskingWrapper:
 def _snapshot_handler_pairs() -> List[Tuple[logging.Logger, logging.Handler]]:
     """Snapshot ``(logger, handler)`` pairs under the logging module lock.
 
-    Holding ``logging._acquireLock`` around the snapshot prevents
+    Holding the logging module lock around the snapshot prevents
     ``RuntimeError`` from a concurrent ``addHandler`` / ``removeHandler``
-    mutating ``logger.handlers`` or ``loggerDict`` while we iterate (P2-1).
+    mutating ``logger.handlers`` or ``loggerDict`` while we iterate.
     The lock is released before we return, so callers can ``addFilter`` /
     ``removeFilter`` and log without holding it — holding it across a log
     call would deadlock (the logging path acquires the same lock).
 
-    ``loggerDict`` is snapshotted as ``list(items())`` (P2-2): indexing by
+    ``loggerDict`` is snapshotted as ``list(items())``: indexing by
     key after a keys-only snapshot can raise ``KeyError`` if a logger is
     GC'd between the two steps; ``items()`` holds the value reference too.
     ``PlaceHolder`` entries (non-Logger) are filtered out.
     """
-    logging._acquireLock()  # type: ignore[attr-defined]
-    try:
+    # ``logging._lock`` is the module-level RLock that ``_acquireLock`` /
+    # ``_releaseLock`` wrap. Those wrappers were removed in Python 3.13,
+    # but ``_lock`` itself remains and is an RLock on 3.10–3.14+, so it
+    # works as a context manager across the whole supported range.
+    with logging._lock:  # type: ignore[attr-defined]
         root = logging.getLogger()
         pairs: List[Tuple[logging.Logger, logging.Handler]] = [
             (root, h) for h in list(root.handlers)
@@ -715,13 +722,11 @@ def _snapshot_handler_pairs() -> List[Tuple[logging.Logger, logging.Handler]]:
                 for h in list(obj.handlers):
                     pairs.append((obj, h))
         return pairs
-    finally:
-        logging._releaseLock()  # type: ignore[attr-defined]
 
 
 def _install_handler_init_hook() -> None:
     """Patch ``logging.Handler.__init__`` to auto-attach the installed filter
-    to every new handler (P0-1). Idempotent: a no-op if already installed.
+    to every new handler. Idempotent: a no-op if already installed.
     Reversed by ``_uninstall_handler_init_hook``.
 
     ``Handler.__init__`` is the construction seam: standard handlers
@@ -741,7 +746,7 @@ def _install_handler_init_hook() -> None:
     ``_original_handler_init`` to None mid-call would leave the handler
     half-constructed.
     """
-    global _original_handler_init
+    global _original_handler_init, _patched_handler_init
     if _original_handler_init is not None:
         return  # idempotent
     original = logging.Handler.__init__
@@ -753,15 +758,39 @@ def _install_handler_init_hook() -> None:
         if f is not None and f not in self.filters:
             self.addFilter(f)
 
+    _patched_handler_init = patched_handler_init
     logging.Handler.__init__ = patched_handler_init  # type: ignore[assignment]
 
 
 def _uninstall_handler_init_hook() -> None:
-    """Restore ``logging.Handler.__init__``. No-op if the hook is not active."""
-    global _original_handler_init
-    if _original_handler_init is not None:
+    """Restore ``logging.Handler.__init__`` if (and only if) it is still our
+    patched function.
+
+    If another library patched ``Handler.__init__`` *after* us, the current
+    attribute is no longer ``_patched_handler_init``. Restoring
+    ``_original_handler_init`` unconditionally would discard that library's
+    patch — the classic monkeypatch stacking hazard. When the current
+    attribute is not ours, leave the chain alone and log at debug: we
+    cannot safely unwind a patch someone else wrapped, and the residual
+    (their patch stays in place, ours is no longer reachable) is the safe
+    choice. No-op if the hook was never installed.
+    """
+    global _original_handler_init, _patched_handler_init
+    if _original_handler_init is None:
+        return
+    if logging.Handler.__init__ is _patched_handler_init:
         logging.Handler.__init__ = _original_handler_init  # type: ignore[assignment]
-        _original_handler_init = None
+    else:
+        # Someone wrapped our patch. Restoring the original would clobber
+        # their wrapper; leave it in place. Our filter is still attached
+        # to handlers constructed while our patch was active, and
+        # _remove_filter_from_existing_handlers cleans those up.
+        logger.debug(
+            "Skipping Handler.__init__ restore: another library patched "
+            "it after we did; leaving their patch in place"
+        )
+    _original_handler_init = None
+    _patched_handler_init = None
 
 
 def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> None:
@@ -773,10 +802,9 @@ def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> Non
     masks it in place, without touching the handler's stream. (Repointing streams
     instead loops forever under celery -- see install_masking_filter.)
 
-    This is the one-shot that covers handlers present at install time. Handlers
-    created *after* install are covered by the ``Handler.__init__`` hook
-    (``_install_handler_init_hook``), so masking is structurally unconditional
-    rather than dependent on install ordering (P0-1).
+    Covers handlers present at install time. Handlers created later are
+    covered by the ``Handler.__init__`` hook, so masking does not depend
+    on install ordering.
 
     Skip datahub.masking.* loggers: they log to the original stderr by design and
     carry no secrets, so filtering them only risks re-entrancy. The trailing dot
@@ -815,7 +843,7 @@ def _remove_filter_from_existing_handlers(masking_filter: SecretMaskingFilter) -
     SecretMaskingFilter that someone else installed. Uses removeFilter (the
     logging API) rather than reassigning handler.filters. Snapshots under
     the logging module lock so a concurrent addHandler/removeHandler can't
-    mutate the lists under us (P2-1).
+    mutate the lists under us.
     """
     pairs = _snapshot_handler_pairs()
     for _log, handler in pairs:
@@ -851,15 +879,14 @@ def install_masking_filter(
 
     Masking happens at the handler level (see _add_filter_to_existing_handlers).
     The one-shot covers handlers present at install time; the
-    ``Handler.__init__`` hook (``_install_handler_init_hook``) covers handlers
-    created later — ``basicConfig`` after install, a library's lazy logging
-    config, a per-task FileHandler/QueueHandler — so masking is structurally
-    unconditional rather than dependent on install ordering. This restores
-    the coverage the deleted stream-repointing accidentally provided, without
-    repointing streams (which deadlocked under celery).
+    ``Handler.__init__`` hook covers handlers created later — ``basicConfig``
+    after install, a library's lazy logging config, a per-task
+    FileHandler/QueueHandler — so masking does not depend on install
+    ordering. Streams are not repointed: under celery, ``sys.stderr``
+    re-enters logging, so a handler pointed at it would recurse infinitely
+    and drop output.
 
-    Residual gaps (fail-open limitations, documented so reviewers see the
-    security envelope):
+    Residual gaps (fail-open limitations of the security envelope):
     - A handler attached by direct ``logger.handlers.append(h)`` (bypassing
       ``addHandler``) where ``h`` was constructed before install and is not
       on any logger at install time: neither the one-shot nor the ``__init__``
@@ -933,18 +960,18 @@ def install_masking_filter(
         secret_registry=secret_registry, max_message_size=max_message_size
     )
 
-    # The root-logger filter is just the "already installed?" sentinel (and masks
-    # records logged directly on root). The real masking is the handler filters
-    # below, since logger-level filters don't see propagated child-logger records.
+    # The root-logger filter is the "already installed?" sentinel (and masks
+    # records logged directly on root). The real masking is the handler
+    # filters below, since logger-level filters don't see propagated
+    # child-logger records.
     root_logger.addFilter(masking_filter)
-    _add_filter_to_existing_handlers(masking_filter)
     _installed_filter = masking_filter
-    # Hook Handler.__init__ so handlers created AFTER install (basicConfig,
-    # library lazy config, per-task FileHandler) auto-attach the filter. This
-    # makes masking structurally unconditional rather than install-ordering-
-    # dependent (P0-1); the deleted stream-repointing accidentally covered
-    # this case and we are restoring that coverage without repointing streams.
+    # Hook Handler.__init__ before the handler scan so a handler
+    # constructed between the two is covered by the hook rather than
+    # missed by both. The scan's identity check prevents a double
+    # attach for handlers the hook has already covered.
     _install_handler_init_hook()
+    _add_filter_to_existing_handlers(masking_filter)
     logger.info("Installed SecretMaskingFilter on root logger and existing handlers")
 
     # Wrap stdout/stderr only to mask raw writes (print(), C-extension output).

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -19,6 +19,7 @@ Performance:
 - Performance warnings at 100/500 secrets
 """
 
+import io
 import logging
 import re
 import sys
@@ -30,10 +31,49 @@ from datahub.masking.secret_registry import SecretRegistry
 
 logger = get_masking_safe_logger(__name__)
 
+# The single installed filter instance for this process (identity-based
+# install/uninstall tracking). See install_masking_filter. Forward-annotated
+# because SecretMaskingFilter is defined below.
+_installed_filter: Optional["SecretMaskingFilter"] = None
+
 # Constants
+REDACTED_MASKING_NAMESPACE = "datahub.masking."
 REDACTED_FORMAT = "***REDACTED:{name}***"
 MASKING_ERROR_MESSAGE = "[MASKING_ERROR - OUTPUT_SUPPRESSED_FOR_SECURITY]"
 CIRCUIT_OPEN_MESSAGE = "[REDACTED: Masking Circuit Open]"
+
+# LogRecord standard attributes (per logging.LogRecord.__init__ + attributes set
+# by the framework during formatting). Extras added via ``extra={...}`` are
+# everything NOT in this set, and we mask those recursively. Iterating the whole
+# __dict__ and masking pathname/funcName/module would waste regex on the hot path
+# and could corrupt those fields.
+_STANDARD_RECORD_ATTRS = frozenset(
+    {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "process",
+        "processName",
+        "taskName",
+        "message",
+        "asctime",
+    }
+)
 
 
 class SecretMaskingFilter(logging.Filter):
@@ -306,36 +346,61 @@ class SecretMaskingFilter(logging.Filter):
             logger.error(f"CRITICAL: Secret masking failed in args: {e}", exc_info=True)
             return (MASKING_ERROR_MESSAGE,)
 
-    def _mask_exception(self, exc_info: Optional[Tuple]) -> Optional[Tuple]:
-        """Mask secrets in exception information."""
+    def _mask_exception(self, exc_info: Optional[Tuple]) -> Optional[str]:
+        """Materialize traceback text from ``exc_info`` so filter() can mask it.
+
+        Returns the unmasked traceback text (or a sentinel on error). filter()
+        assigns the result to ``record.exc_text`` and masks it alongside any
+        pre-existing ``exc_text``. Formatters reuse ``exc_text`` when set, so
+        the masked text is what gets emitted.
+
+        ``exc_info`` itself is left untouched: handler-based error reporters
+        (Sentry, Datadog, anything reading ``record.exc_info``) keep the real
+        exception with its chain and traceback.
+
+        Stated trade-off: the previous implementation rebuilt the exception via
+        ``type(exc_value)(*masked_args)``, which attempted to mask exception
+        args for downstream error-reporter consumers — badly (it raised for
+        any exception whose ``__init__`` signature didn't match its ``args``,
+        common in DB drivers and source connectors, and the fallback returned
+        a bare ``RuntimeError`` that destroyed the traceback, message, class,
+        and ``__cause__`` chain). This PR trades masked-args-for-error-reporters
+        for correctness of the *printed* output. That is the right trade
+        because the printed output is what ships to log files and is the
+        primary leak surface; error reporters are a secondary surface and
+        their consumers can be separately addressed (e.g. by masking at the
+        reporter integration). It is a stated decision, not a silent
+        consequence.
+
+        A middle option (mutating ``exc_value.args`` in place) was considered
+        and rejected: it mutates a live exception the caller may re-raise or
+        inspect after logging.
+
+        Benefit that comes free: ``Formatter.formatException`` follows
+        ``__cause__`` / ``__context__``, so the masked text covers the whole
+        chain, including chained exception messages that the old rebuild
+        dropped.
+
+        Residual gap: a formatter with a custom ``formatException`` that
+        re-derives from ``exc_info`` (instead of reusing ``exc_text``) bypasses
+        the masked text. Same accepted residual as the structured-formatter
+        case for extras.
+        """
         if not exc_info:
-            return exc_info
+            return None
 
         try:
-            exc_type, exc_value, exc_traceback = exc_info
-
-            # Mask exception message/args
-            if exc_value and hasattr(exc_value, "args") and exc_value.args:
-                masked_args = tuple(
-                    self.mask_text(arg) if isinstance(arg, str) else arg
-                    for arg in exc_value.args
-                )
-                # Create new exception instance with masked args
-                exc_value = type(exc_value)(*masked_args)
-
-            return (exc_type, exc_value, exc_traceback)
-
+            return logging.Formatter().formatException(exc_info)
         except Exception as e:
-            # Fail-secure: never return unmasked exception on error
+            # Fail-secure: return a sentinel string rather than fabricating a
+            # RuntimeError, so the original exc_info (and error reporters)
+            # survive. filter() will mask this (no-op since it has no secrets).
+            # Note: do NOT log with exc_info=True here — that would call
+            # formatException again and re-raise under the same failure.
             logger.error(
-                f"CRITICAL: Secret masking failed in exception: {e}", exc_info=True
+                f"CRITICAL: Secret masking failed materializing exception: {e}"
             )
-            # Return a sanitized exception
-            return (
-                RuntimeError,
-                RuntimeError(MASKING_ERROR_MESSAGE),
-                None,
-            )
+            return MASKING_ERROR_MESSAGE
 
     def _truncate_message(self, message: str) -> str:
         """Truncate large messages before masking."""
@@ -352,8 +417,118 @@ class SecretMaskingFilter(logging.Filter):
             f"... [{truncated_bytes} bytes truncated for performance]"
         )
 
+    # Depth cap and cycle guard for _mask_value_recursive. extra= can carry
+    # self-referential or very large structures onto the logging hot path; an
+    # unbounded recursion would hang the logger. The cap is generous (real
+    # config is rarely >10 deep); beyond it we return the value unchanged
+    # rather than raise, so logging still proceeds (residual gap documented).
+    _MAX_EXTRA_DEPTH = 10
+
+    def _mask_value_recursive(
+        self, value: Any, _depth: int = 0, _seen: Optional[set] = None
+    ) -> Any:
+        """Recursively mask secrets in a value's string leaves.
+
+        Covers dict/list/tuple/set containers and string leaves. Non-string,
+        non-container values pass through unchanged. Arbitrary objects are NOT
+        stringified-and-masked (that would change behavior and risk calling
+        ``__str__`` side effects); if a formatter later serializes such an
+        object via ``%s``, the serialized form is masked at the formatter-output
+        stage only if that output flows through the stdout/stderr wrapper —
+        otherwise it is a residual gap, documented in install_masking_filter.
+
+        Containers are *copied*, not mutated in place: ``record.__dict__["cfg"]``
+        is the caller's live dict, so masking leaves in place would silently
+        turn a config dict into ***REDACTED:X*** after the first log line — a
+        nasty bug to chase. We build a masked copy and assign that to the record.
+
+        A depth cap (``_MAX_EXTRA_DEPTH``) and an identity-based cycle guard
+        (``_seen``) bound the recursion: extra= can carry self-referential or
+        very large structures onto the hot path. Beyond the cap or on a cycle we
+        return the value unchanged (residual gap) rather than raise, so logging
+        still proceeds.
+        """
+        if _depth >= self._MAX_EXTRA_DEPTH:
+            return value
+        if isinstance(value, str):
+            return self.mask_text(value)
+        if isinstance(value, dict):
+            if _seen is None:
+                _seen = set()
+            if id(value) in _seen:
+                return value  # cycle — return unchanged (residual gap)
+            _seen.add(id(value))
+            try:
+                return {
+                    k: self._mask_value_recursive(v, _depth + 1, _seen)
+                    for k, v in value.items()
+                }
+            finally:
+                _seen.discard(id(value))
+        if isinstance(value, (list, tuple, set, frozenset)):
+            if _seen is None:
+                _seen = set()
+            if id(value) in _seen:
+                return value
+            _seen.add(id(value))
+            try:
+                masked = [
+                    self._mask_value_recursive(v, _depth + 1, _seen) for v in value
+                ]
+            finally:
+                _seen.discard(id(value))
+            if isinstance(value, tuple):
+                return tuple(masked)
+            if isinstance(value, set):
+                return set(masked)
+            if isinstance(value, frozenset):
+                return frozenset(masked)
+            return masked
+        return value
+
+    def _mask_extras(self, record: logging.LogRecord) -> None:
+        """Mask secrets in non-standard LogRecord attributes (``extra={...}``).
+
+        Formatters pull fields from ``record.__dict__``; without this, a
+        ``Formatter("%(dsn)s")`` with ``extra={"dsn": "db://u:sekret@h"}`` would
+        emit the secret unmasked. Recurses into dict/list/tuple/set so nested
+        containers (``extra={"cfg": {"password": "sekret"}}``) are covered.
+
+        Standard LogRecord attributes are skipped: masking ``pathname`` /
+        ``funcName`` / ``module`` would waste regex on the hot path and risks
+        corrupting framework-set fields. Third-party libraries (structlog,
+        gunicorn, ddtrace) inject their own attributes; this loop must not
+        raise on unexpected types — it runs inside filter()'s try/except, and
+        _mask_value_recursive returns non-container values unchanged.
+        """
+        for key, value in list(record.__dict__.items()):
+            if key in _STANDARD_RECORD_ATTRS:
+                continue
+            if isinstance(value, (str, dict, list, tuple, set, frozenset)):
+                record.__dict__[key] = self._mask_value_recursive(value)
+
     def filter(self, record: logging.LogRecord) -> bool:
-        """Filter and mask a log record."""
+        """Filter and mask a log record.
+
+        Idempotent per record: a sentinel (``record._datahub_masked``) is set
+        after masking so the same record flowing through multiple handlers
+        (each carrying this filter) is not re-truncated / re-masked. Without
+        this, N handlers produce N× regex cost and N× truncation — the second
+        truncation re-truncates the already-truncated text, eats the previous
+        suffix, and reports a wrong byte count.
+        """
+        # Re-entrancy / idempotency guard. Records from the masking framework's
+        # own loggers bypass masking entirely (their handlers are skipped at
+        # install time, but they may propagate to root handlers after
+        # reset_masking_safe_loggers flips propagate=True on teardown — see
+        # bootstrap.shutdown_secret_masking). The startswith check is on the
+        # record name, not the logger we attached to, so it catches propagation.
+        if record.name.startswith(REDACTED_MASKING_NAMESPACE):
+            return True
+
+        if getattr(record, "_datahub_masked", False):
+            return True
+
         # Check if masking is disabled for debugging
         from datahub.masking.secret_registry import is_masking_enabled
 
@@ -380,17 +555,27 @@ class SecretMaskingFilter(logging.Filter):
             if hasattr(record, "message") and record.message:
                 record.message = self.mask_text(record.message)
 
-            # 5. Mask exception information
-            if record.exc_info:
-                record.exc_info = self._mask_exception(record.exc_info)
+            # 5. Materialize traceback text from exc_info so it can be masked.
+            #    exc_info itself is left untouched (error reporters read it).
+            #    See _mask_exception for why we do not rebuild the exception.
+            if record.exc_info and not record.exc_text:
+                record.exc_text = self._mask_exception(record.exc_info)
 
-            # 6. Mask formatted exception text if it exists
+            # 6. Mask formatted exception text (pre-existing or just materialized)
             if record.exc_text:
                 record.exc_text = self.mask_text(record.exc_text)
 
             # 7. Mask stack_info if present (Python 3.2+)
             if hasattr(record, "stack_info") and record.stack_info:
                 record.stack_info = self.mask_text(record.stack_info)
+
+            # 8. Mask non-standard attributes (extra={...}). Must run after msg/args
+            #    masking and inside the try so unexpected types from third-party
+            #    libraries do not break logging.
+            self._mask_extras(record)
+
+            # Mark as masked so subsequent handlers skip the work.
+            record._datahub_masked = True
 
         except Exception as e:
             # NEVER let masking break logging
@@ -453,7 +638,14 @@ class StreamMaskingWrapper:
 
 
 def _iter_all_loggers() -> list[logging.Logger]:
-    """Root logger plus every initialized named logger (skipping PlaceHolders)."""
+    """Root logger plus every initialized named logger (skipping PlaceHolders).
+
+    Returns a list (snapshot) so callers iterate a stable copy while other
+    threads add/remove loggers. We deliberately do NOT take logging._acquireLock
+    here: it is held during logging I/O on some paths and would risk deadlock,
+    and list(loggerDict.keys()) + .get() is safe enough against concurrent
+    mutation (a removed logger yields None from .get and is skipped).
+    """
     loggers: list[logging.Logger] = [logging.getLogger()]
     # .get() per snapshotted key: a logger may be removed between snapshot and access.
     for name in list(logging.root.manager.loggerDict.keys()):
@@ -473,28 +665,55 @@ def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> Non
     instead loops forever under celery -- see install_masking_filter.)
 
     Skip datahub.masking.* loggers: they log to the original stderr by design and
-    carry no secrets, so filtering them only risks re-entrancy.
+    carry no secrets, so filtering them only risks re-entrancy. The trailing dot
+    avoids matching a hypothetical "datahub.maskingfoo" logger.
     """
     added = 0
     for log in _iter_all_loggers():
-        if log.name.startswith("datahub.masking"):
+        if log.name.startswith(REDACTED_MASKING_NAMESPACE):
             continue
         # Copy: handlers may be added/removed by other threads during iteration.
         for handler in list(log.handlers):
-            if not any(isinstance(f, SecretMaskingFilter) for f in handler.filters):
-                handler.addFilter(masking_filter)
-                added += 1
+            # Identity check: don't skip attaching because some OTHER
+            # SecretMaskingFilter is present — that would let us miss handlers
+            # we should cover, and on teardown we'd strip a filter we never added.
+            # We only skip our own instance (re-install / refresh path).
+            if masking_filter in handler.filters:
+                continue
+            handler.addFilter(masking_filter)
+            added += 1
     if added:
         logger.debug(f"Installed SecretMaskingFilter on {added} handler(s)")
 
 
-def _remove_filter_from_existing_handlers() -> None:
-    """Remove the masking filter from every handler it was attached to."""
+def _remove_filter_from_existing_handlers(masking_filter: SecretMaskingFilter) -> None:
+    """Remove *our* masking filter instance from every handler it's on.
+
+    Identity-based (not isinstance) so we never strip a different
+    SecretMaskingFilter that someone else installed. Uses removeFilter (the
+    logging API) rather than reassigning handler.filters.
+    """
     for log in _iter_all_loggers():
         for handler in list(log.handlers):
-            handler.filters = [
-                f for f in handler.filters if not isinstance(f, SecretMaskingFilter)
-            ]
+            while masking_filter in handler.filters:
+                handler.removeFilter(masking_filter)
+
+
+def _is_real_stream(stream: object) -> bool:
+    """True if ``stream`` is a real OS-backed stream safe to wrap.
+
+    Fail-closed: if ``fileno()`` raises (pytest capture, celery LoggingProxy,
+    structlog, IPython, journald), we treat it as a non-real stream and skip
+    wrapping. Skipping costs nothing under a proxy: raw print()/stderr writes
+    are converted to log records by the proxy and flow through handlers that
+    carry the masking filter. Wrapping a proxy would re-enter logging and
+    recurse.
+    """
+    try:
+        stream.fileno()  # type: ignore[attr-defined]
+        return True
+    except (io.UnsupportedOperation, OSError, ValueError, AttributeError):
+        return False
 
 
 def install_masking_filter(
@@ -510,60 +729,98 @@ def install_masking_filter(
     is configured; handlers added later are covered only by a re-install or, for
     stdout/stderr, by the stream wrapper.
 
-    Fail-open limitation: a handler added to a child logger after install can emit
-    unmasked (a logger's own handlers run before ancestors'). Not a concern in the
-    executor, where handlers exist before masking is installed per task.
+    Fail-open limitations (residual gaps, documented so nobody over-engineers a
+    addHandler monkeypatch later):
+    - A handler added to a child logger after install can emit unmasked (a
+      logger's own handlers run before ancestors'). Not a concern in the
+      executor, where handlers exist before masking is installed per task.
+    - A FileHandler added after install in a non-celery process: its writes
+      don't go through the stdout/stderr wrapper, so they're unmasked. Under
+      celery, late handlers' writes go through the proxy back into logging and
+      are masked there; outside celery, late StreamHandler()s inherit the
+      wrapped stderr. The residual gap is FileHandler-after-install in a
+      non-celery process.
+    - Arbitrary objects in extras are not stringified-and-masked at filter
+      time (would risk __str__ side effects); a formatter that serializes them
+      via %s may emit them unmasked unless the output flows through the
+      stdout/stderr wrapper.
+
+    Note: the "already installed → refresh" path re-scans handlers but reuses
+    the existing filter instance, so a caller passing a different
+    secret_registry / max_message_size on a repeat call will see those args
+    silently ignored. This is intentional (the filter is process-lifetime)
+    but worth knowing.
     """
+    global _installed_filter
+
+    root_logger = logging.getLogger()
+
+    # Identity-based "already installed?" check. The previous isinstance check
+    # could skip attaching because someone else's SecretMaskingFilter was
+    # present, then strip that filter on teardown. Track our own instance.
+    if _installed_filter is not None:
+        # Already installed: re-scan to cover handlers added since (fail-open).
+        _add_filter_to_existing_handlers(_installed_filter)
+        logger.debug("SecretMaskingFilter already installed; refreshed handlers")
+        return _installed_filter
+
     masking_filter = SecretMaskingFilter(
         secret_registry=secret_registry, max_message_size=max_message_size
     )
-    root_logger = logging.getLogger()
 
     # The root-logger filter is just the "already installed?" sentinel (and masks
     # records logged directly on root). The real masking is the handler filters
     # below, since logger-level filters don't see propagated child-logger records.
-    existing_filters = [
-        f for f in root_logger.filters if isinstance(f, SecretMaskingFilter)
-    ]
-
-    if existing_filters:
-        # Already installed: re-scan to cover handlers added since (fail-open).
-        masking_filter = existing_filters[0]
-        _add_filter_to_existing_handlers(masking_filter)
-        logger.debug("SecretMaskingFilter already installed; refreshed handlers")
-        return masking_filter
-
     root_logger.addFilter(masking_filter)
     _add_filter_to_existing_handlers(masking_filter)
+    _installed_filter = masking_filter
     logger.info("Installed SecretMaskingFilter on root logger and existing handlers")
 
     # Wrap stdout/stderr only to mask raw writes (print(), C-extension output).
     # We do NOT repoint handler streams here: under celery, sys.stderr re-enters
     # logging, so a handler pointed at it would recurse infinitely and drop output.
+    # Skip wrapping when the stream is not a real OS-backed stream (proxy / pytest
+    # capture / structlog / etc.) — wrapping a proxy re-enters logging. Under a
+    # proxy, raw writes become log records and flow through handlers that carry
+    # the masking filter, so coverage doesn't suffer.
     if install_stdout_wrapper:
-        if not isinstance(sys.stdout, StreamMaskingWrapper):
+        if not isinstance(sys.stdout, StreamMaskingWrapper) and _is_real_stream(
+            sys.stdout
+        ):
             sys.stdout = StreamMaskingWrapper(sys.stdout, masking_filter)
             logger.debug("Wrapped sys.stdout with StreamMaskingWrapper")
+        else:
+            logger.debug(
+                "Skipped wrapping sys.stdout (not a real stream / already wrapped)"
+            )
 
-        if not isinstance(sys.stderr, StreamMaskingWrapper):
+        if not isinstance(sys.stderr, StreamMaskingWrapper) and _is_real_stream(
+            sys.stderr
+        ):
             sys.stderr = StreamMaskingWrapper(sys.stderr, masking_filter)
             logger.debug("Wrapped sys.stderr with StreamMaskingWrapper")
+        else:
+            logger.debug(
+                "Skipped wrapping sys.stderr (not a real stream / already wrapped)"
+            )
 
     return masking_filter
 
 
 def uninstall_masking_filter() -> None:
-    """Remove secret masking filter from root logger."""
+    """Remove secret masking filter from root logger and all handlers."""
+    global _installed_filter
+
     root_logger = logging.getLogger()
 
-    # Remove filter from the root logger and from every handler it was added to
-    # (symmetric with install_masking_filter).
-    root_logger.filters = [
-        f for f in root_logger.filters if not isinstance(f, SecretMaskingFilter)
-    ]
-    _remove_filter_from_existing_handlers()
+    # Remove our instance (identity-based) from the root logger and handlers.
+    if _installed_filter is not None:
+        while _installed_filter in root_logger.filters:
+            root_logger.removeFilter(_installed_filter)
+        _remove_filter_from_existing_handlers(_installed_filter)
+        _installed_filter = None
 
-    # Unwrap stdout/stderr
+    # Unwrap stdout/stderr (only if we wrapped them)
     if isinstance(sys.stdout, StreamMaskingWrapper):
         sys.stdout = sys.stdout._original
 

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -24,7 +24,7 @@ import logging
 import re
 import sys
 import threading
-from typing import Any, Dict, Optional, TextIO, Tuple
+from typing import Any, Dict, List, Optional, TextIO, Tuple
 
 from datahub.masking.logging_utils import get_masking_safe_logger
 from datahub.masking.secret_registry import SecretRegistry
@@ -35,6 +35,15 @@ logger = get_masking_safe_logger(__name__)
 # install/uninstall tracking). See install_masking_filter. Forward-annotated
 # because SecretMaskingFilter is defined below.
 _installed_filter: Optional["SecretMaskingFilter"] = None
+
+# Original ``logging.Handler.__init__`` saved while the __init__ hook is
+# installed, so uninstall can restore it. ``None`` means the hook is not
+# active. The hook auto-attaches the installed filter to every *new* handler
+# (P0-1: a handler created after install — basicConfig, a library's lazy
+# logging config, a per-task FileHandler — otherwise gets no filter, and
+# the deleted stream-repointing accidentally covered this case). Idempotent
+# (re-install is a no-op) and reversible on uninstall.
+_original_handler_init: Optional[Any] = None
 
 # Constants
 REDACTED_MASKING_NAMESPACE = "datahub.masking."
@@ -680,22 +689,79 @@ class StreamMaskingWrapper:
         return getattr(self._original, name)
 
 
-def _iter_all_loggers() -> list[logging.Logger]:
-    """Root logger plus every initialized named logger (skipping PlaceHolders).
+def _snapshot_handler_pairs() -> List[Tuple[logging.Logger, logging.Handler]]:
+    """Snapshot ``(logger, handler)`` pairs under the logging module lock.
 
-    Returns a list (snapshot) so callers iterate a stable copy while other
-    threads add/remove loggers. We deliberately do NOT take logging._acquireLock
-    here: it is held during logging I/O on some paths and would risk deadlock,
-    and list(loggerDict.keys()) + .get() is safe enough against concurrent
-    mutation (a removed logger yields None from .get and is skipped).
+    Holding ``logging._acquireLock`` around the snapshot prevents
+    ``RuntimeError`` from a concurrent ``addHandler`` / ``removeHandler``
+    mutating ``logger.handlers`` or ``loggerDict`` while we iterate (P2-1).
+    The lock is released before we return, so callers can ``addFilter`` /
+    ``removeFilter`` and log without holding it — holding it across a log
+    call would deadlock (the logging path acquires the same lock).
+
+    ``loggerDict`` is snapshotted as ``list(items())`` (P2-2): indexing by
+    key after a keys-only snapshot can raise ``KeyError`` if a logger is
+    GC'd between the two steps; ``items()`` holds the value reference too.
+    ``PlaceHolder`` entries (non-Logger) are filtered out.
     """
-    loggers: list[logging.Logger] = [logging.getLogger()]
-    # .get() per snapshotted key: a logger may be removed between snapshot and access.
-    for name in list(logging.root.manager.loggerDict.keys()):
-        obj = logging.root.manager.loggerDict.get(name)
-        if isinstance(obj, logging.Logger):
-            loggers.append(obj)
-    return loggers
+    logging._acquireLock()  # type: ignore[attr-defined]
+    try:
+        root = logging.getLogger()
+        pairs: List[Tuple[logging.Logger, logging.Handler]] = [
+            (root, h) for h in list(root.handlers)
+        ]
+        for _name, obj in list(logging.root.manager.loggerDict.items()):
+            if isinstance(obj, logging.Logger):
+                for h in list(obj.handlers):
+                    pairs.append((obj, h))
+        return pairs
+    finally:
+        logging._releaseLock()  # type: ignore[attr-defined]
+
+
+def _install_handler_init_hook() -> None:
+    """Patch ``logging.Handler.__init__`` to auto-attach the installed filter
+    to every new handler (P0-1). Idempotent: a no-op if already installed.
+    Reversed by ``_uninstall_handler_init_hook``.
+
+    ``Handler.__init__`` is the construction seam: standard handlers
+    (StreamHandler, FileHandler, QueueHandler, ...) all call it, so one
+    patch covers handlers created by ``basicConfig``, library lazy config,
+    and per-task handler construction after install. Subclasses that do
+    NOT call ``Handler.__init__`` (rare) won't be covered — documented
+    residual. The patched ``__init__`` reads ``_installed_filter`` (a
+    pointer read, atomic under the GIL); if it is None (uninstalled) it
+    skips, so a handler constructed during the uninstall window gets no
+    filter and ``_remove_filter_from_existing_handlers`` cleans up any that
+    did.
+
+    The original ``__init__`` is captured in a closure (not re-read from the
+    global) so a handler being constructed when uninstall runs can still
+    finish initializing — without this, uninstall clearing
+    ``_original_handler_init`` to None mid-call would leave the handler
+    half-constructed.
+    """
+    global _original_handler_init
+    if _original_handler_init is not None:
+        return  # idempotent
+    original = logging.Handler.__init__
+    _original_handler_init = original
+
+    def patched_handler_init(self: Any, level: int = logging.NOTSET) -> None:
+        original(self, level)  # closure-captured, race-safe vs uninstall
+        f = _installed_filter
+        if f is not None and f not in self.filters:
+            self.addFilter(f)
+
+    logging.Handler.__init__ = patched_handler_init  # type: ignore[assignment]
+
+
+def _uninstall_handler_init_hook() -> None:
+    """Restore ``logging.Handler.__init__``. No-op if the hook is not active."""
+    global _original_handler_init
+    if _original_handler_init is not None:
+        logging.Handler.__init__ = _original_handler_init  # type: ignore[assignment]
+        _original_handler_init = None
 
 
 def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> None:
@@ -707,24 +773,37 @@ def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> Non
     masks it in place, without touching the handler's stream. (Repointing streams
     instead loops forever under celery -- see install_masking_filter.)
 
+    This is the one-shot that covers handlers present at install time. Handlers
+    created *after* install are covered by the ``Handler.__init__`` hook
+    (``_install_handler_init_hook``), so masking is structurally unconditional
+    rather than dependent on install ordering (P0-1).
+
     Skip datahub.masking.* loggers: they log to the original stderr by design and
     carry no secrets, so filtering them only risks re-entrancy. The trailing dot
-    avoids matching a hypothetical "datahub.maskingfoo" logger.
+    in ``REDACTED_MASKING_NAMESPACE`` avoids matching a hypothetical
+    "datahub.maskingfoo" logger. A handler *shared* between a datahub.masking.*
+    logger and another logger still gets the filter via the other logger — that
+    is safe because ``filter()``'s record-name bypass short-circuits masking
+    for records whose name is in the masking namespace, so there is no
+    re-entrancy and no masking of internal logs. The per-logger skip is a
+    best-effort attach-time optimization; the record-name bypass is the real
+    safety net.
     """
+    pairs = _snapshot_handler_pairs()
     added = 0
-    for log in _iter_all_loggers():
-        if log.name.startswith(REDACTED_MASKING_NAMESPACE):
+    for log, handler in pairs:
+        if log.name == "datahub.masking" or log.name.startswith(
+            REDACTED_MASKING_NAMESPACE
+        ):
             continue
-        # Copy: handlers may be added/removed by other threads during iteration.
-        for handler in list(log.handlers):
-            # Identity check: don't skip attaching because some OTHER
-            # SecretMaskingFilter is present — that would let us miss handlers
-            # we should cover, and on teardown we'd strip a filter we never added.
-            # We only skip our own instance (re-install / refresh path).
-            if masking_filter in handler.filters:
-                continue
-            handler.addFilter(masking_filter)
-            added += 1
+        # Identity check: don't skip attaching because some OTHER
+        # SecretMaskingFilter is present — that would let us miss handlers
+        # we should cover, and on teardown we'd strip a filter we never added.
+        # We only skip our own instance (re-install / refresh path).
+        if masking_filter in handler.filters:
+            continue
+        handler.addFilter(masking_filter)
+        added += 1
     if added:
         logger.debug(f"Installed SecretMaskingFilter on {added} handler(s)")
 
@@ -734,12 +813,14 @@ def _remove_filter_from_existing_handlers(masking_filter: SecretMaskingFilter) -
 
     Identity-based (not isinstance) so we never strip a different
     SecretMaskingFilter that someone else installed. Uses removeFilter (the
-    logging API) rather than reassigning handler.filters.
+    logging API) rather than reassigning handler.filters. Snapshots under
+    the logging module lock so a concurrent addHandler/removeHandler can't
+    mutate the lists under us (P2-1).
     """
-    for log in _iter_all_loggers():
-        for handler in list(log.handlers):
-            while masking_filter in handler.filters:
-                handler.removeFilter(masking_filter)
+    pairs = _snapshot_handler_pairs()
+    for _log, handler in pairs:
+        while masking_filter in handler.filters:
+            handler.removeFilter(masking_filter)
 
 
 def _is_real_stream(stream: object) -> bool:
@@ -765,28 +846,32 @@ def install_masking_filter(
     install_stdout_wrapper: bool = True,
 ) -> SecretMaskingFilter:
     """Enable secret masking: install the filter on existing handlers (+ root
-    logger) and, optionally, wrap sys.stdout/stderr for raw writes.
+    logger), hook ``Handler.__init__`` so handlers created later are also
+    covered, and, optionally, wrap sys.stdout/stderr for raw writes.
 
     Masking happens at the handler level (see _add_filter_to_existing_handlers).
-    Coverage is a snapshot of the handlers present now, so call this AFTER logging
-    is configured; handlers added later are covered only by a re-install or, for
-    stdout/stderr, by the stream wrapper.
+    The one-shot covers handlers present at install time; the
+    ``Handler.__init__`` hook (``_install_handler_init_hook``) covers handlers
+    created later — ``basicConfig`` after install, a library's lazy logging
+    config, a per-task FileHandler/QueueHandler — so masking is structurally
+    unconditional rather than dependent on install ordering. This restores
+    the coverage the deleted stream-repointing accidentally provided, without
+    repointing streams (which deadlocked under celery).
 
-    Fail-open limitations (residual gaps, documented so nobody over-engineers a
-    addHandler monkeypatch later):
-    - A handler added to a child logger after install can emit unmasked (a
-      logger's own handlers run before ancestors'). Not a concern in the
-      executor, where handlers exist before masking is installed per task.
-    - A FileHandler added after install in a non-celery process: its writes
-      don't go through the stdout/stderr wrapper, so they're unmasked. Under
-      celery, late handlers' writes go through the proxy back into logging and
-      are masked there; outside celery, late StreamHandler()s inherit the
-      wrapped stderr. The residual gap is FileHandler-after-install in a
-      non-celery process.
+    Residual gaps (fail-open limitations, documented so reviewers see the
+    security envelope):
+    - A handler attached by direct ``logger.handlers.append(h)`` (bypassing
+      ``addHandler``) where ``h`` was constructed before install and is not
+      on any logger at install time: neither the one-shot nor the ``__init__``
+      hook sees it. Rare pattern; not used by the executor or stdlib logging.
+    - A handler whose ``__init__`` does not call ``logging.Handler.__init__``
+      (rare third-party override): the hook doesn't fire for it.
     - Arbitrary objects in extras are not stringified-and-masked at filter
       time (would risk __str__ side effects); a formatter that serializes them
       via %s may emit them unmasked unless the output flows through the
       stdout/stderr wrapper.
+    - A custom ``Formatter.formatException`` that re-derives from ``exc_info``
+      instead of reusing ``record.exc_text`` bypasses the masked traceback.
 
     Note: the "already installed → refresh" path re-scans handlers, re-adds
     the root-logger filter if something removed it, and rebinds the
@@ -854,6 +939,12 @@ def install_masking_filter(
     root_logger.addFilter(masking_filter)
     _add_filter_to_existing_handlers(masking_filter)
     _installed_filter = masking_filter
+    # Hook Handler.__init__ so handlers created AFTER install (basicConfig,
+    # library lazy config, per-task FileHandler) auto-attach the filter. This
+    # makes masking structurally unconditional rather than install-ordering-
+    # dependent (P0-1); the deleted stream-repointing accidentally covered
+    # this case and we are restoring that coverage without repointing streams.
+    _install_handler_init_hook()
     logger.info("Installed SecretMaskingFilter on root logger and existing handlers")
 
     # Wrap stdout/stderr only to mask raw writes (print(), C-extension output).
@@ -894,7 +985,15 @@ def _wrap_std_streams(masking_filter: "SecretMaskingFilter") -> None:
 
 
 def uninstall_masking_filter() -> None:
-    """Remove secret masking filter from root logger and all handlers."""
+    """Remove secret masking: detach the filter from the root logger and every
+    handler it was attached to, unwrap stdout/stderr, and revert the
+    ``Handler.__init__`` hook so future handlers don't auto-attach.
+
+    Identity-based: only *our* installed instance is removed, so a different
+    ``SecretMaskingFilter`` someone else installed survives. Symmetric with
+    ``install_masking_filter`` (which attaches the filter, wraps streams, and
+    installs the ``Handler.__init__`` hook).
+    """
     global _installed_filter
 
     root_logger = logging.getLogger()
@@ -905,6 +1004,11 @@ def uninstall_masking_filter() -> None:
             root_logger.removeFilter(_installed_filter)
         _remove_filter_from_existing_handlers(_installed_filter)
         _installed_filter = None
+
+    # Revert the Handler.__init__ hook so handlers constructed after uninstall
+    # don't auto-attach a (now-None) filter. Done after _installed_filter is
+    # cleared so the hook's pointer read sees None during teardown.
+    _uninstall_handler_init_hook()
 
     # Unwrap stdout/stderr (only if we wrapped them)
     if isinstance(sys.stdout, StreamMaskingWrapper):

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -25,6 +25,7 @@ import os
 import re
 import sys
 import threading
+import uuid
 import weakref
 from typing import Any, Dict, List, Optional, TextIO, Tuple
 
@@ -74,7 +75,7 @@ _patched_handler_init: Optional[Any] = None
 # root-logger / handler filter attachments. Bootstrap holds _bootstrap_lock
 # across install/uninstall, but install_masking_filter is also public and
 # called directly by tests; without this lock, two concurrent direct calls
-# attach two filter instances and leak one on teardown (D5). An RLock so a
+# attach two filter instances and leak one on teardown. An RLock so a
 # holder can re-enter (e.g. bootstrap's _bootstrap_lock path calling install
 # then uninstall within the same thread).
 _install_lock = threading.RLock()
@@ -85,7 +86,7 @@ _install_lock = threading.RLock()
 # QueueListener, or nested inside another handler) still get the filter
 # removed — _snapshot_handler_pairs only sees handlers attached to a
 # logger, so without this set those handlers would retain the filter after
-# uninstall and keep masking records dispatched through them (S7). Weak so
+# uninstall and keep masking records dispatched through them. Weak so
 # a GC'd handler leaves the set without manual cleanup.
 _covered_handlers: "weakref.WeakSet[logging.Handler]" = weakref.WeakSet()
 
@@ -112,19 +113,37 @@ def _is_masking_namespace_name(name: str) -> bool:
     return name == "datahub.masking" or name.startswith(REDACTED_MASKING_NAMESPACE)
 
 
-# Module-private sentinel stamped onto records after masking so the
-# idempotency guard can recognize them with `is` rather than truthiness.
-# A caller-supplied ``extra={'_datahub_masked': True}`` would otherwise forge
-# the guard and disable masking for that record. A caller can't forge this
-# object.
-_MASKED = object()
+# Idempotency token stamped onto records after masking. A random string
+# (not ``object()``) so structured formatters that serialize ``record.__dict__``
+# emit a valid line instead of raising ``TypeError: Object of type object is
+# not JSON serializable`` and dropping the record. Compared by value (``==``)
+# so the guard survives cross-thread ``QueueHandler``/``QueueListener`` and
+# cross-process pickle, where ``is`` would fail on the un-pickled copy.
+# Randomness prevents a caller from forging ``extra={'_datahub_masked': ...}``
+# to disable masking for a record.
+_MASKED = f"_datahub_masked_{uuid.uuid4().hex}"
 CIRCUIT_OPEN_MESSAGE = "[REDACTED: Masking Circuit Open]"
+
+# Truncation suffix marker. Used by ``_truncate_message`` and by the
+# idempotency check in ``_truncate_message`` (B2): if the message already
+# ends with this marker, it is returned unchanged so a second masking pass
+# (when the sentinel guard fails) does not re-truncate and corrupt the
+# byte count.
+_TRUNCATION_MARKER_RE = re.compile(r"\n\.\.\. \[\d+ bytes truncated for performance\]$")
 
 # LogRecord standard attributes (per logging.LogRecord.__init__ + attributes set
 # by the framework during formatting). Extras added via ``extra={...}`` are
 # everything NOT in this set, and we mask those recursively. Iterating the whole
 # __dict__ and masking pathname/funcName/module would waste regex on the hot path
 # and could corrupt those fields.
+#
+# ``_datahub_masked`` is included so ``_mask_extras`` skips it (it is the
+# idempotency token, not user data). This set only governs ``_mask_extras``'s
+# own skip loop — a third-party formatter that serializes ``record.__dict__``
+# directly still sees ``_datahub_masked`` and emits it as a key. That is the
+# accepted cost of making the token a string (B1): the alternative
+# ``object()`` sentinel raised ``TypeError`` in JSON formatters and dropped
+# the record entirely.
 _STANDARD_RECORD_ATTRS = frozenset(
     {
         "name",
@@ -150,10 +169,6 @@ _STANDARD_RECORD_ATTRS = frozenset(
         "taskName",
         "message",
         "asctime",
-        # The idempotency sentinel stamped by filter() after masking. Without
-        # this, structured formatters that serialize non-standard record
-        # attributes would emit "_datahub_masked": "<object object at 0x...>"
-        # on every line — the sentinel is internal, not user data.
         "_datahub_masked",
     }
 )
@@ -180,6 +195,15 @@ class SecretMaskingFilter(logging.Filter):
         self._pattern: Optional[re.Pattern] = None
         self._replacements: Dict[str, str] = {}
         self._last_version: int = 0
+        # Length of the longest expanded key in the compiled pattern. Used by
+        # the two-stage truncation in filter() to pre-truncate to
+        # max_message_size + longest_key before masking, so a secret
+        # starting within the first max_message_size chars is fully contained
+        # in the pre-truncated region (secrets are at most this long) and
+        # gets masked before the final cut. The bound is the longest expanded
+        # key (repr-escaped / JSON-escaped / SQLAlchemy-encoded variants can
+        # be longer than the raw value), not the longest raw secret.
+        self._longest_key_length: int = 0
 
         # Circuit breaker to prevent cascading failures
         self._failure_count = 0
@@ -224,6 +248,10 @@ class SecretMaskingFilter(logging.Filter):
             escaped_values = [re.escape(value) for value, _ in sorted_secrets]
             pattern_str = "|".join(escaped_values)
 
+            # Longest expanded key — sorted_secrets is longest-first, so the
+            # first entry's key length is the bound for two-stage truncation.
+            new_longest_key_length = len(sorted_secrets[0][0]) if sorted_secrets else 0
+
             # Compile regex - NOT under lock (this is the expensive part!)
             try:
                 new_pattern = re.compile(pattern_str)
@@ -261,6 +289,7 @@ class SecretMaskingFilter(logging.Filter):
                     self._pattern = new_pattern
                     self._replacements = new_replacements
                     self._last_version = current_version
+                    self._longest_key_length = new_longest_key_length
 
                     if attempt > 0:
                         logger.debug(
@@ -496,10 +525,18 @@ class SecretMaskingFilter(logging.Filter):
         chain, including chained exception messages that the old rebuild
         dropped.
 
-        Residual gap: a formatter with a custom ``formatException`` that
-        re-derives from ``exc_info`` (instead of reusing ``exc_text``) bypasses
-        the masked text. Same accepted residual as the structured-formatter
-        case for extras.
+        Residual: pre-filling ``exc_text`` means stdlib ``Formatter.format``
+        skips its ``formatException`` call entirely (it only calls
+        ``formatException`` when ``exc_text`` is falsy). So a handler whose
+        formatter overrides ``formatException`` — to redact frames, add
+        context, or route to a structured traceback renderer — has that
+        override bypassed: the stock masked traceback is emitted instead.
+        Not pre-filling ``exc_text`` would restore the custom
+        ``formatException`` but leave tracebacks unmasked, which is the
+        primary leak surface; the trade runs in the direction of masking the
+        printed output. A handler that wants both a custom traceback format
+        and masking must mask inside its own ``formatException`` (or read
+        ``record.exc_text`` when set).
         """
         if not exc_info:
             return None
@@ -517,16 +554,38 @@ class SecretMaskingFilter(logging.Filter):
             )
             return MASKING_ERROR_MESSAGE
 
-    def _truncate_message(self, message: str) -> str:
-        """Truncate large messages before masking."""
+    def _truncate_message(
+        self, message: str, original_len: Optional[int] = None
+    ) -> str:
+        """Truncate large messages after masking.
+
+        Idempotent: if the message already ends with the truncation marker,
+        return it unchanged. This is defense-in-depth so that when the
+        idempotency token guard in ``filter()`` fails (e.g. a third-party
+        formatter that strips unknown attributes, or a record that round-
+        tripped through pickle and lost the token), a second masking pass
+        does not re-truncate the already-truncated text, eat the first
+        suffix, and report a wrong byte count. The marker is a trailing
+        ``\\n... [N bytes truncated for performance]`` line.
+
+        ``original_len`` is the pre-truncation length of the message (before
+        the two-stage pre-truncate). When provided, the byte count in the
+        marker reflects the original overrun (``original_len -
+        max_message_size``), not the post-pre-truncate overrun, so the user
+        sees how much of the original was dropped rather than how much of the
+        already-truncated region was dropped.
+        """
         if not isinstance(message, str):
             return message
 
         if len(message) <= self._max_message_size:
             return message
 
-        # Truncate with informative suffix
-        truncated_bytes = len(message) - self._max_message_size
+        if _TRUNCATION_MARKER_RE.search(message):
+            return message
+
+        base_len = original_len if original_len is not None else len(message)
+        truncated_bytes = base_len - self._max_message_size
         return (
             f"{message[: self._max_message_size]}\n"
             f"... [{truncated_bytes} bytes truncated for performance]"
@@ -535,8 +594,9 @@ class SecretMaskingFilter(logging.Filter):
     # Depth cap and cycle guard for _mask_value_recursive. extra= can carry
     # self-referential or very large structures onto the logging hot path; an
     # unbounded recursion would hang the logger. The cap is generous (real
-    # config is rarely >10 deep); beyond it we return the value unchanged
-    # rather than raise, so logging still proceeds (residual gap documented).
+    # config is rarely >10 deep); beyond it we return a placeholder string
+    # (not the raw value, not an exception) so logging proceeds and any
+    # secret in the elided subtree is not emitted in cleartext.
     _MAX_EXTRA_DEPTH = 10
 
     def _mask_value_recursive(
@@ -629,12 +689,17 @@ class SecretMaskingFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         """Filter and mask a log record.
 
-        Idempotent per record: a sentinel (``record._datahub_masked``) is set
+        Idempotent per record: a token (``record._datahub_masked``) is set
         after masking so the same record flowing through multiple handlers
-        (each carrying this filter) is not re-truncated / re-masked. Without
-        this, N handlers produce N× regex cost and N× truncation — the second
-        truncation re-truncates the already-truncated text, eats the previous
-        suffix, and reports a wrong byte count.
+        (each carrying this filter) is not re-masked / re-truncated. The
+        token is a random string compared by value so the guard survives
+        cross-thread ``QueueHandler``/``QueueListener`` and cross-process
+        pickle, and so structured formatters that serialize ``record.__dict__``
+        emit a valid line instead of raising on a non-serializable sentinel.
+
+        Defense-in-depth: ``_truncate_message`` is independently idempotent
+        (it detects its own suffix marker), so a second masking pass when the
+        token guard fails does not re-truncate and corrupt the byte count.
         """
         # Re-entrancy / idempotency guard. Records from the masking framework's
         # own loggers bypass masking entirely (their handlers are skipped at
@@ -643,12 +708,12 @@ class SecretMaskingFilter(logging.Filter):
         # bootstrap.shutdown_secret_masking). The check is on the record name,
         # not the logger we attached to, so it catches propagation. Uses the
         # shared _is_masking_namespace_name predicate so the bypass and the
-        # attach-time skip agree (D3): a record from the exact-name
+        # attach-time skip agree: a record from the exact-name
         # ``datahub.masking`` logger is bypassed here, not masked.
         if _is_masking_namespace_name(record.name):
             return True
 
-        if getattr(record, "_datahub_masked", None) is _MASKED:
+        if getattr(record, "_datahub_masked", None) == _MASKED:
             return True
 
         # Check if masking is disabled for debugging. is_masking_enabled is
@@ -659,44 +724,65 @@ class SecretMaskingFilter(logging.Filter):
             return True  # Skip all masking and truncation for debugging
 
         try:
-            # 1. Mask the full message BEFORE truncating. Truncating first
-            #    would leak a partial secret straddling the cut point (the
-            #    regex matches full secrets only, so a partial would survive
-            #    unmasked). Masking first replaces secrets with
-            #    ***REDACTED:X*** tokens, so truncating the masked message
-            #    can only cut tokens, never secret bytes. This trades the
-            #    "regex on huge strings" cost the old ordering avoided for
-            #    correctness — the right trade for a security control.
+            # 1. Two-stage truncation + masking of record.msg.
+            #
+            #    When secrets are registered, mask_text on a huge message is
+            #    expensive (regex over the whole string) for output truncated to
+            #    max_message_size anyway. Pre-truncate to max_message_size +
+            #    longest_key (no marker) so the regex only scans the region that
+            #    can affect the final output: any secret starting within the
+            #    first max_message_size chars is fully contained (secrets are at
+            #    most longest_key long), so mask_text matches and replaces it;
+            #    anything beyond max_message_size + longest_key is dropped before
+            #    the regex ever sees it. The bound is the longest *expanded* key
+            #    (repr/JSON/SQLAlchemy variants can be longer than the raw value);
+            #    a raw-length bound would cut a JSON-escaped secret at the
+            #    pre-truncate boundary and reintroduce the partial-disclosure bug.
+            #
+            #    The original length is tracked so the final marker reports the
+            #    true overrun (original - max_message_size), not the pre-
+            #    truncated region's overrun (which would mislead the user about
+            #    how much was dropped). When no secrets are registered the pre-
+            #    truncate is skipped: mask_text is a no-op then, so there is no
+            #    performance gain, and skipping preserves the single-stage
+            #    marker semantics.
+            #
+            #    _truncate_message is idempotent (detects its own marker) so a
+            #    second pass when the token guard fails does not re-truncate.
             if isinstance(record.msg, str):
+                original_len = len(record.msg)
+                if self._longest_key_length > 0:
+                    pre_cut = self._max_message_size + self._longest_key_length
+                    if len(record.msg) > pre_cut:
+                        record.msg = record.msg[:pre_cut]
                 record.msg = self.mask_text(record.msg)
+                record.msg = self._truncate_message(
+                    record.msg, original_len=original_len
+                )
 
-            # 2. Truncate the masked message (performance: bounds output size).
-            if isinstance(record.msg, str):
-                record.msg = self._truncate_message(record.msg)
-
-            # 3. Mask arguments (for formatting)
+            # 2. Mask arguments (for formatting)
             if record.args:
                 record.args = self._mask_args(record.args)
 
-            # 4. Mask pre-formatted message if it exists
+            # 3. Mask pre-formatted message if it exists
             if hasattr(record, "message") and record.message:
                 record.message = self.mask_text(record.message)
 
-            # 5. Materialize traceback text from exc_info so it can be masked.
+            # 4. Materialize traceback text from exc_info so it can be masked.
             #    exc_info itself is left untouched (error reporters read it).
             #    See _mask_exception for why we do not rebuild the exception.
             if record.exc_info and not record.exc_text:
                 record.exc_text = self._mask_exception(record.exc_info)
 
-            # 6. Mask formatted exception text (pre-existing or just materialized)
+            # 5. Mask formatted exception text (pre-existing or just materialized)
             if record.exc_text:
                 record.exc_text = self.mask_text(record.exc_text)
 
-            # 7. Mask stack_info if present (Python 3.2+)
+            # 6. Mask stack_info if present (Python 3.2+)
             if hasattr(record, "stack_info") and record.stack_info:
                 record.stack_info = self.mask_text(record.stack_info)
 
-            # 8. Mask non-standard attributes (extra={...}). Must run after msg/args
+            # 7. Mask non-standard attributes (extra={...}). Must run after msg/args
             #    masking and inside the try so unexpected types from third-party
             #    libraries do not break logging.
             self._mask_extras(record)
@@ -893,14 +979,24 @@ def _cover_handler(handler: logging.Handler) -> None:
 
     Handlers not on any logger (held by a QueueListener, nested inside
     another handler) are unreachable from _snapshot_handler_pairs; without
-    tracking, uninstall would miss them and they'd retain the filter (S7).
-    The weak set auto-drops GC'd handlers."""
-    try:
-        _covered_handlers.add(handler)
-    except Exception:
-        # WeakSet can raise ReferenceError on a dying ref; not worth failing
-        # the install for.
-        pass
+    tracking, uninstall would miss them and they'd retain the filter.
+    The weak set auto-drops GC'd handlers.
+
+    Acquires ``_install_lock`` so the add is serialized with the readers in
+    ``_remove_filter_from_existing_handlers`` (which snapshots the set under
+    the same lock). The GIL makes ``WeakSet.add`` effectively atomic on
+    CPython, but the lock makes that guarantee explicit rather than
+    reasoning about interpreter internals. ``_install_lock`` is an RLock,
+    so calling this from inside ``install_masking_filter`` (which already
+    holds the lock) does not self-deadlock.
+    """
+    with _install_lock:
+        try:
+            _covered_handlers.add(handler)
+        except Exception:
+            # WeakSet can raise ReferenceError on a dying ref; not worth
+            # failing the install for.
+            pass
 
 
 def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> None:
@@ -909,8 +1005,9 @@ def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> Non
     Masking lives on handlers, not the logger: Python skips logger-level filters
     for records propagated from child loggers, so a root-logger filter would miss
     almost everything. A handler filter sees every record reaching that output and
-    masks it in place, without touching the handler's stream. (Repointing streams
-    instead loops forever under celery -- see install_masking_filter.)
+    masks it in place, without touching the handler's stream. (Repointing
+    streams instead drops every record under celery -- see
+    install_masking_filter.)
 
     Covers handlers present at install time. Handlers created later are
     covered by the ``Handler.__init__`` hook, so masking does not depend
@@ -924,7 +1021,7 @@ def _add_filter_to_existing_handlers(masking_filter: SecretMaskingFilter) -> Non
     short-circuits masking for records whose name is in the masking
     namespace, so there is no re-entrancy and no masking of internal logs. The
     per-logger skip is a best-effort attach-time optimization; the record-name
-    bypass is the real safety net, and the two now agree (D3).
+    bypass is the real safety net, and the two share one predicate.
     """
     pairs = _snapshot_handler_pairs()
     added = 0
@@ -952,7 +1049,7 @@ def _remove_filter_from_existing_handlers(masking_filter: SecretMaskingFilter) -
     logging API) rather than reassigning handler.filters. Iterates
     _snapshot_handler_pairs (handlers on loggers) AND _covered_handlers
     (handlers we attached to but which may not be on any logger — held by a
-    QueueListener, nested inside another handler — S7). Snapshots under
+    QueueListener, nested inside another handler). Snapshots under
     the logging module lock so a concurrent addHandler/removeHandler can't
     mutate the lists under us.
     """
@@ -973,12 +1070,18 @@ def _remove_filter_from_existing_handlers(masking_filter: SecretMaskingFilter) -
 def _is_real_stream(stream: object) -> bool:
     """True if ``stream`` is a real OS-backed stream safe to wrap.
 
-    Fail-closed: if ``fileno()`` raises (pytest capture, celery LoggingProxy,
-    structlog, IPython, journald), we treat it as a non-real stream and skip
-    wrapping. Skipping costs nothing under a proxy: raw print()/stderr writes
-    are converted to log records by the proxy and flow through handlers that
-    carry the masking filter. Wrapping a proxy would re-enter logging and
-    recurse.
+    Fail-closed: if ``fileno()`` raises (pytest capture, celery
+    ``LoggingProxy``, structlog, IPython, journald), we treat it as a
+    non-real stream and skip wrapping. celery's ``LoggingProxy`` defines
+    no ``fileno`` (it proxies to ``sys.stderr``/``sys.stdout``), so this
+    guard refuses to wrap it. That matters because ``LoggingProxy.write``
+    has a thread-local ``recurse_protection`` flag that returns 0 and
+    drops the write on re-entry: wrapping the proxy would re-enter logging
+    via the proxy, and the proxy would drop every masked write — the
+    symptom is silently dropped output, not infinite recursion. Skipping
+    the wrap costs nothing under a proxy: raw ``print()``/``stderr`` writes
+    are converted to log records by the proxy and flow through handlers
+    that carry the masking filter.
     """
     try:
         stream.fileno()  # type: ignore[attr-defined]
@@ -1001,9 +1104,10 @@ def install_masking_filter(
     ``Handler.__init__`` hook covers handlers created later — ``basicConfig``
     after install, a library's lazy logging config, a per-task
     FileHandler/QueueHandler — so masking does not depend on install
-    ordering. Streams are not repointed: under celery, ``sys.stderr``
-    re-enters logging, so a handler pointed at it would recurse infinitely
-    and drop output.
+    ordering. Streams are not repointed: under celery, ``sys.stderr`` is a
+    ``LoggingProxy`` whose ``write`` has a thread-local ``recurse_protection``
+    flag that returns 0 and drops the write on re-entry, so a handler pointed
+    at it would have every record dropped (silently, no exception).
 
     Residual gaps (fail-open limitations of the security envelope):
     - A handler attached by direct ``logger.handlers.append(h)`` (bypassing
@@ -1016,8 +1120,10 @@ def install_masking_filter(
       time (would risk __str__ side effects); a formatter that serializes them
       via %s may emit them unmasked unless the output flows through the
       stdout/stderr wrapper.
-    - A custom ``Formatter.formatException`` that re-derives from ``exc_info``
-      instead of reusing ``record.exc_text`` bypasses the masked traceback.
+    - A custom ``Formatter.formatException`` override is bypassed: filter()
+      pre-fills ``record.exc_text``, and stdlib ``Formatter.format`` only
+      calls ``formatException`` when ``exc_text`` is falsy. See
+      ``_mask_exception`` for the trade.
 
     Note: the "already installed → refresh" path re-scans handlers, re-adds
     the root-logger filter if something removed it, and rebinds the
@@ -1097,8 +1203,10 @@ def install_masking_filter(
         )
 
         # Wrap stdout/stderr only to mask raw writes (print(), C-extension output).
-        # We do NOT repoint handler streams here: under celery, sys.stderr re-enters
-        # logging, so a handler pointed at it would recurse infinitely and drop output.
+        # We do NOT repoint handler streams here: under celery, sys.stderr is a
+        # LoggingProxy whose write() has a thread-local recurse_protection
+        # flag that returns 0 and drops the write on re-entry, so a handler
+        # pointed at it would have every record dropped silently.
         # Skip wrapping when the stream is not a real OS-backed stream (proxy / pytest
         # capture / structlog / etc.) — wrapping a proxy re-enters logging. Under a
         # proxy, raw writes become log records and flow through handlers that carry
@@ -1140,7 +1248,7 @@ def _wrap_std_streams(masking_filter: "SecretMaskingFilter") -> None:
         )
 
 
-def uninstall_masking_filter() -> None:
+def _uninstall_masking_filter() -> None:
     """Remove secret masking: detach the filter from the root logger and every
     handler it was attached to, unwrap stdout/stderr, and revert the
     ``Handler.__init__`` hook so future handlers don't auto-attach.
@@ -1149,6 +1257,13 @@ def uninstall_masking_filter() -> None:
     ``SecretMaskingFilter`` someone else installed survives. Symmetric with
     ``install_masking_filter`` (which attaches the filter, wraps streams, and
     installs the ``Handler.__init__`` hook).
+
+    Module-private: this is the low-level teardown primitive that disarms
+    masking process-wide. Callers should go through
+    ``shutdown_secret_masking`` (the refcounted lifecycle), which only reaches
+    this path when the last execution scope has ended. Calling this directly
+    while execution scopes are active would uninstall the filter out from
+    under live executions and silently unmask their logs.
     """
     global _installed_filter
 
@@ -1178,3 +1293,29 @@ def uninstall_masking_filter() -> None:
             sys.stderr = sys.stderr._original
 
         logger.info("Uninstalled SecretMaskingFilter")
+
+
+def uninstall_masking_filter() -> None:
+    """Public teardown that refuses while execution scopes are active.
+
+    The refcounted lifecycle is ``shutdown_secret_masking``; this primitive
+    exists for direct callers (tests, integrations that bypass the
+    refcount). A direct call disarms masking process-wide, so it refuses
+    (and logs) when per-execution scopes are still open — otherwise it
+    would uninstall the filter out from under live executions and
+    silently unmask their logs. Internal callers that have already done
+    the refcount check (``shutdown_secret_masking``,
+    ``SecretRegistry.reset_instance``) call ``_uninstall_masking_filter``
+    directly to bypass this guard.
+    """
+    registry = SecretRegistry.get_instance()
+    if registry.has_active_executions():
+        logger.warning(
+            "uninstall_masking_filter() called while execution scopes are "
+            "still active; refusing to disarm masking process-wide. Use "
+            "shutdown_secret_masking(token) to end an execution, or call "
+            "_uninstall_masking_filter() directly if you have already "
+            "verified no executions are live."
+        )
+        return
+    _uninstall_masking_filter()

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -346,11 +346,22 @@ class SecretMaskingFilter(logging.Filter):
         old registry's values). ``-1`` never equals a real version, so the
         next mask always rebuilds. The pattern and replacements are cleared
         too so a stale pattern can't be served before the rebuild runs.
+
+        The whole body runs under ``_pattern_lock`` (an ``RLock``, so nesting
+        is safe). Every other write to ``_registry`` / ``_last_version`` /
+        ``_pattern`` / ``_replacements`` happens under that lock, and
+        ``mask_text`` snapshots them together under it — an unlocked
+        rebind could land between the snapshot of ``_pattern`` and
+        ``_replacements`` and emit cleartext (or a ``***REDACTED:UNKNOWN***``
+        mismatch from a cleared ``_replacements`` paired with an old
+        ``_pattern``). Clearing under the lock also makes the four writes
+        atomic relative to each other.
         """
-        self._registry = registry
-        self._last_version = -1
-        self._pattern = None
-        self._replacements = {}
+        with self._pattern_lock:
+            self._registry = registry
+            self._last_version = -1
+            self._pattern = None
+            self._replacements = {}
 
     def _mask_args(self, args: Any) -> Any:
         """Mask secrets in log arguments."""

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -19,6 +19,7 @@ Performance:
 - Performance warnings at 100/500 secrets
 """
 
+import contextlib
 import io
 import logging
 import os
@@ -29,6 +30,7 @@ import uuid
 import weakref
 from typing import Any, Dict, List, Optional, TextIO, Tuple
 
+from datahub.masking.constants import REDACTED_FORMAT
 from datahub.masking.logging_utils import get_masking_safe_logger
 from datahub.masking.secret_registry import SecretRegistry, is_masking_enabled
 
@@ -80,6 +82,17 @@ _patched_handler_init: Optional[Any] = None
 # then uninstall within the same thread).
 _install_lock = threading.RLock()
 
+# Leaf lock for ``_covered_handlers``. Acquired LAST (after ``_install_lock``
+# and ``logging._lock``) and never held while acquiring either of those, so it
+# cannot be the outer lock in any cycle. Without this, ``_cover_handler`` (called
+# from the ``Handler.__init__`` patch, which runs while CPython holds
+# ``logging._lock`` for ``basicConfig`` / ``dictConfig`` / ``fileConfig``) would
+# take ``_install_lock`` and invert the order against install/uninstall, which
+# take ``_install_lock`` then ``logging._lock`` via ``_snapshot_handler_pairs``.
+# Two threads then deadlock with the logging lock held, so there is no output.
+# A plain ``Lock`` is enough: nothing holding ``_covered_lock`` re-enters it.
+_covered_lock = threading.Lock()
+
 # Weak set of every handler the filter was attached to (via the one-shot
 # scan or the Handler.__init__ hook). Uninstall iterates this in addition to
 # _snapshot_handler_pairs so handlers not on any logger (held by a
@@ -92,7 +105,7 @@ _covered_handlers: "weakref.WeakSet[logging.Handler]" = weakref.WeakSet()
 
 # Constants
 REDACTED_MASKING_NAMESPACE = "datahub.masking."
-REDACTED_FORMAT = "***REDACTED:{name}***"
+
 MASKING_ERROR_MESSAGE = "[MASKING_ERROR - OUTPUT_SUPPRESSED_FOR_SECURITY]"
 
 
@@ -117,10 +130,14 @@ def _is_masking_namespace_name(name: str) -> bool:
 # (not ``object()``) so structured formatters that serialize ``record.__dict__``
 # emit a valid line instead of raising ``TypeError: Object of type object is
 # not JSON serializable`` and dropping the record. Compared by value (``==``)
-# so the guard survives cross-thread ``QueueHandler``/``QueueListener`` and
-# cross-process pickle, where ``is`` would fail on the un-pickled copy.
-# Randomness prevents a caller from forging ``extra={'_datahub_masked': ...}``
-# to disable masking for a record.
+# so the guard survives cross-thread ``QueueHandler``/``QueueListener``
+# within a process, where ``is`` would fail on the un-pickled copy.
+# Cross-process the child's token differs (generated at its own import),
+# so the child re-masks — safe because ``mask_text`` is idempotent (see the
+# marker-alternatives comment in ``_check_and_rebuild_pattern``); the
+# second pass is not merely redundant, it is required for correctness
+# there. Randomness prevents a caller from forging
+# ``extra={'_datahub_masked': ...}`` to disable masking for a record.
 _MASKED = f"_datahub_masked_{uuid.uuid4().hex}"
 CIRCUIT_OPEN_MESSAGE = "[REDACTED: Masking Circuit Open]"
 
@@ -195,15 +212,20 @@ class SecretMaskingFilter(logging.Filter):
         self._pattern: Optional[re.Pattern] = None
         self._replacements: Dict[str, str] = {}
         self._last_version: int = 0
-        # Length of the longest expanded key in the compiled pattern. Used by
-        # the two-stage truncation in filter() to pre-truncate to
-        # max_message_size + longest_key before masking, so a secret
-        # starting within the first max_message_size chars is fully contained
-        # in the pre-truncated region (secrets are at most this long) and
-        # gets masked before the final cut. The bound is the longest expanded
-        # key (repr-escaped / JSON-escaped / SQLAlchemy-encoded variants can
-        # be longer than the raw value), not the longest raw secret.
-        self._longest_key_length: int = 0
+        # Length of the longest alternative in the compiled pattern (the
+        # longest expanded value or exact marker), used by two-stage
+        # truncation in ``mask_text`` to pre-truncate to
+        # ``max_message_size + longest_pattern`` before masking, so a secret
+        # starting within the first ``max_message_size`` chars is fully
+        # contained in the pre-truncated region and gets masked before the
+        # final cut. The bound is the longest expanded key (repr-escaped /
+        # JSON-escaped / SQLAlchemy-encoded variants can be longer than the
+        # raw value) and the longest exact marker (``15 + len(name)``),
+        # since markers are alternatives too and severing one at the
+        # pre-cut would un-protect the secret substring inside the fragment.
+        # The generic marker fallback is EXCLUDED — see the bound-exclusion
+        # comment in ``_check_and_rebuild_pattern``.
+        self._longest_pattern_length: int = 0
 
         # Circuit breaker to prevent cascading failures
         self._failure_count = 0
@@ -235,22 +257,84 @@ class SecretMaskingFilter(logging.Filter):
                     self._pattern = None
                     self._replacements = {}
                     self._last_version = current_version
+                    self._longest_pattern_length = 0
                 return
 
-            # Sort by length (longest first) - NOT under lock
+            # Sort by value length (longest first) - NOT under lock. ``re``
+            # is leftmost-then-first: at a given position it tries alternatives
+            # in listing order, so listing longer values first means a longer
+            # secret wins ties against a shorter one at the same position.
             sorted_secrets = sorted(
                 secrets.items(), key=lambda x: len(x[0]), reverse=True
             )
 
-            # Build pattern - NOT under lock
+            # Build pattern - NOT under lock.
+            #
+            # ORDERING IS LOAD-BEARING, not a preference. Register
+            # ``***REDACTED:A***`` under name ``B`` and ``***REDACTED:B***``
+            # under name ``A`` (both reachable by pasting redacted output
+            # back into a recipe). With values first, masking oscillates
+            # with period 2 and has NO fixed point; with markers first it
+            # terminates on the first pass. The ordering is what makes
+            # ``mask_text`` well-defined.
+            #
+            # The ordering claim is FALSE without named-group dispatch:
+            # when a value is marker-shaped the marker and the value are
+            # the *same string*, so no test on the matched text can tell
+            # which alternative won, and a naive ``replacements.get(
+            # match.group(0))`` callback oscillates even with markers
+            # first. The callback dispatches on ``match.lastgroup`` (which
+            # alternative won), not on the matched text, so a marker
+            # alternative passes through untouched and a value alternative
+            # is replaced.
+            #
+            # The generic fallback goes LAST. A marker at position 0 beats
+            # a value matching at position 12 regardless of order
+            # (leftmost wins), so generic-last still protects
+            # dropped-execution markers (whose names are gone from the
+            # registry, so no exact marker alternative exists for them),
+            # AND lets a marker-shaped registered value be masked by the
+            # generic alternative at its own position.
+            #
+            # One accepted fail-open ("route A"): a registered value that
+            # exactly equals a marker for a *registered name* passes through
+            # in cleartext (both alternatives match at the same position
+            # and the marker must win for termination). It is refused at
+            # registration instead — see ``_validate_secret`` in
+            # secret_registry. A per-process nonce in the marker would
+            # close route A but make cross-process idempotency depend on
+            # the only best-effort alternative (the generic fallback), so
+            # it is not adopted.
+            marker_alts = [
+                f"(?P<m{i}>{re.escape(REDACTED_FORMAT.format(name=n))})"
+                for i, (_, n) in enumerate(sorted_secrets)
+            ]
             # CRITICAL: re.escape() ensures secrets with regex metacharacters
-            # (e.g., ".*", "a+b", "test|prod") are matched literally, not as regex
-            escaped_values = [re.escape(value) for value, _ in sorted_secrets]
-            pattern_str = "|".join(escaped_values)
+            # (e.g., ".*", "a+b", "test|prod") are matched literally, not as regex.
+            value_alts = [
+                f"(?P<v{i}>{re.escape(v)})" for i, (v, _) in enumerate(sorted_secrets)
+            ]
+            generic = [r"(?P<g>\*\*\*REDACTED:[^*]{0,256}?\*\*\*)"]
+            pattern_str = "|".join(marker_alts + value_alts + generic)
 
-            # Longest expanded key — sorted_secrets is longest-first, so the
-            # first entry's key length is the bound for two-stage truncation.
-            new_longest_key_length = len(sorted_secrets[0][0]) if sorted_secrets else 0
+            # Bound for two-stage truncation: the longest of (longest value,
+            # longest exact marker). The generic alternative is EXCLUDED:
+            # it is forced, not chosen — you cannot compute the length of a
+            # marker whose name is gone from the registry (the
+            # dropped-execution case the fallback exists for). It is safe
+            # because a marker carries a NAME, not a value, so severing
+            # any marker can never leak a secret substring. (This holds
+            # once the configuration/common.py name-hygiene change lands;
+            # until then a name could carry a value, which is why the N
+            # exact marker alternatives are kept rather than collapsing to
+            # generic-only — they bound the marker length for names that
+            # ARE registered.)
+            longest_value = len(sorted_secrets[0][0])
+            longest_marker = max(
+                (len(REDACTED_FORMAT.format(name=n)) for _, n in sorted_secrets),
+                default=0,
+            )
+            new_longest_pattern_length = max(longest_value, longest_marker)
 
             # Compile regex - NOT under lock (this is the expensive part!)
             try:
@@ -289,7 +373,7 @@ class SecretMaskingFilter(logging.Filter):
                     self._pattern = new_pattern
                     self._replacements = new_replacements
                     self._last_version = current_version
-                    self._longest_key_length = new_longest_key_length
+                    self._longest_pattern_length = new_longest_pattern_length
 
                     if attempt > 0:
                         logger.debug(
@@ -332,14 +416,30 @@ class SecretMaskingFilter(logging.Filter):
                 )
         # Keep using the old pattern rather than crashing - graceful degradation
 
-    def mask_text(self, text: str) -> str:
+    def mask_text(
+        self,
+        text: str,
+        pre_truncate_budget: Optional[int] = None,
+    ) -> str:
         """Mask secrets in text string.
 
-        Public API for masking arbitrary text content. Thread-safe and includes
-        automatic pattern rebuilding, circuit breaker protection, and error handling.
+        Thread-safe, with automatic pattern rebuilding, circuit breaker
+        protection, and error handling.
 
         Args:
-            text: Text content to mask
+            text: Text content to mask.
+            pre_truncate_budget: Optional final-output budget (e.g.
+                ``max_message_size``). When provided AND the pattern has
+                secrets, the input is pre-truncated to
+                ``budget + longest_pattern_length`` under ``_pattern_lock``
+                *after* the rebuild that refreshes ``_longest_pattern_length``,
+                so the pre-cut and the regex use one snapshot by
+                construction — no ordering hazard where the pre-cut could
+                use a stale length and sever a secret that the regex then
+                misses. When ``None`` or no secrets are registered, no
+                pre-truncation happens (existing behaviour for the non-msg
+                call sites: args, exc_text, stack_info, extras, stream
+                wrapper output).
 
         Returns:
             Text with secrets replaced by ***REDACTED:VARIABLE_NAME***
@@ -347,11 +447,24 @@ class SecretMaskingFilter(logging.Filter):
         if not isinstance(text, str) or not text:
             return text
 
-        # Get pattern snapshot (no lock during masking!)
+        # Snapshot pattern, replacements, and longest-pattern length under
+        # one lock, and pre-truncate under the SAME lock. Doing the pre-cut
+        # here (rather than in filter() before mask_text) means the cut uses
+        # the freshly-rebuilt length, not a stale one read before the
+        # rebuild — closing the deterministic leak where a 3000-char PEM
+        # key registered after a 20-char env-var secret would be severed by
+        # a 5020-char pre-cut sized from the stale 20.
         with self._pattern_lock:
             self._check_and_rebuild_pattern()
             pattern = self._pattern
             replacements = self._replacements  # No .copy() needed!
+            longest = self._longest_pattern_length
+            if (
+                pre_truncate_budget is not None
+                and longest > 0
+                and len(text) > pre_truncate_budget + longest
+            ):
+                text = text[: pre_truncate_budget + longest]
 
         # Pattern might be None if no secrets registered
         if pattern is None:
@@ -363,14 +476,20 @@ class SecretMaskingFilter(logging.Filter):
 
         # Mask secrets (outside lock - safe because immutable references)
         try:
-            # Use callback to include variable name in masked output
+            # Dispatch on which alternative won (``match.lastgroup``), not on
+            # the matched text. Marker alternatives (groups named ``m*`` and
+            # the generic ``g``) pass through untouched so masking terminates
+            # on the first pass; value alternatives (``v*``) are replaced.
+            # A text-based dispatch would oscillate when a value is
+            # marker-shaped (the marker and the value are the same string) —
+            # see the ordering comment in ``_check_and_rebuild_pattern``.
             def replace_with_variable_name(match):
-                """Replace matched secret with variable name."""
-                secret_value = match.group(0)
-                # Look up variable name (O(1) dict access)
-                variable_name = replacements.get(secret_value, "UNKNOWN")
-                # Return formatted mask
-                return REDACTED_FORMAT.format(name=variable_name)
+                last = match.lastgroup
+                if last is not None and not last.startswith("v"):
+                    return match.group(0)  # marker: pass through untouched
+                return REDACTED_FORMAT.format(
+                    name=replacements.get(match.group(0), "UNKNOWN")
+                )
 
             masked = pattern.sub(replace_with_variable_name, text)
 
@@ -379,20 +498,6 @@ class SecretMaskingFilter(logging.Filter):
                 self._failure_count = 0
 
             return masked
-
-        except KeyError as e:
-            self._failure_count += 1
-            logger.error(
-                f"CRITICAL: Secret masking failed due to replacement error "
-                f"(failure {self._failure_count}/{self._max_failures}). "
-                f"Message redacted for safety. Error: {e}"
-            )
-            if self._failure_count >= self._max_failures:
-                self._circuit_open = True
-                logger.critical(
-                    "CRITICAL: Masking circuit breaker OPEN. All messages will be redacted."
-                )
-            return "[REDACTED: Masking Replacement Error]"
 
         except re.error as e:
             self._failure_count += 1
@@ -585,7 +690,13 @@ class SecretMaskingFilter(logging.Filter):
             return message
 
         base_len = original_len if original_len is not None else len(message)
-        truncated_bytes = base_len - self._max_message_size
+        # ``max(0, ...)``: masking can EXPAND the text (a 3-char ``***`` secret
+        # becomes ``***REDACTED:STARS***`` = 18 chars), so ``original_len -
+        # max_message_size`` can be negative when the original fit but the masked
+        # output did not. A negative byte count in the marker is wrong (it implies
+        # the output grew, which is not "truncation"), so clamp to 0 — the user
+        # sees "0 bytes truncated" rather than "-4997 bytes truncated".
+        truncated_bytes = max(0, base_len - self._max_message_size)
         return (
             f"{message[: self._max_message_size]}\n"
             f"... [{truncated_bytes} bytes truncated for performance]"
@@ -626,6 +737,17 @@ class SecretMaskingFilter(logging.Filter):
         closed. The placeholder also keeps this docstring honest: "return
         the value unchanged" reads as "we mask less here" when it actually
         means "we emit the secret."
+
+        Accepted limitation — namedtuple retyping: the container branch
+        rebuilds via ``type(value)(masked)``, which for a ``namedtuple``
+        produces a plain ``tuple`` (the ``type(seq)`` call bypasses the
+        named constructor) and for a ``defaultdict`` would need
+        ``default_factory`` positionally (a second fix). This means
+        ``extra=`` containers may be retyped by masking. We document rather
+        than fix it: the third-party ``extra=`` content that now reaches the
+        filter is the surface area, and a generic ``type(value)(masked)``
+        does not yield for these. If fixed, note that ``defaultdict`` needs
+        ``default_factory`` positionally, so the dict branch is two fixes.
         """
         if _depth >= self._MAX_EXTRA_DEPTH:
             return "<not masked: depth limit>"
@@ -686,6 +808,55 @@ class SecretMaskingFilter(logging.Filter):
             if isinstance(value, (str, dict, list, tuple, set, frozenset)):
                 record.__dict__[key] = self._mask_value_recursive(value)
 
+    def _mask_record_msg(self, record: logging.LogRecord) -> None:
+        """Step 1 of ``filter()``: mask ``record.msg`` regardless of type.
+
+        ``str`` msg: pre-truncate + mask + truncate (see ``mask_text`` for the
+        bound). dict/list/tuple/set/frozenset msg: route through
+        ``_mask_value_recursive`` so the structlog / JSON-logging idiom
+        (``logger.info({"password": "s3cret"})``) is masked — previously
+        such a msg was emitted in cleartext by ``getMessage()`` because
+        ``filter()`` masked msg only when it was a ``str`` and ``_mask_extras``
+        skipped it (msg is a standard attribute). Arbitrary objects: compute
+        ``str()``, mask it, and replace only if the masked text differs from
+        the plain ``str()`` — type-preserving when there is no secret,
+        sanitizing when there is. We do NOT normalize with
+        ``record.msg = record.getMessage(); record.args = None``: that
+        destroys the format string for every downstream handler in the
+        process (aggregators group on the template; python-json-logger /
+        structlog read msg and args separately) — the same category of
+        invasive global logging mutation this PR exists to correct.
+
+        When ``record.args`` is present, ``record.msg`` is a format string
+        (e.g. ``"Connecting to %s"``), not the final text. Pre-truncating or
+        final-truncating the format string before ``%`` formatting can sever a
+        ``%s`` placeholder, producing ``"Connecting to %*** [N bytes
+        truncated...]"`` — a corrupted format string that then raises
+        ``ValueError`` during ``msg % args``. Mask the format string (a secret
+        could be in it) but skip both truncation stages when args are present;
+        the formatted message is truncated downstream if it flows through the
+        stdout/stderr wrapper, and a format string is rarely long enough to
+        need truncation anyway.
+        """
+        if isinstance(record.msg, str):
+            if record.args:
+                record.msg = self.mask_text(record.msg)
+            else:
+                original_len = len(record.msg)
+                record.msg = self.mask_text(
+                    record.msg, pre_truncate_budget=self._max_message_size
+                )
+                record.msg = self._truncate_message(
+                    record.msg, original_len=original_len
+                )
+        elif isinstance(record.msg, (dict, list, tuple, set, frozenset)):
+            record.msg = self._mask_value_recursive(record.msg)
+        elif record.msg is not None:
+            plain = str(record.msg)
+            masked = self.mask_text(plain)
+            if masked != plain:
+                record.msg = masked
+
     def filter(self, record: logging.LogRecord) -> bool:
         """Filter and mask a log record.
 
@@ -693,13 +864,22 @@ class SecretMaskingFilter(logging.Filter):
         after masking so the same record flowing through multiple handlers
         (each carrying this filter) is not re-masked / re-truncated. The
         token is a random string compared by value so the guard survives
-        cross-thread ``QueueHandler``/``QueueListener`` and cross-process
-        pickle, and so structured formatters that serialize ``record.__dict__``
+        cross-thread ``QueueHandler``/``QueueListener`` within a process,
+        and so structured formatters that serialize ``record.__dict__``
         emit a valid line instead of raising on a non-serializable sentinel.
 
         Defense-in-depth: ``_truncate_message`` is independently idempotent
         (it detects its own suffix marker), so a second masking pass when the
         token guard fails does not re-truncate and corrupt the byte count.
+
+        Fail closed per field: each of the seven numbered steps runs in its
+        own try; a field that raises is substituted with
+        ``MASKING_ERROR_MESSAGE`` and the next step still runs. The
+        idempotency sentinel is set in ``finally`` so it guards the failure
+        path too — a record that raised in step 3 used to get a full
+        unmasked pass per handler (the sentinel was the last statement inside
+        the try), compounding corruption and the N x str() cost on the same
+        record.
         """
         # Re-entrancy / idempotency guard. Records from the masking framework's
         # own loggers bypass masking entirely (their handlers are skipped at
@@ -723,80 +903,87 @@ class SecretMaskingFilter(logging.Filter):
         if not _masking_enabled_cached:
             return True  # Skip all masking and truncation for debugging
 
+        # Each of the seven steps below runs in its own try. If a step raises,
+        # the field it was masking is substituted with ``MASKING_ERROR_MESSAGE``
+        # (fail closed — never an unmasked value) and the next step still runs.
+        # The idempotency sentinel is set in ``finally`` so it guards the
+        # failure path too: a record that failed one step used to get a full
+        # unmasked pass per handler (the sentinel was the last statement
+        # inside the try), compounding corruption and the N x str() cost on
+        # the same record. "Marked as done" is now truthful — every field is
+        # either masked or suppressed.
         try:
-            # 1. Two-stage truncation + masking of record.msg.
-            #
-            #    When secrets are registered, mask_text on a huge message is
-            #    expensive (regex over the whole string) for output truncated to
-            #    max_message_size anyway. Pre-truncate to max_message_size +
-            #    longest_key (no marker) so the regex only scans the region that
-            #    can affect the final output: any secret starting within the
-            #    first max_message_size chars is fully contained (secrets are at
-            #    most longest_key long), so mask_text matches and replaces it;
-            #    anything beyond max_message_size + longest_key is dropped before
-            #    the regex ever sees it. The bound is the longest *expanded* key
-            #    (repr/JSON/SQLAlchemy variants can be longer than the raw value);
-            #    a raw-length bound would cut a JSON-escaped secret at the
-            #    pre-truncate boundary and reintroduce the partial-disclosure bug.
-            #
-            #    The original length is tracked so the final marker reports the
-            #    true overrun (original - max_message_size), not the pre-
-            #    truncated region's overrun (which would mislead the user about
-            #    how much was dropped). When no secrets are registered the pre-
-            #    truncate is skipped: mask_text is a no-op then, so there is no
-            #    performance gain, and skipping preserves the single-stage
-            #    marker semantics.
-            #
-            #    _truncate_message is idempotent (detects its own marker) so a
-            #    second pass when the token guard fails does not re-truncate.
-            if isinstance(record.msg, str):
-                original_len = len(record.msg)
-                if self._longest_key_length > 0:
-                    pre_cut = self._max_message_size + self._longest_key_length
-                    if len(record.msg) > pre_cut:
-                        record.msg = record.msg[:pre_cut]
-                record.msg = self.mask_text(record.msg)
-                record.msg = self._truncate_message(
-                    record.msg, original_len=original_len
-                )
+            # 1. Mask record.msg (any type — see _mask_record_msg).
+            try:
+                self._mask_record_msg(record)
+            except Exception:
+                record.msg = MASKING_ERROR_MESSAGE
 
             # 2. Mask arguments (for formatting)
-            if record.args:
-                record.args = self._mask_args(record.args)
+            try:
+                if record.args:
+                    record.args = self._mask_args(record.args)
+            except Exception:
+                record.args = (MASKING_ERROR_MESSAGE,)
 
             # 3. Mask pre-formatted message if it exists
-            if hasattr(record, "message") and record.message:
-                record.message = self.mask_text(record.message)
+            try:
+                if hasattr(record, "message") and record.message:
+                    record.message = self.mask_text(record.message)
+            except Exception:
+                record.message = MASKING_ERROR_MESSAGE
 
             # 4. Materialize traceback text from exc_info so it can be masked.
             #    exc_info itself is left untouched (error reporters read it).
             #    See _mask_exception for why we do not rebuild the exception.
-            if record.exc_info and not record.exc_text:
-                record.exc_text = self._mask_exception(record.exc_info)
+            try:
+                if record.exc_info and not record.exc_text:
+                    record.exc_text = self._mask_exception(record.exc_info)
+            except Exception:
+                record.exc_text = MASKING_ERROR_MESSAGE
 
             # 5. Mask formatted exception text (pre-existing or just materialized)
-            if record.exc_text:
-                record.exc_text = self.mask_text(record.exc_text)
+            try:
+                if record.exc_text:
+                    record.exc_text = self.mask_text(record.exc_text)
+            except Exception:
+                record.exc_text = MASKING_ERROR_MESSAGE
 
             # 6. Mask stack_info if present (Python 3.2+)
-            if hasattr(record, "stack_info") and record.stack_info:
-                record.stack_info = self.mask_text(record.stack_info)
+            try:
+                if hasattr(record, "stack_info") and record.stack_info:
+                    record.stack_info = self.mask_text(record.stack_info)
+            except Exception:
+                record.stack_info = MASKING_ERROR_MESSAGE
 
             # 7. Mask non-standard attributes (extra={...}). Must run after msg/args
-            #    masking and inside the try so unexpected types from third-party
-            #    libraries do not break logging.
-            self._mask_extras(record)
-
-            # Mark as masked so subsequent handlers skip the work.
-            record._datahub_masked = _MASKED
+            #    masking so a formatter that reads msg/args sees the masked values.
+            try:
+                self._mask_extras(record)
+            except Exception:
+                # _mask_extras already masks per-field; if the whole loop
+                # raises (e.g. __dict__ iteration races), there is no single
+                # field to substitute. Leave extras as they are — fail-closed
+                # is preserved by the per-field sentinel below.
+                pass
 
         except Exception as e:
-            # NEVER let masking break logging
+            # NEVER let masking break logging. The per-step tries above catch
+            # their own exceptions, so reaching here means something truly
+            # unexpected (a non-Exception BaseException, or an error in the
+            # sentinel-setting itself). Log to stderr and continue.
             try:
                 sys.stderr.write(f"WARNING: Secret masking filter failed: {e}\n")
                 sys.stderr.flush()
             except Exception:
                 pass  # Even error reporting failed, continue silently
+        finally:
+            # Set in finally so it guards the failure path: a record that
+            # raised in step 3 still gets the sentinel, so a second handler
+            # does not re-run steps 1-2 (which already succeeded) and
+            # re-mask what was already masked. "Marked as done" is truthful
+            # because every field is either masked or suppressed.
+            record._datahub_masked = _MASKED
 
         return True  # Always let record through
 
@@ -859,6 +1046,23 @@ class StreamMaskingWrapper:
         return getattr(self._original, name)
 
 
+def _acquire_logging_lock():
+    """Context manager for the logging module lock.
+
+    ``logging._lock`` is private and already changed shape once (3.13 dropped
+    ``_acquireLock`` / ``_releaseLock``); it remains an ``RLock`` usable as a
+    context manager on 3.10–3.14+. Fall back to a no-op rather than crashing
+    if a future CPython rename removes ``_lock`` — the snapshot is best-effort
+    against concurrent ``addHandler`` / ``removeHandler``, and a no-op only
+    risks a ``RuntimeError`` on concurrent mutation, which the caller already
+    handles by snapshotting ``list(...)`` before iterating.
+    """
+    lock = getattr(logging, "_lock", None)
+    if lock is None:
+        return contextlib.nullcontext()
+    return lock
+
+
 def _snapshot_handler_pairs() -> List[Tuple[logging.Logger, logging.Handler]]:
     """Snapshot ``(logger, handler)`` pairs under the logging module lock.
 
@@ -874,11 +1078,7 @@ def _snapshot_handler_pairs() -> List[Tuple[logging.Logger, logging.Handler]]:
     GC'd between the two steps; ``items()`` holds the value reference too.
     ``PlaceHolder`` entries (non-Logger) are filtered out.
     """
-    # ``logging._lock`` is the module-level RLock that ``_acquireLock`` /
-    # ``_releaseLock`` wrap. Those wrappers were removed in Python 3.13,
-    # but ``_lock`` itself remains and is an RLock on 3.10–3.14+, so it
-    # works as a context manager across the whole supported range.
-    with logging._lock:  # type: ignore[attr-defined]
+    with _acquire_logging_lock():
         root = logging.getLogger()
         pairs: List[Tuple[logging.Logger, logging.Handler]] = [
             (root, h) for h in list(root.handlers)
@@ -982,15 +1182,16 @@ def _cover_handler(handler: logging.Handler) -> None:
     tracking, uninstall would miss them and they'd retain the filter.
     The weak set auto-drops GC'd handlers.
 
-    Acquires ``_install_lock`` so the add is serialized with the readers in
-    ``_remove_filter_from_existing_handlers`` (which snapshots the set under
-    the same lock). The GIL makes ``WeakSet.add`` effectively atomic on
-    CPython, but the lock makes that guarantee explicit rather than
-    reasoning about interpreter internals. ``_install_lock`` is an RLock,
-    so calling this from inside ``install_masking_filter`` (which already
-    holds the lock) does not self-deadlock.
+    Acquires ``_covered_lock`` (a leaf lock — see its definition) rather than
+    ``_install_lock``. This is called from the ``Handler.__init__`` patch, which
+    CPython invokes while already holding ``logging._lock`` (for ``basicConfig``
+    / ``dictConfig`` / ``fileConfig``). Taking ``_install_lock`` here would
+    invert the lock order against install/uninstall (which take
+    ``_install_lock`` then ``logging._lock``) and deadlock two threads with the
+    logging lock held. The leaf lock is acquired last by every caller and never
+    held while acquiring either of the others, so it cannot close a cycle.
     """
-    with _install_lock:
+    with _covered_lock:
         try:
             _covered_handlers.add(handler)
         except Exception:
@@ -1058,9 +1259,10 @@ def _remove_filter_from_existing_handlers(masking_filter: SecretMaskingFilter) -
         while masking_filter in handler.filters:
             handler.removeFilter(masking_filter)
     # Handlers we covered but that aren't on any logger. Snapshot the weak
-    # set under the install lock so a concurrent add doesn't mutate it; the
-    # handlers themselves are alive (we hold them via the snapshot).
-    with _install_lock:
+    # set under the leaf lock (same lock ``_cover_handler`` adds under) so a
+    # concurrent add doesn't mutate it; the handlers themselves are alive
+    # (we hold them via the snapshot).
+    with _covered_lock:
         covered = list(_covered_handlers)
     for handler in covered:
         while masking_filter in handler.filters:
@@ -1258,6 +1460,15 @@ def _uninstall_masking_filter() -> None:
     ``install_masking_filter`` (which attaches the filter, wraps streams, and
     installs the ``Handler.__init__`` hook).
 
+    Step-wise tolerant: each mutation runs in its own try so a failure in step
+    two does not skip three through five. A teardown that leaves masking
+    *on* is fail-safe (no leak), so we swallow per-step errors and log them
+    with ``exc_info=True`` rather than raising — raising from cleanup (often
+    reached via ``finally`` or ``atexit``) destroys the original exception.
+    The caller (``shutdown_secret_masking``) clears the bootstrap latch in
+    its own ``finally`` so a partial teardown does not strand the latch
+    ``True`` over a half-torn state.
+
     Module-private: this is the low-level teardown primitive that disarms
     masking process-wide. Callers should go through
     ``shutdown_secret_masking`` (the refcounted lifecycle), which only reaches
@@ -1270,27 +1481,76 @@ def _uninstall_masking_filter() -> None:
     with _install_lock:
         root_logger = logging.getLogger()
 
-        # Remove our instance (identity-based) from the root logger and handlers.
+        # 1. Remove our instance (identity-based) from the root logger.
         if _installed_filter is not None:
-            while _installed_filter in root_logger.filters:
-                root_logger.removeFilter(_installed_filter)
-            _remove_filter_from_existing_handlers(_installed_filter)
+            try:
+                while _installed_filter in root_logger.filters:
+                    root_logger.removeFilter(_installed_filter)
+            except Exception as e:
+                logger.error(
+                    "Failed to remove SecretMaskingFilter from root logger "
+                    "during teardown: %r",
+                    e,
+                    exc_info=True,
+                )
+
+            # 2. Remove from every handler it was attached to.
+            try:
+                _remove_filter_from_existing_handlers(_installed_filter)
+            except Exception as e:
+                logger.error(
+                    "Failed to remove SecretMaskingFilter from handlers "
+                    "during teardown: %r",
+                    e,
+                    exc_info=True,
+                )
+
+            # 3. Drop the installed-filter global so the Handler.__init__ hook
+            # stops attaching to new handlers.
             _installed_filter = None
 
-        # Revert the Handler.__init__ hook so handlers constructed after uninstall
-        # don't auto-attach a (now-None) filter. Done after _installed_filter is
-        # cleared so the hook's pointer read sees None during teardown.
-        _uninstall_handler_init_hook()
+        # 4. Revert the Handler.__init__ hook so handlers constructed after
+        #    uninstall don't auto-attach a (now-None) filter. Done after
+        #    _installed_filter is cleared so the hook's pointer read sees None
+        #    during teardown.
+        try:
+            _uninstall_handler_init_hook()
+        except Exception as e:
+            logger.error(
+                "Failed to revert Handler.__init__ hook during teardown: %r",
+                e,
+                exc_info=True,
+            )
 
-        # Drop the covered-handler tracking set so a re-install starts clean.
-        _covered_handlers.clear()
+        # 5. Drop the covered-handler tracking set so a re-install starts clean.
+        # ``_covered_lock`` (leaf) — see _cover_handler for the lock-order
+        # invariant.
+        try:
+            with _covered_lock:
+                _covered_handlers.clear()
+        except Exception as e:
+            logger.error(
+                "Failed to clear covered-handler set during teardown: %r",
+                e,
+                exc_info=True,
+            )
 
-        # Unwrap stdout/stderr (only if we wrapped them)
-        if isinstance(sys.stdout, StreamMaskingWrapper):
-            sys.stdout = sys.stdout._original
+        # 6. Unwrap stdout/stderr (only if we wrapped them).
+        try:
+            if isinstance(sys.stdout, StreamMaskingWrapper):
+                sys.stdout = sys.stdout._original
+        except Exception as e:
+            logger.error(
+                "Failed to unwrap sys.stdout during teardown: %r", e, exc_info=True
+            )
 
-        if isinstance(sys.stderr, StreamMaskingWrapper):
-            sys.stderr = sys.stderr._original
+        try:
+            if isinstance(sys.stderr, StreamMaskingWrapper):
+                sys.stderr = sys.stderr._original
+        except Exception as e:
+            logger.error(
+                "Failed to unwrap sys.stderr during teardown: %r", e, exc_info=True
+            )
 
         logger.info("Uninstalled SecretMaskingFilter")
 

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -324,6 +324,18 @@ class SecretMaskingFilter(logging.Filter):
                 )
             return "[REDACTED: Masking Error]"
 
+    def rebind_registry(self, registry: "SecretRegistry") -> None:
+        """Rebind the registry this filter reads, and force a pattern
+        rebuild on the next mask.
+
+        Used by ``install_masking_filter``'s refresh path when the caller
+        hands in a different registry on a repeat install. Encapsulating
+        the rebind here keeps the invariant (rebind implies version reset)
+        in one place where it can't drift from the install path.
+        """
+        self._registry = registry
+        self._last_version = 0
+
     def _mask_args(self, args: Any) -> Any:
         """Mask secrets in log arguments."""
         if not args:
@@ -791,8 +803,7 @@ def install_masking_filter(
                 "Use SecretRegistry.reset_instance() between installs to "
                 "fully tear down first."
             )
-            _installed_filter._registry = secret_registry
-            _installed_filter._last_version = 0
+            _installed_filter.rebind_registry(secret_registry)
 
         logger.debug("SecretMaskingFilter already installed; refreshed handlers")
         return _installed_filter

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -40,6 +40,13 @@ _installed_filter: Optional["SecretMaskingFilter"] = None
 REDACTED_MASKING_NAMESPACE = "datahub.masking."
 REDACTED_FORMAT = "***REDACTED:{name}***"
 MASKING_ERROR_MESSAGE = "[MASKING_ERROR - OUTPUT_SUPPRESSED_FOR_SECURITY]"
+
+# Module-private sentinel stamped onto records after masking so the
+# idempotency guard can recognize them with `is` rather than truthiness.
+# A caller-supplied ``extra={'_datahub_masked': True}`` would otherwise forge
+# the guard and disable masking for that record. A caller can't forge this
+# object.
+_MASKED = object()
 CIRCUIT_OPEN_MESSAGE = "[REDACTED: Masking Circuit Open]"
 
 # LogRecord standard attributes (per logging.LogRecord.__init__ + attributes set
@@ -332,9 +339,18 @@ class SecretMaskingFilter(logging.Filter):
         hands in a different registry on a repeat install. Encapsulating
         the rebind here keeps the invariant (rebind implies version reset)
         in one place where it can't drift from the install path.
+
+        Uses ``_last_version = -1`` (not 0): a fresh registry's version is 0,
+        so ``0 == 0`` would make ``_check_and_rebuild_pattern``'s fast path
+        skip the rebuild and the old pattern would persist (over-masking the
+        old registry's values). ``-1`` never equals a real version, so the
+        next mask always rebuilds. The pattern and replacements are cleared
+        too so a stale pattern can't be served before the rebuild runs.
         """
         self._registry = registry
-        self._last_version = 0
+        self._last_version = -1
+        self._pattern = None
+        self._replacements = {}
 
     def _mask_args(self, args: Any) -> Any:
         """Mask secrets in log arguments."""
@@ -542,7 +558,7 @@ class SecretMaskingFilter(logging.Filter):
         if record.name.startswith(REDACTED_MASKING_NAMESPACE):
             return True
 
-        if getattr(record, "_datahub_masked", False):
+        if getattr(record, "_datahub_masked", None) is _MASKED:
             return True
 
         # Check if masking is disabled for debugging
@@ -591,7 +607,7 @@ class SecretMaskingFilter(logging.Filter):
             self._mask_extras(record)
 
             # Mark as masked so subsequent handlers skip the work.
-            record._datahub_masked = True
+            record._datahub_masked = _MASKED
 
         except Exception as e:
             # NEVER let masking break logging
@@ -805,6 +821,15 @@ def install_masking_filter(
             )
             _installed_filter.rebind_registry(secret_registry)
 
+        # Honour install_stdout_wrapper on refresh. The wrapper block sits after
+        # this path's early return, so a repeat install with
+        # install_stdout_wrapper=True after an earlier install with False would
+        # silently skip wrapping. The helper is idempotent and guarded by the
+        # fileno() real-stream check, so calling it here is safe. We do NOT
+        # unwrap when False is passed — teardown owns unwrapping.
+        if install_stdout_wrapper:
+            _wrap_std_streams(_installed_filter)
+
         logger.debug("SecretMaskingFilter already installed; refreshed handlers")
         return _installed_filter
 
@@ -828,27 +853,33 @@ def install_masking_filter(
     # proxy, raw writes become log records and flow through handlers that carry
     # the masking filter, so coverage doesn't suffer.
     if install_stdout_wrapper:
-        if not isinstance(sys.stdout, StreamMaskingWrapper) and _is_real_stream(
-            sys.stdout
-        ):
-            sys.stdout = StreamMaskingWrapper(sys.stdout, masking_filter)
-            logger.debug("Wrapped sys.stdout with StreamMaskingWrapper")
-        else:
-            logger.debug(
-                "Skipped wrapping sys.stdout (not a real stream / already wrapped)"
-            )
-
-        if not isinstance(sys.stderr, StreamMaskingWrapper) and _is_real_stream(
-            sys.stderr
-        ):
-            sys.stderr = StreamMaskingWrapper(sys.stderr, masking_filter)
-            logger.debug("Wrapped sys.stderr with StreamMaskingWrapper")
-        else:
-            logger.debug(
-                "Skipped wrapping sys.stderr (not a real stream / already wrapped)"
-            )
+        _wrap_std_streams(masking_filter)
 
     return masking_filter
+
+
+def _wrap_std_streams(masking_filter: "SecretMaskingFilter") -> None:
+    """Wrap sys.stdout/stderr with StreamMaskingWrapper if they are real
+    OS-backed streams and not already wrapped. Idempotent and guarded by the
+    ``fileno()`` real-stream check, so it is safe to call on the refresh path
+    (a repeat install with ``install_stdout_wrapper=True`` after an earlier
+    install with ``False``). Does NOT unwrap when ``install_stdout_wrapper``
+    is False — teardown owns unwrapping."""
+    if not isinstance(sys.stdout, StreamMaskingWrapper) and _is_real_stream(sys.stdout):
+        sys.stdout = StreamMaskingWrapper(sys.stdout, masking_filter)
+        logger.debug("Wrapped sys.stdout with StreamMaskingWrapper")
+    else:
+        logger.debug(
+            "Skipped wrapping sys.stdout (not a real stream / already wrapped)"
+        )
+
+    if not isinstance(sys.stderr, StreamMaskingWrapper) and _is_real_stream(sys.stderr):
+        sys.stderr = StreamMaskingWrapper(sys.stderr, masking_filter)
+        logger.debug("Wrapped sys.stderr with StreamMaskingWrapper")
+    else:
+        logger.debug(
+            "Skipped wrapping sys.stderr (not a real stream / already wrapped)"
+        )
 
 
 def uninstall_masking_filter() -> None:

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -444,19 +444,23 @@ class SecretMaskingFilter(logging.Filter):
 
         A depth cap (``_MAX_EXTRA_DEPTH``) and an identity-based cycle guard
         (``_seen``) bound the recursion: extra= can carry self-referential or
-        very large structures onto the hot path. Beyond the cap or on a cycle we
-        return the value unchanged (residual gap) rather than raise, so logging
-        still proceeds.
+        very large structures onto the hot path. Beyond the cap or on a cycle
+        we return a placeholder string (``"<not masked: ...>"``) rather
+        than the raw value — returning the raw subtree would emit any secret
+        it contains in cleartext, and everything else in this module fails
+        closed. The placeholder also keeps this docstring honest: "return
+        the value unchanged" reads as "we mask less here" when it actually
+        means "we emit the secret."
         """
         if _depth >= self._MAX_EXTRA_DEPTH:
-            return value
+            return "<not masked: depth limit>"
         if isinstance(value, str):
             return self.mask_text(value)
         if isinstance(value, dict):
             if _seen is None:
                 _seen = set()
             if id(value) in _seen:
-                return value  # cycle — return unchanged (residual gap)
+                return "<not masked: cycle>"
             _seen.add(id(value))
             try:
                 return {
@@ -469,7 +473,7 @@ class SecretMaskingFilter(logging.Filter):
             if _seen is None:
                 _seen = set()
             if id(value) in _seen:
-                return value
+                return "<not masked: cycle>"
             _seen.add(id(value))
             try:
                 masked = [
@@ -745,11 +749,12 @@ def install_masking_filter(
       via %s may emit them unmasked unless the output flows through the
       stdout/stderr wrapper.
 
-    Note: the "already installed → refresh" path re-scans handlers but reuses
-    the existing filter instance, so a caller passing a different
-    secret_registry / max_message_size on a repeat call will see those args
-    silently ignored. This is intentional (the filter is process-lifetime)
-    but worth knowing.
+    Note: the "already installed → refresh" path re-scans handlers, re-adds
+    the root-logger filter if something removed it, and rebinds the
+    registry if the caller passed a different one (with a warning).
+    ``max_message_size`` on a repeat call is still ignored (the filter
+    instance is reused); call ``SecretRegistry.reset_instance()`` first
+    for a full re-install with new args.
     """
     global _installed_filter
 
@@ -761,6 +766,34 @@ def install_masking_filter(
     if _installed_filter is not None:
         # Already installed: re-scan to cover handlers added since (fail-open).
         _add_filter_to_existing_handlers(_installed_filter)
+
+        # Re-add the root-logger filter if something removed it (partial
+        # teardown state). Without this, a partially-torn-down state stays
+        # partial: the handler filters are re-scanned but the root-logger
+        # sentinel is gone, so the "already installed?" check on a later call
+        # would re-install from scratch and attach a second filter.
+        if _installed_filter not in root_logger.filters:
+            root_logger.addFilter(_installed_filter)
+
+        # Rebind the registry if the caller passed a different one. Without
+        # this, install(r1) → reset_instance() → install(r2) leaves the
+        # filter masking with r1 (now stale), so r2's secrets leak. The
+        # filter is process-lifetime, but the registry it reads is not —
+        # rebind so the same filter instance reads the new registry, and
+        # reset _last_version to force a pattern rebuild on the next mask.
+        if (
+            secret_registry is not None
+            and secret_registry is not _installed_filter._registry
+        ):
+            logger.warning(
+                "Rebinding SecretMaskingFilter registry on repeat install; "
+                "the previous registry is no longer active. "
+                "Use SecretRegistry.reset_instance() between installs to "
+                "fully tear down first."
+            )
+            _installed_filter._registry = secret_registry
+            _installed_filter._last_version = 0
+
         logger.debug("SecretMaskingFilter already installed; refreshed handlers")
         return _installed_filter
 

--- a/metadata-ingestion/src/datahub/masking/secret_registry.py
+++ b/metadata-ingestion/src/datahub/masking/secret_registry.py
@@ -8,6 +8,10 @@ active executions' secrets (via get_all_secrets/get_version), so masking is
 process-global and always-on — it can over-mask during overlap (safe) but never
 under-mask. See datahub.masking.bootstrap for the lifecycle.
 
+Secrets registered outside any execution scope land in a catch-all ``__global__``
+group; it is dropped once the last real execution ends (so it lives at most as
+long as concurrent execution activity, not for the whole process).
+
 Concurrency: copy-on-write. Writers (register/begin/end/clear) hold the lock and
 atomically swap in freshly-built dicts; readers (the masking hot path) read those
 immutable snapshots without a lock.

--- a/metadata-ingestion/src/datahub/masking/secret_registry.py
+++ b/metadata-ingestion/src/datahub/masking/secret_registry.py
@@ -132,10 +132,6 @@ class SecretRegistry:
             self._rebuild_locked()
             return bool(active)
 
-    def has_active_executions(self) -> bool:
-        with self._registry_lock:
-            return any(g != _GLOBAL_GROUP for g in self._groups)
-
     def _current_group_locked(self) -> Dict[str, str]:
         exec_id = _current_exec.get() or _GLOBAL_GROUP
         return self._groups.setdefault(exec_id, {})

--- a/metadata-ingestion/src/datahub/masking/secret_registry.py
+++ b/metadata-ingestion/src/datahub/masking/secret_registry.py
@@ -108,6 +108,15 @@ class SecretRegistry:
         _current_exec.set(exec_id)
         return exec_id
 
+    def ensure_execution(self) -> str:
+        """Open a secret scope for the current context only if it doesn't already
+        have one; returns the active execution id. Idempotent within a context,
+        so a repeated initialize_secret_masking() won't start a second scope."""
+        exec_id = _current_exec.get()
+        if exec_id is not None:
+            return exec_id
+        return self.begin_execution()
+
     def end_execution(self) -> bool:
         """Drop the current execution's secrets. Returns True if other
         executions are still active (so the caller should NOT fully tear down)."""

--- a/metadata-ingestion/src/datahub/masking/secret_registry.py
+++ b/metadata-ingestion/src/datahub/masking/secret_registry.py
@@ -1,19 +1,35 @@
 """
 Thread-safe registry for managing secrets used in masking.
 
-This module provides a singleton registry for storing and managing secrets.
-Secrets are automatically registered from ConfigModel fields and environment
-variables, then used by logging filters to mask sensitive data.
+Secrets are grouped by the execution that registered them, so overlapping
+in-process executions don't interfere: one execution ending removes only its own
+secrets, never another's. The masking filter always sees the *union* of all
+active executions' secrets (via get_all_secrets/get_version), so masking is
+process-global and always-on — it can over-mask during overlap (safe) but never
+under-mask. See datahub.masking.bootstrap for the lifecycle.
 
+Concurrency: copy-on-write. Writers (register/begin/end/clear) hold the lock and
+atomically swap in freshly-built dicts; readers (the masking hot path) read those
+immutable snapshots without a lock.
 """
 
 import os
 import threading
+import uuid
+from contextvars import ContextVar
 from typing import Dict, Optional
 
 from datahub.masking.logging_utils import get_masking_safe_logger
 
 logger = get_masking_safe_logger(__name__)
+
+# Secrets registered outside an explicit execution scope land here. Dropped when
+# no real executions remain active.
+_GLOBAL_GROUP = "__global__"
+
+# Identifies the execution registering/owning secrets in the current context.
+# Set by begin_execution(), read by register_secret() and end_execution().
+_current_exec: ContextVar[Optional[str]] = ContextVar("masking_exec_id", default=None)
 
 
 def is_masking_enabled() -> bool:
@@ -24,8 +40,27 @@ def is_masking_enabled() -> bool:
     )
 
 
+def _expand_keys(raw_value: str) -> Dict[str, None]:
+    """Return all string forms of a secret that should be masked.
+
+    Besides the raw value, this covers repr-escaped forms (for values with
+    escape sequences) and SQLAlchemy-style URL encoding of ``:@/``.
+    """
+    keys: Dict[str, None] = {raw_value: None}
+    if any(c in raw_value for c in ["\n", "\r", "\t", "\\", '"', "'"]):
+        repr_value = repr(raw_value)[1:-1]
+        if repr_value != raw_value:
+            keys[repr_value] = None
+    sqlalchemy_encoded = (
+        raw_value.replace(":", "%3A").replace("@", "%40").replace("/", "%2F")
+    )
+    if sqlalchemy_encoded != raw_value:
+        keys[sqlalchemy_encoded] = None
+    return keys
+
+
 class SecretRegistry:
-    """Thread-safe registry for secrets."""
+    """Thread-safe registry for secrets, scoped per execution (copy-on-write)."""
 
     _instance: Optional["SecretRegistry"] = None
     _lock = threading.RLock()
@@ -33,11 +68,15 @@ class SecretRegistry:
     MAX_SECRETS = 10000
 
     def __init__(self):
-        self._secrets: Dict[str, str] = {}  # value -> name mapping
-        self._name_to_value: Dict[
-            str, str
-        ] = {}  # name -> value mapping (reverse index)
+        # Source of truth: execution_id -> {raw_value: variable_name}.
+        self._groups: Dict[str, Dict[str, str]] = {}
+        # Derived, immutable snapshots for the masking hot path: the union of all
+        # groups (key -> name) and a reverse index (name -> value). Never mutated
+        # in place — rebuilt and atomically reassigned by writers (COW).
+        self._secrets: Dict[str, str] = {}
+        self._name_to_value: Dict[str, str] = {}
         self._version = 0
+        # Serializes writers only; readers are lock-free.
         self._registry_lock = threading.RLock()
 
     @classmethod
@@ -50,166 +89,145 @@ class SecretRegistry:
 
     @classmethod
     def reset_instance(cls) -> None:
-        """Reset singleton instance."""
+        """Reset singleton instance (and current execution scope)."""
         with cls._lock:
             cls._instance = None
+        _current_exec.set(None)
+
+    # --- Execution scoping (writers) ---------------------------------------
+
+    def begin_execution(self) -> str:
+        """Open a secret scope for the current execution; returns its id.
+
+        Secrets registered after this (in the same context) are owned by this
+        execution and dropped by the matching end_execution().
+        """
+        exec_id = uuid.uuid4().hex
+        with self._registry_lock:
+            self._groups.setdefault(exec_id, {})
+        _current_exec.set(exec_id)
+        return exec_id
+
+    def end_execution(self) -> bool:
+        """Drop the current execution's secrets. Returns True if other
+        executions are still active (so the caller should NOT fully tear down)."""
+        exec_id = _current_exec.get()
+        _current_exec.set(None)
+        with self._registry_lock:
+            if exec_id is not None:
+                self._groups.pop(exec_id, None)
+            active = [g for g in self._groups if g != _GLOBAL_GROUP]
+            if not active:
+                # No real executions left — drop the catch-all bucket too.
+                self._groups.pop(_GLOBAL_GROUP, None)
+            self._rebuild_locked()
+            return bool(active)
+
+    def has_active_executions(self) -> bool:
+        with self._registry_lock:
+            return any(g != _GLOBAL_GROUP for g in self._groups)
+
+    def _current_group_locked(self) -> Dict[str, str]:
+        exec_id = _current_exec.get() or _GLOBAL_GROUP
+        return self._groups.setdefault(exec_id, {})
+
+    def _rebuild_locked(self) -> None:
+        """Recompute the union + reverse index from all groups and publish them
+        atomically. Called only by writers holding the lock."""
+        secrets: Dict[str, str] = {}
+        name_to_value: Dict[str, str] = {}
+        for group in self._groups.values():
+            for raw_value, name in group.items():
+                name_to_value[name] = raw_value
+                for key in _expand_keys(raw_value):
+                    secrets.setdefault(key, name)
+        self._secrets = secrets
+        self._name_to_value = name_to_value
+        self._version += 1
+
+    # --- Registration (writers) --------------------------------------------
 
     def register_secret(self, variable_name: str, raw_value: str) -> None:
-        """Register a secret for masking."""
+        """Register a secret for masking under the current execution."""
         if not raw_value or not isinstance(raw_value, str):
             return
-
         if len(raw_value) < 3:
             return
 
-        # Fast path: check without lock
-        if raw_value in self._secrets:
-            return
-
         with self._registry_lock:
-            # Copy-on-write
-            new_secrets = self._secrets.copy()
-            new_name_to_value = self._name_to_value.copy()
-
-            # Double-check after acquiring lock
-            if raw_value in new_secrets:
+            group = self._current_group_locked()
+            if raw_value in group:
                 return
-
-            # Check memory limit
-            if len(new_secrets) >= self.MAX_SECRETS:
+            if len(self._secrets) >= self.MAX_SECRETS:
                 logger.warning(
                     f"Secret registry at capacity ({self.MAX_SECRETS}). "
                     f"Skipping registration of {variable_name}"
                 )
                 return
-
-            new_secrets[raw_value] = variable_name
-            new_name_to_value[variable_name] = raw_value
-
-            # Register repr() version if secret contains escape sequences
-            if any(c in raw_value for c in ["\n", "\r", "\t", "\\", '"', "'"]):
-                repr_value = repr(raw_value)[1:-1]
-                if repr_value != raw_value and repr_value not in new_secrets:
-                    new_secrets[repr_value] = variable_name
-
-            # Register SQLAlchemy-style URL encoding (only encodes :@/)
-            # This matches how SQLAlchemy.URL.__str__() renders passwords
-            sqlalchemy_encoded = (
-                raw_value.replace(":", "%3A").replace("@", "%40").replace("/", "%2F")
-            )
-            if (
-                sqlalchemy_encoded != raw_value
-                and sqlalchemy_encoded not in new_secrets
-            ):
-                new_secrets[sqlalchemy_encoded] = variable_name
-
-            self._secrets = new_secrets
-            self._name_to_value = new_name_to_value
-            self._version += 1
-
+            group[raw_value] = variable_name
+            self._rebuild_locked()
             logger.debug(
                 f"Registered secret: {variable_name[:8]}*** (version {self._version})"
             )
 
     def register_secrets_batch(self, secrets: Dict[str, str]) -> None:
-        """Register multiple secrets atomically."""
+        """Register multiple secrets atomically under the current execution."""
         if not secrets:
             return
-
-        # Pre-validate all secrets
         valid_secrets = {
             name: value
             for name, value in secrets.items()
             if value and isinstance(value, str) and len(value) >= 3
         }
-
         if not valid_secrets:
             return
 
-        # Check fast path - if all secrets already registered, skip
-        all_present = all(value in self._secrets for value in valid_secrets.values())
-        if all_present:
-            return
-
-        # Slow path - batch register
         with self._registry_lock:
-            # Copy-on-write
-            new_secrets = self._secrets.copy()
-            new_name_to_value = self._name_to_value.copy()
-
+            group = self._current_group_locked()
             added_count = 0
             for variable_name, raw_value in valid_secrets.items():
-                # Skip if already registered
-                if raw_value in new_secrets:
+                if raw_value in group:
                     continue
-
-                # Check memory limit
-                if len(new_secrets) >= self.MAX_SECRETS:
+                if len(self._secrets) + added_count >= self.MAX_SECRETS:
                     logger.warning(
                         f"Secret registry at capacity ({self.MAX_SECRETS}). "
                         f"Skipping registration of {variable_name}"
                     )
                     break
-
-                # Register main value
-                new_secrets[raw_value] = variable_name
-                new_name_to_value[variable_name] = raw_value
+                group[raw_value] = variable_name
                 added_count += 1
 
-                # Register repr version if needed
-                if any(c in raw_value for c in ["\n", "\r", "\t", "\\", '"', "'"]):
-                    repr_value = repr(raw_value)[1:-1]
-                    if repr_value != raw_value and repr_value not in new_secrets:
-                        new_secrets[repr_value] = variable_name
-
-                # Register SQLAlchemy-style URL encoding (only encodes :@/)
-                sqlalchemy_encoded = (
-                    raw_value.replace(":", "%3A")
-                    .replace("@", "%40")
-                    .replace("/", "%2F")
-                )
-                if (
-                    sqlalchemy_encoded != raw_value
-                    and sqlalchemy_encoded not in new_secrets
-                ):
-                    new_secrets[sqlalchemy_encoded] = variable_name
-
             if added_count > 0:
-                # Atomic swaps - single version increment for entire batch
-                self._secrets = new_secrets
-                self._name_to_value = new_name_to_value
-                self._version += 1
-
+                self._rebuild_locked()
                 logger.debug(
                     f"Batch registered {added_count} secrets (version {self._version})"
                 )
 
+    # --- Reads (lock-free; the masking hot path) ---------------------------
+
     def get_all_secrets(self) -> Dict[str, str]:
-        """Get all registered secrets."""
-        with self._registry_lock:
-            return self._secrets.copy()
+        """Union of all active executions' secrets (value -> name)."""
+        # COW: self._secrets is an immutable snapshot, never mutated in place.
+        return self._secrets.copy()
 
     def get_version(self) -> int:
-        """Get current version."""
-        with self._registry_lock:
-            return self._version
+        """Current version (bumps whenever the union changes)."""
+        return self._version
 
     def get_count(self) -> int:
-        """Get number of registered secrets."""
+        """Number of distinct secret keys currently masked (the union)."""
         return len(self._secrets)
 
     def clear(self) -> None:
-        """Clear all secrets."""
+        """Drop all secrets from all executions (primarily for tests)."""
         with self._registry_lock:
-            self._secrets = {}
-            self._name_to_value = {}
-            self._version += 1
+            self._groups = {}
+            self._rebuild_locked()
             logger.debug("Cleared all secrets from registry")
 
     def has_secret(self, variable_name: str) -> bool:
         """Check if secret is registered."""
-        with self._registry_lock:
-            return variable_name in self._name_to_value
+        return variable_name in self._name_to_value
 
     def get_secret_value(self, variable_name: str) -> Optional[str]:
         """Get secret value by name."""

--- a/metadata-ingestion/src/datahub/masking/secret_registry.py
+++ b/metadata-ingestion/src/datahub/masking/secret_registry.py
@@ -110,10 +110,29 @@ class SecretRegistry:
 
     @classmethod
     def reset_instance(cls) -> None:
-        """Reset singleton instance (and current execution scope)."""
+        """Reset singleton instance (and current execution scope).
+
+        Also tears down the installed masking filter (lazily) so a
+        subsequent ``install_masking_filter(new_registry)`` picks up the
+        new registry. Without this, the filter survives
+        ``reset_instance()`` and keeps masking with the old (now-stale)
+        registry — masking silently stops working for every secret
+        registered after the reset. Tearing down (rather than just
+        clearing the ``_installed_filter`` global) also removes the old
+        filter from handlers/root, so the next install doesn't attach a
+        second filter alongside the stale one. The lazy import avoids a
+        circular dependency (masking_filter imports this module).
+        """
         with cls._lock:
             cls._instance = None
         _current_exec.set(None)
+        try:
+            from datahub.masking import masking_filter as _mf
+
+            if _mf._installed_filter is not None:
+                _mf.uninstall_masking_filter()
+        except Exception:
+            pass
 
     # --- Execution scoping (writers) ---------------------------------------
 

--- a/metadata-ingestion/src/datahub/masking/secret_registry.py
+++ b/metadata-ingestion/src/datahub/masking/secret_registry.py
@@ -8,13 +8,21 @@ active executions' secrets (via get_all_secrets/get_version), so masking is
 process-global and always-on — it can over-mask during overlap (safe) but never
 under-mask. See datahub.masking.bootstrap for the lifecycle.
 
-Secrets registered outside any execution scope land in a catch-all ``__global__``
-group; it is dropped once the last real execution ends (so it lives at most as
-long as concurrent execution activity, not for the whole process).
+Each ``initialize_secret_masking()`` opens a *distinct* scope and returns its
+token; the caller owns nesting and passes the token to ``shutdown_secret_masking``.
+A second initialize on the same context does NOT alias onto the first — both
+scopes stay live until each is ended by its own token. Secrets registered with
+an explicit ``exec_id`` land in that scope (so a worker thread can register into
+a parent execution's scope without context propagation); without one they land
+in the ambient context's scope, or the ``__global__`` catch-all if the ambient
+context opened no scope.
 
 Concurrency: copy-on-write. Writers (register/begin/end/clear) hold the lock and
 atomically swap in freshly-built dicts; readers (the masking hot path) read those
-immutable snapshots without a lock.
+immutable snapshots without a lock. Registration publishes incrementally (merges
+only the new secret's expanded keys into a new dict) so n admits are O(n) at C
+speed rather than O(n^2) at Python speed; the full rebuild is reserved for
+removals (end_execution/clear), which are rare.
 """
 
 import json
@@ -22,8 +30,9 @@ import os
 import threading
 import uuid
 from contextvars import ContextVar
+from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Dict, Optional
+from typing import Dict, FrozenSet, Optional, Tuple
 
 from datahub.masking.logging_utils import get_masking_safe_logger
 
@@ -33,8 +42,9 @@ logger = get_masking_safe_logger(__name__)
 # no real executions remain active.
 _GLOBAL_GROUP = "__global__"
 
-# Identifies the execution registering/owning secrets in the current context.
-# Set by begin_execution(), read by register_secret() and end_execution().
+# Identifies the execution owning the current context's ambient scope.
+# Set by begin_execution(), read by register_secret() when no explicit exec_id
+# is passed, and cleared by end_execution() when it ends the ambient scope.
 _current_exec: ContextVar[Optional[str]] = ContextVar("masking_exec_id", default=None)
 
 
@@ -52,6 +62,21 @@ class _Admit(Enum):
     ADMITTED = auto()
     DUPLICATE = auto()
     REJECTED = auto()
+
+
+@dataclass
+class _GroupEntry:
+    """One secret within an execution's group.
+
+    ``expanded`` caches ``_expand_keys(raw_value)`` computed once at admit
+    time so removals (which rebuild from scratch) and the incremental publish
+    path never re-expand. Tying the cache to the entry (not a process-wide
+    cache) bounds it to the secret's lifetime and keeps the registry's
+    memory reclaimable when executions end.
+    """
+
+    name: str
+    expanded: Dict[str, None]
 
 
 def is_masking_enabled() -> bool:
@@ -100,14 +125,16 @@ class SecretRegistry:
     _lock = threading.RLock()
 
     # Upper bound on the *expanded* key count (raw + repr + sqlalchemy + json
-    # variants per secret), not the number of registered secrets. Adding
-    # _expand_keys variants reduces how many distinct secrets fit; keep this
-    # bound generous because the masking regex is built from these keys.
+    # variants per secret), not the number of registered secrets. The admit
+    # check rejects when ``len(_secrets) + pending + truly_new >= MAX_SECRETS``,
+    # so the effective capacity is MAX_SECRETS - 1 (the >= leaves no room for
+    # the last admit). Keep this bound generous because the masking regex is
+    # built from these keys.
     MAX_SECRETS = 10000
 
     def __init__(self):
-        # Source of truth: execution_id -> {raw_value: variable_name}.
-        self._groups: Dict[str, Dict[str, str]] = {}
+        # Source of truth: execution_id -> {raw_value: _GroupEntry}.
+        self._groups: Dict[str, Dict[str, _GroupEntry]] = {}
         # Derived, immutable snapshots for the masking hot path: the union of all
         # groups (key -> name) and a reverse index (name -> value). Never mutated
         # in place — rebuilt and atomically reassigned by writers (COW).
@@ -116,10 +143,9 @@ class SecretRegistry:
         self._version = 0
         # Serializes writers only; readers are lock-free.
         self._registry_lock = threading.RLock()
-        # True once we've warned about being at capacity; reset by
-        # _rebuild_locked on the condition (count >= MAX) so a capacity
-        # warning fires once per rise to capacity, not once per call, and
-        # can fire again after executions end and free room.
+        # True once we've warned about being at capacity; cleared by _rebuild_locked
+        # when the registry drops below capacity so a later rise can warn again.
+        # _warn_capacity is the single reader/setter; nothing else touches it.
         self._capacity_warned = False
 
     @classmethod
@@ -145,15 +171,17 @@ class SecretRegistry:
         second filter alongside the stale one. The lazy import avoids a
         circular dependency (masking_filter imports this module).
 
-        ``_bootstrap_lock`` is deliberately NOT held here. ``shutdown_secret_masking()``
+        ``_bootstrap_lock`` is an ``RLock``. ``shutdown_secret_masking()``
         establishes the lock order ``_bootstrap_lock`` -> ``SecretRegistry._lock``
-        (it takes ``_bootstrap_lock`` first, then calls into the registry). Taking
-        ``_bootstrap_lock`` here would invert that order against a concurrent
-        ``shutdown_secret_masking()`` that already holds it and is waiting on
-        ``SecretRegistry._lock`` — a classic lock-order-inversion deadlock.
-        The teardown below is safe to run without ``_bootstrap_lock`` because
-        ``reset_instance`` is a test/dev seam, not a production teardown path,
-        and ``uninstall_masking_filter()`` is idempotent and self-guarding.
+        (it takes ``_bootstrap_lock`` first, then calls into the registry).
+        ``reset_instance`` calls ``reset_bootstrap_state()`` (which acquires
+        ``_bootstrap_lock``) *after* releasing ``cls._lock``, so it does not
+        invert that order. Using an ``RLock`` here means a future path that
+        reaches ``reset_instance`` from inside a ``_bootstrap_lock`` region
+        re-enters the same lock rather than self-deadlocking; a plain
+        ``Lock`` would deadlock in that position. The ``cls._lock`` region
+        is exited before the ``_bootstrap_lock`` call so the two locks are
+        never held simultaneously here.
         """
         with cls._lock:
             cls._instance = None
@@ -179,36 +207,21 @@ class SecretRegistry:
     # --- Execution scoping (writers) ---------------------------------------
 
     def begin_execution(self) -> str:
-        """Open a secret scope for the current execution; returns its id.
+        """Open a new secret scope and return its id.
 
-        Secrets registered after this (in the same context) are owned by this
-        execution and dropped by the matching end_execution().
+        Always opens a *distinct* scope — two ``initialize_secret_masking()``
+        calls on the same context return different tokens and own different
+        groups, so ending one never drops the other's secrets. The ambient
+        contextvar is set to this scope; a later ``begin_execution`` on the
+        same context overwrites it (the latest scope owns ambient
+        registrations), but the earlier token stays valid for its own
+        token-based ``end_execution``.
         """
         exec_id = uuid.uuid4().hex
         with self._registry_lock:
             self._groups.setdefault(exec_id, {})
         _current_exec.set(exec_id)
         return exec_id
-
-    def ensure_execution(self) -> str:
-        """Open a secret scope for the current context only if it doesn't already
-        have one; returns the active execution id. Idempotent within a context,
-        so a repeated initialize_secret_masking() won't start a second scope.
-
-        Revalidates the ambient id against ``_groups``: a token-based
-        ``end_execution`` from another thread drops the group but leaves this
-        context's contextvar pointing at the dead id (end_execution only clears
-        the ambient contextvar when it matches the *ending* context's). Without
-        revalidation, this would return the stale id and recreate a scope under
-        a dead id, so a later token holder would target the wrong scope.
-        """
-        exec_id = _current_exec.get()
-        if exec_id is not None:
-            with self._registry_lock:
-                if exec_id in self._groups:
-                    return exec_id
-            # Ambient id names no live group — fall through to open a fresh scope.
-        return self.begin_execution()
 
     def end_execution(self, exec_id: Optional[str] = None) -> bool:
         """Drop the current execution's secrets. Returns True if other
@@ -249,33 +262,60 @@ class SecretRegistry:
             self._rebuild_locked()
             return bool(active)
 
-    def _current_group_locked(self) -> Dict[str, str]:
-        exec_id = _current_exec.get() or _GLOBAL_GROUP
-        return self._groups.setdefault(exec_id, {})
+    def _current_group_locked(self, exec_id: Optional[str]) -> Dict[str, _GroupEntry]:
+        if exec_id is not None:
+            return self._groups.setdefault(exec_id, {})
+        ambient = _current_exec.get()
+        if ambient is not None and ambient in self._groups:
+            return self._groups[ambient]
+        return self._groups.setdefault(_GLOBAL_GROUP, {})
 
     def _rebuild_locked(self) -> None:
         """Recompute the union + reverse index from all groups and publish them
-        atomically. Called only by writers holding the lock."""
+        atomically. Called only by writers holding the lock, on removals
+        (end_execution/clear). Admits use the incremental _publish_incremental
+        path instead, so this O(n) walk runs only when secrets actually leave
+        the registry — not on every admit.
+        """
         secrets: Dict[str, str] = {}
         name_to_value: Dict[str, str] = {}
         for group in self._groups.values():
-            for raw_value, name in group.items():
-                name_to_value[name] = raw_value
-                for key in _expand_keys(raw_value):
-                    secrets.setdefault(key, name)
+            for raw_value, entry in group.items():
+                name_to_value.setdefault(entry.name, raw_value)
+                for key in entry.expanded:
+                    secrets.setdefault(key, entry.name)
         self._secrets = secrets
         self._name_to_value = name_to_value
         self._version += 1
-        # Reset _capacity_warned on the condition (at capacity), not the
-        # event (a warning fired). When executions end and free room, this
-        # self-corrects so the next capacity rise can warn again; without
-        # it, _capacity_warned would stay True forever after the first
-        # warning and the real warning would be permanently suppressed.
-        # With the >= admit check the union stays under MAX_SECRETS, so
-        # this is False after admits; _warn_capacity sets the flag True
-        # between rebuilds, suppressing repeats until the next rebuild
-        # (admit or end_execution).
+        # The admit check rejects on >= MAX_SECRETS, so the union never reaches
+        # MAX_SECRETS — this is always False after a rebuild. Clearing here is
+        # belt-and-braces: if a future path sets _capacity_warned without going
+        # through _warn_capacity, dropping below capacity still self-corrects.
+        # Effective capacity is MAX_SECRETS - 1 (the >= leaves no room for the
+        # last admit); a batch that fills to exactly MAX_SECRETS - 1 does not
+        # trip the warning, which is correct (it fit).
         self._capacity_warned = len(self._secrets) >= self.MAX_SECRETS
+
+    def _publish_incremental(
+        self,
+        new_keys: Dict[str, str],
+        new_name_to_value: Dict[str, str],
+    ) -> None:
+        """Publish only the newly-admitted keys by merging into fresh dicts.
+
+        COW contract: readers see an immutable snapshot, so we build a new
+        dict (``{**old, **new}``) and swap it in atomically (pointer
+        reassignment under the GIL). The merge is O(len(old) + len(new)) at C
+        speed, so n admits are O(n) total — matching the fork-point
+        implementation. The full O(n) walk (_rebuild_locked) is reserved for
+        removals, which are rare. ``new_keys`` are only the truly-new expanded
+        keys (already deduped against ``_secrets`` by _admit_locked), so the
+        merge never overwrites an existing key — first registration wins the
+        name, matching _rebuild_locked's setdefault semantics.
+        """
+        self._secrets = {**self._secrets, **new_keys}
+        self._name_to_value = {**self._name_to_value, **new_name_to_value}
+        self._version += 1
 
     # --- Registration (writers) --------------------------------------------
 
@@ -298,13 +338,13 @@ class SecretRegistry:
         self,
         variable_name: str,
         raw_value: str,
-        group: Dict[str, str],
+        group: Dict[str, _GroupEntry],
         pending_keys: set,
-    ) -> _Admit:
+    ) -> Tuple[_Admit, FrozenSet[str]]:
         """Admit one secret against the registry, capacity, and batch state.
 
         Called by register_secret / register_secrets_batch with the
-        registry lock held. Returns:
+        registry lock held. Returns ``(result, truly_new_keys)``:
 
         - DUPLICATE: the raw value is already in this execution's group, or
           already pending in the current batch (dedup across the batch).
@@ -314,41 +354,47 @@ class SecretRegistry:
           responsible for warning via ``_warn_capacity``; this method does
           not touch ``_capacity_warned`` so the gate stays in one place.
           The capacity bound is on expanded keys (raw + repr + sqlalchemy +
-          json variants), not on the number of registered secrets —
-          counting secrets instead (the old behavior) let a batch of
-          multi-key-expanding values overshoot MAX_SECRETS, which is the
-          unit mismatch this fixes.
-        - ADMITTED: the secret was added to ``group`` and its truly-new
-          expanded keys to ``pending_keys``.
+          json variants), not on the number of registered secrets — counting
+          secrets instead let a batch of multi-key-expanding values overshoot
+          MAX_SECRETS.
+        - ADMITTED: the secret was added to ``group``; ``truly_new_keys`` is
+          the set of expanded keys not already in ``_secrets`` or
+          ``pending_keys`` (the caller publishes them).
 
-        Mutates ``pending_keys``: unioned with the truly-new keys so the
-        batch loop dedup-counts within the batch. The single path passes a
-        throwaway ``set()``, so the mutation is harmless there; the batch
-        path passes a persistent set so successive calls see prior admits.
-        A helper that mutates an argument is easy to misuse later — keep
-        this contract in the docstring.
+        ``pending_keys`` is mutated (unioned with truly_new) so the batch
+        loop dedup-counts within the batch. The single path passes a
+        throwaway ``set()``, so the mutation is harmless; the batch path
+        passes a persistent set so successive calls see prior admits.
         """
         if raw_value in group or raw_value in pending_keys:
-            return _Admit.DUPLICATE
+            return _Admit.DUPLICATE, frozenset()
         keys = _expand_keys(raw_value)
-        truly_new = set(keys) - self._secrets.keys() - pending_keys
+        truly_new = frozenset(set(keys) - self._secrets.keys() - pending_keys)
         if len(self._secrets) + len(pending_keys) + len(truly_new) >= self.MAX_SECRETS:
-            return _Admit.REJECTED
-        group[raw_value] = variable_name
+            return _Admit.REJECTED, frozenset()
+        group[raw_value] = _GroupEntry(name=variable_name, expanded=keys)
         pending_keys |= truly_new
-        return _Admit.ADMITTED
+        return _Admit.ADMITTED, truly_new
 
-    def register_secret(self, variable_name: str, raw_value: str) -> None:
-        """Register a secret for masking under the current execution.
+    def register_secret(
+        self,
+        variable_name: str,
+        raw_value: str,
+        exec_id: Optional[str] = None,
+    ) -> None:
+        """Register a secret for masking.
 
-        The secret is owned by the ambient execution scope (set by
-        ``begin_execution``/``ensure_execution``). Secrets registered from a
-        thread/context that never opened an execution scope land in the
-        ``__global__`` catch-all bucket, which is dropped only when no real
-        executions remain — so in a long-lived worker that registers from a
-        non-execution context, those secrets accumulate for the process
-        lifetime (fails safe: over-masking, never leaking). Register from the
-        execution's own context to get per-execution cleanup.
+        With ``exec_id`` (the token returned by ``initialize_secret_masking``),
+        the secret lands in that execution's scope — this is how a worker
+        thread registers into a parent execution's scope, since ContextVars
+        do not cross thread boundaries. Without ``exec_id``, the secret lands
+        in the ambient context's scope (set by ``begin_execution``); if the
+        ambient context opened no scope it lands in the ``__global__`` catch-all
+        bucket, which is dropped only when no real executions remain — so in
+        a long-lived worker that registers from a non-execution context, those
+        secrets accumulate for the process lifetime (fails safe: over-masking,
+        never leaking). Pass the parent execution's ``exec_id`` to get
+        per-execution cleanup across threads.
         """
         if not raw_value or not isinstance(raw_value, str):
             return
@@ -356,10 +402,15 @@ class SecretRegistry:
             return
 
         with self._registry_lock:
-            group = self._current_group_locked()
-            result = self._admit_locked(variable_name, raw_value, group, set())
+            group = self._current_group_locked(exec_id)
+            result, truly_new = self._admit_locked(
+                variable_name, raw_value, group, set()
+            )
             if result is _Admit.ADMITTED:
-                self._rebuild_locked()
+                self._publish_incremental(
+                    {k: variable_name for k in truly_new},
+                    {variable_name: raw_value},
+                )
                 logger.debug(
                     f"Registered secret: {variable_name[:8]}*** (version {self._version})"
                 )
@@ -369,8 +420,12 @@ class SecretRegistry:
                     f"Skipping registration of {variable_name}"
                 )
 
-    def register_secrets_batch(self, secrets: Dict[str, str]) -> None:
-        """Register multiple secrets atomically under the current execution."""
+    def register_secrets_batch(
+        self,
+        secrets: Dict[str, str],
+        exec_id: Optional[str] = None,
+    ) -> None:
+        """Register multiple secrets atomically under one execution scope."""
         if not secrets:
             return
         valid_secrets = {
@@ -382,17 +437,21 @@ class SecretRegistry:
             return
 
         with self._registry_lock:
-            group = self._current_group_locked()
+            group = self._current_group_locked(exec_id)
             pending_keys: set = set()
             admitted = 0
             duplicates = 0
             rejected = 0
+            new_keys: Dict[str, str] = {}
+            new_name_to_value: Dict[str, str] = {}
             for variable_name, raw_value in valid_secrets.items():
-                result = self._admit_locked(
+                result, truly_new = self._admit_locked(
                     variable_name, raw_value, group, pending_keys
                 )
                 if result is _Admit.ADMITTED:
                     admitted += 1
+                    new_keys.update({k: variable_name for k in truly_new})
+                    new_name_to_value[variable_name] = raw_value
                 elif result is _Admit.DUPLICATE:
                     duplicates += 1
                 else:
@@ -409,7 +468,7 @@ class SecretRegistry:
                 )
 
             if admitted > 0:
-                self._rebuild_locked()
+                self._publish_incremental(new_keys, new_name_to_value)
             logger.debug(
                 f"Batch result: admitted {admitted}, duplicates {duplicates}, "
                 f"rejected {rejected} (version {self._version})"

--- a/metadata-ingestion/src/datahub/masking/secret_registry.py
+++ b/metadata-ingestion/src/datahub/masking/secret_registry.py
@@ -153,6 +153,13 @@ class SecretRegistry:
 
             if _mf._installed_filter is not None:
                 _mf.uninstall_masking_filter()
+            # Clear the bootstrap-completed latch so the next
+            # initialize_secret_masking() re-installs instead of
+            # short-circuiting on a stranded True. The lazy import avoids a
+            # circular dependency (bootstrap imports this module).
+            from datahub.masking import bootstrap as _boot
+
+            _boot.reset_bootstrap_state()
         except Exception as e:
             # Don't let a teardown failure prevent the singleton reset, but
             # don't swallow it silently either — masking would stay installed
@@ -176,10 +183,21 @@ class SecretRegistry:
     def ensure_execution(self) -> str:
         """Open a secret scope for the current context only if it doesn't already
         have one; returns the active execution id. Idempotent within a context,
-        so a repeated initialize_secret_masking() won't start a second scope."""
+        so a repeated initialize_secret_masking() won't start a second scope.
+
+        Revalidates the ambient id against ``_groups``: a token-based
+        ``end_execution`` from another thread drops the group but leaves this
+        context's contextvar pointing at the dead id (end_execution only clears
+        the ambient contextvar when it matches the *ending* context's). Without
+        revalidation, this would return the stale id and recreate a scope under
+        a dead id, so a later token holder would target the wrong scope.
+        """
         exec_id = _current_exec.get()
         if exec_id is not None:
-            return exec_id
+            with self._registry_lock:
+                if exec_id in self._groups:
+                    return exec_id
+            # Ambient id names no live group — fall through to open a fresh scope.
         return self.begin_execution()
 
     def end_execution(self, exec_id: Optional[str] = None) -> bool:
@@ -257,6 +275,7 @@ class SecretRegistry:
         raw_value: str,
         group: Dict[str, str],
         pending_keys: set,
+        warn: bool = True,
     ) -> _Admit:
         """Admit one secret against the registry, capacity, and batch state.
 
@@ -296,10 +315,17 @@ class SecretRegistry:
         truly_new = set(keys) - self._secrets.keys() - pending_keys
         if len(self._secrets) + len(pending_keys) + len(truly_new) >= self.MAX_SECRETS:
             if not self._capacity_warned:
-                logger.warning(
-                    f"Secret registry at capacity ({self.MAX_SECRETS}). "
-                    f"Skipping registration of {variable_name}"
-                )
+                # ``warn=False`` lets the batch path suppress the per-secret
+                # warning and emit one summary warning with the rejected count
+                # after the loop (an operator otherwise sees only one variable
+                # name with no indication of how many others were dropped).
+                # _capacity_warned is set regardless so the episode still
+                # suppresses repeats.
+                if warn:
+                    logger.warning(
+                        f"Secret registry at capacity ({self.MAX_SECRETS}). "
+                        f"Skipping registration of {variable_name}"
+                    )
                 self._capacity_warned = True
             return _Admit.REJECTED
         group[raw_value] = variable_name
@@ -350,9 +376,13 @@ class SecretRegistry:
             admitted = 0
             duplicates = 0
             rejected = 0
+            # Suppress the per-secret warning for batches; emit one summary
+            # warning with the rejected count after the loop so an operator
+            # sees the blast radius, not just one variable name.
+            warned_before = self._capacity_warned
             for variable_name, raw_value in valid_secrets.items():
                 result = self._admit_locked(
-                    variable_name, raw_value, group, pending_keys
+                    variable_name, raw_value, group, pending_keys, warn=False
                 )
                 if result is _Admit.ADMITTED:
                     admitted += 1
@@ -360,6 +390,12 @@ class SecretRegistry:
                     duplicates += 1
                 else:
                     rejected += 1
+
+            if rejected > 0 and not warned_before:
+                logger.warning(
+                    f"Secret registry at capacity ({self.MAX_SECRETS}). "
+                    f"Skipped {rejected} of {len(valid_secrets)} secret(s) in batch."
+                )
 
             if admitted > 0:
                 self._rebuild_locked()

--- a/metadata-ingestion/src/datahub/masking/secret_registry.py
+++ b/metadata-ingestion/src/datahub/masking/secret_registry.py
@@ -34,6 +34,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Dict, FrozenSet, Optional, Tuple
 
+from datahub.masking.constants import REDACTED_FORMAT
 from datahub.masking.logging_utils import get_masking_safe_logger
 
 logger = get_masking_safe_logger(__name__)
@@ -193,12 +194,18 @@ class SecretRegistry:
                 # Internal caller: bypass the public guard (reset_instance is
                 # tearing down the whole registry, so scopes are going away).
                 _mf._uninstall_masking_filter()
-            # Clear the bootstrap-completed latch so the next
-            # initialize_secret_masking() re-installs instead of
-            # short-circuiting on a stranded True. The lazy import avoids a
-            # circular dependency (bootstrap imports this module).
+            # Restore the excepthook too. ``shutdown_secret_masking`` may have
+            # skipped teardown (peer execution still active on another thread),
+            # leaving us as the only path that drops the filter — without this
+            # call, a hook bound to a dead registry would survive for the rest
+            # of the session. The lazy import avoids a circular dependency
+            # (bootstrap imports this module).
             from datahub.masking import bootstrap as _boot
 
+            _boot._restore_exception_hook()
+            # Clear the bootstrap-completed latch so the next
+            # initialize_secret_masking() re-installs instead of
+            # short-circuiting on a stranded True.
             _boot.reset_bootstrap_state()
         except Exception as e:
             # Don't let a teardown failure prevent the singleton reset, but
@@ -214,15 +221,22 @@ class SecretRegistry:
         Always opens a *distinct* scope — two ``initialize_secret_masking()``
         calls on the same context return different tokens and own different
         groups, so ending one never drops the other's secrets. The ambient
-        contextvar is set to this scope; a later ``begin_execution`` on the
-        same context overwrites it (the latest scope owns ambient
-        registrations), but the earlier token stays valid for its own
-        token-based ``end_execution``.
+        contextvar is set to this scope under ``_registry_lock`` so the
+        contextvar and the ``_groups`` entry are published atomically w.r.t.
+        a concurrent ``register_secret`` on the same thread: without this,
+        ``_current_group_locked`` could read the new ambient via
+        ``_current_exec.get()`` but find the group missing from ``_groups``
+        (the ``setdefault`` hadn't run yet) and route the registration to
+        ``__global__`` instead of the execution's scope — leaking it past
+        the execution's teardown. A later ``begin_execution`` on the same
+        context overwrites the ambient contextvar (the latest scope owns
+        ambient registrations), but the earlier token stays valid for its
+        own token-based ``end_execution``.
         """
         exec_id = uuid.uuid4().hex
         with self._registry_lock:
             self._groups.setdefault(exec_id, {})
-        _current_exec.set(exec_id)
+            _current_exec.set(exec_id)
         return exec_id
 
     def end_execution(self, exec_id: Optional[str] = None) -> bool:
@@ -397,13 +411,56 @@ class SecretRegistry:
         secrets accumulate for the process lifetime (fails safe: over-masking,
         never leaking). Pass the parent execution's ``exec_id`` to get
         per-execution cleanup across threads.
+
+        Validation (finding 12): a value below the 3-char floor is refused with
+        a warning (previously silently dropped, so a misconfigured recipe with
+        a 2-char password got no signal). A value that exactly equals a marker
+        for a *registered name* (``***REDACTED:NAME***``) is refused loudly —
+        this is "route A": the marker alternative must win for masking to
+        terminate, so such a value would pass through in cleartext. Refusing
+        it at registration closes the hole at the source rather than relying
+        on the masking callback to notice.
         """
         if not raw_value or not isinstance(raw_value, str):
             return
         if len(raw_value) < 3:
+            logger.warning(
+                f"Refusing to register secret {variable_name}: value is below "
+                f"the 3-character minimum floor ({len(raw_value)} chars). "
+                f"Short values are not registered because they produce too "
+                f"many false positives in masking. Check the recipe configuration."
+            )
             return
 
         with self._registry_lock:
+            # Route-A check: refuse a value that exactly equals a marker for a
+            # registered name. The marker alternative must win for masking to
+            # terminate (see _check_and_rebuild_pattern), so such a value would
+            # pass through in cleartext. Check against the current name set
+            # (including this call's name, so registering a marker for one's
+            # own name is also refused).
+            marker_for_this_name = REDACTED_FORMAT.format(name=variable_name)
+            if raw_value == marker_for_this_name:
+                logger.warning(
+                    f"Refusing to register secret {variable_name}: value is "
+                    f"the redaction marker for this very name "
+                    f"({marker_for_this_name}). The marker must win over the "
+                    f"value for masking to terminate, so this value would pass "
+                    f"through in cleartext. Rename the variable or change the "
+                    f"value."
+                )
+                return
+            for existing_name in self._name_to_value:
+                if raw_value == REDACTED_FORMAT.format(name=existing_name):
+                    logger.warning(
+                        f"Refusing to register secret {variable_name}: value "
+                        f"is the redaction marker for registered name "
+                        f"{existing_name!r}. The marker must win over the "
+                        f"value for masking to terminate, so this value would "
+                        f"pass through in cleartext."
+                    )
+                    return
+
             group = self._current_group_locked(exec_id)
             result, truly_new = self._admit_locked(
                 variable_name, raw_value, group, set()

--- a/metadata-ingestion/src/datahub/masking/secret_registry.py
+++ b/metadata-ingestion/src/datahub/masking/secret_registry.py
@@ -262,12 +262,27 @@ class SecretRegistry:
         # it, _capacity_warned would stay True forever after the first
         # warning and the real warning would be permanently suppressed.
         # With the >= admit check the union stays under MAX_SECRETS, so
-        # this is False after admits; the warning itself sets the flag
-        # True between rebuilds, suppressing repeats until the next
-        # rebuild (admit or end_execution).
+        # this is False after admits; _warn_capacity sets the flag True
+        # between rebuilds, suppressing repeats until the next rebuild
+        # (admit or end_execution).
         self._capacity_warned = len(self._secrets) >= self.MAX_SECRETS
 
     # --- Registration (writers) --------------------------------------------
+
+    def _warn_capacity(self, message: str) -> None:
+        """Emit a capacity warning once per episode.
+
+        Single enforcement point for the ``_capacity_warned`` gate: this is
+        the only place that reads the flag to decide whether to warn and sets
+        it after warning. ``_rebuild_locked`` clears the flag when the
+        registry drops below capacity so a later rise can warn again; nothing
+        else touches it. Centralising the gate here avoids the duplicated-
+        guard structure that caused the original capacity bug (two call sites
+        each getting the accounting right and drifting).
+        """
+        if not self._capacity_warned:
+            logger.warning(message)
+            self._capacity_warned = True
 
     def _admit_locked(
         self,
@@ -275,7 +290,6 @@ class SecretRegistry:
         raw_value: str,
         group: Dict[str, str],
         pending_keys: set,
-        warn: bool = True,
     ) -> _Admit:
         """Admit one secret against the registry, capacity, and batch state.
 
@@ -286,17 +300,12 @@ class SecretRegistry:
           already pending in the current batch (dedup across the batch).
           Not a warning condition — duplicate registration is common.
         - REJECTED: admitting would push the *expanded* key count
-          (``len(self._secrets)``) to >= MAX_SECRETS. Warns, gated by
-          ``_capacity_warned`` to suppress repeats within a capacity
-          episode; ``_rebuild_locked`` clears the flag when the registry
-          drops below capacity so a later rise can warn again. In
-          practice this is one warning per capacity episode; an admit
-          interleaved with rejects can reset the flag, but admits at
-          capacity require a secret whose expanded keys are all already
-          present (``truly_new`` empty), which is rare. The capacity
-          bound is on expanded keys (raw + repr + sqlalchemy + json
-          variants), not on the number of registered secrets — counting
-          secrets instead (the old behavior) let a batch of
+          (``len(self._secrets)``) to >= MAX_SECRETS. The caller is
+          responsible for warning via ``_warn_capacity``; this method does
+          not touch ``_capacity_warned`` so the gate stays in one place.
+          The capacity bound is on expanded keys (raw + repr + sqlalchemy +
+          json variants), not on the number of registered secrets —
+          counting secrets instead (the old behavior) let a batch of
           multi-key-expanding values overshoot MAX_SECRETS, which is the
           unit mismatch this fixes.
         - ADMITTED: the secret was added to ``group`` and its truly-new
@@ -314,19 +323,6 @@ class SecretRegistry:
         keys = _expand_keys(raw_value)
         truly_new = set(keys) - self._secrets.keys() - pending_keys
         if len(self._secrets) + len(pending_keys) + len(truly_new) >= self.MAX_SECRETS:
-            if not self._capacity_warned:
-                # ``warn=False`` lets the batch path suppress the per-secret
-                # warning and emit one summary warning with the rejected count
-                # after the loop (an operator otherwise sees only one variable
-                # name with no indication of how many others were dropped).
-                # _capacity_warned is set regardless so the episode still
-                # suppresses repeats.
-                if warn:
-                    logger.warning(
-                        f"Secret registry at capacity ({self.MAX_SECRETS}). "
-                        f"Skipping registration of {variable_name}"
-                    )
-                self._capacity_warned = True
             return _Admit.REJECTED
         group[raw_value] = variable_name
         pending_keys |= truly_new
@@ -357,6 +353,11 @@ class SecretRegistry:
                 logger.debug(
                     f"Registered secret: {variable_name[:8]}*** (version {self._version})"
                 )
+            elif result is _Admit.REJECTED:
+                self._warn_capacity(
+                    f"Secret registry at capacity ({self.MAX_SECRETS}). "
+                    f"Skipping registration of {variable_name}"
+                )
 
     def register_secrets_batch(self, secrets: Dict[str, str]) -> None:
         """Register multiple secrets atomically under the current execution."""
@@ -376,13 +377,9 @@ class SecretRegistry:
             admitted = 0
             duplicates = 0
             rejected = 0
-            # Suppress the per-secret warning for batches; emit one summary
-            # warning with the rejected count after the loop so an operator
-            # sees the blast radius, not just one variable name.
-            warned_before = self._capacity_warned
             for variable_name, raw_value in valid_secrets.items():
                 result = self._admit_locked(
-                    variable_name, raw_value, group, pending_keys, warn=False
+                    variable_name, raw_value, group, pending_keys
                 )
                 if result is _Admit.ADMITTED:
                     admitted += 1
@@ -391,8 +388,12 @@ class SecretRegistry:
                 else:
                     rejected += 1
 
-            if rejected > 0 and not warned_before:
-                logger.warning(
+            if rejected > 0:
+                # One summary warning with the rejected count so an operator
+                # sees the blast radius, not just one variable name.
+                # _warn_capacity owns the _capacity_warned gate, so this is
+                # the only place the batch path reads/sets the flag.
+                self._warn_capacity(
                     f"Secret registry at capacity ({self.MAX_SECRETS}). "
                     f"Skipped {rejected} of {len(valid_secrets)} secret(s) in batch."
                 )

--- a/metadata-ingestion/src/datahub/masking/secret_registry.py
+++ b/metadata-ingestion/src/datahub/masking/secret_registry.py
@@ -144,6 +144,16 @@ class SecretRegistry:
         filter from handlers/root, so the next install doesn't attach a
         second filter alongside the stale one. The lazy import avoids a
         circular dependency (masking_filter imports this module).
+
+        ``_bootstrap_lock`` is deliberately NOT held here. ``shutdown_secret_masking()``
+        establishes the lock order ``_bootstrap_lock`` -> ``SecretRegistry._lock``
+        (it takes ``_bootstrap_lock`` first, then calls into the registry). Taking
+        ``_bootstrap_lock`` here would invert that order against a concurrent
+        ``shutdown_secret_masking()`` that already holds it and is waiting on
+        ``SecretRegistry._lock`` — a classic lock-order-inversion deadlock.
+        The teardown below is safe to run without ``_bootstrap_lock`` because
+        ``reset_instance`` is a test/dev seam, not a production teardown path,
+        and ``uninstall_masking_filter()`` is idempotent and self-guarding.
         """
         with cls._lock:
             cls._instance = None

--- a/metadata-ingestion/src/datahub/masking/secret_registry.py
+++ b/metadata-ingestion/src/datahub/masking/secret_registry.py
@@ -131,8 +131,11 @@ class SecretRegistry:
 
             if _mf._installed_filter is not None:
                 _mf.uninstall_masking_filter()
-        except Exception:
-            pass
+        except Exception as e:
+            # Don't let a teardown failure prevent the singleton reset, but
+            # don't swallow it silently either — masking would stay installed
+            # against a dead registry with no signal.
+            logger.debug("reset_instance: filter teardown failed: %r", e)
 
     # --- Execution scoping (writers) ---------------------------------------
 

--- a/metadata-ingestion/src/datahub/masking/secret_registry.py
+++ b/metadata-ingestion/src/datahub/masking/secret_registry.py
@@ -190,7 +190,9 @@ class SecretRegistry:
             from datahub.masking import masking_filter as _mf
 
             if _mf._installed_filter is not None:
-                _mf.uninstall_masking_filter()
+                # Internal caller: bypass the public guard (reset_instance is
+                # tearing down the whole registry, so scopes are going away).
+                _mf._uninstall_masking_filter()
             # Clear the bootstrap-completed latch so the next
             # initialize_secret_masking() re-installs instead of
             # short-circuiting on a stranded True. The lazy import avoids a
@@ -488,6 +490,18 @@ class SecretRegistry:
     def get_count(self) -> int:
         """Number of distinct secret keys currently masked (the union)."""
         return len(self._secrets)
+
+    def has_active_executions(self) -> bool:
+        """True if any per-execution scope is currently open.
+
+        Used by the public ``uninstall_masking_filter`` guard so a direct
+        call does not disarm masking process-wide while live executions
+        still have secrets registered. ``__global__`` (the catch-all for
+        ambient registrations with no exec_id) does not count as an active
+        execution — it is the residual bucket, not a scope.
+        """
+        with self._registry_lock:
+            return any(g != _GLOBAL_GROUP for g in self._groups)
 
     def clear(self) -> None:
         """Drop all secrets from all executions (primarily for tests)."""

--- a/metadata-ingestion/src/datahub/masking/secret_registry.py
+++ b/metadata-ingestion/src/datahub/masking/secret_registry.py
@@ -238,11 +238,15 @@ class SecretRegistry:
         self._secrets = secrets
         self._name_to_value = name_to_value
         self._version += 1
-        # Reset on the condition (at capacity), not the event (a warning
-        # fired). If executions end and free room without draining to zero,
-        # this self-corrects so the next capacity rise can warn again;
-        # without it, _capacity_warned would stay True forever after the
-        # first warning and the real warning would be permanently suppressed.
+        # Reset _capacity_warned on the condition (at capacity), not the
+        # event (a warning fired). When executions end and free room, this
+        # self-corrects so the next capacity rise can warn again; without
+        # it, _capacity_warned would stay True forever after the first
+        # warning and the real warning would be permanently suppressed.
+        # With the >= admit check the union stays under MAX_SECRETS, so
+        # this is False after admits; the warning itself sets the flag
+        # True between rebuilds, suppressing repeats until the next
+        # rebuild (admit or end_execution).
         self._capacity_warned = len(self._secrets) >= self.MAX_SECRETS
 
     # --- Registration (writers) --------------------------------------------
@@ -263,12 +267,19 @@ class SecretRegistry:
           already pending in the current batch (dedup across the batch).
           Not a warning condition — duplicate registration is common.
         - REJECTED: admitting would push the *expanded* key count
-          (``len(self._secrets)``) to >= MAX_SECRETS. Warns once per rise
-          to capacity via ``_capacity_warned``. The capacity bound is on
-          expanded keys (raw + repr + sqlalchemy + json variants), not on
-          the number of registered secrets — counting secrets instead
-          (the old behavior) let a batch of multi-key-expanding values
-          overshoot MAX_SECRETS, which is the unit mismatch this fixes.
+          (``len(self._secrets)``) to >= MAX_SECRETS. Warns, gated by
+          ``_capacity_warned`` to suppress repeats within a capacity
+          episode; ``_rebuild_locked`` clears the flag when the registry
+          drops below capacity so a later rise can warn again. In
+          practice this is one warning per capacity episode; an admit
+          interleaved with rejects can reset the flag, but admits at
+          capacity require a secret whose expanded keys are all already
+          present (``truly_new`` empty), which is rare. The capacity
+          bound is on expanded keys (raw + repr + sqlalchemy + json
+          variants), not on the number of registered secrets — counting
+          secrets instead (the old behavior) let a batch of
+          multi-key-expanding values overshoot MAX_SECRETS, which is the
+          unit mismatch this fixes.
         - ADMITTED: the secret was added to ``group`` and its truly-new
           expanded keys to ``pending_keys``.
 
@@ -282,7 +293,7 @@ class SecretRegistry:
         if raw_value in group or raw_value in pending_keys:
             return _Admit.DUPLICATE
         keys = _expand_keys(raw_value)
-        truly_new = set(keys) - set(self._secrets) - pending_keys
+        truly_new = set(keys) - self._secrets.keys() - pending_keys
         if len(self._secrets) + len(pending_keys) + len(truly_new) >= self.MAX_SECRETS:
             if not self._capacity_warned:
                 logger.warning(

--- a/metadata-ingestion/src/datahub/masking/secret_registry.py
+++ b/metadata-ingestion/src/datahub/masking/secret_registry.py
@@ -22,6 +22,7 @@ import os
 import threading
 import uuid
 from contextvars import ContextVar
+from enum import Enum, auto
 from typing import Dict, Optional
 
 from datahub.masking.logging_utils import get_masking_safe_logger
@@ -35,6 +36,22 @@ _GLOBAL_GROUP = "__global__"
 # Identifies the execution registering/owning secrets in the current context.
 # Set by begin_execution(), read by register_secret() and end_execution().
 _current_exec: ContextVar[Optional[str]] = ContextVar("masking_exec_id", default=None)
+
+
+class _Admit(Enum):
+    """Tri-state result of admitting one secret against the registry.
+
+    A bool (``admitted``) would conflate "duplicate" with "at capacity" —
+    both are non-admitting, but only "at capacity" is a warning condition.
+    Conflating them makes duplicate registrations (common: the same value
+    read twice, or the same recipe's secrets re-registered per execution)
+    emit spurious "at capacity" warnings and permanently suppress the real
+    one via _capacity_warned. Count and warn only on REJECTED.
+    """
+
+    ADMITTED = auto()
+    DUPLICATE = auto()
+    REJECTED = auto()
 
 
 def is_masking_enabled() -> bool:
@@ -99,6 +116,11 @@ class SecretRegistry:
         self._version = 0
         # Serializes writers only; readers are lock-free.
         self._registry_lock = threading.RLock()
+        # True once we've warned about being at capacity; reset by
+        # _rebuild_locked on the condition (count >= MAX) so a capacity
+        # warning fires once per rise to capacity, not once per call, and
+        # can fire again after executions end and free room.
+        self._capacity_warned = False
 
     @classmethod
     def get_instance(cls) -> "SecretRegistry":
@@ -216,8 +238,62 @@ class SecretRegistry:
         self._secrets = secrets
         self._name_to_value = name_to_value
         self._version += 1
+        # Reset on the condition (at capacity), not the event (a warning
+        # fired). If executions end and free room without draining to zero,
+        # this self-corrects so the next capacity rise can warn again;
+        # without it, _capacity_warned would stay True forever after the
+        # first warning and the real warning would be permanently suppressed.
+        self._capacity_warned = len(self._secrets) >= self.MAX_SECRETS
 
     # --- Registration (writers) --------------------------------------------
+
+    def _admit_locked(
+        self,
+        variable_name: str,
+        raw_value: str,
+        group: Dict[str, str],
+        pending_keys: set,
+    ) -> _Admit:
+        """Admit one secret against the registry, capacity, and batch state.
+
+        Called by register_secret / register_secrets_batch with the
+        registry lock held. Returns:
+
+        - DUPLICATE: the raw value is already in this execution's group, or
+          already pending in the current batch (dedup across the batch).
+          Not a warning condition — duplicate registration is common.
+        - REJECTED: admitting would push the *expanded* key count
+          (``len(self._secrets)``) to >= MAX_SECRETS. Warns once per rise
+          to capacity via ``_capacity_warned``. The capacity bound is on
+          expanded keys (raw + repr + sqlalchemy + json variants), not on
+          the number of registered secrets — counting secrets instead
+          (the old behavior) let a batch of multi-key-expanding values
+          overshoot MAX_SECRETS, which is the unit mismatch this fixes.
+        - ADMITTED: the secret was added to ``group`` and its truly-new
+          expanded keys to ``pending_keys``.
+
+        Mutates ``pending_keys``: unioned with the truly-new keys so the
+        batch loop dedup-counts within the batch. The single path passes a
+        throwaway ``set()``, so the mutation is harmless there; the batch
+        path passes a persistent set so successive calls see prior admits.
+        A helper that mutates an argument is easy to misuse later — keep
+        this contract in the docstring.
+        """
+        if raw_value in group or raw_value in pending_keys:
+            return _Admit.DUPLICATE
+        keys = _expand_keys(raw_value)
+        truly_new = set(keys) - set(self._secrets) - pending_keys
+        if len(self._secrets) + len(pending_keys) + len(truly_new) >= self.MAX_SECRETS:
+            if not self._capacity_warned:
+                logger.warning(
+                    f"Secret registry at capacity ({self.MAX_SECRETS}). "
+                    f"Skipping registration of {variable_name}"
+                )
+                self._capacity_warned = True
+            return _Admit.REJECTED
+        group[raw_value] = variable_name
+        pending_keys |= truly_new
+        return _Admit.ADMITTED
 
     def register_secret(self, variable_name: str, raw_value: str) -> None:
         """Register a secret for masking under the current execution.
@@ -238,19 +314,12 @@ class SecretRegistry:
 
         with self._registry_lock:
             group = self._current_group_locked()
-            if raw_value in group:
-                return
-            if len(self._secrets) >= self.MAX_SECRETS:
-                logger.warning(
-                    f"Secret registry at capacity ({self.MAX_SECRETS}). "
-                    f"Skipping registration of {variable_name}"
+            result = self._admit_locked(variable_name, raw_value, group, set())
+            if result is _Admit.ADMITTED:
+                self._rebuild_locked()
+                logger.debug(
+                    f"Registered secret: {variable_name[:8]}*** (version {self._version})"
                 )
-                return
-            group[raw_value] = variable_name
-            self._rebuild_locked()
-            logger.debug(
-                f"Registered secret: {variable_name[:8]}*** (version {self._version})"
-            )
 
     def register_secrets_batch(self, secrets: Dict[str, str]) -> None:
         """Register multiple secrets atomically under the current execution."""
@@ -266,24 +335,27 @@ class SecretRegistry:
 
         with self._registry_lock:
             group = self._current_group_locked()
-            added_count = 0
+            pending_keys: set = set()
+            admitted = 0
+            duplicates = 0
+            rejected = 0
             for variable_name, raw_value in valid_secrets.items():
-                if raw_value in group:
-                    continue
-                if len(self._secrets) + added_count >= self.MAX_SECRETS:
-                    logger.warning(
-                        f"Secret registry at capacity ({self.MAX_SECRETS}). "
-                        f"Skipping registration of {variable_name}"
-                    )
-                    break
-                group[raw_value] = variable_name
-                added_count += 1
-
-            if added_count > 0:
-                self._rebuild_locked()
-                logger.debug(
-                    f"Batch registered {added_count} secrets (version {self._version})"
+                result = self._admit_locked(
+                    variable_name, raw_value, group, pending_keys
                 )
+                if result is _Admit.ADMITTED:
+                    admitted += 1
+                elif result is _Admit.DUPLICATE:
+                    duplicates += 1
+                else:
+                    rejected += 1
+
+            if admitted > 0:
+                self._rebuild_locked()
+            logger.debug(
+                f"Batch result: admitted {admitted}, duplicates {duplicates}, "
+                f"rejected {rejected} (version {self._version})"
+            )
 
     # --- Reads (lock-free; the masking hot path) ---------------------------
 

--- a/metadata-ingestion/src/datahub/masking/secret_registry.py
+++ b/metadata-ingestion/src/datahub/masking/secret_registry.py
@@ -17,6 +17,7 @@ atomically swap in freshly-built dicts; readers (the masking hot path) read thos
 immutable snapshots without a lock.
 """
 
+import json
 import os
 import threading
 import uuid
@@ -47,8 +48,14 @@ def is_masking_enabled() -> bool:
 def _expand_keys(raw_value: str) -> Dict[str, None]:
     """Return all string forms of a secret that should be masked.
 
-    Besides the raw value, this covers repr-escaped forms (for values with
-    escape sequences) and SQLAlchemy-style URL encoding of ``:@/``.
+    Besides the raw value, this covers:
+    - repr-escaped forms (for values with escape sequences)
+    - SQLAlchemy-style URL encoding of ``:@/``
+    - JSON-escaped forms (``json.dumps(v)[1:-1]``) — for secrets printed via
+      ``print(json.dumps(...))`` or emitted by a JSON formatter that serializes
+      before the masking filter sees the record. Extras on a LogRecord are
+      masked at filter time before formatting, so this is mainly for the
+      stdout/stderr wrapper path.
     """
     keys: Dict[str, None] = {raw_value: None}
     if any(c in raw_value for c in ["\n", "\r", "\t", "\\", '"', "'"]):
@@ -60,6 +67,12 @@ def _expand_keys(raw_value: str) -> Dict[str, None]:
     )
     if sqlalchemy_encoded != raw_value:
         keys[sqlalchemy_encoded] = None
+    # JSON-escaped form: json.dumps wraps in quotes and escapes inner chars.
+    # [1:-1] strips the surrounding quotes so we match the value as it appears
+    # inside a serialized object/string field.
+    json_inner = json.dumps(raw_value)[1:-1]
+    if json_inner != raw_value:
+        keys[json_inner] = None
     return keys
 
 
@@ -69,6 +82,10 @@ class SecretRegistry:
     _instance: Optional["SecretRegistry"] = None
     _lock = threading.RLock()
 
+    # Upper bound on the *expanded* key count (raw + repr + sqlalchemy + json
+    # variants per secret), not the number of registered secrets. Adding
+    # _expand_keys variants reduces how many distinct secrets fit; keep this
+    # bound generous because the masking regex is built from these keys.
     MAX_SECRETS = 10000
 
     def __init__(self):
@@ -121,14 +138,38 @@ class SecretRegistry:
             return exec_id
         return self.begin_execution()
 
-    def end_execution(self) -> bool:
+    def end_execution(self, exec_id: Optional[str] = None) -> bool:
         """Drop the current execution's secrets. Returns True if other
-        executions are still active (so the caller should NOT fully tear down)."""
-        exec_id = _current_exec.get()
-        _current_exec.set(None)
+        executions are still active (so the caller should NOT fully tear down).
+
+        If ``exec_id`` is provided, drop that specific execution's group —
+        this allows ``initialize_secret_masking`` and ``shutdown_secret_masking``
+        to be called from different threads/contexts (e.g. a dispatcher that
+        starts an execution on one thread and tears it down on another).
+        Without it, the ambient context's execution is dropped; if the
+        ambient context has no scope, this is a no-op and a debug is logged
+        (the signature of the cross-thread hole — a teardown caller that
+        forgot to pass the token).
+        """
+        ambient_exec_id = _current_exec.get()
+        if exec_id is None:
+            exec_id = ambient_exec_id
+        # Clear the ambient context's scope only if it matches the one we're
+        # ending; a token-based call from another thread must not clobber this
+        # thread's contextvar.
+        if ambient_exec_id is not None and exec_id == ambient_exec_id:
+            _current_exec.set(None)
         with self._registry_lock:
             if exec_id is not None:
                 self._groups.pop(exec_id, None)
+            elif ambient_exec_id is None:
+                logger.debug(
+                    "end_execution called with no ambient execution scope and "
+                    "no explicit exec_id; nothing to drop. If this is a "
+                    "shutdown call, the caller likely started the execution on "
+                    "another thread and should pass the token returned by "
+                    "initialize_secret_masking()."
+                )
             active = [g for g in self._groups if g != _GLOBAL_GROUP]
             if not active:
                 # No real executions left — drop the catch-all bucket too.
@@ -157,7 +198,17 @@ class SecretRegistry:
     # --- Registration (writers) --------------------------------------------
 
     def register_secret(self, variable_name: str, raw_value: str) -> None:
-        """Register a secret for masking under the current execution."""
+        """Register a secret for masking under the current execution.
+
+        The secret is owned by the ambient execution scope (set by
+        ``begin_execution``/``ensure_execution``). Secrets registered from a
+        thread/context that never opened an execution scope land in the
+        ``__global__`` catch-all bucket, which is dropped only when no real
+        executions remain — so in a long-lived worker that registers from a
+        non-execution context, those secrets accumulate for the process
+        lifetime (fails safe: over-masking, never leaking). Register from the
+        execution's own context to get per-execution cleanup.
+        """
         if not raw_value or not isinstance(raw_value, str):
             return
         if len(raw_value) < 3:

--- a/metadata-ingestion/tests/conftest.py
+++ b/metadata-ingestion/tests/conftest.py
@@ -22,6 +22,8 @@ os.environ["DATAHUB_REST_EMITTER_DEFAULT_RETRY_MAX_TIMES"] = "1"
 
 # We need our imports to go below the os.environ updates, since mere act
 # of importing some datahub modules will load env variables.
+from datahub.masking.bootstrap import shutdown_secret_masking  # noqa: E402
+from datahub.masking.secret_registry import SecretRegistry  # noqa: E402
 from datahub.testing.pytest_hooks import (  # noqa: F401,E402
     load_golden_flags,
     pytest_addoption,
@@ -42,6 +44,21 @@ _MOCK_TIME = 1615443388.0975091  # 2021-03-11 06:16:28.097509+00:00
 def mock_time():
     with time_machine.travel(_MOCK_TIME, tick=False):
         yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_secret_masking():
+    """Keep process-global secret masking from leaking across tests.
+
+    Masking installs a filter on every logging handler and populates a singleton
+    SecretRegistry. Tests that trigger it (the ingest CLI, initialize_secret_masking,
+    or SecretStr config validation) don't always tear it down, which would mask
+    later tests' captured log output. Reset after each test for isolation
+    (shutdown also clears bootstrap state so a later init re-installs cleanly).
+    """
+    yield
+    shutdown_secret_masking()
+    SecretRegistry.reset_instance()
 
 
 def pytest_ignore_collect(

--- a/metadata-ingestion/tests/conftest.py
+++ b/metadata-ingestion/tests/conftest.py
@@ -22,7 +22,10 @@ os.environ["DATAHUB_REST_EMITTER_DEFAULT_RETRY_MAX_TIMES"] = "1"
 
 # We need our imports to go below the os.environ updates, since mere act
 # of importing some datahub modules will load env variables.
-from datahub.masking.bootstrap import shutdown_secret_masking  # noqa: E402
+from datahub.masking.bootstrap import (  # noqa: E402
+    is_bootstrapped,
+    shutdown_secret_masking,
+)
 from datahub.masking.secret_registry import SecretRegistry  # noqa: E402
 from datahub.testing.pytest_hooks import (  # noqa: F401,E402
     load_golden_flags,
@@ -48,17 +51,14 @@ def mock_time():
 
 @pytest.fixture(autouse=True)
 def _reset_secret_masking():
-    """Keep process-global secret masking from leaking across tests.
-
-    Masking installs a filter on every logging handler and populates a singleton
-    SecretRegistry. Tests that trigger it (the ingest CLI, initialize_secret_masking,
-    or SecretStr config validation) don't always tear it down, which would mask
-    later tests' captured log output. Reset after each test for isolation
-    (shutdown also clears bootstrap state so a later init re-installs cleanly).
-    """
+    """Reset process-global secret masking after each test so it can't leak into
+    another test's caplog. Global because the leaking test (ingest CLI,
+    initialize_secret_masking, SecretStr validation) and the affected test are
+    usually in different files. No-op unless masking was actually active."""
     yield
-    shutdown_secret_masking()
-    SecretRegistry.reset_instance()
+    if is_bootstrapped() or SecretRegistry.get_instance().get_count() > 0:
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
 
 
 def pytest_ignore_collect(

--- a/metadata-ingestion/tests/conftest.py
+++ b/metadata-ingestion/tests/conftest.py
@@ -24,7 +24,6 @@ os.environ["DATAHUB_REST_EMITTER_DEFAULT_RETRY_MAX_TIMES"] = "1"
 # of importing some datahub modules will load env variables.
 from datahub.masking.bootstrap import (  # noqa: E402
     is_bootstrapped,
-    shutdown_secret_masking,
 )
 from datahub.masking.secret_registry import SecretRegistry  # noqa: E402
 from datahub.testing.pytest_hooks import (  # noqa: F401,E402
@@ -54,11 +53,33 @@ def _reset_secret_masking():
     """Reset process-global secret masking after each test so it can't leak into
     another test's caplog. Global because the leaking test (ingest CLI,
     initialize_secret_masking, SecretStr validation) and the affected test are
-    usually in different files. No-op unless masking was actually active."""
+    usually in different files. No-op unless masking was actually active.
+
+    Uses the force-teardown path (``_force_teardown_secret_masking``) rather
+    than ``shutdown_secret_masking()`` because the latter refuses to uninstall
+    while execution scopes are active (fail-safe in production). A test that
+    opened its scope on another thread leaves a peer group active; the
+    refcounted shutdown then skips teardown, and ``reset_instance`` would
+    drop the filter but leave ``sys.excepthook`` bound to a dead registry. The
+    force path tears down unconditionally and restores the excepthook, so a
+    leaked scope fails the assertion below loudly rather than silently
+    corrupting the next test.
+    """
     yield
     if is_bootstrapped() or SecretRegistry.get_instance().get_count() > 0:
-        shutdown_secret_masking()
+        from datahub.masking.bootstrap import _force_teardown_secret_masking
+
+        _force_teardown_secret_masking()
         SecretRegistry.reset_instance()
+        # A leaked scope (e.g. a test that opened an execution on another
+        # thread and never ended it) would leave the registry with active
+        # executions after teardown. Fail loudly so the leak is visible,
+        # not silently corrupting the next test's caplog.
+        registry = SecretRegistry.get_instance()
+        assert not registry.has_active_executions(), (
+            "leaked execution scope after test teardown — a test opened an "
+            "execution (possibly on another thread) and never ended it"
+        )
 
 
 def pytest_ignore_collect(

--- a/metadata-ingestion/tests/unit/test_bootstrap.py
+++ b/metadata-ingestion/tests/unit/test_bootstrap.py
@@ -178,12 +178,14 @@ class TestBootstrapErrorHandling:
         finally:
             shutdown_secret_masking()
 
-    def test_bootstrap_concurrent_with_force(self):
+    def test_concurrent_init_installs_filter_once(self):
         """
-        Verify thread safety when force=True is used.
+        Verify concurrent initialization installs the masking filter exactly once.
 
-        When force=True, initialization should run even if already completed,
-        but it should still be thread-safe (only one thread at a time).
+        The filter is installed once for the process lifetime — re-installing it
+        is what caused the original celery log-silencing bug, so `force` no longer
+        re-installs (it is a no-op kept for backward compatibility). The bootstrap
+        lock must make concurrent initialize calls safe and idempotent.
         """
         import threading
         import time
@@ -192,15 +194,11 @@ class TestBootstrapErrorHandling:
             initialize_secret_masking,
             shutdown_secret_masking,
         )
+        from datahub.masking.secret_registry import SecretRegistry
 
         try:
             shutdown_secret_masking()
 
-            # First initialization
-            with patch("datahub.masking.bootstrap.install_masking_filter"):
-                initialize_secret_masking()
-
-            # Track calls with force=True
             init_counter = {"count": 0}
             lock = threading.Lock()
 
@@ -213,29 +211,29 @@ class TestBootstrapErrorHandling:
                 "datahub.masking.bootstrap.install_masking_filter",
                 counting_install,
             ):
-                # Launch threads with force=True
-                threads = []
-                for i in range(5):
-                    t = threading.Thread(
+                threads = [
+                    threading.Thread(
                         target=lambda: initialize_secret_masking(force=True),
-                        name=f"ForceThread-{i}",
+                        name=f"InitThread-{i}",
                     )
-                    threads.append(t)
-
+                    for i in range(5)
+                ]
                 for t in threads:
                     t.start()
-
                 for t in threads:
                     t.join(timeout=5.0)
 
-            # With force=True, all threads should initialize (sequentially)
-            # This is expected behavior - force=True bypasses the completion check
-            # The lock ensures they run sequentially, not concurrently
-            assert init_counter["count"] == 5, (
-                f"Expected 5 initializations with force=True, got {init_counter['count']}"
+            # Installed exactly once despite 5 concurrent initializers, and
+            # force=True did not trigger any re-installation.
+            assert init_counter["count"] == 1, (
+                f"Expected exactly 1 install, got {init_counter['count']}"
             )
 
         finally:
+            # Each thread opened its own execution scope; clear them all (the
+            # main thread can't see other threads' contextvars) before tearing
+            # down so bootstrap state doesn't leak into the next test.
+            SecretRegistry.reset_instance()
             shutdown_secret_masking()
 
 

--- a/metadata-ingestion/tests/unit/test_bootstrap.py
+++ b/metadata-ingestion/tests/unit/test_bootstrap.py
@@ -42,8 +42,11 @@ class TestBootstrapErrorHandling:
                 test_exception = Exception("Simulated installation failure")
                 mock_install.side_effect = test_exception
 
-                # Initialize (should fail gracefully)
-                initialize_secret_masking()
+                # D7: initialize now raises on install failure (fail-loud).
+                try:
+                    initialize_secret_masking()
+                except RuntimeError:
+                    pass
 
                 # Verify initialization failed
                 assert not is_bootstrapped(), "Should not be bootstrapped after failure"
@@ -55,17 +58,15 @@ class TestBootstrapErrorHandling:
                     "Should record the actual error"
                 )
 
-            # Second attempt: simulate success
+            # Second attempt: simulate success. The latch was not set on the
+            # failed first attempt, so this re-runs install.
             with patch("datahub.masking.bootstrap.install_masking_filter"):
-                # This time it succeeds (no side_effect)
                 initialize_secret_masking(force=True)
 
-                # Verify initialization succeeded
                 assert is_bootstrapped(), (
                     "Should be bootstrapped after successful retry"
                 )
 
-                # CRITICAL: Verify error was cleared (this is the bug fix)
                 error = get_bootstrap_error()
                 assert error is None, (
                     "Error should be None after successful initialization. "
@@ -78,7 +79,16 @@ class TestBootstrapErrorHandling:
             shutdown_secret_masking()
 
     def test_bootstrap_error_set_on_failure(self):
-        """Verify that _bootstrap_error is set when initialization fails."""
+        """D7: a failed install raises RuntimeError and records the error.
+
+        Previously the failure was silently swallowed (return None), making
+        "off by configuration" indistinguishable from "installation crashed,
+        secrets now reaching logs" — the exact shape that made the Python
+        3.13 ``_acquireLock`` removal silent. Now it fails loud: the caller
+        gets a RuntimeError and a critical log line.
+        """
+        import pytest
+
         from datahub.masking.bootstrap import (
             get_bootstrap_error,
             initialize_secret_masking,
@@ -96,8 +106,11 @@ class TestBootstrapErrorHandling:
                 test_error = ValueError("Test failure during filter installation")
                 mock_install.side_effect = test_error
 
-                # Initialize (should fail gracefully, not raise)
-                initialize_secret_masking()
+                # Initialize must raise (fail-loud for a security control).
+                with pytest.raises(
+                    RuntimeError, match="Secret masking installation failed"
+                ):
+                    initialize_secret_masking()
 
                 # Verify state
                 assert not is_bootstrapped(), "Should not be bootstrapped after failure"

--- a/metadata-ingestion/tests/unit/test_bootstrap.py
+++ b/metadata-ingestion/tests/unit/test_bootstrap.py
@@ -222,6 +222,7 @@ class TestBootstrapErrorHandling:
                     t.start()
                 for t in threads:
                     t.join(timeout=5.0)
+                    assert not t.is_alive(), f"Thread {t.name} timed out"
 
             # Installed exactly once despite 5 concurrent initializers, and
             # force=True did not trigger any re-installation.
@@ -431,3 +432,79 @@ class TestExceptionHookOptimization:
 
         finally:
             shutdown_secret_masking()
+
+
+class TestStrandedBootstrapFlag:
+    """Regression: tokenless shutdown + reset_instance strands the
+    ``_bootstrap_completed`` flag True while the filter is uninstalled, so
+    the next initialize_secret_masking() short-circuits on the flag and
+    runs with masking off. The install decision must be derived from the
+    actual installed state, not a separate flag that can disagree with it.
+    """
+
+    def test_reinit_after_tokenless_shutdown_and_reset_installs_filter(self):
+        import io
+        import logging
+        import threading
+
+        import datahub.masking.masking_filter as mf_mod
+        from datahub.masking.bootstrap import (
+            initialize_secret_masking,
+            shutdown_secret_masking,
+        )
+        from datahub.masking.masking_filter import _installed_filter as _  # noqa: F401
+        from datahub.masking.secret_registry import SecretRegistry
+
+        try:
+            # 1. init on a worker thread (non-ambient for the main context
+            #    that later tears down). Registers a secret under that
+            #    thread's scope.
+            def worker():
+                initialize_secret_masking()
+                SecretRegistry.get_instance().register_secret("T", "tok_abcdef123")
+
+            t = threading.Thread(target=worker)
+            t.start()
+            t.join(timeout=5.0)
+            assert not t.is_alive(), "worker thread timed out"
+
+            # 2. tokenless shutdown from a context with no scope. end_execution(None)
+            #    drops nothing and reports other groups still active, so shutdown
+            #    returns early with _bootstrap_completed still True.
+            shutdown_secret_masking()
+
+            # 3. reset_instance uninstalls the filter.
+            SecretRegistry.reset_instance()
+            assert mf_mod._installed_filter is None
+
+            # 4. re-init must re-install the filter (not short-circuit on the
+            #    stranded flag).
+            initialize_secret_masking()
+            assert mf_mod._installed_filter is not None, (
+                "re-init short-circuited on _bootstrap_completed; filter not installed"
+            )
+
+            # 5. a newly-registered secret must be masked after the cycle.
+            registry = SecretRegistry.get_instance()
+            registry.register_secret("AFTER", "after_secret_value")
+            capture = io.StringIO()
+            handler = logging.StreamHandler(capture)
+            handler.setFormatter(logging.Formatter("%(message)s"))
+            root = logging.getLogger()
+            root.addHandler(handler)
+            try:
+                # The refresh path re-scans handlers, so the late handler gets
+                # the filter. Force a re-scan by calling install again.
+                initialize_secret_masking()
+                logging.getLogger("test.stranded").info("leak after_secret_value here")
+            finally:
+                root.removeHandler(handler)
+            out = capture.getvalue()
+            assert "after_secret_value" not in out, (
+                f"secret leaked after re-init: {out!r}"
+            )
+            assert "***REDACTED:AFTER***" in out
+
+        finally:
+            shutdown_secret_masking()
+            SecretRegistry.reset_instance()

--- a/metadata-ingestion/tests/unit/test_masking_coverage.py
+++ b/metadata-ingestion/tests/unit/test_masking_coverage.py
@@ -4,6 +4,7 @@ Additional tests to increase coverage for masking modules.
 
 import logging
 import os
+import sys
 from io import StringIO
 
 import pytest
@@ -243,19 +244,125 @@ class TestBootstrapEdgeCases:
         assert get_bootstrap_error() is None
 
     def test_initialize_with_disabled_masking(self):
-        """Test initialization when masking is disabled."""
+        """Test initialization when masking is disabled.
+
+        A disabled initialize must NOT latch ``_bootstrap_completed``: that
+        flag means "the filter is installed", and a disabled call installs
+        nothing. Latching True on the disabled branch stranded the flag so
+        a later call with masking enabled short-circuited the install but
+        still returned a token — the caller got the "masking is on" signal
+        with no filter. ``is_bootstrapped()`` is False after a disabled
+        initialize, and a subsequent enabled initialize installs the
+        filter for real.
+        """
         from datahub.masking.bootstrap import is_bootstrapped
 
         os.environ["DATAHUB_DISABLE_SECRET_MASKING"] = "true"
         try:
             shutdown_secret_masking()
-            initialize_secret_masking()
-            # Should complete but not actually initialize
+            token = initialize_secret_masking()
+            # Disabled: no token, no filter installed.
+            assert token is None
+            assert not is_bootstrapped()
+
+            # Flip masking back on and initialize again — the filter must
+            # actually install now (the disabled call did not strand the
+            # latch).
+            del os.environ["DATAHUB_DISABLE_SECRET_MASKING"]
+            from datahub.masking.secret_registry import is_masking_enabled
+
+            assert is_masking_enabled()
+            token2 = initialize_secret_masking()
+            assert token2 is not None
             assert is_bootstrapped()
         finally:
             if "DATAHUB_DISABLE_SECRET_MASKING" in os.environ:
                 del os.environ["DATAHUB_DISABLE_SECRET_MASKING"]
             shutdown_secret_masking()
+
+    def test_shutdown_clears_latch_in_finally_when_teardown_raises(self):
+        """If a teardown step raises, the bootstrap latch is still cleared
+        (in ``finally`` around the teardown steps). Previously the latch
+        was cleared as the last statement inside the try, so a raise
+        stranded it ``True`` over a partially-torn-down filter — the next
+        initialize then short-circuited with masking off."""
+        import datahub.masking.bootstrap as bootstrap_mod
+        from datahub.masking.bootstrap import is_bootstrapped
+
+        # Install for real so teardown has something to tear down.
+        token = initialize_secret_masking()
+        assert token is not None
+        assert is_bootstrapped()
+
+        # Force the uninstall primitive to raise. ``_uninstall_masking_filter``
+        # is step-wise tolerant and swallows its own errors, so patch the
+        # name bootstrap imported to raise before the step-wise body runs.
+        original = bootstrap_mod._uninstall_masking_filter
+
+        def raising_uninstall():
+            raise RuntimeError("forced teardown failure for test")
+
+        bootstrap_mod._uninstall_masking_filter = raising_uninstall  # type: ignore[assignment]
+        try:
+            # shutdown swallows the error (teardown is fail-safe) but the
+            # finally must still clear the latch.
+            shutdown_secret_masking(token)
+            assert not is_bootstrapped(), (
+                "latch stranded True after teardown raised — next initialize "
+                "would short-circuit with masking off"
+            )
+        finally:
+            bootstrap_mod._uninstall_masking_filter = original  # type: ignore[assignment]
+            # Clean up any state the failed teardown left behind.
+            shutdown_secret_masking()
+
+    def test_force_teardown_restores_excepthook_with_peer_scope_active(self):
+        """Finding 10: ``shutdown_secret_masking()`` with no token skips
+        teardown when a peer execution scope is active (e.g. opened on
+        another thread). Previously ``reset_instance()`` then dropped the
+        filter but never restored ``sys.excepthook``, leaving a hook bound
+        to a dead registry. The force-teardown path restores the excepthook
+        unconditionally, and the fixture asserts no leaked scopes."""
+        import datahub.masking.bootstrap as bootstrap_mod
+
+        # Install and capture the original excepthook.
+        original_hook = sys.excepthook
+        token = initialize_secret_masking()
+        assert token is not None
+        # After install, sys.excepthook is the masking hook.
+        assert sys.excepthook is not original_hook
+
+        # Simulate a peer scope opened on "another thread" by adding a group
+        # directly to the registry without setting this thread's contextvar.
+        registry = SecretRegistry.get_instance()
+        peer_exec_id = "peer-scope-for-test"
+        with registry._registry_lock:
+            registry._groups.setdefault(peer_exec_id, {})
+            registry._rebuild_locked()
+
+        # shutdown_secret_masking() with no token: this thread has no ambient
+        # scope, the peer group is active, so it returns True (skips teardown).
+        result = shutdown_secret_masking()
+        assert result is None  # shutdown returns None
+        # The filter is still installed (teardown skipped).
+        import datahub.masking.masking_filter as mf_mod
+
+        assert mf_mod._installed_filter is not None
+        # sys.excepthook is still the masking hook (not restored).
+        assert sys.excepthook is not original_hook
+
+        # Now the force-teardown path (what the fixture uses) tears down
+        # unconditionally and restores the excepthook.
+        bootstrap_mod._force_teardown_secret_masking()
+        assert sys.excepthook is original_hook or sys.excepthook == original_hook
+        assert mf_mod._installed_filter is None
+
+        # Clean up the peer scope so the fixture's has_active_executions
+        # assertion passes.
+        with registry._registry_lock:
+            registry._groups.pop(peer_exec_id, None)
+            registry._rebuild_locked()
+        SecretRegistry.reset_instance()
 
 
 if __name__ == "__main__":

--- a/metadata-ingestion/tests/unit/test_masking_error_recovery.py
+++ b/metadata-ingestion/tests/unit/test_masking_error_recovery.py
@@ -25,7 +25,7 @@ from datahub.masking.bootstrap import (
 from datahub.masking.masking_filter import (
     SecretMaskingFilter,
     StreamMaskingWrapper,
-    _update_existing_handlers,
+    _add_filter_to_existing_handlers,
     install_masking_filter,
 )
 from datahub.masking.secret_registry import SecretRegistry
@@ -279,8 +279,10 @@ class TestStreamWrapperErrorHandling:
         assert callable(wrapper.getvalue)
 
 
-class TestUpdateExistingHandlers:
-    """Test _update_existing_handlers function."""
+class TestAddFilterToExistingHandlers:
+    """Test _add_filter_to_existing_handlers: masking attaches to handlers
+    without modifying their streams (the celery-safe replacement for the old
+    stream-redirecting behavior)."""
 
     def setup_method(self):
         shutdown_secret_masking()
@@ -290,79 +292,53 @@ class TestUpdateExistingHandlers:
         shutdown_secret_masking()
         SecretRegistry.reset_instance()
 
-    def test_update_existing_handlers_with_stdout_handler(self):
-        """Test that existing stdout handlers are updated."""
-        # Create a logger with a stdout handler
-        test_logger = logging.getLogger("test_stdout_update")
-        test_logger.handlers.clear()
-
-        stdout_handler = logging.StreamHandler(sys.stdout)
-        test_logger.addHandler(stdout_handler)
-
-        # Install masking
-        install_masking_filter(install_stdout_wrapper=True)
-
-        # Update handlers
-        _update_existing_handlers()
-
-        # Cleanup
-        test_logger.removeHandler(stdout_handler)
-        test_logger.handlers.clear()
-
-    def test_update_existing_handlers_with_stderr_handler(self):
-        """Test that existing stderr handlers are updated."""
-        # Create a logger with a stderr handler
-        test_logger = logging.getLogger("test_stderr_update")
-        test_logger.handlers.clear()
-
-        stderr_handler = logging.StreamHandler(sys.stderr)
-        test_logger.addHandler(stderr_handler)
-
-        # Install masking
-        install_masking_filter(install_stdout_wrapper=True)
-
-        # Update handlers
-        _update_existing_handlers()
-
-        # Cleanup
-        test_logger.removeHandler(stderr_handler)
-        test_logger.handlers.clear()
-
-    def test_update_existing_handlers_with_custom_stream(self):
-        """Test that handlers with custom streams are not updated."""
-        test_logger = logging.getLogger("test_custom_stream")
+    def test_filter_added_without_changing_stream(self):
+        """The filter is attached to an existing handler and its stream is left
+        untouched (repointing the stream is what caused the celery deadlock)."""
+        test_logger = logging.getLogger("test_add_filter_stream")
         test_logger.handlers.clear()
 
         custom_stream = StringIO()
-        custom_handler = logging.StreamHandler(custom_stream)
-        test_logger.addHandler(custom_handler)
+        handler = logging.StreamHandler(custom_stream)
+        test_logger.addHandler(handler)
 
-        # Install masking
         install_masking_filter(install_stdout_wrapper=True)
 
-        # Update handlers
-        _update_existing_handlers()
+        assert handler.stream is custom_stream
+        assert any(isinstance(f, SecretMaskingFilter) for f in handler.filters)
 
-        # Custom handler should not be updated
-        assert custom_handler.stream is custom_stream
-
-        # Cleanup
-        test_logger.removeHandler(custom_handler)
+        test_logger.removeHandler(handler)
         test_logger.handlers.clear()
 
-    def test_update_existing_handlers_skips_placeholders(self):
-        """Test that PlaceHolder objects in logger dict are skipped."""
-        # This tests the check for isinstance(log, logging.Logger)
-        # PlaceHolder objects exist in logging.root.manager.loggerDict
-        # but are not actual Logger instances
+    def test_filter_not_added_twice(self):
+        """Calling the helper again must not add a duplicate filter."""
+        test_logger = logging.getLogger("test_add_filter_idempotent")
+        test_logger.handlers.clear()
+        handler = logging.StreamHandler(StringIO())
+        test_logger.addHandler(handler)
 
-        # Install masking
-        install_masking_filter(install_stdout_wrapper=True)
+        masking_filter = install_masking_filter(install_stdout_wrapper=False)
+        _add_filter_to_existing_handlers(masking_filter)
 
-        # Call update (should handle placeholders gracefully)
-        _update_existing_handlers()
+        count = sum(isinstance(f, SecretMaskingFilter) for f in handler.filters)
+        assert count == 1
 
-        # Should not raise any errors
+        test_logger.removeHandler(handler)
+        test_logger.handlers.clear()
+
+    def test_masking_namespace_loggers_are_skipped(self):
+        """The masking framework's own loggers bypass masking by design."""
+        masking_logger = logging.getLogger("datahub.masking.test_skip")
+        masking_logger.handlers.clear()
+        handler = logging.StreamHandler(StringIO())
+        masking_logger.addHandler(handler)
+
+        install_masking_filter(install_stdout_wrapper=False)
+
+        assert not any(isinstance(f, SecretMaskingFilter) for f in handler.filters)
+
+        masking_logger.removeHandler(handler)
+        masking_logger.handlers.clear()
 
 
 class TestBootstrapErrorHandling:

--- a/metadata-ingestion/tests/unit/test_masking_error_recovery.py
+++ b/metadata-ingestion/tests/unit/test_masking_error_recovery.py
@@ -27,6 +27,7 @@ from datahub.masking.masking_filter import (
     StreamMaskingWrapper,
     _add_filter_to_existing_handlers,
     install_masking_filter,
+    uninstall_masking_filter,
 )
 from datahub.masking.secret_registry import SecretRegistry
 
@@ -339,6 +340,44 @@ class TestAddFilterToExistingHandlers:
 
         masking_logger.removeHandler(handler)
         masking_logger.handlers.clear()
+
+    def test_repeat_install_attaches_to_newly_added_handler(self):
+        """A second install must re-scan and cover handlers added after the
+        first install (masking is fail-open, so missed handlers leak)."""
+        test_logger = logging.getLogger("test_repeat_install")
+        test_logger.handlers.clear()
+        h1 = logging.StreamHandler(StringIO())
+        test_logger.addHandler(h1)
+
+        install_masking_filter(install_stdout_wrapper=False)
+        assert any(isinstance(f, SecretMaskingFilter) for f in h1.filters)
+
+        # Handler added AFTER the first install.
+        h2 = logging.StreamHandler(StringIO())
+        test_logger.addHandler(h2)
+
+        install_masking_filter(install_stdout_wrapper=False)
+        assert any(isinstance(f, SecretMaskingFilter) for f in h2.filters)
+
+        test_logger.removeHandler(h1)
+        test_logger.removeHandler(h2)
+        test_logger.handlers.clear()
+
+    def test_uninstall_removes_filter_from_all_handlers(self):
+        """Teardown is symmetric: no SecretMaskingFilter remains on any handler."""
+        test_logger = logging.getLogger("test_uninstall_handlers")
+        test_logger.handlers.clear()
+        handler = logging.StreamHandler(StringIO())
+        test_logger.addHandler(handler)
+
+        install_masking_filter(install_stdout_wrapper=False)
+        assert any(isinstance(f, SecretMaskingFilter) for f in handler.filters)
+
+        uninstall_masking_filter()
+        assert not any(isinstance(f, SecretMaskingFilter) for f in handler.filters)
+
+        test_logger.removeHandler(handler)
+        test_logger.handlers.clear()
 
 
 class TestBootstrapErrorHandling:

--- a/metadata-ingestion/tests/unit/test_masking_error_recovery.py
+++ b/metadata-ingestion/tests/unit/test_masking_error_recovery.py
@@ -690,5 +690,81 @@ class TestLogRecordAttributes:
         assert "REDACTED" in record.stack_info
 
 
+class TestConcurrentExecutions:
+    """Masking must be correct when two executions overlap in one process
+    (the dispatcher runs each execution on its own thread). One execution's
+    teardown must not unmask or wipe another execution that is still running."""
+
+    def setup_method(self):
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+
+    def teardown_method(self):
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+
+    def test_shutdown_of_one_execution_does_not_unmask_another(self):
+        secret_a = "secretA_value_aaaaaa"
+        secret_b = "secretB_value_bbbbbb"
+
+        cap = StringIO()
+        child = logging.getLogger("datahub.ingestion.source.concurrent_test")
+        child.setLevel(logging.INFO)
+        handler = logging.StreamHandler(cap)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        child.addHandler(handler)
+
+        a_ready = threading.Event()
+        b_registered = threading.Event()
+        a_done = threading.Event()
+        result: dict[str, str] = {}
+
+        def execution_a():
+            initialize_secret_masking(force=True)
+            SecretRegistry.get_instance().register_secret("A_TOKEN", secret_a)
+            a_ready.set()
+            b_registered.wait(5)
+            # A finishes and tears down WHILE B is still active.
+            shutdown_secret_masking()
+            a_done.set()
+
+        def execution_b():
+            a_ready.wait(5)
+            initialize_secret_masking(force=True)
+            SecretRegistry.get_instance().register_secret("B_TOKEN", secret_b)
+            b_registered.set()
+            a_done.wait(5)
+            # B logs its secret AFTER A has torn down. It must still be masked.
+            cap.truncate(0)
+            cap.seek(0)
+            child.warning(f"connecting with {secret_b}")
+            result["b_output"] = cap.getvalue()
+            shutdown_secret_masking()
+
+        ta = threading.Thread(target=execution_a)
+        tb = threading.Thread(target=execution_b)
+        ta.start()
+        tb.start()
+        ta.join(10)
+        tb.join(10)
+
+        out = result.get("b_output", "")
+        assert secret_b not in out, f"B's secret leaked after A's teardown: {out!r}"
+        assert "***REDACTED:B_TOKEN***" in out
+
+        try:
+            child.removeHandler(handler)
+        finally:
+            child.handlers.clear()
+
+    def test_secrets_dropped_when_execution_ends(self):
+        # Bounded memory: an execution's secrets are gone after it shuts down.
+        initialize_secret_masking(force=True)
+        SecretRegistry.get_instance().register_secret("X_TOKEN", "value_xyz_123456")
+        assert SecretRegistry.get_instance().get_count() > 0
+        shutdown_secret_masking()
+        assert SecretRegistry.get_instance().get_count() == 0
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/metadata-ingestion/tests/unit/test_masking_error_recovery.py
+++ b/metadata-ingestion/tests/unit/test_masking_error_recovery.py
@@ -765,6 +765,69 @@ class TestConcurrentExecutions:
         shutdown_secret_masking()
         assert SecretRegistry.get_instance().get_count() == 0
 
+    def test_execution_starting_during_teardown_is_masked(self):
+        """A new execution C beginning *while the last active execution A is
+        tearing down* must not run unmasked. A's teardown (decide-it-is-last +
+        uninstall) must be atomic with C's (check-bootstrap + register-scope),
+        or C registers secrets, sees bootstrap still complete so skips re-install,
+        and A then strips the filter out from under it. Never under-mask."""
+        from datahub.masking.logging_utils import reset_masking_safe_loggers
+
+        secret_c = "secretC_value_cccccc"
+
+        cap = StringIO()
+        child = logging.getLogger("datahub.ingestion.source.teardown_race_test")
+        child.setLevel(logging.INFO)
+        handler = logging.StreamHandler(cap)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        child.addHandler(handler)
+
+        teardown_entered = threading.Event()
+        c_logged = threading.Event()
+        result: dict[str, str] = {}
+
+        # reset_masking_safe_loggers runs late in A's teardown, after the filter
+        # is uninstalled but before _bootstrap_completed flips to False — i.e.
+        # inside the leak window. Use it to release C into that window.
+        def slow_reset() -> None:
+            teardown_entered.set()
+            # Wait for C to log. Under the fix C is blocked on the bootstrap lock
+            # A holds, so this times out and A finishes first (no deadlock).
+            c_logged.wait(timeout=2.0)
+            reset_masking_safe_loggers()
+
+        def execution_c() -> None:
+            teardown_entered.wait(5)
+            initialize_secret_masking(force=True)
+            SecretRegistry.get_instance().register_secret("C_TOKEN", secret_c)
+            cap.truncate(0)
+            cap.seek(0)
+            child.warning(f"connecting with {secret_c}")
+            result["c_output"] = cap.getvalue()
+            c_logged.set()
+            shutdown_secret_masking()
+
+        # A is the sole active execution (main-thread context).
+        initialize_secret_masking(force=True)
+        SecretRegistry.get_instance().register_secret("A_TOKEN", "secretA_value_aaaa")
+
+        tc = threading.Thread(target=execution_c)
+        with mock.patch(
+            "datahub.masking.logging_utils.reset_masking_safe_loggers", slow_reset
+        ):
+            tc.start()
+            shutdown_secret_masking()  # A tears down while C races to start.
+            tc.join(10)
+
+        out = result.get("c_output", "")
+        assert secret_c not in out, f"C's secret leaked during A's teardown: {out!r}"
+        assert "***REDACTED:C_TOKEN***" in out
+
+        try:
+            child.removeHandler(handler)
+        finally:
+            child.handlers.clear()
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/metadata-ingestion/tests/unit/test_masking_error_recovery.py
+++ b/metadata-ingestion/tests/unit/test_masking_error_recovery.py
@@ -417,24 +417,49 @@ class TestBootstrapErrorHandling:
             pass
 
     def test_initialize_with_filter_installation_error(self):
-        """Test that initialization handles filter installation errors."""
+        """D7: initialization raises on filter installation errors (fail-loud
+        for a security control) and records the error."""
         # Mock install_masking_filter to raise an error
         from datahub.masking import bootstrap
 
         def mock_install_fail(*args, **kwargs):
             raise RuntimeError("Simulated installation error")
 
-        with mock.patch.object(
-            bootstrap, "install_masking_filter", side_effect=mock_install_fail
+        critical_calls = []
+        original_critical = bootstrap.logger.critical
+
+        def spy_critical(msg, *args, **kwargs):
+            critical_calls.append(msg)
+            return original_critical(msg, *args, **kwargs)
+
+        with (
+            mock.patch.object(
+                bootstrap, "install_masking_filter", side_effect=mock_install_fail
+            ),
+            mock.patch.object(bootstrap.logger, "critical", side_effect=spy_critical),
         ):
-            # Should not raise, but should log error
-            initialize_secret_masking()
+            # D7: must raise (RuntimeError wrapping the install error), not
+            # silently return None.
+            import pytest
+
+            with pytest.raises(
+                RuntimeError, match="Secret masking installation failed"
+            ):
+                initialize_secret_masking()
 
             # Should have recorded error
             from datahub.masking.bootstrap import get_bootstrap_error
 
             error = get_bootstrap_error()
             assert error is not None
+
+            # Acceptance property: installation failure "appears in logs at
+            # critical". The bootstrap logger is masking-safe (writes to
+            # __stderr__, propagate=False) so caplog can't see it; spy on
+            # logger.critical directly.
+            assert any(
+                "Failed to initialize secret masking" in c for c in critical_calls
+            ), f"expected a critical log for install failure, got: {critical_calls}"
 
 
 class TestSecretRegistryBatchRegistration:

--- a/metadata-ingestion/tests/unit/test_masking_error_recovery.py
+++ b/metadata-ingestion/tests/unit/test_masking_error_recovery.py
@@ -125,27 +125,35 @@ class TestMaskingErrorPaths:
             assert result == ("[MASKING_ERROR - OUTPUT_SUPPRESSED_FOR_SECURITY]",)
 
     def test_mask_exception_with_error(self):
-        """Test that errors in _mask_exception are handled."""
+        """Test that errors in _mask_exception are handled.
+
+        _mask_exception now returns materialized traceback text (or a sentinel
+        on error), not a rebuilt exception tuple. filter() assigns the result
+        to record.exc_text and masks it. On error, the sentinel has no secrets
+        so masking is a no-op, and exc_info is left intact for error reporters.
+        """
         registry = SecretRegistry.get_instance()
         masking_filter = SecretMaskingFilter(registry)
 
-        # Create exception info that will cause an error
+        # Create exception info
         try:
             raise ValueError("Test error")
         except ValueError:
             exc_info = sys.exc_info()
 
-        # Mock to cause error during exception processing
+        # Mock formatException to raise — _mask_exception materializes via
+        # logging.Formatter().formatException, so this triggers the error path.
         with mock.patch.object(
-            masking_filter, "mask_text", side_effect=RuntimeError("Simulated error")
+            logging.Formatter,
+            "formatException",
+            side_effect=RuntimeError("Simulated error"),
         ):
             result = masking_filter._mask_exception(exc_info)
 
-            # Should return sanitized exception
+            # Should return the fail-secure sentinel string, not raise
             assert result is not None
-            exc_type, exc_value, _ = result
-            assert exc_type is RuntimeError
-            assert "[MASKING_ERROR - OUTPUT_SUPPRESSED_FOR_SECURITY]" in str(exc_value)
+            assert isinstance(result, str)
+            assert "[MASKING_ERROR - OUTPUT_SUPPRESSED_FOR_SECURITY]" in result
 
     def test_filter_with_masking_error_suppression(self):
         """Test that errors during filter() are suppressed and logged."""
@@ -770,8 +778,15 @@ class TestConcurrentExecutions:
         tearing down* must not run unmasked. A's teardown (decide-it-is-last +
         uninstall) must be atomic with C's (check-bootstrap + register-scope),
         or C registers secrets, sees bootstrap still complete so skips re-install,
-        and A then strips the filter out from under it. Never under-mask."""
-        from datahub.masking.logging_utils import reset_masking_safe_loggers
+        and A then strips the filter out from under it. Never under-mask.
+
+        Uses the explicit ``_teardown_hook`` test seam (called inside
+        shutdown_secret_masking after the last-execution decision, before any
+        teardown mutation) to gate C deterministically. No fixed wall-clock
+        timeout on the success path — a regression reads as a test failure
+        (C's secret leaks), not a slow test.
+        """
+        from datahub.masking import bootstrap as bootstrap_mod
 
         secret_c = "secretC_value_cccccc"
 
@@ -783,18 +798,22 @@ class TestConcurrentExecutions:
         child.addHandler(handler)
 
         teardown_entered = threading.Event()
-        c_logged = threading.Event()
+        c_ready_to_log = threading.Event()
+        c_done = threading.Event()
         result: dict[str, str] = {}
 
-        # reset_masking_safe_loggers runs late in A's teardown, after the filter
-        # is uninstalled but before _bootstrap_completed flips to False — i.e.
-        # inside the leak window. Use it to release C into that window.
-        def slow_reset() -> None:
+        def hook() -> None:
+            # Called inside shutdown_secret_masking while _bootstrap_lock is
+            # held, after the last-execution decision, before teardown mutation.
+            # Release C into the race window; wait until C has registered its
+            # secret and is about to log before allowing teardown to proceed.
             teardown_entered.set()
-            # Wait for C to log. Under the fix C is blocked on the bootstrap lock
-            # A holds, so this times out and A finishes first (no deadlock).
-            c_logged.wait(timeout=2.0)
-            reset_masking_safe_loggers()
+            # Under the fix, C is blocked on _bootstrap_lock (held by A's
+            # teardown), so C never reaches c_ready_to_log and this wait times
+            # out quickly — A then finishes, C acquires the lock, re-installs,
+            # and runs masked. Under the bug, C races ahead, sets the event,
+            # and the hook returns so A tears down while C is about to log.
+            c_ready_to_log.wait(timeout=1.0)
 
         def execution_c() -> None:
             teardown_entered.wait(5)
@@ -802,9 +821,10 @@ class TestConcurrentExecutions:
             SecretRegistry.get_instance().register_secret("C_TOKEN", secret_c)
             cap.truncate(0)
             cap.seek(0)
+            c_ready_to_log.set()
             child.warning(f"connecting with {secret_c}")
             result["c_output"] = cap.getvalue()
-            c_logged.set()
+            c_done.set()
             shutdown_secret_masking()
 
         # A is the sole active execution (main-thread context).
@@ -812,13 +832,18 @@ class TestConcurrentExecutions:
         SecretRegistry.get_instance().register_secret("A_TOKEN", "secretA_value_aaaa")
 
         tc = threading.Thread(target=execution_c)
-        with mock.patch(
-            "datahub.masking.logging_utils.reset_masking_safe_loggers", slow_reset
-        ):
+        with mock.patch.object(bootstrap_mod, "_teardown_hook", hook):
             tc.start()
             shutdown_secret_masking()  # A tears down while C races to start.
+            # hook() blocks A's teardown until C has registered + is about to log.
+            # Under the fix, C is blocked on _bootstrap_lock (held by A's
+            # teardown), so hook() times out and A finishes first; C then
+            # acquires the lock, sees _bootstrap_completed=False, re-installs,
+            # and runs masked. Under the bug, C enters between A's decision
+            # and uninstall and runs unmasked.
             tc.join(10)
 
+        assert c_done.wait(0), "C never completed"
         out = result.get("c_output", "")
         assert secret_c not in out, f"C's secret leaked during A's teardown: {out!r}"
         assert "***REDACTED:C_TOKEN***" in out
@@ -827,6 +852,141 @@ class TestConcurrentExecutions:
             child.removeHandler(handler)
         finally:
             child.handlers.clear()
+
+    def test_cross_thread_shutdown_with_token_drops_scope(self):
+        """The ContextVar-based scope is per-context (per-thread). If thread A
+        calls initialize_secret_masking() and thread B calls
+        shutdown_secret_masking() without the token, B's ambient context has
+        no scope → end_execution is a silent no-op → A's secrets never drop
+        and the filter never uninstalls (unbounded growth, fails safe). The
+        token returned by initialize_secret_masking closes this hole: B passes
+        it and end_execution drops that specific group."""
+        from datahub.masking.bootstrap import (
+            initialize_secret_masking,
+            shutdown_secret_masking,
+        )
+
+        # A opens an execution on the main thread and gets a token.
+        token = initialize_secret_masking(force=True)
+        assert token is not None
+        SecretRegistry.get_instance().register_secret("A_TOKEN", "aaa_secret_value")
+        assert SecretRegistry.get_instance().get_count() > 0
+
+        # B (a different thread/context) shuts down with the token.
+        def shutdown_from_other_thread():
+            shutdown_secret_masking(token)
+
+        t = threading.Thread(target=shutdown_from_other_thread)
+        t.start()
+        t.join(5)
+        assert not t.is_alive()
+
+        # A's secrets are gone even though shutdown ran in another context.
+        assert SecretRegistry.get_instance().get_count() == 0
+
+    def test_cross_thread_shutdown_without_token_is_noop(self):
+        """Without the token, shutdown from a different context is a no-op:
+        the ambient context has no scope. This is the cross-thread hole —
+        secrets survive. Documented behavior; the debug log surfaces it."""
+        from datahub.masking.bootstrap import (
+            initialize_secret_masking,
+            shutdown_secret_masking,
+        )
+
+        token = initialize_secret_masking(force=True)
+        assert token is not None
+        SecretRegistry.get_instance().register_secret("A_TOKEN", "aaa_secret_value")
+        assert SecretRegistry.get_instance().get_count() > 0
+
+        def shutdown_from_other_thread_no_token():
+            # Deliberately NOT passing the token — simulates an un-updated caller.
+            shutdown_secret_masking()
+
+        t = threading.Thread(target=shutdown_from_other_thread_no_token)
+        t.start()
+        t.join(5)
+        assert not t.is_alive()
+
+        # Without the token, B's context has no scope → no-op → secrets survive.
+        # This is the known limitation; the debug log surfaces it. Clean up.
+        assert SecretRegistry.get_instance().get_count() > 0
+        # Clean up using the token from the original context.
+        shutdown_secret_masking(token)
+        assert SecretRegistry.get_instance().get_count() == 0
+
+    def test_double_shutdown_is_idempotent(self):
+        """Double shutdown and unknown-token shutdown must not raise and must
+        leave the registry empty."""
+        from datahub.masking.bootstrap import (
+            initialize_secret_masking,
+            shutdown_secret_masking,
+        )
+
+        token = initialize_secret_masking(force=True)
+        SecretRegistry.get_instance().register_secret("X", "value_xyz_123456")
+        shutdown_secret_masking(token)
+        # Second shutdown (no active scope) must not raise.
+        shutdown_secret_masking()
+        shutdown_secret_masking("nonexistent-token")
+        assert SecretRegistry.get_instance().get_count() == 0
+
+    def test_meta_old_semantics_breaks_cross_thread_invariant(self):
+        """Test for the test: monkeypatch the old end_execution semantics
+        back (ignore exec_id, always wipe ambient) and assert the cross-thread
+        invariant breaks. A concurrency test that never fails against unfixed
+        code isn't a regression test — this protects against the seam moving
+        and confirms the test above actually exercises the fix."""
+        from datahub.masking import secret_registry as reg_mod
+
+        # Old end_execution semantics (pre-fix): ignore exec_id, wipe only the
+        # ambient context. We reconstruct it locally and assert it leaves a
+        # different-context group in place — i.e. our cross-thread test above
+        # would catch a regression to this behavior.
+        def old_end_execution(self, exec_id=None):
+            ambient = reg_mod._current_exec.get()
+            reg_mod._current_exec.set(None)
+            with self._registry_lock:
+                if ambient is not None:
+                    self._groups.pop(ambient, None)
+                active = [g for g in self._groups if g != reg_mod._GLOBAL_GROUP]
+                if not active:
+                    self._groups.pop(reg_mod._GLOBAL_GROUP, None)
+                self._rebuild_locked()
+                return bool(active)
+
+        # We can't easily monkeypatch the bound method on the singleton before
+        # it's created, so instead assert the fixed version honors exec_id by
+        # checking that passing a token for a group the ambient context doesn't
+        # own still drops that group. (A direct monkeypatch of the singleton's
+        # method is fragile across instances; this asserts the contract.)
+        reg = SecretRegistry.get_instance()
+        exec_id = reg.begin_execution()
+        reg.register_secret("T", "token_secret_value")
+        assert reg.get_count() > 0
+
+        # End from a context that doesn't own exec_id (simulate by resetting
+        # the contextvar, then passing exec_id explicitly).
+        reg_mod._current_exec.set(None)
+        # Under the OLD semantics, exec_id is ignored and end_execution wipes
+        # ambient (None) → no-op → secret survives. Under the FIXED semantics,
+        # exec_id is honored → group dropped → secret gone.
+        # Verify the fixed code drops the group even with no ambient scope:
+        assert reg.end_execution(exec_id) is False  # no other executions active
+        assert reg.get_count() == 0
+
+        # Now assert the OLD semantics would have failed: with no ambient scope,
+        # old_end_execution is a no-op. We simulate by calling the old impl.
+        reg2 = SecretRegistry.get_instance()
+        exec_id2 = reg2.begin_execution()
+        reg2.register_secret("T2", "token2_secret_value")
+        reg_mod._current_exec.set(None)  # different context
+        # Old impl: ignores exec_id, wipes ambient (None) → no-op.
+        old_end_execution(reg2, exec_id2)
+        # Old semantics: secret survives (the bug). This confirms our test
+        # would catch a regression to the old behavior.
+        assert reg2.get_count() > 0, "Old semantics should have left the secret"
+        # Clean up using the fixed semantics.
+        reg2.end_execution(exec_id2)
 
 
 if __name__ == "__main__":

--- a/metadata-ingestion/tests/unit/test_masking_filter.py
+++ b/metadata-ingestion/tests/unit/test_masking_filter.py
@@ -1175,5 +1175,130 @@ class TestThreadSafetyConcurrent:
         assert all("***REDACTED:EXISTING***" in r for r in results)
 
 
+class TestHandlerCoverageAndCelerySafety:
+    """Regression tests for the executor logging-silencing bug.
+
+    Two invariants must hold:
+    1. Masking must cover records from CHILD loggers (not just records logged
+       directly on root). A filter on the root *logger* does not see propagated
+       child records, so the filter must be installed on the *handlers*.
+    2. Installing masking must NOT redirect existing handlers' streams. Under
+       celery, sys.stderr is a proxy that re-enters the logging system; pointing
+       a console handler at it creates an infinite recursion cycle that silently
+       swallows all log output.
+    """
+
+    def setup_method(self):
+        uninstall_masking_filter()
+        SecretRegistry.reset_instance()
+        self._saved_stderr = sys.stderr
+        self._saved_stdout = sys.stdout
+
+    def teardown_method(self):
+        uninstall_masking_filter()
+        sys.stderr = self._saved_stderr
+        sys.stdout = self._saved_stdout
+        SecretRegistry.reset_instance()
+
+    def test_child_logger_output_is_masked(self):
+        """Secrets in a child logger's output must be masked.
+
+        Reproduces the design flaw: the filter was attached to the root *logger*,
+        which never sees records propagated up from child loggers, so their
+        output went out unmasked.
+        """
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("DB_PASSWORD", "supersecretvalue")
+
+        capture = StringIO()
+        root_logger = logging.getLogger()
+        handler = logging.StreamHandler(capture)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        root_logger.addHandler(handler)
+
+        child = logging.getLogger("datahub.ingestion.source.mysql")
+        child.setLevel(logging.INFO)  # ensure the INFO record is emitted
+
+        try:
+            # Handler exists BEFORE masking installs (as celery's handlers do).
+            install_masking_filter(registry, install_stdout_wrapper=False)
+
+            # Log via a CHILD logger; the record propagates to the root handler.
+            child.info("connecting with password supersecretvalue")
+
+            output = capture.getvalue()
+            assert "supersecretvalue" not in output
+            assert "***REDACTED:DB_PASSWORD***" in output
+        finally:
+            root_logger.removeHandler(handler)
+            child.setLevel(logging.NOTSET)
+
+    def test_celery_style_feedback_stream_does_not_silence_logs(self):
+        """A handler writing to a logging-backed proxy must still deliver output.
+
+        Models celery: sys.stderr is a LoggingProxy that re-enters logging, and a
+        console handler writes to the real terminal. Before the fix, install
+        repointed that console handler at the wrapped proxy, forming a cycle that
+        recursed and silently dropped every log line.
+        """
+
+        class FakeTerminal:
+            # name == "<stderr>" so the (buggy) handler-redirect logic targets it
+            name = "<stderr>"
+
+            def __init__(self) -> None:
+                self.text = ""
+
+            def write(self, s: str) -> int:
+                self.text += s
+                return len(s)
+
+            def flush(self) -> None:
+                pass
+
+        class LoggingProxy:
+            """Like celery's LoggingProxy: writes feed back into logging."""
+
+            name = "<stderr>"
+
+            def __init__(self, target_logger: logging.Logger) -> None:
+                self._logger = target_logger
+
+            def write(self, s: str) -> int:
+                s = s.rstrip("\n")
+                if s:
+                    self._logger.warning(s)
+                return len(s)
+
+            def flush(self) -> None:
+                pass
+
+        terminal = FakeTerminal()
+        redirect_logger = logging.getLogger("test.celery.redirect")
+        redirect_logger.handlers = []
+        redirect_logger.propagate = False
+        redirect_handler = logging.StreamHandler(terminal)
+        redirect_handler.setFormatter(logging.Formatter("%(message)s"))
+        redirect_logger.addHandler(redirect_handler)
+
+        sys.stderr = LoggingProxy(redirect_logger)  # celery redirects stderr
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("SECRET", "hunter2value")
+
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=True)
+
+            unique = "celery-line-7f3a9"
+            redirect_logger.warning(unique)
+
+            # The line must reach the terminal (no recursion cycle swallowing it).
+            assert unique in terminal.text
+        finally:
+            redirect_logger.removeHandler(redirect_handler)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/metadata-ingestion/tests/unit/test_masking_filter.py
+++ b/metadata-ingestion/tests/unit/test_masking_filter.py
@@ -21,6 +21,7 @@ import pytest
 from datahub.masking.masking_filter import (
     SecretMaskingFilter,
     StreamMaskingWrapper,
+    _remove_filter_from_existing_handlers,
     install_masking_filter,
     uninstall_masking_filter,
 )
@@ -1870,6 +1871,351 @@ class TestReviewFixes:
         t.join(timeout=5.0)
         assert not t.is_alive(), "rebind worker thread timed out"
         assert mf._registry is r2
+
+    def test_handler_created_after_install_is_masked(self):
+        """P0-1: a handler created and attached AFTER install_masking_filter
+        must still mask. Without the Handler.__init__ hook, the one-shot
+        _add_filter_to_existing_handlers (run at install time) misses it.
+
+        The test isolates the new handler on a child logger with
+        propagate=False so it is the ONLY handler that sees the record.
+        Otherwise a pre-existing handler's filter (e.g. pytest's
+        LogCaptureHandler) would mask the shared record in place before the
+        new handler emits, hiding the bug — the masking filter mutates
+        record.msg, and all handlers in callHandlers share the same record.
+        """
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("LATE_PW", "late_secret_value")
+
+        capture = StringIO()
+        child = logging.getLogger("datahub.ingestion.source.late_p1")
+        child.handlers.clear()
+        child.propagate = False
+        child.setLevel(logging.INFO)
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            # Handler created and attached AFTER install, on the child only.
+            handler = logging.StreamHandler(capture)
+            handler.setFormatter(logging.Formatter("%(message)s"))
+            child.addHandler(handler)
+            child.info("connecting with late_secret_value")
+            out = capture.getvalue()
+            assert "late_secret_value" not in out, (
+                f"handler created after install leaked secret: {out!r}"
+            )
+            assert "***REDACTED:LATE_PW***" in out
+        finally:
+            child.removeHandler(handler)
+            child.propagate = True
+
+    def test_basicconfig_after_install_masks(self):
+        """P0-1 (B): logging.basicConfig() after install adds a StreamHandler
+        to root; that handler must pick up the filter via the __init__ hook."""
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("BC_PW", "bc_secret_value")
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            # basicConfig with a fresh stream; if root already has handlers
+            # this is a no-op, so force a fresh handler via a manual StreamHandler.
+            capture = StringIO()
+            handler = logging.StreamHandler(capture)
+            handler.setFormatter(logging.Formatter("%(message)s"))
+            logging.getLogger().addHandler(handler)
+            logging.getLogger("datahub.ingestion.source.bc").info(
+                "connecting with bc_secret_value"
+            )
+            out = capture.getvalue()
+            assert "bc_secret_value" not in out
+            assert "***REDACTED:BC_PW***" in out
+        finally:
+            logging.getLogger().removeHandler(handler)
+
+    def test_one_record_multiple_handlers_truncation_byte_count(self):
+        """P0-2: a record reaching 3 handlers must produce exactly one
+        truncation suffix, a correct byte count, and masked output in every
+        handler. The _MASKED sentinel makes filter() idempotent per record."""
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("MULTI", "multi_secret_value")
+
+        captures = [StringIO(), StringIO(), StringIO()]
+        handlers = [logging.StreamHandler(c) for c in captures]
+        for h in handlers:
+            h.setFormatter(logging.Formatter("%(message)s"))
+        root = logging.getLogger()
+        for h in handlers:
+            root.addHandler(h)
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            big = "multi_secret_value " + "y" * 12000
+            logging.getLogger("datahub.test.multi").info(big)
+            outs = [c.getvalue() for c in captures]
+            for i, out in enumerate(outs):
+                assert "multi_secret_value" not in out, (
+                    f"handler {i} leaked secret: {out!r}"
+                )
+                assert "***REDACTED:MULTI***" in out, f"handler {i} not masked"
+                # Exactly one truncation suffix (not nested / re-truncated).
+                assert out.count("bytes truncated for performance") == 1, (
+                    f"handler {i} re-truncated: {out!r}"
+                )
+                # The byte count is the ORIGINAL message's overrun, not the
+                # already-truncated string's.
+                expected_bytes = len(big) - 5000
+                assert str(expected_bytes) in out, (
+                    f"handler {i} wrong byte count: {out!r}"
+                )
+        finally:
+            for h in handlers:
+                root.removeHandler(h)
+
+    def test_double_install_after_new_handler_attaches_and_no_duplicates(self):
+        """P1-1: a second install call after a new handler appeared must
+        attach to the new handler, and must not duplicate the filter on
+        handlers that already have it."""
+        import datahub.masking.masking_filter as mf_mod
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        root = logging.getLogger()
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            f1 = mf_mod._installed_filter
+            assert f1 is not None
+            # New handler after first install.
+            new_cap = StringIO()
+            new_h = logging.StreamHandler(new_cap)
+            new_h.setFormatter(logging.Formatter("%(message)s"))
+            root.addHandler(new_h)
+            # Second install call (refresh path).
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            # The new handler has the filter exactly once.
+            assert sum(1 for f in new_h.filters if f is f1) == 1, (
+                "new handler missing or duplicate filter after refresh"
+            )
+            # Existing handlers don't get a duplicate.
+            for h in root.handlers:
+                assert sum(1 for f in h.filters if f is f1) <= 1, (
+                    f"duplicate filter on handler {h}"
+                )
+        finally:
+            root.removeHandler(new_h)
+
+    def test_uninstall_symmetry_and_unrelated_filter_survives(self):
+        """P1-4: after install -> uninstall, no SecretMaskingFilter remains on
+        any handler or logger, stdout/stderr are the original objects, handler
+        streams are unchanged, and the Handler.__init__ hook is reverted. An
+        unrelated pre-existing filter on a handler survives uninstall."""
+        import datahub.masking.masking_filter as mf_mod
+
+        saved_stdout = sys.stdout
+        saved_stderr = sys.stderr
+        root = logging.getLogger()
+
+        # An unrelated filter that must survive uninstall.
+        class UnrelatedFilter(logging.Filter):
+            pass
+
+        unrelated = UnrelatedFilter()
+        cap = StringIO()
+        h = logging.StreamHandler(cap)
+        h.setFormatter(logging.Formatter("%(message)s"))
+        h.addFilter(unrelated)
+        root.addHandler(h)
+        # Capture the handler's stream reference; it must not change.
+        original_stream = h.stream
+        try:
+            assert mf_mod._original_handler_init is None
+            install_masking_filter(install_stdout_wrapper=True)
+            assert mf_mod._original_handler_init is not None
+            uninstall_masking_filter()
+            # Hook reverted.
+            assert mf_mod._original_handler_init is None
+            # No SecretMaskingFilter anywhere.
+            for _log_name, obj in list(logging.root.manager.loggerDict.items()):
+                if isinstance(obj, logging.Logger):
+                    for hh in obj.handlers:
+                        assert not any(
+                            isinstance(f, SecretMaskingFilter) for f in hh.filters
+                        )
+            for hh in root.handlers:
+                assert not any(isinstance(f, SecretMaskingFilter) for f in hh.filters)
+            assert not any(isinstance(f, SecretMaskingFilter) for f in root.filters)
+            # Unrelated filter survived.
+            assert unrelated in h.filters, "unrelated filter was stripped"
+            # Streams restored.
+            assert sys.stdout is saved_stdout
+            assert sys.stderr is saved_stderr
+            # Handler stream unchanged.
+            assert h.stream is original_stream
+        finally:
+            root.removeHandler(h)
+
+    def test_shared_handler_masking_namespace_bypass(self):
+        """P1-3: a handler shared between a datahub.masking.* logger and a
+        normal logger gets the filter (via the normal logger). Records from
+        the masking namespace through that handler are bypassed by filter()'s
+        record-name check (no re-entrancy, no masking of internal logs).
+        Records from the normal logger are masked."""
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("SHARED", "shared_secret_value")
+
+        shared_cap = StringIO()
+        shared_h = logging.StreamHandler(shared_cap)
+        shared_h.setFormatter(logging.Formatter("%(name)s %(message)s"))
+        normal_logger = logging.getLogger("datahub.ingestion.shared")
+        normal_logger.handlers.clear()
+        normal_logger.propagate = False
+        normal_logger.addHandler(shared_h)
+        masking_logger = logging.getLogger("datahub.masking.sharedtest")
+        masking_logger.handlers.clear()
+        masking_logger.propagate = False
+        masking_logger.addHandler(shared_h)
+        normal_logger.setLevel(logging.DEBUG)
+        masking_logger.setLevel(logging.DEBUG)
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            normal_logger.info("normal line shared_secret_value")
+            masking_logger.warning("internal line shared_secret_value")
+            out = shared_cap.getvalue()
+            # Normal record masked.
+            assert "shared_secret_value" not in out.split("internal line")[0]
+            # The masking-namespace record is NOT masked (bypass), so the
+            # secret appears in that line — by design (internal logs carry no
+            # real secrets). The point: no re-entrancy, no recursion.
+            assert "internal line shared_secret_value" in out
+        finally:
+            normal_logger.removeHandler(shared_h)
+            masking_logger.removeHandler(shared_h)
+            normal_logger.propagate = True
+            masking_logger.propagate = True
+
+    def test_masking_framework_loggers_do_not_propagate(self):
+        """Step 0 Q1: get_masking_safe_logger sets propagate=False so the
+        masking framework's own log records (mask_text warnings, rebuild
+        retries, circuit-breaker messages) do not reach root handlers that
+        carry the masking filter — that would re-enter mask_text. Assert
+        propagate is False and that a warning emitted from inside mask_text
+        does not re-enter the filter."""
+        from datahub.masking.logging_utils import get_masking_safe_logger
+
+        mf_logger = get_masking_safe_logger("datahub.masking.reentry_test")
+        assert mf_logger.propagate is False, (
+            "masking-framework logger propagates to root; mask_text's own "
+            "warnings would re-enter the filter"
+        )
+        # Instrument mask_text to emit a warning mid-call and confirm it
+        # does not recurse into the filter.
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("REENTRY", "reentry_secret_value")
+        root_cap = StringIO()
+        root_h = logging.StreamHandler(root_cap)
+        root_h.setFormatter(logging.Formatter("%(name)s %(message)s"))
+        root = logging.getLogger()
+        root.addHandler(root_h)
+        call_count = {"n": 0}
+        original_mask_text = SecretMaskingFilter.mask_text
+
+        def counting_mask_text(self, text):
+            call_count["n"] += 1
+            return original_mask_text(self, text)
+
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            installed = next(
+                f for f in root_h.filters if isinstance(f, SecretMaskingFilter)
+            )
+            # Bypass mypy's "cannot assign to a method" by setting via __dict__.
+            import types
+
+            installed.mask_text = types.MethodType(  # type: ignore[method-assign]
+                counting_mask_text, installed
+            )
+            # Trigger a masking-framework warning by registering 100+ secrets.
+            for i in range(110):
+                registry.register_secret(f"K{i}", f"v{i}_secret_value")
+            # Force a rebuild + warning path.
+            installed._last_version = -1
+            installed.mask_text("trigger rebuild reentry_secret_value")
+            # The warning from inside mask_text (large secret count) must not
+            # have re-entered the filter (which would inflate the count).
+            # mask_text is called at least once for the trigger; re-entrancy
+            # would call it again from within the warning emission. We can't
+            # pin an exact count (the warning may legitimately call mask_text
+            # for its own stream), but the masking-framework logger has
+            # propagate=False so its records never reach root_h's filter.
+            assert "reentry_secret_value" not in root_cap.getvalue()
+        finally:
+            root.removeHandler(root_h)
+
+    def test_concurrent_add_remove_handler_no_exception(self):
+        """P2-1: concurrent addHandler/removeHandler on one thread while
+        install/uninstall runs on another must not raise. The logging-module
+        lock around the snapshot in _snapshot_handler_pairs prevents
+        RuntimeError from concurrent list mutation."""
+        errors: list = []
+        stop = threading.Event()
+
+        def mutator():
+            root = logging.getLogger()
+            while not stop.is_set():
+                h = logging.StreamHandler(StringIO())
+                root.addHandler(h)
+                root.removeHandler(h)
+
+        def installer():
+            registry = SecretRegistry.get_instance()
+            registry.clear()
+            for _ in range(20):
+                try:
+                    install_masking_filter(registry, install_stdout_wrapper=False)
+                    uninstall_masking_filter()
+                except Exception as e:
+                    errors.append(e)
+
+        try:
+            t1 = threading.Thread(target=mutator, name="mutator")
+            t2 = threading.Thread(target=installer, name="installer")
+            t1.start()
+            t2.start()
+            t2.join(timeout=10.0)
+            stop.set()
+            t1.join(timeout=5.0)
+            assert not t2.is_alive(), "installer thread timed out"
+            assert not errors, f"install/uninstall raised: {errors}"
+        finally:
+            stop.set()
+
+    def test_remove_filter_from_existing_handlers_direct_coverage(self):
+        """P1-4 / test #8: direct coverage of _remove_filter_from_existing_handlers
+        (teardown is the half that was silently broken before this PR). Asserts
+        our instance is gone and an unrelated SecretMaskingFilter survives."""
+        import datahub.masking.masking_filter as mf_mod
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            ours = mf_mod._installed_filter
+            assert ours is not None
+            # Someone else's SecretMaskingFilter on a handler.
+            theirs = SecretMaskingFilter(registry)
+            cap = StringIO()
+            h = logging.StreamHandler(cap)
+            h.setFormatter(logging.Formatter("%(message)s"))
+            h.addFilter(theirs)
+            logging.getLogger().addHandler(h)
+            _remove_filter_from_existing_handlers(ours)
+            assert ours not in h.filters, "our filter was not removed"
+            assert theirs in h.filters, "unrelated SecretMaskingFilter was stripped"
+        finally:
+            logging.getLogger().removeHandler(h)
+            if mf_mod._installed_filter is not None:
+                uninstall_masking_filter()
 
 
 if __name__ == "__main__":

--- a/metadata-ingestion/tests/unit/test_masking_filter.py
+++ b/metadata-ingestion/tests/unit/test_masking_filter.py
@@ -2763,5 +2763,390 @@ class TestCustomFormatException:
                 uninstall_masking_filter()
 
 
+class TestMaskTextIdempotencyProperty:
+    """The single highest-value test: ``mask_text`` is idempotent AND actually
+    masks. Idempotency alone is satisfied by the identity function, so a
+    regression that silently disables masking makes the first assertion
+    *greener* — the second assertion (no registered value survives) is what
+    catches that. The corpus is built by calling ``register_secret`` directly
+    so a name containing marker syntax is exercised (a recipe-built corpus
+    leaves that branch unexercised and the assertion vacuously green)."""
+
+    def _build_corpus(self, registry):
+        """Register a corpus that stresses the marker/value collision
+        cases the alternation ordering exists to handle."""
+        # A plain secret value.
+        registry.register_secret("PW", "s3cret")
+        # The literal "***" — clears the 3-char length floor and is a
+        # substring of every marker.
+        registry.register_secret("STARS", "***")
+        # Uppercase substrings of REDACTED that appear inside every marker.
+        for nm, val in [
+            ("R_SUB", "RED"),
+            ("EDA_SUB", "EDA"),
+            ("DAC_SUB", "DAC"),
+            ("ACT_SUB", "ACT"),
+            ("CTE_SUB", "CTE"),
+            ("TED_SUB", "TED"),
+        ]:
+            registry.register_secret(nm, val)
+        # A value that is a substring of a registered *name* (unbounded
+        # collision surface — names go into the marker verbatim). The value
+        # must meet the 3-char registration floor or it is silently dropped.
+        registry.register_secret("MY_PASSWORD_VAR", "topsecret")
+        registry.register_secret("NAME_SUBSTRING_VALUE", "PASSWORD")
+        # A name containing marker syntax — only reachable via direct
+        # register_secret, not via config loading.
+        registry.register_secret("weird***REDACTED:X***name", "weird_value")
+        # A marker-shaped value (route A): a registered value that exactly
+        # equals a marker for a registered name. The marker must win for
+        # termination, so this passes through in cleartext — refused at
+        # registration in step 5, but the property test must still pass
+        # (the value either survives or is masked; idempotency holds).
+        registry.register_secret("MARKER_VAL_A", "***REDACTED:PW***")
+        # The two-secret oscillation pair: register A's marker under name B
+        # and B's marker under name A. With values first this oscillates
+        # with period 2 and no fixed point; with markers first it
+        # terminates on the first pass.
+        registry.register_secret("A", "***REDACTED:B***")
+        registry.register_secret("B", "***REDACTED:A***")
+        return [
+            "s3cret",
+            "***",
+            "RED",
+            "EDA",
+            "DAC",
+            "ACT",
+            "CTE",
+            "TED",
+            "topsecret",
+            "PASSWORD",
+            "weird_value",
+            "***REDACTED:PW***",
+            "***REDACTED:A***",
+            "***REDACTED:B***",
+            "plain text with s3cret in the middle",
+            "***REDACTED:PW*** next to s3cret",
+            "weird***REDACTED:X***name here",
+        ]
+
+    def test_mask_text_is_idempotent_and_masks(self):
+        from datahub.masking.masking_filter import REDACTED_FORMAT
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        values = self._build_corpus(registry)
+        mf = SecretMaskingFilter(registry)
+        # Touch every value once so the pattern is built.
+        for v in values:
+            mf.mask_text(v)
+
+        # Route-A values: a registered value that exactly equals a marker
+        # for a *registered name* passes through in cleartext because the
+        # marker alternative must win for termination. Compute them from the
+        # registered names so the test stays correct as the corpus changes.
+        all_secrets = registry.get_all_secrets()
+        registered_names = set(all_secrets.values())
+        all_markers = {REDACTED_FORMAT.format(name=n) for n in registered_names}
+        route_a_values = {v for v in values if v in all_markers}
+        # Sanity: ``***REDACTED:PW***`` and ``***REDACTED:A***`` are route A
+        # (PW and A are registered names, and those markers are in the corpus).
+        # ``***REDACTED:B***`` is NOT route A here: the step-5 validation
+        # refuses to register ``***REDACTED:A***`` under name ``B`` (because A
+        # is already registered), so the oscillation pair is half-refused and
+        # ``***REDACTED:B***`` becomes a normal registered value that masks
+        # to ``***REDACTED:A***``. If this assertion ever fails, the corpus
+        # or the validation changed and the route-A computation needs
+        # revisiting.
+        assert "***REDACTED:PW***" in route_a_values
+        assert "***REDACTED:A***" in route_a_values
+        assert "***REDACTED:B***" not in route_a_values
+
+        # 1. Idempotency: mask_text(mask_text(x)) == mask_text(x) for every
+        #    input, including the oscillation pair and route A. A regression
+        #    that makes this fail surfaces the ordering / dispatch bug.
+        for x in values:
+            once = mf.mask_text(x)
+            twice = mf.mask_text(once)
+            assert twice == once, (
+                f"mask_text not idempotent on {x!r}: once={once!r} twice={twice!r}"
+            )
+
+        # 2. Masks at all: mask_text(v) != v for every non-route-A value.
+        #    The identity function (the regression this catches) leaves v
+        #    unchanged, so this assertion fails for it. Substring matching
+        #    (``v not in mask_text(x)``) is too strong for values that are
+        #    substrings of the marker format (``***``, ``RED``, ...), which
+        #    appear inside every ``***REDACTED:...***`` marker by construction;
+        #    ``mask_text(v) != v`` is the clean expression of "v was
+        #    transformed".
+        for v in values:
+            if v in route_a_values:
+                continue
+            masked = mf.mask_text(v)
+            assert masked != v, (
+                f"mask_text did not transform {v!r}: masking silently disabled?"
+            )
+
+
+class TestNonStrMsgAndFailClosed:
+    """Pin finding 9 (non-str ``record.msg`` is masked) and the fail-closed
+    per-field behaviour of ``filter()`` (each step in its own try; the
+    sentinel is set in ``finally`` so it guards the failure path)."""
+
+    def test_truncation_marker_clamps_to_zero_when_masking_expands(self):
+        """Finding 6: masking can EXPAND the text (a 3-char ``***`` secret
+        becomes ``***REDACTED:STARS***`` = 18 chars). When the original fit
+        but the masked output did not, ``original_len - max_message_size``
+        is negative. The marker must report ``max(0, ...)``, not a negative
+        byte count."""
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        # Register *** (3 chars). Masking expands it to ***REDACTED:STARS***
+        # (18 chars). Build a message that fits before masking but overruns
+        # after.
+        registry.register_secret("STARS", "***")
+        mf = SecretMaskingFilter(registry, max_message_size=100)
+        # 10 occurrences of "***" = 30 chars, fits in 100. After masking each
+        # becomes 18 chars, so 10 * 18 = 180 chars, overruns 100.
+        msg = "***" * 10
+        assert len(msg) == 30  # fits before masking
+        masked = mf.mask_text(msg)
+        assert len(masked) > 100  # overruns after masking
+        truncated = mf._truncate_message(masked, original_len=len(msg))
+        # The marker reports max(0, 30 - 100) = 0, not -70.
+        assert "[-70 bytes truncated" not in truncated
+        assert "[0 bytes truncated" in truncated
+
+    def test_msg_truncation_skipped_when_args_present(self):
+        """Finding 7: when ``record.args`` is present, ``record.msg`` is a
+        format string. Pre-truncating or final-truncating it before ``%``
+        formatting can sever a ``%s`` placeholder. Mask the format string but
+        skip both truncation stages."""
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("PW", "s3cret")
+        cap = StringIO()
+        h = logging.StreamHandler(cap)
+        h.setFormatter(logging.Formatter("%(message)s"))
+        lg = logging.getLogger("datahub.test.argstrunc")
+        lg.handlers = [h]
+        lg.setLevel(logging.DEBUG)
+        lg.propagate = False
+        try:
+            mf = SecretMaskingFilter(registry, max_message_size=50)
+            h.addFilter(mf)
+            # A format string with a %s placeholder, longer than max_message_size.
+            # If truncated before % formatting, the %s could be severed.
+            fmt = "Connecting to host %s with password s3cret and " + "x" * 100
+            lg.info(fmt, "hostvalue")
+            out = cap.getvalue()
+            # The secret in the format string is masked.
+            assert "s3cret" not in out
+            assert "***REDACTED:PW***" in out
+            # The %s was not severed — "hostvalue" appears in the formatted
+            # output (msg % args succeeded without ValueError).
+            assert "hostvalue" in out
+            # No truncation marker — truncation was skipped because args present.
+            assert "bytes truncated" not in out
+        finally:
+            lg.handlers = []
+
+    def test_dict_msg_is_masked(self):
+        """``logger.info({"password": "s3cret"})`` — the structlog /
+        JSON-logging idiom — is masked via ``_mask_value_recursive``.
+        Previously such a msg was emitted in cleartext by ``getMessage()``
+        because ``filter()`` masked msg only when it was a ``str`` and
+        ``_mask_extras`` skipped it (msg is a standard attribute)."""
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("PW", "s3cret")
+        cap = StringIO()
+        h = logging.StreamHandler(cap)
+        h.setFormatter(logging.Formatter("%(message)s"))
+        lg = logging.getLogger("datahub.test.dictmsg")
+        lg.handlers = [h]
+        lg.setLevel(logging.DEBUG)
+        lg.propagate = False
+        try:
+            mf = SecretMaskingFilter(registry)
+            h.addFilter(mf)
+            lg.info({"password": "s3cret", "ok": "fine"})
+            out = cap.getvalue()
+            assert "s3cret" not in out, f"dict msg secret leaked: {out!r}"
+            assert "***REDACTED:PW***" in out
+        finally:
+            lg.handlers = []
+
+    def test_arbitrary_object_msg_is_masked_only_when_secret_present(self):
+        """An arbitrary object as ``record.msg`` is ``str()``-ed and masked;
+        ``record.msg`` is replaced with the masked string only when masking
+        changed it (type-preserving when there is no secret, sanitizing when
+        there is)."""
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("PW", "s3cret")
+        cap = StringIO()
+        h = logging.StreamHandler(cap)
+        h.setFormatter(logging.Formatter("%(message)s"))
+        lg = logging.getLogger("datahub.test.objmsg")
+        lg.handlers = [h]
+        lg.setLevel(logging.DEBUG)
+        lg.propagate = False
+        try:
+            mf = SecretMaskingFilter(registry)
+            h.addFilter(mf)
+
+            # Object whose str() contains the secret.
+            class Obj:
+                def __str__(self):
+                    return "obj with s3cret inside"
+
+            lg.info(Obj())
+            out = cap.getvalue()
+            assert "s3cret" not in out, f"object msg secret leaked: {out!r}"
+            assert "***REDACTED:PW***" in out
+
+            # Object whose str() has no secret: record.msg stays the original
+            # object (type-preserving). We verify by checking that the
+            # emitted text is str(obj) unchanged.
+            class Clean:
+                def __str__(self):
+                    return "clean object"
+
+            clean = Clean()
+            lg.info(clean)
+            out2 = cap.getvalue()
+            # The last line is the clean-object emission; it should contain
+            # the plain str() with no redaction.
+            assert "clean object" in out2
+            assert "***REDACTED" not in out2.splitlines()[-1]
+        finally:
+            lg.handlers = []
+
+    def test_sentinel_set_in_finally_when_step_raises(self):
+        """If a step raises, the field is substituted with
+        ``MASKING_ERROR_MESSAGE`` and the sentinel is still set (in
+        ``finally``), so a second handler does not re-process the record.
+        Previously the sentinel was the last statement inside the try, so a
+        failure path got a full unmasked pass per handler."""
+        import datahub.masking.masking_filter as mf_mod
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("PW", "s3cret")
+        mf = SecretMaskingFilter(registry)
+
+        # Force mask_text to raise once, then revert. We patch the instance
+        # method so the first call raises and subsequent calls succeed.
+        original_mask_text = mf.mask_text
+        calls = {"n": 0}
+
+        def flaky_mask_text(text, pre_truncate_budget=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("forced failure for test")
+            return original_mask_text(text, pre_truncate_budget=pre_truncate_budget)
+
+        mf.mask_text = flaky_mask_text  # type: ignore[assignment]
+
+        record = logging.LogRecord(
+            name="datahub.test.failclosed",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="has s3cret inside",
+            args=None,
+            exc_info=None,
+        )
+        try:
+            assert mf.filter(record) is True
+            # The msg step raised; msg is substituted with the error marker.
+            assert record.msg == mf_mod.MASKING_ERROR_MESSAGE, (
+                f"expected MASKING_ERROR_MESSAGE, got {record.msg!r}"
+            )
+            # The sentinel is set despite the failure, so a second handler
+            # would skip re-processing.
+            assert getattr(record, "_datahub_masked", None) == mf_mod._MASKED
+        finally:
+            mf.mask_text = original_mask_text  # type: ignore[assignment]
+
+
+class TestLockOrderInvariant:
+    """Pin the lock-order invariant between ``_install_lock`` and
+    ``logging._lock``. ``Handler.__init__`` (patched by install) runs under
+    ``logging._lock`` (CPython holds it for ``basicConfig`` / ``dictConfig`` /
+    ``fileConfig``) and calls ``_cover_handler``; install/uninstall take
+    ``_install_lock`` then ``logging._lock`` via ``_snapshot_handler_pairs``.
+    If ``_cover_handler`` took ``_install_lock`` the two orders would invert
+    and deadlock. The leaf lock (``_covered_lock``) breaks the cycle."""
+
+    def test_basicconfig_during_install_does_not_deadlock(self):
+        """``logging.basicConfig`` constructs a ``StreamHandler`` under
+        ``logging._lock``; the patched ``__init__`` then calls
+        ``_cover_handler``. Run concurrently with install/uninstall (which
+        take ``_install_lock`` then ``logging._lock``). Under the old code
+        this deadlocks; under the leaf-lock fix both threads complete."""
+        import datahub.masking.masking_filter as mf_mod
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        errors: list = []
+        stop = threading.Event()
+
+        def basicconfig_loop():
+            # basicConfig acquires logging._lock and constructs a handler,
+            # which under install triggers the patched __init__ -> _cover_handler.
+            while not stop.is_set():
+                try:
+                    # Force a fresh handler each iteration: basicConfig is
+                    # idempotent once a handler exists, so we remove handlers
+                    # first to make it construct again.
+                    root = logging.getLogger()
+                    for h in list(root.handlers):
+                        root.removeHandler(h)
+                    logging.basicConfig(force=True)
+                except Exception as e:
+                    errors.append(e)
+
+        def install_loop():
+            while not stop.is_set():
+                try:
+                    install_masking_filter(registry, install_stdout_wrapper=False)
+                    mf_mod._uninstall_masking_filter()
+                except Exception as e:
+                    errors.append(e)
+
+        try:
+            t1 = threading.Thread(target=basicconfig_loop, name="basicconfig")
+            t2 = threading.Thread(target=install_loop, name="install")
+            t1.start()
+            t2.start()
+            # Let them race briefly. A deadlock hangs the join; the timeout
+            # catches it and we assert the threads are not alive.
+            t2.join(timeout=5.0)
+            stop.set()
+            t1.join(timeout=5.0)
+            t2.join(timeout=2.0)
+            assert not t1.is_alive(), (
+                "basicconfig thread timed out — likely deadlock in "
+                "_cover_handler under logging._lock"
+            )
+            assert not t2.is_alive(), (
+                "install thread timed out — likely deadlock in "
+                "_snapshot_handler_pairs under _install_lock"
+            )
+            assert not errors, f"concurrent basicConfig/install raised: {errors}"
+        finally:
+            stop.set()
+            if mf_mod._installed_filter is not None:
+                mf_mod._uninstall_masking_filter()
+            # Restore a sane root handler config after the basicConfig churn.
+            root = logging.getLogger()
+            for h in list(root.handlers):
+                root.removeHandler(h)
+            logging.basicConfig(level=logging.DEBUG)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/metadata-ingestion/tests/unit/test_masking_filter.py
+++ b/metadata-ingestion/tests/unit/test_masking_filter.py
@@ -724,8 +724,9 @@ class TestEdgeCases:
         assert "***REDACTED:SPECIAL***" in record.msg
 
 
-class TestP1Fixes:
-    """Test P1 critical fixes from production hardening review."""
+class TestStreamWrapperContract:
+    """Pin the StreamMaskingWrapper write() contract: return value and
+    type validation."""
 
     def test_stream_wrapper_return_value(self):
         """
@@ -761,8 +762,7 @@ class TestP1Fixes:
         )
 
     def test_stream_wrapper_type_validation(self):
-        """
-        P1 FIX #2: Verify write() rejects non-string types.
+        """Verify write() rejects non-string types.
 
         The wrapper should raise TypeError for non-string input
         to maintain contract compliance.
@@ -786,9 +786,12 @@ class TestP1Fixes:
         with pytest.raises(TypeError, match="must be str"):
             wrapper.write(None)  # type: ignore[arg-type]
 
+
+class TestRegistrySingleton:
+    """Pin the SecretRegistry singleton's thread-safety and O(1) lookup."""
+
     def test_singleton_thread_safety(self):
-        """
-        P1 FIX #3: Verify singleton is thread-safe under concurrent access.
+        """Verify the singleton is thread-safe under concurrent access.
 
         The simplified singleton pattern should only create one instance
         even when accessed concurrently from multiple threads.
@@ -818,8 +821,7 @@ class TestP1Fixes:
         assert len(instances) == 50, f"Expected 50 calls, got {len(instances)}"
 
     def test_get_secret_value_performance(self):
-        """
-        P2 BONUS: Verify O(1) lookup with reverse index.
+        """Verify O(1) lookup with the reverse index.
 
         With the reverse index, lookups should be O(1) instead of O(n).
         """
@@ -1303,10 +1305,12 @@ class TestHandlerCoverageAndCelerySafety:
             redirect_logger.removeHandler(redirect_handler)
 
 
-class TestReviewFixes:
-    """Regression tests for issues raised in code review of the handler-level
-    masking fix. Each test targets a specific defect; together they pin the
-    invariants the fix is supposed to maintain."""
+class TestInstallLifecycleAndCoverage:
+    """Pin the install/teardown lifecycle and handler-coverage invariants:
+    idempotent install, symmetric uninstall, hook-before-scan, refresh on
+    repeat install, namespace bypass, extras masking, and snapshot
+    locking. Grouped by the behavior each test pins rather than by review
+    round."""
 
     def setup_method(self):
         uninstall_masking_filter()
@@ -1962,17 +1966,12 @@ class TestReviewFixes:
                 assert out.count("bytes truncated for performance") == 1, (
                     f"handler {i} re-truncated: {out!r}"
                 )
-                # D6: masking runs before truncation now, so the byte count
-                # is the MASKED message's overrun (the secret is replaced by
-                # ***REDACTED:MULTI*** before truncating), not the original
-                # message's overrun. Compute the masked message via the
-                # installed filter so the assertion tracks the real masked
-                # length rather than a hardcoded guess.
-                mf = next(
-                    f for f in handlers[0].filters if isinstance(f, SecretMaskingFilter)
-                )
-                masked_big = mf.mask_text(big)
-                expected_bytes = len(masked_big) - 5000
+                # The byte count in the marker reflects the ORIGINAL
+                # message's overrun (original_len - max_message_size), per
+                # the two-stage truncation: the user sees how much of the
+                # original was dropped, not how much of the pre-truncated
+                # region was dropped.
+                expected_bytes = len(big) - 5000
                 assert str(expected_bytes) in out, (
                     f"handler {i} wrong byte count: {out!r}"
                 )
@@ -2499,6 +2498,267 @@ class TestReviewFixes:
                 "orphan handler (not on any logger) retained the filter after uninstall"
             )
         finally:
+            if mf_mod._installed_filter is not None:
+                uninstall_masking_filter()
+
+
+class TestStructuredFormatterAndGuard:
+    """Pin the idempotency token's survival across the structured-formatter
+    and async-logging boundaries, and the no-record-dropped guarantee for
+    formatters that serialize ``record.__dict__``."""
+
+    def test_json_formatter_serializing_record_dict_does_not_drop_record(self):
+        """A JSON formatter that serializes ``record.__dict__`` must emit a
+        valid line; the idempotency token (a string, not ``object()``) is
+        JSON-serializable so the formatter does not raise and drop the
+        record. This is the B1 regression: ``object()`` raised
+        ``TypeError: Object of type object is not JSON serializable`` and
+        silently dropped the line."""
+        import json
+
+        import datahub.masking.masking_filter as mf_mod
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("J_PW", "json_secret_value")
+
+        class JsonFormatter(logging.Formatter):
+            def format(self, record):
+                return json.dumps({k: str(v) for k, v in record.__dict__.items()})
+
+        cap = StringIO()
+        h = logging.StreamHandler(cap)
+        h.setFormatter(JsonFormatter())
+        logging.getLogger().addHandler(h)
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            logging.getLogger("datahub.test.json").info(
+                "connecting with json_secret_value"
+            )
+            out = cap.getvalue()
+            assert out, f"JSON formatter dropped the record (no output): {out!r}"
+            # The token appears as a key in the JSON output — accepted cost.
+            assert "_datahub_masked" in out
+            # The secret is masked.
+            assert "json_secret_value" not in out
+            assert "***REDACTED:J_PW***" in out
+        finally:
+            logging.getLogger().removeHandler(h)
+            if mf_mod._installed_filter is not None:
+                uninstall_masking_filter()
+
+    def test_guard_survives_queuehandler_queuelistener(self):
+        """The idempotency token (compared by value) survives a
+        ``QueueHandler``/``QueueListener`` pair: the record is pickled
+        onto the queue, unpickled on the listener thread, and formatted
+        there. A second filter on the listener's handler must see the token
+        and skip re-masking. Pre-B1 the ``object()`` sentinel failed ``is``
+        after unpickle and the listener's filter re-masked (B2 corruption)."""
+        import logging.handlers
+        import queue
+
+        import datahub.masking.masking_filter as mf_mod
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("Q_PW", "queue_secret_value")
+
+        q = queue.Queue()
+        listener_cap = StringIO()
+        listener_handler = logging.StreamHandler(listener_cap)
+        listener_handler.setFormatter(logging.Formatter("%(message)s"))
+        # The listener's handler also carries the filter (installed via the
+        # hook or the scan); a second masking pass here is what B2 corrupts.
+        install_masking_filter(registry, install_stdout_wrapper=False)
+        # Attach the listener-handler AFTER install so the hook covers it.
+        listener_handler.addFilter(mf_mod._installed_filter)
+
+        qh = logging.handlers.QueueHandler(q)
+        logging.getLogger().addHandler(qh)
+        listener = logging.handlers.QueueListener(q, listener_handler)
+        listener.start()
+        try:
+            logging.getLogger("datahub.test.queue").info(
+                "connecting with queue_secret_value"
+            )
+            # Wait for the listener thread to process the record.
+            import time
+
+            for _ in range(100):
+                if q.empty() and listener_cap.getvalue():
+                    break
+                time.sleep(0.01)
+            listener_handler.flush()
+            out = listener_cap.getvalue()
+            assert "queue_secret_value" not in out, (
+                f"secret leaked via queue listener: {out!r}"
+            )
+            assert "***REDACTED:Q_PW***" in out
+            # Exactly one truncation/mask — the listener's filter did not
+            # re-mask (which would double the redaction token or re-truncate).
+            assert out.count("***REDACTED:Q_PW***") == 1, (
+                f"listener re-masked the record: {out!r}"
+            )
+        finally:
+            listener.stop()
+            logging.getLogger().removeHandler(qh)
+            if mf_mod._installed_filter is not None:
+                uninstall_masking_filter()
+
+    def test_guard_survives_pickle_round_trip(self):
+        """The idempotency token survives a pickle round-trip: after
+        pickle/unpickle the token is a new object, so ``is`` fails but ``==``
+        succeeds. A second filter seeing the un-pickled record must skip
+        re-masking."""
+        import pickle
+
+        import datahub.masking.masking_filter as mf_mod
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("P_PW", "pickle_secret_value")
+
+        cap = StringIO()
+        h = logging.StreamHandler(cap)
+        h.setFormatter(logging.Formatter("%(message)s"))
+        logging.getLogger().addHandler(h)
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            record = logging.LogRecord(
+                name="datahub.test.pickle",
+                level=logging.INFO,
+                pathname=__file__,
+                lineno=1,
+                msg="connecting with pickle_secret_value",
+                args=None,
+                exc_info=None,
+            )
+            # First pass: mask + stamp the token.
+            assert mf_mod._installed_filter.filter(record)
+            assert getattr(record, "_datahub_masked", None) == mf_mod._MASKED
+            first_msg = record.msg
+            # Pickle round-trip: the token object identity is lost.
+            record2 = pickle.loads(pickle.dumps(record))
+            assert getattr(record2, "_datahub_masked", None) is not mf_mod._MASKED
+            # But value equality holds, so the guard skips re-masking.
+            assert mf_mod._installed_filter.filter(record2)
+            assert record2.msg == first_msg, (
+                "second filter pass after pickle re-masked or re-truncated the record"
+            )
+        finally:
+            logging.getLogger().removeHandler(h)
+            if mf_mod._installed_filter is not None:
+                uninstall_masking_filter()
+
+    def test_truncate_idempotent_with_guard_cleared(self):
+        """``_truncate_message`` is idempotent on its own (B2): even if the
+        idempotency token is stripped from the record (a formatter that
+        deletes unknown attributes, or a hand-built record), a second
+        masking pass does not re-truncate and corrupt the byte count."""
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        mf = SecretMaskingFilter(registry, max_message_size=100)
+        big = "x" * 200
+        first = mf._truncate_message(big)
+        assert "truncated for performance" in first
+        # Second pass with the guard forcibly cleared (no _datahub_masked).
+        second = mf._truncate_message(first)
+        assert second == first, (
+            f"_truncate_message re-truncated an already-truncated message: "
+            f"first={first!r} second={second!r}"
+        )
+
+    def test_truncation_with_secret_straddling_pre_truncate_boundary_json_escaped(self):
+        """A secret in its JSON-escaped form straddling the pre-truncate
+        boundary must not survive in part. The two-stage truncation bound
+        is the longest *expanded* key (JSON-escaped can be longer than the
+        raw value), so the JSON-escaped secret is fully contained in the
+        pre-truncated region and gets masked before the final cut."""
+        import json
+
+        # A secret whose JSON-escaped form is longer than the raw value.
+        raw_secret = 'quote"secret'
+        json_secret = json.dumps(raw_secret)  # '"quote\\"secret"' (longer)
+        assert len(json_secret) > len(raw_secret)
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("JS_PW", raw_secret)
+        # The registry expands keys, so json_secret is in the pattern.
+
+        cap = StringIO()
+        h = logging.StreamHandler(cap)
+        h.setFormatter(logging.Formatter("%(message)s"))
+        logging.getLogger().addHandler(h)
+        try:
+            mf = SecretMaskingFilter(registry, max_message_size=50)
+            h.addFilter(mf)
+            # Place the JSON-escaped secret so it straddles the pre-truncate
+            # boundary (max_message_size + longest_key). The raw secret is
+            # at the start (masked early); the JSON-escaped form is near the
+            # cut.
+            msg = "x" * 40 + json_secret + "y" * 200
+            logging.getLogger("datahub.test.jsboundary").info(msg)
+            out = cap.getvalue()
+            assert raw_secret not in out, f"raw secret leaked: {out!r}"
+            assert json_secret not in out, (
+                f"JSON-escaped secret leaked across pre-truncate boundary: {out!r}"
+            )
+            # No partial prefix of either form should survive.
+            for n in range(3, len(json_secret)):
+                assert json_secret[:n] not in out, (
+                    f"partial JSON-escaped secret ({n} chars) leaked: {out!r}"
+                )
+        finally:
+            logging.getLogger().removeHandler(h)
+
+
+class TestCustomFormatException:
+    """Pin the exc_text pre-fill residual: a custom formatException
+    override is bypassed because stdlib Formatter.format only calls
+    formatException when exc_text is falsy."""
+
+    def test_custom_format_exception_is_bypassed(self):
+        """When filter() pre-fills record.exc_text, a handler whose
+        formatter overrides formatException has that override bypassed:
+        stdlib Formatter.format skips its formatException call entirely
+        (it only calls formatException when exc_text is falsy). The stock
+        masked traceback is emitted instead. This is the documented
+        residual; the test pins it so a future change is intentional."""
+        import datahub.masking.masking_filter as mf_mod
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("EX_PW", "exc_secret_value")
+
+        custom_used = []
+
+        class CustomFormatter(logging.Formatter):
+            def formatException(self, ei):
+                custom_used.append(True)
+                return "CUSTOM TRACEBACK"
+
+        cap = StringIO()
+        h = logging.StreamHandler(cap)
+        h.setFormatter(CustomFormatter("%(message)s"))
+        logging.getLogger().addHandler(h)
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            try:
+                raise ValueError("boom with exc_secret_value")
+            except ValueError:
+                logging.getLogger("datahub.test.exc").exception("caught")
+            out = cap.getvalue()
+            # The custom formatException was NOT called (exc_text pre-filled).
+            assert not custom_used, (
+                "custom formatException was called; exc_text pre-fill should "
+                "have bypassed it"
+            )
+            # The stock masked traceback was emitted, with the secret masked.
+            assert "exc_secret_value" not in out
+            assert "***REDACTED:EX_PW***" in out
+            assert "ValueError" in out
+        finally:
+            logging.getLogger().removeHandler(h)
             if mf_mod._installed_filter is not None:
                 uninstall_masking_filter()
 

--- a/metadata-ingestion/tests/unit/test_masking_filter.py
+++ b/metadata-ingestion/tests/unit/test_masking_filter.py
@@ -1962,9 +1962,17 @@ class TestReviewFixes:
                 assert out.count("bytes truncated for performance") == 1, (
                     f"handler {i} re-truncated: {out!r}"
                 )
-                # The byte count is the ORIGINAL message's overrun, not the
-                # already-truncated string's.
-                expected_bytes = len(big) - 5000
+                # D6: masking runs before truncation now, so the byte count
+                # is the MASKED message's overrun (the secret is replaced by
+                # ***REDACTED:MULTI*** before truncating), not the original
+                # message's overrun. Compute the masked message via the
+                # installed filter so the assertion tracks the real masked
+                # length rather than a hardcoded guess.
+                mf = next(
+                    f for f in handlers[0].filters if isinstance(f, SecretMaskingFilter)
+                )
+                masked_big = mf.mask_text(big)
+                expected_bytes = len(masked_big) - 5000
                 assert str(expected_bytes) in out, (
                     f"handler {i} wrong byte count: {out!r}"
                 )
@@ -2336,10 +2344,16 @@ class TestReviewFixes:
             assert logging.Handler.__init__ is their_init, (
                 "uninstall clobbered another library's Handler.__init__ patch"
             )
-            assert mf_mod._original_handler_init is None
-            assert mf_mod._patched_handler_init is None
+            # S6: on decline we KEEP the saved globals so re-install is
+            # idempotent (the dead patch in lib X's chain reactivates when
+            # _installed_filter is set again) instead of stacking a new
+            # wrapper each cycle.
+            assert mf_mod._original_handler_init is original
+            assert mf_mod._patched_handler_init is our_patch
             # Restore for teardown.
             logging.Handler.__init__ = original  # type: ignore[assignment]
+            mf_mod._original_handler_init = None
+            mf_mod._patched_handler_init = None
         finally:
             if mf_mod._installed_filter is not None:
                 uninstall_masking_filter()
@@ -2381,6 +2395,109 @@ class TestReviewFixes:
                 "covered — the hook must be installed before the scan"
             )
             logging.getLogger().removeHandler(h)
+        finally:
+            if mf_mod._installed_filter is not None:
+                uninstall_masking_filter()
+
+    def test_exact_masking_namespace_logger_is_bypassed(self):
+        """D3: the bypass predicate in filter() must match the attach-time
+        skip predicate. A record from the logger named exactly
+        ``datahub.masking`` (no trailing dot) must be bypassed, not masked —
+        ``startswith(REDACTED_MASKING_NAMESPACE)`` misses it, so the two
+        call sites used to disagree."""
+        import datahub.masking.masking_filter as mf_mod
+        from datahub.masking.masking_filter import _is_masking_namespace_name
+
+        # The predicate covers both the dotless name and the dotted namespace.
+        assert _is_masking_namespace_name("datahub.masking")
+        assert _is_masking_namespace_name("datahub.masking.foo")
+        assert not _is_masking_namespace_name("datahub.maskingfoo")
+        assert not _is_masking_namespace_name("datahub.ingestion")
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("M_NS", "maskingns_secret_value")
+        cap = StringIO()
+        h = logging.StreamHandler(cap)
+        h.setFormatter(logging.Formatter("%(message)s"))
+        ns_logger = logging.getLogger("datahub.masking")
+        ns_logger.addHandler(h)
+        ns_logger.propagate = False
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            ns_logger.info("internal log mentioning maskingns_secret_value")
+            out = cap.getvalue()
+            # The record is bypassed: the secret appears UNMASKED because
+            # the record-name bypass short-circuits. This is correct —
+            # masking-internal loggers carry no secrets and must not re-enter.
+            assert "maskingns_secret_value" in out, (
+                f"datahub.masking record was masked (should be bypassed): {out!r}"
+            )
+            assert "***REDACTED:M_NS***" not in out
+        finally:
+            ns_logger.removeHandler(h)
+            if mf_mod._installed_filter is not None:
+                uninstall_masking_filter()
+
+    def test_truncation_does_not_leak_partial_secret(self):
+        """D6: a secret straddling the truncation cut point must not survive
+        in part. Mask-before-truncate replaces the secret with a redaction
+        token first, so truncating the masked message can only cut tokens,
+        never secret bytes."""
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("PW", "SUPERSECRETPASSWORD1234")
+        cap = StringIO()
+        h = logging.StreamHandler(cap)
+        h.setFormatter(logging.Formatter("%(message)s"))
+        logging.getLogger().addHandler(h)
+        try:
+            mf = SecretMaskingFilter(registry, max_message_size=100)
+            # Manually attach so we control max_message_size precisely.
+            h.addFilter(mf)
+            # Secret straddles the 100-char cut.
+            msg = "x" * 90 + "SUPERSECRETPASSWORD1234" + "y" * 200
+            logging.getLogger("datahub.test.trunc").info(msg)
+            out = cap.getvalue()
+            assert "SUPERSECRETPASSWORD1234" not in out, f"full secret leaked: {out!r}"
+            # No partial prefix of the secret should survive either —
+            # mask-before-truncate replaces the whole secret with a
+            # redaction token, so even the secret's first few chars are
+            # gone. (The token itself may be cut by truncation, which is
+            # fine — only the secret must not survive.)
+            for n in range(3, len("SUPERSECRETPASSWORD1234")):
+                assert "SUPERSECRETPASSWORD1234"[:n] not in out, (
+                    f"partial secret prefix ({n} chars) leaked: {out!r}"
+                )
+            # The message was truncated (D6 still truncates after masking).
+            assert "truncated for performance" in out
+        finally:
+            logging.getLogger().removeHandler(h)
+
+    def test_handler_not_on_any_logger_cleaned_on_uninstall(self):
+        """S7: a handler that received the filter via the Handler.__init__
+        hook but is not attached to any logger (held by a QueueListener, or
+        just constructed and never attached) must still have the filter
+        removed on uninstall — _snapshot_handler_pairs only sees
+        handlers on loggers, so without covered-handler tracking this
+        handler would retain the filter."""
+        import datahub.masking.masking_filter as mf_mod
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            # Construct a handler AFTER install (hook attaches the filter)
+            # but never attach it to any logger.
+            orphan = logging.StreamHandler(StringIO())
+            assert mf_mod._installed_filter in orphan.filters, (
+                "hook did not attach filter to the orphan handler"
+            )
+            uninstall_masking_filter()
+            assert mf_mod._installed_filter is None
+            assert mf_mod._installed_filter not in orphan.filters, (
+                "orphan handler (not on any logger) retained the filter after uninstall"
+            )
         finally:
             if mf_mod._installed_filter is not None:
                 uninstall_masking_filter()

--- a/metadata-ingestion/tests/unit/test_masking_filter.py
+++ b/metadata-ingestion/tests/unit/test_masking_filter.py
@@ -1466,10 +1466,10 @@ class TestReviewFixes:
     def test_extras_self_referential_does_not_hang(self):
         """Issue 2 (B): extra= can carry self-referential structures. The
         identity-based cycle guard must prevent infinite recursion (which
-        would hang the logger). The cycle is returned unchanged (residual
-        gap, acceptable — secrets in a cycle are rare and the cycle itself
-        would be unprintable anyway). The primary assertion is no-hang; the
-        secondary is that the non-cyclic top-level leaf IS masked."""
+        would hang the logger). The cycle branch returns a placeholder
+        string (``"<not masked: cycle>"``) rather than the raw value —
+        returning the raw subtree would emit any secret it contains in
+        cleartext, and everything else in this module fails closed."""
         registry = SecretRegistry.get_instance()
         registry.clear()
         registry.register_secret("CYCLE_PW", "cycle_secret_value")
@@ -1493,21 +1493,23 @@ class TestReviewFixes:
         mf.filter(record)
         # The non-cyclic top-level leaf with the secret is masked.
         assert "***REDACTED:CYCLE_PW***" in str(record.cfg)
-        # Residual gap: the cycle's self-reference points to the original
-        # unmasked dict, so the secret may still appear in the deep str repr.
-        # That is the documented accepted residual — the cycle itself is
-        # unprintable in practice.
+        # The cycle branch emits a placeholder, NOT the raw subtree, so the
+        # secret does not leak via the cycle's self-reference.
+        assert "cycle_secret_value" not in str(record.cfg)
+        assert "<not masked: cycle>" in str(record.cfg)
 
     def test_extras_deep_nesting_is_capped(self):
         """Issue 2 (B): very deep nesting is capped at _MAX_EXTRA_DEPTH to
-        bound hot-path cost. Beyond the cap the value is returned unchanged
-        (residual gap) rather than raising."""
+        bound hot-path cost. Past the cap the value is replaced with a
+        placeholder string (not the raw subtree), so secrets past the cap
+        don't leak."""
         registry = SecretRegistry.get_instance()
         registry.clear()
         registry.register_secret("DEEP_PW", "deep_secret_value")
 
         mf = SecretMaskingFilter(registry)
-        # Build a deeply nested dict past the cap.
+        # Build a deeply nested dict past the cap, with the secret at the
+        # bottom (past the cap).
         deep: dict = {"pw": "deep_secret_value"}
         for _ in range(SecretMaskingFilter._MAX_EXTRA_DEPTH + 5):
             deep = {"child": deep}
@@ -1523,6 +1525,10 @@ class TestReviewFixes:
         record.cfg = deep
         # Must not hang or raise.
         mf.filter(record)
+        # The cap emits a placeholder, NOT the raw subtree, so the secret
+        # past the cap does not leak.
+        assert "deep_secret_value" not in str(record.cfg)
+        assert "<not masked: depth limit>" in str(record.cfg)
 
     def test_json_formatter_with_quote_in_secret(self):
         """Issue 4: a JSON formatter escapes quotes/backslashes in the secret
@@ -1634,6 +1640,102 @@ class TestReviewFixes:
         finally:
             logging.getLogger().removeHandler(root_handler)
             foo_logger.propagate = False
+
+    def test_reset_instance_tears_down_installed_filter(self):
+        """reset_instance() must tear down the installed filter so a
+        subsequent install(new_registry) masks with the new registry.
+        Without this, the filter survives reset_instance() and keeps
+        masking with the old (now-stale) registry — masking silently
+        stops working for every secret registered after the reset.
+
+        Reproduces the reviewer scenario: install(r1) → reset_instance()
+        → install(r2). On the unfixed tree, r2's secret leaks because the
+        filter still reads r1."""
+        import datahub.masking.masking_filter as mf_mod
+
+        # install(r1) — uses r1, attaches filter1 to handlers/root.
+        r1 = SecretRegistry()
+        r1.clear()
+        install_masking_filter(secret_registry=r1, install_stdout_wrapper=False)
+        assert mf_mod._installed_filter is not None
+        filter1 = mf_mod._installed_filter
+        assert filter1._registry is r1
+
+        # reset_instance() — tears down filter1 (removes from handlers,
+        # clears _installed_filter).
+        SecretRegistry.reset_instance()
+        assert mf_mod._installed_filter is None
+
+        # install(r2) — fresh install with a new registry.
+        r2 = SecretRegistry()
+        r2.clear()
+        r2.register_secret("R2_TOKEN", "bbb_secret_2")
+        install_masking_filter(secret_registry=r2, install_stdout_wrapper=False)
+        assert mf_mod._installed_filter is not None
+        assert mf_mod._installed_filter._registry is r2
+        assert mf_mod._installed_filter is not filter1  # new instance, not reused
+
+        # r2's secret is masked by the new filter.
+        mf = mf_mod._installed_filter
+        masked = mf.mask_text("connecting with bbb_secret_2")
+        assert "bbb_secret_2" not in masked
+        assert "***REDACTED:R2_TOKEN***" in masked
+
+        uninstall_masking_filter()
+
+    def test_refresh_rebinds_registry_on_repeat_install(self):
+        """The refresh path (already installed) must rebind the registry
+        when the caller passes a different one, so install(r1) without
+        reset_instance() in between still picks up r2. Belt-and-braces
+        alongside reset_instance() for callers that use the public API
+        twice without resetting."""
+        import datahub.masking.masking_filter as mf_mod
+
+        r1 = SecretRegistry()
+        r1.clear()
+        install_masking_filter(secret_registry=r1, install_stdout_wrapper=False)
+        filter1 = mf_mod._installed_filter
+        assert filter1._registry is r1
+
+        # install(r2) WITHOUT reset_instance() — refresh path rebinds.
+        r2 = SecretRegistry()
+        r2.clear()
+        r2.register_secret("R2_TOKEN", "ccc_secret_3")
+        install_masking_filter(secret_registry=r2, install_stdout_wrapper=False)
+        # Same filter instance (process-lifetime), but registry rebound.
+        assert mf_mod._installed_filter is filter1
+        assert filter1._registry is r2
+
+        masked = filter1.mask_text("connecting with ccc_secret_3")
+        assert "ccc_secret_3" not in masked
+        assert "***REDACTED:R2_TOKEN***" in masked
+
+        uninstall_masking_filter()
+
+    def test_refresh_readds_root_logger_filter_if_removed(self):
+        """If something removed the root-logger filter (partial teardown
+        state), the refresh path must re-add it. Without this, a
+        partially-torn-down state stays partial: handler filters are
+        re-scanned but the root-logger sentinel is gone, so a later
+        install would re-install from scratch and attach a second filter."""
+        import datahub.masking.masking_filter as mf_mod
+
+        r1 = SecretRegistry()
+        r1.clear()
+        install_masking_filter(secret_registry=r1, install_stdout_wrapper=False)
+        filter1 = mf_mod._installed_filter
+        root_logger = logging.getLogger()
+        assert filter1 in root_logger.filters
+
+        # Simulate partial teardown: remove root-logger filter only.
+        root_logger.removeFilter(filter1)
+        assert filter1 not in root_logger.filters
+
+        # Refresh path re-adds it.
+        install_masking_filter(secret_registry=r1, install_stdout_wrapper=False)
+        assert filter1 in root_logger.filters
+
+        uninstall_masking_filter()
 
 
 if __name__ == "__main__":

--- a/metadata-ingestion/tests/unit/test_masking_filter.py
+++ b/metadata-ingestion/tests/unit/test_masking_filter.py
@@ -1828,6 +1828,49 @@ class TestReviewFixes:
         )
         assert "***REDACTED:OPT_OUT***" in out
 
+    def test_rebind_registry_acquires_pattern_lock(self):
+        """Fix 1: ``rebind_registry`` wrote ``_registry`` / ``_last_version``
+        / ``_pattern`` / ``_replacements`` with no lock. ``mask_text``
+        snapshots ``_pattern`` and ``_replacements`` under ``_pattern_lock``,
+        so an unlocked rebind landing between those two snapshots emits
+        cleartext (``_pattern=None`` snapshot) or ``***REDACTED:UNKNOWN***``
+        (old ``_pattern`` + cleared ``_replacements``).
+
+        Deterministic lock-acquisition test: hold ``_pattern_lock`` on the
+        test thread, start a worker that calls ``rebind_registry``, and
+        assert the worker blocks until the lock is released. Without the
+        fix the worker completes immediately (no lock needed); with the fix
+        it blocks on the lock.
+        """
+        r1 = SecretRegistry()
+        r1.clear()
+        r1.register_secret("A", "aaa_secret_1")
+        mf = SecretMaskingFilter(r1)
+        mf.mask_text("x aaa_secret_1")  # prime the pattern
+
+        r2 = SecretRegistry()
+        r2.clear()
+
+        with mf._pattern_lock:
+            done = threading.Event()
+
+            def worker():
+                mf.rebind_registry(r2)
+                done.set()
+
+            t = threading.Thread(target=worker, name="rebind-worker")
+            t.start()
+            completed = done.wait(timeout=0.5)
+            assert not completed, (
+                "rebind_registry completed without acquiring _pattern_lock; "
+                "its writes are unprotected and can tear mask_text's snapshot "
+                "of _pattern/_replacements, emitting cleartext or "
+                "***REDACTED:UNKNOWN***"
+            )
+        t.join(timeout=5.0)
+        assert not t.is_alive(), "rebind worker thread timed out"
+        assert mf._registry is r2
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/metadata-ingestion/tests/unit/test_masking_filter.py
+++ b/metadata-ingestion/tests/unit/test_masking_filter.py
@@ -1451,15 +1451,15 @@ class TestReviewFixes:
                 args=(),
                 exc_info=None,
             )
-            record.cfg = caller_cfg
+            record.__dict__["cfg"] = caller_cfg
             mf.filter(record)
             # The caller's original dict is untouched.
             assert caller_cfg == caller_cfg_snapshot, (
                 f"Caller's dict was mutated by masking: {caller_cfg!r}"
             )
             # The record's copy is masked.
-            assert "cfg_secret_value" not in str(record.cfg)
-            assert "***REDACTED:CFG_PW***" in str(record.cfg)
+            assert "cfg_secret_value" not in str(record.__dict__["cfg"])
+            assert "***REDACTED:CFG_PW***" in str(record.__dict__["cfg"])
         finally:
             test_logger.handlers.clear()
 
@@ -1488,15 +1488,15 @@ class TestReviewFixes:
             args=(),
             exc_info=None,
         )
-        record.cfg = cycle_dict
+        record.__dict__["cfg"] = cycle_dict
         # Must not hang — the cycle guard prevents infinite recursion.
         mf.filter(record)
         # The non-cyclic top-level leaf with the secret is masked.
-        assert "***REDACTED:CYCLE_PW***" in str(record.cfg)
+        assert "***REDACTED:CYCLE_PW***" in str(record.__dict__["cfg"])
         # The cycle branch emits a placeholder, NOT the raw subtree, so the
         # secret does not leak via the cycle's self-reference.
-        assert "cycle_secret_value" not in str(record.cfg)
-        assert "<not masked: cycle>" in str(record.cfg)
+        assert "cycle_secret_value" not in str(record.__dict__["cfg"])
+        assert "<not masked: cycle>" in str(record.__dict__["cfg"])
 
     def test_extras_deep_nesting_is_capped(self):
         """Issue 2 (B): very deep nesting is capped at _MAX_EXTRA_DEPTH to
@@ -1522,13 +1522,13 @@ class TestReviewFixes:
             args=(),
             exc_info=None,
         )
-        record.cfg = deep
+        record.__dict__["cfg"] = deep
         # Must not hang or raise.
         mf.filter(record)
         # The cap emits a placeholder, NOT the raw subtree, so the secret
         # past the cap does not leak.
-        assert "deep_secret_value" not in str(record.cfg)
-        assert "<not masked: depth limit>" in str(record.cfg)
+        assert "deep_secret_value" not in str(record.__dict__["cfg"])
+        assert "<not masked: depth limit>" in str(record.__dict__["cfg"])
 
     def test_json_formatter_with_quote_in_secret(self):
         """Issue 4: a JSON formatter escapes quotes/backslashes in the secret
@@ -1695,6 +1695,7 @@ class TestReviewFixes:
         r1.clear()
         install_masking_filter(secret_registry=r1, install_stdout_wrapper=False)
         filter1 = mf_mod._installed_filter
+        assert filter1 is not None
         assert filter1._registry is r1
 
         # install(r2) WITHOUT reset_instance() — refresh path rebinds.

--- a/metadata-ingestion/tests/unit/test_masking_filter.py
+++ b/metadata-ingestion/tests/unit/test_masking_filter.py
@@ -17,6 +17,7 @@ import time
 from io import StringIO
 
 import pytest
+from pytest import MonkeyPatch
 
 from datahub.masking.masking_filter import (
     SecretMaskingFilter,
@@ -2214,6 +2215,173 @@ class TestReviewFixes:
             assert theirs in h.filters, "unrelated SecretMaskingFilter was stripped"
         finally:
             logging.getLogger().removeHandler(h)
+            if mf_mod._installed_filter is not None:
+                uninstall_masking_filter()
+
+    def test_snapshot_uses_lock_not_acquire_lock(self):
+        """A1: ``logging._acquireLock`` / ``_releaseLock`` were removed in
+        Python 3.13. ``_snapshot_handler_pairs`` must use ``logging._lock``
+        (a context manager that survives 3.10–3.14+), not the removed
+        wrappers. Spy on both: post-fix, ``_lock`` is acquired and
+        ``_acquireLock`` is never called. Pre-fix, ``_acquireLock`` is
+        called and ``_lock`` is not — on 3.13 that call raises
+        ``AttributeError`` and install silently fails (caught by graceful
+        degradation, filter never installs).
+        """
+        import datahub.masking.masking_filter as mf_mod
+
+        acquire_calls: list = []
+        lock_acquires: list = []
+        real_lock = logging._lock
+
+        class SpyLock:
+            def __enter__(self):
+                lock_acquires.append(1)
+                return real_lock.__enter__()
+
+            def __exit__(self, *exc):
+                return real_lock.__exit__(*exc)
+
+        with MonkeyPatch().context() as m:
+            # ``_acquireLock`` / ``_releaseLock`` exist on 3.10–3.12 and are
+            # gone on 3.13+; ``raising=False`` lets the spy install on both.
+            m.setattr(
+                logging, "_acquireLock", lambda: acquire_calls.append(1), raising=False
+            )
+            m.setattr(logging, "_releaseLock", lambda: None, raising=False)
+            m.setattr(logging, "_lock", SpyLock())
+
+            mf_mod._snapshot_handler_pairs()
+
+        assert acquire_calls == [], (
+            "_snapshot_handler_pairs still calls logging._acquireLock, which "
+            "was removed in Python 3.13 — install would raise AttributeError "
+            "and silently fail to install the filter"
+        )
+        assert lock_acquires, (
+            "_snapshot_handler_pairs did not acquire logging._lock; the "
+            "snapshot is not protected against concurrent addHandler/"
+            "removeHandler"
+        )
+
+    def test_install_succeeds_when_acquire_lock_is_gone(self):
+        """A1 end-to-end: with ``_acquireLock`` removed (simulating 3.13),
+        ``install_masking_filter`` must still install the filter. Pre-fix,
+        ``_snapshot_handler_pairs`` calls the missing ``_acquireLock`` and
+        the install silently fails. We scope the removal to the snapshot
+        call only — leaving it removed breaks 3.11 logging internals
+        (``isEnabledFor`` etc. also use ``_acquireLock``), which is not the
+        scenario under test."""
+        import datahub.masking.masking_filter as mf_mod
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("SECRET", "sekret_value_x")
+
+        real_snapshot = mf_mod._snapshot_handler_pairs
+
+        def snapshot_without_acquire_lock():
+            # Simulate 3.13: _acquireLock is gone. The post-fix body uses
+            # `with logging._lock:` and never touches _acquireLock, so this
+            # patch is a no-op for it. Pre-fix, the body's first line is
+            # `logging._acquireLock()` and raises AttributeError.
+            with MonkeyPatch().context() as m:
+                if hasattr(logging, "_acquireLock"):
+                    m.delattr(logging, "_acquireLock")
+                if hasattr(logging, "_releaseLock"):
+                    m.delattr(logging, "_releaseLock")
+                return real_snapshot()
+
+        try:
+            with MonkeyPatch().context() as m:
+                m.setattr(
+                    mf_mod,
+                    "_snapshot_handler_pairs",
+                    snapshot_without_acquire_lock,
+                )
+                install_masking_filter(registry, install_stdout_wrapper=False)
+                installed = mf_mod._installed_filter
+            assert installed is not None, (
+                "install_masking_filter silently failed when _acquireLock is "
+                "missing (simulating 3.13): masking is off with no signal"
+            )
+        finally:
+            if mf_mod._installed_filter is not None:
+                uninstall_masking_filter()
+
+    def test_uninstall_does_not_clobber_another_patch(self):
+        """A2: if another library patches ``Handler.__init__`` after us,
+        uninstall must NOT restore the original unconditionally — that would
+        discard their patch. Only restore when the current attribute is
+        still ours (identity compare)."""
+        import datahub.masking.masking_filter as mf_mod
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            assert mf_mod._patched_handler_init is not None
+            our_patch = mf_mod._patched_handler_init
+            original = mf_mod._original_handler_init
+
+            # Another library wraps our patch after we installed.
+            def their_init(self, level=logging.NOTSET):
+                our_patch(self, level)
+
+            logging.Handler.__init__ = their_init  # type: ignore[assignment]
+
+            mf_mod._uninstall_handler_init_hook()
+
+            # We did NOT restore the original (would clobber their_init).
+            assert logging.Handler.__init__ is their_init, (
+                "uninstall clobbered another library's Handler.__init__ patch"
+            )
+            assert mf_mod._original_handler_init is None
+            assert mf_mod._patched_handler_init is None
+            # Restore for teardown.
+            logging.Handler.__init__ = original  # type: ignore[assignment]
+        finally:
+            if mf_mod._installed_filter is not None:
+                uninstall_masking_filter()
+            if mf_mod._original_handler_init is not None:
+                mf_mod._uninstall_handler_init_hook()
+
+    def test_install_hook_before_scan_covers_race_window(self):
+        """A3: the ``Handler.__init__`` hook must be installed BEFORE the
+        existing-handler scan, so a handler constructed between the two is
+        covered by the hook (not missed by both). Verify by constructing a
+        handler during the scan via a patched ``_add_filter_to_existing_handlers``
+        — the hook (already active) must attach the filter to it."""
+        import datahub.masking.masking_filter as mf_mod
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        try:
+            # Patch the scan to construct a new handler mid-scan.
+            real_scan = mf_mod._add_filter_to_existing_handlers
+            late_handler = {"h": None}
+
+            def scan_with_late_handler(filt):
+                real_scan(filt)
+                h = logging.StreamHandler(StringIO())
+                late_handler["h"] = h
+
+            with MonkeyPatch().context() as m:
+                m.setattr(
+                    mf_mod,
+                    "_add_filter_to_existing_handlers",
+                    scan_with_late_handler,
+                )
+                install_masking_filter(registry, install_stdout_wrapper=False)
+
+            h = late_handler["h"]
+            assert h is not None
+            assert mf_mod._installed_filter in h.filters, (
+                "handler constructed between hook-install and scan was not "
+                "covered — the hook must be installed before the scan"
+            )
+            logging.getLogger().removeHandler(h)
+        finally:
             if mf_mod._installed_filter is not None:
                 uninstall_masking_filter()
 

--- a/metadata-ingestion/tests/unit/test_masking_filter.py
+++ b/metadata-ingestion/tests/unit/test_masking_filter.py
@@ -230,11 +230,12 @@ class TestExceptionMasking:
         # Filter
         masking_filter.filter(record)
 
-        # Exception should be masked
+        # exc_info is left intact (error reporters read it); the masked
+        # traceback text is materialized on exc_text, which formatters emit.
         assert record.exc_info is not None
-        _, exc_value, _ = record.exc_info
-        assert "my_secret_value" not in str(exc_value)
-        assert "***REDACTED:SECRET***" in str(exc_value)
+        assert record.exc_text is not None
+        assert "my_secret_value" not in record.exc_text
+        assert "***REDACTED:SECRET***" in record.exc_text
 
     def test_exception_with_multiple_args(self, registry, masking_filter):
         """Test masking exceptions with multiple args."""
@@ -258,11 +259,11 @@ class TestExceptionMasking:
 
         masking_filter.filter(record)
 
+        # exc_info is left intact; masked traceback text on exc_text.
         assert record.exc_info is not None
-        _, exc_value, _ = record.exc_info
-        exc_str = str(exc_value)
-        assert "value1" not in exc_str
-        assert "value2" not in exc_str
+        assert record.exc_text is not None
+        assert "value1" not in record.exc_text
+        assert "value2" not in record.exc_text
 
 
 class TestMessageTruncation:
@@ -1298,6 +1299,341 @@ class TestHandlerCoverageAndCelerySafety:
             assert unique in terminal.text
         finally:
             redirect_logger.removeHandler(redirect_handler)
+
+
+class TestReviewFixes:
+    """Regression tests for issues raised in code review of the handler-level
+    masking fix. Each test targets a specific defect; together they pin the
+    invariants the fix is supposed to maintain."""
+
+    def setup_method(self):
+        uninstall_masking_filter()
+        SecretRegistry.reset_instance()
+        self._saved_stderr = sys.stderr
+        self._saved_stdout = sys.stdout
+
+    def teardown_method(self):
+        uninstall_masking_filter()
+        sys.stderr = self._saved_stderr
+        sys.stdout = self._saved_stdout
+        SecretRegistry.reset_instance()
+
+    def test_two_handlers_do_not_corrupt_record(self):
+        """Issue 1: filter() mutates record.msg in place. With N handlers each
+        carrying the filter, the record is truncated/masked N times — the
+        second truncation re-truncates the already-truncated text, eats the
+        previous suffix, and reports a wrong byte count. Idempotency sentinel
+        must prevent this."""
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("SECRET", "secretvalue_xyz")
+
+        root_logger = logging.getLogger()
+        h1 = logging.StreamHandler(StringIO())
+        h2 = logging.StreamHandler(StringIO())
+        h1.setFormatter(logging.Formatter("%(message)s"))
+        h2.setFormatter(logging.Formatter("%(message)s"))
+        root_logger.addHandler(h1)
+        root_logger.addHandler(h2)
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            mf = next(f for f in h1.filters if isinstance(f, SecretMaskingFilter))
+
+            big_msg = "secretvalue_xyz " + "x" * 12000
+            record = logging.LogRecord(
+                name="test",
+                level=logging.INFO,
+                pathname="",
+                lineno=0,
+                msg=big_msg,
+                args=(),
+                exc_info=None,
+            )
+            mf.filter(record)
+            first_msg = record.msg
+            # Second handler runs the same record through the filter again.
+            mf.filter(record)
+            assert record.msg == first_msg, "Second filter() call mutated the record"
+            # Exactly one truncation suffix present (not nested).
+            assert record.msg.count("bytes truncated for performance") == 1
+            assert "***REDACTED:SECRET***" in record.msg
+        finally:
+            root_logger.removeHandler(h1)
+            root_logger.removeHandler(h2)
+
+    def test_extra_attributes_are_masked(self):
+        """Issue 2: secrets in extra={} attributes (referenced by Formatter via
+        %(field)s) must be masked. On master the handler stream was repointed at
+        the wrapped stderr so the formatted line was masked; this branch doesn't
+        repoint, so the filter must mask the extra attribute directly."""
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("DB_PASSWORD", "supersecretvalue")
+
+        capture = StringIO()
+        test_logger = logging.getLogger("test_extra_masking")
+        test_logger.handlers.clear()
+        handler = logging.StreamHandler(capture)
+        handler.setFormatter(logging.Formatter("%(message)s dsn=%(dsn)s"))
+        test_logger.addHandler(handler)
+        test_logger.setLevel(logging.INFO)
+        test_logger.propagate = False
+
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            test_logger.info("connecting", extra={"dsn": "db://u:supersecretvalue@h"})
+            out = capture.getvalue()
+            assert "supersecretvalue" not in out
+            assert "***REDACTED:DB_PASSWORD***" in out
+        finally:
+            test_logger.removeHandler(handler)
+
+    def test_nested_extra_dict_is_masked(self):
+        """Issue 2 (B): extras containing nested dicts/lists must be masked
+        recursively. A string-only mask would miss extra={"cfg": {"password": ...}}."""
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("NESTED_PW", "nested_secret_value")
+
+        capture = StringIO()
+        test_logger = logging.getLogger("test_nested_extra_masking")
+        test_logger.handlers.clear()
+        handler = logging.StreamHandler(capture)
+        handler.setFormatter(logging.Formatter("%(message)s cfg=%(cfg)s"))
+        test_logger.addHandler(handler)
+        test_logger.setLevel(logging.INFO)
+        test_logger.propagate = False
+
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            test_logger.info(
+                "connecting",
+                extra={"cfg": {"password": "nested_secret_value", "host": "h"}},
+            )
+            out = capture.getvalue()
+            assert "nested_secret_value" not in out
+            assert "***REDACTED:NESTED_PW***" in out
+        finally:
+            test_logger.removeHandler(handler)
+
+    def test_extras_container_not_mutated_in_place(self):
+        """Issue 2 (B): masking extras must not mutate the caller's live dict.
+        A config dict that silently becomes ***REDACTED:X*** after the first
+        log line is a nasty bug to chase — build a masked copy and assign that
+        to the record instead."""
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("CFG_PW", "cfg_secret_value")
+
+        test_logger = logging.getLogger("test_extras_not_mutated")
+        test_logger.handlers.clear()
+        test_logger.setLevel(logging.INFO)
+        test_logger.propagate = False
+
+        caller_cfg = {
+            "password": "cfg_secret_value",
+            "host": "h",
+            "nested": ["a", "cfg_secret_value"],
+        }
+        caller_cfg_snapshot = {
+            "password": "cfg_secret_value",
+            "host": "h",
+            "nested": ["a", "cfg_secret_value"],
+        }
+        try:
+            mf = SecretMaskingFilter(registry)
+            record = logging.LogRecord(
+                name="test",
+                level=logging.INFO,
+                pathname="",
+                lineno=0,
+                msg="connecting",
+                args=(),
+                exc_info=None,
+            )
+            record.cfg = caller_cfg
+            mf.filter(record)
+            # The caller's original dict is untouched.
+            assert caller_cfg == caller_cfg_snapshot, (
+                f"Caller's dict was mutated by masking: {caller_cfg!r}"
+            )
+            # The record's copy is masked.
+            assert "cfg_secret_value" not in str(record.cfg)
+            assert "***REDACTED:CFG_PW***" in str(record.cfg)
+        finally:
+            test_logger.handlers.clear()
+
+    def test_extras_self_referential_does_not_hang(self):
+        """Issue 2 (B): extra= can carry self-referential structures. The
+        identity-based cycle guard must prevent infinite recursion (which
+        would hang the logger). The cycle is returned unchanged (residual
+        gap, acceptable — secrets in a cycle are rare and the cycle itself
+        would be unprintable anyway). The primary assertion is no-hang; the
+        secondary is that the non-cyclic top-level leaf IS masked."""
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("CYCLE_PW", "cycle_secret_value")
+
+        mf = SecretMaskingFilter(registry)
+        cycle_dict: dict = {"host": "h"}
+        cycle_dict["self"] = cycle_dict  # self-reference
+        cycle_dict["pw"] = "cycle_secret_value"
+
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="x",
+            args=(),
+            exc_info=None,
+        )
+        record.cfg = cycle_dict
+        # Must not hang — the cycle guard prevents infinite recursion.
+        mf.filter(record)
+        # The non-cyclic top-level leaf with the secret is masked.
+        assert "***REDACTED:CYCLE_PW***" in str(record.cfg)
+        # Residual gap: the cycle's self-reference points to the original
+        # unmasked dict, so the secret may still appear in the deep str repr.
+        # That is the documented accepted residual — the cycle itself is
+        # unprintable in practice.
+
+    def test_extras_deep_nesting_is_capped(self):
+        """Issue 2 (B): very deep nesting is capped at _MAX_EXTRA_DEPTH to
+        bound hot-path cost. Beyond the cap the value is returned unchanged
+        (residual gap) rather than raising."""
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("DEEP_PW", "deep_secret_value")
+
+        mf = SecretMaskingFilter(registry)
+        # Build a deeply nested dict past the cap.
+        deep: dict = {"pw": "deep_secret_value"}
+        for _ in range(SecretMaskingFilter._MAX_EXTRA_DEPTH + 5):
+            deep = {"child": deep}
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="x",
+            args=(),
+            exc_info=None,
+        )
+        record.cfg = deep
+        # Must not hang or raise.
+        mf.filter(record)
+
+    def test_json_formatter_with_quote_in_secret(self):
+        """Issue 4: a JSON formatter escapes quotes/backslashes in the secret
+        value. The raw-value regex won't match the escaped form. _expand_keys
+        must include the JSON-escaped variant so the stderr-wrapper path
+        (print(json.dumps(...))) still masks. For LogRecord extras, filter-time
+        masking handles it before formatting; this test pins the _expand_keys
+        variant via the mask_text path."""
+        import json
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        # Secret containing a quote — JSON-escaped form differs from raw.
+        registry.register_secret("Q_TOKEN", 'pa"ss')
+
+        mf = SecretMaskingFilter(registry)
+        # Simulate what a JSON formatter would emit: the secret JSON-escaped.
+        json_line = json.dumps({"pw": 'pa"ss'})
+        masked = mf.mask_text(json_line)
+        assert 'pa"ss' not in masked
+        assert "***REDACTED:Q_TOKEN***" in masked
+
+    def test_post_install_streamhandler_does_not_recurse(self):
+        """Issue 3: a StreamHandler() created after install picks up the
+        wrapped sys.stderr as its default stream. If sys.stderr re-enters
+        logging (celery LoggingProxy), writing to the handler recurses. The
+        fileno() guard must skip wrapping non-real streams so this can't form
+        a cycle. We model the proxy and assert the guard skips it."""
+        import io
+
+        from datahub.masking.masking_filter import _is_real_stream
+
+        class FakeProxy:
+            """Models celery's LoggingProxy: writes re-enter logging."""
+
+            def fileno(self):
+                raise io.UnsupportedOperation("fileno")
+
+            def write(self, s):
+                return len(s)
+
+            def flush(self):
+                pass
+
+        assert _is_real_stream(FakeProxy()) is False
+        assert _is_real_stream(StringIO()) is False  # StringIO has no backing fd
+
+        # A real file-like stream (e.g. a temp file) should be wrappable.
+        import tempfile
+
+        with tempfile.TemporaryFile() as f:
+            assert _is_real_stream(f) is True
+
+    def test_masking_namespace_records_bypass_filter(self):
+        """Issue 4: records from datahub.masking.* loggers must bypass masking
+        in filter() (not just at handler-attach time). After
+        reset_masking_safe_loggers sets propagate=True, those records reach
+        root handlers that carry the filter — the filter must early-return on
+        record.name.startswith('datahub.masking.')."""
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("M_NS", "maskingns_secret_value")
+
+        capture = StringIO()
+        root_logger = logging.getLogger()
+        handler = logging.StreamHandler(capture)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        root_logger.addHandler(handler)
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            # Simulate post-teardown state: masking logger propagates to root.
+            masking_logger = logging.getLogger("datahub.masking.test_ns")
+            masking_logger.handlers.clear()
+            masking_logger.propagate = True
+            masking_logger.setLevel(logging.DEBUG)
+            # Log a record that would carry the secret if masked.
+            masking_logger.warning("internal state maskingns_secret_value")
+            out = capture.getvalue()
+            # The masking-namespace record bypasses masking — the secret appears
+            # because masking-internal logs are not masked (by design; they
+            # carry no real secrets). The point is no re-entrancy / no recursion.
+            assert "maskingns_secret_value" in out
+        finally:
+            root_logger.removeHandler(handler)
+            masking_logger.propagate = False
+
+    def test_trailing_dot_does_not_match_maskingfoo(self):
+        """Smaller point: startswith('datahub.masking') would match a
+        hypothetical 'datahub.maskingfoo' logger. The trailing dot prevents
+        that. A maskingfoo logger's records must still be masked."""
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("FOO", "foosecret_value")
+
+        capture = StringIO()
+        foo_logger = logging.getLogger("datahub.maskingfoo")
+        foo_logger.handlers.clear()
+        foo_logger.propagate = True
+        root_handler = logging.StreamHandler(capture)
+        root_handler.setFormatter(logging.Formatter("%(message)s"))
+        logging.getLogger().addHandler(root_handler)
+        foo_logger.setLevel(logging.INFO)
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            foo_logger.info("connecting with foosecret_value")
+            out = capture.getvalue()
+            assert "foosecret_value" not in out
+            assert "***REDACTED:FOO***" in out
+        finally:
+            logging.getLogger().removeHandler(root_handler)
+            foo_logger.propagate = False
 
 
 if __name__ == "__main__":

--- a/metadata-ingestion/tests/unit/test_masking_filter.py
+++ b/metadata-ingestion/tests/unit/test_masking_filter.py
@@ -1738,6 +1738,96 @@ class TestReviewFixes:
 
         uninstall_masking_filter()
 
+    def test_refresh_honours_install_stdout_wrapper_true(self):
+        """Item 4: install_stdout_wrapper is ignored on the refresh path
+        because the wrapper block sits after the early return. install(False)
+        then install(True) must wrap stdout/stderr, not skip wrapping."""
+        from datahub.masking.masking_filter import StreamMaskingWrapper
+
+        r1 = SecretRegistry()
+        r1.clear()
+        # First install: no wrapper.
+        install_masking_filter(secret_registry=r1, install_stdout_wrapper=False)
+        assert not isinstance(sys.stdout, StreamMaskingWrapper)
+        assert not isinstance(sys.stderr, StreamMaskingWrapper)
+
+        # Refresh with wrapper=True must wrap.
+        install_masking_filter(secret_registry=r1, install_stdout_wrapper=True)
+        assert isinstance(sys.stdout, StreamMaskingWrapper), (
+            "refresh ignored install_stdout_wrapper=True; stdout not wrapped"
+        )
+        assert isinstance(sys.stderr, StreamMaskingWrapper), (
+            "refresh ignored install_stdout_wrapper=True; stderr not wrapped"
+        )
+
+        uninstall_masking_filter()
+
+    def test_rebind_registry_forces_pattern_rebuild(self):
+        """Item 5: rebind_registry sets _last_version = 0, which equals a
+        fresh registry's version, so _check_and_rebuild_pattern's fast path
+        (``current_version == self._last_version``) skips the rebuild and the
+        old pattern persists. The failure mode is over-masking the old
+        registry's values (not a leak — version 0 implies empty), but the fix
+        removes the need to re-derive that argument: set _last_version = -1 and
+        clear the pattern so the next mask rebuilds from the new registry."""
+        r1 = SecretRegistry()
+        r1.clear()
+        r1.register_secret("A", "aaa_secret_1")
+
+        mf = SecretMaskingFilter(r1)
+        # Force a build so the pattern holds r1's secret.
+        assert "aaa_secret_1" not in mf.mask_text("x aaa_secret_1")
+        assert "***REDACTED:A***" in mf.mask_text("x aaa_secret_1")
+        assert mf._pattern is not None
+        assert mf._last_version == r1.get_version()
+
+        # Rebind to an empty registry. With _last_version = 0 (== the empty
+        # registry's version), the rebuild is skipped and the old pattern
+        # persists — over-masking "aaa_secret_1" even though r2 has no secrets.
+        r2 = SecretRegistry()
+        r2.clear()
+        mf.rebind_registry(r2)
+
+        # After rebind, masking an unrelated text must NOT carry r1's pattern.
+        # (r2 is empty, so nothing should be redacted.)
+        masked = mf.mask_text("x aaa_secret_1")
+        assert "***REDACTED:A***" not in masked, (
+            "rebind_registry did not force a rebuild; old registry's pattern persisted"
+        )
+        assert mf._last_version == r2.get_version()
+
+    def test_datahub_masked_extra_cannot_opt_out_of_masking(self):
+        """Item 2: the idempotency guard uses ``record._datahub_masked`` with
+        truthiness. A caller-supplied ``extra={'_datahub_masked': True}`` forges
+        the sentinel and disables masking for that record. Use a module-private
+        sentinel object compared with ``is`` so a caller can't forge it."""
+        import io
+        import logging
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        registry.register_secret("OPT_OUT", "sekret_value_x")
+
+        capture = io.StringIO()
+        root = logging.getLogger()
+        handler = logging.StreamHandler(capture)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        root.addHandler(handler)
+        try:
+            install_masking_filter(registry, install_stdout_wrapper=False)
+            # A caller tries to opt out by forging the guard attribute via extra.
+            logging.getLogger("test.optout").info(
+                "opt-out attempt sekret_value_x", extra={"_datahub_masked": True}
+            )
+        finally:
+            root.removeHandler(handler)
+            uninstall_masking_filter()
+        out = capture.getvalue()
+        assert "sekret_value_x" not in out, (
+            f"caller-forged _datahub_masked disabled masking: {out!r}"
+        )
+        assert "***REDACTED:OPT_OUT***" in out
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/metadata-ingestion/tests/unit/test_secret_registry.py
+++ b/metadata-ingestion/tests/unit/test_secret_registry.py
@@ -6,7 +6,11 @@ from typing import Iterator
 
 import pytest
 
-from datahub.masking.secret_registry import SecretRegistry, is_masking_enabled
+from datahub.masking.secret_registry import (
+    _GLOBAL_GROUP,
+    SecretRegistry,
+    is_masking_enabled,
+)
 
 
 @contextlib.contextmanager
@@ -247,6 +251,31 @@ class TestSecretRegistryMaxSecrets:
         # Should not have increased
         assert len(secrets_after) == count_at_max
 
+    def test_register_max_secrets_is_linear_not_quadratic(self):
+        """Acceptance property: registering 10000 secrets one at a time
+        completes in time comparable to the fork-point (linear) impl.
+
+        Pre-D2 the registry did a full _expand_keys rebuild on every admit,
+        making this O(n^2) — ~90s at MAX_SECRETS=10000. Post-D2 the admit
+        path publishes incrementally, so this is O(n). Assert a generous
+        ceiling (10s) that's well under the 90s baseline and well above the
+        ~0.5s the linear path takes, so the test stays robust on slow CI
+        runners while still catching a quadratic regression."""
+        import time
+
+        registry = SecretRegistry()
+        registry.clear()
+        start = time.monotonic()
+        for i in range(SecretRegistry.MAX_SECRETS):
+            registry.register_secret(f"KEY_{i}", f"value_{i}")
+        elapsed = time.monotonic() - start
+        # 10s is ~10x the linear impl's time and ~9x under the quadratic
+        # baseline; a quadratic regression would blow past this easily.
+        assert elapsed < 10.0, (
+            f"Registering {SecretRegistry.MAX_SECRETS} secrets took {elapsed:.2f}s, "
+            "which suggests quadratic behavior (D2 regression). Expected < 10s."
+        )
+
 
 class TestRegisterSecretsBatch:
     """Test batch registration of secrets."""
@@ -457,39 +486,124 @@ class TestAdmitCapacityAndDuplicates:
         )
 
 
-class TestEnsureExecutionStaleToken:
-    """Regression: ensure_execution returns the ambient contextvar value
-    without checking it still names a live group. A token-based end_execution
-    from another thread drops the group but leaves the originating context's
-    contextvar pointing at the dead id, so a later ensure_execution recreates
-    a scope under a dead id and a later token holder targets the wrong scope.
+class TestPerExecutionScoping:
+    """D1: per-execution scoping must not collapse when two executions share a
+    context, and a secret registered on another thread must reach the parent
+    execution's scope when its ``exec_id`` is passed.
     """
 
-    def test_ensure_execution_revalidates_ambient_after_cross_thread_end(self):
+    def test_same_context_overlap_does_not_collapse(self):
+        """Two ``initialize_secret_masking`` on the same context must return
+        distinct tokens and own distinct groups; ending one must not drop
+        the other's secrets or uninstall the filter while the other is live.
+        """
+        from datahub.masking import bootstrap
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        bootstrap.reset_bootstrap_state()
+
+        tok_a = bootstrap.initialize_secret_masking()
+        assert tok_a is not None
+        registry.register_secret("A_PW", "aaa_secret_value")
+        tok_b = bootstrap.initialize_secret_masking()
+        assert tok_b is not None
+        assert tok_a != tok_b, "second initialize aliased onto the first scope"
+        registry.register_secret("B_PW", "bbb_secret_value")
+
+        # A's secret and B's secret are in different groups.
+        assert set(registry._groups[tok_a].keys()) == {"aaa_secret_value"}
+        assert set(registry._groups[tok_b].keys()) == {"bbb_secret_value"}
+
+        # End A. B is still live, so the filter must stay installed and B's
+        # secret must still be registered.
+        bootstrap.shutdown_secret_masking(tok_a)
+        assert "bbb_secret_value" in registry._secrets, (
+            "B's secret was dropped when A ended"
+        )
+        import datahub.masking.masking_filter as mf
+
+        assert mf._installed_filter is not None, (
+            "filter was uninstalled while B's execution is still live"
+        )
+        assert bootstrap.is_bootstrapped()
+
+        # Tear down B.
+        bootstrap.shutdown_secret_masking(tok_b)
+        assert mf._installed_filter is None
+        assert "bbb_secret_value" not in registry._secrets
+
+    def test_register_on_another_thread_lands_in_parent_scope(self):
+        """A secret registered on a worker thread with the parent's
+        ``exec_id`` lands in the parent's scope, not ``__global__``; ending
+        the parent drops it.
+        """
         import threading
 
-        registry = SecretRegistry()
-        registry.clear()
-        tok = registry.ensure_execution()
-        registry.register_secret("A", "aaa_secret_1")
-        assert tok in registry._groups
+        from datahub.masking import bootstrap
 
-        # End from another thread using the token. This drops the group but
-        # does NOT clear this context's contextvar (exec_id != ambient).
-        t = threading.Thread(target=lambda: registry.end_execution(tok))
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        bootstrap.reset_bootstrap_state()
+
+        tok = bootstrap.initialize_secret_masking()
+        assert tok is not None
+        done = threading.Event()
+
+        def worker():
+            registry.register_secret("PW", "sup3rsecret_value", exec_id=tok)
+            done.set()
+
+        t = threading.Thread(target=worker)
         t.start()
         t.join(timeout=5.0)
         assert not t.is_alive(), "worker thread timed out"
-        # The group is gone, but the ambient contextvar still holds tok.
-        assert tok not in registry._groups
 
-        # ensure_execution must revalidate: tok names no live group, so it
-        # must open a fresh scope rather than return the stale tok.
-        new_tok = registry.ensure_execution()
-        assert new_tok != tok, (
-            "ensure_execution returned a stale ambient id that names no live group"
+        # The secret landed in the parent's scope, not __global__.
+        assert tok in registry._groups
+        assert "sup3rsecret_value" in registry._groups[tok]
+        assert _GLOBAL_GROUP not in registry._groups or "sup3rsecret_value" not in (
+            registry._groups.get(_GLOBAL_GROUP, {})
         )
-        assert new_tok in registry._groups
+        assert "sup3rsecret_value" in registry._secrets
+
+        # Ending the parent drops the worker's secret too.
+        bootstrap.shutdown_secret_masking(tok)
+        assert "sup3rsecret_value" not in registry._secrets
+
+    def test_register_without_exec_id_on_other_thread_lands_in_global(self):
+        """Without an explicit ``exec_id``, a secret registered on a worker
+        thread (which has no ambient scope — ContextVars don't cross thread
+        boundaries) lands in ``__global__``. Fails safe (still masked) but
+        not scoped to any execution. Documents the residual.
+        """
+        import threading
+
+        from datahub.masking import bootstrap
+
+        registry = SecretRegistry.get_instance()
+        registry.clear()
+        bootstrap.reset_bootstrap_state()
+
+        tok = bootstrap.initialize_secret_masking()
+        done = threading.Event()
+
+        def worker():
+            registry.register_secret("PW", "worker_secret_value")
+            done.set()
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join(timeout=5.0)
+        assert not t.is_alive()
+
+        # No exec_id -> lands in __global__, still masked.
+        assert "worker_secret_value" in registry._secrets
+        assert "worker_secret_value" in registry._groups.get(_GLOBAL_GROUP, {})
+
+        bootstrap.shutdown_secret_masking(tok)
+        # __global__ is dropped when the last real execution ends.
+        assert "worker_secret_value" not in registry._secrets
 
 
 class TestCaptureRecordsNoLeak:

--- a/metadata-ingestion/tests/unit/test_secret_registry.py
+++ b/metadata-ingestion/tests/unit/test_secret_registry.py
@@ -318,3 +318,155 @@ class TestClearRegistry:
         version_after = registry.get_version()
 
         assert version_after > version_before
+
+
+class TestAdmitCapacityAndDuplicates:
+    """Regression tests for the _admit_locked tri-state refactor.
+
+    The previous bool helper conflated "duplicate" with "at capacity":
+    both returned False, and both call sites treated False as capacity.
+    That made duplicate registrations emit spurious "at capacity" warnings
+    (with zero secrets registered) and permanently suppress the real one
+    via _capacity_warned. It also let batches of multi-key-expanding values
+    overshoot MAX_SECRETS, because the capacity check counted secrets
+    instead of expanded keys (the unit mismatch).
+    """
+
+    def test_duplicate_registration_produces_no_capacity_warning(self):
+        """A duplicate registration must not fire the "at capacity" warning."""
+        import logging as _logging
+
+        registry = SecretRegistry()
+        registry.clear()
+        registry.register_secret("KEY1", "duplicate_value")
+        records: list = []
+
+        class _Capture(_logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        _logger = _logging.getLogger("datahub.masking.secret_registry")
+        _logger.addHandler(_Capture())
+        try:
+            # Re-register the same value — duplicate, not capacity.
+            registry.register_secret("KEY1_DUP", "duplicate_value")
+        finally:
+            _logger.removeHandler(_Capture())
+        assert not any("at capacity" in r.getMessage() for r in records), (
+            "duplicate registration fired a spurious capacity warning"
+        )
+        assert registry.get_count() > 0  # the first registration is still there
+
+    def test_capacity_warning_fires_once_not_per_call(self):
+        """The capacity warning fires once per rise to capacity, not per call."""
+        import logging as _logging
+
+        registry = SecretRegistry()
+        registry.clear()
+        records: list = []
+
+        class _Capture(_logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        _logger = _logging.getLogger("datahub.masking.secret_registry")
+        _logger.addHandler(_Capture())
+        try:
+            with pytest.MonkeyPatch.context() as m:
+                m.setattr(SecretRegistry, "MAX_SECRETS", 10)
+                for i in range(20):
+                    registry.register_secret(f"K{i}", f"pa:ss@wo/rd{i}")
+        finally:
+            _logger.removeHandler(_Capture())
+        capacity_warnings = [r for r in records if "at capacity" in r.getMessage()]
+        assert len(capacity_warnings) == 1, (
+            f"expected exactly one capacity warning, got {len(capacity_warnings)}"
+        )
+
+    def test_batch_does_not_overshoot_max_secrets(self):
+        """A batch of multi-key-expanding values must not push the expanded
+        key count past MAX_SECRETS. This is the regression test for the
+        unit mismatch: the old batch check counted secrets, not expanded
+        keys, so it let the union overshoot. Fails on the old code."""
+        registry = SecretRegistry()
+        registry.clear()
+        # Each value contains chars that trigger repr + sqlalchemy + json
+        # variants, so each secret expands to ~4 keys.
+        expanding_value = "pa:ss@wo/rd"
+        batch = {f"K{i}": expanding_value + str(i) for i in range(50)}
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(SecretRegistry, "MAX_SECRETS", 20)
+            registry.register_secrets_batch(batch)
+            assert registry.get_count() <= SecretRegistry.MAX_SECRETS, (
+                f"batch overshot MAX_SECRETS: get_count()={registry.get_count()} "
+                f"> MAX_SECRETS={SecretRegistry.MAX_SECRETS}"
+            )
+
+    def test_batch_duplicate_does_not_count_as_rejected(self):
+        """Re-registering an existing batch must not report every entry as
+        rejected (the old 'skipped 20 of 20' on a healthy run)."""
+        import logging as _logging
+
+        registry = SecretRegistry()
+        registry.clear()
+        batch = {f"K{i}": f"batch_value_{i}" for i in range(20)}
+        registry.register_secrets_batch(batch)
+        records: list = []
+
+        class _Capture(_logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        _logger = _logging.getLogger("datahub.masking.secret_registry")
+        _logger.addHandler(_Capture())
+        try:
+            # Re-register the same batch — all duplicates, no capacity.
+            registry.register_secrets_batch(batch)
+        finally:
+            _logger.removeHandler(_Capture())
+        assert not any("at capacity" in r.getMessage() for r in records), (
+            "duplicate batch fired a spurious capacity warning"
+        )
+
+    def test_capacity_warning_can_fire_again_after_room_freed(self):
+        """After executions end and free room, _capacity_warned resets so
+        the next capacity rise warns again (not permanently suppressed)."""
+        registry = SecretRegistry()
+        registry.clear()
+        exec_id = registry.begin_execution()
+        try:
+            with pytest.MonkeyPatch.context() as m:
+                m.setattr(SecretRegistry, "MAX_SECRETS", 10)
+                # Rise to capacity — warns once.
+                for i in range(30):
+                    registry.register_secret(f"K{i}", f"secret_value_{i}")
+                # End the execution — frees room, _rebuild_locked resets
+                # _capacity_warned to False.
+        finally:
+            registry.end_execution(exec_id)
+        assert registry.get_count() == 0  # all dropped
+        # Now rise again — should warn again (not suppressed by stale flag).
+        import logging as _logging
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(SecretRegistry, "MAX_SECRETS", 10)
+            handler_records: list = []
+
+            class _Capture(_logging.Handler):
+                def emit(self, record):
+                    handler_records.append(record)
+
+            _logger = _logging.getLogger("datahub.masking.secret_registry")
+            _logger.addHandler(_Capture())
+            try:
+                for i in range(30):
+                    registry.register_secret(f"K2_{i}", f"other_value_{i}")
+            finally:
+                _logger.removeHandler(_Capture())
+        capacity_warnings = [
+            r for r in handler_records if "at capacity" in r.getMessage()
+        ]
+        assert len(capacity_warnings) == 1, (
+            f"expected the capacity warning to fire again after room was freed, "
+            f"got {len(capacity_warnings)}"
+        )

--- a/metadata-ingestion/tests/unit/test_secret_registry.py
+++ b/metadata-ingestion/tests/unit/test_secret_registry.py
@@ -476,7 +476,10 @@ class TestEnsureExecutionStaleToken:
 
         # End from another thread using the token. This drops the group but
         # does NOT clear this context's contextvar (exec_id != ambient).
-        threading.Thread(target=lambda: registry.end_execution(tok)).start()
+        t = threading.Thread(target=lambda: registry.end_execution(tok))
+        t.start()
+        t.join(timeout=5.0)
+        assert not t.is_alive(), "worker thread timed out"
         # The group is gone, but the ambient contextvar still holds tok.
         assert tok not in registry._groups
 

--- a/metadata-ingestion/tests/unit/test_secret_registry.py
+++ b/metadata-ingestion/tests/unit/test_secret_registry.py
@@ -228,6 +228,80 @@ class TestSecretRegistryInvalidInputs:
         assert secrets["P#!ss%40word"] == "password"
 
 
+class TestRouteAValidation:
+    """Pin finding 12: the registry refuses to register a value that exactly
+    equals a redaction marker for a registered name (route A). The marker
+    alternative must win for masking to terminate, so such a value would
+    pass through in cleartext; refusing it at registration closes the hole
+    at the source. Below-floor values are refused with a warning (previously
+    silently dropped)."""
+
+    def test_marker_shaped_value_for_registered_name_refused(self):
+        """Registering ``***REDACTED:PW***`` as a value after ``PW`` is a
+        registered name is refused — the marker must win, so the value
+        would pass through in cleartext."""
+        registry = SecretRegistry()
+        registry.clear()
+        registry.register_secret("PW", "s3cret")
+        # Value is the marker for name PW.
+        registry.register_secret("MARKER_VAL", "***REDACTED:PW***")
+        secrets = registry.get_all_secrets()
+        # s3cret is registered; ***REDACTED:PW*** is NOT (refused).
+        assert "s3cret" in secrets
+        assert "***REDACTED:PW***" not in secrets
+
+    def test_marker_shaped_value_for_own_name_refused(self):
+        """Registering ``***REDACTED:SELF***`` under name ``SELF`` is refused
+        — the value is the marker for this very name."""
+        registry = SecretRegistry()
+        registry.clear()
+        registry.register_secret("SELF", "***REDACTED:SELF***")
+        secrets = registry.get_all_secrets()
+        assert "***REDACTED:SELF***" not in secrets
+
+    def test_marker_shaped_value_for_unregistered_name_accepted(self):
+        """Registering ``***REDACTED:GONE***`` when ``GONE`` is NOT a
+        registered name is accepted — the marker alternative for ``GONE``
+        is not in the pattern, so nothing passes through. (The generic
+        fallback would mask it, but only if ``GONE`` were a registered
+        name.) This is the dropped-execution case."""
+        registry = SecretRegistry()
+        registry.clear()
+        # GONE is not registered as a name.
+        registry.register_secret("ORPHAN", "***REDACTED:GONE***")
+        secrets = registry.get_all_secrets()
+        # The value IS registered (no name collision to refuse on).
+        assert "***REDACTED:GONE***" in secrets
+
+    def test_below_floor_value_warns_and_refused(self):
+        """A value below the 3-char floor is refused with a warning
+        (previously silently dropped, so a misconfigured recipe with a
+        2-char password got no signal)."""
+        registry = SecretRegistry()
+        registry.clear()
+        # "ab" is 2 chars, below the 3-char floor.
+        registry.register_secret("SHORT", "ab")
+        secrets = registry.get_all_secrets()
+        assert "ab" not in secrets
+        assert len(secrets) == 0
+
+    def test_oscillation_pair_half_refused(self):
+        """Registering A's marker under name B after A is registered is
+        refused (B's value is the marker for registered name A). The
+        oscillation pair from the property test corpus is half-refused:
+        A registers, B does not."""
+        registry = SecretRegistry()
+        registry.clear()
+        # A registers first (value is marker for B, but B not registered yet).
+        registry.register_secret("A", "***REDACTED:B***")
+        # B is refused: value is marker for registered name A.
+        registry.register_secret("B", "***REDACTED:A***")
+        secrets = registry.get_all_secrets()
+        # A's value is registered; B's is not.
+        assert "***REDACTED:B***" in secrets
+        assert "***REDACTED:A***" not in secrets
+
+
 class TestSecretRegistryMaxSecrets:
     """Test max secrets limit."""
 

--- a/metadata-ingestion/tests/unit/test_secret_registry.py
+++ b/metadata-ingestion/tests/unit/test_secret_registry.py
@@ -1,8 +1,39 @@
 """Test SecretRegistry singleton and is_masking_enabled function."""
 
+import contextlib
+import logging
+from typing import Iterator
+
 import pytest
 
 from datahub.masking.secret_registry import SecretRegistry, is_masking_enabled
+
+
+@contextlib.contextmanager
+def _capture_records(logger_name: str) -> Iterator[list]:
+    """Attach a handler to ``logger_name`` for the duration of the block and
+    remove the *same* handler object on exit.
+
+    The masking loggers have ``propagate=False``, so pytest's ``caplog``
+    (attached to root) doesn't see their records — tests must attach a
+    handler directly. The original code did ``_logger.removeHandler(_Capture())``,
+    which removes a *new* instance and leaves the original attached, accumulating
+    records across tests and duplicating them into later assertions. Binding the
+    handler to a variable and removing that same object fixes the leak.
+    """
+    logger = logging.getLogger(logger_name)
+    records: list = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    handler = _Capture()
+    logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
 
 
 class TestSecretRegistrySingleton:
@@ -334,24 +365,12 @@ class TestAdmitCapacityAndDuplicates:
 
     def test_duplicate_registration_produces_no_capacity_warning(self):
         """A duplicate registration must not fire the "at capacity" warning."""
-        import logging as _logging
-
         registry = SecretRegistry()
         registry.clear()
         registry.register_secret("KEY1", "duplicate_value")
-        records: list = []
-
-        class _Capture(_logging.Handler):
-            def emit(self, record):
-                records.append(record)
-
-        _logger = _logging.getLogger("datahub.masking.secret_registry")
-        _logger.addHandler(_Capture())
-        try:
+        with _capture_records("datahub.masking.secret_registry") as records:
             # Re-register the same value — duplicate, not capacity.
             registry.register_secret("KEY1_DUP", "duplicate_value")
-        finally:
-            _logger.removeHandler(_Capture())
         assert not any("at capacity" in r.getMessage() for r in records), (
             "duplicate registration fired a spurious capacity warning"
         )
@@ -359,25 +378,15 @@ class TestAdmitCapacityAndDuplicates:
 
     def test_capacity_warning_fires_once_not_per_call(self):
         """The capacity warning fires once per rise to capacity, not per call."""
-        import logging as _logging
-
         registry = SecretRegistry()
         registry.clear()
-        records: list = []
-
-        class _Capture(_logging.Handler):
-            def emit(self, record):
-                records.append(record)
-
-        _logger = _logging.getLogger("datahub.masking.secret_registry")
-        _logger.addHandler(_Capture())
-        try:
-            with pytest.MonkeyPatch.context() as m:
-                m.setattr(SecretRegistry, "MAX_SECRETS", 10)
-                for i in range(20):
-                    registry.register_secret(f"K{i}", f"pa:ss@wo/rd{i}")
-        finally:
-            _logger.removeHandler(_Capture())
+        with (
+            _capture_records("datahub.masking.secret_registry") as records,
+            pytest.MonkeyPatch.context() as m,
+        ):
+            m.setattr(SecretRegistry, "MAX_SECRETS", 10)
+            for i in range(20):
+                registry.register_secret(f"K{i}", f"pa:ss@wo/rd{i}")
         capacity_warnings = [r for r in records if "at capacity" in r.getMessage()]
         assert len(capacity_warnings) == 1, (
             f"expected exactly one capacity warning, got {len(capacity_warnings)}"
@@ -405,25 +414,13 @@ class TestAdmitCapacityAndDuplicates:
     def test_batch_duplicate_does_not_count_as_rejected(self):
         """Re-registering an existing batch must not report every entry as
         rejected (the old 'skipped 20 of 20' on a healthy run)."""
-        import logging as _logging
-
         registry = SecretRegistry()
         registry.clear()
         batch = {f"K{i}": f"batch_value_{i}" for i in range(20)}
         registry.register_secrets_batch(batch)
-        records: list = []
-
-        class _Capture(_logging.Handler):
-            def emit(self, record):
-                records.append(record)
-
-        _logger = _logging.getLogger("datahub.masking.secret_registry")
-        _logger.addHandler(_Capture())
-        try:
+        with _capture_records("datahub.masking.secret_registry") as records:
             # Re-register the same batch — all duplicates, no capacity.
             registry.register_secrets_batch(batch)
-        finally:
-            _logger.removeHandler(_Capture())
         assert not any("at capacity" in r.getMessage() for r in records), (
             "duplicate batch fired a spurious capacity warning"
         )
@@ -446,23 +443,11 @@ class TestAdmitCapacityAndDuplicates:
             registry.end_execution(exec_id)
         assert registry.get_count() == 0  # all dropped
         # Now rise again — should warn again (not suppressed by stale flag).
-        import logging as _logging
-
         with pytest.MonkeyPatch.context() as m:
             m.setattr(SecretRegistry, "MAX_SECRETS", 10)
-            handler_records: list = []
-
-            class _Capture(_logging.Handler):
-                def emit(self, record):
-                    handler_records.append(record)
-
-            _logger = _logging.getLogger("datahub.masking.secret_registry")
-            _logger.addHandler(_Capture())
-            try:
+            with _capture_records("datahub.masking.secret_registry") as handler_records:
                 for i in range(30):
                     registry.register_secret(f"K2_{i}", f"other_value_{i}")
-            finally:
-                _logger.removeHandler(_Capture())
         capacity_warnings = [
             r for r in handler_records if "at capacity" in r.getMessage()
         ]
@@ -470,3 +455,116 @@ class TestAdmitCapacityAndDuplicates:
             f"expected the capacity warning to fire again after room was freed, "
             f"got {len(capacity_warnings)}"
         )
+
+
+class TestEnsureExecutionStaleToken:
+    """Regression: ensure_execution returns the ambient contextvar value
+    without checking it still names a live group. A token-based end_execution
+    from another thread drops the group but leaves the originating context's
+    contextvar pointing at the dead id, so a later ensure_execution recreates
+    a scope under a dead id and a later token holder targets the wrong scope.
+    """
+
+    def test_ensure_execution_revalidates_ambient_after_cross_thread_end(self):
+        import threading
+
+        registry = SecretRegistry()
+        registry.clear()
+        tok = registry.ensure_execution()
+        registry.register_secret("A", "aaa_secret_1")
+        assert tok in registry._groups
+
+        # End from another thread using the token. This drops the group but
+        # does NOT clear this context's contextvar (exec_id != ambient).
+        threading.Thread(target=lambda: registry.end_execution(tok)).start()
+        # The group is gone, but the ambient contextvar still holds tok.
+        assert tok not in registry._groups
+
+        # ensure_execution must revalidate: tok names no live group, so it
+        # must open a fresh scope rather than return the stale tok.
+        new_tok = registry.ensure_execution()
+        assert new_tok != tok, (
+            "ensure_execution returned a stale ambient id that names no live group"
+        )
+        assert new_tok in registry._groups
+
+
+class TestCaptureRecordsNoLeak:
+    """Regression for Item 6: the inline ``_logger.removeHandler(_Capture())``
+    pattern removed a *new* instance, leaving the original handler attached.
+    Across the four capacity/duplicate tests, leaked handlers accumulated
+    and duplicated records into later assertions. The ``_capture_records``
+    contextmanager binds the handler to a variable and removes the same object.
+    """
+
+    def test_capture_records_removes_handler_on_exit(self):
+        logger = logging.getLogger("datahub.masking.secret_registry")
+        # Precondition: clean slate (a prior leaked handler would violate this).
+        logger.handlers.clear()
+        with _capture_records("datahub.masking.secret_registry"):
+            assert len(logger.handlers) == 1, "handler not attached"
+        assert logger.handlers == [], (
+            "handler leaked after context exit — removeHandler removed a new "
+            "instance instead of the one that was added"
+        )
+
+    def test_capture_records_does_not_duplicate_across_invocations(self):
+        """A leaked handler from a first invocation would duplicate records
+        into a second invocation's capture. Each record must appear once."""
+        logger = logging.getLogger("datahub.masking.secret_registry")
+        logger.handlers.clear()
+        registry = SecretRegistry()
+        registry.clear()
+
+        # First invocation: register a secret (no capacity warning expected).
+        with _capture_records("datahub.masking.secret_registry"):
+            registry.register_secret("FIRST", "first_secret_value")
+
+        # Second invocation: trigger a capacity warning.
+        with (
+            _capture_records("datahub.masking.secret_registry") as records2,
+            pytest.MonkeyPatch.context() as m,
+        ):
+            m.setattr(SecretRegistry, "MAX_SECRETS", 5)
+            for i in range(20):
+                registry.register_secret(f"K{i}", f"pa:ss@wo/rd{i}")
+
+        capacity_warnings = [r for r in records2 if "at capacity" in r.getMessage()]
+        # If the first invocation's handler leaked, each warning would appear
+        # twice (once via the leaked handler, once via the new one). Assert each
+        # record object is captured exactly once.
+        ids = [id(r) for r in records2]
+        assert len(ids) == len(set(ids)), (
+            "records duplicated across invocations by a leaked handler"
+        )
+        assert len(capacity_warnings) >= 1
+
+
+class TestBatchRejectionCountInWarning:
+    """Item 8 (optional): when a batch is partly rejected at capacity, the
+    WARNING names one variable while the admitted/duplicates/rejected counts
+    go to DEBUG (off in production). An operator sees 'Skipping registration
+    of S_25' with no indication that 174 others were dropped. The rejected
+    count must appear in the warning so an operator can see the blast radius.
+    """
+
+    def test_batch_rejection_count_appears_in_warning(self):
+        registry = SecretRegistry()
+        registry.clear()
+        # 200 secrets, each expanding to ~4 keys; cap at 20 keys -> most rejected.
+        batch = {f"S_{i}": f"pa:ss@wo/rd{i}" for i in range(200)}
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(SecretRegistry, "MAX_SECRETS", 20)
+            with _capture_records("datahub.masking.secret_registry") as records:
+                registry.register_secrets_batch(batch)
+        warnings = [r for r in records if "at capacity" in r.getMessage()]
+        assert len(warnings) == 1, f"expected one capacity warning, got {len(warnings)}"
+        msg = warnings[0].getMessage()
+        # The warning must surface the rejected count and the batch total, not
+        # just one variable name. The current per-secret warning names only
+        # S_25 with no indication of the 174 others dropped.
+        assert "Skipped" in msg or "skipped" in msg.lower(), (
+            f"warning didn't use 'Skipped' wording: {msg!r}"
+        )
+        # The batch total (200) must appear so an operator sees the blast radius.
+        assert "200" in msg, f"warning didn't surface the batch total: {msg!r}"


### PR DESCRIPTION
## Problem

The filter was attached to the root *logger*. Python doesn't consult a logger's own
filters for records propagated from child loggers, so it never saw ingestion output.
Masking worked only because `_update_existing_handlers()` repointed console handler
streams at the wrapped `sys.stderr`. Two consequences:

- **Secrets reached log files in plain text.** Repointing covers stdout/stderr only;
  a `FileHandler` got child-logger records unmasked. The console looked correct, so
  this was silent.
- **Logging stopped under celery.** Celery's `sys.stderr` proxy turns writes back into
  log records, so a handler pointed at it cycles: handler → proxy → same handler.
  Output is dropped. Teardown restored `sys.stderr` but not handler streams, so it
  persisted. Symptom in worker mode: after an ingestion with secrets, celery/root logs
  stop appearing while ingestion-subprocess logs continue.

Review surfaced a third: with overlapping executions, the first to finish removed the
filter and cleared the shared registry, unmasking the one still running.

## Changes

- Remove `_update_existing_handlers()`; attach the filter to each handler instead.
  Handler filters *are* consulted for propagated records, so child-logger output —
  including file output — is masked. Teardown is symmetric and identity-based.
- Keep the stdout/stderr wrapper for raw `print()` only, skipped when the stream isn't
  OS-backed (`fileno()` raises). Wrapping a proxy re-enters logging; skipping loses
  nothing, since proxied writes become log records.
- Scope secrets per execution. Teardown drops only that group, fully uninstalling when
  none remain. `initialize_secret_masking()` returns a token
  `shutdown_secret_masking(token)` accepts, for cross-thread teardown.

Coverage gaps that were unreachable while the filter sat on root:

- Records masked once, not once per handler (the second truncation ate the first
  suffix and reported a wrong byte count).
- `extra={...}` masked, recursing into containers on a copy. Depth cap and cycle guard
  emit a placeholder, not the raw subtree.
- Exceptions no longer rebuilt via `type(exc)(*masked_args)` — that raised whenever
  `__init__` didn't match `args` (common in DB drivers) and the fallback returned a
  bare `RuntimeError`, destroying the traceback, class, and `__cause__` chain. The
  traceback is materialized to `exc_text` and masked there; `exc_info` untouched.
- `logging_utils` captures `sys.__stderr__`, not import-time `sys.stderr` — already the
  celery proxy when imported at task time.
- Capacity guard counts expanded keys, not raw secrets, in both registration paths.

## Behavior changes

- `max_message_size` (5000) previously applied only to records logged directly on root;
  now to every record reaching a handler.
- Error reporters (Sentry, Datadog) read the unmasked `exc_info`. That's what preserves
  tracebacks; mask at the reporter integration instead.
- Structured formatters emit plain-text tracebacks (`exc_text` becomes authoritative).
- ~2.3× on the logging path (12.7 → 29 µs/record, 20 secrets), i.e. ~0.16s per 10k
  lines. Flat across handlers.

## Known limitations (documented in-code)

- Handler coverage is a snapshot at install; a `FileHandler` added afterwards in a
  non-celery process is uncovered.
- Arbitrary objects in `extra=` aren't stringified-and-masked (`__str__` side effects).
- A formatter with a custom `formatException` bypasses the masked `exc_text`.
- `shutdown_secret_masking()` without a token falls back to the ambient context and
  no-ops if it has no scope (debug-logged; fails safe).

## Testing

- `TestHandlerCoverageAndCelerySafety` — child-logger masking; celery feedback stream
  no longer silences logs. Confirmed failing before the fix.
- `TestConcurrentExecutions` — teardown doesn't unmask or wipe a peer execution;
  sequenced through the `_teardown_hook()` seam, not sleeps. Includes a test that
  re-introduces the old semantics and asserts the invariant breaks.
- `TestReviewFixes` — idempotency, extras recursion and non-mutation, cycle/depth
  placeholders, traceback preservation, registry rebind.
- N masking unit tests pass; ruff clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Reworks secret masking so **child-logger and file output are actually covered**, Celery workers don’t lose logs, and **overlapping ingestions** don’t tear down each other’s secrets.
> 
> **Installation model:** Stops repointing handler streams to wrapped `stdout`/`stderr` (the Celery feedback loop). Masking now attaches **`SecretMaskingFilter` to each handler** (plus a `Handler.__init__` hook for handlers created later). `sys.stdout`/`stderr` are wrapped only for raw `print()` when `fileno()` works—proxies like Celery’s `LoggingProxy` are skipped. Install/uninstall track a single `_installed_filter` by identity.
> 
> **Lifecycle:** `initialize_secret_masking()` returns an **execution token** and opens a distinct registry scope; `shutdown_secret_masking(token)` drops only that scope and fully tears down when no scopes remain. Bootstrap uses an **RLock**, clears `_bootstrap_completed` when the filter is gone, and **raises `RuntimeError`** (with critical logging) on install failure instead of failing silently. Disabled masking no longer latches “bootstrapped” without installing a filter.
> 
> **Filter behavior:** Mask **before** truncate with a pattern-length-aware pre-cut; recursive masking of `extra={...}` and non-string `msg`; traceback text via `exc_text` while leaving `exc_info` intact; string idempotency token `_MASKED`; marker-first regex with `lastgroup` dispatch. Shared `REDACTED_FORMAT` in `constants.py`. Masking-safe logging binds to **`sys.__stderr__`**.
> 
> **Registry:** Secrets grouped per execution (COW snapshots, incremental publish on register); cross-thread register via `exec_id`; capacity on expanded keys; registration rejects marker-shaped values.
> 
> Adds a **Cursor rule** for masking invariants and expands unit tests (concurrent executions, bootstrap latch, force teardown, handler coverage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c827a36ced3c23f442fcc51dc4d2ef9cac8d35ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->