### PR TITLE
ci(playwright): increase timeout for fork PRs on ubuntu-latest runners

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -213,9 +213,9 @@ jobs:
                 echo "playwright_timeout=20"
               } >> "$GITHUB_OUTPUT"
             else
-              # Fork PRs on ubuntu-latest have no warm Yarn/Chromium cache; the cold
-              # start (yarn install + browser download + quickstart) easily exceeds the
-              # 20-minute budget, so we give these runs extra headroom.
+              # Fork PRs on ubuntu-latest build Docker images locally during the job
+              # (no Depot cache available), which easily exceeds the 20-minute budget.
+              # Give these runs extra headroom.
               {
                 echo "test_runner_type=ubuntu-latest"
                 echo "playwright_timeout=45"

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -94,6 +94,7 @@ jobs:
       test_runner_type: ${{ steps.set-runner.outputs.test_runner_type }}
       test_runner_type_small: ${{ steps.set-runner.outputs.test_runner_type_small }}
       use_depot_cache: ${{ steps.set-runner.outputs.use_depot_cache }}
+      playwright_timeout: ${{ steps.set-runner.outputs.playwright_timeout }}
       uv_cache_key: ${{ steps.uv-cache-key.outputs.uv_cache_key }}
       uv_cache_key_prefix: ${{ steps.uv-cache-key.outputs.uv_cache_key_prefix }}
       yarn_cache_key: ${{ steps.yarn-cache-key.outputs.yarn_cache_key }}
@@ -202,13 +203,23 @@ jobs:
               echo "test_runner_type=depot-ubuntu-24.04-4"
               echo "test_runner_type_small=depot-ubuntu-24.04-small"
               echo "use_depot_cache=true"
+              echo "playwright_timeout=20"
             } >> "$GITHUB_OUTPUT"
           else
             echo "build_runner_type=ubuntu-latest" >> "$GITHUB_OUTPUT"
             if [[ "${{ env.HAS_DEPOT_LABEL }}" == "true" ]]; then
-              echo "test_runner_type=depot-ubuntu-24.04-4" >> "$GITHUB_OUTPUT"
+              {
+                echo "test_runner_type=depot-ubuntu-24.04-4"
+                echo "playwright_timeout=20"
+              } >> "$GITHUB_OUTPUT"
             else
-              echo "test_runner_type=ubuntu-latest" >> "$GITHUB_OUTPUT"
+              # Fork PRs on ubuntu-latest have no warm Yarn/Chromium cache; the cold
+              # start (yarn install + browser download + quickstart) easily exceeds the
+              # 20-minute budget, so we give these runs extra headroom.
+              {
+                echo "test_runner_type=ubuntu-latest"
+                echo "playwright_timeout=45"
+              } >> "$GITHUB_OUTPUT"
             fi
             {
               echo "test_runner_type_small=ubuntu-latest"
@@ -1207,7 +1218,7 @@ jobs:
     name: Playwright E2E Tests (Shard ${{ matrix.shard }}/${{ matrix.shard_count }})
     runs-on: ${{ needs.setup.outputs.test_runner_type }}
     needs: [setup, base_build]
-    timeout-minutes: 20
+    timeout-minutes: ${{ fromJson(needs.setup.outputs.playwright_timeout || '20') }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.playwright_matrix || '{"include":[]}') }}

--- a/e2e-test/ui/playwright/tests/global.setup.ts
+++ b/e2e-test/ui/playwright/tests/global.setup.ts
@@ -1,3 +1,4 @@
+// TODO: remove — dummy change to trigger Playwright CI on workflow-only PRs
 /**
  * Global Setup — runs ONCE before all test projects (after auth-setup).
  *

--- a/e2e-test/ui/playwright/tests/global.setup.ts
+++ b/e2e-test/ui/playwright/tests/global.setup.ts
@@ -1,4 +1,3 @@
-// TODO: remove — dummy change to trigger Playwright CI on workflow-only PRs
 /**
  * Global Setup — runs ONCE before all test projects (after auth-setup).
  *


### PR DESCRIPTION
## Summary

Fork PRs (community contributions) run on `ubuntu-latest` without a warm Yarn or Chromium cache. The cold start — yarn install + browser download + Docker quickstart — reliably exceeds the 20-minute `timeout-minutes` budget, causing **all Playwright shards to be cancelled before any tests run**.

Observed concretely on PR #17668 (`fix/search-skip-pagination-truncation`): all 5 shards hit the 20-minute wall, produced zero artifacts, and required a maintainer to:
1. Add the `depot` label to opt the fork into Depot runners
2. Push a dummy commit to re-trigger CI

This PR eliminates that manual intervention for the cold-start case.

### Changes

- Emit a `playwright_timeout` output from the `set-runner` step:
  - **20 min** — internal PRs and fork PRs with the `depot` label (Depot runners, warm cache)
  - **45 min** — fork PRs on `ubuntu-latest` (cold start needs headroom)
- Expose `playwright_timeout` as a `setup` job output
- Use `${{ fromJson(needs.setup.outputs.playwright_timeout || '20') }}` as `timeout-minutes` in `playwright_test`

No change in behaviour for internal PRs or `depot`-labelled fork PRs.

## Test plan

- [ ] Verify a fork PR without the `depot` label gets `timeout-minutes: 45` (check the `setup` job output in the Actions log)
- [ ] Verify an internal PR still gets `timeout-minutes: 20`
- [ ] Verify a fork PR with the `depot` label still gets `timeout-minutes: 20`

🤖 Generated with [Claude Code](https://claude.com/claude-code)