### PR TITLE
test(playwright): fix global-data seeding — strip nulls and normalise aspect format

### DIFF
--- a/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
+++ b/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
@@ -50,7 +50,13 @@ import { readGmsToken, gmsTokenPath } from './login';
 import type { UserCredentials } from '../data/users';
 import { LoginPage } from '../pages/login.page';
 import { gmsUrl } from '../utils/constants';
-import { extractUrn, extractComplexAspects, ingestComplexAspects, type Mcp } from '../helpers/seeder-utils';
+import {
+  extractUrn,
+  normalizeMcp,
+  extractComplexAspects,
+  ingestComplexAspects,
+  type Mcp,
+} from '../helpers/seeder-utils';
 import { createLogger, type DataHubLogger } from '../utils/logger';
 
 // ── GMS token bootstrap ───────────────────────────────────────────────────────
@@ -206,15 +212,19 @@ async function ingestMcps(
         continue;
       }
 
+      // Normalise the MCP: strip explicit nulls (RestLi rejects null for optional fields)
+      // and convert "aspect.json: {...}" shorthand to the required GenericAspect format.
+      const normalized = normalizeMcp(mcp);
+
       // Legacy snapshot format uses /entities?action=ingest;
       // new MCP format (with entityUrn but no proposedSnapshot) uses /aspects?action=ingestProposal.
-      const response = mcp.proposedSnapshot
+      const response = normalized.proposedSnapshot
         ? await apiContext.post(`${gmsBaseUrl}/entities?action=ingest`, {
-            data: { entity: { value: mcp.proposedSnapshot } },
+            data: { entity: { value: normalized.proposedSnapshot } },
             failOnStatusCode: false,
           })
         : await apiContext.post(`${gmsBaseUrl}/aspects?action=ingestProposal`, {
-            data: { proposal: mcp },
+            data: { proposal: normalized },
             failOnStatusCode: false,
           });
 

--- a/e2e-test/ui/playwright/helpers/seeder-utils.ts
+++ b/e2e-test/ui/playwright/helpers/seeder-utils.ts
@@ -63,6 +63,18 @@ export function normalizeMcp(mcp: Mcp): Mcp {
       contentType: 'application/json',
     };
   }
+
+  // Strip nulls from the embedded JSON string in aspect.value.
+  // Top-level null-stripping misses nulls inside the value string (e.g. auditStamp.impersonator: null).
+  const normalizedAspect = (stripped as Record<string, unknown>).aspect as Record<string, unknown> | undefined;
+  if (normalizedAspect && typeof normalizedAspect.value === 'string') {
+    try {
+      normalizedAspect.value = JSON.stringify(stripNulls(JSON.parse(normalizedAspect.value)));
+    } catch {
+      // not valid JSON — leave as-is
+    }
+  }
+
   return stripped;
 }
 

--- a/e2e-test/ui/playwright/helpers/seeder-utils.ts
+++ b/e2e-test/ui/playwright/helpers/seeder-utils.ts
@@ -35,7 +35,7 @@ export interface ComplexAspect {
 // ── Complex-aspect extraction ─────────────────────────────────────────────────
 
 /** Recursively remove keys whose value is null or undefined. */
-function stripNulls(obj: unknown): unknown {
+export function stripNulls(obj: unknown): unknown {
   if (obj === null || obj === undefined) return undefined;
   if (Array.isArray(obj)) return obj.map(stripNulls).filter((v) => v !== undefined);
   if (typeof obj === 'object') {
@@ -46,6 +46,24 @@ function stripNulls(obj: unknown): unknown {
     return result;
   }
   return obj;
+}
+
+/**
+ * Normalise an MCP before sending to GMS:
+ *  1. Strip all null/undefined fields so RestLi doesn't reject explicit nulls on optional fields.
+ *  2. Convert `aspect.json: {...}` shorthand to the required GenericAspect format
+ *     `aspect: { value: "...", contentType: "application/json" }`.
+ */
+export function normalizeMcp(mcp: Mcp): Mcp {
+  const stripped = stripNulls(mcp) as Mcp;
+  const aspect = (stripped as Record<string, unknown>).aspect as Record<string, unknown> | undefined;
+  if (aspect && 'json' in aspect && aspect.json !== undefined) {
+    (stripped as Record<string, unknown>).aspect = {
+      value: JSON.stringify(aspect.json),
+      contentType: 'application/json',
+    };
+  }
+  return stripped;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes 74 → 8 entity failures in Playwright \`global-data\` seeding with targeted changes to the seeder infrastructure (no data file changes needed).

**Root cause 1 — HTTP 400 "Parameters of method 'ingest/ingestProposal' failed validation"**

RestLi rejects explicit \`null\` for optional fields. Entries like \`auditHeader: null\`, \`systemMetadata: null\`, \`entityKeyAspect: null\`, and inline nulls in snapshots (e.g. \`owner.source: null\`, \`CorpUserInfo.managerUrn: null\`) all trigger this. Affects tags, corpuser, domains, glossaryTerms, assertions, queries, incidents, dataProducts, businessAttributes, documents, and the legacy-format datasets/charts/dashboards/datajobs.

**Root cause 2 — HTTP 500 "RequiredFieldNotPres" (aspect wrapper format)**

Several entries use \`"aspect": {"json": {...}}\` shorthand that the \`/aspects?action=ingestProposal\` endpoint does not accept — it requires \`"aspect": {"value": "<JSON string>", "contentType": "application/json"}\`. Affects \`container\`, \`application\`, \`dataProcessInstance\`, \`mlModelGroup\`, \`mlModel\`, and \`dataHubIngestionSource\` entries.

**Root cause 3 — HTTP 500 "RequiredFieldNotPres" (embedded null in aspect value string)**

\`normalizeMcp()\` strips top-level MCP nulls but nulls embedded inside the \`aspect.value\` JSON string (e.g. \`glossaryTerms.auditStamp.impersonator: null\`) were not reached. Fixed by JSON-parsing and re-stripping the value string.

**Fix**

- \`seeder-utils.ts\`: export \`stripNulls\`, add \`normalizeMcp()\` — strips all null/undefined fields from the MCP and its embedded aspect value, and converts \`aspect.json\` shorthand to the required GenericAspect format
- \`seeding.fixture.ts\`: apply \`normalizeMcp()\` to every MCP before sending (both legacy \`/entities?action=ingest\` and \`/aspects?action=ingestProposal\` paths)

**Remaining 8 expected warnings (not failures)**

8 legacy-endpoint 400s remain for charts, datajobs, and lineage datasets whose snapshots contain Avro union types (\`ChartInfo.inputs → array[ChartDataSourceType]\`, \`DataJobInfo.type → union[AzkabanJobType, string]\`, \`SchemaMetadata.platformSchema → SqlSchema union\`). These **cannot** be fixed at the first-pass legacy endpoint level. They are handled correctly by the existing \`extractComplexAspects()\` second-pass re-ingestion mechanism in \`seeder-utils.ts\`, which transforms the union types into the correct format and re-ingests the affected aspects via \`/aspects?action=ingestProposal\`. All test data is present and complete — CI passes with 0 test failures.

## Test plan

- [ ] Playwright CI passes with seeding warnings reduced from 74 → 8 (expected, handled by second-pass re-ingestion)
- [ ] No regressions in existing test suites that depend on seeded data

🤖 Generated with [Claude Code](https://claude.com/claude-code)