### PR TITLE
feat(i18n): translate governance.glossary to German (CAT-2319)

### DIFF
--- a/datahub-web-react/src/i18n/locales/de/governance.glossary.json
+++ b/datahub-web-react/src/i18n/locales/de/governance.glossary.json
@@ -1,0 +1,17 @@
+{
+    "card.nodeGroupCountTooltip_one": "Enthält {{count}} Begriffsgruppe",
+    "card.nodeGroupCountTooltip_other": "Enthält {{count}} Begriffsgruppen",
+    "card.termCountTooltip_one": "Enthält {{count}} Begriff",
+    "card.termCountTooltip_other": "Enthält {{count}} Begriffe",
+    "empty.addTerm": "Begriff hinzufügen",
+    "empty.addTermGroup": "Begriffsgruppe hinzufügen",
+    "empty.description": "Erstellen Sie Begriffe und Begriffsgruppen, um Daten-Assets mit einem gemeinsamen Vokabular zu organisieren.",
+    "empty.title": "Leeres Glossar",
+    "list.error": "Glossar konnte nicht geladen werden! Ein unerwarteter Fehler ist aufgetreten.",
+    "list.loading": "Glossar wird geladen...",
+    "page.createGlossary": "Glossar erstellen",
+    "page.subtitle": "Klassifizieren Sie Ihre Daten-Assets und Spalten mithilfe von Daten-Wörterbüchern",
+    "page.title": "Business-Glossar",
+    "section.glossaryTerms": "Glossarbegriffe",
+    "section.termGroups": "Begriffsgruppen"
+}


### PR DESCRIPTION
## Summary

Adds the German (DE) translation for the `governance.glossary` namespace — the EN extraction (from [CAT-2232](https://linear.app/acryl-data/issue/CAT-2232) → PR [#17688](https://github.com/datahub-project/datahub/pull/17688)) was already merged, this PR fills in the matching DE keys.

- New file: `datahub-web-react/src/i18n/locales/de/governance.glossary.json`
- 15 keys translated from EN to formal German (Sie form)
- Glossary terminology: `Term → Begriff`, `Term Group → Begriffsgruppe`, `Business Glossary → Business-Glossar` (matches the `Begriffe & Begriffsgruppen` convention already used in `settings.permissions.json` DE)
- Anglicisms kept as-is (`Data Assets`, `DataHub`) — matches existing DE files
- i18next plural forms (`_one` / `_other`) and `{{count}}` interpolations preserved verbatim

Closes [CAT-2319](https://linear.app/acryl-data/issue/CAT-2319/oss-translate-governance-glossary-de).

## Test plan

- [x] `node scripts/check-translations.mjs --lang de` — `governance.glossary.json` no longer reports any missing keys for DE
- [x] `prettier --write` on the new file is a no-op (already correctly formatted)
- [ ] Spot-check the Business Glossary page in the UI with DE locale enabled (reviewer)


Made with [Cursor](https://cursor.com)