### PR TITLE
test(playwright/autocomplete): migrate autocomplete tests to playwright

### DIFF
--- a/e2e-test/ui/playwright/pages/autocomplete.page.ts
+++ b/e2e-test/ui/playwright/pages/autocomplete.page.ts
@@ -1,0 +1,114 @@
+import { Page, Locator, expect } from '@playwright/test';
+import { BasePage } from './base.page';
+import { TIMEOUTS, LOAD_STATES } from '../utils/constants';
+import type { DataHubLogger } from '../utils/logger';
+
+/**
+ * AutocompletePage — Page Object for search bar autocomplete functionality
+ *
+ * Encapsulates all autocomplete-specific interactions:
+ * - Typing in search bar to trigger dropdown
+ * - Verifying autocomplete results appear
+ * - Clicking results to navigate
+ * - Clearing search input
+ */
+export class AutocompletePage extends BasePage {
+  readonly searchInput: Locator;
+  readonly autocompleteDropdown: Locator;
+  readonly autocompleteOptions: Locator;
+  readonly entityHeader: Locator;
+
+  constructor(page: Page, logger?: DataHubLogger, logDir?: string) {
+    super(page, logger, logDir);
+    this.searchInput = page.getByTestId('search-input');
+    this.autocompleteDropdown = page.getByTestId('search-bar-dropdown');
+    this.autocompleteOptions = this.autocompleteDropdown.getByRole('option');
+    this.entityHeader = page.getByTestId('entity-header-test-id');
+  }
+
+  /**
+   * Dynamic selectors are in private methods instead of constructor
+   */
+
+  private getAutocompleteItemByUrn(urn: string): Locator {
+    const testId = `autocomplete-item-${urn}`;
+    return this.page.getByTestId(testId);
+  }
+
+  private getEntityHeaderByName(entityName: string): Locator {
+    return this.entityHeader.getByText(entityName, { exact: false });
+  }
+
+  async navigateToHome(): Promise<void> {
+    this.logger?.step('navigateToHome');
+    await this.suppressOnboardingOverlay();
+    await this.navigate('/');
+    await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
+    await this.searchInput.waitFor({ state: 'visible', timeout: TIMEOUTS.LONG });
+  }
+
+  async typeInSearchBar(query: string): Promise<void> {
+    this.logger?.step('typeInSearchBar', { query });
+    await this.searchInput.click();
+    await this.searchInput.type(query);
+    await this.page.waitForTimeout(TIMEOUTS.QUICK);
+  }
+
+  async clearSearchInput(): Promise<void> {
+    this.logger?.step('clearSearchInput');
+    await this.searchInput.clear();
+  }
+
+  async expectAutocompleteVisible(): Promise<void> {
+    this.logger?.step('expectAutocompleteVisible');
+    await expect(this.autocompleteDropdown).toBeVisible({ timeout: TIMEOUTS.LONG });
+  }
+
+  async expectAutocompleteItemsVisible(minCount: number = 1): Promise<void> {
+    this.logger?.step('expectAutocompleteItemsVisible', { minCount });
+    await this.autocompleteOptions.waitFor({ state: 'attached', timeout: TIMEOUTS.MEDIUM });
+    const items = await this.autocompleteOptions.all();
+    expect(items.length).toBeGreaterThanOrEqual(minCount);
+  }
+
+  async expectAutocompleteResultByUrn(urn: string): Promise<void> {
+    this.logger?.step('expectAutocompleteResultByUrn', { urn });
+    await this.getAutocompleteItemByUrn(urn).waitFor({ state: 'attached', timeout: TIMEOUTS.MEDIUM });
+  }
+
+  async clickAutocompleteOptionByUrn(urn: string): Promise<void> {
+    this.logger?.step('clickAutocompleteOptionByUrn', { urn });
+    await this.getAutocompleteItemByUrn(urn).click({ timeout: TIMEOUTS.MEDIUM });
+  }
+
+  async expectNavigationToEntity(entityName: string): Promise<void> {
+    this.logger?.step('expectNavigationToEntity', { entityName });
+    await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
+    await this.getEntityHeaderByName(entityName).waitFor({
+      state: 'visible',
+      timeout: TIMEOUTS.MEDIUM,
+    });
+    expect(this.page.url()).toContain(entityName);
+  }
+
+  async searchAndVerifyResult(entityName: string, entityUrn: string): Promise<void> {
+    this.logger?.step('searchAndVerifyResult', { entityName, entityUrn });
+    await this.typeInSearchBar(entityName);
+    await this.expectAutocompleteVisible();
+    await this.expectAutocompleteItemsVisible(1);
+    await this.expectAutocompleteResultByUrn(entityUrn);
+  }
+
+  async searchAndNavigateToEntity(entityName: string, entityUrn: string): Promise<void> {
+    this.logger?.step('searchAndNavigateToEntity', { entityName, entityUrn });
+    await this.searchAndVerifyResult(entityName, entityUrn);
+    await this.clickAutocompleteOptionByUrn(entityUrn);
+    await this.expectNavigationToEntity(entityName);
+  }
+
+  private async suppressOnboardingOverlay(): Promise<void> {
+    await this.page.addInitScript(() => {
+      localStorage.setItem('skipOnboardingTour', 'true');
+    });
+  }
+}

--- a/e2e-test/ui/playwright/tests/autocomplete-v2/autocomplete.spec.ts
+++ b/e2e-test/ui/playwright/tests/autocomplete-v2/autocomplete.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Autocomplete Search Bar tests — migrated from Cypress
+ *
+ * Coverage:
+ * 1. Typing in search bar triggers autocomplete dropdown
+ * 2. Results appear grouped by entity type with section headers
+ * 3. Multiple entity types searchable (datasets, dashboards, dataflows)
+ * 4. Clearing input and searching again works
+ * 5. Clicking a result navigates to entity profile with correct URN
+ *
+ * Test Data (fixtures/data.json):
+ * - SamplePlaywrightHdfsDataset (DATASET / hdfs)
+ * - SamplePlaywrightDashboard (DASHBOARD / looker)
+ * - SamplePlaywrightDataflow (DATA_JOB / airflow)
+ */
+
+import { test } from '../../fixtures/base-test';
+import { AutocompletePage } from '../../pages/autocomplete.page';
+
+test.use({ featureName: 'autocomplete-v2' });
+
+const SAMPLE_DATASET_NAME = 'SamplePlaywrightHdfsDataset';
+const SAMPLE_DATASET_URN = 'urn:li:dataset:(urn:li:dataPlatform:hdfs,SamplePlaywrightHdfsDataset,PROD)';
+const SAMPLE_DASHBOARD_NAME = 'SamplePlaywrightDashboard';
+const SAMPLE_DASHBOARD_URN = 'urn:li:dashboard:(looker,sample-dashboard)';
+const SAMPLE_CHART_NAME = 'SamplePlaywrightChart';
+const SAMPLE_CHART_URN = 'urn:li:chart:(looker,sample-chart)';
+
+test.describe('Autocomplete Search Bar', () => {
+  let autocompletePage: AutocompletePage;
+
+  test.beforeEach(async ({ page, logger, logDir }) => {
+    autocompletePage = new AutocompletePage(page, logger, logDir);
+    await autocompletePage.navigateToHome();
+  });
+
+  test('should see auto-complete results after typing in a search query', async () => {
+    // Test 1: Search for dataset — verify autocomplete appears with results
+    await autocompletePage.searchAndVerifyResult(SAMPLE_DATASET_NAME, SAMPLE_DATASET_URN);
+    await autocompletePage.clearSearchInput();
+
+    // Test 2: Search for dashboard — verify autocomplete with different entity
+    await autocompletePage.searchAndVerifyResult(SAMPLE_DASHBOARD_NAME, SAMPLE_DASHBOARD_URN);
+    await autocompletePage.clearSearchInput();
+
+    // Test 3: Search for chart — verify autocomplete works for multiple entity types
+    await autocompletePage.searchAndVerifyResult(SAMPLE_CHART_NAME, SAMPLE_CHART_URN);
+  });
+
+  test('should send you to the entity profile after clicking on an auto-complete option', async () => {
+    // Search for dataset, verify autocomplete, click result, and verify navigation
+    await autocompletePage.searchAndNavigateToEntity(SAMPLE_DATASET_NAME, SAMPLE_DATASET_URN);
+  });
+});

--- a/e2e-test/ui/playwright/tests/autocomplete-v2/fixtures/data.json
+++ b/e2e-test/ui/playwright/tests/autocomplete-v2/fixtures/data.json
@@ -1,0 +1,63 @@
+[
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:hdfs,SamplePlaywrightHdfsDataset,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "Test dataset for autocomplete search",
+              "customProperties": {}
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DashboardSnapshot": {
+        "urn": "urn:li:dashboard:(looker,sample-dashboard)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dashboard.DashboardInfo": {
+              "customProperties": {},
+              "externalUrl": "https://sample.looker.com/dashboards/1",
+              "title": "SamplePlaywrightDashboard",
+              "description": "Test dashboard for autocomplete search",
+              "charts": [],
+              "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:datahub"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.ChartSnapshot": {
+        "urn": "urn:li:chart:(looker,sample-chart)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.chart.ChartInfo": {
+              "customProperties": {},
+              "externalUrl": "https://sample.looker.com/looks/1",
+              "title": "SamplePlaywrightChart",
+              "description": "Test chart for autocomplete search",
+              "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:datahub"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+]


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/PFP-4093/migrate-tests-in-autocompletev2-folder

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
