### PR TITLE
fix(looker): set HTTPAdapter pool size to match max_threads

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_config.py
@@ -1,5 +1,4 @@
 import dataclasses
-import os
 import re
 from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
 
@@ -272,10 +271,6 @@ class LookerDashboardSourceConfig(
         False,
         description="Whether to skip ingestion of dashboards in personal folders. Setting this to True will only "
         "ingest dashboards in the Shared folder space.",
-    )
-    max_threads: int = Field(
-        default_factory=lambda: os.cpu_count() or 40,
-        description="Max parallelism for Looker API calls. Defaults to cpuCount or 40",
     )
     external_base_url: Optional[str] = Field(
         None,

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_lib_wrapper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_lib_wrapper.py
@@ -1,6 +1,7 @@
 # Looker SDK is imported here and higher level wrapper functions/classes are provided to interact with Looker Server
 import json
 import logging
+import os
 from enum import Enum
 from functools import lru_cache
 from typing import Dict, List, MutableMapping, Optional, Sequence, Set, Union, cast
@@ -60,6 +61,10 @@ class LookerAPIConfig(ConfigModel):
         description="Populates the [TransportOptions](https://github.com/looker-open-source/sdk-codegen/blob/94d6047a0d52912ac082eb91616c1e7c379ab262/python/looker_sdk/rtl/transport.py#L70) struct for looker client",
     )
     max_retries: int = Field(3, description="Number of retries for Looker API calls")
+    max_threads: int = Field(
+        default_factory=lambda: os.cpu_count() or 40,
+        description="Max parallelism for Looker API calls. Defaults to cpuCount or 40",
+    )
 
 
 class LookerAPIStats(BaseModel):
@@ -129,8 +134,11 @@ class LookerAPI:
         if isinstance(
             self.client.transport, looker_requests_transport.RequestsTransport
         ):
+            pool_size = self.config.max_threads + 10
             adapter = HTTPAdapter(
                 max_retries=self.config.max_retries,
+                pool_connections=pool_size,
+                pool_maxsize=pool_size,
             )
             self.client.transport.session.mount("http://", adapter)
             self.client.transport.session.mount("https://", adapter)

--- a/metadata-ingestion/tests/unit/looker/test_looker_lib_wrapper.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_lib_wrapper.py
@@ -1,7 +1,9 @@
 import os
 from unittest import mock
 
+import looker_sdk.rtl.requests_transport as looker_requests_transport
 import pytest
+from requests.adapters import HTTPAdapter
 
 from datahub.ingestion.source.looker.looker_lib_wrapper import (
     LookerAPI,
@@ -79,3 +81,36 @@ def test_settings_read_config_ignores_lookersdk_env_vars(monkeypatch):
     assert data["client_secret"] == "real-secret"
     assert data["base_url"] == "https://real.example.com"
     assert settings.base_url == "https://real.example.com"
+
+
+def test_http_adapter_pool_size_matches_max_threads():
+    """HTTPAdapter pool size must be set to max_threads + 10 to avoid connection pool warnings."""
+    config = LookerAPIConfig(
+        base_url="https://looker.example.com",
+        client_id="test-client-id",
+        client_secret="test-client-secret",
+        max_threads=20,
+    )
+
+    mock_session = mock.MagicMock()
+    mock_transport = mock.MagicMock(spec=looker_requests_transport.RequestsTransport)
+    mock_transport.session = mock_session
+
+    mock_client = mock.MagicMock()
+    mock_client.transport = mock_transport
+
+    with (
+        mock.patch("looker_sdk.init40", return_value=mock_client),
+        mock.patch(
+            "datahub.ingestion.source.looker.looker_lib_wrapper.HTTPAdapter",
+            wraps=HTTPAdapter,
+        ) as mock_adapter_cls,
+    ):
+        LookerAPI(config=config)
+
+    mock_adapter_cls.assert_called_once_with(
+        max_retries=config.max_retries,
+        pool_connections=30,
+        pool_maxsize=30,
+    )
+    assert mock_session.mount.call_count == 2


### PR DESCRIPTION
Hey 👋 
While using the Looker source ingestion, the connector emitted repeated `urllib3` warnings during ingestion:
```
[2026-06-03 08:43:16,208] WARNING  {urllib3.connectionpool:327} - Connection pool is full, discarding connection: XYZ.cloud.looker.com. Connection pool size: 10
```
Seems like the root cause was that `HTTPAdapter` was only configured with `max_retries`, leaving the connection pool at urllib3's [default of 10](https://requests.readthedocs.io/en/latest/api/#requests.adapters.HTTPAdapter). While we made parallel API calls, the pool was consistently exhausted, causing connections to be discarded and re-created.

This PR:
1. Moves the `max_threads` from `LookerDashboardSourceConfig` to `LookerAPIConfig`.
2. Sets `pool_connections` and `pool_maxsize` on the `HTTPAdapter` to `max_threads + 10` (same as the Superset source connector)
3. Add a unit test that verifies the pool size.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
