### PR TITLE
feat(i18n): translate analytics to German (CAT-2325)

### DIFF
--- a/datahub-web-react/src/i18n/locales/de/analytics.json
+++ b/datahub-web-react/src/i18n/locales/de/analytics.json
@@ -1,0 +1,11 @@
+{
+    "allDomains": "Alle Domänen",
+    "dataLandscapeSummary": "Übersicht der Datenlandschaft",
+    "domainLandscapeSummary": "Übersicht der Domänenlandschaft",
+    "failedToLoadCharts": "Charts konnten nicht geladen werden",
+    "failedToLoadDomains": "Domänen konnten nicht geladen werden",
+    "failedToLoadHighlights": "Highlights konnten nicht geladen werden",
+    "noDomainData": "Keine Analysedaten für diese Domäne",
+    "selectDomain": "Domäne auswählen",
+    "usageAnalytics": "Nutzungsanalysen"
+}


### PR DESCRIPTION
## Summary

Adds `de/analytics.json` with all 9 keys from the EN `analytics` namespace translated to formal German (Sie), per the DataHub DE style guide.

The Analytics extraction ([CAT-2237](https://linear.app/acryl-data/issue/CAT-2237/oss-extract-analytics-30-files) / #17706) created the `analytics` namespace covering the Analytics page summaries, domain filters, and load-error messages. This PR fills in the matching DE translations.

### Terminology

Follows existing DE conventions in this repo:

- `Domain → Domäne`, `Domains → Domänen`
- `Summary → Übersicht`, `Landscape → Landschaft` (`Datenlandschaft`, `Domänenlandschaft`)
- DataHub product Anglicisms kept: `Charts`, `Highlights`
- `analytics data → Analysedaten`
- `Usage Analytics → Nutzungsanalysen` (natural German for the section title)

Closes [CAT-2325](https://linear.app/acryl-data/issue/CAT-2325/oss-translate-analytics-de).

## Test plan

- [x] All 9 EN keys translated, no missing/extra keys
- [x] No `{{interpolation}}` placeholders or JSX tags in this namespace — n/a
- [x] `node scripts/check-translations.mjs --lang de` reports no errors for `[de] analytics`
- [x] `yarn prettier --write` reports file unchanged (clean formatting)


Made with [Cursor](https://cursor.com)