### PR TITLE
fix(frontend): allow data: and blob: in CSP img-src directive

### DIFF
--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -112,7 +112,7 @@ play.filters {
       style-src = "'unsafe-inline' https: http:"
       style-src = ${?DATAHUB_CSP_STYLE_SRC}
 
-      img-src = "*"
+      img-src = "* data: blob:"
       img-src = ${?DATAHUB_CSP_IMG_SRC}
 
       font-src = "* data:"


### PR DESCRIPTION
Permits inline and blob-backed images in the frontend Content Security Policy.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
