### PR TITLE
fix(lookml): Preserve cross-project view assignments in Looker ingestion

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
@@ -219,8 +219,13 @@ class LookerViewId:
         for pattern in str_to_remove:
             new_file_path = re.sub(pattern, "", new_file_path)
 
+        # Use the project embedded in the file path itself when it is a cross-project import so
+        # that the prefix strip succeeds even if self.project_name is the explore's project.
+        project_in_path = (
+            extract_project_from_imported_file_path(new_file_path) or self.project_name
+        )
         str_to_replace: Dict[str, str] = {
-            f"^imported_projects/{re.escape(self.project_name)}/": "",  # escape any special regex character present in project-name
+            f"^imported_projects/{re.escape(project_in_path)}/": "",  # escape any special regex character present in project-name
             "/": ".",  # / is not urn friendly
         }
 
@@ -490,6 +495,20 @@ class ExploreUpstreamViewField:
         )
 
 
+def extract_project_from_imported_file_path(file_path: str) -> Optional[str]:
+    """
+    Returns the project name embedded in an imported_projects/ file path, or None.
+
+    Example: "imported_projects/project-a/views/foo.view.lkml" -> "project-a"
+    """
+    prefix = f"{IMPORTED_PROJECTS}/"
+    if file_path.startswith(prefix):
+        tokens = file_path.split("/")
+        if len(tokens) >= 2:
+            return tokens[1]
+    return None
+
+
 def create_view_project_map(
     view_fields: List[ViewField],
     explore_primary_view: Optional[str] = None,
@@ -507,19 +526,11 @@ def create_view_project_map(
     view_project_map: Dict[str, str] = {}
     for view_field in view_fields:
         if view_field.view_name is not None and view_field.project_name is not None:
-            # Override field-level project assignment for the primary view when different
-            if (
-                view_field.view_name == explore_primary_view
-                and explore_project_name is not None
-                and explore_project_name != view_field.project_name
-            ):
-                logger.debug(
-                    f"Overriding project assignment for primary view '{view_field.view_name}': "
-                    f"field-level project '{view_field.project_name}' → explore-level project '{explore_project_name}'"
-                )
-                view_project_map[view_field.view_name] = explore_project_name
-            else:
-                view_project_map[view_field.view_name] = view_field.project_name
+            # project_name is only non-None when set by extract_project_name_from_source_file(),
+            # which only returns a value for imported_projects/ paths (cross-project imports).
+            # Same-project views have project_name=None, so they never enter this map and fall
+            # back to explore_project_name via the BASE_PROJECT_NAME sentinel in _form_field_name().
+            view_project_map[view_field.view_name] = view_field.project_name
 
     return view_project_map
 

--- a/metadata-ingestion/tests/integration/looker/golden_test_external_project_view_mces.json
+++ b/metadata-ingestion/tests/integration/looker/golden_test_external_project_view_mces.json
@@ -625,7 +625,7 @@
                         "time": 1586847600000,
                         "actor": "urn:li:corpuser:datahub"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:looker,looker_hub.view.faa_flights,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:looker,datahub-demo.view.faa_flights,PROD)",
                     "type": "VIEW"
                 }
             ]

--- a/metadata-ingestion/tests/integration/looker/golden_test_file_path_ingest.json
+++ b/metadata-ingestion/tests/integration/looker/golden_test_file_path_ingest.json
@@ -699,7 +699,7 @@
                         "time": 1586847600000,
                         "actor": "urn:li:corpuser:datahub"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:looker,looker_hub.imported_projects.datahub-demo.views.datahub-demo.datasets.faa_flights.view.faa_flights,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:looker,datahub-demo.views.datahub-demo.datasets.faa_flights.view.faa_flights,PROD)",
                     "type": "VIEW"
                 }
             ]

--- a/metadata-ingestion/tests/unit/looker/test_looker_common.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_common.py
@@ -4,7 +4,13 @@ from unittest.mock import MagicMock
 import pytest
 from looker_sdk.sdk.api40.models import LookmlModelExplore, LookmlModelExploreField
 
-from datahub.ingestion.source.looker.looker_common import ExploreUpstreamViewField
+from datahub.ingestion.source.looker.looker_common import (
+    ExploreUpstreamViewField,
+    ViewField,
+    ViewFieldType,
+    create_view_project_map,
+    extract_project_from_imported_file_path,
+)
 from datahub.ingestion.source.looker.looker_config import LookerCommonConfig
 
 
@@ -91,3 +97,73 @@ class TestExploreUpstreamViewFieldFormFieldName:
 
             assert result is None
             assert "Empty field name detected" in caplog.text
+
+
+class TestExtractProjectFromImportedFilePath:
+    @pytest.mark.parametrize(
+        "file_path,expected",
+        [
+            (
+                "imported_projects/project-a/views/foo.view.lkml",
+                "project-a",
+            ),
+            (
+                "imported_projects/my-project/path/to/file.view.lkml",
+                "my-project",
+            ),
+            (
+                "views/foo.view.lkml",  # same-project path, no imported_projects/ prefix
+                None,
+            ),
+            (
+                "imported_projects",  # malformed: no slash after the prefix
+                None,
+            ),
+        ],
+    )
+    def test_extract(self, file_path: str, expected: "str | None") -> None:
+        assert extract_project_from_imported_file_path(file_path) == expected
+
+
+class TestCreateViewProjectMap:
+    def _make_view_field(self, view_name: str, project_name: "str | None") -> ViewField:
+        return ViewField(
+            name=f"{view_name}.some_field",
+            label=None,
+            type="string",
+            description="",
+            field_type=ViewFieldType.DIMENSION,
+            project_name=project_name,
+            view_name=view_name,
+        )
+
+    def test_cross_project_primary_view_not_overridden(self) -> None:
+        # Regression test: the primary view's project must NOT be replaced with the explore's
+        # project when the view is a cross-project import (project_name already set correctly).
+        view_field = self._make_view_field("my_view", project_name="project-a")
+        result = create_view_project_map(
+            view_fields=[view_field],
+            explore_primary_view="my_view",
+            explore_project_name="project-b",
+        )
+        assert result["my_view"] == "project-a"
+
+    def test_cross_project_non_primary_view(self) -> None:
+        view_field = self._make_view_field("other_view", project_name="project-a")
+        result = create_view_project_map(
+            view_fields=[view_field],
+            explore_primary_view="my_view",
+            explore_project_name="project-b",
+        )
+        assert result["other_view"] == "project-a"
+
+    def test_same_project_view_not_in_map(self) -> None:
+        # Same-project views have project_name=None; they should not appear in the map
+        # and fall back to explore_project_name via the BASE_PROJECT_NAME sentinel.
+        view_field = self._make_view_field("my_view", project_name=None)
+        result = create_view_project_map(
+            view_fields=[view_field],
+            explore_primary_view="my_view",
+            explore_project_name="project-b",
+        )
+        assert "my_view" not in result


### PR DESCRIPTION
## Description

Fixes a bug in the Looker ingestion source where cross-project view imports were incorrectly having their project assignments overridden by the explore's project name.

### Changes

1. **Added `extract_project_from_imported_file_path()` function**: Extracts the project name from imported_projects/ file paths to identify cross-project imports.

2. **Updated `preprocess_file_path()` method**: Now uses the project name embedded in the file path itself (for cross-project imports) when stripping the `imported_projects/` prefix, rather than always using `self.project_name`. This ensures the prefix strip succeeds even when processing an explore from a different project.

3. **Simplified `create_view_project_map()` logic**: Removed the override logic that was incorrectly replacing field-level project assignments with the explore's project name. Now the function respects the project assignment from the source file path for all cross-project imports. Same-project views (with `project_name=None`) continue to fall back to the explore's project via the `BASE_PROJECT_NAME` sentinel.

### Testing

Added comprehensive unit tests covering:
- `extract_project_from_imported_file_path()`: Tests extraction from various file path formats
- `create_view_project_map()`: Regression tests ensuring cross-project primary views are not overridden, cross-project non-primary views are preserved, and same-project views are excluded from the map

All new tests pass and validate the fix.

https://claude.ai/code/session_01Ak3UPKVEjgoAZiJNEpJf41