### PR TITLE
refactor(sql-parsing): drop Node subclass patch, store subfield in sqlglot Node.payload

### DIFF
--- a/metadata-ingestion/src/datahub/sql_parsing/_sqlglot_patch.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/_sqlglot_patch.py
@@ -1,4 +1,3 @@
-import dataclasses
 import difflib
 import logging
 import typing as t
@@ -138,17 +137,6 @@ def _patch_lineage() -> None:
     sys.modules["sqlglot._lineage_py"] = lineage_py
     spec.loader.exec_module(lineage_py)  # type: ignore
 
-    # Add the "subfield" attribute to the Node dataclass.
-    # lineage_py.Node is a pure Python dataclass (not compiled), so inheritance works.
-    # Unfortunately, mypy won't pick up on the new field, so we need to
-    # use type ignores everywhere we use subfield.
-    @dataclasses.dataclass(frozen=True)
-    class Node(lineage_py.Node):  # type: ignore[name-defined]
-        subfield: str = ""
-
-    lineage_py.Node = Node  # type: ignore
-    sqlglot.lineage.Node = Node  # type: ignore
-
     patchy.patch(
         lineage_py.lineage,
         """\
@@ -181,7 +169,7 @@ def _patch_lineage() -> None:
 """,
     )
 
-    # Patch 2: Add subfield extraction for struct field access (e.g. col.subfield)
+    # Patch 2: Add subfield extraction for struct field access (e.g. col.subfield).
     patchy.patch(
         lineage_py.to_node,
         """\
@@ -202,7 +190,7 @@ def _patch_lineage() -> None:
 +                name=c.sql(comments=False),
 +                source=col_expr,
 +                expression=col_expr,
-+                subfield=subfield,
++                payload={"subfield": subfield},
 +            )
              node.downstream.append(leaf)
              if on_node:

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -1274,10 +1274,9 @@ def _get_direct_raw_col_upstreams(
             # Parse the column name out of the node name.
             # Sqlglot calls .sql(), so we have to do the inverse.
             normalized_col = sqlglot.parse_one(node.name).this.name
-            if hasattr(node, "subfield") and node.subfield:
-                # The hasattr check is necessary, since it lets us be compatible with
-                # sqlglot versions that don't have the subfield attribute.
-                normalized_col = f"{normalized_col}.{node.subfield}"
+            subfield = node.payload.get("subfield")
+            if subfield:
+                normalized_col = f"{normalized_col}.{subfield}"
 
             direct_raw_col_upstreams.add(
                 _ColumnRef(table=table_ref, column=normalized_col)

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_patch.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_patch.py
@@ -50,8 +50,10 @@ def test_scope_circular_dependency() -> None:
 
 def test_lineage_node_subfield() -> None:
     expression = sqlglot.parse_one("SELECT 1 AS test")
-    node = sqlglot.lineage.Node("test", expression, expression, subfield="subfield")  # type: ignore
-    assert node.subfield == "subfield"  # type: ignore
+    node = sqlglot.lineage.Node(
+        "test", expression, expression, payload={"subfield": "subfield"}
+    )
+    assert node.payload["subfield"] == "subfield"
 
 
 def test_decorrelate_null_parent_predicate() -> None:


### PR DESCRIPTION
## Summary

Removes one of our sqlglot runtime patches (the `Node` subclass) by adopting sqlglot's built-in `Node.payload` field.

### Background

For struct field-level lineage (e.g. `SELECT t.col.subfield FROM t`), we track which nested field of a struct column was accessed. Previously this required **subclassing** sqlglot's lineage `Node` dataclass to bolt on a `subfield: str` field, re-injected on every sqlglot upgrade.

sqlglot [#7575](https://github.com/tobymao/sqlglot/pull/7575) added `Node.payload: dict[str, Any]` — a generic, caller-owned slot intended exactly for attaching per-node metadata *without* subclassing. It's present in our pinned `sqlglot[c]==30.8.0`.

### Changes

- **`_sqlglot_patch.py`**: delete the `Node` subclass and its reassignments; the subfield-extraction patch now writes `payload={"subfield": subfield}` into the stock `Node` constructor. Removes the now-unused `import dataclasses`.
- **`sqlglot_lineage.py`**: read `node.payload.get("subfield")` instead of `node.subfield`. Drops the `hasattr(node, "subfield")` version-compat guard and two `# type: ignore`s (no longer needed — `payload` is a real typed field).
- **`test_sqlglot_patch.py`**: update `test_lineage_node_subfield` to use `payload=`.

Net **−20 / +9 lines**, no behavior change.

### Why this is safe

- We construct the `Node` ourselves inside the patched `to_node`, so we set `payload` directly — no reliance on sqlglot's `on_node` callback (which we don't register).
- sqlglot never writes to `payload` itself; we own the `"subfield"` key.
- `payload` is part of sqlglot's public `Node` API, so this survives version bumps.
