### PR TITLE
docs: add connector CLI version pinning page

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -1,6 +1,7 @@
 // note: to handle errors where you don't want a markdown file in the sidebar, add it as a comment.
 // this will fix errors like `Error: File not accounted for in sidebar: ...`
 // smoke-test/tests/library_examples/README.md
+// docs/managed-datahub/connector-versioning/connector-version-pinning
 module.exports = {
   overviewSidebar: [
     // Getting Started.

--- a/docs/managed-datahub/connector-versioning/connector-version-pinning.md
+++ b/docs/managed-datahub/connector-versioning/connector-version-pinning.md
@@ -1,0 +1,14 @@
+---
+title: Connector CLI Version Pinning
+description: Pin a specific ingestion connector to a specific DataHub CLI version, independently of other connectors.
+---
+
+import FeatureAvailability from '@site/src/components/FeatureAvailability';
+
+# Connector CLI Version Pinning
+
+<FeatureAvailability saasOnly />
+
+Connector CLI version pinning lets you assign a specific DataHub CLI version to a specific connector type, independently of every other connector.
+
+<!-- Configuration and usage details to follow. -->


### PR DESCRIPTION
## Summary

Adds a minimal documentation page for the connector CLI version pinning feature, which allows assigning a specific DataHub CLI version to a specific connector type, independently of other connectors.

- New page: `docs/managed-datahub/connector-versioning/connector-version-pinning.md`
- New folder `connector-versioning/` to house this and related docs going forward
- Registered in `sidebars.js` per the repo's comment convention

## Notes

- The page is intentionally minimal; configuration and usage details to follow.

## Test plan

- [ ] Build docs locally and confirm the page renders without warnings
EOF