### PR TITLE
fix(ingest/powerbi): strip Athena catalog prefix from ODBC navigation lineage URNs

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
@@ -1593,7 +1593,7 @@ class OdbcLineage(AbstractLineage):
             return self.query_lineage(query, platform_pair, server_name, dsn)
         else:
             return self.expression_lineage(
-                data_access_func_detail, data_platform, platform_pair, server_name
+                data_access_func_detail, data_platform, platform_pair, server_name, dsn
             )
 
     def query_lineage(
@@ -1638,18 +1638,28 @@ class OdbcLineage(AbstractLineage):
         )
         logger.debug(f"ODBC query lineage generated {len(result.upstreams)} upstreams")
 
-        # Athena-specific processing: catalog stripping and federated table platform override
+        return self._apply_athena_post_processing(result, platform_pair, dsn)
+
+    def _apply_athena_post_processing(
+        self, lineage: Lineage, platform_pair: DataPlatformPair, dsn: str
+    ) -> Lineage:
+        """Normalize Athena ODBC lineage; no-op for other platforms.
+
+        Shared by both ODBC paths (SQL ``query_lineage`` and navigation
+        ``expression_lineage``) so their Athena handling can't drift:
+        - strip the catalog prefix so URNs match the standalone Athena connector
+          (``database.table``, e.g. ``awsdatacatalog.db.t`` -> ``db.t``)
+        - remap federated tables to their real platform (e.g. athena -> mysql)
+        """
         if (
             platform_pair.datahub_data_platform_name
-            == SupportedDataPlatform.AMAZON_ATHENA.value.datahub_data_platform_name
+            != SupportedDataPlatform.AMAZON_ATHENA.value.datahub_data_platform_name
         ):
-            # Strip Athena catalog prefix (e.g., "awsdatacatalog.") from URNs
-            # This ensures URN consistency with the standalone Athena connector
-            result = self._strip_athena_catalog_from_lineage(result)
-            # Apply table-specific platform overrides (e.g., athena -> mysql for federated tables)
-            result = self._apply_table_platform_override(result, dsn)
+            return lineage
 
-        return result
+        lineage = self._strip_athena_catalog_from_lineage(lineage)
+        lineage = self._apply_table_platform_override(lineage, dsn)
+        return lineage
 
     @staticmethod
     def _transform_lineage_urns(
@@ -1805,6 +1815,7 @@ class OdbcLineage(AbstractLineage):
         data_platform: str,
         platform_pair: DataPlatformPair,
         server_name: str,
+        dsn: str,
     ) -> Lineage:
         database_name = None
         schema_name = None
@@ -1840,6 +1851,11 @@ class OdbcLineage(AbstractLineage):
         ):
             qualified_table_name = f"{database_name}.{schema_name}.{table_name}"
         elif database_name is not None and table_name is not None:
+            # 2-level navigation (Database + Table, no Schema). For Athena this is ambiguous —
+            # the single level could be the catalog or the glue database — so the catalog is left
+            # in place (the 2-part stripper can't tell them apart, and the native Athena connector
+            # likewise requires a full catalog.schema.table hierarchy). Athena navigation is
+            # normally 3-level, so this branch is the non-Athena / degenerate case.
             qualified_table_name = f"{database_name}.{table_name}"
 
         if not qualified_table_name:
@@ -1868,7 +1884,7 @@ class OdbcLineage(AbstractLineage):
 
         column_lineage = self.create_table_column_lineage(urn)
 
-        return Lineage(
+        result = Lineage(
             upstreams=[
                 DataPlatformTable(
                     data_platform_pair=platform_pair,
@@ -1877,6 +1893,13 @@ class OdbcLineage(AbstractLineage):
             ],
             column_lineage=column_lineage,
         )
+
+        # Odbc.DataSource hierarchical navigation against Athena surfaces the catalog (e.g.
+        # "AwsDataCatalog") as the Database level, so the typical qualified name is 3-part
+        # (catalog.database.table). The standalone Athena connector omits the catalog, so without
+        # the shared post-processing below the navigation-based URNs never match Athena entities.
+        # (A degenerate 2-level navigation keeps the catalog — see the qualified-name branch above.)
+        return self._apply_athena_post_processing(result, platform_pair, dsn)
 
     @staticmethod
     def create_platform_pair(

--- a/metadata-ingestion/tests/unit/test_powerbi_parser.py
+++ b/metadata-ingestion/tests/unit/test_powerbi_parser.py
@@ -1197,6 +1197,132 @@ def test_odbc_query_lineage_integration_catalog_stripping_and_platform_override(
     )
 
 
+def test_odbc_expression_lineage_strips_athena_catalog(odbc_lineage):
+    """
+    Verify catalog stripping through the Odbc.DataSource navigation path
+    (expression_lineage), not just the SQL query path.
+
+    Reports built with Odbc.DataSource("dsn=...", [HierarchicalNavigation=true]) surface the
+    Athena catalog as the Database navigation level, yielding 3-part catalog.database.table names.
+    The catalog must be stripped so the upstream URN matches the standalone Athena connector.
+    """
+    from datahub.ingestion.source.powerbi.config import DataPlatformPair
+
+    table_accessor = IdentifierAccessor(
+        identifier="table", items={"Name": "country", "Kind": "Table"}, next=None
+    )
+    schema_accessor = IdentifierAccessor(
+        identifier="schema",
+        items={"Name": "dimensions", "Kind": "Schema"},
+        next=table_accessor,
+    )
+    catalog_accessor = IdentifierAccessor(
+        identifier="database",
+        items={"Name": "AwsDataCatalog", "Kind": "Database"},
+        next=schema_accessor,
+    )
+
+    data_access_func_detail = DataAccessFunctionDetail(
+        arg_list={},
+        data_access_function_name="Odbc.DataSource",
+        identifier_accessor=catalog_accessor,
+        node_map={},
+    )
+
+    platform_pair = DataPlatformPair(
+        datahub_data_platform_name="athena",
+        powerbi_data_platform_name="Amazon Athena",
+    )
+
+    lineage = odbc_lineage.expression_lineage(
+        data_access_func_detail=data_access_func_detail,
+        data_platform="athena",
+        platform_pair=platform_pair,
+        server_name="dwh-prod-athena",
+        dsn="dwh-prod-athena",
+    )
+
+    assert len(lineage.upstreams) == 1
+    # 3-part catalog.database.table is collapsed to database.table, matching Athena entities
+    assert (
+        lineage.upstreams[0].urn
+        == "urn:li:dataset:(urn:li:dataPlatform:athena,dimensions.country,PROD)"
+    )
+    assert "awsdatacatalog" not in lineage.upstreams[0].urn
+
+
+def test_odbc_expression_lineage_integration_catalog_stripping_and_platform_override():
+    """
+    Integration test for the navigation path: catalog stripping AND federated platform override
+    run together through expression_lineage() (symmetric to the query_lineage integration test).
+    """
+    from datahub.ingestion.source.powerbi.config import DataPlatformPair
+    from datahub.ingestion.source.powerbi.m_query.pattern_handler import OdbcLineage
+
+    config = PowerBiDashboardSourceConfig(
+        tenant_id="test-tenant-id",
+        client_id="test-client-id",
+        client_secret="test-client-secret",
+        dsn_to_platform_name={"dwh-prod-athena": "athena"},
+        athena_table_platform_override=[
+            # Override uses the 2-part name produced AFTER catalog stripping
+            AthenaPlatformOverride(
+                database="federated", table="orders", platform="mysql"
+            ),
+        ],
+    )
+
+    odbc = OdbcLineage(
+        ctx=PipelineContext(run_id="test-run-id"),
+        table=Table(name="orders", full_name="awsdatacatalog.federated.orders"),
+        reporter=PowerBiDashboardSourceReport(),
+        config=config,
+        platform_instance_resolver=ResolvePlatformInstanceFromDatasetTypeMapping(
+            config
+        ),
+    )
+
+    table_accessor = IdentifierAccessor(
+        identifier="table", items={"Name": "orders", "Kind": "Table"}, next=None
+    )
+    schema_accessor = IdentifierAccessor(
+        identifier="schema",
+        items={"Name": "federated", "Kind": "Schema"},
+        next=table_accessor,
+    )
+    catalog_accessor = IdentifierAccessor(
+        identifier="database",
+        items={"Name": "AwsDataCatalog", "Kind": "Database"},
+        next=schema_accessor,
+    )
+
+    data_access_func_detail = DataAccessFunctionDetail(
+        arg_list={},
+        data_access_function_name="Odbc.DataSource",
+        identifier_accessor=catalog_accessor,
+        node_map={},
+    )
+
+    lineage = odbc.expression_lineage(
+        data_access_func_detail=data_access_func_detail,
+        data_platform="athena",
+        platform_pair=DataPlatformPair(
+            datahub_data_platform_name="athena",
+            powerbi_data_platform_name="Amazon Athena",
+        ),
+        server_name="dwh-prod-athena",
+        dsn="dwh-prod-athena",
+    )
+
+    assert len(lineage.upstreams) == 1
+    # Catalog stripped (awsdatacatalog.federated.orders -> federated.orders) AND platform
+    # overridden athena -> mysql for the federated table.
+    assert (
+        lineage.upstreams[0].urn
+        == "urn:li:dataset:(urn:li:dataPlatform:mysql,federated.orders,PROD)"
+    )
+
+
 # Tests for athena_table_platform_override config validation
 def test_athena_table_platform_override_unknown_platform_raises():
     """Test that unknown platform names raise validation error."""


### PR DESCRIPTION
## Summary

PowerBI reports that connect to Athena via `Odbc.DataSource(..., [HierarchicalNavigation=true])` and navigate `Catalog → Schema → Table` produce upstream lineage URNs that **keep the Athena catalog** as a third name segment, e.g.:

```
urn:li:dataset:(urn:li:dataPlatform:athena,awsdatacatalog.dimensions.country,PROD)
```

The standalone Athena connector emits 2-part `athena,dimensions.country,PROD`, so these navigation-based PowerBI edges dangle to orphan stub datasets and no lineage shows in the UI.

## Problem

`OdbcLineage` has two paths:
- `Odbc.Query` (SQL) → `query_lineage()` — already strips the Athena catalog (added in #15746).
- `Odbc.DataSource` (hierarchical navigation) → `expression_lineage()` — builds `database.schema.table` from the navigation accessors where `database` is the catalog (`AwsDataCatalog`) and **never strips it**.

So catalog stripping only ran for the SQL path. Reports using navigation (the common case for Athena-via-ODBC) got mismatched URNs.

## Solution

- Extract the Athena post-processing (catalog stripping + federated `_apply_table_platform_override`) into a shared `OdbcLineage._apply_athena_post_processing(lineage, platform_pair, dsn)` helper, gated on `platform == athena` (no-op otherwise).
- Call it from both `query_lineage()` and `expression_lineage()` (the latter now threads `dsn` so federated overrides work there too). Single source of truth — the two paths can't drift.

## Known limitation

Only 3-part navigation names are catalog-stripped. A degenerate 2-level navigation (`Database` + `Table`, no `Schema`) keeps the catalog because the single level is ambiguous (catalog vs glue database) and the shared stripper can't safely strip 2-part names (the SQL path uses 2-part for a legitimate `database.table`). This matches the native Athena connector, which requires a full `catalog.schema.table` hierarchy. Documented in code comments.

## Testing

- `test_odbc_expression_lineage_strips_athena_catalog` — navigation `AwsDataCatalog → dimensions → country` → `athena,dimensions.country,PROD`.
- `test_odbc_expression_lineage_integration_catalog_stripping_and_platform_override` — navigation + override config → `mysql,federated.orders,PROD` (exercises both strip and override through `expression_lineage`).
- `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/test_powerbi_parser.py` → 29 passed.
- `./gradlew :metadata-ingestion:lintFix` → clean.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR title format)
- [x] Tests added
- [ ] Breaking changes — none
- [ ] Docs — none (behavior fix)
