### PR TITLE
fix(search): structured property filters honor valueType and show all allowedValues

### DIFF
--- a/datahub-web-react/src/app/searchV2/filters/utils.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/utils.tsx
@@ -48,7 +48,7 @@ import {
 import { capitalizeFirstLetterOnly, forcePluralize, pluralizeIfIrregular } from '@app/shared/textUtil';
 import getTypeIcon from '@app/sharedV2/icons/getTypeIcon';
 import { removeMarkdown } from '@src/app/entity/shared/components/styled/StripMarkdownText';
-import { DATE_TYPE_URN } from '@src/app/shared/constants';
+import { DATE_TYPE_URN, URN_TYPE_URN } from '@src/app/shared/constants';
 import { useEntityRegistryV2 } from '@src/app/useEntityRegistry';
 import { EntityRegistry } from '@src/entityRegistryContext';
 import dayjs from '@utils/dayjs';
@@ -474,13 +474,33 @@ function getDynamicFilterField(field: string, availableFilters: FacetMetadata[])
     const filterAggregations = availableFilters?.find(
         (availableFilter) => availableFilter.field === field,
     )?.aggregations;
+    const entity = associatedAvailableFilter?.entity || undefined;
+
+    let type = getFilterFieldType(field, filterAggregations || []);
+    let entityTypes = getFilterEntityTypes(field, filterAggregations);
+
+    // For structured property fields, use the property's valueType definition to determine the
+    // correct filter UI — prevents URN-type properties from falling back to a plain text dropdown.
+    if (field.startsWith(STRUCTURED_PROPERTIES_FILTER_NAME) && entity) {
+        const structuredPropEntity = entity as StructuredPropertyEntity;
+        const valueTypeUrn = structuredPropEntity.definition?.valueType?.urn;
+        if (valueTypeUrn === URN_TYPE_URN) {
+            type = FieldType.ENTITY;
+            // Prefer the explicit typeQualifier allowedTypes; fall back to inference from aggregations.
+            const qualifierTypes = structuredPropEntity.definition?.typeQualifier?.allowedTypes;
+            if (qualifierTypes?.length) {
+                entityTypes = qualifierTypes.map((t) => t.type).filter(Boolean) as EntityType[];
+            }
+        }
+    }
+
     return {
         field,
         displayName: filterDisplayName || field,
-        type: getFilterFieldType(field, filterAggregations || []),
-        entityTypes: getFilterEntityTypes(field, filterAggregations),
+        type,
+        entityTypes,
         icon: getFilterDropdownIcon(field),
-        entity: associatedAvailableFilter?.entity || undefined,
+        entity,
     };
 }
 

--- a/datahub-web-react/src/app/searchV2/filters/value/utils.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/utils.tsx
@@ -21,7 +21,7 @@ import {
     useGetAutoCompleteMultipleResultsQuery,
     useGetSearchResultsForMultipleQuery,
 } from '@graphql/search.generated';
-import { AndFilterInput, EntityType } from '@types';
+import { AndFilterInput, EntityType, NumberValue, StringValue, StructuredPropertyEntity } from '@types';
 
 const MAX_AGGREGATION_COUNT = 40;
 
@@ -102,6 +102,35 @@ export const useLoadAggregationOptions = ({
             displayName: getStructuredPropFilterDisplayName(field.field, aggregation.value, field.entity),
         };
     });
+    // For structured property fields with allowedValues, surface every allowed value even if it
+    // has no indexed documents yet — so the full set of filterable choices is always visible.
+    const structuredPropEntity =
+        requestedAgg?.entity?.__typename === 'StructuredPropertyEntity'
+            ? (requestedAgg.entity as StructuredPropertyEntity)
+            : undefined;
+    const allowedValuesFromDefinition = structuredPropEntity?.definition?.allowedValues;
+    if (allowedValuesFromDefinition?.length) {
+        const existingValues = new Set((options || []).map((o) => o.value));
+        const extraOptions: FilterValueOption[] = allowedValuesFromDefinition
+            .map((av): FilterValueOption | null => {
+                let rawValue: string | null = null;
+                if (av.value?.__typename === 'StringValue') {
+                    rawValue = (av.value as StringValue).stringValue;
+                } else if (av.value?.__typename === 'NumberValue') {
+                    rawValue = String((av.value as NumberValue).numberValue);
+                }
+                if (rawValue === null || existingValues.has(rawValue)) return null;
+                return {
+                    value: rawValue,
+                    icon: field.icon,
+                    count: includeCounts ? 0 : undefined,
+                    displayName: getStructuredPropFilterDisplayName(field.field, rawValue, field.entity),
+                };
+            })
+            .filter((opt): opt is FilterValueOption => opt !== null);
+        return { options: [...(options || []), ...extraOptions], loading };
+    }
+
     return { options: options || [], loading };
 };
 

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -1270,6 +1270,22 @@ fragment facetFields on FacetMetadata {
                 valueType {
                     urn
                 }
+                allowedValues {
+                    value {
+                        ... on StringValue {
+                            stringValue
+                        }
+                        ... on NumberValue {
+                            numberValue
+                        }
+                    }
+                }
+                typeQualifier {
+                    allowedTypes {
+                        urn
+                        type
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Two fixes for structured property filter UX in search:

- **URN-type properties rendered as plain text dropdowns**: `getDynamicFilterField` was inferring `FieldType` from aggregation value shapes rather than reading the property's declared `valueType`. Now reads `valueType.urn` and maps `urn:li:dataType:datahub.urn` → `FieldType.ENTITY`, with `typeQualifier.allowedTypes` used to constrain the entity type picker.

- **Declared `allowedValues` not shown without indexed documents**: Valid filter choices were invisible until at least one document was indexed with that value. Now supplements aggregation options with any `allowedValues` from the property definition (count = 0), so the full set is always shown.

Extends the `facetFields` GraphQL fragment to fetch `allowedValues` and `typeQualifier.allowedTypes` alongside the existing `valueType`.

Port of acryldata/datahub-fork#9914.

## Test plan

- [ ] Structured property with `valueType=urn` renders an entity picker in search filters (not a text dropdown)
- [ ] Structured property with `allowedValues` shows all declared values in the filter dropdown before any entity is indexed with those values
- [ ] Existing structured property filters (string, date, number) continue to work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)