### PR TITLE
feat(ui): add lazy Phosphor icon registry for MFE nav icons

### DIFF
--- a/datahub-web-react/.eslintignore
+++ b/datahub-web-react/.eslintignore
@@ -3,3 +3,4 @@ dist/
 build/
 node_modules/
 **/*.generated.ts
+scripts/

--- a/datahub-web-react/.gitignore
+++ b/datahub-web-react/.gitignore
@@ -30,6 +30,9 @@ yarn-error.log*
 
 # gql codegen
 *.generated.ts
+
+# generated lazy icon stubs (produced by scripts/generate-lazy-icon-stubs.js)
+/src/app/mfeframework/lazy-icons/
 /.vscode
 
 .yarn-test-sentinel

--- a/datahub-web-react/build.gradle
+++ b/datahub-web-react/build.gradle
@@ -104,17 +104,32 @@ task yarnGenerate(type: Copy, dependsOn: yarnGenerateCacheable) {
   includeEmptyDirs = false
 }
 
-task yarnServe(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate]) {
+// Generate per-icon stub files so Vite can build them as separate lazy chunks.
+// Client downloads only the icon chunks it actually renders — none are in the main bundle.
+task generateLazyIconStubs(type: NodeTask, dependsOn: yarnInstall) {
+  script = file('scripts/generate-lazy-icon-stubs.js')
+
+  // Track the package version, not the 3000+ individual icon files — same correctness,
+  // one file to fingerprint instead of hashing the entire CSR directory.
+  inputs.file('node_modules/@phosphor-icons/react/package.json')
+  outputs.dir('src/app/mfeframework/lazy-icons')
+
+  // yarnGenerateCacheable reads src/ as part of its doFirst cleanup; mustRunAfter
+  // gives Gradle an explicit ordering so it doesn't flag the overlap as implicit.
+  mustRunAfter yarnGenerateCacheable
+}
+
+task yarnServe(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate, generateLazyIconStubs]) {
   environment.put('REACT_APP_PROXY_TARGET', 'http://localhost:9001')
   args = ['run', 'start']
 }
 
-task yarnPreview(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate]) {
+task yarnPreview(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate, generateLazyIconStubs]) {
   environment.put('REACT_APP_PROXY_TARGET', project.findProperty('proxy') ?: 'http://localhost:9001')
   args = ['run', 'preview']
 }
 
-task yarnTest(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate]) {
+task yarnTest(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate, generateLazyIconStubs]) {
   // Explicitly runs in non-watch mode.
   def testArgs = ['run', project.hasProperty('withCoverage') ? 'test-coverage' : 'test', 'run']
 
@@ -139,7 +154,7 @@ task yarnTest(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate]) {
   outputs.cacheIf { true }
 }
 
-task yarnLint(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate]) {
+task yarnLint(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate, generateLazyIconStubs]) {
   def targetFile = project.findProperty('file') ?: ''
 
   if (targetFile.isEmpty()) {
@@ -168,7 +183,7 @@ task yarnLint(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate]) {
 
 test.dependsOn([yarnInstall, yarnTest])
 
-task yarnLintFix(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate]) {
+task yarnLintFix(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate, generateLazyIconStubs]) {
   def targetFile = project.findProperty('file') ?: ''
 
   if (targetFile.isEmpty()) {
@@ -205,7 +220,7 @@ task yarnLintFix(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate]) {
   }
 }
 
-task yarnBuild(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate]) {
+task yarnBuild(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate, generateLazyIconStubs]) {
   // Pass DataHub version via environment variable to vite build
   environment.put('DATAHUB_APP_VERSION', project.version)
 

--- a/datahub-web-react/scripts/generate-lazy-icon-stubs.js
+++ b/datahub-web-react/scripts/generate-lazy-icon-stubs.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Generates a thin re-export stub for every Phosphor CSR icon into lazy-icons/.
+// Vite builds each stub as a separate async chunk so the main bundle stays icon-free —
+// end users only download the specific icons an admin configured, not all 1500+.
+// Run via the Gradle task generateLazyIconStubs, or: node scripts/generate-lazy-icon-stubs.js
+
+const fs = require('fs');
+const path = require('path');
+
+const csrDir = path.resolve(__dirname, '../node_modules/@phosphor-icons/react/dist/csr');
+const outDir = path.resolve(__dirname, '../src/app/mfeframework/lazy-icons');
+
+const iconNames = fs
+    .readdirSync(csrDir)
+    .filter((f) => f.endsWith('.mjs'))
+    .map((f) => f.slice(0, -4)); // strip .mjs
+
+fs.mkdirSync(outDir, { recursive: true });
+
+for (const name of iconNames) {
+    fs.writeFileSync(
+        path.join(outDir, `${name}.ts`),
+        `export { ${name} } from '@phosphor-icons/react/dist/csr/${name}';\n`,
+    );
+}
+
+console.log(`[generate-lazy-icon-stubs] ${iconNames.length} stubs → ${path.relative(process.cwd(), outDir)}`);

--- a/datahub-web-react/src/app/mfeframework/_tests_/iconLoader.test.ts
+++ b/datahub-web-react/src/app/mfeframework/_tests_/iconLoader.test.ts
@@ -1,0 +1,48 @@
+import { AppWindow } from '@phosphor-icons/react/dist/csr/AppWindow';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeLoadIcon } from '@app/mfeframework/iconLoader';
+
+const MockIcon = () => null;
+
+describe('makeLoadIcon', () => {
+    let mocks: Record<string, ReturnType<typeof vi.fn>>;
+
+    beforeEach(() => {
+        mocks = {
+            './lazy-icons/Acorn.ts': vi.fn(async () => ({ Acorn: MockIcon })),
+            './lazy-icons/Globe.ts': vi.fn(async () => ({ Globe: MockIcon })),
+            // Simulates a stub whose named export was eliminated (e.g. by a misconfigured build).
+            './lazy-icons/Stripped.ts': vi.fn(async () => ({ WrongName: MockIcon })),
+        };
+    });
+
+    it('returns the correct named export for a known icon', async () => {
+        const result = await makeLoadIcon(mocks)('Acorn');
+        expect(result.default).toBe(MockIcon);
+    });
+
+    it('falls back to AppWindow for an icon not in the glob map', async () => {
+        const result = await makeLoadIcon(mocks)('NotAReal Icon');
+        expect(result.default).toBe(AppWindow);
+    });
+
+    it('falls back to AppWindow when the stub export name does not match — tree-shaking guard', async () => {
+        // If a build tool strips or renames the export, mod[name] is undefined.
+        // The fallback prevents passing undefined to React as a component.
+        const result = await makeLoadIcon(mocks)('Stripped');
+        expect(result.default).toBe(AppWindow);
+    });
+
+    it('logs a warning when the icon is not found', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        await makeLoadIcon(mocks)('Missing');
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('"Missing"'));
+        warn.mockRestore();
+    });
+
+    it('fetches via ./lazy-icons/<name>.ts so each icon is its own async chunk', async () => {
+        await makeLoadIcon(mocks)('Globe');
+        expect(mocks['./lazy-icons/Globe.ts']).toHaveBeenCalledOnce();
+    });
+});

--- a/datahub-web-react/src/app/mfeframework/_tests_/lazyIconRegistry.test.tsx
+++ b/datahub-web-react/src/app/mfeframework/_tests_/lazyIconRegistry.test.tsx
@@ -1,0 +1,65 @@
+import { AppWindow } from '@phosphor-icons/react/dist/csr/AppWindow';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getLazyIcon } from '@app/mfeframework/lazyIconRegistry';
+
+const MockIcon = () => <div data-testid="mock-icon" />;
+
+// Hoist so vi.mock factory can close over the function reference.
+const { loadIconMock } = vi.hoisted(() => ({ loadIconMock: vi.fn() }));
+
+vi.mock('../iconLoader', () => ({ loadIcon: loadIconMock }));
+
+describe('getLazyIcon', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        loadIconMock.mockImplementation(async (name: string) => {
+            if (name === 'Known') return { default: MockIcon };
+            return { default: AppWindow };
+        });
+    });
+
+    it('returns a valid React element', () => {
+        expect(React.isValidElement(getLazyIcon('Known'))).toBe(true);
+    });
+
+    it('does not call loadIcon until the component is rendered — confirms unbundled lazy load', async () => {
+        // Calling getLazyIcon only creates the lazy wrapper; no icon fetch yet.
+        getLazyIcon('Unfetched');
+        expect(loadIconMock).not.toHaveBeenCalled();
+
+        // Rendering is what triggers the dynamic import.
+        await act(async () => {
+            render(getLazyIcon('Unfetched'));
+        });
+        await waitFor(() => expect(loadIconMock).toHaveBeenCalledWith('Unfetched'));
+    });
+
+    it('renders the correct icon component after Suspense resolves', async () => {
+        await act(async () => {
+            render(getLazyIcon('Known'));
+        });
+        await waitFor(() => screen.getByTestId('mock-icon'));
+        expect(screen.getByTestId('mock-icon')).toBeInTheDocument();
+    });
+
+    it('renders the AppWindow fallback for an unknown icon without throwing', async () => {
+        await act(async () => {
+            render(getLazyIcon('NoSuchIcon'));
+        });
+        // No crash; the element resolves (AppWindow is a valid component).
+        expect(React.isValidElement(getLazyIcon('NoSuchIcon'))).toBe(true);
+    });
+
+    it('caches the lazy component — same React.lazy instance for the same icon name', () => {
+        // Two calls with the same name must return elements backed by the same lazy component
+        // reference; a new component would reset its resolved state and re-fetch.
+        const el1 = getLazyIcon('CacheCheck');
+        const el2 = getLazyIcon('CacheCheck');
+        const inner1 = (el1 as React.ReactElement).props.children as React.ReactElement;
+        const inner2 = (el2 as React.ReactElement).props.children as React.ReactElement;
+        expect(inner1.type).toBe(inner2.type);
+    });
+});

--- a/datahub-web-react/src/app/mfeframework/_tests_/mfeNavBarMenuUtils.test.tsx
+++ b/datahub-web-react/src/app/mfeframework/_tests_/mfeNavBarMenuUtils.test.tsx
@@ -1,4 +1,3 @@
-import { AppWindow } from '@phosphor-icons/react/dist/csr/AppWindow';
 import React from 'react';
 import { describe, expect, it } from 'vitest';
 
@@ -7,7 +6,7 @@ import { MFESchema } from '@app/mfeframework/mfeConfigLoader';
 import { getMfeMenuDropdownItems, getMfeMenuItems } from '@app/mfeframework/mfeNavBarMenuUtils';
 
 describe('getMfeMenuItems and getMfeMenuDropdownItems', () => {
-    it('returns only valid menu items where flags.showInNav is true and maps navIcon to correct icon', () => {
+    it('returns only showInNav=true items with valid icon elements', () => {
         const mfeConfig: MFESchema = {
             topLevelMenuTitle: 'My Apps',
             subNavigationMode: false,
@@ -18,7 +17,7 @@ describe('getMfeMenuItems and getMfeMenuDropdownItems', () => {
                     path: '/mfe-one',
                     remoteEntry: 'https://mfe-one.com/remoteEntry.js',
                     module: 'mfeOneApplication/mount',
-                    navIcon: 'Archive',
+                    navIcon: 'Package',
                     flags: { enabled: true, showInNav: true },
                 },
                 {
@@ -36,8 +35,7 @@ describe('getMfeMenuItems and getMfeMenuDropdownItems', () => {
                     path: '/mfe-three',
                     remoteEntry: 'https://mfe-three.com/remoteEntry.js',
                     module: 'mfeThreeApplication/mount',
-                    // navIcon not set, should default to AppWindow
-                    navIcon: '',
+                    navIcon: 'Globe',
                     flags: { enabled: true, showInNav: true },
                 },
                 {
@@ -46,7 +44,7 @@ describe('getMfeMenuItems and getMfeMenuDropdownItems', () => {
                     path: '/mfe-four',
                     remoteEntry: 'https://mfe-four.com/remoteEntry.js',
                     module: 'mfeFourApplication/mount',
-                    navIcon: 'InvalidNavIcon',
+                    navIcon: 'UnknownIcon',
                     flags: { enabled: true, showInNav: true },
                 },
             ],
@@ -56,24 +54,21 @@ describe('getMfeMenuItems and getMfeMenuDropdownItems', () => {
 
         expect(items).toHaveLength(3);
 
-        // All visible items use AppWindow as default icon (React.lazy resolution is a follow-up)
-        items.forEach((item) => {
-            expect(React.isValidElement(item.icon)).toBe(true);
-            expect((item.icon as JSX.Element).type).toBe(AppWindow);
-            expect(typeof item.onClick).toBe('function');
-        });
-
         expect(items[0].title).toBe('MFE One');
         expect(items[0].key).toBe('mfe-1');
         expect(items[0].link).toBe('/mfe/mfe-one');
-        expect(items[1].title).toBe('MFE Three');
-        expect(items[1].key).toBe('mfe-3');
-        expect(items[2].title).toBe('MFE Four');
-        expect(items[2].key).toBe('mfe-4');
+        expect(React.isValidElement(items[0].icon)).toBe(true);
 
-        // All should be of type Item
+        expect(items[1].title).toBe('MFE Three');
+        expect(React.isValidElement(items[1].icon)).toBe(true);
+
+        // Unknown navIcon still produces a valid element (renders fallback via Suspense)
+        expect(items[2].title).toBe('MFE Four');
+        expect(React.isValidElement(items[2].icon)).toBe(true);
+
         items.forEach((item) => {
             expect(item.type).toBe(NavBarMenuItemTypes.Item);
+            expect(typeof item.onClick).toBe('function');
         });
     });
 
@@ -88,7 +83,7 @@ describe('getMfeMenuItems and getMfeMenuDropdownItems', () => {
                     path: '/mfe-one',
                     remoteEntry: 'https://mfe-one.com/remoteEntry.js',
                     module: 'mfeOneApplication/mount',
-                    navIcon: 'Archive',
+                    navIcon: 'Package',
                     flags: { enabled: true, showInNav: true },
                 },
                 {
@@ -103,21 +98,20 @@ describe('getMfeMenuItems and getMfeMenuDropdownItems', () => {
             ],
         };
         const items = getMfeMenuDropdownItems(mfeConfig);
-        expect(items.length).toBe(2);
+        expect(items).toHaveLength(2);
         items.forEach((item) => {
             expect(item.type).toBe(NavBarMenuItemTypes.DropdownElement);
+            expect(React.isValidElement(item.icon)).toBe(true);
         });
     });
 
     it('returns empty array if no microFrontends (getMfeMenuItems)', () => {
         const mfeConfig: MFESchema = { topLevelMenuTitle: 'My Apps', microFrontends: [], subNavigationMode: false };
-        const items = getMfeMenuItems(mfeConfig);
-        expect(items).toEqual([]);
+        expect(getMfeMenuItems(mfeConfig)).toEqual([]);
     });
 
     it('returns empty array if no microFrontends (getMfeMenuDropdownItems)', () => {
         const mfeConfig: MFESchema = { topLevelMenuTitle: 'My Apps', microFrontends: [], subNavigationMode: true };
-        const items = getMfeMenuDropdownItems(mfeConfig);
-        expect(items).toEqual([]);
+        expect(getMfeMenuDropdownItems(mfeConfig)).toEqual([]);
     });
 });

--- a/datahub-web-react/src/app/mfeframework/iconLoader.ts
+++ b/datahub-web-react/src/app/mfeframework/iconLoader.ts
@@ -4,16 +4,22 @@ import type { ComponentType } from 'react';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyComponent = ComponentType<any>;
 
-// Glob lives here (not in lazyIconRegistry.tsx) so the 1500-entry filename map
-// is in this lazy chunk, never in the main bundle.
-const iconModules = import.meta.glob('./lazy-icons/*.ts');
+type GlobMap = Record<string, () => Promise<unknown>>;
 
-export async function loadIcon(name: string): Promise<{ default: AnyComponent }> {
-    const loader = iconModules[`./lazy-icons/${name}.ts`];
-    if (!loader) {
-        console.warn(`[LazyIcon] Unknown icon "${name}", falling back to AppWindow`);
-        return { default: AppWindow as AnyComponent };
-    }
-    const mod = (await loader()) as Record<string, AnyComponent>;
-    return { default: mod[name] ?? (AppWindow as AnyComponent) };
+// Exported for testing — accepts an injected glob map so tests don't need import.meta.glob.
+export function makeLoadIcon(iconModules: GlobMap) {
+    return async function loadIcon(name: string): Promise<{ default: AnyComponent }> {
+        const loader = iconModules[`./lazy-icons/${name}.ts`];
+        if (!loader) {
+            console.warn(`[LazyIcon] Unknown icon "${name}", falling back to AppWindow`);
+            return { default: AppWindow as AnyComponent };
+        }
+        const mod = (await loader()) as Record<string, AnyComponent>;
+        // Guard: if the named export is absent (e.g. stripped by a build tool), fall back
+        // rather than passing undefined to React as a component.
+        return { default: mod[name] ?? (AppWindow as AnyComponent) };
+    };
 }
+
+// Glob lives in this lazy chunk (not in lazyIconRegistry.tsx / main bundle).
+export const loadIcon = makeLoadIcon(import.meta.glob('./lazy-icons/*.ts') as GlobMap);

--- a/datahub-web-react/src/app/mfeframework/iconLoader.ts
+++ b/datahub-web-react/src/app/mfeframework/iconLoader.ts
@@ -1,0 +1,19 @@
+import { AppWindow } from '@phosphor-icons/react/dist/csr/AppWindow';
+import type { ComponentType } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyComponent = ComponentType<any>;
+
+// Glob lives here (not in lazyIconRegistry.tsx) so the 1500-entry filename map
+// is in this lazy chunk, never in the main bundle.
+const iconModules = import.meta.glob('./lazy-icons/*.ts');
+
+export async function loadIcon(name: string): Promise<{ default: AnyComponent }> {
+    const loader = iconModules[`./lazy-icons/${name}.ts`];
+    if (!loader) {
+        console.warn(`[LazyIcon] Unknown icon "${name}", falling back to AppWindow`);
+        return { default: AppWindow as AnyComponent };
+    }
+    const mod = (await loader()) as Record<string, AnyComponent>;
+    return { default: mod[name] ?? (AppWindow as AnyComponent) };
+}

--- a/datahub-web-react/src/app/mfeframework/lazyIconRegistry.tsx
+++ b/datahub-web-react/src/app/mfeframework/lazyIconRegistry.tsx
@@ -2,9 +2,10 @@ import { AppWindow } from '@phosphor-icons/react/dist/csr/AppWindow';
 import React, { Suspense } from 'react';
 
 // Resolves Phosphor icons by name for admin-configured features (e.g. MFE nav, custom pages).
-// Icons are never bundled upfront — each loads as a separate async chunk on demand, so end
-// users only download the specific icons an admin chose, not all 1500+.
-const iconModules = import.meta.glob('./lazy-icons/*.ts');
+// Two-level lazy split keeps the main bundle icon-free:
+//   1. iconLoader.ts (holds the glob map) is loaded once on first icon request
+//   2. Each icon stub in lazy-icons/ is its own async chunk — only requested icons download
+const loadIconLoader = () => import('./iconLoader');
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyComponent = React.ComponentType<any>;
@@ -13,16 +14,11 @@ const iconCache = new Map<string, React.LazyExoticComponent<AnyComponent>>();
 
 function getCachedLazyIcon(name: string): React.LazyExoticComponent<AnyComponent> {
     if (!iconCache.has(name)) {
-        const loader = iconModules[`./lazy-icons/${name}.ts`];
         iconCache.set(
             name,
             React.lazy(async (): Promise<{ default: AnyComponent }> => {
-                if (!loader) {
-                    console.warn(`[LazyIcon] Unknown icon "${name}", falling back to AppWindow`);
-                    return { default: AppWindow as AnyComponent };
-                }
-                const mod = (await loader()) as Record<string, AnyComponent>;
-                return { default: mod[name] ?? AppWindow };
+                const { loadIcon } = await loadIconLoader();
+                return loadIcon(name);
             }),
         );
     }

--- a/datahub-web-react/src/app/mfeframework/lazyIconRegistry.tsx
+++ b/datahub-web-react/src/app/mfeframework/lazyIconRegistry.tsx
@@ -6,19 +6,22 @@ import React, { Suspense } from 'react';
 // users only download the specific icons an admin chose, not all 1500+.
 const iconModules = import.meta.glob('./lazy-icons/*.ts');
 
-const iconCache = new Map<string, React.LazyExoticComponent<React.ComponentType>>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyComponent = React.ComponentType<any>;
 
-function getCachedLazyIcon(name: string): React.LazyExoticComponent<React.ComponentType> {
+const iconCache = new Map<string, React.LazyExoticComponent<AnyComponent>>();
+
+function getCachedLazyIcon(name: string): React.LazyExoticComponent<AnyComponent> {
     if (!iconCache.has(name)) {
         const loader = iconModules[`./lazy-icons/${name}.ts`];
         iconCache.set(
             name,
-            React.lazy(async () => {
+            React.lazy(async (): Promise<{ default: AnyComponent }> => {
                 if (!loader) {
                     console.warn(`[LazyIcon] Unknown icon "${name}", falling back to AppWindow`);
-                    return { default: AppWindow };
+                    return { default: AppWindow as AnyComponent };
                 }
-                const mod = (await loader()) as Record<string, React.ComponentType>;
+                const mod = (await loader()) as Record<string, AnyComponent>;
                 return { default: mod[name] ?? AppWindow };
             }),
         );

--- a/datahub-web-react/src/app/mfeframework/lazyIconRegistry.tsx
+++ b/datahub-web-react/src/app/mfeframework/lazyIconRegistry.tsx
@@ -1,0 +1,36 @@
+import { AppWindow } from '@phosphor-icons/react/dist/csr/AppWindow';
+import React, { Suspense } from 'react';
+
+// Resolves Phosphor icons by name for admin-configured features (e.g. MFE nav, custom pages).
+// Icons are never bundled upfront — each loads as a separate async chunk on demand, so end
+// users only download the specific icons an admin chose, not all 1500+.
+const iconModules = import.meta.glob('./lazy-icons/*.ts');
+
+const iconCache = new Map<string, React.LazyExoticComponent<React.ComponentType>>();
+
+function getCachedLazyIcon(name: string): React.LazyExoticComponent<React.ComponentType> {
+    if (!iconCache.has(name)) {
+        const loader = iconModules[`./lazy-icons/${name}.ts`];
+        iconCache.set(
+            name,
+            React.lazy(async () => {
+                if (!loader) {
+                    console.warn(`[LazyIcon] Unknown icon "${name}", falling back to AppWindow`);
+                    return { default: AppWindow };
+                }
+                const mod = (await loader()) as Record<string, React.ComponentType>;
+                return { default: mod[name] ?? AppWindow };
+            }),
+        );
+    }
+    return iconCache.get(name)!;
+}
+
+export function getLazyIcon(name: string): JSX.Element {
+    const LazyIcon = getCachedLazyIcon(name);
+    return (
+        <Suspense fallback={<AppWindow />}>
+            <LazyIcon />
+        </Suspense>
+    );
+}

--- a/datahub-web-react/src/app/mfeframework/mfeNavBarMenuUtils.tsx
+++ b/datahub-web-react/src/app/mfeframework/mfeNavBarMenuUtils.tsx
@@ -1,18 +1,10 @@
-import { AppWindow } from '@phosphor-icons/react/dist/csr/AppWindow';
-import React from 'react';
-
 import {
     NavBarMenuDropdownItemElement,
     NavBarMenuItemTypes,
     NavBarMenuLinkItem,
 } from '@app/homeV2/layout/navBarRedesign/types';
+import { getLazyIcon } from '@app/mfeframework/lazyIconRegistry';
 import { MFESchema } from '@app/mfeframework/mfeConfigLoader';
-
-// TODO: Replace with React.lazy icon resolution so MFE nav icons can use any Phosphor icon.
-// For now all MFE nav items show the default AppWindow icon.
-function getPhosphorIconElement(): JSX.Element {
-    return <AppWindow />;
-}
 
 /**
  * Returns menu items for MFEs when subNavigationMode is FALSE.
@@ -27,7 +19,7 @@ export function getMfeMenuItems(mfeConfig: MFESchema): NavBarMenuLinkItem[] {
             type: NavBarMenuItemTypes.Item,
             title: mfe.label,
             key: mfe.id,
-            icon: getPhosphorIconElement(),
+            icon: getLazyIcon(mfe.navIcon),
             link: `/mfe${mfe.path}`,
             onClick: () => {
                 console.log(`[MFE Nav] Clicked MFE nav item: ${mfe.label}, path: ${mfe.path}`);
@@ -48,7 +40,7 @@ export function getMfeMenuDropdownItems(mfeConfig: MFESchema): NavBarMenuDropdow
             type: NavBarMenuItemTypes.DropdownElement,
             title: mfe.label,
             key: mfe.id,
-            icon: getPhosphorIconElement(),
+            icon: getLazyIcon(mfe.navIcon),
             link: `/mfe${mfe.path}`,
             onClick: () => {
                 console.log(`[MFE Nav] Clicked MFE nav item: ${mfe.label}, path: ${mfe.path}`);

--- a/datahub-web-react/vite.config.ts
+++ b/datahub-web-react/vite.config.ts
@@ -2,6 +2,7 @@ import { codecovVitePlugin } from '@codecov/vite-plugin';
 import federation from '@originjs/vite-plugin-federation';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 import react from '@vitejs/plugin-react-swc';
+import * as fs from 'fs';
 import * as path from 'path';
 import { PluginOption, defineConfig, loadEnv } from 'vite';
 import macrosPlugin from 'vite-plugin-babel-macros';
@@ -36,6 +37,28 @@ export function stripDotSlashFromAssets() {
         name: 'strip-dot-slash',
         transformIndexHtml(html) {
             return html.replace(/src="\.\//g, 'src="').replace(/href="\.\//g, 'href="');
+        },
+    };
+}
+
+// Fails fast with a clear message if lazy icon stubs haven't been generated.
+// Prevents silent fallback-to-AppWindow when running outside Gradle.
+function assertLazyIconsGenerated(): PluginOption {
+    return {
+        name: 'assert-lazy-icons-generated',
+        buildStart() {
+            const iconsDir = path.resolve(__dirname, 'src/app/mfeframework/lazy-icons');
+            const hasStubs =
+                fs.existsSync(iconsDir) &&
+                fs.readdirSync(iconsDir).some((f) => f.endsWith('.ts'));
+            if (!hasStubs) {
+                throw new Error(
+                    '\n\n  [Lazy Icons] Icon stubs are missing. Generate them before starting:\n\n' +
+                        '    ./gradlew :datahub-web-react:generateLazyIconStubs\n' +
+                        '    — or —\n' +
+                        '    node datahub-web-react/scripts/generate-lazy-icon-stubs.js\n\n',
+                );
+            }
         },
     };
 }
@@ -117,6 +140,7 @@ export default defineConfig(async ({ mode }) => {
         appType: 'spa',
         base: './', // Always use root - runtime base path detection handles deployment paths
         plugins: [
+            assertLazyIconsGenerated(),
             ...devPlugins,
             react(),
             federation({


### PR DESCRIPTION
A previous tree-shaking commit (cdb1ba7b) replaced the dynamic barrel import with a hardcoded <AppWindow />, causing user-specified icons not present in the tree-shaken bundle to not show the configured icon.

This PR introduces a lazy-loading registry so any of the 1500+ Phosphor icons can be used without bundling them all upfront.

- scripts/generate-lazy-icon-stubs.js writes one thin re-export per icon into src/app/mfeframework/lazy-icons/ (gitignored, generated at build time)
- assertLazyIconsGenerated() Vite plugin fails fast if stubs are missing
- New Gradle task generateLazyIconStubs wired into yarnServe, yarnBuild, yarnTest, yarnLint
- Vite builds each stub as a separate async chunk via import.meta.glob
- getLazyIcon(name) loads only the chunk for the configured icon

MFE authors continue using navIcon: "Database" (any Phosphor name) unchanged.

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)