### PR TITLE
perf(ebean): enable autoCommit on connection pool to eliminate no-op commits on read-only queries

### DIFF
--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -550,6 +550,7 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "cassandra.hosts",
           "cassandra.port",
           "cassandra.useSsl",
+          "ebean.autoCommit",
           "ebean.autoCreateDdl",
           "ebean.batchGetMethod",
           "ebean.queryKeysCountForBatch",

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -361,6 +361,7 @@ ebean:
   maxAgeMinutes: ${EBEAN_MAX_AGE_MINUTES:120}
   leakTimeMinutes: ${EBEAN_LEAK_TIME_MINUTES:15}
   waitTimeoutMillis: ${EBEAN_WAIT_TIMEOUT_MILLIS:1000}
+  autoCommit: ${EBEAN_DATASOURCE_AUTOCOMMIT:true}
   autoCreateDdl: ${EBEAN_AUTOCREATE:false}
   postgresUseIamAuth: ${EBEAN_POSTGRES_USE_AWS_IAM_AUTH:false}
   useIamAuth: ${EBEAN_USE_IAM_AUTH:false} # Generic IAM auth for cross-cloud compatibility

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/LocalEbeanConfigFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/LocalEbeanConfigFactory.java
@@ -45,6 +45,9 @@ public class LocalEbeanConfigFactory {
   @Value("${ebean.waitTimeoutMillis:1000}")
   private Integer ebeanWaitTimeoutMillis;
 
+  @Value("${ebean.autoCommit:true}")
+  private Boolean ebeanAutoCommit;
+
   @Value("${ebean.autoCreateDdl:false}")
   private Boolean ebeanAutoCreate;
 
@@ -130,6 +133,7 @@ public class LocalEbeanConfigFactory {
     dataSourceConfig.setMaxAgeMinutes(ebeanMaxAgeMinutes);
     dataSourceConfig.setLeakTimeMinutes(ebeanLeakTimeMinutes);
     dataSourceConfig.setWaitTimeoutMillis(ebeanWaitTimeoutMillis);
+    dataSourceConfig.setAutoCommit(ebeanAutoCommit);
     dataSourceConfig.setListener(getListenerToTrackCounts(metricUtils, "main"));
     EbeanPoolDefaults.applyDefaultTransactionIsolation(dataSourceConfig);
 


### PR DESCRIPTION
## Summary

Enable `autoCommit=true` on the Ebean DataSource connection pool, eliminating ~21K/sec unnecessary `COMMIT` statements generated by read-only queries.

## Problem

Ebean's `DataSourceConfig` defaults to `autoCommit=false`. This has a cascading effect through Ebean's transaction internals:

1. **Read-only queries** (the dominant traffic — `server.find()`, `server.sqlQuery()`) create an `ImplicitReadOnlyTransaction`. This class has logic to skip the JDBC commit when autocommit is enabled:

   ```java
   // ImplicitReadOnlyTransaction constructor
   this.useCommit = useCommit && !connection.getAutoCommit();
   ```

   But since the pool has `autoCommit=false`, `getAutoCommit()` returns `false`, so `useCommit = true` — and **every read-only query issues a `connection.commit()`** on completion.

2. **Write operations** create a `JdbcTransaction` which calls `setAutoCommit(false)` at start, commits, then restores `setAutoCommit(true)` on deactivation — this path works correctly regardless of the pool default.

### Measured impact on a production MySQL instance

Sampling `use1-saas-prod-shared-mysql-01` over a 10-second window:

| Metric | Rate |
|--------|------|
| `Com_commit` | **23,264/sec** |
| `Com_select` | 29,727/sec |
| `Com_insert` + `Com_update` + `Com_delete_multi` | 1,850/sec |
| `Com_rollback` | 23/sec |
| `Com_set_option` | 244/sec |
| **Commits per actual write** | **12.6x** |

~21K of those 23K commits/sec are no-op commits from read-only queries. With `innodb_flush_log_at_trx_commit=1` and `sync_binlog=1` (full durability), even no-op commits are not free — they touch the InnoDB commit code path and contribute to group commit contention across 880 connected threads.

## Fix

Set `autoCommit=true` on the Ebean connection pool via `DataSourceConfig.setAutoCommit(true)`.

**What changes for read-only queries:**
- `ImplicitReadOnlyTransaction` sees `getAutoCommit()=true`, sets [`useCommit=false`](https://github.com/ebean-orm/ebean/blob/94e63cc30fb5144714b3f0d2920c3b62a324a538/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java#L80), and [skips the JDBC commit](https://github.com/ebean-orm/ebean/blob/94e63cc30fb5144714b3f0d2920c3b62a324a538/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java#L520) entirely
- Eliminates ~21K/sec no-op `COMMIT` statements

**What changes for write operations:**
- `JdbcTransaction.checkAutoCommit()` detects `autoCommit=true`, calls `setAutoCommit(false)` to start a real transaction, does the work, commits, then restores `setAutoCommit(true)` on deactivation — this is the same behavior it already had, just with the pool default flipped
- The `Com_set_option` counter (244/sec currently) will increase to ~2x the write rate as connections toggle autocommit per write transaction, but this is a cheap metadata operation compared to the 21K/sec commits it replaces

**Rollback path:** The env var `EBEAN_DATASOURCE_AUTOCOMMIT=false` restores the previous behavior without a code change.

## Files changed

- **`application.yaml`** — adds `ebean.autoCommit` property, defaulting to `true` (overridable via `EBEAN_DATASOURCE_AUTOCOMMIT`)
- **`LocalEbeanConfigFactory.java`** — wires the property through to `DataSourceConfig.setAutoCommit()`