### PR TITLE
fix(ingest): enable faulthandler so native crashes leave a diagnosable stack

### DIFF
--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -1,3 +1,4 @@
+import faulthandler
 import importlib.resources
 import logging
 import multiprocessing
@@ -568,6 +569,16 @@ enable_auto_decorators(datahub)
 
 
 def main(**kwargs):
+    # Dump a Python traceback to stderr on fatal signals (SIGSEGV, SIGABRT,
+    # SIGFPE, SIGBUS). Native crashes — e.g. a C-stack overflow inside sqlglot's
+    # compiled parser on pathologically nested SQL, or a segfault in a C
+    # extension like pyarrow — otherwise kill the process with no traceback,
+    # leaving an ingestion log that just stops mid-line. CPython enables this
+    # automatically when PYTHONFAULTHANDLER is set; we enable it by default so
+    # managed runners get a diagnosable stack without extra configuration.
+    if not faulthandler.is_enabled():
+        faulthandler.enable()
+
     # We use threads in a variety of places within our CLI. The multiprocessing
     # "fork" start method is not safe to use with threads.
     # MacOS and Windows already default to "spawn", and Linux will as well starting in Python 3.14.


### PR DESCRIPTION
## Summary

Fatal signals — `SIGSEGV`, `SIGABRT`, `SIGFPE`, `SIGBUS` — kill the `datahub ingest` process with **no Python traceback**, leaving an ingestion log that simply stops mid-line and gives no indication of which statement or component crashed. This happens for native crashes such as a C-stack overflow inside sqlglot's compiled (`sqlglot[c]`) parser on pathologically nested SQL, or a segfault in a native extension like pyarrow.

This enables `faulthandler` at CLI startup so those crashes dump a **per-thread Python traceback to stderr** (captured into the ingestion log) right before the process dies — turning an undiagnosable silent death into a stack that points at the failing phase.

## Details

- CPython already enables faulthandler automatically when `PYTHONFAULTHANDLER` is set; enabling it in code makes it **default-on** for managed runners where setting env vars is awkward.
- The call is guarded by `faulthandler.is_enabled()`, so it's a no-op when `PYTHONFAULTHANDLER` already enabled it.
- faulthandler dumps the Python stack (the last Python frame before native code), which is enough to attribute a crash to e.g. SQL parsing vs. a different extension. Negligible overhead; only acts on fatal signals.

## Testing

`ruff` and `mypy` clean. The change is a startup-time diagnostic with no behavioral effect on success paths.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline
- [ ] Tests added/updated (startup diagnostic; no behavior change)
- [ ] Docs added/updated
