### PR TITLE
fix(docker): install MSSQL ODBC driver on Wolfi full images

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -89,19 +89,22 @@ acryldata/datahub-ingestion:v0.x.y-locked   # locked
 | Glue                  | Yes  | Yes  |   -    |
 | Spark lineage (JRE)   | Yes  |  -   |   -    |
 | Oracle client         | Yes  |  -   |   -    |
+| MSSQL ODBC driver     | Yes  |  -   |   -    |
 | Runtime `pip install` | Yes  | Yes  |   -    |
 
 ### datahub-actions Feature Matrix
 
-| Feature                      | full | slim | locked |
-| ---------------------------- | :--: | :--: | :----: |
-| Core actions                 | Yes  | Yes  |  Yes   |
-| Kafka / Executor             | Yes  | Yes  |  Yes   |
-| Slack / Teams                | Yes  | Yes  |  Yes   |
-| Tag / Term / Doc propagation | Yes  | Yes  |  Yes   |
-| Snowflake tag propagation    | Yes  | Yes  |  Yes   |
-| Bundled CLI venvs            | Yes  | Yes  |  Yes   |
-| Runtime `pip install`        | Yes  | Yes  |   -    |
+| Feature                       | full | slim | locked |
+| ----------------------------- | :--: | :--: | :----: |
+| Core actions                  | Yes  | Yes  |  Yes   |
+| Kafka / Executor              | Yes  | Yes  |  Yes   |
+| Slack / Teams                 | Yes  | Yes  |  Yes   |
+| Tag / Term / Doc propagation  | Yes  | Yes  |  Yes   |
+| Snowflake tag propagation     | Yes  | Yes  |  Yes   |
+| Bundled CLI venvs             | Yes  | Yes  |  Yes   |
+| Oracle client (full only)     | Yes  |  -   |   -    |
+| MSSQL ODBC driver (full only) | Yes  |  -   |   -    |
+| Runtime `pip install`         | Yes  | Yes  |   -    |
 
 ### CI Testing Coverage
 

--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # full / slim / locked variants (see APP_ENV). Base OS: Wolfi (Chainguard); override via BASE_IMAGE.
-# The full variant has additional deps preinstalled, like a JRE and Oracle client.
+# The full variant has additional deps preinstalled, like a JRE, Oracle client, and MSSQL ODBC driver.
 ARG APP_ENV=full
 ARG PYTHON_VERSION=3.11
 ARG BASE_IMAGE=cgr.dev/chainguard/wolfi-base:latest
@@ -9,7 +9,7 @@ ARG BASE_IMAGE=cgr.dev/chainguard/wolfi-base:latest
 # Stages:
 # - python-base: python, uv, venv, user datahub (UID 1000)
 # - ingestion-base-slim: LDAP/SASL/Kerberos, librdkafka, ODBC, etc.
-# - ingestion-base-full: JRE, build toolchain, Oracle Instant Client
+# - ingestion-base-full: JRE, build toolchain, Oracle Instant Client, MSSQL ODBC driver
 
 FROM ${BASE_IMAGE} AS python-base
 
@@ -104,6 +104,9 @@ RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
 
 RUN --mount=type=bind,source=./docker/snippets/oracle_instantclient.sh,target=/oracle_instantclient.sh \
     /oracle_instantclient.sh
+
+RUN --mount=type=bind,source=./docker/snippets/mssql_odbc.sh,target=/mssql_odbc.sh \
+    /mssql_odbc.sh
 
 USER datahub
 # INLINE-END

--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -72,11 +72,15 @@ RUN --mount=type=bind,source=./docker/snippets/uv,target=/tmp/uv-config \
 FROM python-base AS ingestion-base-slim
 
 USER 0
+# cyrus-sasl-mit-* avoids Heimdal SASL (cyrus-sasl-libs resolves via provides:).
+# glibc-iconv: gconv modules required for msodbcsql18 iconv (without it, ODBC init fails with IM004).
 RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
     apk add --no-cache --update-cache \
     openldap-2.6-dev \
-    cyrus-sasl-dev \
-    cyrus-sasl-libs \
+    cyrus-sasl-mit-dev \
+    cyrus-sasl-mit-libs \
+    glibc-iconv \
+    krb5 \
     krb5-dev \
     krb5-libs \
     libaio-dev \

--- a/docker/datahub-ingestion-base/Dockerfile
+++ b/docker/datahub-ingestion-base/Dockerfile
@@ -115,6 +115,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 RUN --mount=type=bind,source=./docker/snippets/oracle_instantclient.sh,target=/oracle_instantclient.sh \
     /oracle_instantclient.sh
 
+RUN --mount=type=bind,source=./docker/snippets/mssql_odbc.sh,target=/mssql_odbc.sh \
+    /mssql_odbc.sh
+
 USER datahub
 # INLINE-END
 

--- a/docker/datahub-ingestion/Dockerfile
+++ b/docker/datahub-ingestion/Dockerfile
@@ -128,6 +128,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 RUN --mount=type=bind,source=./docker/snippets/oracle_instantclient.sh,target=/oracle_instantclient.sh \
     /oracle_instantclient.sh
 
+RUN --mount=type=bind,source=./docker/snippets/mssql_odbc.sh,target=/mssql_odbc.sh \
+    /mssql_odbc.sh
+
 USER datahub
 
 # Locked variant uses the same base as slim (no JRE/Oracle needed)

--- a/docker/snippets/ingestion_full_deps
+++ b/docker/snippets/ingestion_full_deps
@@ -6,3 +6,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y -qq \
 
 RUN --mount=type=bind,source=./docker/snippets/oracle_instantclient.sh,target=/oracle_instantclient.sh \
     /oracle_instantclient.sh
+
+RUN --mount=type=bind,source=./docker/snippets/mssql_odbc.sh,target=/mssql_odbc.sh \
+    /mssql_odbc.sh

--- a/docker/snippets/mssql_odbc.sh
+++ b/docker/snippets/mssql_odbc.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Install Microsoft ODBC Driver 18 for SQL Server.
+#
+# Wolfi is glibc-based but uses apk. Microsoft's Alpine .apk packages are musl-linked
+# and must NOT be used on Wolfi. Install the RHEL 9 glibc RPM instead (--nodeps because
+# Wolfi packages are apk-managed and invisible to rpm's dependency solver).
+#
+# Ubuntu/Debian: use Microsoft's apt repository (glibc .deb packages).
+#
+# Bumping versions: update MSODBCSQL_VERSION and MSODBCSQL_RELEASE to match a row at
+# https://packages.microsoft.com/rhel/9/prod/Packages/m/msodbcsql18-*
+set -euxo pipefail
+
+MSODBCSQL_VERSION=18.6.2.1
+MSODBCSQL_RELEASE=1
+MSODBCSQL_RHEL_REPO="https://packages.microsoft.com/rhel/9/prod/Packages/m"
+ODBC_DRIVER_NAME="ODBC Driver 18 for SQL Server"
+
+list_shared_lib_deps() {
+  local lib_path="$1"
+  if command -v ldd >/dev/null 2>&1; then
+    ldd "${lib_path}"
+    return 0
+  fi
+
+  local loader=""
+  case "$(uname -m)" in
+    x86_64) loader=/lib/ld-linux-x86-64.so.2 ;;
+    aarch64) loader=/lib/ld-linux-aarch64.so.1 ;;
+    *)
+      echo "Unsupported architecture for shared library verification: $(uname -m)"
+      exit 1
+      ;;
+  esac
+  test -x "${loader}" || { echo "missing dynamic linker: ${loader}"; exit 1; }
+  "${loader}" --list "${lib_path}"
+}
+
+verify_shared_lib() {
+  local lib_path="$1"
+  local deps=""
+  test -n "${lib_path}"
+  test -f "${lib_path}" || { echo "missing library: ${lib_path}"; exit 1; }
+  deps="$(list_shared_lib_deps "${lib_path}")"
+  if echo "${deps}" | grep -q 'not found'; then
+    echo "unresolved shared library dependencies for ${lib_path}:"
+    echo "${deps}"
+    exit 1
+  fi
+}
+
+verify_driver() {
+  odbcinst -j
+  driver_so="$(odbcinst -q -d -n "${ODBC_DRIVER_NAME}" | sed -n 's/^Driver=//p')"
+  test -n "${driver_so}" || {
+    echo "ODBC driver not registered: ${ODBC_DRIVER_NAME}"
+    odbcinst -q -d
+    exit 1
+  }
+  verify_shared_lib "${driver_so}"
+  odbcinst -q -d -n "${ODBC_DRIVER_NAME}"
+}
+
+install_wolfi() {
+  case "$(uname -m)" in
+    x86_64) arch="x86_64" ;;
+    aarch64) arch="aarch64" ;;
+    *)
+      echo "Unsupported architecture $(uname -m) for msodbcsql18 on Wolfi"
+      exit 1
+      ;;
+  esac
+
+  if ! command -v rpm >/dev/null 2>&1; then
+    apk add --no-cache rpm
+  fi
+
+  rpm_pkg="msodbcsql18-${MSODBCSQL_VERSION}-${MSODBCSQL_RELEASE}.${arch}.rpm"
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "${tmp_dir}"' EXIT
+  cd "${tmp_dir}"
+
+  curl -fsSL -O "${MSODBCSQL_RHEL_REPO}/${rpm_pkg}"
+
+  # EULA auto-accept for driver >= 18.4 (must exist before install).
+  mkdir -p /opt/microsoft/msodbcsql18
+  touch /opt/microsoft/msodbcsql18/ACCEPT_EULA
+
+  # --nodeps: glibc, unixODBC, krb5, openssl, etc. are already on the image via apk.
+  # --nosignature: Microsoft RPM signing key is not in Wolfi's rpm keyring.
+  rpm -ivh --nodeps --nosignature "${rpm_pkg}"
+
+  verify_driver
+}
+
+install_debian() {
+  case "${ID}" in
+    ubuntu)
+      ms_version="$(grep VERSION_ID /etc/os-release | cut -d '"' -f 2)"
+      ms_repo="https://packages.microsoft.com/config/ubuntu/${ms_version}/packages-microsoft-prod.deb"
+      ;;
+    debian)
+      ms_version="$(cut -d . -f 1 /etc/debian_version)"
+      ms_repo="https://packages.microsoft.com/config/debian/${ms_version}/packages-microsoft-prod.deb"
+      ;;
+    *)
+      echo "Unsupported Debian-family ID=${ID} for mssql_odbc.sh"
+      exit 1
+      ;;
+  esac
+
+  curl -fsSL -o /tmp/packages-microsoft-prod.deb "${ms_repo}"
+  dpkg -i /tmp/packages-microsoft-prod.deb
+  rm -f /tmp/packages-microsoft-prod.deb
+
+  apt-get update
+  ACCEPT_EULA=Y apt-get install -y -qq msodbcsql18
+  rm -rf /var/lib/apt/lists/*
+
+  verify_driver
+}
+
+. /etc/os-release
+case "${ID}" in
+  wolfi) install_wolfi ;;
+  ubuntu | debian) install_debian ;;
+  *)
+    echo "Unsupported OS ID=${ID} for mssql_odbc.sh"
+    exit 1
+    ;;
+esac

--- a/docker/snippets/oracle_instantclient.sh
+++ b/docker/snippets/oracle_instantclient.sh
@@ -63,3 +63,62 @@ ln -sfn "/opt/oracle/${IC_UNZIP_DIR}" /opt/oracle/instantclient
 # Register the client directory with the dynamic linker (libclntsh.so, etc.).
 sh -c "echo /opt/oracle/instantclient > /etc/ld.so.conf.d/oracle-instantclient.conf"
 ldconfig
+
+list_shared_lib_deps() {
+  local lib_path="$1"
+  if command -v ldd >/dev/null 2>&1; then
+    ldd "${lib_path}"
+    return 0
+  fi
+
+  local loader=""
+  case "$(uname -m)" in
+    x86_64) loader=/lib/ld-linux-x86-64.so.2 ;;
+    aarch64) loader=/lib/ld-linux-aarch64.so.1 ;;
+    *)
+      echo "Unsupported architecture for shared library verification: $(uname -m)"
+      exit 1
+      ;;
+  esac
+  test -x "${loader}" || { echo "missing dynamic linker: ${loader}"; exit 1; }
+  "${loader}" --list "${lib_path}"
+}
+
+verify_shared_lib() {
+  local lib_path="$1"
+  local deps=""
+  test -n "${lib_path}"
+  test -f "${lib_path}" || { echo "missing library: ${lib_path}"; exit 1; }
+  deps="$(list_shared_lib_deps "${lib_path}")"
+  if echo "${deps}" | grep -q 'not found'; then
+    echo "unresolved shared library dependencies for ${lib_path}:"
+    echo "${deps}"
+    exit 1
+  fi
+}
+
+verify_oracle_instantclient() {
+  client_dir="/opt/oracle/instantclient"
+  test -e "${client_dir}" || { echo "missing Oracle Instant Client directory: ${client_dir}"; exit 1; }
+
+  clntsh=""
+  for candidate in \
+    "${client_dir}/libclntsh.so" \
+    "${client_dir}"/libclntsh.so.*; do
+    if [ -e "${candidate}" ]; then
+      clntsh="$(readlink -f "${candidate}")"
+      break
+    fi
+  done
+  test -n "${clntsh}" || { echo "libclntsh.so not found under ${client_dir}"; ls -la "${client_dir}"; exit 1; }
+
+  verify_shared_lib "${clntsh}"
+
+  if ! ldconfig -p 2>/dev/null | grep -q libclntsh; then
+    echo "libclntsh not registered with dynamic linker after ldconfig"
+    ldconfig -p | grep -i oracle || true
+    exit 1
+  fi
+}
+
+verify_oracle_instantclient


### PR DESCRIPTION
## Summary

- Add `docker/snippets/mssql_odbc.sh` to install Microsoft ODBC Driver 18 on Wolfi via RHEL 9 glibc RPMs (Alpine `.apk` packages are musl-linked and incompatible with Wolfi)
- Wire the script into `full` image builds for `datahub-actions`, `datahub-ingestion`, and `datahub-ingestion-base`
- Add build-time library verification to both `mssql_odbc.sh` and `oracle_instantclient.sh` (driver/client `.so` exists, dependencies resolve via `ldd` or `ld-linux --list`, and Oracle `libclntsh` is registered with `ldconfig`)
- Update docker README feature matrix to document MSSQL ODBC support on `full` variants

## Test plan

- [x] Verified `mssql_odbc.sh` on Wolfi amd64: `odbcinst` registers `ODBC Driver 18 for SQL Server` and shared library deps resolve
- [x] Verified `oracle_instantclient.sh` on Wolfi amd64: `libclntsh` resolves including `libaio.so.1`
- [ ] CI Docker build for `datahub-actions` full variant


Made with [Cursor](https://cursor.com)