### PR TITLE
perf(ingest/dataplex): stream list_entries / search_entries instead of eager list()

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
@@ -260,20 +260,20 @@ class DataplexEntriesProcessor:
 
             request = dataplex_v1.ListEntriesRequest(parent=entry_group.name)
             with PerfTimer() as timer:
-                entries = list(self.catalog_client.list_entries(request=request))
-            self.report.report_catalog_api_call("list_entries", timer.elapsed_seconds())
-
-            for entry in entries:
-                logger.info(f"Listing entry {entry.name} from group {entry_group.name}")
-                logger.info(f"ListEntries payload: {entry}")
-                if self._report_and_should_process_entry(entry):
-                    entry_names.append(entry.name)
-                else:
-                    logger.debug(
-                        "Skipping entry stub for filtered entry %s from group %s",
-                        entry.name,
-                        entry_group.name,
+                for entry in self.catalog_client.list_entries(request=request):
+                    logger.info(
+                        f"Listing entry {entry.name} from group {entry_group.name}"
                     )
+                    logger.info(f"ListEntries payload: {entry}")
+                    if self._report_and_should_process_entry(entry):
+                        entry_names.append(entry.name)
+                    else:
+                        logger.debug(
+                            "Skipping entry stub for filtered entry %s from group %s",
+                            entry.name,
+                            entry_group.name,
+                        )
+            self.report.report_catalog_api_call("list_entries", timer.elapsed_seconds())
         return entry_names
 
     def _fetch_entry_detail(self, entry_name: str) -> dataplex_v1.Entry:
@@ -347,9 +347,25 @@ class DataplexEntriesProcessor:
         )
         try:
             with PerfTimer() as timer:
-                search_results = list(
-                    self.catalog_client.search_entries(request=request)
-                )
+                for result in self.catalog_client.search_entries(request=request):
+                    logger.info(f"SearchEntries result payload: {result}")
+                    dataplex_entry = getattr(result, "dataplex_entry", None)
+                    if dataplex_entry is None:
+                        continue
+                    if not self._report_and_should_process_entry(dataplex_entry):
+                        logger.debug(
+                            "Skipping filtered spanner entry %s from search_entries",
+                            dataplex_entry.name,
+                        )
+                        continue
+                    try:
+                        detailed_entry = self._fetch_entry_detail(dataplex_entry.name)
+                    except Exception as exc:
+                        logger.warning(
+                            f"Failed to fetch detail for Spanner entry {dataplex_entry.name}: {exc}"
+                        )
+                        continue
+                    yield from self._build_entities_for_entry(detailed_entry, location)
             self.report.report_catalog_api_call(
                 "search_entries", timer.elapsed_seconds()
             )
@@ -358,26 +374,6 @@ class DataplexEntriesProcessor:
                 f"Spanner workaround search failed for {project_id}/{location}: {exc}"
             )
             return
-
-        for result in search_results:
-            logger.info(f"SearchEntries result payload: {result}")
-            dataplex_entry = getattr(result, "dataplex_entry", None)
-            if dataplex_entry is None:
-                continue
-            if not self._report_and_should_process_entry(dataplex_entry):
-                logger.debug(
-                    "Skipping filtered spanner entry %s from search_entries",
-                    dataplex_entry.name,
-                )
-                continue
-            try:
-                detailed_entry = self._fetch_entry_detail(dataplex_entry.name)
-            except Exception as exc:
-                logger.warning(
-                    f"Failed to fetch detail for Spanner entry {dataplex_entry.name}: {exc}"
-                )
-                continue
-            yield from self._build_entities_for_entry(detailed_entry, location)
 
     def _track_entry_for_lineage(
         self, dataplex_location: str, entry: dataplex_v1.Entry

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_glossary.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_glossary.py
@@ -252,14 +252,8 @@ class DataplexGlossaryProcessor:
         parent = f"projects/{project_id}/locations/{location}"
         request = dataplex_v1.ListGlossariesRequest(parent=parent)
         with PerfTimer() as timer:
-            response = list(self._glossary_client.list_glossaries(request=request))
+            response = self._glossary_client.list_glossaries(request=request)
         self._report.report_api_call("list_glossaries", timer.elapsed_seconds())
-        logger.debug(
-            "list_glossaries parent=%s returned %d glossaries in %.2fs",
-            parent,
-            len(response),
-            timer.elapsed_seconds(),
-        )
         logger.debug("list_glossaries payload: %s", response)
         return response
 
@@ -294,12 +288,6 @@ class DataplexGlossaryProcessor:
         # Fetch categories and terms.
         categories = self._list_categories(project_id, location, glossary_id)
         terms = self._list_terms(project_id, location, glossary_id)
-        logger.debug(
-            "Glossary %s: %d categories, %d terms",
-            glossary_id,
-            len(categories),
-            len(terms),
-        )
 
         for category in categories:
             cat_id = _resource_id(category.name)
@@ -360,39 +348,25 @@ class DataplexGlossaryProcessor:
 
     def _list_categories(
         self, project_id: str, location: str, glossary_id: str
-    ) -> List[dataplex_v1.GlossaryCategory]:
+    ) -> Iterable[dataplex_v1.GlossaryCategory]:
         parent = f"projects/{project_id}/locations/{location}/glossaries/{glossary_id}"
         request = dataplex_v1.ListGlossaryCategoriesRequest(parent=parent)
         with PerfTimer() as timer:
-            categories = list(
-                self._glossary_client.list_glossary_categories(request=request)
-            )
+            categories = self._glossary_client.list_glossary_categories(request=request)
         self._report.report_api_call(
             "list_glossary_categories", timer.elapsed_seconds()
-        )
-        logger.debug(
-            "list_glossary_categories parent=%s returned %d categories in %.2fs",
-            parent,
-            len(categories),
-            timer.elapsed_seconds(),
         )
         logger.debug("list_glossary_categories payload: %s", categories)
         return categories
 
     def _list_terms(
         self, project_id: str, location: str, glossary_id: str
-    ) -> List[dataplex_v1.GlossaryTerm]:
+    ) -> Iterable[dataplex_v1.GlossaryTerm]:
         parent = f"projects/{project_id}/locations/{location}/glossaries/{glossary_id}"
         request = dataplex_v1.ListGlossaryTermsRequest(parent=parent)
         with PerfTimer() as timer:
-            terms = list(self._glossary_client.list_glossary_terms(request=request))
+            terms = self._glossary_client.list_glossary_terms(request=request)
         self._report.report_api_call("list_glossary_terms", timer.elapsed_seconds())
-        logger.debug(
-            "list_glossary_terms parent=%s returned %d terms in %.2fs",
-            parent,
-            len(terms),
-            timer.elapsed_seconds(),
-        )
         logger.debug("list_glossary_terms payload: %s", terms)
         return terms
 

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_glossary.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_glossary.py
@@ -252,8 +252,14 @@ class DataplexGlossaryProcessor:
         parent = f"projects/{project_id}/locations/{location}"
         request = dataplex_v1.ListGlossariesRequest(parent=parent)
         with PerfTimer() as timer:
-            response = self._glossary_client.list_glossaries(request=request)
+            response = list(self._glossary_client.list_glossaries(request=request))
         self._report.report_api_call("list_glossaries", timer.elapsed_seconds())
+        logger.debug(
+            "list_glossaries parent=%s returned %d glossaries in %.2fs",
+            parent,
+            len(response),
+            timer.elapsed_seconds(),
+        )
         logger.debug("list_glossaries payload: %s", response)
         return response
 
@@ -288,6 +294,12 @@ class DataplexGlossaryProcessor:
         # Fetch categories and terms.
         categories = self._list_categories(project_id, location, glossary_id)
         terms = self._list_terms(project_id, location, glossary_id)
+        logger.debug(
+            "Glossary %s: %d categories, %d terms",
+            glossary_id,
+            len(categories),
+            len(terms),
+        )
 
         for category in categories:
             cat_id = _resource_id(category.name)
@@ -348,25 +360,39 @@ class DataplexGlossaryProcessor:
 
     def _list_categories(
         self, project_id: str, location: str, glossary_id: str
-    ) -> Iterable[dataplex_v1.GlossaryCategory]:
+    ) -> List[dataplex_v1.GlossaryCategory]:
         parent = f"projects/{project_id}/locations/{location}/glossaries/{glossary_id}"
         request = dataplex_v1.ListGlossaryCategoriesRequest(parent=parent)
         with PerfTimer() as timer:
-            categories = self._glossary_client.list_glossary_categories(request=request)
+            categories = list(
+                self._glossary_client.list_glossary_categories(request=request)
+            )
         self._report.report_api_call(
             "list_glossary_categories", timer.elapsed_seconds()
+        )
+        logger.debug(
+            "list_glossary_categories parent=%s returned %d categories in %.2fs",
+            parent,
+            len(categories),
+            timer.elapsed_seconds(),
         )
         logger.debug("list_glossary_categories payload: %s", categories)
         return categories
 
     def _list_terms(
         self, project_id: str, location: str, glossary_id: str
-    ) -> Iterable[dataplex_v1.GlossaryTerm]:
+    ) -> List[dataplex_v1.GlossaryTerm]:
         parent = f"projects/{project_id}/locations/{location}/glossaries/{glossary_id}"
         request = dataplex_v1.ListGlossaryTermsRequest(parent=parent)
         with PerfTimer() as timer:
-            terms = self._glossary_client.list_glossary_terms(request=request)
+            terms = list(self._glossary_client.list_glossary_terms(request=request))
         self._report.report_api_call("list_glossary_terms", timer.elapsed_seconds())
+        logger.debug(
+            "list_glossary_terms parent=%s returned %d terms in %.2fs",
+            parent,
+            len(terms),
+            timer.elapsed_seconds(),
+        )
         logger.debug("list_glossary_terms payload: %s", terms)
         return terms
 


### PR DESCRIPTION
## Why

The Dataplex `@bigquery` entry group is a virtual group that automatically contains metadata for every BigQuery dataset and table in a project. For large projects this can be tens or hundreds of thousands of entries.

The old code wrapped both `list_entries` and `search_entries` in `list(...)`, which forces the GCP client library to fetch **every page** before the first entry is processed. With a page size of 100, a project with 50 k tables requires 500 sequential API calls before anything happens — causing an apparent hang.

## What changed

`dataplex_entries.py` only:

- `_list_entry_stubs`: iterate the `list_entries` pager directly; the processing loop is now inside the `PerfTimer` block so it fires page-by-page.
- `_process_spanner_entries`: same treatment for `search_entries`; the result loop moved inside the existing `try/except` so lazy page-fetch errors are still caught.

Glossary/term/category calls are left unchanged — those datasets are small and don't exhibit the problem.

---
_Generated by [Claude Code](https://claude.ai/code/session_019UExFjBkJnaKzN4BbdPt9o)_