### PR TITLE
ci(playwright): move S3 role ARN and bucket to GitHub vars

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -1441,7 +1441,7 @@ jobs:
         if: always()
         continue-on-error: true
         with:
-          role-to-assume: ${{ secrets.PLAYWRIGHT_REPORTS_OSS_ROLE_ARN }}
+          role-to-assume: ${{ vars.PLAYWRIGHT_TEST_REPORT_PUBLISH_ROLE_ARN }}
           aws-region: us-west-2
 
       - name: Publish Playwright report to S3
@@ -1455,13 +1455,14 @@ jobs:
           GH_EVENT_NAME: ${{ github.event_name }}
           GH_RUN_ID: ${{ github.run_id }}
           GH_RUN_ATTEMPT: ${{ github.run_attempt }}
+          PLAYWRIGHT_REPORTS_S3_BUCKET: ${{ vars.PLAYWRIGHT_REPORTS_S3_BUCKET }}
         run: |
           if [[ ! -d playwright-report ]] || [[ -z "$(ls -A playwright-report 2>/dev/null)" ]]; then
             echo "No playwright-report directory — skipping S3 upload"
             exit 0
           fi
 
-          BUCKET="datahub-oss-ci-build-artifacts.dev.dh-int.zone"
+          BUCKET="${PLAYWRIGHT_REPORTS_S3_BUCKET}"
 
           WORKFLOW_NAME=$(echo "$GH_WORKFLOW" \
             | tr '[:upper:]' '[:lower:]' \

--- a/.github/workflows/playwright-e2e-tests.yml
+++ b/.github/workflows/playwright-e2e-tests.yml
@@ -295,7 +295,7 @@ jobs:
         if: always()
         continue-on-error: true
         with:
-          role-to-assume: ${{ secrets.PLAYWRIGHT_REPORTS_OSS_ROLE_ARN }}
+          role-to-assume: ${{ vars.PLAYWRIGHT_TEST_REPORT_PUBLISH_ROLE_ARN }}
           aws-region: us-west-2
 
       - name: Publish Playwright report to S3
@@ -309,13 +309,14 @@ jobs:
           GH_EVENT_NAME: ${{ github.event_name }}
           GH_RUN_ID: ${{ github.run_id }}
           GH_RUN_ATTEMPT: ${{ github.run_attempt }}
+          PLAYWRIGHT_REPORTS_S3_BUCKET: ${{ vars.PLAYWRIGHT_REPORTS_S3_BUCKET }}
         run: |
           if [[ ! -d playwright-report ]] || [[ -z "$(ls -A playwright-report 2>/dev/null)" ]]; then
             echo "No playwright-report directory — skipping S3 upload"
             exit 0
           fi
 
-          BUCKET="datahub-oss-ci-build-artifacts.dev.dh-int.zone"
+          BUCKET="${PLAYWRIGHT_REPORTS_S3_BUCKET}"
 
           WORKFLOW_NAME=$(echo "$GH_WORKFLOW" \
             | tr '[:upper:]' '[:lower:]' \

--- a/e2e-test/ui/playwright/playwright.config.ts
+++ b/e2e-test/ui/playwright/playwright.config.ts
@@ -1,5 +1,4 @@
 // Playwright configuration for DataHub E2E tests
-// trigger-ci
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({

--- a/e2e-test/ui/playwright/playwright.config.ts
+++ b/e2e-test/ui/playwright/playwright.config.ts
@@ -1,4 +1,5 @@
 // Playwright configuration for DataHub E2E tests
+// trigger-ci
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

- Replace `secrets.PLAYWRIGHT_REPORTS_OSS_ROLE_ARN` with `vars.PLAYWRIGHT_TEST_REPORT_PUBLISH_ROLE_ARN` in both workflow files — role ARNs are not sensitive and using `vars` ensures OSS and fork workflow code stays identical
- Move hardcoded S3 bucket name to `vars.PLAYWRIGHT_REPORTS_S3_BUCKET` so it can be changed without a code edit
- Applied to both `docker-unified.yml` and `playwright-e2e-tests.yml`

Addresses review comments from @devashish2203 on #17510.

**Required GitHub repo variable setup (Settings → Secrets and variables → Actions → Variables):**
- `PLAYWRIGHT_TEST_REPORT_PUBLISH_ROLE_ARN` — the IAM role ARN (previously stored as secret `PLAYWRIGHT_REPORTS_OSS_ROLE_ARN`)
- `PLAYWRIGHT_REPORTS_S3_BUCKET` — `datahub-oss-ci-build-artifacts.dev.dh-int.zone`

## Test plan

- [ ] Confirm `PLAYWRIGHT_TEST_REPORT_PUBLISH_ROLE_ARN` and `PLAYWRIGHT_REPORTS_S3_BUCKET` vars are set in repo settings before merging
- [ ] Verify Playwright report uploads to S3 successfully on a test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)