### PR TITLE
fix(ingestion): handle LossyList sentinel string in LogEntry deserialization

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/ingestion/IngestionRunReport.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/ingestion/IngestionRunReport.java
@@ -4,6 +4,14 @@ import static com.linkedin.metadata.ingestion.Constants.*;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -106,10 +114,16 @@ public class IngestionRunReport {
     @Nullable
     private Map<String, Double> ingestionHighStageSeconds;
 
+    @JsonDeserialize(contentUsing = LogEntryDeserializer.class)
+    @JsonSetter(contentNulls = Nulls.SKIP)
     private List<LogEntry> warnings = Collections.emptyList();
 
+    @JsonDeserialize(contentUsing = LogEntryDeserializer.class)
+    @JsonSetter(contentNulls = Nulls.SKIP)
     private List<LogEntry> failures = Collections.emptyList();
 
+    @JsonDeserialize(contentUsing = LogEntryDeserializer.class)
+    @JsonSetter(contentNulls = Nulls.SKIP)
     private List<LogEntry> infos = Collections.emptyList();
   }
 
@@ -143,6 +157,8 @@ public class IngestionRunReport {
 
     @Nullable private String mode;
 
+    @JsonDeserialize(contentUsing = LogEntryDeserializer.class)
+    @JsonSetter(contentNulls = Nulls.SKIP)
     private List<LogEntry> failures = Collections.emptyList();
   }
 
@@ -159,5 +175,45 @@ public class IngestionRunReport {
     @JsonProperty(LOG_CATEGORY)
     @Nullable
     private String logCategory;
+  }
+
+  /**
+   * Custom element deserializer for {@code List<LogEntry>} fields.
+   *
+   * <p>The Python ingestion framework's {@code LossyList} caps log-entry arrays at 10 items and
+   * appends a plain-string sentinel (e.g. {@code "... sampled of 1246 total elements"}) as the 11th
+   * element when the original list was larger. Without this deserializer, Jackson throws a {@code
+   * MismatchedInputException} when it encounters that sentinel string while trying to construct a
+   * {@link LogEntry} object.
+   *
+   * <p>Strategy: annotate every {@code List<LogEntry>} field with
+   * {@code @JsonDeserialize(contentUsing = LogEntryDeserializer.class)}. When Jackson processes
+   * each list element it dispatches here:
+   *
+   * <ul>
+   *   <li>String token → return an empty {@link LogEntry} (silently dropped by {@code
+   *       toLogEntryMaps} because all fields are null and the resulting map is empty).
+   *   <li>Object token → delegate to standard bean deserialization via {@code ctxt.readValue(p,
+   *       LogEntry.class)}, which is safe because {@link LogEntry} itself does <em>not</em> carry
+   *       {@code @JsonDeserialize} — so there is no recursion.
+   * </ul>
+   */
+  public static class LogEntryDeserializer extends StdDeserializer<LogEntry> {
+
+    public LogEntryDeserializer() {
+      super(LogEntry.class);
+    }
+
+    @Override
+    public LogEntry deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+      if (p.currentToken() == JsonToken.VALUE_STRING) {
+        // Python LossyList sentinel string — return null so @JsonSetter(contentNulls = Nulls.SKIP)
+        // excludes it from the list entirely. This keeps list.size() == real entry count.
+        return null;
+      }
+      // Standard bean deserialization. No recursion: LogEntry itself has no @JsonDeserialize,
+      // so ctxt.readValue uses the default BeanDeserializer, not this class.
+      return ctxt.readValue(p, LogEntry.class);
+    }
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/ingestion/IngestionMetricsEmitterTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/ingestion/IngestionMetricsEmitterTest.java
@@ -394,6 +394,78 @@ public class IngestionMetricsEmitterTest {
     assertTrue(runsCounter == null || runsCounter.count() == 0.0);
   }
 
+  /**
+   * Regression test for the LossyList sentinel bug.
+   *
+   * <p>When the Python ingestion framework's {@code LossyList} truncates a list that exceeds 10
+   * entries, it appends a plain-string sentinel as the 11th element (e.g. {@code "... sampled of
+   * 1246 total elements"}). Without {@link IngestionRunReport.LogEntryDeserializer}, Jackson throws
+   * a {@code MismatchedInputException} when it encounters that string while trying to construct a
+   * {@code LogEntry} object.
+   *
+   * <p>This test verifies that a report with more than 10 failures (triggering the sentinel) is
+   * deserialized successfully and that only the real log entries are counted/surfaced.
+   */
+  @Test
+  public void testLossyListSentinelDoesNotThrow() throws Exception {
+    // Build a failures array with 10 real LogEntry objects followed by the LossyList sentinel
+    // string — exactly what Python emits when sampled=True.
+    StringBuilder failuresJson = new StringBuilder("[");
+    for (int i = 0; i < 10; i++) {
+      if (i > 0) failuresJson.append(",");
+      failuresJson.append(
+          "{\"title\":\"Extraction error\",\"message\":\"error " + i + "\",\"context\":[]}");
+    }
+    failuresJson.append(",\"... sampled of 1246 total elements\"");
+    failuresJson.append("]");
+
+    String reportJson =
+        "{"
+            + "\"cli\": {\"cli_version\": \"1.2.0\"},"
+            + "\"source\": {"
+            + "  \"type\": \"mysql\","
+            + "  \"report\": {"
+            + "    \"events_produced\": 500,"
+            + "    \"warnings\": [],"
+            + "    \"failures\": "
+            + failuresJson
+            + ","
+            + "    \"platform\": \"mysql\""
+            + "  }"
+            + "},"
+            + "\"sink\": {"
+            + "  \"type\": \"datahub-rest\","
+            + "  \"report\": {"
+            + "    \"total_records_written\": 400,"
+            + "    \"failures\": []"
+            + "  }"
+            + "}"
+            + "}";
+
+    ExecutionRequestResult result = new ExecutionRequestResult();
+    result.setStatus("FAILURE");
+    result.setDurationMs(3000L);
+
+    StructuredExecutionReport structuredReport = new StructuredExecutionReport();
+    structuredReport.setType("CLI_INGEST");
+    structuredReport.setSerializedValue(reportJson);
+    structuredReport.setContentType("application/json");
+    result.setStructuredReport(structuredReport);
+
+    // Must not throw MismatchedInputException
+    emitter.observeMCPs(List.of(createBatchItem(result, ChangeType.UPSERT)), retrieverContext);
+
+    // Run is counted
+    Counter runsCounter = meterRegistry.find("com.datahub.ingest.runs").counter();
+    assertNotNull(runsCounter);
+    assertEquals(runsCounter.count(), 1.0);
+
+    // Only the 10 real entries are counted — the sentinel is silently dropped
+    Counter failuresCounter = meterRegistry.find("com.datahub.ingest.failures").counter();
+    assertNotNull(failuresCounter);
+    assertEquals(failuresCounter.count(), 10.0);
+  }
+
   // Helper methods
 
   private BatchItem createBatchItem(ExecutionRequestResult result, ChangeType changeType)


### PR DESCRIPTION
## Summary

- The Python ingestion framework's `LossyList` appends a plain-string sentinel (e.g. `"... sampled of N total elements"`) as the 11th element when a warnings/failures/infos list exceeds 10 entries.
- Jackson throws `MismatchedInputException` when it encounters that sentinel string while deserializing `List<LogEntry>`, causing `IngestionMetricsEmitter` to crash the Kafka consumer thread for high-failure runs.
- Fix: add `LogEntryDeserializer` that maps string tokens to an empty `LogEntry` (which `toLogEntryMaps()` silently drops) and delegates object tokens to standard bean deserialization; annotate all four `List<LogEntry>` fields with `@JsonDeserialize(contentUsing = LogEntryDeserializer.class)`.
- Couple of failures . https://github.com/datahub-project/datahub/actions/runs/27151079465/job/80151440137?pr=17808
https://github.com/datahub-project/datahub/actions/runs/27152353194/job/80153609414

- `2026-06-08 17:11:42,178 [ThreadPoolTaskExecutor-1] ERROR c.l.m.i.IngestionMetricsEmitter urn=none aspect=none entityType=none changeType=none - Error recording metrics for urn:li:dataHubExecutionRequest:datapack-showcase-ecommerce-1780938689918: Cannot construct instance of `com.linkedin.metadata.ingestion.IngestionRunReport$LogEntry` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('... sampled of 1246 total elements')
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 115, column: 9] (through reference chain: com.linkedin.metadata.ingestion.IngestionRunReport$Report["source"]->com.linkedin.metadata.ingestion.IngestionRunReport$SourceSection["report"]->com.linkedin.metadata.ingestion.IngestionRunReport$SourceReport["failures"]->java.util.ArrayList[10])
com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of `com.linkedin.metadata.ingestion.IngestionRunReport$LogEntry` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('... sampled of 1246 total elements')
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 115, column: 9] (through reference chain: com.linkedin.metadata.ingestion.IngestionRunReport$Report["source"]->com.linkedin.metadata.ingestion.IngestionRunReport$SourceSection["report"]->com.linkedin.metadata.ingestion.IngestionRunReport$SourceReport["failures"]->java.util.ArrayList[10])
	at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:76)
	at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1801)
	at com.fasterxml.jackson.databind.DeserializationContext.handleMissingInstantiator(DeserializationContext.java:1426)
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer._deserializeFromString(StdDeserializer.java:310)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromString(BeanDeserializerBase.java:1594)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeOther(BeanDeserializer.java:189)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:179)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer._deserializeNoNullChecks(CollectionDeserializer.java:545)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer._deserializeFromArray(CollectionDeserializer.java:358)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:245)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:29)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:302)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:169)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:302)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:169)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:302)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:169)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:342)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:5052)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3954)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3922)
	at com.linkedin.metadata.ingestion.IngestionMetricsEmitter.recordMetrics(IngestionMetricsEmitter.java:125)
	at com.linkedin.metadata.ingestion.IngestionMetricsEmitter.observeMCPs(IngestionMetricsEmitter.java:96)
	at com.linkedin.metadata.aspect.plugins.hooks.MCPObserver.apply(MCPObserver.java:29)
	at com.linkedin.metadata.aspect.batch.AspectsBatch.applyMCPObservers(AspectsBatch.java:215)
	at com.linkedin.metadata.aspect.batch.AspectsBatch.applyMCPObservers(AspectsBatch.java:207)
	at com.linkedin.metadata.entity.EntityServiceImpl.ingestProposal(EntityServiceImpl.java:1693)
	at com.linkedin.metadata.client.JavaEntityClient.lambda$batchIngestProposals$11(JavaEntityClient.java:784)
	at java.base/java.util.Iterator.forEachRemaining(Unknown Source)
	at com.linkedin.metadata.client.JavaEntityClient.batchIngestProposals(JavaEntityClient.java:772)
	at com.linkedin.metadata.kafka.batch.BatchMetadataChangeProposalsProcessor.processBatch(BatchMetadataChangeProposalsProcessor.java:214)
	at com.linkedin.metadata.kafka.batch.BatchMetadataChangeProposalsProcessor.processInBatches(BatchMetadataChangeProposalsProcessor.java:188)
	at com.linkedin.metadata.kafka.batch.BatchMetadataChangeProposalsProcessor.lambda$consume$1(BatchMetadataChangeProposalsProcessor.java:140)
	at io.datahubproject.metadata.context.SystemTelemetryContext.withQueueSpan(SystemTelemetryContext.java:230)
	at io.datahubproject.metadata.context.OperationContext.withQueueSpan(OperationContext.java:455)
	at com.linkedin.metadata.kafka.batch.BatchMetadataChangeProposalsProcessor.consume(BatchMetadataChangeProposalsProcessor.java:133)
	at com.linkedin.metadata.kafka.batch.BatchMetadataChangeProposalsProcessor.consume(BatchMetadataChangeProposalsProcessor.java:72)
	at com.linkedin.metadata.kafka.batch.BatchMetadataChangeProposalsKafkaListener.consume(BatchMetadataChangeProposalsKafkaListener.java:38)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at org.springframework.messaging.handler.invocation.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:168)
	at org.springframework.kafka.listener.adapter.KotlinAwareInvocableHandlerMethod.doInvoke(KotlinAwareInvocableHandlerMethod.java:48)
	at org.springframework.messaging.handler.invocation.InvocableHandlerMethod.invoke(InvocableHandlerMethod.java:119)
	at org.springframework.kafka.listener.adapter.HandlerAdapter.invoke(HandlerAdapter.java:80)
	at org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter.invokeHandler(MessagingMessageListenerAdapter.java:488)
	at org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter.invoke(MessagingMessageListenerAdapter.java:425)
	at org.springframework.kafka.listener.adapter.BatchMessagingMessageListenerAdapter.onMessage(BatchMessagingMessageListenerAdapter.java:194)
	at org.springframework.kafka.listener.adapter.BatchMessagingMessageListenerAdapter.onMessage(BatchMessagingMessageListenerAdapter.java:62)
	at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.doInvokeBatchOnMessage(KafkaMessageListenerContainer.java:2522)
	at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.invokeBatchOnMessageWithRecordsOrList(KafkaMessageListenerContainer.java:2503)
	at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.invokeBatchOnMessage(KafkaMessageListenerContainer.java:2420)
	at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.doInvokeBatchListener(KafkaMessageListenerContainer.java:2298)
	at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.invokeBatchListener(KafkaMessageListenerContainer.java:2222)
	at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.invokeListener(KafkaMessageListenerContainer.java:2201)
	at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.invokeIfHaveRecords(KafkaMessageListenerContainer.java:1559)
	at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.pollAndInvoke(KafkaMessageListenerContainer.java:1499)
	at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.run(KafkaMessageListenerContainer.java:1368)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)`

## Changes

- `IngestionRunReport.java`: add Jackson imports, `@JsonDeserialize(contentUsing = LogEntryDeserializer.class)` on `SourceReport.warnings`, `SourceReport.failures`, `SourceReport.infos`, and `SinkReport.failures`; add new inner class `LogEntryDeserializer`.
- `IngestionMetricsEmitter.java`: update NOTE comment to accurately describe the LossyList sentinel handling; add null-entry guard in `toLogEntryMaps()`; update Javadoc for that method.
- `IngestionMetricsEmitterTest.java`: add regression test `testLossyListSentinelDoesNotThrow` that passes a report with mixed object + string sentinel elements and verifies correct counter values.