### PR TITLE
chore(sql-parsing): remove redundant unnest_subqueries null-predicate patch

### DIFF
--- a/metadata-ingestion/src/datahub/sql_parsing/_sqlglot_patch.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/_sqlglot_patch.py
@@ -8,7 +8,6 @@ import sqlglot
 import sqlglot.expressions
 import sqlglot.lineage
 import sqlglot.optimizer.scope
-import sqlglot.optimizer.unnest_subqueries
 
 from datahub.utilities.is_pytest import is_pytest_running
 from datahub.utilities.unified_diff import apply_diff
@@ -117,39 +116,6 @@ def _patch_scope_traverse() -> None:
     sqlglot.optimizer.scope.Scope.traverse = _traverse_with_cycle_detection  # type: ignore
 
 
-def _patch_unnest_subqueries() -> None:
-    patchy.patch(
-        sqlglot.optimizer.unnest_subqueries.decorrelate,
-        """\
-@@ -148,16 +148,19 @@
-         if key in group_by:
-             key.replace(nested)
-         elif isinstance(predicate, exp.EQ):
--            parent_predicate = _replace(
--                parent_predicate,
--                f"({parent_predicate} AND ARRAY_CONTAINS({nested}, {column}))",
--            )
-+            if parent_predicate:
-+                parent_predicate = _replace(
-+                    parent_predicate,
-+                    f"({parent_predicate} AND ARRAY_CONTAINS({nested}, {column}))",
-+                )
-         else:
-             key.replace(exp.to_identifier("_x"))
--            parent_predicate = _replace(
--                parent_predicate,
--                f"({parent_predicate} AND ARRAY_ANY({nested}, _x -> {predicate}))",
--            )
-+
-+            if parent_predicate:
-+                parent_predicate = _replace(
-+                    parent_predicate,
-+                    f"({parent_predicate} AND ARRAY_ANY({nested}, _x -> {predicate}))",
-+                )
-""",
-    )
-
-
 def _patch_lineage() -> None:
     import importlib.util
     import os
@@ -255,7 +221,6 @@ def _patch_lineage() -> None:
 
 sqlglot.expressions.Expression.__deepcopy__ = _deepcopy_wrapper  # type: ignore
 _patch_scope_traverse()
-_patch_unnest_subqueries()
 _patch_lineage()
 
 SQLGLOT_PATCHED = True

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_patch.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_patch.py
@@ -7,6 +7,8 @@ import sqlglot
 import sqlglot.errors
 import sqlglot.lineage
 import sqlglot.optimizer
+import sqlglot.optimizer.unnest_subqueries
+from sqlglot import exp
 
 from datahub.utilities.cooperative_timeout import (
     CooperativeTimeoutError,
@@ -50,3 +52,37 @@ def test_lineage_node_subfield() -> None:
     expression = sqlglot.parse_one("SELECT 1 AS test")
     node = sqlglot.lineage.Node("test", expression, expression, subfield="subfield")  # type: ignore
     assert node.subfield == "subfield"  # type: ignore
+
+
+def test_decorrelate_null_parent_predicate() -> None:
+    # Regression guard for the removed _patch_unnest_subqueries() patch.
+    #
+    # When a correlated subquery is wrapped in a function (e.g. COALESCE) in the
+    # SELECT list, it is neither a direct projection nor inside a predicate, so
+    # decorrelate()'s `parent_predicate` is None. A non-EQ correlation (y.c > x.c)
+    # then routes into the ARRAY_ANY branch that interpolates `parent_predicate`,
+    # which used to crash with "'NoneType' object has no attribute 'replace'".
+    #
+    # sqlglot v30+ guards this with an early return; if a future upgrade drops
+    # that guard, this test fails instead of silently reintroducing the crash.
+    sql = "SELECT COALESCE((SELECT y.b FROM y WHERE y.a = x.a AND y.c > x.c), 0) AS c FROM x"
+    optimized = sqlglot.optimizer.unnest_subqueries.unnest_subqueries(
+        sqlglot.parse_one(sql)
+    )
+    # The guard leaves the un-decorrelatable subquery in place rather than crashing.
+    assert optimized.find(exp.Subquery) is not None
+
+
+def test_decorrelate_subquery_projection() -> None:
+    # The other shape where decorrelate()'s `parent_predicate` is None: a correlated
+    # subquery used directly as a SELECT projection. Here `is_subquery_projection` is
+    # True, so the rewrite loop takes the `continue` path and never touches the
+    # patched `parent_predicate` branches. This case is decorrelated into a LEFT JOIN
+    # (rather than left in place), so it complements the COALESCE case above.
+    sql = "SELECT x.a, (SELECT y.b FROM y WHERE y.a = x.a) AS sub FROM x"
+    optimized = sqlglot.optimizer.unnest_subqueries.unnest_subqueries(
+        sqlglot.parse_one(sql)
+    )
+    # The correlated projection is rewritten into a LEFT JOIN against an aggregated
+    # derived table; reaching this without crashing is the regression guard.
+    assert optimized.find(exp.Join) is not None


### PR DESCRIPTION
## Summary

- Removes `_patch_unnest_subqueries()` from `_sqlglot_patch.py`, which guarded two `_replace(parent_predicate, ...)` call sites against `parent_predicate` being `None`.

The patch targets the last for loop in decorrelate, specifically the part after if key in group_by.

original sqlglot

```
if key in group_by:
    key.replace(nested)
elif isinstance(predicate, exp.EQ):
    parent_predicate = _replace(
        parent_predicate,
        f"({parent_predicate} AND ARRAY_CONTAINS({nested}, {column}))",
    )
else:
    key.replace(exp.to_identifier("_x"))
    parent_predicate = _replace(
        parent_predicate,
        f"({parent_predicate} AND ARRAY_ANY({nested}, _x -> {predicate}))",
    )

```

with patch applied
```

if key in group_by:
    key.replace(nested)
elif isinstance(predicate, exp.EQ):
    if parent_predicate:                          # <-- guard added
        parent_predicate = _replace(
            parent_predicate,
            f"({parent_predicate} AND ARRAY_CONTAINS({nested}, {column}))",
        )
else:
    key.replace(exp.to_identifier("_x"))
                                                  # <-- blank line added
    if parent_predicate:                          # <-- guard added
        parent_predicate = _replace(
            parent_predicate,
            f"({parent_predicate} AND ARRAY_ANY({nested}, _x -> {predicate}))",
        )

```

## Why it's safe to remove

sqlglot v30.0.0 (https://github.com/tobymao/sqlglot/pull/7300) introduced an early return in `decorrelate()`:
```python
if parent_predicate is None and not is_subquery_projection:
    return
```
Combined with an existing continue in the loop [for the is_subquery_projection=True path](https://github.com/tobymao/sqlglot/blob/22ee9336e2f198ebea38640caa59f8f551fb1982/sqlglot/optimizer/unnest_subqueries.py#L288), parent_predicate can never be None when reaching the elif/else branches in v30+. We're on v30.8.0.

Note: Our patch and sqlglot's fix are not the same approach — ours was a broad call-site guard, theirs closes the gap through two separate mechanisms. They produce equivalent safety for all reachable paths in v30+.

History
The patch originated in the [hsheth2/sqlglot fork (PR)](https://github.com/hsheth2/sqlglot/pull/2) before sqlglot had any fix. It was ported into _sqlglot_patch.py in #11693 when we migrated from the fork to mainline sqlglot + patchy.