### PR TITLE
ci(ci-optimization): remove empty token from dorny/paths-filter to fix false positive path detections on PRs

### DIFF
--- a/.github/actions/ci-optimization/action.yml
+++ b/.github/actions/ci-optimization/action.yml
@@ -57,7 +57,7 @@ runs:
         else
           echo "trigger=pr" >> $GITHUB_OUTPUT
         fi
-    - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
       id: filter
       with:
         filters: |

--- a/.github/actions/ci-optimization/action.yml
+++ b/.github/actions/ci-optimization/action.yml
@@ -60,7 +60,6 @@ runs:
     - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
       id: filter
       with:
-        token: "" # Empty token forces it to use raw git commands.
         filters: |
           frontend:
             - "datahub-frontend/**"

--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -35,7 +35,6 @@ jobs:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
-          token: "" # Empty token forces raw git commands
           filters: .github/path-filters/lint-jobs-filters.yml
       - uses: ./.github/actions/determine-runners
         id: runners


### PR DESCRIPTION
## Summary

- Removes `token: ""` from `dorny/paths-filter` in both `ci-optimization/action.yml` and `lint-jobs.yml`
- With an empty token, the action falls back to `git diff merge_base..auto_merge_commit`, which includes all files changed on master since the PR branched — not just the PR's own files. This caused unrelated jobs (e.g. `datahub-web-react-lint`) to trigger on PRs that didn't touch those paths.
- Without the override, the action defaults to `${{ github.token }}` and uses the GitHub API (`GET /repos/{owner}/{repo}/pulls/{number}/files`), which returns only the files the PR itself changed.

Ex: https://github.com/datahub-project/datahub/actions/runs/27003986653/job/79692482085?pr=17691#step:3:67 ran datahub-web-react lint job even though there are no changes in datahub-web-react in this PR.

## Test plan

- [ ] Open a PR that does not touch `datahub-web-react/**` and verify `datahub-web-react-lint` does not run
- [ ] Open a PR that does touch `datahub-web-react/**` and verify `datahub-web-react-lint` still runs
- [ ] Verify push and workflow_dispatch triggers continue to work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)