### PR TITLE
feat(i18n): extract keys from analytics page

### DIFF
--- a/datahub-web-react/src/app/analyticsDashboardV2/components/AnalyticsPage.tsx
+++ b/datahub-web-react/src/app/analyticsDashboardV2/components/AnalyticsPage.tsx
@@ -1,6 +1,7 @@
 import { Loader, PageTitle, SelectOption, SimpleSelect, Text } from '@components';
 import { Alert } from 'antd';
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { ChartGroup } from '@app/analyticsDashboardV2/components/ChartGroup';
@@ -79,6 +80,7 @@ const EmptyDomainText = styled(Text)`
 `;
 
 export const AnalyticsPage = () => {
+    const { t } = useTranslation('analytics');
     const isShowNavBarRedesign = useShowNavBarRedesign();
     const me = useUserContext();
     const canManageDomains = me?.platformPrivileges?.createDomains;
@@ -131,7 +133,7 @@ export const AnalyticsPage = () => {
 
     const domainOptions =
         domainData?.listDomains?.domains?.map((d) => ({ value: d.urn, label: d?.properties?.name || '' })) || [];
-    const options: SelectOption[] = [{ value: 'ALL', label: 'All Domains' }, ...domainOptions];
+    const options: SelectOption[] = [{ value: 'ALL', label: t('allDomains') }, ...domainOptions];
 
     return (
         <PageContainer $isShowNavBarRedesign={isShowNavBarRedesign}>
@@ -144,7 +146,7 @@ export const AnalyticsPage = () => {
                 <>
                     <HighlightGroup>
                         {highlightError && (
-                            <Alert type="error" message={highlightError?.message || 'Failed to load highlights'} />
+                            <Alert type="error" message={highlightError?.message || t('failedToLoadHighlights')} />
                         )}
                         {highlightData?.getHighlights?.map((highlight) => (
                             <Highlight highlight={highlight} shortenValue key={highlight.title} />
@@ -152,29 +154,29 @@ export const AnalyticsPage = () => {
                     </HighlightGroup>
 
                     {chartError && (
-                        <Alert type="error" message={metadataAnalyticsError?.message || 'Failed to load charts'} />
+                        <Alert type="error" message={metadataAnalyticsError?.message || t('failedToLoadCharts')} />
                     )}
                     {chartData?.getAnalyticsCharts
                         ?.filter((chartGroup) => chartGroup.groupId === 'GlobalMetadataAnalytics')
                         .map((chartGroup) => (
                             <ChartGroup
-                                chartGroup={{ ...chartGroup, title: 'Data Landscape Summary' }}
+                                chartGroup={{ ...chartGroup, title: t('dataLandscapeSummary') }}
                                 key={chartGroup.title}
                             />
                         ))}
 
                     <DomainSection>
-                        <PageTitle title="Domain Landscape Summary" variant="sectionHeader" />
+                        <PageTitle title={t('domainLandscapeSummary')} variant="sectionHeader" />
                         <FilterSection>
                             {domainError && (
                                 <Alert
                                     type="error"
-                                    message={metadataAnalyticsError?.message || 'Failed to load domains'}
+                                    message={metadataAnalyticsError?.message || t('failedToLoadDomains')}
                                 />
                             )}
                             <DomainSelect
                                 showSearch
-                                placeholder="Select domain"
+                                placeholder={t('selectDomain')}
                                 values={[domain]}
                                 onUpdate={onDomainChange}
                                 filterResultsByQuery
@@ -188,7 +190,7 @@ export const AnalyticsPage = () => {
                     </DomainSection>
 
                     {metadataAnalyticsError && (
-                        <Alert type="error" message={metadataAnalyticsError?.message || 'Failed to load charts'} />
+                        <Alert type="error" message={metadataAnalyticsError?.message || t('failedToLoadCharts')} />
                     )}
                     {metadataAnalyticsData?.getMetadataAnalyticsCharts?.map((chartGroup) => (
                         <ChartGroup chartGroup={{ ...chartGroup, title: '' }} key={chartGroup.groupId} />
@@ -198,16 +200,16 @@ export const AnalyticsPage = () => {
                         (!metadataAnalyticsData?.getMetadataAnalyticsCharts?.length ||
                             !metadataAnalyticsData?.getMetadataAnalyticsCharts[0]?.charts?.length) && (
                             <EmptyDomainText size="md" weight="bold" color="gray" colorLevel={600}>
-                                No analytics data for this domain
+                                {t('noDomainData')}
                             </EmptyDomainText>
                         )}
 
-                    {chartError && <Alert type="error" message={chartError?.message || 'Failed to load charts'} />}
+                    {chartError && <Alert type="error" message={chartError?.message || t('failedToLoadCharts')} />}
                     {chartData?.getAnalyticsCharts
                         ?.filter((chartGroup) => chartGroup.groupId === 'DataHubUsageAnalytics')
                         .map((chartGroup) => (
                             <React.Fragment key={chartGroup.title}>
-                                <ChartGroup chartGroup={{ ...chartGroup, title: 'Usage Analytics' }} />
+                                <ChartGroup chartGroup={{ ...chartGroup, title: t('usageAnalytics') }} />
                             </React.Fragment>
                         ))}
                 </>

--- a/datahub-web-react/src/i18n/i18n.ts
+++ b/datahub-web-react/src/i18n/i18n.ts
@@ -4,6 +4,7 @@ import resourcesToBackend from 'i18next-resources-to-backend';
 import { initReactI18next } from 'react-i18next';
 
 export const NAMESPACES = [
+    'analytics',
     'common.actions',
     'common.feedback',
     'common.labels',

--- a/datahub-web-react/src/i18n/locales/en/analytics.json
+++ b/datahub-web-react/src/i18n/locales/en/analytics.json
@@ -1,0 +1,11 @@
+{
+    "allDomains": "All Domains",
+    "dataLandscapeSummary": "Data Landscape Summary",
+    "domainLandscapeSummary": "Domain Landscape Summary",
+    "failedToLoadCharts": "Failed to load charts",
+    "failedToLoadDomains": "Failed to load domains",
+    "failedToLoadHighlights": "Failed to load highlights",
+    "noDomainData": "No analytics data for this domain",
+    "selectDomain": "Select domain",
+    "usageAnalytics": "Usage Analytics"
+}

--- a/datahub-web-react/src/setupTests.ts
+++ b/datahub-web-react/src/setupTests.ts
@@ -6,6 +6,7 @@ import '@testing-library/jest-dom/vitest';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
+import enAnalytics from '@src/i18n/locales/en/analytics.json';
 import enCommonActions from '@src/i18n/locales/en/common.actions.json';
 import enCommonFeedback from '@src/i18n/locales/en/common.feedback.json';
 import enCommonLabels from '@src/i18n/locales/en/common.labels.json';
@@ -41,6 +42,7 @@ i18n.use(initReactI18next).init({
     fallbackLng: 'en',
     initImmediate: false,
     ns: [
+        'analytics',
         'common.actions',
         'common.feedback',
         'common.labels',
@@ -72,6 +74,7 @@ i18n.use(initReactI18next).init({
     ],
     resources: {
         en: {
+            analytics: enAnalytics,
             'common.actions': enCommonActions,
             'common.feedback': enCommonFeedback,
             'common.labels': enCommonLabels,

--- a/datahub-web-react/translated-files.txt
+++ b/datahub-web-react/translated-files.txt
@@ -1,3 +1,4 @@
+src/app/analyticsDashboardV2/components/AnalyticsPage.tsx
 src/app/domain/**/*.{ts,tsx}
 src/app/domainV2/**/*.{ts,tsx}
 src/app/entityV2/ownership/ManageOwnership.tsx


### PR DESCRIPTION
## Summary

Extracts the hardcoded user-visible strings from the **analytics dashboard page** (`src/app/analyticsDashboardV2/components/AnalyticsPage.tsx`) into a new **`analytics`** namespace. **English-only** — translations follow in a separate PR.

The analytics surface is almost entirely **data-driven**: chart titles, group names, axis labels, and table headers all come from the GMS analytics API, not hardcoded text. So the real extractable scope is just the page's static chrome — section titles, the domain filter, error fallbacks, and the empty state (9 keys, one file).

- New `en/analytics.json` (9 keys): `allDomains`, `selectDomain`, `dataLandscapeSummary`, `domainLandscapeSummary`, `usageAnalytics`, `failedToLoadHighlights`, `failedToLoadCharts`, `failedToLoadDomains`, `noDomainData`
- Registers `analytics` in `i18n.ts` and `setupTests.ts`; adds `AnalyticsPage.tsx` to `translated-files.txt`

**Out of scope (no user-visible strings):** `src/app/analytics/` is the analytics tracking SDK (event identifiers, amplitude/mixpanel/GA plugins — programmatic, never translated). `src/app/analyticsDashboard/` (V1) and the remaining `analyticsDashboardV2` chart components are 100% data-driven — only SVG/CSS style values and date-format tokens, which are not translatable.

## Pages to verify

- **Analytics** (left nav → Analytics; requires analytics enabled + the `viewAnalytics` privilege): the "Data Landscape Summary" and "Usage Analytics" section titles, the "Domain Landscape Summary" header with its **All Domains / Select domain** filter, the three "Failed to load …" error banners (highlights / charts / domains), and the "No analytics data for this domain" empty state when a domain has no metadata analytics.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Lint/format/type-check pass (`./gradlew :datahub-web-react:lint` — ESLint, Prettier, tsc all green)
- [ ] Tests — n/a for the changed file; the only failures in scope are pre-existing `localStorage`/theme jsdom failures in `AnalyticsChart.test.tsx` (verified identical on master — that component and test are untouched here)
- [ ] Docs — n/a (no user-facing behavior change)
- [ ] Breaking change — n/a (non-breaking, English fallback unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
