### PR TITLE
fix(sql-parsing): remove sqlglot.Expression compat shim

### DIFF
--- a/metadata-ingestion/src/datahub/sdk/dataset.py
+++ b/metadata-ingestion/src/datahub/sdk/dataset.py
@@ -886,7 +886,7 @@ class Dataset(
 
         dialect_str = get_dialect_str(platform)
 
-        # Parse the SQL (returns sqlglot.Expression)
+        # Parse the SQL (returns sqlglot.expressions.Expression)
         try:
             dialect = sqlglot.Dialect.get_or_raise(dialect_str)
             # Type annotation uses string literal since sqlglot is lazily imported

--- a/metadata-ingestion/src/datahub/sql_parsing/_sqlglot_patch.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/_sqlglot_patch.py
@@ -253,10 +253,6 @@ def _patch_lineage() -> None:
 
 # Apply patches
 
-# sqlglot.Expression was removed as a top-level re-export in v30; restore it for
-# backward compatibility with existing DataHub type annotations.
-sqlglot.Expression = sqlglot.expressions.Expression  # type: ignore
-
 sqlglot.expressions.Expression.__deepcopy__ = _deepcopy_wrapper  # type: ignore
 _patch_scope_traverse()
 _patch_unnest_subqueries()


### PR DESCRIPTION
## Summary

- Removes the `sqlglot.Expression = sqlglot.expressions.Expression` compat shim from `_sqlglot_patch.py`
- Updates a comment in `dataset.py` that referenced `sqlglot.Expression` to use the correct `sqlglot.expressions.Expression`

No runtime code used `sqlglot.Expression` — confirmed by grepping the full codebase.
