### PR TITLE
fix(search): structured property filters honor valueType and show all…

### DIFF
--- a/datahub-web-react/src/app/searchV2/filters/utils.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/utils.tsx
@@ -48,7 +48,7 @@ import {
 import { capitalizeFirstLetterOnly, forcePluralize, pluralizeIfIrregular } from '@app/shared/textUtil';
 import getTypeIcon from '@app/sharedV2/icons/getTypeIcon';
 import { removeMarkdown } from '@src/app/entity/shared/components/styled/StripMarkdownText';
-import { DATE_TYPE_URN } from '@src/app/shared/constants';
+import { DATE_TYPE_URN, URN_TYPE_URN } from '@src/app/shared/constants';
 import { useEntityRegistryV2 } from '@src/app/useEntityRegistry';
 import { EntityRegistry } from '@src/entityRegistryContext';
 import dayjs from '@utils/dayjs';
@@ -474,13 +474,33 @@ function getDynamicFilterField(field: string, availableFilters: FacetMetadata[])
     const filterAggregations = availableFilters?.find(
         (availableFilter) => availableFilter.field === field,
     )?.aggregations;
+    const entity = associatedAvailableFilter?.entity || undefined;
+
+    let type = getFilterFieldType(field, filterAggregations || []);
+    let entityTypes = getFilterEntityTypes(field, filterAggregations);
+
+    // For structured property fields, use the property's valueType definition to determine the
+    // correct filter UI — prevents URN-type properties from falling back to a plain text dropdown.
+    if (field.startsWith(STRUCTURED_PROPERTIES_FILTER_NAME) && entity) {
+        const structuredPropEntity = entity as StructuredPropertyEntity;
+        const valueTypeUrn = structuredPropEntity.definition?.valueType?.urn;
+        if (valueTypeUrn === URN_TYPE_URN) {
+            type = FieldType.ENTITY;
+            // Prefer the explicit typeQualifier allowedTypes; fall back to inference from aggregations.
+            const qualifierTypes = structuredPropEntity.definition?.typeQualifier?.allowedTypes;
+            if (qualifierTypes?.length) {
+                entityTypes = qualifierTypes.map((t) => t.type).filter(Boolean) as EntityType[];
+            }
+        }
+    }
+
     return {
         field,
         displayName: filterDisplayName || field,
-        type: getFilterFieldType(field, filterAggregations || []),
-        entityTypes: getFilterEntityTypes(field, filterAggregations),
+        type,
+        entityTypes,
         icon: getFilterDropdownIcon(field),
-        entity: associatedAvailableFilter?.entity || undefined,
+        entity,
     };
 }
 

--- a/datahub-web-react/src/app/searchV2/filters/value/utils.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/utils.tsx
@@ -21,7 +21,7 @@ import {
     useGetAutoCompleteMultipleResultsQuery,
     useGetSearchResultsForMultipleQuery,
 } from '@graphql/search.generated';
-import { AndFilterInput, EntityType } from '@types';
+import { AndFilterInput, EntityType, NumberValue, StringValue, StructuredPropertyEntity } from '@types';
 
 const MAX_AGGREGATION_COUNT = 40;
 
@@ -102,6 +102,35 @@ export const useLoadAggregationOptions = ({
             displayName: getStructuredPropFilterDisplayName(field.field, aggregation.value, field.entity),
         };
     });
+    // For structured property fields with allowedValues, surface every allowed value even if it
+    // has no indexed documents yet — so the full set of filterable choices is always visible.
+    const structuredPropEntity =
+        requestedAgg?.entity?.__typename === 'StructuredPropertyEntity'
+            ? (requestedAgg.entity as StructuredPropertyEntity)
+            : undefined;
+    const allowedValuesFromDefinition = structuredPropEntity?.definition?.allowedValues;
+    if (allowedValuesFromDefinition?.length) {
+        const existingValues = new Set((options || []).map((o) => o.value));
+        const extraOptions: FilterValueOption[] = allowedValuesFromDefinition
+            .map((av): FilterValueOption | null => {
+                let rawValue: string | null = null;
+                if (av.value?.__typename === 'StringValue') {
+                    rawValue = (av.value as StringValue).stringValue;
+                } else if (av.value?.__typename === 'NumberValue') {
+                    rawValue = String((av.value as NumberValue).numberValue);
+                }
+                if (rawValue === null || existingValues.has(rawValue)) return null;
+                return {
+                    value: rawValue,
+                    icon: field.icon,
+                    count: includeCounts ? 0 : undefined,
+                    displayName: getStructuredPropFilterDisplayName(field.field, rawValue, field.entity),
+                };
+            })
+            .filter((opt): opt is FilterValueOption => opt !== null);
+        return { options: [...(options || []), ...extraOptions], loading };
+    }
+
     return { options: options || [], loading };
 };
 

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -1270,6 +1270,22 @@ fragment facetFields on FacetMetadata {
                 valueType {
                     urn
                 }
+                allowedValues {
+                    value {
+                        ... on StringValue {
+                            stringValue
+                        }
+                        ... on NumberValue {
+                            numberValue
+                        }
+                    }
+                }
+                typeQualifier {
+                    allowedTypes {
+                        urn
+                        type
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
… allowedValues

Two issues fixed for structured property filter UX:

1. URN-type structured properties were falling back to a plain text dropdown because getDynamicFilterField inferred FieldType from aggregation values rather than reading the property's declared valueType. Now reads valueType.urn and typeQualifier.allowedTypes from the StructuredPropertyEntity definition to set the correct FieldType.ENTITY + entityTypes combination.

2. allowedValues defined on a structured property were only shown if they had indexed documents. Now surfaces all declared allowedValues in the filter dropdown, padding missing ones with a count of 0.

Requires the facetFields GraphQL fragment to fetch allowedValues and typeQualifier alongside the existing valueType.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
