### PR TITLE
fix(dbt): use dbt adapter type as SQL dialect for column lineage parsing

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -2243,7 +2243,8 @@ class DBTSourceBase(StatefulIngestionSourceBase):
                     ]
                     if upstream_node.is_ephemeral_model()
                     for cte_name in _get_dbt_cte_names(
-                        upstream_node.name, schema_resolver.platform
+                        upstream_node.name,
+                        upstream_node.dbt_adapter or schema_resolver.platform,
                     )
                 }
                 if cte_mapping:
@@ -2328,10 +2329,15 @@ class DBTSourceBase(StatefulIngestionSourceBase):
     ) -> SqlParsingResult:
         assert node.compiled_code is not None
 
+        # Use the dbt adapter as the SQL dialect (e.g. "trino", "snowflake").
+        # schema_resolver.platform is the storage platform (e.g. "glue") which
+        # is used for URN construction, not SQL parsing.
+        sql_dialect: str = node.dbt_adapter or schema_resolver.platform
+
         try:
             picked_statement = parse_statements_and_pick(
                 node.compiled_code,
-                platform=schema_resolver.platform,
+                platform=sql_dialect,
             )
         except Exception as e:
             logger.debug(
@@ -2344,7 +2350,7 @@ class DBTSourceBase(StatefulIngestionSourceBase):
         try:
             preprocessed_sql = detach_ctes(
                 picked_statement,
-                platform=schema_resolver.platform,
+                platform=sql_dialect,
                 cte_mapping=cte_mapping,
             )
         except Exception as e:
@@ -2355,7 +2361,11 @@ class DBTSourceBase(StatefulIngestionSourceBase):
             )
             return SqlParsingResult.make_from_error(e)
 
-        sql_result = sqlglot_lineage(preprocessed_sql, schema_resolver=schema_resolver)
+        sql_result = sqlglot_lineage(
+            preprocessed_sql,
+            schema_resolver=schema_resolver,
+            override_dialect=sql_dialect,
+        )
         if sql_result.debug_info.table_error:
             self.report.sql_parser_table_errors += 1
             logger.info(
@@ -2895,7 +2905,8 @@ class DBTSourceBase(StatefulIngestionSourceBase):
         compiled_code = None
         if self.config.include_compiled_code and node.compiled_code:
             compiled_code = try_format_query(
-                node.compiled_code, platform=self.config.target_platform
+                node.compiled_code,
+                platform=node.dbt_adapter or self.config.target_platform,
             )
             compiled_code = self._truncate_code(compiled_code, _DBT_MAX_SQL_LENGTH)
 

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -1247,7 +1247,7 @@ def get_custom_properties(node: DBTNode) -> Dict[str, str]:
     return custom_properties
 
 
-def _get_dbt_cte_names(name: str, target_platform: str) -> List[str]:
+def _get_dbt_cte_names(name: str, adapter: str) -> List[str]:
     # Match the dbt CTE naming scheme:
     # The default is defined here https://github.com/dbt-labs/dbt-core/blob/4122f6c308c88be4a24c1ea490802239a4c1abb8/core/dbt/adapters/base/relation.py#L222
     # However, since this PR https://github.com/dbt-labs/dbt-core/pull/2712, it's also possible
@@ -1266,8 +1266,8 @@ def _get_dbt_cte_names(name: str, target_platform: str) -> List[str]:
     }
 
     cte_names = [default_cte_name]
-    if target_platform in adapter_cte_names:
-        cte_names.append(adapter_cte_names[target_platform])
+    if adapter in adapter_cte_names:
+        cte_names.append(adapter_cte_names[adapter])
 
     return cte_names
 

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_events_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_events_golden.json
@@ -204,6 +204,85 @@
                                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
                                     "type": "TRANSFORMED"
                                 }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),first_order)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),most_recent_order)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),number_of_orders)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD),customer_lifetime_value)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
                             ]
                         }
                     },
@@ -211,7 +290,7 @@
                         "com.linkedin.pegasus2avro.dataset.ViewProperties": {
                             "materialized": true,
                             "viewLogic": "with customers as (\n\n    select * from {{ ref('stg_customers') }}\n\n),\n\norders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders on\n         payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders\n        on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments\n        on  customers.customer_id = customer_payments.customer_id\n\n)\n\nselect * from final",
-                            "formattedViewLogic": "with customers as (\n\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`stg_customers`\n\n),\n\norders as (\n\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`stg_orders`\n\n),\n\npayments as (\n\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`stg_payments`\n\n),\n\ncustomer_orders as (\n\n        select\n        customer_id,\n\n        min(order_date) as first_order,\n        max(order_date) as most_recent_order,\n        count(order_id) as number_of_orders\n    from orders\n\n    group by customer_id\n\n),\n\ncustomer_payments as (\n\n    select\n        orders.customer_id,\n        sum(amount) as total_amount\n\n    from payments\n\n    left join orders on\n         payments.order_id = orders.order_id\n\n    group by orders.customer_id\n\n),\n\nfinal as (\n\n    select\n        customers.customer_id,\n        customers.first_name,\n        customers.last_name,\n        customer_orders.first_order,\n        customer_orders.most_recent_order,\n        customer_orders.number_of_orders,\n        customer_payments.total_amount as customer_lifetime_value\n\n    from customers\n\n    left join customer_orders\n        on customers.customer_id = customer_orders.customer_id\n\n    left join customer_payments\n        on  customers.customer_id = customer_payments.customer_id\n\n)\n\nselect * from final",
+                            "formattedViewLogic": "WITH customers AS (\n  SELECT\n    *\n  FROM `calm-pagoda-323403`.`jaffle_shop`.`stg_customers`\n), orders AS (\n  SELECT\n    *\n  FROM `calm-pagoda-323403`.`jaffle_shop`.`stg_orders`\n), payments AS (\n  SELECT\n    *\n  FROM `calm-pagoda-323403`.`jaffle_shop`.`stg_payments`\n), customer_orders AS (\n  SELECT\n    customer_id,\n    MIN(order_date) AS first_order,\n    MAX(order_date) AS most_recent_order,\n    count(order_id) AS number_of_orders\n  FROM orders\n  GROUP BY\n    customer_id\n), customer_payments AS (\n  SELECT\n    orders.customer_id,\n    sum(amount) AS total_amount\n  FROM payments\n  LEFT JOIN orders\n    ON payments.order_id = orders.order_id\n  GROUP BY\n    orders.customer_id\n), final AS (\n  SELECT\n    customers.customer_id,\n    customers.first_name,\n    customers.last_name,\n    customer_orders.first_order,\n    customer_orders.most_recent_order,\n    customer_orders.number_of_orders,\n    customer_payments.total_amount AS customer_lifetime_value\n  FROM customers\n  LEFT JOIN customer_orders\n    ON customers.customer_id = customer_orders.customer_id\n  LEFT JOIN customer_payments\n    ON customers.customer_id = customer_payments.customer_id\n)\nSELECT\n  *\nFROM final",
                             "viewLanguage": "SQL"
                         }
                     }
@@ -471,6 +550,111 @@
                                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
                                     "type": "TRANSFORMED"
                                 }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),order_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),customer_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),order_date)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),status)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),status)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_method)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),credit_card_amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_method)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),coupon_amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_method)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),bank_transfer_amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),amount)",
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_method)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),gift_card_amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
                             ]
                         }
                     },
@@ -478,7 +662,7 @@
                         "com.linkedin.pegasus2avro.dataset.ViewProperties": {
                             "materialized": true,
                             "viewLogic": "{% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}\n\nwith orders as (\n\n    select * from {{ ref('stg_orders') }}\n\n),\n\npayments as (\n\n    select * from {{ ref('stg_payments') }}\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        {% for payment_method in payment_methods -%}\n        sum(case when payment_method = '{{ payment_method }}' then amount else 0 end) as {{ payment_method }}_amount,\n        {% endfor -%}\n\n        sum(amount) as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        {% for payment_method in payment_methods -%}\n\n        order_payments.{{ payment_method }}_amount,\n\n        {% endfor -%}\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final",
-                            "formattedViewLogic": "\n\nwith orders as (\n\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`stg_orders`\n\n),\n\npayments as (\n\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`stg_payments`\n\n),\n\norder_payments as (\n\n    select\n        order_id,\n\n        sum(case when payment_method = 'credit_card' then amount else 0 end) as credit_card_amount,\n        sum(case when payment_method = 'coupon' then amount else 0 end) as coupon_amount,\n        sum(case when payment_method = 'bank_transfer' then amount else 0 end) as bank_transfer_amount,\n        sum(case when payment_method = 'gift_card' then amount else 0 end) as gift_card_amount,\n        sum(amount) as total_amount\n\n    from payments\n\n    group by order_id\n\n),\n\nfinal as (\n\n    select\n        orders.order_id,\n        orders.customer_id,\n        orders.order_date,\n        orders.status,\n\n        order_payments.credit_card_amount,\n\n        order_payments.coupon_amount,\n\n        order_payments.bank_transfer_amount,\n\n        order_payments.gift_card_amount,\n\n        order_payments.total_amount as amount\n\n    from orders\n\n\n    left join order_payments\n        on orders.order_id = order_payments.order_id\n\n)\n\nselect * from final",
+                            "formattedViewLogic": "WITH orders AS (\n  SELECT\n    *\n  FROM `calm-pagoda-323403`.`jaffle_shop`.`stg_orders`\n), payments AS (\n  SELECT\n    *\n  FROM `calm-pagoda-323403`.`jaffle_shop`.`stg_payments`\n), order_payments AS (\n  SELECT\n    order_id,\n    sum(CASE WHEN payment_method = 'credit_card' THEN amount ELSE 0 END) AS credit_card_amount,\n    sum(CASE WHEN payment_method = 'coupon' THEN amount ELSE 0 END) AS coupon_amount,\n    sum(CASE WHEN payment_method = 'bank_transfer' THEN amount ELSE 0 END) AS bank_transfer_amount,\n    sum(CASE WHEN payment_method = 'gift_card' THEN amount ELSE 0 END) AS gift_card_amount,\n    sum(amount) AS total_amount\n  FROM payments\n  GROUP BY\n    order_id\n), final AS (\n  SELECT\n    orders.order_id,\n    orders.customer_id,\n    orders.order_date,\n    orders.status,\n    order_payments.credit_card_amount,\n    order_payments.coupon_amount,\n    order_payments.bank_transfer_amount,\n    order_payments.gift_card_amount,\n    order_payments.total_amount AS amount\n  FROM orders\n  LEFT JOIN order_payments\n    ON orders.order_id = order_payments.order_id\n)\nSELECT\n  *\nFROM final",
                             "viewLanguage": "SQL"
                         }
                     }
@@ -649,6 +833,41 @@
                                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
                                     "type": "TRANSFORMED"
                                 }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_customers,PROD),id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_customers,PROD),first_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),first_name)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_customers,PROD),last_name)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD),last_name)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
                             ]
                         }
                     },
@@ -656,7 +875,7 @@
                         "com.linkedin.pegasus2avro.dataset.ViewProperties": {
                             "materialized": false,
                             "viewLogic": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_customers') }}\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
-                            "formattedViewLogic": "with source as (\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`raw_customers`\n\n),\n\nrenamed as (\n\n    select\n        id as customer_id,\n        first_name,\n        last_name\n\n    from source\n\n)\n\nselect * from renamed",
+                            "formattedViewLogic": "WITH source AS (\n  SELECT\n    *\n  FROM `calm-pagoda-323403`.`jaffle_shop`.`raw_customers`\n), renamed AS (\n  SELECT\n    id AS customer_id,\n    first_name,\n    last_name\n  FROM source\n)\nSELECT\n  *\nFROM renamed",
                             "viewLanguage": "SQL"
                         }
                     }
@@ -816,6 +1035,52 @@
                                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
                                     "type": "TRANSFORMED"
                                 }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),user_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),customer_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),order_date)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),order_date)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD),status)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD),status)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
                             ]
                         }
                     },
@@ -823,7 +1088,7 @@
                         "com.linkedin.pegasus2avro.dataset.ViewProperties": {
                             "materialized": false,
                             "viewLogic": "with source as (\n\n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_orders') }}\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
-                            "formattedViewLogic": "with source as (\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`raw_orders`\n\n),\n\nrenamed as (\n\n    select\n        id as order_id,\n        user_id as customer_id,\n        order_date,\n        status\n\n    from source\n\n)\n\nselect * from renamed",
+                            "formattedViewLogic": "WITH source AS (\n  SELECT\n    *\n  FROM `calm-pagoda-323403`.`jaffle_shop`.`raw_orders`\n), renamed AS (\n  SELECT\n    id AS order_id,\n    user_id AS customer_id,\n    order_date,\n    status\n  FROM source\n)\nSELECT\n  *\nFROM renamed",
                             "viewLanguage": "SQL"
                         }
                     }
@@ -983,6 +1248,52 @@
                                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
                                     "type": "TRANSFORMED"
                                 }
+                            ],
+                            "fineGrainedLineages": [
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),order_id)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),order_id)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),payment_method)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),payment_method)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                },
+                                {
+                                    "upstreamType": "FIELD_SET",
+                                    "upstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD),amount)"
+                                    ],
+                                    "downstreamType": "FIELD",
+                                    "downstreams": [
+                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD),amount)"
+                                    ],
+                                    "confidenceScore": 0.9
+                                }
                             ]
                         }
                     },
@@ -990,7 +1301,7 @@
                         "com.linkedin.pegasus2avro.dataset.ViewProperties": {
                             "materialized": false,
                             "viewLogic": "with source as (\n    \n    {#-\n    Normally we would select from the table here, but we are using seeds to load\n    our data in this project\n    #}\n    select * from {{ ref('raw_payments') }}\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
-                            "formattedViewLogic": "with source as (\n    select * from `calm-pagoda-323403`.`jaffle_shop`.`raw_payments`\n\n),\n\nrenamed as (\n\n    select\n        id as payment_id,\n        order_id,\n        payment_method,\n\n        -- `amount` is currently stored in cents, so we convert it to dollars\n        amount / 100 as amount\n\n    from source\n\n)\n\nselect * from renamed",
+                            "formattedViewLogic": "WITH source AS (\n  SELECT\n    *\n  FROM `calm-pagoda-323403`.`jaffle_shop`.`raw_payments`\n), renamed AS (\n  SELECT\n    id AS payment_id,\n    order_id,\n    payment_method,\n    amount /* `amount` is currently stored in cents, so we convert it to dollars */ / 100 AS amount\n  FROM source\n)\nSELECT\n  *\nFROM renamed",
                             "viewLanguage": "SQL"
                         }
                     }


### PR DESCRIPTION
## Summary

When running the dbt connector with `target_platform: glue` (or any platform whose name is not a valid sqlglot dialect), SQL parsing for column-level lineage fails with `ValueError: Unknown dialect 'glue'`.

The root cause is that `schema_resolver.platform` (the storage platform, e.g. `"glue"`) was being passed as the SQL dialect to sqlglot. These are two different concepts:

- **Storage platform** (`"glue"`) — where the data lives; used for URN construction. Not a SQL dialect.
- **dbt adapter** (`"trino"`) — how SQL is written against those tables; the correct SQL dialect for parsing.

## Changes

- `_parse_cll`: use `node.dbt_adapter` as the SQL dialect for `parse_statements_and_pick`, `detach_ctes`, and `sqlglot_lineage` instead of `schema_resolver.platform`
- `_get_dbt_cte_names`: use `upstream_node.dbt_adapter` for adapter-specific CTE name lookup instead of `schema_resolver.platform`
- `_create_view_properties_aspect`: use `node.dbt_adapter` for SQL formatting instead of `self.config.target_platform`

All three changes fall back to the original platform value if `dbt_adapter` is `None`, preserving existing behaviour for all other setups.

## Root cause

Ingestion report showed `ValueError: Unknown dialect 'glue'` for nodes that had `compiled_code` present, and `sql_parser_successes: 0` across models in a Glue-backed dbt project.
