### PR TITLE
docs(release notes): document Wolfi base image breaking change for v1.1.0-cloud

### DIFF
--- a/docs/managed-datahub/release-notes/v_1_1_0.md
+++ b/docs/managed-datahub/release-notes/v_1_1_0.md
@@ -46,7 +46,7 @@ v1.1.0 inherits breaking changes from upstream OSS v1.6.0. Scan the categories b
 - **Play 3 + `DATAHUB_SECRET`** — secret must be ≥32 bytes or `datahub-frontend` fails on startup.
 - **Micrometer / JMX scrape paths** — Actuator now on port **4319**, JMX agent metrics path now **`/metrics`**. Prometheus and Grafana configs need updating.
 - **Docker custom builds** — `BASE_IMAGE` and `apkRepositoryUrl` build args required.
-- **Remote Executor (Cloud) — Wolfi replaces Ubuntu** — `v1.1.0-cloud` executor images use Chainguard Wolfi instead of Ubuntu 24.04. Custom Dockerfile layers must use **`apk`** (not **`apt`**) and a Wolfi-compatible **`BASE_IMAGE`**.
+- **Remote Executor (Cloud) — Wolfi replaces Ubuntu** — `v1.1.0-cloud` executor images use Chainguard Wolfi instead of Ubuntu 24.04. Custom Dockerfile layers must use **`apk`** (not **`apt`**) and a Wolfi-compatible **`BASE_IMAGE`**. See [Wolfi overview](https://edu.chainguard.dev/open-source/wolfi/overview/) and [searching for packages on Wolfi](https://edu.chainguard.dev/chainguard/migration/migrating-to-chainguard-images/#searching-for-packages).
 
 **Auth & API contracts** — affects custom integrations
 

--- a/docs/managed-datahub/release-notes/v_1_1_0.md
+++ b/docs/managed-datahub/release-notes/v_1_1_0.md
@@ -46,6 +46,7 @@ v1.1.0 inherits breaking changes from upstream OSS v1.6.0. Scan the categories b
 - **Play 3 + `DATAHUB_SECRET`** — secret must be ≥32 bytes or `datahub-frontend` fails on startup.
 - **Micrometer / JMX scrape paths** — Actuator now on port **4319**, JMX agent metrics path now **`/metrics`**. Prometheus and Grafana configs need updating.
 - **Docker custom builds** — `BASE_IMAGE` and `apkRepositoryUrl` build args required.
+- **Remote Executor (Cloud) — Wolfi replaces Ubuntu** — `v1.1.0-cloud` executor images use Chainguard Wolfi instead of Ubuntu 24.04. Custom Dockerfile layers must use **`apk`** (not **`apt`**) and a Wolfi-compatible **`BASE_IMAGE`**.
 
 **Auth & API contracts** — affects custom integrations
 


### PR DESCRIPTION
## Summary
- Add a breaking change to the DataHub Cloud v1.1.0 release notes for the Remote Executor migration from Ubuntu 24.04 to Chainguard Wolfi.
- Notes that custom executor Dockerfile layers must use `apk` and a Wolfi-compatible `BASE_IMAGE`.

## Test plan
- [x] Verified release note renders in `docs/managed-datahub/release-notes/v_1_1_0.md`
- [ ] Docs preview (optional): `scripts/dev/datahub-dev.sh docs`


Made with [Cursor](https://cursor.com)