### PR TITLE
ci: skip metadata model upload when DataHub secret is unset instead of failing

### DIFF
--- a/.github/workflows/metadata-model.yml
+++ b/.github/workflows/metadata-model.yml
@@ -19,12 +19,22 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       publish: ${{ steps.publish.outputs.publish }}
+      datahub_configured: ${{ steps.publish.outputs.datahub_configured }}
     steps:
       - name: Check whether upload to datahub is enabled
         id: publish
+        # secrets cannot be referenced directly in step `if:` conditions, so we
+        # resolve the DataHub target here and expose a boolean output instead.
+        env:
+          DATAHUB_SERVER: ${{ secrets.DataHubServer }}
         run: |
           echo "Enable publish: ${{ github.repository == 'datahub-project/datahub' }}"
           echo "publish=${{ github.repository == 'datahub-project/datahub' }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$DATAHUB_SERVER" ]; then
+            echo "datahub_configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "datahub_configured=false" >> "$GITHUB_OUTPUT"
+          fi
   metadata-ingestion-docgen:
     runs-on: ubuntu-latest
     needs: setup
@@ -57,8 +67,11 @@ jobs:
       - name: Upload metadata to S3
         if: ${{ needs.setup.outputs.publish == 'true' }}
         run: aws s3 cp ./metadata-ingestion/generated/docs/metadata_model_mces.json s3://${{ secrets.ACRYL_CI_ARTIFACTS_BUCKET }}/datahub/demo/metadata/
+      - name: Warn if DataHub upload target is not configured
+        if: ${{ needs.setup.outputs.publish == 'true' && needs.setup.outputs.datahub_configured != 'true' }}
+        run: echo "::warning::Skipping 'Upload metadata to DataHub' because the DataHubServer secret is not set. The model was still generated and uploaded to S3."
       - name: Upload metadata to DataHub
-        if: ${{ needs.setup.outputs.publish == 'true' }}
+        if: ${{ needs.setup.outputs.publish == 'true' && needs.setup.outputs.datahub_configured == 'true' }}
         env:
           DATAHUB_SERVER: ${{ secrets.DataHubServer }}
           DATAHUB_TOKEN: ${{ secrets.DataHubToken }}


### PR DESCRIPTION
## Summary

The `metadata model generate` workflow (`.github/workflows/metadata-model.yml`) gated its publishing steps on whether the run is on the canonical repo (`needs.setup.outputs.publish`), but **not** on whether the DataHub upload target was actually configured.

When the `DataHubServer` secret is empty or expired, the `Upload metadata to DataHub` step falls back to the DataHub CLI default of `http://localhost:8080`, retries for ~28s, and then fails the entire workflow with a connection-refused error — even though model generation and the S3 upload both succeeded.

Observed in [this run](https://github.com/datahub-project/datahub/actions/runs/27132469737/job/80076595458):

```
Failed to configure the sink (datahub-rest): 💥 Failed to connect to DataHub
with DataHubRestEmitter: configured to talk to http://localhost:8080
...
ConnectionRefusedError: [Errno 111] Connection refused
```

## Changes

- Resolve the `DataHubServer` secret into a `datahub_configured` boolean output in the `setup` job. (Secrets cannot be referenced directly in step `if:` conditions, so the check is done once in a `run:` step and exposed as an output, mirroring the existing `publish` gate.)
- Gate the `Upload metadata to DataHub` step on `datahub_configured == 'true'`.
- Emit a `::warning::` annotation when publishing is enabled but the secret is missing, so the skip is visible in the Actions summary without hard-failing the run.

## Behavior

| Scenario | Before | After |
| --- | --- | --- |
| Secret set | uploads | uploads |
| Secret empty/expired | **workflow fails** (connection refused) | model still generated + uploaded to S3; upload step skipped with a warning |

Note: this makes the workflow resilient to a missing secret — it does not replace setting/refreshing the `DataHubServer` / `DataHubToken` secrets when the live publish is actually desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)