### PR TITLE
fix(ui): escape CSS selector in SchemaTable to prevent SyntaxError on special characters

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/SchemaTable.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/SchemaTable.tsx
@@ -402,7 +402,7 @@ export default function SchemaTable({
 
             if (tableRef.current) {
                 const tableBody = tableRef.current.querySelector('.ant-table-body');
-                const row = tableBody?.querySelector(`[data-row-key="${expandedDrawerFieldPath}"]`);
+                const row = tableBody?.querySelector(`[data-row-key="${CSS.escape(expandedDrawerFieldPath)}"]`);
                 if (row) {
                     row.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
                 }


### PR DESCRIPTION
## Summary

- Field paths containing special CSS selector characters (e.g. `.`, `[`, `]`) caused a `DOMException: SyntaxError` when passed directly to `querySelector`.
- Wraps `expandedDrawerFieldPath` with `CSS.escape()` before building the attribute selector, so any field path is safely escaped.

This is a cherry-pick of the same fix from the Acryl fork (acryldata/datahub-fork#9902).

## Test plan

- [ ] Open a dataset with a schema that has fields using dotted or bracketed names (e.g. `foo.bar`, `items[0]`)
- [ ] Click a field to open the side drawer
- [ ] Verify no `SyntaxError` is thrown in the browser console and the row scrolls into view correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)