### PR TITLE
docs(release-notes): stage v1.1.1 hotfix changelog under v1.1.0

### DIFF
--- a/docs/managed-datahub/release-notes/v_1_1_0.md
+++ b/docs/managed-datahub/release-notes/v_1_1_0.md
@@ -6,6 +6,41 @@ description: "DataHub Cloud v1.1.0 release notes covering OAuth2 dynamic client 
 
 ## Release Changelog
 
+### v1.1.1
+
+This release rolls up hotfixes on top of v1.1.0. There are no breaking changes or deprecations.
+
+#### Release Availability Date
+
+TBD
+
+**Recommended Versions**
+
+- **CLI/SDK**: v1.6.0
+- **Remote Executor**: v1.1.1-cloud
+- **Helm**: TBD
+
+#### DataHub Observe
+
+- **Smart Assertions — v1 inference improvements**: Enhanced preprocessing and training in the v1 smart assertion inference pipeline, improving prediction quality and stability for newly created smart assertions.
+- **Assertion Validator — reject `_NATIVE_` on Field assertions**: Field Values and Field Metric assertions no longer accept the `_NATIVE_` source type, which was never a valid combination and could leave assertions in an unrunnable state.
+- **Assertions — `_NATIVE_` tab rendering and monitor error handling**: Fixed rendering of the `_NATIVE_` tab in the assertion builder and improved error handling for monitor failures so underlying errors surface correctly in the UI.
+- **Assertions — falsy parameter evaluation (CUS-9005)**: Fixed assertion evaluation when threshold or comparison parameters are falsy values (e.g., `0`, `false`), which were previously being skipped instead of compared.
+
+#### Product
+
+- **Dataset Summary — Generate Documentation flow**: Restored the Generate Documentation entry point on the Dataset Summary page so users can trigger AI-generated documentation directly from the summary view.
+- **Action Workflows — skip `WORKFLOW_FORM_REQUEST` (CAT-2218)**: The action request owner source now skips `WORKFLOW_FORM_REQUEST` entries, preventing workflow form requests from being routed through the standard action request owner resolution.
+
+#### AI / MCP
+
+- **MCP — marketplace review hotfixes**: Fixed `get_lineage` behavior surfaced during MCP marketplace review and disabled the versioning tools that aren't ready for general agent use.
+
+#### Platform
+
+- **Search — ES8 settings reindex loop**: Prevented a reindex loop triggered by Elasticsearch 8 settings comparison and removed range query deprecation warnings, restoring stable index management on ES8 clusters.
+- **Ebean — autoCommit on connection pool**: Enabled `autoCommit` on the Ebean connection pool, reducing transaction overhead on read-heavy workloads.
+
 ### v1.1.0
 
 Includes all upstream OSS changes through DataHub Core [v1.6.0](https://github.com/datahub-project/datahub/releases/tag/v1.6.0) — see [Updating DataHub](https://docs.datahub.com/docs/how/updating-datahub) for breaking changes.


### PR DESCRIPTION
Adds the v1.1.1 patch section above v1.1.0 in the managed DataHub release notes, grouping the rolled-up hotfixes into Observe, Product, AI/MCP, and Platform.
