### PR TITLE
docs(release): add v1.1.2-cloud hotfix release notes

### DIFF
--- a/docs/managed-datahub/release-notes/v_1_1_0.md
+++ b/docs/managed-datahub/release-notes/v_1_1_0.md
@@ -6,6 +6,25 @@ description: "DataHub Cloud v1.1.0 release notes covering OAuth2 dynamic client 
 
 ## Release Changelog
 
+### v1.1.2
+
+Hotfix release on top of **v1.1.1**. There are no breaking changes or deprecations.
+
+#### Release Availability Date
+
+09-June-2026
+
+**Recommended Versions**
+
+- **CLI / SDK**: v1.6.0
+- **Remote Executor**: v1.1.2-cloud
+- **Helm**: 1.6.142
+
+#### Bug Fixes
+
+- **Remote executor — MSSQL ODBC on Wolfi full images** — The Microsoft ODBC Driver 18 for SQL Server is now installed on Wolfi-based datahub-executor full images. Restores MSSQL ingestion that uses `mssql-odbc` on the v1.1.0 Wolfi executor, where the driver was missing after the Ubuntu → Wolfi migration.
+- **UI — inline SVG icon rendering (CSP)** — Content-Security-Policy `img-src` now allows `data:` and `blob:` URLs so inline SVG icons render correctly in the frontend after CSP hardening shipped in v1.1.0.
+
 ### v1.1.1
 
 This release rolls up hotfixes on top of v1.1.0. There are no breaking changes or deprecations.


### PR DESCRIPTION
## Summary

- Adds v1.1.2 hotfix section to `v_1_1_0.md` release notes (patch on v1.1.1)
- Documents MSSQL ODBC Driver 18 installation on Wolfi-based datahub-executor full images (#17818)
- Documents CSP `img-src` fix for inline SVG icon rendering (#17827)

## Test plan

- [x] Verified release notes render in docs sidebar under v1.1.0
- [x] Markdown formatting passes pre-commit (`mdPrettierWriteChanged`, Docusaurus lint)


Made with [Cursor](https://cursor.com)