### PR TITLE
feat(auth): add LDAP groups check during OIDC login

### DIFF
--- a/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
+++ b/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
@@ -55,6 +55,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -256,6 +257,10 @@ public class OidcCallbackLogic extends DefaultCallbackLogic {
       final String userName = extractUserNameOrThrow(oidcConfigs, profile);
       final CorpuserUrn corpUserUrn = new CorpuserUrn(userName);
 
+      // If RequiredGroups has groups, ensure that the user belongs to at least one of the required
+      // groups.
+      checkRequiredGroups(profile, userName, oidcConfigs);
+
       try {
         // If just-in-time User Provisioning is enabled, try to create the DataHub user if it does
         // not exist.
@@ -322,6 +327,42 @@ public class OidcCallbackLogic extends DefaultCallbackLogic {
     }
     return internalServerError(
         "Failed to authenticate current user. Cannot find valid identity provider profile in session.");
+  }
+
+  public static void checkRequiredGroups(
+      CommonProfile profile, String userName, OidcConfigs oidcConfigs) {
+    if (!oidcConfigs.getRequiredGroups().isEmpty()) {
+      final Set<String> required = oidcConfigs.getRequiredGroups();
+      final String claimName = oidcConfigs.getGroupsClaimName();
+
+      final Set<String> userGroups = new HashSet<>();
+      if (profile.containsAttribute(claimName)) {
+        Collection<String> groupNames =
+            getGroupNames(profile, profile.getAttribute(claimName), claimName);
+        userGroups.addAll(groupNames);
+      }
+
+      Set<String> matchingGroups = new HashSet<>(userGroups);
+      matchingGroups.retainAll(required);
+
+      if (matchingGroups.isEmpty()) {
+        log.warn(
+            "User {} has none of the required groups. Required (any)={}, User has={}",
+            userName,
+            required,
+            userGroups);
+        throw new RequiredGroupsException(
+            String.format(
+                "Access denied: User %s does not have any of the required groups. Required (any): %s",
+                userName, required));
+      }
+
+      log.debug(
+          "User {} passed IAM group check. Matching groups={}, User groups={}",
+          userName,
+          matchingGroups,
+          userGroups);
+    }
   }
 
   private String extractUserNameOrThrow(

--- a/datahub-frontend/app/auth/sso/oidc/OidcConfigs.java
+++ b/datahub-frontend/app/auth/sso/oidc/OidcConfigs.java
@@ -4,8 +4,12 @@ import static auth.AuthUtils.*;
 import static auth.ConfigUtil.*;
 
 import auth.sso.SsoConfigs;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.Getter;
 
 /** Class responsible for extracting and validating OIDC related configurations. */
@@ -48,6 +52,7 @@ public class OidcConfigs extends SsoConfigs {
   public static final String OIDC_HTTP_RETRY_DELAY = "auth.oidc.httpRetryDelay";
   public static final String OIDC_ACCESS_DENIED_REDIRECT_URL = "auth.oidc.accessDeniedRedirectUrl";
   public static final String OIDC_DISABLE_PKCE = "auth.oidc.disablePkce";
+  public static final String OIDC_REQUIRED_GROUPS_CONFIG_PATH = "auth.oidc.requiredGroups";
 
   /** Default values */
   private static final String DEFAULT_OIDC_USERNAME_CLAIM = "email";
@@ -94,6 +99,9 @@ public class OidcConfigs extends SsoConfigs {
   private final Optional<String> accessDeniedRedirectUrl;
   private final boolean disablePkce;
 
+  /* Group Access Control */
+  private final Set<String> requiredGroups;
+
   public OidcConfigs(Builder builder) {
     super(builder);
     this.clientId = builder.clientId;
@@ -122,6 +130,7 @@ public class OidcConfigs extends SsoConfigs {
     this.httpRetryDelay = builder.httpRetryDelay;
     this.accessDeniedRedirectUrl = builder.accessDeniedRedirectUrl;
     this.disablePkce = builder.disablePkce;
+    this.requiredGroups = builder.requiredGroups;
   }
 
   public String getHttpRetryAttempts() {
@@ -162,6 +171,7 @@ public class OidcConfigs extends SsoConfigs {
     private String httpRetryDelay = DEFAULT_OIDC_HTTP_RETRY_DELAY;
     private Optional<String> accessDeniedRedirectUrl = Optional.empty();
     private boolean disablePkce = false;
+    private Set<String> requiredGroups = Collections.emptySet();
 
     public Builder from(final com.typesafe.config.Config configs) {
       super.from(configs);
@@ -218,6 +228,15 @@ public class OidcConfigs extends SsoConfigs {
       if (configs.hasPath(OIDC_DISABLE_PKCE)) {
         disablePkce = configs.getBoolean(OIDC_DISABLE_PKCE);
       }
+      requiredGroups =
+          getOptional(configs, OIDC_REQUIRED_GROUPS_CONFIG_PATH)
+              .map(
+                  s ->
+                      Arrays.stream(s.split(","))
+                          .map(String::trim)
+                          .filter(str -> !str.isEmpty())
+                          .collect(Collectors.toSet()))
+              .orElse(Collections.emptySet());
       return this;
     }
 

--- a/datahub-frontend/app/auth/sso/oidc/RequiredGroupsException.java
+++ b/datahub-frontend/app/auth/sso/oidc/RequiredGroupsException.java
@@ -1,0 +1,8 @@
+package auth.sso.oidc;
+
+/** Exception thrown when a user does not belong to any of the required groups for OIDC login. */
+public class RequiredGroupsException extends RuntimeException {
+  public RequiredGroupsException(String message) {
+    super(message);
+  }
+}

--- a/datahub-frontend/app/controllers/SsoCallbackController.java
+++ b/datahub-frontend/app/controllers/SsoCallbackController.java
@@ -4,6 +4,7 @@ import auth.CookieConfigs;
 import auth.sso.SsoManager;
 import auth.sso.SsoProvider;
 import auth.sso.oidc.OidcCallbackLogic;
+import auth.sso.oidc.RequiredGroupsException;
 import client.AuthServiceClient;
 import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.metadata.utils.BasePathUtils;
@@ -46,6 +47,7 @@ public class SsoCallbackController extends CallbackController {
   private final com.typesafe.config.Config configs;
   private final String normalizedBasePath;
   private final boolean authVerboseLogging;
+  private final String accessDeniedMessage;
 
   @Inject
   public SsoCallbackController(
@@ -58,6 +60,10 @@ public class SsoCallbackController extends CallbackController {
     this.ssoManager = ssoManager;
     this.config = config;
     this.configs = configs;
+    this.accessDeniedMessage =
+        configs.hasPath("auth.oidc.accessDeniedMessage")
+            ? configs.getString("auth.oidc.accessDeniedMessage")
+            : null;
 
     // Set default URL with proper base path - redirects to Home Page on log in
     normalizedBasePath = BasePathUtils.normalizeBasePath(configs.getString("datahub.basePath"));
@@ -105,19 +111,24 @@ public class SsoCallbackController extends CallbackController {
           .handle(
               (res, e) -> {
                 if (e != null) {
-                  log.error(
-                      "Caught exception while attempting to handle SSO callback! It's likely that SSO integration is mis-configured.",
-                      e);
                   String basePath =
                       BasePathUtils.normalizeBasePath(configs.getString("datahub.basePath"));
                   String loginUrl = BasePathUtils.addBasePath("/login", basePath);
+                  String message;
+                  if (e.getCause() instanceof RequiredGroupsException) {
+                    log.warn("User missing required groups.");
+                    message =
+                        (accessDeniedMessage != null && !accessDeniedMessage.isEmpty())
+                            ? accessDeniedMessage
+                            : "Access Denied: You do not belong to the required groups to access this application. Please contact your administrator.";
+                  } else {
+                    message =
+                        "Failed to sign in using Single Sign-On provider. Please try again, or contact your DataHub Administrator.";
+                  }
                   return Results.redirect(
                           String.format(
                               "%s?error_msg=%s",
-                              loginUrl,
-                              URLEncoder.encode(
-                                  "Failed to sign in using Single Sign-On provider. Please try again, or contact your DataHub Administrator.",
-                                  StandardCharsets.UTF_8)))
+                              loginUrl, URLEncoder.encode(message, StandardCharsets.UTF_8)))
                       .discardingCookie("actor")
                       .withNewSession();
                 }

--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -275,6 +275,8 @@ auth.oidc.accessDeniedRedirectUrl = ${?AUTH_OIDC_ACCESS_DENIED_REDIRECT_URL} # O
 # Pac4j 6+ enables PKCE (RFC 7636) by default. Set to true (or env AUTH_OIDC_DISABLE_PKCE) for IdPs or test mocks that do not support PKCE.
 auth.oidc.disablePkce = false
 auth.oidc.disablePkce = ${?AUTH_OIDC_DISABLE_PKCE}
+auth.oidc.accessDeniedMessage = ${?AUTH_OIDC_ACCESS_DENIED_MESSAGE} # Optional: Message to display if user is missing required groups. If not set, shows default error message.
+auth.oidc.requiredGroups = ${?AUTH_OIDC_REQUIRED_GROUPS} # Optional: Comma-separated list of required IAM groups for login. If set, users must have ANY of the specified groups. Leave unset to disable group enforcement.
 
 #
 # By default, the callback URL that should be registered with the identity provider is computed as {$baseUrl}/callback/oidc.

--- a/docs/authentication/guides/sso/configure-oidc-react.md
+++ b/docs/authentication/guides/sso/configure-oidc-react.md
@@ -108,6 +108,20 @@ AUTH_OIDC_CLIENT_AUTHENTICATION_METHOD=authentication-method
 | AUTH_OIDC_CLIENT_AUTHENTICATION_METHOD | a string representing the token authentication method to use with the identity provider. Default value is `client_secret_basic`, which uses HTTP Basic authentication. Another option is `client_secret_post`, which includes the client_id and secret_id as form parameters in the HTTP POST request. For more info, see [OAuth 2.0 Client Authentication](https://darutk.medium.com/oauth-2-0-client-authentication-4b5f929305d4) | client_secret_basic |
 | AUTH_OIDC_PREFERRED_JWS_ALGORITHM      | Can be used to select a preferred signing algorithm for id tokens. Examples include: `RS256` or `HS256`. If your IdP includes `none` before `RS256`/`HS256` in the list of signing algorithms, then this value **MUST** be set.                                                                                                                                                                                                     |                     |
 
+## SSO Group-Based Access Control and Custom Messaging
+
+DataHub's SSO (Single Sign-On) integration supports group-based access control and customizable access denied messages using the following environment variables:
+
+- `AUTH_OIDC_REQUIRED_GROUPS`: A comma-separated list of required groups, extracted from the OIDC groups claim, for login. If set, users must have ANY of the specified groups to access DataHub. If unset, group enforcement is disabled and any authenticated user can log in.
+- `AUTH_OIDC_ACCESS_DENIED_MESSAGE`: The message displayed to users who are denied access because they do not belong to the required groups. If not set, a default error message is shown.
+
+**Example usage:**
+
+```
+AUTH_OIDC_REQUIRED_GROUPS=engineering,admins
+AUTH_OIDC_ACCESS_DENIED_MESSAGE=Access Denied: You do not belong to the required groups to access this application. Please contact your administrator.
+```
+
 ### User & Group Provisioning (JIT Provisioning)
 
 By default, DataHub will optimistically attempt to provision users and groups that do not already exist at the time of login.

--- a/docs/deploy/environment-vars.md
+++ b/docs/deploy/environment-vars.md
@@ -1158,6 +1158,8 @@ Reference Links:
 | `AUTH_OIDC_JIT_PROVISIONING_ENABLED`        | `true`                | Whether DataHub users should be provisioned on login if they don't exist | Frontend   |
 | `AUTH_OIDC_PRE_PROVISIONING_REQUIRED`       | `false`               | Whether the user should already exist in DataHub on login                | Frontend   |
 | `AUTH_OIDC_EXTRACT_GROUPS_ENABLED`          | `true`                | Whether groups should be extracted from a claim in the OIDC profile      | Frontend   |
+| `AUTH_OIDC_REQUIRED_GROUPS`                 | `null`                | Comma-separated list of required groups, from the OIDC groups claim.     | Frontend   |
+| `AUTH_OIDC_ACCESS_DENIED_MESSAGE`           | `null`                | Message shown to users when denied access for missing required groups.   | Frontend   |
 | `AUTH_OIDC_GROUPS_CLAIM`                    | `groups`              | The OIDC claim to extract groups information from                        | Frontend   |
 | `AUTH_OIDC_RESPONSE_TYPE`                   | `null`                | OIDC response type                                                       | Frontend   |
 | `AUTH_OIDC_RESPONSE_MODE`                   | `null`                | OIDC response mode                                                       | Frontend   |


### PR DESCRIPTION
After OIDC authentication, optionally verify the user belongs to at least one group from AUTH_OIDC_REQUIRED_GROUPS before completing login. Denied users are redirected to the login page with AUTH_OIDC_ACCESS_DENIED_MESSAGE or a default message. Enforcement is disabled when the env var is unset.

Updates to https://github.com/datahub-project/datahub/pull/15419

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
