### PR TITLE
ci(fix): Capture exit code without failing action

### DIFF
--- a/.github/actions/smoke-test-retry/action.yml
+++ b/.github/actions/smoke-test-retry/action.yml
@@ -101,11 +101,14 @@ runs:
 
         OUTPUT_FILE="${GITHUB_WORKSPACE}/failed-tests-batch-${BATCH}.txt"
 
+        # The parser uses non-zero exit codes as signals (1=error, 2=all_passed,
+        # 3=no_artifacts), not failures. GitHub runs composite bash steps with
+        # `-eo pipefail`, so capture the code via `|| EXIT_CODE=$?` to keep
+        # errexit from aborting the step before the case below can read it.
+        EXIT_CODE=0
         python3 .github/scripts/parse_failed_cypress_tests.py \
           --input-dir "${GITHUB_WORKSPACE}/previous-test-results" \
-          --output "${OUTPUT_FILE}"
-
-        EXIT_CODE=$?
+          --output "${OUTPUT_FILE}" || EXIT_CODE=$?
 
         case $EXIT_CODE in
           0)
@@ -139,11 +142,12 @@ runs:
 
         OUTPUT_FILE="${GITHUB_WORKSPACE}/failed-modules-batch-${BATCH}.txt"
 
+        # See the cypress parse step: capture the parser's signal exit code via
+        # `|| EXIT_CODE=$?` so `bash -e` doesn't abort the step before the case.
+        EXIT_CODE=0
         python3 .github/scripts/parse_failed_pytest_tests.py \
           --input-dir "${GITHUB_WORKSPACE}/previous-test-results" \
-          --output "${OUTPUT_FILE}"
-
-        EXIT_CODE=$?
+          --output "${OUTPUT_FILE}" || EXIT_CODE=$?
 
         case $EXIT_CODE in
           0)


### PR DESCRIPTION
## Summary

The `smoke-test-retry` composite action parses the previous attempt's test<br>results and maps the parser's exit code to a `parse_result` (`has_failures` /<br>`all_passed` / `no_artifacts` / `error`) via a `case` statement.

GitHub runs composite `shell: bash` steps with `-eo pipefail` (errexit on). The<br>parser scripts deliberately use og**non-zero exit codes as signals**, not failures<br>(`1=error`, `2=all_passed`, `3=no_artifacts`). With errexit on, any of those<br>non-zero exits aborted the step at the `python3` line — **before** `EXIT_CODE=$?`<br>and the `case` could run. The result: only `has_failures` (exit 0) was everogog<br>reachable; on `all_passed` (exit 2) the step failed and took the whole job down<br>with it.

The original inline retry logic guarded against this with a `set +e` before the<br>`python3` call. That guard was dropped when the logic was extracted into this<br>reusable action in datahub-project/datahub#17643 — this PR restores the behavior.

## Change

Capture the parser's exit code without disabling errexit for the rest of the step:

```bash
EXIT_CODE=0
python3 .github/scripts/parse_failed_*.py ... || EXIT_CODE=$?
```

The `|| EXIT_CODE=$?` puts the call in an OR-list (exempt from errexit) and<br>records the signal, while `-eo pipefail` stays active for everything else.<br>Applied to both the cypress and pytest parse steps. All four `parse_result`<br>branches are now reachable again.

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](<https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md>) (particularly [PR Title Format](<https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format>))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](<https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md>)