### PR TITLE
ci(playwright): increase timeout for non-Depot runners in OSS workflow

### DIFF
--- a/.github/workflows/playwright-e2e-tests.yml
+++ b/.github/workflows/playwright-e2e-tests.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-slim
     outputs:
       test_runner_type: ${{ steps.set-runner.outputs.test_runner_type }}
+      playwright_timeout: ${{ steps.set-runner.outputs.playwright_timeout }}
       yarn_cache_key: ${{ steps.yarn-cache-key.outputs.yarn_cache_key }}
       yarn_cache_key_prefix: ${{ steps.yarn-cache-key.outputs.yarn_cache_key_prefix }}
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -45,6 +46,13 @@ jobs:
         id: set-runner
         run: |
           echo "test_runner_type=${{ steps.determine-runners.outputs.default-runner }}" >> "$GITHUB_OUTPUT"
+          # Give ubuntu-latest (non-Depot) runs 45 min to survive a cold start;
+          # Depot runners are fast enough to stay within 20 min.
+          if [[ "${{ steps.determine-runners.outputs.depot-config-set }}" == "true" ]]; then
+            echo "playwright_timeout=20" >> "$GITHUB_OUTPUT"
+          else
+            echo "playwright_timeout=45" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set shard count
         id: set-shard-count
@@ -90,7 +98,7 @@ jobs:
     name: Playwright E2E (Shard ${{ matrix.shard }}/${{ matrix.shard_count }})
     runs-on: ${{ needs.setup.outputs.test_runner_type }}
     needs: [setup]
-    timeout-minutes: 20
+    timeout-minutes: ${{ fromJson(needs.setup.outputs.playwright_timeout || '20') }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.matrix || '{"include":[]}') }}


### PR DESCRIPTION
## Summary

The standalone `playwright-e2e-tests.yml` workflow has the same `timeout-minutes: 20` problem as the main CI pipeline: on non-Depot runners (`ubuntu-latest` / `ubuntu-24.04`) a cold start — yarn install + Chromium download + Docker quickstart — can exceed the budget before any tests run, producing zero artifacts.

Companion to #17774, which applied the same fix to `docker-unified.yml`.

### Changes

- In the `Select runner` step, emit `playwright_timeout`:
  - **20 min** when `depot-config-set == true` (Depot runners available, warm cache)
  - **45 min** otherwise (cold start on `ubuntu-latest` needs headroom)
- Expose `playwright_timeout` as a `setup` job output
- Use `${{ fromJson(needs.setup.outputs.playwright_timeout || '20') }}` as `timeout-minutes` in `playwright_test`

No behaviour change when Depot is configured.

## Test plan

- [ ] Confirm a run on a non-Depot environment gets `timeout-minutes: 45` (check `setup` job output in the Actions log)
- [ ] Confirm a Depot-backed run still sees `timeout-minutes: 20`

🤖 Generated with [Claude Code](https://claude.com/claude-code)