### PR TITLE
build(docker): add openssh-client to datahub-actions image

### DIFF
--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -36,7 +36,8 @@ RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
     curl \
     zip \
     unzip \
-    bash
+    bash \
+    openssh-client
 
 # PAM's unix_chkpwd is setuid/setgid in many images for interactive logins. This container does
 # not rely on PAM password checks; clearing bits avoids ABC/DoD-style SUID-SGID file findings


### PR DESCRIPTION
Install the Wolfi openssh-client package so the ssh binary is available in all datahub-actions image variants.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
