### PR TITLE
docs(databricks): clarify required permissions and connection test behavior

### DIFF
--- a/docs/automations/databricks-metadata-sync.md
+++ b/docs/automations/databricks-metadata-sync.md
@@ -61,7 +61,8 @@ _Note: If using governed tags, you may also need ASSIGN permission on the tag po
 
 #### Permissions for Description Synchronization
 
-- **MODIFY**: Required to update comments/descriptions on Unity Catalog objects (catalogs, schemas, tables, columns)
+- **MODIFY**: Required to update comments/descriptions on Unity Catalog objects (tables, columns, catalogs, schemas)
+- **SELECT**: Required alongside MODIFY for table and column description operations
 
 ### Example Permission Configuration
 
@@ -87,10 +88,9 @@ GRANT APPLY TAG ON ALL TABLES IN SCHEMA your_catalog.your_schema TO `datahub-aut
 GRANT USE CATALOG ON CATALOG your_catalog TO `datahub-automation@your-domain.com`;
 GRANT USE SCHEMA ON SCHEMA your_catalog.your_schema TO `datahub-automation@your-domain.com`;
 
--- Description modification permissions
-GRANT MODIFY ON CATALOG your_catalog TO `datahub-automation@your-domain.com`;
+-- Description modification permissions (both MODIFY and SELECT are required)
 GRANT MODIFY ON SCHEMA your_catalog.your_schema TO `datahub-automation@your-domain.com`;
-GRANT MODIFY ON ALL TABLES IN SCHEMA your_catalog.your_schema TO `datahub-automation@your-domain.com`;
+GRANT SELECT ON SCHEMA your_catalog.your_schema TO `datahub-automation@your-domain.com`;
 ```
 
 #### For Both Tags and Descriptions
@@ -105,10 +105,9 @@ GRANT APPLY TAG ON CATALOG your_catalog TO `datahub-automation@your-domain.com`;
 GRANT APPLY TAG ON SCHEMA your_catalog.your_schema TO `datahub-automation@your-domain.com`;
 GRANT APPLY TAG ON ALL TABLES IN SCHEMA your_catalog.your_schema TO `datahub-automation@your-domain.com`;
 
--- Description modification permissions
-GRANT MODIFY ON CATALOG your_catalog TO `datahub-automation@your-domain.com`;
+-- Description modification permissions (both MODIFY and SELECT are required)
 GRANT MODIFY ON SCHEMA your_catalog.your_schema TO `datahub-automation@your-domain.com`;
-GRANT MODIFY ON ALL TABLES IN SCHEMA your_catalog.your_schema TO `datahub-automation@your-domain.com`;
+GRANT SELECT ON SCHEMA your_catalog.your_schema TO `datahub-automation@your-domain.com`;
 ```
 
 ### Connection Requirements
@@ -182,6 +181,8 @@ Complete the Databricks connection configuration:
 #### Test Connection
 
 Click **Test Connection** to verify your configuration before proceeding.
+
+> **Note:** If you use a **remote executor** for your automation (can be selected under "Advanced"), the connection test may fail with _"Unauthorized network access to workspace"_. This may be expected, since the test runs directly from DataHub Cloud and not from your remote executor. The actual metadata sync will still work correctly via the remote executor.
 
 ### Step 5: Configure Automation Details
 


### PR DESCRIPTION
## Summary

Updates the **Databricks Metadata Sync** automation guide (`docs/automations/databricks-metadata-sync.md`):

- **Add the missing `SELECT` privilege** for description synchronization. `SELECT` is required alongside `MODIFY` for table and column description operations — without it, description sync fails with `PERMISSION_DENIED: User does not have SELECT`.
- **Fix invalid SQL in the grant examples.** `GRANT MODIFY ON ALL TABLES IN SCHEMA ...` is a parse error in Unity Catalog; a schema-level `GRANT MODIFY`/`GRANT SELECT ON SCHEMA` already covers the tables within it.
- **Document remote-executor connection-test behavior.** Add a note that the **Test Connection** step may report _"Unauthorized network access to workspace"_ when a remote executor is configured. This can be expected, since the connection test runs from DataHub Cloud rather than from the remote executor — metadata sync itself still works correctly via the remote executor.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)