### PR TITLE
ci: Revert to cloudflare pages action

### DIFF
--- a/.github/workflows/python-build-pages.yml
+++ b/.github/workflows/python-build-pages.yml
@@ -63,13 +63,14 @@ jobs:
           DATAHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Publish
         id: cloudflare
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca # v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ vars.CLOUDFLARE_WHEELS_PROJECT_NAME }}
           workingDirectory: python-build
+          directory: site
           gitHubToken: ${{ github.token }}
-          command: pages deploy site --project-name=${{ vars.CLOUDFLARE_WHEELS_PROJECT_NAME }}
 
       - name: Set PyPI index URL output
         id: set-pypi-url

--- a/.github/workflows/react-cloudflare-pages.yml
+++ b/.github/workflows/react-cloudflare-pages.yml
@@ -65,10 +65,11 @@ jobs:
           ./gradlew :datahub-web-react:build -x test -x check --parallel
       - name: Publish
         if: ${{ needs.setup.outputs.frontend_change == 'true' && needs.setup.outputs.cloudflare_token_available == 'true' }}
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca # v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: datahub-project-web-react
           workingDirectory: datahub-web-react
+          directory: dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          command: pages deploy dist --project-name=datahub-project-web-react

--- a/datahub-web-react/src/App.tsx
+++ b/datahub-web-react/src/App.tsx
@@ -44,6 +44,7 @@ const errorLink = onError((error) => {
         }
     }
     // Disabled behavior for now -> Components are expected to handle their errors.
+    //
     // if (graphQLErrors && graphQLErrors.length) {
     //     const firstError = graphQLErrors[0];
     //     const { extensions } = firstError;


### PR DESCRIPTION
https://datahub.slack.com/archives/C087J8S1VD2/p1780522902145659
Revert Cloudflare wrangler-action to pages-action due to missing parity.
https://github.com/cloudflare/wrangler-action/issues/333#issuecomment-3609128629
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
