### PR TITLE
feat(ingest): improve sync schedule UX with toggle, info tooltip, and conditional fields

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/builder/CreateScheduleStep.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/builder/CreateScheduleStep.tsx
@@ -144,7 +144,7 @@ export const CreateScheduleStep = ({ state, updateState, goTo, prev }: StepProps
             </Section>
             <RequiredFieldForm layout="vertical">
                 <Form.Item
-                    tooltip="Enable to run ingestion syncs on a schedule. Running syncs on a schedule helps to keep information up to date."
+                    tooltip="Keep metadata current by automatically syncing on a regular interval"
                     label={
                         <Typography.Text strong>
                             Run on a schedule <Typography.Text type="secondary">(Recommended)</Typography.Text>
@@ -159,51 +159,55 @@ export const CreateScheduleStep = ({ state, updateState, goTo, prev }: StepProps
                         </WarningContainer>
                     )}
                 </Form.Item>
-                <StyledFormItem required label={<Typography.Text strong>Schedule</Typography.Text>}>
-                    <Schedule>
-                        {advancedCronCheck ? (
-                            <CronInput
-                                placeholder={DAILY_MIDNIGHT_CRON_INTERVAL}
-                                autoFocus
-                                value={scheduleCronInterval}
-                                onChange={(e) => setScheduleCronInterval(e.target.value)}
-                            />
-                        ) : (
-                            <Cron
-                                value={scheduleCronInterval}
-                                setValue={setScheduleCronInterval}
-                                clearButton={false}
-                                className="cron-builder"
-                                leadingZero
-                            />
-                        )}
-                        <AdvancedSchedule>
-                            <AdvancedCheckBox type="secondary">Show Advanced</AdvancedCheckBox>
-                            <Checkbox
-                                checked={advancedCronCheck}
-                                onChange={(event) => setAdvancedCronCheck(event.target.checked)}
-                            />
-                        </AdvancedSchedule>
-                    </Schedule>
-                    <CronText>
-                        {cronAsText.error && <>Invalid cron schedule. Cron must be of UNIX form:</>}
-                        {!cronAsText.text && (
-                            <Typography.Paragraph keyboard style={{ marginTop: 4 }}>
-                                minute, hour, day, month, day of week
-                            </Typography.Paragraph>
-                        )}
-                        {cronAsText.text && (
-                            <>
-                                <CronSuccessCheck />
-                                {cronAsText.text}
-                            </>
-                        )}
-                    </CronText>
-                </StyledFormItem>
-                <Form.Item required label={<Typography.Text strong>Timezone</Typography.Text>}>
-                    <ItemDescriptionText>Choose a timezone for the schedule.</ItemDescriptionText>
-                    <TimezoneSelect value={scheduleTimezone} onChange={setScheduleTimezone} />
-                </Form.Item>
+                {scheduleEnabled && (
+                    <>
+                        <StyledFormItem required label={<Typography.Text strong>Schedule</Typography.Text>}>
+                            <Schedule>
+                                {advancedCronCheck ? (
+                                    <CronInput
+                                        placeholder={DAILY_MIDNIGHT_CRON_INTERVAL}
+                                        autoFocus
+                                        value={scheduleCronInterval}
+                                        onChange={(e) => setScheduleCronInterval(e.target.value)}
+                                    />
+                                ) : (
+                                    <Cron
+                                        value={scheduleCronInterval}
+                                        setValue={setScheduleCronInterval}
+                                        clearButton={false}
+                                        className="cron-builder"
+                                        leadingZero
+                                    />
+                                )}
+                                <AdvancedSchedule>
+                                    <AdvancedCheckBox type="secondary">Show Advanced</AdvancedCheckBox>
+                                    <Checkbox
+                                        checked={advancedCronCheck}
+                                        onChange={(event) => setAdvancedCronCheck(event.target.checked)}
+                                    />
+                                </AdvancedSchedule>
+                            </Schedule>
+                            <CronText>
+                                {cronAsText.error && <>Invalid cron schedule. Cron must be of UNIX form:</>}
+                                {!cronAsText.text && (
+                                    <Typography.Paragraph keyboard style={{ marginTop: 4 }}>
+                                        minute, hour, day, month, day of week
+                                    </Typography.Paragraph>
+                                )}
+                                {cronAsText.text && (
+                                    <>
+                                        <CronSuccessCheck />
+                                        {cronAsText.text}
+                                    </>
+                                )}
+                            </CronText>
+                        </StyledFormItem>
+                        <Form.Item required label={<Typography.Text strong>Timezone</Typography.Text>}>
+                            <ItemDescriptionText>Choose a timezone for the schedule.</ItemDescriptionText>
+                            <TimezoneSelect value={scheduleTimezone} onChange={setScheduleTimezone} />
+                        </Form.Item>
+                    </>
+                )}
             </RequiredFieldForm>
             <ControlsContainer>
                 <Button variant="outline" color="gray" onClick={prev}>

--- a/datahub-web-react/src/app/ingestV2/source/builder/CreateScheduleStep.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/builder/CreateScheduleStep.tsx
@@ -144,7 +144,7 @@ export const CreateScheduleStep = ({ state, updateState, goTo, prev }: StepProps
             </Section>
             <RequiredFieldForm layout="vertical">
                 <Form.Item
-                    tooltip="Enable to run ingestion syncs on a schedule. Running syncs on a schedule helps to keep information up to date"
+                    tooltip="Enable to run ingestion syncs on a schedule. Running syncs on a schedule helps to keep information up to date."
                     label={
                         <Typography.Text strong>
                             Run on a schedule <Typography.Text type="secondary">(Recommended)</Typography.Text>

--- a/datahub-web-react/src/app/ingestV2/source/builder/CreateScheduleStep.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/builder/CreateScheduleStep.tsx
@@ -144,7 +144,7 @@ export const CreateScheduleStep = ({ state, updateState, goTo, prev }: StepProps
             </Section>
             <RequiredFieldForm layout="vertical">
                 <Form.Item
-                    tooltip="Keep metadata current by automatically syncing on a regular interval"
+                    tooltip="Enable to run ingestion syncs on a schedule. Running syncs on a schedule helps to keep information up to date"
                     label={
                         <Typography.Text strong>
                             Run on a schedule <Typography.Text type="secondary">(Recommended)</Typography.Text>

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/syncScheduleSection/ScheduleSection.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/syncScheduleSection/ScheduleSection.tsx
@@ -126,7 +126,7 @@ export function ScheduleSection() {
                         Run on a schedule
                     </Text>
                     <Text size="sm" weight="bold" color="gray" colorLevel={1700}>
-                        (recommended)
+                        (Recommended)
                     </Text>
                 </SwitchLabel>
                 <Icon

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/syncScheduleSection/ScheduleSection.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/syncScheduleSection/ScheduleSection.tsx
@@ -1,4 +1,5 @@
 import { Icon, Switch, Text } from '@components';
+import { Info } from '@phosphor-icons/react/dist/csr/Info';
 import { Warning } from '@phosphor-icons/react/dist/csr/Warning';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
@@ -19,6 +20,12 @@ const SectionContainer = styled.div`
     display: flex;
     flex-direction: column;
     gap: 16px;
+`;
+
+const ScheduleToggleRow = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 8px;
 `;
 
 const SwitchLabel = styled.div`
@@ -107,21 +114,28 @@ export function ScheduleSection() {
     return (
         <SectionContainer data-testid="sync-schedule-section">
             <SectionName name="Sync Schedule" description={subtitle} />
-            <SwitchLabel>
-                <Text size="sm" weight="bold" color="gray" colorLevel={600}>
-                    Run on a schedule
-                </Text>
-                <Text size="sm" weight="bold" color="gray" colorLevel={1700}>
-                    (recommended)
-                </Text>
-            </SwitchLabel>
-            <Switch
-                label="Keep metadata current by automatically syncing on a regular interval"
-                checked={scheduleEnabled}
-                onChange={(e) => setScheduleEnabled(e.target.checked)}
-                labelPosition="right"
-                data-testid="schedule-enabled-switch"
-            />
+            <ScheduleToggleRow>
+                <Switch
+                    label=""
+                    checked={scheduleEnabled}
+                    onChange={(e) => setScheduleEnabled(e.target.checked)}
+                    data-testid="schedule-enabled-switch"
+                />
+                <SwitchLabel>
+                    <Text size="sm" weight="bold" color="gray" colorLevel={600}>
+                        Run on a schedule
+                    </Text>
+                    <Text size="sm" weight="bold" color="gray" colorLevel={1700}>
+                        (recommended)
+                    </Text>
+                </SwitchLabel>
+                <Icon
+                    icon={Info}
+                    color="gray"
+                    size="md"
+                    tooltipText="Keep metadata current by automatically syncing on a regular interval"
+                />
+            </ScheduleToggleRow>
             {!scheduleEnabled && (
                 <WarningContainer>
                     <Icon icon={Warning} color="yellow" colorLevel={1000} size="md" />
@@ -130,15 +144,19 @@ export function ScheduleSection() {
                     </Text>
                 </WarningContainer>
             )}
-            <CronField
-                scheduleCronInterval={scheduleCronInterval}
-                setScheduleCronInterval={setScheduleCronInterval}
-                cronAsText={cronAsText}
-            />
-            <TimezoneContainer>
-                <Text color="gray">Choose a timezone for the schedule.</Text>
-                <TimezoneSelect value={scheduleTimezone} onChange={setScheduleTimezone} />
-            </TimezoneContainer>
+            {scheduleEnabled && (
+                <>
+                    <CronField
+                        scheduleCronInterval={scheduleCronInterval}
+                        setScheduleCronInterval={setScheduleCronInterval}
+                        cronAsText={cronAsText}
+                    />
+                    <TimezoneContainer>
+                        <Text color="gray">Choose a timezone for the schedule.</Text>
+                        <TimezoneSelect value={scheduleTimezone} onChange={setScheduleTimezone} />
+                    </TimezoneContainer>
+                </>
+            )}
         </SectionContainer>
     );
 }


### PR DESCRIPTION

## Summary

Improves the ingestion **Sync Schedule** UX so a disabled schedule no longer shows confusing time controls, and the "Run on a schedule" affordance reads more clearly.

Applies to both schedule builders:

- **`ScheduleSection.tsx`** — the new multi-step builder (shown when the `ingestionOnboardingRedesignV1` flag is on)
- **`CreateScheduleStep.tsx`** — the legacy modal builder (shown when the flag is off)

### Changes

- **Inline toggle** — the enable/disable switch now sits directly next to the **"Run on a schedule (recommended)"** heading instead of below it.
- **Info tooltip** — the copy *"Keep metadata current by automatically syncing on a regular interval"* moved out of the toggle label into a hover tooltip on an **ⓘ** icon, decluttering the row.
- **Conditional fields** — the cron schedule (Every / at / time / View Advanced Settings) and the timezone selector now render **only when the toggle is enabled**. When disabled, the user just sees the toggle plus the existing out-of-date warning.


## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated (if applicable) — N/A, presentational change
- [x] Docs added/updated (if applicable) — N/A
- [x] No breaking changes


<img width="1301" height="165" alt="Screenshot 2026-06-03 at 8 50 53 PM" src="https://github.com/user-attachments/assets/433a084d-ff18-4822-9cee-62177d50328e" />
<img width="1276" height="268" alt="Screenshot 2026-06-03 at 8 51 27 PM" src="https://github.com/user-attachments/assets/d868b8ae-1007-45f6-be9a-4a1016a7b5e7" />
