### PR TITLE
perf(ingest): back UsageAggregator with SQL-side incremental counting

### DIFF
--- a/.github/workflows/connector-tests-trigger.yml
+++ b/.github/workflows/connector-tests-trigger.yml
@@ -58,11 +58,29 @@ jobs:
           SHA="${{ github.event.workflow_run.head_sha }}"
           REPO="${{ github.repository }}"
 
-          DEPLOY_ID=$(gh api "/repos/${REPO}/deployments?sha=${SHA}&per_page=10" \
-            --jq '[.[] | select(.environment | test("wheels"; "i"))][0].id // empty')
+          find_wheels_deploy() {
+            gh api "/repos/${REPO}/deployments?sha=$1&per_page=10" \
+              --jq '[.[] | select(.environment | test("wheels"; "i"))][0].id // empty'
+          }
+
+          DEPLOY_ID=$(find_wheels_deploy "$SHA")
+
+          # On pull_request runs the wheels deployment is registered against the PR's
+          # *merge* commit (github.sha), not the PR head (workflow_run.head_sha) that we
+          # search above — so a same-repo PR's deployment is invisible under the head SHA.
+          # (On master push the two coincide, so the first lookup already succeeds.)
+          # Fall back to the PR's merge commit before giving up.
+          if [ -z "$DEPLOY_ID" ]; then
+            MERGE_SHA=$(gh api "/repos/${REPO}/commits/${SHA}/pulls" \
+              --jq '.[0].merge_commit_sha // empty')
+            if [ -n "$MERGE_SHA" ] && [ "$MERGE_SHA" != "$SHA" ]; then
+              echo "No wheels deployment under head ${SHA}; trying PR merge commit ${MERGE_SHA}"
+              DEPLOY_ID=$(find_wheels_deploy "$MERGE_SHA")
+            fi
+          fi
 
           if [ -z "$DEPLOY_ID" ]; then
-            echo "::error::No Cloudflare deployment found for SHA ${SHA}. Re-run the Python Build workflow."
+            echo "::error::No Cloudflare deployment found for SHA ${SHA} (or its PR merge commit). Re-run the Python Build workflow."
             exit 1
           fi
 

--- a/.github/workflows/connector-tests-trigger.yml
+++ b/.github/workflows/connector-tests-trigger.yml
@@ -58,37 +58,24 @@ jobs:
           SHA="${{ github.event.workflow_run.head_sha }}"
           REPO="${{ github.repository }}"
 
-          find_wheels_deploy() {
-            gh api "/repos/${REPO}/deployments?sha=$1&per_page=10" \
-              --jq '[.[] | select(.environment | test("wheels"; "i"))][0].id // empty'
-          }
-
-          DEPLOY_ID=$(find_wheels_deploy "$SHA")
-
-          # On pull_request runs the wheels deployment is registered against the PR's
-          # *merge* commit (github.sha), not the PR head (workflow_run.head_sha) that we
-          # search above — so a same-repo PR's deployment is invisible under the head SHA.
-          # (On master push the two coincide, so the first lookup already succeeds.)
-          # Fall back to the PR's merge commit before giving up.
-          if [ -z "$DEPLOY_ID" ]; then
-            MERGE_SHA=$(gh api "/repos/${REPO}/commits/${SHA}/pulls" \
-              --jq '.[0].merge_commit_sha // empty')
-            if [ -n "$MERGE_SHA" ] && [ "$MERGE_SHA" != "$SHA" ]; then
-              echo "No wheels deployment under head ${SHA}; trying PR merge commit ${MERGE_SHA}"
-              DEPLOY_ID=$(find_wheels_deploy "$MERGE_SHA")
-            fi
-          fi
-
-          if [ -z "$DEPLOY_ID" ]; then
-            echo "::error::No Cloudflare deployment found for SHA ${SHA} (or its PR merge commit). Re-run the Python Build workflow."
-            exit 1
-          fi
-
-          DEPLOY_URL=$(gh api "/repos/${REPO}/deployments/${DEPLOY_ID}/statuses" \
-            --jq '.[0].environment_url // empty')
+          # The wheels build publishes to Cloudflare Pages, which registers a GitHub
+          # deployment whose .environment is the generic Pages environment ("preview" on
+          # PRs, "production" on master) — it does NOT contain "wheels". The wheels project
+          # is only identifiable by its deployment URL (*.datahub-wheels.pages.dev). The
+          # same SHA also carries unrelated docs/frontend Pages deployments, so we scan all
+          # deployments for the SHA and pick the one whose success-status URL is the wheels
+          # site.
+          DEPLOY_URL=""
+          for ID in $(gh api "/repos/${REPO}/deployments?sha=${SHA}&per_page=30" --jq '.[].id'); do
+            URL=$(gh api "/repos/${REPO}/deployments/${ID}/statuses" \
+              --jq '[.[] | select(.state == "success") | .environment_url][0] // empty')
+            case "$URL" in
+              *wheels*) DEPLOY_URL="$URL"; break ;;
+            esac
+          done
 
           if [ -z "$DEPLOY_URL" ]; then
-            echo "::error::Cloudflare deployment ${DEPLOY_ID} exists but has no URL."
+            echo "::error::No Cloudflare wheels deployment (*.datahub-wheels.pages.dev) found for SHA ${SHA}. Re-run the Python Build workflow."
             exit 1
           fi
 

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
@@ -77,6 +77,13 @@ class UnityCatalogUsageExtractor:
         except Exception as e:
             logger.error("Error processing usage", exc_info=True)
             self.report.report_warning("usage-extraction", str(e))
+        finally:
+            # Release the aggregator's temp SQLite database once usage emission is done.
+            # Guarded so a close() failure can't mask an exception from the generator body.
+            try:
+                self.usage_aggregator.close()
+            except Exception:
+                logger.warning("Failed to close usage aggregator", exc_info=True)
 
     def _get_workunits_internal(
         self, table_refs: Set[TableReference]

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
@@ -293,6 +293,8 @@ class UsageAggregator(Generic[ResourceType], Closeable):
 
         # FileBackedDict's bounded in-memory cache acts as the write buffer and dedups
         # repeated sets of the same key, so set unconditionally (no per-event read).
+        # This is last-write-wins (a deliberate, immaterial divergence from the prior
+        # first-write-wins, since resources with equal str() are interchangeable).
         self._resources[resource_key] = resource
         # Sentinel item records the group's existence even for denied/empty events, so
         # they still emit an empty workunit (matches the in-memory implementation).

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
@@ -1,7 +1,7 @@
 import dataclasses
 import logging
-from collections import defaultdict
-from datetime import datetime
+import pickle
+from datetime import datetime, timezone
 from typing import (
     Callable,
     Counter,
@@ -10,6 +10,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Set,
     Tuple,
     TypeVar,
 )
@@ -26,6 +27,7 @@ from datahub.configuration.time_window_config import (
     get_time_bucket,
 )
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.closeable import Closeable
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import (
     DatasetFieldUsageCountsClass,
@@ -33,6 +35,7 @@ from datahub.metadata.schema_classes import (
     DatasetUserUsageCountsClass,
     TimeWindowSizeClass,
 )
+from datahub.utilities.file_backed_collections import ConnectionWrapper
 from datahub.utilities.sql_formatter import format_sql_query, trim_query
 
 logger = logging.getLogger(__name__)
@@ -240,14 +243,57 @@ class BaseUsageConfig(BaseTimeWindowConfig):
         return v
 
 
-class UsageAggregator(Generic[ResourceType]):
+class UsageAggregator(Generic[ResourceType], Closeable):
     # TODO: Move over other connectors to use this class
 
-    def __init__(self, config: BaseUsageConfig):
+    _UPSERT_COUNT = (
+        "INSERT INTO usage_counts(bucket, resource_key, dim, item, cnt) "
+        "VALUES (?, ?, ?, ?, ?) "
+        "ON CONFLICT(bucket, resource_key, dim, item) "
+        "DO UPDATE SET cnt = cnt + excluded.cnt"
+    )
+
+    def __init__(
+        self,
+        config: BaseUsageConfig,
+        *,
+        shared_connection: Optional[ConnectionWrapper] = None,
+        batch_size: int = 50000,
+    ) -> None:
         self.config = config
-        self.aggregation: Dict[
-            datetime, Dict[ResourceType, GenericAggregatedDataset[ResourceType]]
-        ] = defaultdict(dict)
+        self._batch_size = batch_size
+        self._conn = shared_connection or ConnectionWrapper()
+        self._owns_connection = shared_connection is None
+        self._closed = False
+
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS usage_resources("
+            "resource_key TEXT PRIMARY KEY, resource BLOB)"
+        )
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS usage_aggregates("
+            "bucket INTEGER, resource_key TEXT, PRIMARY KEY(bucket, resource_key))"
+        )
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS usage_counts("
+            "bucket INTEGER, resource_key TEXT, dim TEXT, item TEXT, cnt INTEGER, "
+            "PRIMARY KEY(bucket, resource_key, dim, item))"
+        )
+
+        # All unbounded data lives in SQLite so heap memory stays flat regardless of
+        # resource cardinality: the high-cardinality per-query/user/column counts go to
+        # usage_counts, and the resource objects themselves are pickled to disk in
+        # usage_resources (one row per distinct resource) rather than retained in memory.
+        self._resource_buf: Dict[str, bytes] = {}
+
+        # Write buffers, deduplicated/combined within a flush window. counts are
+        # pre-summed so repeated increments to the same key become one upsert.
+        self._aggregate_buf: Set[Tuple[int, str]] = set()
+        self._count_buf: Dict[Tuple[int, str, str, str], int] = {}
+
+    @staticmethod
+    def _bucket_millis(start_time: datetime, bucket_duration: BucketDuration) -> int:
+        return int(get_time_bucket(start_time, bucket_duration).timestamp() * 1000)
 
     def aggregate_event(
         self,
@@ -259,34 +305,139 @@ class UsageAggregator(Generic[ResourceType]):
         fields: List[str],
         count: int = 1,
     ) -> None:
-        floored_ts: datetime = get_time_bucket(start_time, self.config.bucket_duration)
-        self.aggregation[floored_ts].setdefault(
-            resource,
-            GenericAggregatedDataset[ResourceType](
-                bucket_start_time=floored_ts,
-                resource=resource,
-            ),
-        ).add_read_entry(
-            user,
-            query,
-            fields,
-            user_email_pattern=self.config.user_email_pattern,
-            count=count,
-        )
+        bucket = self._bucket_millis(start_time, self.config.bucket_duration)
+        # str(resource) is the identity key; resources whose str() are equal are
+        # intentionally aggregated together (holds for UrnStr and usage-path
+        # TableReference, whose last_updated is unset).
+        resource_key = str(resource)
+
+        # Always record existence + resource, even for denied/empty events, so they
+        # still emit an empty workunit (matches the in-memory implementation).
+        self._aggregate_buf.add((bucket, resource_key))
+        if resource_key not in self._resource_buf:
+            self._resource_buf[resource_key] = pickle.dumps(resource)
+
+        # Replicate add_read_entry's filter: a denied user records nothing further.
+        if not (user and not self.config.user_email_pattern.allowed(user)):
+            if user:
+                self._bump(bucket, resource_key, "user", user, count)
+            if query:
+                self._bump(bucket, resource_key, "query", query, count)
+            for field in fields:
+                self._bump(bucket, resource_key, "column", field, count)
+
+        if (
+            len(self._count_buf) >= self._batch_size
+            or len(self._aggregate_buf) >= self._batch_size
+        ):
+            self._flush()
+
+    def _bump(
+        self, bucket: int, resource_key: str, dim: str, item: str, count: int
+    ) -> None:
+        key = (bucket, resource_key, dim, item)
+        self._count_buf[key] = self._count_buf.get(key, 0) + count
+
+    def _flush(self) -> None:
+        if self._resource_buf:
+            self._conn.executemany(
+                "INSERT OR IGNORE INTO usage_resources(resource_key, resource) "
+                "VALUES (?, ?)",
+                list(self._resource_buf.items()),
+            )
+            self._resource_buf.clear()
+        if self._aggregate_buf:
+            self._conn.executemany(
+                "INSERT OR IGNORE INTO usage_aggregates(bucket, resource_key) "
+                "VALUES (?, ?)",
+                list(self._aggregate_buf),
+            )
+            self._aggregate_buf.clear()
+        if self._count_buf:
+            self._conn.executemany(
+                self._UPSERT_COUNT,
+                [
+                    (bucket, rk, dim, item, cnt)
+                    for (bucket, rk, dim, item), cnt in self._count_buf.items()
+                ],
+            )
+            self._count_buf.clear()
 
     def generate_workunits(
         self,
         resource_urn_builder: Callable[[ResourceType], str],
         user_urn_builder: Optional[Callable[[str], str]] = None,
     ) -> Iterable[MetadataWorkUnit]:
-        for time_bucket in self.aggregation.values():
-            for aggregate in time_bucket.values():
-                yield aggregate.make_usage_workunit(
-                    bucket_duration=self.config.bucket_duration,
-                    top_n_queries=self.config.top_n_queries,
-                    format_sql_queries=self.config.format_sql_queries,
-                    include_top_n_queries=self.config.include_top_n_queries,
-                    resource_urn_builder=resource_urn_builder,
-                    user_urn_builder=user_urn_builder,
-                    queries_character_limit=self.config.queries_character_limit,
-                )
+        self._flush()
+        # c.rowid ASC is a deterministic tie-break for equal counts: the ON CONFLICT
+        # upsert preserves a row's rowid on update, so rowid reflects first-insertion
+        # order of each (bucket, resource_key, dim, item). This mirrors
+        # Counter.most_common's insertion-order tie-break, keeping output (and usage
+        # golden files) stable.
+        cursor = self._conn.execute(
+            "SELECT a.bucket, a.resource_key, r.resource, c.dim, c.item, c.cnt "
+            "FROM usage_aggregates a "
+            "JOIN usage_resources r ON r.resource_key = a.resource_key "
+            "LEFT JOIN usage_counts c "
+            "  ON c.bucket = a.bucket AND c.resource_key = a.resource_key "
+            "ORDER BY a.bucket, a.resource_key, c.dim, c.cnt DESC, c.rowid ASC"
+        )
+
+        cur_key: Optional[Tuple[int, str]] = None
+        cur_resource: Optional[ResourceType] = None
+        query_freq: List[Tuple[str, int]] = []
+        user_freq: List[Tuple[str, int]] = []
+        column_freq: List[Tuple[str, int]] = []
+        query_count = 0
+
+        def build() -> MetadataWorkUnit:
+            assert cur_key is not None
+            assert cur_resource is not None  # narrows Optional for mypy
+            return make_usage_workunit(
+                bucket_start_time=datetime.fromtimestamp(
+                    cur_key[0] / 1000, tz=timezone.utc
+                ),
+                resource=cur_resource,
+                query_count=query_count,
+                query_freq=(
+                    query_freq[: self.config.top_n_queries]
+                    if self.config.include_top_n_queries
+                    else None
+                ),
+                user_freq=user_freq,
+                column_freq=column_freq,
+                bucket_duration=self.config.bucket_duration,
+                resource_urn_builder=resource_urn_builder,
+                user_urn_builder=user_urn_builder,
+                top_n_queries=self.config.top_n_queries,
+                format_sql_queries=self.config.format_sql_queries,
+                queries_character_limit=self.config.queries_character_limit,
+            )
+
+        for bucket, resource_key, resource_blob, dim, item, cnt in cursor:
+            key = (bucket, resource_key)
+            if key != cur_key:
+                if cur_key is not None:
+                    yield build()
+                cur_key = key
+                cur_resource = pickle.loads(resource_blob)
+                query_freq, user_freq, column_freq, query_count = [], [], [], 0
+            if dim is None:
+                continue  # empty aggregate (LEFT JOIN miss)
+            if dim == "query":
+                query_freq.append((item, cnt))
+                query_count += cnt
+            elif dim == "user":
+                user_freq.append((item, cnt))
+            elif dim == "column":
+                column_freq.append((item, cnt))
+        if cur_key is not None:
+            yield build()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._flush()
+        if self._owns_connection:
+            self._conn.close()
+        self._closed = True

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
@@ -246,20 +246,41 @@ class BaseUsageConfig(BaseTimeWindowConfig):
 
 
 class _Dim:
-    """The counted dimensions stored as item-key prefixes in the usage counter."""
+    """The counted dimensions, stored as item-key prefixes in the usage counter."""
 
     USER = "user"
     QUERY = "query"
     COLUMN = "column"
 
 
-def _encode_item(dim: str, value: str) -> str:
-    return f"{dim}:{value}"
+class _UsageKeys:
+    """Single source of truth for the usage counter's (group_key, item_key) encoding.
 
+    Keys are colon-joined. The prefixes -- an integer bucket and a fixed dim name --
+    never contain ':', so str.partition(':') round-trips arbitrary resource/value content.
+    """
 
-def _decode_item(item_key: str) -> Tuple[str, str]:
-    dim, _, value = item_key.partition(":")
-    return dim, value
+    # Item key recording group existence even when there are no real counts (denied or
+    # empty events), so the group still emits an (empty) workunit.
+    EXISTENCE = ""
+
+    @staticmethod
+    def group(bucket_millis: int, resource_key: str) -> str:
+        return f"{bucket_millis}:{resource_key}"
+
+    @staticmethod
+    def split_group(group_key: str) -> Tuple[int, str]:
+        bucket_str, _, resource_key = group_key.partition(":")
+        return int(bucket_str), resource_key
+
+    @staticmethod
+    def item(dim: str, value: str) -> str:
+        return f"{dim}:{value}"
+
+    @staticmethod
+    def split_item(item_key: str) -> Tuple[str, str]:
+        dim, _, value = item_key.partition(":")
+        return dim, value
 
 
 class UsageAggregator(Generic[ResourceType], Closeable):
@@ -307,32 +328,43 @@ class UsageAggregator(Generic[ResourceType], Closeable):
         bucket = self._bucket_millis(start_time, self.config.bucket_duration)
         # str(resource) is the identity key; resources whose str() are equal are
         # intentionally aggregated together (holds for UrnStr and usage-path
-        # TableReference, whose last_updated is unset). bucket is a leading integer and
-        # dim is a ":"-free enum, so the keys decode unambiguously via str.partition(":").
+        # TableReference, whose last_updated is unset).
         resource_key = str(resource)
-        group_key = f"{bucket}:{resource_key}"
+        group_key = _UsageKeys.group(bucket, resource_key)
 
         # FileBackedDict's bounded in-memory cache acts as the write buffer and dedups
-        # repeated sets of the same key, so set unconditionally (no per-event read).
-        # This is last-write-wins (a deliberate, immaterial divergence from the prior
-        # first-write-wins, since resources with equal str() are interchangeable).
+        # repeated sets of the same key, so set unconditionally (last-write-wins; an
+        # immaterial divergence from the prior first-write-wins, since resources with
+        # equal str() are interchangeable).
         self._resources[resource_key] = resource
-        # Sentinel item records the group's existence even for denied/empty events, so
-        # they still emit an empty workunit (matches the in-memory implementation).
-        self._counts.increment(group_key, "", count=0)
+        self._add_read_entry(
+            group_key, user=user, query=query, fields=fields, count=count
+        )
 
-        # Replicate add_read_entry's filter: a denied user records nothing further.
-        if not (user and not self.config.user_email_pattern.allowed(user)):
-            if user:
-                self._counts.increment(group_key, _encode_item(_Dim.USER, user), count)
-            if query:
-                self._counts.increment(
-                    group_key, _encode_item(_Dim.QUERY, query), count
-                )
-            for field in fields:
-                self._counts.increment(
-                    group_key, _encode_item(_Dim.COLUMN, field), count
-                )
+    def _add_read_entry(
+        self,
+        group_key: str,
+        *,
+        user: Optional[str],
+        query: Optional[str],
+        fields: List[str],
+        count: int,
+    ) -> None:
+        # Record the group's existence even for denied/empty events, so they still emit
+        # an empty workunit (mirrors GenericAggregatedDataset.add_read_entry, which
+        # always creates the aggregate before its denied-user early return).
+        self._counts.increment(group_key, _UsageKeys.EXISTENCE, count=0)
+        # A denied user records nothing further.
+        if user and not self.config.user_email_pattern.allowed(user):
+            return
+        if user:
+            self._counts.increment(group_key, _UsageKeys.item(_Dim.USER, user), count)
+        if query:
+            self._counts.increment(group_key, _UsageKeys.item(_Dim.QUERY, query), count)
+        for field in fields:
+            self._counts.increment(
+                group_key, _UsageKeys.item(_Dim.COLUMN, field), count
+            )
 
     def generate_workunits(
         self,
@@ -340,7 +372,7 @@ class UsageAggregator(Generic[ResourceType], Closeable):
         user_urn_builder: Optional[Callable[[str], str]] = None,
     ) -> Iterable[MetadataWorkUnit]:
         for group_key, items in self._counts.most_common_by_group():
-            bucket_str, _, resource_key = group_key.partition(":")
+            bucket_millis, resource_key = _UsageKeys.split_group(group_key)
             resource = self._resources[resource_key]
 
             query_freq: List[Tuple[str, int]] = []
@@ -348,7 +380,7 @@ class UsageAggregator(Generic[ResourceType], Closeable):
             column_freq: List[Tuple[str, int]] = []
             query_count = 0
             for item_key, cnt in items:
-                dim, item = _decode_item(item_key)
+                dim, item = _UsageKeys.split_item(item_key)
                 if dim == _Dim.QUERY:
                     query_freq.append((item, cnt))
                     query_count += cnt
@@ -360,7 +392,7 @@ class UsageAggregator(Generic[ResourceType], Closeable):
 
             yield make_usage_workunit(
                 bucket_start_time=datetime.fromtimestamp(
-                    int(bucket_str) / 1000, tz=timezone.utc
+                    bucket_millis / 1000, tz=timezone.utc
                 ),
                 resource=resource,
                 query_count=query_count,

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
@@ -1,16 +1,13 @@
 import dataclasses
 import logging
-import pickle
 from datetime import datetime, timezone
 from typing import (
     Callable,
     Counter,
-    Dict,
     Generic,
     Iterable,
     List,
     Optional,
-    Set,
     Tuple,
     TypeVar,
 )
@@ -35,7 +32,11 @@ from datahub.metadata.schema_classes import (
     DatasetUserUsageCountsClass,
     TimeWindowSizeClass,
 )
-from datahub.utilities.file_backed_collections import ConnectionWrapper
+from datahub.utilities.file_backed_collections import (
+    ConnectionWrapper,
+    FileBackedCounter,
+    FileBackedDict,
+)
 from datahub.utilities.sql_formatter import format_sql_query, trim_query
 
 logger = logging.getLogger(__name__)
@@ -246,13 +247,6 @@ class BaseUsageConfig(BaseTimeWindowConfig):
 class UsageAggregator(Generic[ResourceType], Closeable):
     # TODO: Move over other connectors to use this class
 
-    _UPSERT_COUNT = (
-        "INSERT INTO usage_counts(bucket, resource_key, dim, item, cnt) "
-        "VALUES (?, ?, ?, ?, ?) "
-        "ON CONFLICT(bucket, resource_key, dim, item) "
-        "DO UPDATE SET cnt = cnt + excluded.cnt"
-    )
-
     def __init__(
         self,
         config: BaseUsageConfig,
@@ -261,35 +255,19 @@ class UsageAggregator(Generic[ResourceType], Closeable):
         batch_size: int = 50000,
     ) -> None:
         self.config = config
-        self._batch_size = batch_size
-        self._conn = shared_connection or ConnectionWrapper()
-        self._owns_connection = shared_connection is None
         self._closed = False
-
-        self._conn.execute(
-            "CREATE TABLE IF NOT EXISTS usage_resources("
-            "resource_key TEXT PRIMARY KEY, resource BLOB)"
+        # Counts of (query|user|column) items per (bucket, resource), on disk.
+        self._counts: FileBackedCounter = FileBackedCounter(
+            shared_connection=shared_connection,
+            tablename="usage_counts",
+            batch_size=batch_size,
         )
-        self._conn.execute(
-            "CREATE TABLE IF NOT EXISTS usage_aggregates("
-            "bucket INTEGER, resource_key TEXT, PRIMARY KEY(bucket, resource_key))"
+        # Resource objects, pickled to disk keyed by resource_key, so heap memory stays
+        # flat regardless of resource cardinality.
+        self._resources: FileBackedDict[ResourceType] = FileBackedDict(
+            shared_connection=shared_connection,
+            tablename="usage_resources",
         )
-        self._conn.execute(
-            "CREATE TABLE IF NOT EXISTS usage_counts("
-            "bucket INTEGER, resource_key TEXT, dim TEXT, item TEXT, cnt INTEGER, "
-            "PRIMARY KEY(bucket, resource_key, dim, item))"
-        )
-
-        # All unbounded data lives in SQLite so heap memory stays flat regardless of
-        # resource cardinality: the high-cardinality per-query/user/column counts go to
-        # usage_counts, and the resource objects themselves are pickled to disk in
-        # usage_resources (one row per distinct resource) rather than retained in memory.
-        self._resource_buf: Dict[str, bytes] = {}
-
-        # Write buffers, deduplicated/combined within a flush window. counts are
-        # pre-summed so repeated increments to the same key become one upsert.
-        self._aggregate_buf: Set[Tuple[int, str]] = set()
-        self._count_buf: Dict[Tuple[int, str, str, str], int] = {}
 
     @staticmethod
     def _bucket_millis(start_time: datetime, bucket_duration: BucketDuration) -> int:
@@ -308,96 +286,56 @@ class UsageAggregator(Generic[ResourceType], Closeable):
         bucket = self._bucket_millis(start_time, self.config.bucket_duration)
         # str(resource) is the identity key; resources whose str() are equal are
         # intentionally aggregated together (holds for UrnStr and usage-path
-        # TableReference, whose last_updated is unset).
+        # TableReference, whose last_updated is unset). bucket is a leading integer and
+        # dim is a ":"-free enum, so the keys decode unambiguously via str.partition(":").
         resource_key = str(resource)
+        group_key = f"{bucket}:{resource_key}"
 
-        # Always record existence + resource, even for denied/empty events, so they
-        # still emit an empty workunit (matches the in-memory implementation).
-        self._aggregate_buf.add((bucket, resource_key))
-        if resource_key not in self._resource_buf:
-            self._resource_buf[resource_key] = pickle.dumps(resource)
+        # FileBackedDict's bounded in-memory cache acts as the write buffer and dedups
+        # repeated sets of the same key, so set unconditionally (no per-event read).
+        self._resources[resource_key] = resource
+        # Sentinel item records the group's existence even for denied/empty events, so
+        # they still emit an empty workunit (matches the in-memory implementation).
+        self._counts.increment(group_key, "", count=0)
 
         # Replicate add_read_entry's filter: a denied user records nothing further.
         if not (user and not self.config.user_email_pattern.allowed(user)):
             if user:
-                self._bump(bucket, resource_key, "user", user, count)
+                self._counts.increment(group_key, f"user:{user}", count)
             if query:
-                self._bump(bucket, resource_key, "query", query, count)
+                self._counts.increment(group_key, f"query:{query}", count)
             for field in fields:
-                self._bump(bucket, resource_key, "column", field, count)
-
-        if (
-            len(self._count_buf) >= self._batch_size
-            or len(self._aggregate_buf) >= self._batch_size
-        ):
-            self._flush()
-
-    def _bump(
-        self, bucket: int, resource_key: str, dim: str, item: str, count: int
-    ) -> None:
-        key = (bucket, resource_key, dim, item)
-        self._count_buf[key] = self._count_buf.get(key, 0) + count
-
-    def _flush(self) -> None:
-        if self._resource_buf:
-            self._conn.executemany(
-                "INSERT OR IGNORE INTO usage_resources(resource_key, resource) "
-                "VALUES (?, ?)",
-                list(self._resource_buf.items()),
-            )
-            self._resource_buf.clear()
-        if self._aggregate_buf:
-            self._conn.executemany(
-                "INSERT OR IGNORE INTO usage_aggregates(bucket, resource_key) "
-                "VALUES (?, ?)",
-                list(self._aggregate_buf),
-            )
-            self._aggregate_buf.clear()
-        if self._count_buf:
-            self._conn.executemany(
-                self._UPSERT_COUNT,
-                [
-                    (bucket, rk, dim, item, cnt)
-                    for (bucket, rk, dim, item), cnt in self._count_buf.items()
-                ],
-            )
-            self._count_buf.clear()
+                self._counts.increment(group_key, f"column:{field}", count)
 
     def generate_workunits(
         self,
         resource_urn_builder: Callable[[ResourceType], str],
         user_urn_builder: Optional[Callable[[str], str]] = None,
     ) -> Iterable[MetadataWorkUnit]:
-        self._flush()
-        # c.rowid ASC is a deterministic tie-break for equal counts: the ON CONFLICT
-        # upsert preserves a row's rowid on update, so rowid reflects first-insertion
-        # order of each (bucket, resource_key, dim, item). This mirrors
-        # Counter.most_common's insertion-order tie-break, keeping output (and usage
-        # golden files) stable.
-        cursor = self._conn.execute(
-            "SELECT a.bucket, a.resource_key, r.resource, c.dim, c.item, c.cnt "
-            "FROM usage_aggregates a "
-            "JOIN usage_resources r ON r.resource_key = a.resource_key "
-            "LEFT JOIN usage_counts c "
-            "  ON c.bucket = a.bucket AND c.resource_key = a.resource_key "
-            "ORDER BY a.bucket, a.resource_key, c.dim, c.cnt DESC, c.rowid ASC"
-        )
+        for group_key, items in self._counts.most_common_by_group():
+            bucket_str, _, resource_key = group_key.partition(":")
+            resource = self._resources[resource_key]
 
-        cur_key: Optional[Tuple[int, str]] = None
-        cur_resource: Optional[ResourceType] = None
-        query_freq: List[Tuple[str, int]] = []
-        user_freq: List[Tuple[str, int]] = []
-        column_freq: List[Tuple[str, int]] = []
-        query_count = 0
+            query_freq: List[Tuple[str, int]] = []
+            user_freq: List[Tuple[str, int]] = []
+            column_freq: List[Tuple[str, int]] = []
+            query_count = 0
+            for item_key, cnt in items:
+                dim, _, item = item_key.partition(":")
+                if dim == "query":
+                    query_freq.append((item, cnt))
+                    query_count += cnt
+                elif dim == "user":
+                    user_freq.append((item, cnt))
+                elif dim == "column":
+                    column_freq.append((item, cnt))
+                # dim == "" -> existence sentinel, skip
 
-        def build() -> MetadataWorkUnit:
-            assert cur_key is not None
-            assert cur_resource is not None  # narrows Optional for mypy
-            return make_usage_workunit(
+            yield make_usage_workunit(
                 bucket_start_time=datetime.fromtimestamp(
-                    cur_key[0] / 1000, tz=timezone.utc
+                    int(bucket_str) / 1000, tz=timezone.utc
                 ),
-                resource=cur_resource,
+                resource=resource,
                 query_count=query_count,
                 query_freq=(
                     query_freq[: self.config.top_n_queries]
@@ -414,30 +352,9 @@ class UsageAggregator(Generic[ResourceType], Closeable):
                 queries_character_limit=self.config.queries_character_limit,
             )
 
-        for bucket, resource_key, resource_blob, dim, item, cnt in cursor:
-            key = (bucket, resource_key)
-            if key != cur_key:
-                if cur_key is not None:
-                    yield build()
-                cur_key = key
-                cur_resource = pickle.loads(resource_blob)
-                query_freq, user_freq, column_freq, query_count = [], [], [], 0
-            if dim is None:
-                continue  # empty aggregate (LEFT JOIN miss)
-            if dim == "query":
-                query_freq.append((item, cnt))
-                query_count += cnt
-            elif dim == "user":
-                user_freq.append((item, cnt))
-            elif dim == "column":
-                column_freq.append((item, cnt))
-        if cur_key is not None:
-            yield build()
-
     def close(self) -> None:
         if self._closed:
             return
-        self._flush()
-        if self._owns_connection:
-            self._conn.close()
+        self._counts.close()
+        self._resources.close()
         self._closed = True

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
@@ -284,6 +284,14 @@ class _UsageKeys:
 
 
 class UsageAggregator(Generic[ResourceType], Closeable):
+    """Aggregates usage events into per-(bucket, resource) workunits.
+
+    Single-writer per instance: ``aggregate_event`` must not be called concurrently on
+    the same aggregator. The counter (``FileBackedCounter``) is thread-safe, but the
+    resource store (``FileBackedDict``) is not, so a shared instance would need an
+    external lock. For parallel ingestion, use one aggregator per worker.
+    """
+
     # TODO: Move over other connectors to use this class
 
     def __init__(

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
@@ -36,6 +36,7 @@ from datahub.utilities.file_backed_collections import (
     ConnectionWrapper,
     FileBackedCounter,
     FileBackedDict,
+    GroupedItemCounter,
 )
 from datahub.utilities.sql_formatter import format_sql_query, trim_query
 
@@ -244,6 +245,23 @@ class BaseUsageConfig(BaseTimeWindowConfig):
         return v
 
 
+class _Dim:
+    """The counted dimensions stored as item-key prefixes in the usage counter."""
+
+    USER = "user"
+    QUERY = "query"
+    COLUMN = "column"
+
+
+def _encode_item(dim: str, value: str) -> str:
+    return f"{dim}:{value}"
+
+
+def _decode_item(item_key: str) -> Tuple[str, str]:
+    dim, _, value = item_key.partition(":")
+    return dim, value
+
+
 class UsageAggregator(Generic[ResourceType], Closeable):
     # TODO: Move over other connectors to use this class
 
@@ -253,11 +271,14 @@ class UsageAggregator(Generic[ResourceType], Closeable):
         *,
         shared_connection: Optional[ConnectionWrapper] = None,
         batch_size: int = 50000,
+        counter: Optional[GroupedItemCounter] = None,
     ) -> None:
         self.config = config
         self._closed = False
-        # Counts of (query|user|column) items per (bucket, resource), on disk.
-        self._counts: FileBackedCounter = FileBackedCounter(
+        # Counts of (query|user|column) items per (bucket, resource). Defaults to the
+        # disk-backed counter; an in-memory counter can be injected (e.g. for tests or
+        # small workloads).
+        self._counts: GroupedItemCounter = counter or FileBackedCounter(
             shared_connection=shared_connection,
             tablename="usage_counts",
             batch_size=batch_size,
@@ -303,11 +324,15 @@ class UsageAggregator(Generic[ResourceType], Closeable):
         # Replicate add_read_entry's filter: a denied user records nothing further.
         if not (user and not self.config.user_email_pattern.allowed(user)):
             if user:
-                self._counts.increment(group_key, f"user:{user}", count)
+                self._counts.increment(group_key, _encode_item(_Dim.USER, user), count)
             if query:
-                self._counts.increment(group_key, f"query:{query}", count)
+                self._counts.increment(
+                    group_key, _encode_item(_Dim.QUERY, query), count
+                )
             for field in fields:
-                self._counts.increment(group_key, f"column:{field}", count)
+                self._counts.increment(
+                    group_key, _encode_item(_Dim.COLUMN, field), count
+                )
 
     def generate_workunits(
         self,
@@ -323,13 +348,13 @@ class UsageAggregator(Generic[ResourceType], Closeable):
             column_freq: List[Tuple[str, int]] = []
             query_count = 0
             for item_key, cnt in items:
-                dim, _, item = item_key.partition(":")
-                if dim == "query":
+                dim, item = _decode_item(item_key)
+                if dim == _Dim.QUERY:
                     query_freq.append((item, cnt))
                     query_count += cnt
-                elif dim == "user":
+                elif dim == _Dim.USER:
                     user_freq.append((item, cnt))
-                elif dim == "column":
+                elif dim == _Dim.COLUMN:
                     column_freq.append((item, cnt))
                 # dim == "" -> existence sentinel, skip
 

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
@@ -379,6 +379,10 @@ class UsageAggregator(Generic[ResourceType], Closeable):
         resource_urn_builder: Callable[[ResourceType], str],
         user_urn_builder: Optional[Callable[[str], str]] = None,
     ) -> Iterable[MetadataWorkUnit]:
+        # Cap query items to top_n while streaming so a single high-cardinality group
+        # never has to be fully materialized in memory. Items stream in count-desc order,
+        # so the first top_n query items are the top ones; query_count still sums all.
+        top_n = self.config.top_n_queries if self.config.include_top_n_queries else 0
         for group_key, items in self._counts.most_common_by_group():
             bucket_millis, resource_key = _UsageKeys.split_group(group_key)
             resource = self._resources[resource_key]
@@ -390,7 +394,8 @@ class UsageAggregator(Generic[ResourceType], Closeable):
             for item_key, cnt in items:
                 dim, item = _UsageKeys.split_item(item_key)
                 if dim == _Dim.QUERY:
-                    query_freq.append((item, cnt))
+                    if len(query_freq) < top_n:
+                        query_freq.append((item, cnt))
                     query_count += cnt
                 elif dim == _Dim.USER:
                     user_freq.append((item, cnt))
@@ -404,11 +409,7 @@ class UsageAggregator(Generic[ResourceType], Closeable):
                 ),
                 resource=resource,
                 query_count=query_count,
-                query_freq=(
-                    query_freq[: self.config.top_n_queries]
-                    if self.config.include_top_n_queries
-                    else None
-                ),
+                query_freq=query_freq if self.config.include_top_n_queries else None,
                 user_freq=user_freq,
                 column_freq=column_freq,
                 bucket_duration=self.config.bucket_duration,

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/usage_common.py
@@ -379,10 +379,6 @@ class UsageAggregator(Generic[ResourceType], Closeable):
         resource_urn_builder: Callable[[ResourceType], str],
         user_urn_builder: Optional[Callable[[str], str]] = None,
     ) -> Iterable[MetadataWorkUnit]:
-        # Cap query items to top_n while streaming so a single high-cardinality group
-        # never has to be fully materialized in memory. Items stream in count-desc order,
-        # so the first top_n query items are the top ones; query_count still sums all.
-        top_n = self.config.top_n_queries if self.config.include_top_n_queries else 0
         for group_key, items in self._counts.most_common_by_group():
             bucket_millis, resource_key = _UsageKeys.split_group(group_key)
             resource = self._resources[resource_key]
@@ -394,8 +390,7 @@ class UsageAggregator(Generic[ResourceType], Closeable):
             for item_key, cnt in items:
                 dim, item = _UsageKeys.split_item(item_key)
                 if dim == _Dim.QUERY:
-                    if len(query_freq) < top_n:
-                        query_freq.append((item, cnt))
+                    query_freq.append((item, cnt))
                     query_count += cnt
                 elif dim == _Dim.USER:
                     user_freq.append((item, cnt))
@@ -409,7 +404,11 @@ class UsageAggregator(Generic[ResourceType], Closeable):
                 ),
                 resource=resource,
                 query_count=query_count,
-                query_freq=query_freq if self.config.include_top_n_queries else None,
+                query_freq=(
+                    query_freq[: self.config.top_n_queries]
+                    if self.config.include_top_n_queries
+                    else None
+                ),
                 user_freq=user_freq,
                 column_freq=column_freq,
                 bucket_duration=self.config.bucket_duration,

--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
@@ -576,13 +576,16 @@ class SqlParsingAggregator(Closeable):
         self._exit_stack.push(self._table_swaps)
 
         # Usage aggregator. This will only be initialized if usage statistics are enabled.
-        # TODO: Replace with FileBackedDict.
         # TODO: The BaseUsageConfig class is much too broad for our purposes, and has a number of
         # configs that won't be respected here. Using it is misleading.
         self._usage_aggregator: Optional[UsageAggregator[UrnStr]] = None
         if self.generate_usage_statistics:
             assert self.usage_config is not None
-            self._usage_aggregator = UsageAggregator(config=self.usage_config)
+            self._usage_aggregator = UsageAggregator(
+                config=self.usage_config,
+                shared_connection=self._shared_connection,
+            )
+            self._exit_stack.push(self._usage_aggregator)
 
         # Query usage aggregator.
         # Map of query ID -> { bucket -> count }

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -607,7 +607,9 @@ class FileBackedCounter(Closeable):
         self._batch_size = batch_size
         self._closed = False
         # Write buffer, pre-summing repeated keys within a flush window so they collapse
-        # to a single upsert.
+        # to a single upsert. _lock guards _buf so concurrent increment()/_flush() calls
+        # don't lose counts or mutate the dict mid-iteration.
+        self._lock = threading.Lock()
         self._buf: Dict[Tuple[str, str], int] = {}
         self._upsert = (
             f"INSERT INTO {tablename}(group_key, item_key, cnt) VALUES (?, ?, ?) "
@@ -632,14 +634,21 @@ class FileBackedCounter(Closeable):
 
     def increment(self, group_key: str, item_key: str, count: int = 1) -> None:
         key = (group_key, item_key)
-        self._buf[key] = self._buf.get(key, 0) + count
-        if len(self._buf) >= self._batch_size:
+        with self._lock:
+            self._buf[key] = self._buf.get(key, 0) + count
+            over_batch = len(self._buf) >= self._batch_size
+        if over_batch:
             self._flush()
 
     def _flush(self) -> None:
-        if not self._buf:
-            return
-        rows = [(group, item, cnt) for (group, item), cnt in self._buf.items()]
+        # Snapshot and clear the buffer under the lock, then write outside it: the SQL
+        # write is serialized separately by ConnectionWrapper's own lock, and holding
+        # _lock across I/O would needlessly block concurrent increment() calls.
+        with self._lock:
+            if not self._buf:
+                return
+            rows = [(group, item, cnt) for (group, item), cnt in self._buf.items()]
+            self._buf.clear()
         if self._use_sqlite_on_conflict:
             self._conn.executemany(self._upsert, rows)
         else:
@@ -658,7 +667,6 @@ class FileBackedCounter(Closeable):
                         "WHERE group_key = ? AND item_key = ?",
                         (cnt, group, item),
                     )
-        self._buf.clear()
 
     def most_common_by_group(self) -> Iterator[Tuple[str, List[Tuple[str, int]]]]:
         """Yield (group_key, items) for each group in group_key order, where items are

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -573,3 +573,116 @@ class FileBackedList(Generic[_VT], Closeable):
 
     def __del__(self) -> None:
         self.close()
+
+
+class FileBackedCounter(Closeable):
+    """A disk-backed two-level counter: counts items within groups.
+
+    Stores ``(group_key, item_key) -> count`` in SQLite, incrementing via batched
+    upserts, and reads back the most-common items per group. A member of the
+    FileBacked* family, for when the set of counted keys is too large to hold in memory.
+
+    Callers that need a composite group or item encode it into the string key with a
+    separator their prefix cannot contain.
+
+    Unlike FileBackedDict/FileBackedList, FileBackedCounter does NOT register itself in
+    ``ConnectionWrapper._dependent_objects``. When sharing a connection, the owner must
+    therefore call ``close()`` explicitly to flush buffered increments (the
+    ``UsageAggregator`` consumer does this).
+    """
+
+    def __init__(
+        self,
+        *,
+        shared_connection: Optional[ConnectionWrapper] = None,
+        tablename: str = "counter",
+        batch_size: int = 50000,
+    ) -> None:
+        self._conn = shared_connection or ConnectionWrapper()
+        self._owns_connection = shared_connection is None
+        self._tablename = tablename
+        self._batch_size = batch_size
+        self._closed = False
+        # Write buffer, pre-summing repeated keys within a flush window so they collapse
+        # to a single upsert.
+        self._buf: Dict[Tuple[str, str], int] = {}
+        self._upsert = (
+            f"INSERT INTO {tablename}(group_key, item_key, cnt) VALUES (?, ?, ?) "
+            f"ON CONFLICT(group_key, item_key) DO UPDATE SET cnt = cnt + excluded.cnt"
+        )
+        self._use_sqlite_on_conflict = True
+        if sqlite3.sqlite_version_info < (3, 24, 0):
+            # ON CONFLICT was added in SQLite 3.24.0 (2018-06-04).
+            # See https://www.sqlite.org/lang_conflict.html
+            if _get_sqlite_version_override():
+                self._use_sqlite_on_conflict = False
+            else:
+                raise RuntimeError("SQLite version 3.24.0 or later is required")
+        # Always use IF NOT EXISTS: this counter may share a connection or be re-opened
+        # against an existing table, unlike FileBackedDict which gates table reuse via
+        # allow_table_name_reuse.
+        self._conn.execute(
+            f"CREATE TABLE IF NOT EXISTS {tablename}("
+            "group_key TEXT, item_key TEXT, cnt INTEGER, "
+            "PRIMARY KEY(group_key, item_key))"
+        )
+
+    def increment(self, group_key: str, item_key: str, count: int = 1) -> None:
+        key = (group_key, item_key)
+        self._buf[key] = self._buf.get(key, 0) + count
+        if len(self._buf) >= self._batch_size:
+            self._flush()
+
+    def _flush(self) -> None:
+        if not self._buf:
+            return
+        rows = [(group, item, cnt) for (group, item), cnt in self._buf.items()]
+        if self._use_sqlite_on_conflict:
+            self._conn.executemany(self._upsert, rows)
+        else:
+            # Fallback for SQLite < 3.24.0 (no ON CONFLICT support): INSERT, and on a
+            # primary-key collision add to the existing count via UPDATE.
+            for group, item, cnt in rows:
+                try:
+                    self._conn.execute(
+                        f"INSERT INTO {self._tablename}(group_key, item_key, cnt) "
+                        "VALUES (?, ?, ?)",
+                        (group, item, cnt),
+                    )
+                except sqlite3.IntegrityError:
+                    self._conn.execute(
+                        f"UPDATE {self._tablename} SET cnt = cnt + ? "
+                        "WHERE group_key = ? AND item_key = ?",
+                        (cnt, group, item),
+                    )
+        self._buf.clear()
+
+    def most_common_by_group(self) -> Iterator[Tuple[str, List[Tuple[str, int]]]]:
+        """Yield (group_key, items) for each group in group_key order, where items are
+        (item_key, count) ordered by count DESC then rowid ASC. The ON CONFLICT upsert
+        preserves a row's rowid on update, so rowid reflects first-insertion order,
+        making the tie-break deterministic (mirrors collections.Counter.most_common)."""
+        self._flush()
+        cursor = self._conn.execute(
+            f"SELECT group_key, item_key, cnt FROM {self._tablename} "
+            "ORDER BY group_key, cnt DESC, rowid ASC"
+        )
+        cur_group: Optional[str] = None
+        items: List[Tuple[str, int]] = []
+        for group_key, item_key, cnt in cursor:
+            if group_key != cur_group:
+                if cur_group is not None:
+                    yield cur_group, items
+                cur_group = group_key
+                items = []
+            items.append((item_key, cnt))
+        if cur_group is not None:
+            yield cur_group, items
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._flush()
+        if self._owns_connection:
+            self._conn.close()
+        self._closed = True

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -76,7 +76,9 @@ class ConnectionWrapper:
     filename: pathlib.Path
 
     _temp_directory: Optional[str]
-    _dependent_objects: List[Union["FileBackedList", "FileBackedDict"]]
+    _dependent_objects: List[
+        Union["FileBackedList", "FileBackedDict", "FileBackedCounter"]
+    ]
 
     def __init__(self, filename: Optional[pathlib.Path] = None):
         self._temp_directory = None
@@ -588,10 +590,9 @@ class FileBackedCounter(Closeable):
     Callers that need a composite group or item encode it into the string key with a
     separator their prefix cannot contain.
 
-    Unlike FileBackedDict/FileBackedList, FileBackedCounter does NOT register itself in
-    ``ConnectionWrapper._dependent_objects``. When sharing a connection, the owner must
-    therefore call ``close()`` explicitly to flush buffered increments (the
-    ``UsageAggregator`` consumer does this).
+    When given a shared connection, it registers itself in the connection's dependent
+    objects (like FileBackedDict/FileBackedList), so closing the connection flushes any
+    buffered increments before the connection is torn down.
     """
 
     def __init__(
@@ -607,6 +608,10 @@ class FileBackedCounter(Closeable):
             raise ValueError(f"tablename must be a valid identifier, got {tablename!r}")
         self._conn = shared_connection or ConnectionWrapper()
         self._owns_connection = shared_connection is None
+        if shared_connection is not None:
+            # Flush buffered increments when the shared connection is closed, even if
+            # the owner forgets to close() this counter first.
+            shared_connection._dependent_objects.append(self)
         self._tablename = tablename
         self._batch_size = batch_size
         self._closed = False

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -601,6 +601,10 @@ class FileBackedCounter(Closeable):
         tablename: str = "counter",
         batch_size: int = 50000,
     ) -> None:
+        # tablename is interpolated into the SQL below (SQLite cannot bind identifiers),
+        # so require a safe identifier instead of trusting the caller blindly.
+        if not tablename.isidentifier():
+            raise ValueError(f"tablename must be a valid identifier, got {tablename!r}")
         self._conn = shared_connection or ConnectionWrapper()
         self._owns_connection = shared_connection is None
         self._tablename = tablename

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -13,6 +13,7 @@ from types import TracebackType
 from typing import (
     Any,
     Callable,
+    Counter,
     Dict,
     Generic,
     Iterator,
@@ -20,11 +21,13 @@ from typing import (
     MutableMapping,
     Optional,
     OrderedDict,
+    Protocol,
     Sequence,
     Tuple,
     Type,
     TypeVar,
     Union,
+    runtime_checkable,
 )
 
 from datahub.configuration.env_vars import get_override_sqlite_version_req
@@ -689,3 +692,39 @@ class FileBackedCounter(Closeable):
 
     def __del__(self) -> None:
         self.close()
+
+
+@runtime_checkable
+class GroupedItemCounter(Protocol):
+    """A counter of items within groups. Satisfied by FileBackedCounter (disk) and
+    InMemoryGroupedCounter (memory), so consumers can swap backends.
+
+    most_common_by_group yields groups in group_key order; items within a group are
+    ordered by count descending then first-insertion order.
+    """
+
+    def increment(self, group_key: str, item_key: str, count: int = 1) -> None: ...
+
+    def most_common_by_group(self) -> Iterator[Tuple[str, List[Tuple[str, int]]]]: ...
+
+    def close(self) -> None: ...
+
+
+class InMemoryGroupedCounter:
+    """In-memory GroupedItemCounter. collections.Counter.most_common() orders by count
+    descending with insertion-order ties, matching FileBackedCounter's
+    `cnt DESC, rowid ASC`, so the two backends are interchangeable."""
+
+    def __init__(self) -> None:
+        self._groups: Dict[str, "Counter[str]"] = {}
+
+    def increment(self, group_key: str, item_key: str, count: int = 1) -> None:
+        # `+= count` with count=0 still materializes the item (existence sentinel).
+        self._groups.setdefault(group_key, collections.Counter())[item_key] += count
+
+    def most_common_by_group(self) -> Iterator[Tuple[str, List[Tuple[str, int]]]]:
+        for group_key in sorted(self._groups):
+            yield group_key, self._groups[group_key].most_common()
+
+    def close(self) -> None:
+        pass

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -686,3 +686,6 @@ class FileBackedCounter(Closeable):
         if self._owns_connection:
             self._conn.close()
         self._closed = True
+
+    def __del__(self) -> None:
+        self.close()

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -1,5 +1,6 @@
 import collections
 import gzip
+import itertools
 import logging
 import pathlib
 import pickle
@@ -677,27 +678,26 @@ class FileBackedCounter(Closeable):
                         (cnt, group, item),
                     )
 
-    def most_common_by_group(self) -> Iterator[Tuple[str, List[Tuple[str, int]]]]:
-        """Yield (group_key, items) for each group in group_key order, where items are
-        (item_key, count) ordered by count DESC then rowid ASC. The ON CONFLICT upsert
-        preserves a row's rowid on update, so rowid reflects first-insertion order,
-        making the tie-break deterministic (mirrors collections.Counter.most_common)."""
+    def most_common_by_group(
+        self,
+    ) -> Iterator[Tuple[str, Iterator[Tuple[str, int]]]]:
+        """Yield (group_key, items) for each group in group_key order, where items is a
+        lazy iterator of (item_key, count) ordered by count DESC then rowid ASC. The
+        ON CONFLICT upsert preserves a row's rowid on update, so rowid reflects
+        first-insertion order, making the tie-break deterministic (mirrors
+        collections.Counter.most_common).
+
+        Items are streamed, not materialized, so a single huge group does not have to fit
+        in memory. Each group's iterator is only valid until the next group is requested
+        (itertools.groupby semantics): consume a group fully before advancing.
+        """
         self._flush()
         cursor = self._conn.execute(
             f"SELECT group_key, item_key, cnt FROM {self._tablename} "
             "ORDER BY group_key, cnt DESC, rowid ASC"
         )
-        cur_group: Optional[str] = None
-        items: List[Tuple[str, int]] = []
-        for group_key, item_key, cnt in cursor:
-            if group_key != cur_group:
-                if cur_group is not None:
-                    yield cur_group, items
-                cur_group = group_key
-                items = []
-            items.append((item_key, cnt))
-        if cur_group is not None:
-            yield cur_group, items
+        for group_key, rows in itertools.groupby(cursor, key=lambda row: row[0]):
+            yield group_key, ((item_key, cnt) for _, item_key, cnt in rows)
 
     def close(self) -> None:
         if self._closed:
@@ -722,7 +722,9 @@ class GroupedItemCounter(Protocol):
 
     def increment(self, group_key: str, item_key: str, count: int = 1) -> None: ...
 
-    def most_common_by_group(self) -> Iterator[Tuple[str, List[Tuple[str, int]]]]: ...
+    def most_common_by_group(
+        self,
+    ) -> Iterator[Tuple[str, Iterator[Tuple[str, int]]]]: ...
 
     def close(self) -> None: ...
 
@@ -739,9 +741,11 @@ class InMemoryGroupedCounter:
         # `+= count` with count=0 still materializes the item (existence sentinel).
         self._groups.setdefault(group_key, collections.Counter())[item_key] += count
 
-    def most_common_by_group(self) -> Iterator[Tuple[str, List[Tuple[str, int]]]]:
+    def most_common_by_group(
+        self,
+    ) -> Iterator[Tuple[str, Iterator[Tuple[str, int]]]]:
         for group_key in sorted(self._groups):
-            yield group_key, self._groups[group_key].most_common()
+            yield group_key, iter(self._groups[group_key].most_common())
 
     def close(self) -> None:
         pass

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -1,6 +1,5 @@
 import collections
 import gzip
-import itertools
 import logging
 import pathlib
 import pickle
@@ -678,26 +677,27 @@ class FileBackedCounter(Closeable):
                         (cnt, group, item),
                     )
 
-    def most_common_by_group(
-        self,
-    ) -> Iterator[Tuple[str, Iterator[Tuple[str, int]]]]:
-        """Yield (group_key, items) for each group in group_key order, where items is a
-        lazy iterator of (item_key, count) ordered by count DESC then rowid ASC. The
-        ON CONFLICT upsert preserves a row's rowid on update, so rowid reflects
-        first-insertion order, making the tie-break deterministic (mirrors
-        collections.Counter.most_common).
-
-        Items are streamed, not materialized, so a single huge group does not have to fit
-        in memory. Each group's iterator is only valid until the next group is requested
-        (itertools.groupby semantics): consume a group fully before advancing.
-        """
+    def most_common_by_group(self) -> Iterator[Tuple[str, List[Tuple[str, int]]]]:
+        """Yield (group_key, items) for each group in group_key order, where items are
+        (item_key, count) ordered by count DESC then rowid ASC. The ON CONFLICT upsert
+        preserves a row's rowid on update, so rowid reflects first-insertion order,
+        making the tie-break deterministic (mirrors collections.Counter.most_common)."""
         self._flush()
         cursor = self._conn.execute(
             f"SELECT group_key, item_key, cnt FROM {self._tablename} "
             "ORDER BY group_key, cnt DESC, rowid ASC"
         )
-        for group_key, rows in itertools.groupby(cursor, key=lambda row: row[0]):
-            yield group_key, ((item_key, cnt) for _, item_key, cnt in rows)
+        cur_group: Optional[str] = None
+        items: List[Tuple[str, int]] = []
+        for group_key, item_key, cnt in cursor:
+            if group_key != cur_group:
+                if cur_group is not None:
+                    yield cur_group, items
+                cur_group = group_key
+                items = []
+            items.append((item_key, cnt))
+        if cur_group is not None:
+            yield cur_group, items
 
     def close(self) -> None:
         if self._closed:
@@ -722,9 +722,7 @@ class GroupedItemCounter(Protocol):
 
     def increment(self, group_key: str, item_key: str, count: int = 1) -> None: ...
 
-    def most_common_by_group(
-        self,
-    ) -> Iterator[Tuple[str, Iterator[Tuple[str, int]]]]: ...
+    def most_common_by_group(self) -> Iterator[Tuple[str, List[Tuple[str, int]]]]: ...
 
     def close(self) -> None: ...
 
@@ -741,11 +739,9 @@ class InMemoryGroupedCounter:
         # `+= count` with count=0 still materializes the item (existence sentinel).
         self._groups.setdefault(group_key, collections.Counter())[item_key] += count
 
-    def most_common_by_group(
-        self,
-    ) -> Iterator[Tuple[str, Iterator[Tuple[str, int]]]]:
+    def most_common_by_group(self) -> Iterator[Tuple[str, List[Tuple[str, int]]]]:
         for group_key in sorted(self._groups):
-            yield group_key, iter(self._groups[group_key].most_common())
+            yield group_key, self._groups[group_key].most_common()
 
     def close(self) -> None:
         pass

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sql_aggregator.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sql_aggregator.py
@@ -1651,3 +1651,21 @@ def test_lineage_consistency_multiple_missing_tables() -> None:
     # Verify metrics: 3 tables were added (2, 3, 4)
     assert aggregator.report.num_tables_added_from_column_lineage == 3
     assert aggregator.report.num_queries_with_lineage_inconsistencies_fixed == 1
+
+
+def test_usage_aggregator_uses_shared_connection() -> None:
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=False,
+        generate_usage_statistics=True,
+        generate_operations=False,
+        usage_config=BaseUsageConfig(),
+        query_log=QueryLogSetting.STORE_ALL,
+    )
+    try:
+        assert aggregator._usage_aggregator is not None
+        assert aggregator._shared_connection is not None
+        # Usage store reuses the shared connection, not a second DB.
+        assert aggregator._usage_aggregator._conn is aggregator._shared_connection
+    finally:
+        aggregator.close()

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sql_aggregator.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sql_aggregator.py
@@ -1666,6 +1666,12 @@ def test_usage_aggregator_uses_shared_connection() -> None:
         assert aggregator._usage_aggregator is not None
         assert aggregator._shared_connection is not None
         # Usage store reuses the shared connection, not a second DB.
-        assert aggregator._usage_aggregator._conn is aggregator._shared_connection
+        assert (
+            aggregator._usage_aggregator._counts._conn is aggregator._shared_connection
+        )
+        assert (
+            aggregator._usage_aggregator._resources._conn
+            is aggregator._shared_connection
+        )
     finally:
         aggregator.close()

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sql_aggregator.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sql_aggregator.py
@@ -28,6 +28,7 @@ from datahub.sql_parsing.sqlglot_lineage import (
     DownstreamColumnRef,
 )
 from datahub.testing import mce_helpers
+from datahub.utilities.file_backed_collections import FileBackedCounter
 from tests.test_helpers.click_helpers import run_datahub_cmd
 
 RESOURCE_DIR = pathlib.Path(__file__).parent / "aggregator_goldens"
@@ -1665,10 +1666,11 @@ def test_usage_aggregator_uses_shared_connection() -> None:
     try:
         assert aggregator._usage_aggregator is not None
         assert aggregator._shared_connection is not None
-        # Usage store reuses the shared connection, not a second DB.
-        assert (
-            aggregator._usage_aggregator._counts._conn is aggregator._shared_connection
-        )
+        # Usage store reuses the shared connection, not a second DB. The default
+        # counter backend is a FileBackedCounter; narrow the protocol type to reach _conn.
+        counts = aggregator._usage_aggregator._counts
+        assert isinstance(counts, FileBackedCounter)
+        assert counts._conn is aggregator._shared_connection
         assert (
             aggregator._usage_aggregator._resources._conn
             is aggregator._shared_connection

--- a/metadata-ingestion/tests/unit/test_usage_common.py
+++ b/metadata-ingestion/tests/unit/test_usage_common.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime
 
 import pytest
@@ -19,11 +21,30 @@ from datahub.metadata.schema_classes import (
     DatasetUsageStatisticsClass,
 )
 from datahub.testing.doctest import assert_doctest
+from datahub.utilities.file_backed_collections import ConnectionWrapper
 
 _TestTableRef = str
 
 _TestAggregatedDataset = GenericAggregatedDataset[_TestTableRef]
 USAGE_ASPECT_NAME = DatasetUsageStatisticsClass.get_aspect_name()
+
+
+@dataclass(frozen=True)
+class _MergeRes:
+    table: str
+    version: int  # in __eq__ but omitted from __str__
+
+    def __str__(self) -> str:
+        return self.table
+
+
+@dataclass(frozen=True)
+class _RoundtripRes:
+    db: str
+    table: str
+
+    def __str__(self) -> str:
+        return f"{self.db}.{self.table}"
 
 
 def _simple_urn_builder(resource):
@@ -305,25 +326,211 @@ def test_extract_user_email():
 
 
 def test_usage_aggregator_passes_user_email_pattern():
-    test_email = "test_email@test.com"
-    test_query = "select * from test"
-    event_time = datetime(2020, 1, 1)
-    resource = "test_db.test_schema.test_table"
-    user_email_pattern = AllowDenyPattern(deny=["test_email@test.com"])
-
-    config = BaseUsageConfig(user_email_pattern=user_email_pattern)
-    aggregator: UsageAggregator[str] = UsageAggregator(config)
-
-    aggregator.aggregate_event(
-        resource=resource,
-        start_time=event_time,
-        query=test_query,
-        user=test_email,
+    config = BaseUsageConfig(
+        user_email_pattern=AllowDenyPattern(deny=["test_email@test.com"])
+    )
+    agg: UsageAggregator[str] = UsageAggregator(config)
+    agg.aggregate_event(
+        resource="test_db.test_schema.test_table",
+        start_time=datetime(2020, 1, 1),
+        query="select * from test",
+        user="test_email@test.com",
         fields=[],
     )
+    wus = list(agg.generate_workunits(_urn))
+    assert len(wus) == 1
+    assert wus[0].metadata.aspect.totalSqlQueries == 0  # type: ignore[union-attr]
+    assert wus[0].metadata.aspect.userCounts == []  # type: ignore[union-attr]
+    agg.close()
 
-    floored_ts = get_time_bucket(event_time, BucketDuration.DAY)
-    aggregated_dataset = aggregator.aggregation[floored_ts][resource]
 
-    assert aggregated_dataset.queryCount == 0
-    assert aggregated_dataset.userFreq[test_email] == 0
+def _urn(resource: object) -> str:
+    return f"urn:li:dataset:(urn:li:dataPlatform:test,{resource},PROD)"
+
+
+def _normalize(wu: MetadataWorkUnit) -> tuple:
+    assert isinstance(wu.metadata, MetadataChangeProposalWrapper)
+    a = wu.metadata.aspect
+    assert isinstance(a, DatasetUsageStatisticsClass)
+    return (
+        wu.get_urn(),
+        a.timestampMillis,
+        a.totalSqlQueries,
+        a.uniqueUserCount,
+        sorted((u.user, u.count) for u in (a.userCounts or [])),
+        sorted((f.fieldPath, f.count) for f in (a.fieldCounts or [])),
+        frozenset(a.topSqlQueries or []),
+    )
+
+
+def _reference_workunits(events: list, config: BaseUsageConfig) -> list:
+    agg: dict = defaultdict(dict)
+    for resource, start_time, query, user, fields, count in events:
+        ts = get_time_bucket(start_time, config.bucket_duration)
+        agg[ts].setdefault(
+            resource,
+            GenericAggregatedDataset(bucket_start_time=ts, resource=resource),
+        ).add_read_entry(
+            user,
+            query,
+            fields,
+            user_email_pattern=config.user_email_pattern,
+            count=count,
+        )
+    out = []
+    for bucket in agg.values():
+        for a in bucket.values():
+            out.append(
+                a.make_usage_workunit(
+                    bucket_duration=config.bucket_duration,
+                    resource_urn_builder=_urn,
+                    top_n_queries=config.top_n_queries,
+                    format_sql_queries=config.format_sql_queries,
+                    include_top_n_queries=config.include_top_n_queries,
+                    queries_character_limit=config.queries_character_limit,
+                )
+            )
+    return out
+
+
+def _feed(agg: UsageAggregator, events: list) -> None:
+    for resource, start_time, query, user, fields, count in events:
+        agg.aggregate_event(
+            resource=resource,
+            start_time=start_time,
+            query=query,
+            user=user,
+            fields=fields,
+            count=count,
+        )
+
+
+def _varied_events() -> list:
+    day1 = datetime(2020, 1, 1)
+    day2 = datetime(2020, 1, 2)
+    return [
+        ("db.t1", day1, "select * from t1", "a@x.com", [], 1),
+        ("db.t1", day1, "select * from t1", "a@x.com", [], 2),
+        ("db.t1", day1, "select count(*) from t1", "b@x.com", ["c1", "c2"], 1),
+        ("db.t2", day1, "select * from t2", "b@x.com", ["c1"], 1),
+        ("db.t1", day2, "select * from t1", "a@x.com", [], 1),
+        ("db.t3", day1, None, None, [], 1),
+    ]
+
+
+def test_usage_aggregator_parity_with_reference():
+    config = BaseUsageConfig()
+    events = _varied_events()
+    agg: UsageAggregator[str] = UsageAggregator(config)
+    _feed(agg, events)
+    actual = sorted(_normalize(wu) for wu in agg.generate_workunits(_urn))
+    agg.close()
+    expected = sorted(_normalize(wu) for wu in _reference_workunits(events, config))
+    assert actual == expected
+
+
+def test_usage_aggregator_parity_with_denied_user():
+    config = BaseUsageConfig(user_email_pattern=AllowDenyPattern(deny=["denied@x.com"]))
+    day1 = datetime(2020, 1, 1)
+    events: list = [
+        ("db.t1", day1, "select 1", "denied@x.com", [], 1),
+        ("db.t1", day1, "select 1", "ok@x.com", [], 1),
+    ]
+    agg: UsageAggregator[str] = UsageAggregator(config)
+    _feed(agg, events)
+    actual = sorted(_normalize(wu) for wu in agg.generate_workunits(_urn))
+    agg.close()
+    expected = sorted(_normalize(wu) for wu in _reference_workunits(events, config))
+    assert actual == expected
+
+
+def test_usage_aggregator_top_n_tie_break_matches_reference():
+    # Tied query counts at the top-N cutoff: the SQL path must break ties the same way
+    # as Counter.most_common (insertion order) so output is deterministic and matches.
+    config = BaseUsageConfig(top_n_queries=2)
+    day1 = datetime(2020, 1, 1)
+    # Three distinct queries, each seen once (all tied at count 1); top_n=2.
+    events: list = [
+        ("db.t", day1, "q_first", "a@x.com", [], 1),
+        ("db.t", day1, "q_second", "a@x.com", [], 1),
+        ("db.t", day1, "q_third", "a@x.com", [], 1),
+    ]
+    agg: UsageAggregator[str] = UsageAggregator(config)
+    _feed(agg, events)
+    actual = list(agg.generate_workunits(_urn))
+    agg.close()
+    expected = _reference_workunits(events, config)
+    assert len(actual) == 1 and len(expected) == 1
+    assert (
+        actual[0].metadata.aspect.topSqlQueries  # type: ignore[union-attr]
+        == expected[0].metadata.aspect.topSqlQueries  # type: ignore[union-attr]
+    )
+
+
+def test_usage_aggregator_merges_resources_with_equal_str():
+    config = BaseUsageConfig()
+    agg: UsageAggregator[_MergeRes] = UsageAggregator(config)
+    day1 = datetime(2020, 1, 1)
+    for res in (_MergeRes("db.t", 1), _MergeRes("db.t", 2)):
+        agg.aggregate_event(
+            resource=res, start_time=day1, query="select 1", user="a@x.com", fields=[]
+        )
+    wus = list(agg.generate_workunits(resource_urn_builder=lambda r: _urn(r)))
+    assert len(wus) == 1
+    assert wus[0].metadata.aspect.totalSqlQueries == 2  # type: ignore[union-attr]
+    agg.close()
+
+
+def test_usage_aggregator_non_str_resource_roundtrip():
+    config = BaseUsageConfig()
+    agg: UsageAggregator[_RoundtripRes] = UsageAggregator(config)
+    day1 = datetime(2020, 1, 1)
+    agg.aggregate_event(
+        resource=_RoundtripRes("db", "t1"),
+        start_time=day1,
+        query="select 1",
+        user="a@x.com",
+        fields=[],
+    )
+    wus = list(
+        agg.generate_workunits(
+            resource_urn_builder=lambda r: f"urn:li:dataset:(urn:li:dataPlatform:test,{r.db}.{r.table},PROD)"
+        )
+    )
+    assert len(wus) == 1
+    assert "db.t1" in wus[0].get_urn()
+    agg.close()
+
+
+def test_usage_aggregator_close_is_idempotent():
+    agg: UsageAggregator[str] = UsageAggregator(BaseUsageConfig())
+    agg.aggregate_event(
+        resource="db.t",
+        start_time=datetime(2020, 1, 1),
+        query="select 1",
+        user="a@x.com",
+        fields=[],
+    )
+    agg.close()
+    agg.close()
+
+
+def test_usage_aggregator_shared_connection_not_closed_on_close():
+    conn = ConnectionWrapper()
+    try:
+        agg: UsageAggregator[str] = UsageAggregator(
+            BaseUsageConfig(), shared_connection=conn
+        )
+        agg.aggregate_event(
+            resource="db.t",
+            start_time=datetime(2020, 1, 1),
+            query="select 1",
+            user="a@x.com",
+            fields=[],
+        )
+        wus = list(agg.generate_workunits(_urn))
+        assert len(wus) == 1
+        agg.close()
+        conn.execute("SELECT 1").fetchone()
+    finally:
+        conn.close()

--- a/metadata-ingestion/tests/unit/test_usage_common.py
+++ b/metadata-ingestion/tests/unit/test_usage_common.py
@@ -429,6 +429,21 @@ def test_usage_aggregator_parity_with_reference():
     assert actual == expected
 
 
+@pytest.mark.parametrize("batch_size", [1, 3, 50000])
+def test_usage_aggregator_parity_across_flush_sizes(batch_size: int) -> None:
+    # A small batch_size forces many flushes, exercising cross-flush count
+    # accumulation (ON CONFLICT upsert) and the rowid tie-break — the core of the
+    # incremental-counting design — which a single-flush run would not cover.
+    config = BaseUsageConfig()
+    events = _varied_events()
+    agg: UsageAggregator[str] = UsageAggregator(config, batch_size=batch_size)
+    _feed(agg, events)
+    actual = sorted(_normalize(wu) for wu in agg.generate_workunits(_urn))
+    agg.close()
+    expected = sorted(_normalize(wu) for wu in _reference_workunits(events, config))
+    assert actual == expected
+
+
 def test_usage_aggregator_parity_with_denied_user():
     config = BaseUsageConfig(user_email_pattern=AllowDenyPattern(deny=["denied@x.com"]))
     day1 = datetime(2020, 1, 1)

--- a/metadata-ingestion/tests/unit/test_usage_common.py
+++ b/metadata-ingestion/tests/unit/test_usage_common.py
@@ -515,6 +515,31 @@ def test_usage_aggregator_top_n_tie_break_matches_reference():
     )
 
 
+def test_usage_aggregator_caps_top_queries_but_sums_all():
+    # topSqlQueries is capped at top_n_queries (streamed cap), but totalSqlQueries still
+    # reflects ALL query counts.
+    config = BaseUsageConfig(top_n_queries=2)
+    day1 = datetime(2020, 1, 1)
+    agg: UsageAggregator[str] = UsageAggregator(config)
+    for i, n in enumerate([5, 4, 3, 2, 1]):  # 5 distinct queries, distinct counts
+        for _ in range(n):
+            agg.aggregate_event(
+                resource="db.t",
+                start_time=day1,
+                query=f"q{i}",
+                user="u@x.com",
+                fields=[],
+            )
+    wus = list(agg.generate_workunits(_urn))
+    agg.close()
+    assert len(wus) == 1
+    assert isinstance(wus[0].metadata, MetadataChangeProposalWrapper)
+    aspect = wus[0].metadata.aspect
+    assert isinstance(aspect, DatasetUsageStatisticsClass)
+    assert aspect.totalSqlQueries == 15  # 5+4+3+2+1 — all queries summed
+    assert aspect.topSqlQueries == ["q0", "q1"]  # only the top 2 retained
+
+
 def test_usage_aggregator_merges_resources_with_equal_str():
     config = BaseUsageConfig()
     agg: UsageAggregator[_MergeRes] = UsageAggregator(config)

--- a/metadata-ingestion/tests/unit/test_usage_common.py
+++ b/metadata-ingestion/tests/unit/test_usage_common.py
@@ -16,6 +16,8 @@ from datahub.ingestion.source.usage.usage_common import (
     BaseUsageConfig,
     GenericAggregatedDataset,
     UsageAggregator,
+    _Dim,
+    _UsageKeys,
 )
 from datahub.metadata.schema_classes import (
     DatasetUsageStatisticsClass,
@@ -322,6 +324,21 @@ def test_make_usage_workunit_include_top_n_queries():
     du: DatasetUsageStatisticsClass = wu.metadata.aspect
     assert du.totalSqlQueries == 1
     assert du.topSqlQueries is None
+
+
+def test_usage_keys_group_roundtrip():
+    # resource_key containing ":" must round-trip (partition splits on the first ":").
+    gk = _UsageKeys.group(1700000000000, "urn:li:dataset:(x,y,PROD)")
+    assert _UsageKeys.split_group(gk) == (1700000000000, "urn:li:dataset:(x,y,PROD)")
+
+
+def test_usage_keys_item_roundtrip():
+    # value containing ":" must round-trip; dim prefix is ":"-free.
+    ik = _UsageKeys.item(_Dim.QUERY, "SELECT a::int FROM t WHERE x = 'a:b'")
+    assert _UsageKeys.split_item(ik) == (
+        _Dim.QUERY,
+        "SELECT a::int FROM t WHERE x = 'a:b'",
+    )
 
 
 def test_extract_user_email():

--- a/metadata-ingestion/tests/unit/test_usage_common.py
+++ b/metadata-ingestion/tests/unit/test_usage_common.py
@@ -21,7 +21,10 @@ from datahub.metadata.schema_classes import (
     DatasetUsageStatisticsClass,
 )
 from datahub.testing.doctest import assert_doctest
-from datahub.utilities.file_backed_collections import ConnectionWrapper
+from datahub.utilities.file_backed_collections import (
+    ConnectionWrapper,
+    InMemoryGroupedCounter,
+)
 
 _TestTableRef = str
 
@@ -422,6 +425,19 @@ def test_usage_aggregator_parity_with_reference():
     config = BaseUsageConfig()
     events = _varied_events()
     agg: UsageAggregator[str] = UsageAggregator(config)
+    _feed(agg, events)
+    actual = sorted(_normalize(wu) for wu in agg.generate_workunits(_urn))
+    agg.close()
+    expected = sorted(_normalize(wu) for wu in _reference_workunits(events, config))
+    assert actual == expected
+
+
+@pytest.mark.parametrize("use_in_memory", [False, True])
+def test_usage_aggregator_parity_across_backends(use_in_memory):
+    config = BaseUsageConfig()
+    events = _varied_events()
+    counter = InMemoryGroupedCounter() if use_in_memory else None
+    agg: UsageAggregator[str] = UsageAggregator(config, counter=counter)
     _feed(agg, events)
     actual = sorted(_normalize(wu) for wu in agg.generate_workunits(_urn))
     agg.close()

--- a/metadata-ingestion/tests/unit/test_usage_common.py
+++ b/metadata-ingestion/tests/unit/test_usage_common.py
@@ -549,3 +549,32 @@ def test_usage_aggregator_shared_connection_not_closed_on_close():
         conn.execute("SELECT 1").fetchone()
     finally:
         conn.close()
+
+
+def test_usage_aggregator_parity_with_colons_in_keys():
+    config = BaseUsageConfig()
+    day1 = datetime(2020, 1, 1)
+    events = [
+        (
+            "db:weird.tbl",
+            day1,
+            "SELECT a::int FROM t WHERE x = 'a:b'",
+            "u:1@x.com",
+            ["col:1"],
+            1,
+        ),
+        (
+            "db:weird.tbl",
+            day1,
+            "SELECT a::int FROM t WHERE x = 'a:b'",
+            "u:1@x.com",
+            ["col:1"],
+            1,
+        ),
+    ]
+    agg: UsageAggregator[str] = UsageAggregator(config)
+    _feed(agg, events)
+    actual = sorted(_normalize(wu) for wu in agg.generate_workunits(_urn))
+    agg.close()
+    expected = sorted(_normalize(wu) for wu in _reference_workunits(events, config))
+    assert actual == expected

--- a/metadata-ingestion/tests/unit/test_usage_common.py
+++ b/metadata-ingestion/tests/unit/test_usage_common.py
@@ -515,31 +515,6 @@ def test_usage_aggregator_top_n_tie_break_matches_reference():
     )
 
 
-def test_usage_aggregator_caps_top_queries_but_sums_all():
-    # topSqlQueries is capped at top_n_queries (streamed cap), but totalSqlQueries still
-    # reflects ALL query counts.
-    config = BaseUsageConfig(top_n_queries=2)
-    day1 = datetime(2020, 1, 1)
-    agg: UsageAggregator[str] = UsageAggregator(config)
-    for i, n in enumerate([5, 4, 3, 2, 1]):  # 5 distinct queries, distinct counts
-        for _ in range(n):
-            agg.aggregate_event(
-                resource="db.t",
-                start_time=day1,
-                query=f"q{i}",
-                user="u@x.com",
-                fields=[],
-            )
-    wus = list(agg.generate_workunits(_urn))
-    agg.close()
-    assert len(wus) == 1
-    assert isinstance(wus[0].metadata, MetadataChangeProposalWrapper)
-    aspect = wus[0].metadata.aspect
-    assert isinstance(aspect, DatasetUsageStatisticsClass)
-    assert aspect.totalSqlQueries == 15  # 5+4+3+2+1 — all queries summed
-    assert aspect.topSqlQueries == ["q0", "q1"]  # only the top 2 retained
-
-
 def test_usage_aggregator_merges_resources_with_equal_str():
     config = BaseUsageConfig()
     agg: UsageAggregator[_MergeRes] = UsageAggregator(config)

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
@@ -1,3 +1,4 @@
+import threading
 from typing import Iterator
 
 import pytest
@@ -38,6 +39,30 @@ def test_counter_close_is_idempotent():
     c.increment("g", "a", 1)
     c.close()
     c.close()
+
+
+def test_counter_increment_is_thread_safe():
+    # Concurrent increments must not lose counts or hit "dict changed size during
+    # iteration" in _flush. A tiny batch_size forces flushes to interleave with the
+    # increments running on other threads.
+    c = FileBackedCounter(batch_size=5)
+    items = [chr(ord("a") + i) for i in range(10)]
+    n_threads, per_thread = 8, 500
+
+    def work() -> None:
+        for _ in range(per_thread):
+            for item in items:
+                c.increment("g", item, 1)
+
+    threads = [threading.Thread(target=work) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    counts = dict(dict(c.most_common_by_group())["g"])
+    c.close()
+    assert all(counts[item] == n_threads * per_thread for item in items), counts
 
 
 def test_counter_flushes_on_del():

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
@@ -101,13 +101,3 @@ def test_grouped_counter_increment_defaults_to_one(counter):
     counter.increment("g", "a")
     counter.increment("g", "a")
     assert dict(counter.most_common_by_group())["g"] == [("a", 2)]
-
-
-def test_file_backed_counter_satisfies_protocol():
-    c = FileBackedCounter()
-    assert isinstance(c, GroupedItemCounter)
-    c.close()
-
-
-def test_in_memory_counter_satisfies_protocol():
-    assert isinstance(InMemoryGroupedCounter(), GroupedItemCounter)

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
@@ -41,6 +41,26 @@ def test_counter_close_is_idempotent():
     c.close()
 
 
+def test_counter_flushed_when_shared_connection_closes(tmp_path):
+    # Closing a shared connection must flush a registered counter's buffered increments
+    # before the connection is torn down, even if the counter wasn't close()d directly.
+    db = tmp_path / "shared.db"
+    conn = ConnectionWrapper(filename=db)
+    counter = FileBackedCounter(shared_connection=conn, tablename="counts")
+    counter.increment("g", "a", 3)
+    # Deliberately do NOT call counter.close(); closing the connection should flush it.
+    conn.close()
+
+    reopened = ConnectionWrapper(filename=db)
+    try:
+        rows = reopened.execute(
+            "SELECT group_key, item_key, cnt FROM counts"
+        ).fetchall()
+        assert [tuple(r) for r in rows] == [("g", "a", 3)]
+    finally:
+        reopened.close()
+
+
 def test_counter_rejects_unsafe_tablename():
     # tablename is interpolated into SQL (SQLite can't bind identifiers), so it must be
     # a safe identifier, not attacker-controlled text.
@@ -70,20 +90,6 @@ def test_counter_increment_is_thread_safe():
     counts = dict(dict(c.most_common_by_group())["g"])
     c.close()
     assert all(counts[item] == n_threads * per_thread for item in items), counts
-
-
-def test_counter_flushes_on_del():
-    conn = ConnectionWrapper()
-    try:
-        c = FileBackedCounter(shared_connection=conn, tablename="del_counter")
-        c.increment("g", "a", 2)
-        del c  # __del__ -> close() -> flush; shared conn stays open
-        rows = conn.execute(
-            "SELECT group_key, item_key, cnt FROM del_counter"
-        ).fetchall()
-        assert [tuple(r) for r in rows] == [("g", "a", 2)]
-    finally:
-        conn.close()
 
 
 @pytest.fixture(params=["file", "memory"])

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
@@ -1,19 +1,13 @@
+from typing import Iterator
+
+import pytest
+
 from datahub.utilities.file_backed_collections import (
     ConnectionWrapper,
     FileBackedCounter,
+    GroupedItemCounter,
+    InMemoryGroupedCounter,
 )
-
-
-def test_counter_most_common_by_group():
-    c = FileBackedCounter()
-    c.increment("g1", "a", 3)
-    c.increment("g1", "b", 1)
-    c.increment("g1", "a", 2)  # a -> 5
-    c.increment("g2", "x", 1)
-    result = dict(c.most_common_by_group())
-    c.close()
-    assert result["g1"] == [("a", 5), ("b", 1)]
-    assert result["g2"] == [("x", 1)]
 
 
 def test_counter_cross_flush_accumulation():
@@ -25,27 +19,6 @@ def test_counter_cross_flush_accumulation():
     result = dict(c.most_common_by_group())
     c.close()
     assert result["g"] == [("a", 3), ("b", 1)]
-
-
-def test_counter_tie_break_is_insertion_order():
-    # Tied counts must break by insertion order (rowid ASC), deterministically,
-    # mirroring Counter.most_common — across flushes too.
-    c = FileBackedCounter(batch_size=1)
-    c.increment("g", "first", 1)
-    c.increment("g", "second", 1)
-    c.increment("g", "third", 1)
-    result = dict(c.most_common_by_group())
-    c.close()
-    assert result["g"] == [("first", 1), ("second", 1), ("third", 1)]
-
-
-def test_counter_zero_count_sentinel_creates_group():
-    # An item incremented by 0 still creates the group (used for existence tracking).
-    c = FileBackedCounter()
-    c.increment("g", "", 0)
-    result = dict(c.most_common_by_group())
-    c.close()
-    assert result == {"g": [("", 0)]}
 
 
 def test_counter_shared_connection_not_closed_on_close():
@@ -67,24 +40,6 @@ def test_counter_close_is_idempotent():
     c.close()
 
 
-def test_counter_groups_yielded_in_key_order():
-    c = FileBackedCounter()
-    c.increment("g2", "x", 1)  # inserted before g1
-    c.increment("g1", "y", 1)
-    groups = [g for g, _ in c.most_common_by_group()]
-    c.close()
-    assert groups == ["g1", "g2"]
-
-
-def test_counter_increment_defaults_to_one():
-    c = FileBackedCounter()
-    c.increment("g", "a")  # default count=1
-    c.increment("g", "a")
-    result = dict(c.most_common_by_group())
-    c.close()
-    assert result["g"] == [("a", 2)]
-
-
 def test_counter_flushes_on_del():
     conn = ConnectionWrapper()
     try:
@@ -97,3 +52,62 @@ def test_counter_flushes_on_del():
         assert [tuple(r) for r in rows] == [("g", "a", 2)]
     finally:
         conn.close()
+
+
+@pytest.fixture(params=["file", "memory"])
+def counter(request: pytest.FixtureRequest) -> Iterator[GroupedItemCounter]:
+    c: GroupedItemCounter = (
+        FileBackedCounter(batch_size=1)  # batch_size=1 also exercises the flush path
+        if request.param == "file"
+        else InMemoryGroupedCounter()
+    )
+    yield c
+    c.close()
+
+
+def test_grouped_counter_most_common_by_group(counter):
+    counter.increment("g1", "a", 3)
+    counter.increment("g1", "b", 1)
+    counter.increment("g1", "a", 2)  # a -> 5
+    counter.increment("g2", "x", 1)
+    result = dict(counter.most_common_by_group())
+    assert result["g1"] == [("a", 5), ("b", 1)]
+    assert result["g2"] == [("x", 1)]
+
+
+def test_grouped_counter_tie_break_is_insertion_order(counter):
+    counter.increment("g", "first", 1)
+    counter.increment("g", "second", 1)
+    counter.increment("g", "third", 1)
+    assert dict(counter.most_common_by_group())["g"] == [
+        ("first", 1),
+        ("second", 1),
+        ("third", 1),
+    ]
+
+
+def test_grouped_counter_zero_count_sentinel_creates_group(counter):
+    counter.increment("g", "", 0)
+    assert dict(counter.most_common_by_group()) == {"g": [("", 0)]}
+
+
+def test_grouped_counter_groups_yielded_in_key_order(counter):
+    counter.increment("g2", "x", 1)  # inserted before g1
+    counter.increment("g1", "y", 1)
+    assert [g for g, _ in counter.most_common_by_group()] == ["g1", "g2"]
+
+
+def test_grouped_counter_increment_defaults_to_one(counter):
+    counter.increment("g", "a")
+    counter.increment("g", "a")
+    assert dict(counter.most_common_by_group())["g"] == [("a", 2)]
+
+
+def test_file_backed_counter_satisfies_protocol():
+    c = FileBackedCounter()
+    assert isinstance(c, GroupedItemCounter)
+    c.close()
+
+
+def test_in_memory_counter_satisfies_protocol():
+    assert isinstance(InMemoryGroupedCounter(), GroupedItemCounter)

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
@@ -11,19 +11,13 @@ from datahub.utilities.file_backed_collections import (
 )
 
 
-def _grouped(counter: GroupedItemCounter) -> dict:
-    # most_common_by_group yields lazy per-group iterators that are only valid until the
-    # next group is requested, so materialize each group's items during iteration.
-    return {group: list(items) for group, items in counter.most_common_by_group()}
-
-
 def test_counter_cross_flush_accumulation():
     # batch_size=1 forces a flush per increment, exercising the cross-flush upsert.
     c = FileBackedCounter(batch_size=1)
     for _ in range(3):
         c.increment("g", "a", 1)
     c.increment("g", "b", 1)
-    result = _grouped(c)
+    result = dict(c.most_common_by_group())
     c.close()
     assert result["g"] == [("a", 3), ("b", 1)]
 
@@ -33,7 +27,7 @@ def test_counter_shared_connection_not_closed_on_close():
     try:
         c = FileBackedCounter(shared_connection=conn)
         c.increment("g", "a", 1)
-        assert _grouped(c)["g"] == [("a", 1)]
+        assert dict(c.most_common_by_group())["g"] == [("a", 1)]
         c.close()
         conn.execute("SELECT 1").fetchone()  # still usable
     finally:
@@ -93,7 +87,7 @@ def test_counter_increment_is_thread_safe():
     for t in threads:
         t.join()
 
-    counts = dict(_grouped(c)["g"])
+    counts = dict(dict(c.most_common_by_group())["g"])
     c.close()
     assert all(counts[item] == n_threads * per_thread for item in items), counts
 
@@ -114,7 +108,7 @@ def test_grouped_counter_most_common_by_group(counter):
     counter.increment("g1", "b", 1)
     counter.increment("g1", "a", 2)  # a -> 5
     counter.increment("g2", "x", 1)
-    result = _grouped(counter)
+    result = dict(counter.most_common_by_group())
     assert result["g1"] == [("a", 5), ("b", 1)]
     assert result["g2"] == [("x", 1)]
 
@@ -123,7 +117,7 @@ def test_grouped_counter_tie_break_is_insertion_order(counter):
     counter.increment("g", "first", 1)
     counter.increment("g", "second", 1)
     counter.increment("g", "third", 1)
-    assert _grouped(counter)["g"] == [
+    assert dict(counter.most_common_by_group())["g"] == [
         ("first", 1),
         ("second", 1),
         ("third", 1),
@@ -132,7 +126,7 @@ def test_grouped_counter_tie_break_is_insertion_order(counter):
 
 def test_grouped_counter_zero_count_sentinel_creates_group(counter):
     counter.increment("g", "", 0)
-    assert _grouped(counter) == {"g": [("", 0)]}
+    assert dict(counter.most_common_by_group()) == {"g": [("", 0)]}
 
 
 def test_grouped_counter_groups_yielded_in_key_order(counter):
@@ -144,4 +138,4 @@ def test_grouped_counter_groups_yielded_in_key_order(counter):
 def test_grouped_counter_increment_defaults_to_one(counter):
     counter.increment("g", "a")
     counter.increment("g", "a")
-    assert _grouped(counter)["g"] == [("a", 2)]
+    assert dict(counter.most_common_by_group())["g"] == [("a", 2)]

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
@@ -41,6 +41,13 @@ def test_counter_close_is_idempotent():
     c.close()
 
 
+def test_counter_rejects_unsafe_tablename():
+    # tablename is interpolated into SQL (SQLite can't bind identifiers), so it must be
+    # a safe identifier, not attacker-controlled text.
+    with pytest.raises(ValueError):
+        FileBackedCounter(tablename="counts; DROP TABLE x --")
+
+
 def test_counter_increment_is_thread_safe():
     # Concurrent increments must not lose counts or hit "dict changed size during
     # iteration" in _flush. A tiny batch_size forces flushes to interleave with the

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
@@ -83,3 +83,17 @@ def test_counter_increment_defaults_to_one():
     result = dict(c.most_common_by_group())
     c.close()
     assert result["g"] == [("a", 2)]
+
+
+def test_counter_flushes_on_del():
+    conn = ConnectionWrapper()
+    try:
+        c = FileBackedCounter(shared_connection=conn, tablename="del_counter")
+        c.increment("g", "a", 2)
+        del c  # __del__ -> close() -> flush; shared conn stays open
+        rows = conn.execute(
+            "SELECT group_key, item_key, cnt FROM del_counter"
+        ).fetchall()
+        assert [tuple(r) for r in rows] == [("g", "a", 2)]
+    finally:
+        conn.close()

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
@@ -1,0 +1,85 @@
+from datahub.utilities.file_backed_collections import (
+    ConnectionWrapper,
+    FileBackedCounter,
+)
+
+
+def test_counter_most_common_by_group():
+    c = FileBackedCounter()
+    c.increment("g1", "a", 3)
+    c.increment("g1", "b", 1)
+    c.increment("g1", "a", 2)  # a -> 5
+    c.increment("g2", "x", 1)
+    result = dict(c.most_common_by_group())
+    c.close()
+    assert result["g1"] == [("a", 5), ("b", 1)]
+    assert result["g2"] == [("x", 1)]
+
+
+def test_counter_cross_flush_accumulation():
+    # batch_size=1 forces a flush per increment, exercising the cross-flush upsert.
+    c = FileBackedCounter(batch_size=1)
+    for _ in range(3):
+        c.increment("g", "a", 1)
+    c.increment("g", "b", 1)
+    result = dict(c.most_common_by_group())
+    c.close()
+    assert result["g"] == [("a", 3), ("b", 1)]
+
+
+def test_counter_tie_break_is_insertion_order():
+    # Tied counts must break by insertion order (rowid ASC), deterministically,
+    # mirroring Counter.most_common — across flushes too.
+    c = FileBackedCounter(batch_size=1)
+    c.increment("g", "first", 1)
+    c.increment("g", "second", 1)
+    c.increment("g", "third", 1)
+    result = dict(c.most_common_by_group())
+    c.close()
+    assert result["g"] == [("first", 1), ("second", 1), ("third", 1)]
+
+
+def test_counter_zero_count_sentinel_creates_group():
+    # An item incremented by 0 still creates the group (used for existence tracking).
+    c = FileBackedCounter()
+    c.increment("g", "", 0)
+    result = dict(c.most_common_by_group())
+    c.close()
+    assert result == {"g": [("", 0)]}
+
+
+def test_counter_shared_connection_not_closed_on_close():
+    conn = ConnectionWrapper()
+    try:
+        c = FileBackedCounter(shared_connection=conn)
+        c.increment("g", "a", 1)
+        assert dict(c.most_common_by_group())["g"] == [("a", 1)]
+        c.close()
+        conn.execute("SELECT 1").fetchone()  # still usable
+    finally:
+        conn.close()
+
+
+def test_counter_close_is_idempotent():
+    c = FileBackedCounter()
+    c.increment("g", "a", 1)
+    c.close()
+    c.close()
+
+
+def test_counter_groups_yielded_in_key_order():
+    c = FileBackedCounter()
+    c.increment("g2", "x", 1)  # inserted before g1
+    c.increment("g1", "y", 1)
+    groups = [g for g, _ in c.most_common_by_group()]
+    c.close()
+    assert groups == ["g1", "g2"]
+
+
+def test_counter_increment_defaults_to_one():
+    c = FileBackedCounter()
+    c.increment("g", "a")  # default count=1
+    c.increment("g", "a")
+    result = dict(c.most_common_by_group())
+    c.close()
+    assert result["g"] == [("a", 2)]

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_counter.py
@@ -11,13 +11,19 @@ from datahub.utilities.file_backed_collections import (
 )
 
 
+def _grouped(counter: GroupedItemCounter) -> dict:
+    # most_common_by_group yields lazy per-group iterators that are only valid until the
+    # next group is requested, so materialize each group's items during iteration.
+    return {group: list(items) for group, items in counter.most_common_by_group()}
+
+
 def test_counter_cross_flush_accumulation():
     # batch_size=1 forces a flush per increment, exercising the cross-flush upsert.
     c = FileBackedCounter(batch_size=1)
     for _ in range(3):
         c.increment("g", "a", 1)
     c.increment("g", "b", 1)
-    result = dict(c.most_common_by_group())
+    result = _grouped(c)
     c.close()
     assert result["g"] == [("a", 3), ("b", 1)]
 
@@ -27,7 +33,7 @@ def test_counter_shared_connection_not_closed_on_close():
     try:
         c = FileBackedCounter(shared_connection=conn)
         c.increment("g", "a", 1)
-        assert dict(c.most_common_by_group())["g"] == [("a", 1)]
+        assert _grouped(c)["g"] == [("a", 1)]
         c.close()
         conn.execute("SELECT 1").fetchone()  # still usable
     finally:
@@ -87,7 +93,7 @@ def test_counter_increment_is_thread_safe():
     for t in threads:
         t.join()
 
-    counts = dict(dict(c.most_common_by_group())["g"])
+    counts = dict(_grouped(c)["g"])
     c.close()
     assert all(counts[item] == n_threads * per_thread for item in items), counts
 
@@ -108,7 +114,7 @@ def test_grouped_counter_most_common_by_group(counter):
     counter.increment("g1", "b", 1)
     counter.increment("g1", "a", 2)  # a -> 5
     counter.increment("g2", "x", 1)
-    result = dict(counter.most_common_by_group())
+    result = _grouped(counter)
     assert result["g1"] == [("a", 5), ("b", 1)]
     assert result["g2"] == [("x", 1)]
 
@@ -117,7 +123,7 @@ def test_grouped_counter_tie_break_is_insertion_order(counter):
     counter.increment("g", "first", 1)
     counter.increment("g", "second", 1)
     counter.increment("g", "third", 1)
-    assert dict(counter.most_common_by_group())["g"] == [
+    assert _grouped(counter)["g"] == [
         ("first", 1),
         ("second", 1),
         ("third", 1),
@@ -126,7 +132,7 @@ def test_grouped_counter_tie_break_is_insertion_order(counter):
 
 def test_grouped_counter_zero_count_sentinel_creates_group(counter):
     counter.increment("g", "", 0)
-    assert dict(counter.most_common_by_group()) == {"g": [("", 0)]}
+    assert _grouped(counter) == {"g": [("", 0)]}
 
 
 def test_grouped_counter_groups_yielded_in_key_order(counter):
@@ -138,4 +144,4 @@ def test_grouped_counter_groups_yielded_in_key_order(counter):
 def test_grouped_counter_increment_defaults_to_one(counter):
     counter.increment("g", "a")
     counter.increment("g", "a")
-    assert dict(counter.most_common_by_group())["g"] == [("a", 2)]
+    assert _grouped(counter)["g"] == [("a", 2)]


### PR DESCRIPTION
## Summary

Backs `UsageAggregator` with **SQLite-side incremental counting** so the usage aggregation hot path is fast *and* memory stays bounded for high-cardinality workloads (ING-2749), and extracts the counting machinery into a reusable, swappable `FileBackedCounter` primitive. The public interface (`aggregate_event` / `generate_workunits` / `close`) and the emitted `DatasetUsageStatistics` workunits are **behavior-equivalent**. `GenericAggregatedDataset` and `make_usage_workunit` are unchanged (other extractors depend on them).

**Supersedes #17684** (the earlier FileBackedDict-of-whole-aggregates approach, which benchmarked as CPU-bound on per-event pickling).

### What's here
1. **`FileBackedCounter`** (`file_backed_collections.py`) — a new member of the `FileBacked*` family: a disk-backed two-level counter `(group_key, item_key) -> count` with batched increment-upserts and grouped most-common reads (deterministic `cnt DESC, rowid ASC`, insertion-order tie-break — matches `Counter.most_common`). It is **thread-safe** (a lock guards the in-memory write buffer), **validates `tablename`** as an identifier (it's interpolated into SQL — SQLite can't bind identifiers), mirrors `FileBackedDict`'s SQLite ≥3.24 `ON CONFLICT` guard/fallback, and **registers itself in the shared connection's dependents** so closing the connection flushes buffered increments.
2. **`GroupedItemCounter` protocol + `InMemoryGroupedCounter`** — the counter backend is a clean swap seam: `UsageAggregator(config, counter=...)` accepts any implementation (defaults to `FileBackedCounter`; an in-memory backend is available for tests / small workloads). The two are proven interchangeable by a dual-backend parity test.
3. **`UsageAggregator` rewired** (`usage_common.py`) — composes a `FileBackedCounter` (counts) + a `FileBackedDict` (resource objects); group existence is folded into a sentinel row so denied/empty events still emit. The `(group_key, item_key)` encoding is centralized in a single `_UsageKeys` codec, and the per-event recording rule lives in one `_add_read_entry` method. No hand-rolled SQL remains in `usage_common.py`.
4. `SqlParsingAggregator` shares its SQLite connection with the aggregator (closed via its exit stack); Unity closes its own temp DB in a guarded `finally`.

### Benchmark (10M events, 1M resources, worst case)
| Approach | Time | Peak RAM |
| --- | --- | --- |
| Old in-memory | 44 s | 1,426 MB |
| FileBackedDict-of-aggregates (#17684) | 431 s | 85 MB |
| **This PR (SQL counting)** | **166 s** | **93 MB** |

2.6× faster than #17684, flat ~90 MB vs 1.4 GB in-memory.

### Why this over the FileBackedDict approach (#17684)?

The core difference is **the storage granularity matches the operation**. Both approaches spill to disk (both fix the OOM), but they differ in what a single usage event costs:

| | FileBackedDict-of-aggregates (#17684) | This PR (SQL counting) |
| --- | --- | --- |
| Stores | `key -> GenericAggregatedDataset` (a whole object: 3 `Counter`s) | `(bucket, resource, dim, item) -> count` rows |
| Per-event cost | load + unpickle the whole aggregate → mutate one counter → re-pickle the whole object on eviction = **O(aggregate size)** | a batched `INSERT ... ON CONFLICT DO UPDATE SET cnt = cnt + 1` = **O(1) increment**, done by SQLite |

The usage workload is *"increment a count," millions of times*. `FileBackedDict` is built for *get/put a whole value*, so every increment paid the cost of (de)serializing the entire aggregate just to bump one number — which is why #17684 was CPU-bound on pickle. Concretely, this version is:

- **2.6× faster** (166 s vs 431 s) — no per-event object (de)serialization; aggregation happens in SQLite.
- **Robust to a single hot resource** — `FileBackedDict` spills at the granularity of a whole aggregate, so one resource with millions of unique queries is a single giant object that must fit in RAM to be mutated (disk can't help). SQL-counting spills at the row level, so even that case stays bounded.
- **Smaller on disk** (344 MB vs 536 MB) — compact count rows vs pickled dataclasses-with-`Counter`s.

Trade-off: it adds a new primitive (`FileBackedCounter`) and rewires the aggregator rather than reusing `FileBackedDict` as-is — but the primitive is reusable and the swap seam keeps the aggregator clean. Net across the three options: in-memory is fastest but OOMs; FileBackedDict bounds memory but is pickle-bound; SQL counting bounds memory **and** recovers most of the speed.

### Concurrency contract
`FileBackedCounter` is thread-safe. `UsageAggregator` as a whole is **single-writer per instance** (its `FileBackedDict` resource store is not thread-safe) — documented in its docstring; for parallel ingestion, use one aggregator per worker. This matches how the sources drive it today (sequential per source).

Independent of #17705 (FileBackedDict iteration/cache improvements); they touch different regions of `file_backed_collections.py`.

## Test Plan
- [x] `pytest tests/unit/utilities/test_file_backed_counter.py` — **16 passed**: dual-backend (file + in-memory) most-common/tie-break/sentinel/group-order/default-count, cross-flush accumulation, shared-connection-not-closed, **thread-safety** (8 threads), **flush-on-connection-close**, idempotent close, unsafe-tablename rejection.
- [x] `pytest tests/unit/test_usage_common.py` — **26 passed**: semantic-parity vs an in-memory `GenericAggregatedDataset` reference (denied-user, empty events, multi-bucket, equal-`str()` merge, **colons in keys**, non-str resource round-trip), multi-flush parity (`batch_size` 1/3/50000), **dual-backend parity**, top-N tie-break exact match, `_UsageKeys` codec round-trips, shared-connection.
- [x] `pytest tests/unit/sql_parsing/test_sql_aggregator.py` — **31 passed** (incl. `test_basic_usage`, a full-pipeline golden carrying a real `datasetUsageStatistics` aspect generated with the old logic → byte-identical output).
- [x] `pytest tests/unit -k unity` — **281 passed**.
- [x] `pytest tests/integration/sql_queries` — **9 passed**: full `sql_queries` ingestion (usage aspects included) byte-identical to goldens generated with the old in-memory logic.
- [x] `./gradlew :metadata-ingestion:lintFix` clean; mypy clean on changed files.

## Checklist
- [x] PR title format
- [x] Related issue — ING-2749; supersedes #17684
- [x] Tests added/updated
- [ ] Docs — n/a (internal storage change; no recipe-facing config)
- [ ] Breaking changes — none


