### PR TITLE
feat(openapi/lineage): Add lineage scroll endpoint

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/graph/openapi.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/openapi.py
@@ -364,8 +364,91 @@ class OpenApiAPI(OpenAPIGraphProtocol):
             - scroll_id: cursor to pass in the next call (None when exhausted)
             - relationships: list of Relationship objects with source/destination info
         """
-        url = f"{self._gms_server}/openapi/v3/relationship/scroll"
+        return self._scroll_relationships_impl(
+            url=f"{self._gms_server}/openapi/v3/relationship/scroll",
+            relationship_types=relationship_types,
+            source_types=source_types,
+            destination_types=destination_types,
+            direction=direction,
+            source_urns=source_urns,
+            destination_urns=destination_urns,
+            source_filter=source_filter,
+            destination_filter=destination_filter,
+            edge_filter=edge_filter,
+            count=count,
+            scroll_id=scroll_id,
+            include_soft_delete=include_soft_delete,
+            slice_id=slice_id,
+            slice_max=slice_max,
+            pit_keep_alive=pit_keep_alive,
+        )
 
+    def scroll_lineage(
+        self,
+        *,
+        relationship_types: Optional[List[str]] = None,
+        source_types: Optional[List[str]] = None,
+        destination_types: Optional[List[str]] = None,
+        direction: Optional[RelationshipDirection] = None,
+        source_urns: Optional[List[str]] = None,
+        destination_urns: Optional[List[str]] = None,
+        source_filter: Optional[RawSearchFilter] = None,
+        destination_filter: Optional[RawSearchFilter] = None,
+        edge_filter: Optional[RawSearchFilter] = None,
+        count: Optional[int] = None,
+        scroll_id: Optional[str] = None,
+        include_soft_delete: Optional[bool] = None,
+        slice_id: Optional[int] = None,
+        slice_max: Optional[int] = None,
+        pit_keep_alive: Optional[str] = None,
+    ) -> RelationshipScrollResult:
+        """Scroll through lineage relationships using the scrollLineage endpoint.
+
+        Behaves identically to scroll_relationships but additionally applies a
+        triplet-based lineage filter from the entity registry so that only edges
+        annotated as lineage are returned.
+
+        See scroll_relationships for parameter documentation.
+        """
+        return self._scroll_relationships_impl(
+            url=f"{self._gms_server}/openapi/v3/relationship/scrollLineage",
+            relationship_types=relationship_types,
+            source_types=source_types,
+            destination_types=destination_types,
+            direction=direction,
+            source_urns=source_urns,
+            destination_urns=destination_urns,
+            source_filter=source_filter,
+            destination_filter=destination_filter,
+            edge_filter=edge_filter,
+            count=count,
+            scroll_id=scroll_id,
+            include_soft_delete=include_soft_delete,
+            slice_id=slice_id,
+            slice_max=slice_max,
+            pit_keep_alive=pit_keep_alive,
+        )
+
+    def _scroll_relationships_impl(
+        self,
+        *,
+        url: str,
+        relationship_types: Optional[List[str]] = None,
+        source_types: Optional[List[str]] = None,
+        destination_types: Optional[List[str]] = None,
+        direction: Optional[RelationshipDirection] = None,
+        source_urns: Optional[List[str]] = None,
+        destination_urns: Optional[List[str]] = None,
+        source_filter: Optional[RawSearchFilter] = None,
+        destination_filter: Optional[RawSearchFilter] = None,
+        edge_filter: Optional[RawSearchFilter] = None,
+        count: Optional[int] = None,
+        scroll_id: Optional[str] = None,
+        include_soft_delete: Optional[bool] = None,
+        slice_id: Optional[int] = None,
+        slice_max: Optional[int] = None,
+        pit_keep_alive: Optional[str] = None,
+    ) -> RelationshipScrollResult:
         params: Dict[str, Any] = {}
         if relationship_types is not None:
             params["relationshipTypes"] = relationship_types

--- a/metadata-ingestion/src/datahub/ingestion/graph/openapi.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/openapi.py
@@ -411,7 +411,7 @@ class OpenApiAPI(OpenAPIGraphProtocol):
         See scroll_relationships for parameter documentation.
         """
         return self._scroll_relationships_impl(
-            url=f"{self._gms_server}/openapi/v3/relationship/scrollLineage",
+            url=f"{self._gms_server}/openapi/v3/lineage/scroll",
             relationship_types=relationship_types,
             source_types=source_types,
             destination_types=destination_types,

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/utils/GraphQueryUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/utils/GraphQueryUtils.java
@@ -149,6 +149,21 @@ public final class GraphQueryUtils {
       finalQuery.filter(relationshipQuery);
     }
 
+    // Triplet-based edge filter: OR over (sourceType, destType, relType) triples.
+    // Applied additively — all other filters above still apply.
+    if (graphFilters.getAllowedEdgeTriplets() != null
+        && !graphFilters.getAllowedEdgeTriplets().isEmpty()) {
+      BoolQueryBuilder tripletQuery = QueryBuilders.boolQuery();
+      graphFilters
+          .getAllowedEdgeTriplets()
+          .forEach(
+              pair ->
+                  tripletQuery.should(
+                      GraphFilterUtils.getAggregationFilter(pair, pair.getValue().getDirection())));
+      tripletQuery.minimumShouldMatch(1);
+      finalQuery.filter(tripletQuery);
+    }
+
     // general filter
     Optional.ofNullable(graphFilters.getRelationshipFilter())
         .map(RelationshipFilter::getOr)

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/utils/GraphQueryUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/utils/GraphQueryUtilsTest.java
@@ -15,6 +15,7 @@ import com.linkedin.metadata.config.search.GraphQueryConfiguration;
 import com.linkedin.metadata.graph.GraphFilters;
 import com.linkedin.metadata.graph.LineageRelationship;
 import com.linkedin.metadata.graph.elastic.ThreadSafePathStore;
+import com.linkedin.metadata.models.registry.LineageRegistry;
 import com.linkedin.metadata.query.SearchFlags;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
@@ -31,6 +32,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.action.search.SearchResponse;
@@ -378,6 +380,98 @@ public class GraphQueryUtilsTest {
     assertTrue(GraphQueryUtils.isRelationshipConnectedToInput(relationship, TEST_URN_1, pathStore));
     assertFalse(
         GraphQueryUtils.isRelationshipConnectedToInput(relationship, TEST_URN_3, pathStore));
+  }
+
+  @Test
+  public void testBuildQueryWithTripletFilter() {
+    GraphQueryConfiguration config = new GraphQueryConfiguration();
+    config.setGraphStatusEnabled(true);
+
+    Filter emptyFilter = new Filter();
+    emptyFilter.setOr(new ConjunctiveCriterionArray());
+    RelationshipFilter relationshipFilter =
+        new RelationshipFilter().setDirection(RelationshipDirection.OUTGOING);
+
+    GraphFilters filters =
+        new GraphFilters(emptyFilter, emptyFilter, null, null, Set.of(), relationshipFilter);
+
+    // Add triplets
+    Set<Pair<String, LineageRegistry.EdgeInfo>> triplets = new HashSet<>();
+    triplets.add(
+        Pair.of(
+            "dataset",
+            new LineageRegistry.EdgeInfo(
+                "DownstreamOf", RelationshipDirection.OUTGOING, "dataset")));
+    triplets.add(
+        Pair.of(
+            "chart",
+            new LineageRegistry.EdgeInfo("Consumes", RelationshipDirection.OUTGOING, "dataset")));
+    filters.setAllowedEdgeTriplets(triplets);
+
+    BoolQueryBuilder result = GraphQueryUtils.buildQuery(mockOpContext, config, filters);
+
+    assertNotNull(result);
+    // Should have filter clauses including the triplet bool query
+    assertFalse(result.filter().isEmpty());
+
+    // Verify the triplet filter is present: look for a bool query with should clauses
+    String queryString = result.toString();
+    assertTrue(queryString.contains("DownstreamOf"), "Query should contain DownstreamOf triplet");
+    assertTrue(queryString.contains("Consumes"), "Query should contain Consumes triplet");
+    assertTrue(
+        queryString.contains("minimum_should_match"),
+        "Query should have minimum_should_match for triplets");
+  }
+
+  @Test
+  public void testBuildQueryWithoutTripletFilter() {
+    GraphQueryConfiguration config = new GraphQueryConfiguration();
+    config.setGraphStatusEnabled(true);
+
+    Filter emptyFilter = new Filter();
+    emptyFilter.setOr(new ConjunctiveCriterionArray());
+    RelationshipFilter relationshipFilter =
+        new RelationshipFilter().setDirection(RelationshipDirection.OUTGOING);
+
+    // null triplets (default)
+    GraphFilters filters =
+        new GraphFilters(emptyFilter, emptyFilter, null, null, Set.of(), relationshipFilter);
+
+    BoolQueryBuilder result = GraphQueryUtils.buildQuery(mockOpContext, config, filters);
+
+    assertNotNull(result);
+    String queryString = result.toString();
+    // With no types, no triplets, and empty filters, the only filters should be soft-delete
+    assertFalse(
+        queryString.contains("DownstreamOf"),
+        "Query should not contain triplet filters when not set");
+  }
+
+  @Test
+  public void testBuildQueryWithEmptyTripletFilter() {
+    GraphQueryConfiguration config = new GraphQueryConfiguration();
+    config.setGraphStatusEnabled(true);
+
+    Filter emptyFilter = new Filter();
+    emptyFilter.setOr(new ConjunctiveCriterionArray());
+    RelationshipFilter relationshipFilter =
+        new RelationshipFilter().setDirection(RelationshipDirection.OUTGOING);
+
+    GraphFilters filters =
+        new GraphFilters(emptyFilter, emptyFilter, null, null, Set.of(), relationshipFilter);
+    filters.setAllowedEdgeTriplets(Set.of()); // empty set
+
+    BoolQueryBuilder result = GraphQueryUtils.buildQuery(mockOpContext, config, filters);
+
+    assertNotNull(result);
+    // Empty triplet set should not add any triplet filter clause
+    // Count filter clauses - should be same as without triplets
+    GraphFilters filtersNoTriplets =
+        new GraphFilters(emptyFilter, emptyFilter, null, null, Set.of(), relationshipFilter);
+    BoolQueryBuilder resultNoTriplets =
+        GraphQueryUtils.buildQuery(mockOpContext, config, filtersNoTriplets);
+
+    assertEquals(result.filter().size(), resultNoTriplets.filter().size());
   }
 
   @Test

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/GenericRelationshipController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/GenericRelationshipController.java
@@ -13,6 +13,7 @@ import com.linkedin.data.template.SetMode;
 import com.linkedin.metadata.aspect.models.graph.Edge;
 import com.linkedin.metadata.aspect.models.graph.RelatedEntities;
 import com.linkedin.metadata.aspect.models.graph.RelatedEntitiesScrollResult;
+import com.linkedin.metadata.graph.GraphFilters;
 import com.linkedin.metadata.graph.GraphService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.query.SliceOptions;
@@ -302,6 +303,86 @@ public abstract class GenericRelationshipController {
       @RequestParam(value = "pitKeepAlive", required = false, defaultValue = "5m")
           String pitKeepAlive,
       @RequestBody @Nonnull ScrollRelationshipsRequestBody body) {
+    return doScrollRelationships(
+        request,
+        "scrollRelationships",
+        relationshipTypes,
+        sourceTypes,
+        destinationTypes,
+        direction,
+        count,
+        scrollId,
+        includeSoftDelete,
+        sliceId,
+        sliceMax,
+        pitKeepAlive,
+        body,
+        null);
+  }
+
+  /**
+   * Scrolls lineage relationship edges. Accepts the same parameters as /scroll but additionally
+   * applies a triplet-based lineage filter from the entity registry so that only edges annotated as
+   * lineage are returned. Callers can still layer on source/destination/relationship type filters,
+   * entity filters, and direction as needed.
+   */
+  @PostMapping(value = "/scrollLineage", produces = MediaType.APPLICATION_JSON_VALUE)
+  @Operation(
+      summary =
+          "Scroll lineage relationships with configurable filters on source/destination types and edges.")
+  public ResponseEntity<GenericScrollResult<GenericRelationship>> scrollLineage(
+      HttpServletRequest request,
+      @RequestParam(value = "relationshipTypes", required = false) String[] relationshipTypes,
+      @RequestParam(value = "sourceTypes", required = false) String[] sourceTypes,
+      @RequestParam(value = "destinationTypes", required = false) String[] destinationTypes,
+      @RequestParam(value = "direction", defaultValue = "OUTGOING") String direction,
+      @RequestParam(value = "count", defaultValue = "10") Integer count,
+      @RequestParam(value = "scrollId", required = false) String scrollId,
+      @RequestParam(value = "includeSoftDelete", required = false, defaultValue = "false")
+          Boolean includeSoftDelete,
+      @RequestParam(value = "sliceId", required = false) Integer sliceId,
+      @RequestParam(value = "sliceMax", required = false) Integer sliceMax,
+      @RequestParam(value = "pitKeepAlive", required = false, defaultValue = "5m")
+          String pitKeepAlive,
+      @RequestBody @Nonnull ScrollRelationshipsRequestBody body) {
+    GraphFilters baseFilters = GraphFilters.forLineage(graphService.getLineageRegistry());
+    return doScrollRelationships(
+        request,
+        "scrollLineage",
+        relationshipTypes,
+        sourceTypes,
+        destinationTypes,
+        direction,
+        count,
+        scrollId,
+        includeSoftDelete,
+        sliceId,
+        sliceMax,
+        pitKeepAlive,
+        body,
+        baseFilters);
+  }
+
+  /**
+   * Shared implementation for scrollRelationships and scrollLineage. When {@code baseFilters} is
+   * non-null its filters (e.g. lineage triplets) are applied additively to the filters derived from
+   * the request parameters.
+   */
+  private ResponseEntity<GenericScrollResult<GenericRelationship>> doScrollRelationships(
+      HttpServletRequest request,
+      String operationName,
+      String[] relationshipTypes,
+      String[] sourceTypes,
+      String[] destinationTypes,
+      String direction,
+      Integer count,
+      String scrollId,
+      Boolean includeSoftDelete,
+      Integer sliceId,
+      Integer sliceMax,
+      String pitKeepAlive,
+      ScrollRelationshipsRequestBody body,
+      GraphFilters baseFilters) {
 
     Authentication authentication = AuthenticationContext.getAuthentication();
     OperationContext opContext =
@@ -309,10 +390,7 @@ public abstract class GenericRelationshipController {
                 systemOperationContext,
                 RequestContext.builder()
                     .buildOpenapi(
-                        authentication.getActor().toUrnStr(),
-                        request,
-                        "scrollRelationships",
-                        List.of()),
+                        authentication.getActor().toUrnStr(), request, operationName, List.of()),
                 authorizationChain,
                 authentication,
                 true)
@@ -364,17 +442,27 @@ public abstract class GenericRelationshipController {
           "Direction must be INCOMING, OUTGOING, or UNDIRECTED, got: " + direction);
     }
 
-    RelatedEntitiesScrollResult result =
-        graphService.scrollRelatedEntities(
-            opContext,
-            sourceTypesSet,
+    // Build GraphFilters from the request parameters.
+    GraphFilters graphFilters =
+        new GraphFilters(
             sourceEntityFilter,
-            destinationTypesSet,
             destinationEntityFilter,
+            sourceTypesSet,
+            destinationTypesSet,
             relationshipTypes != null
                 ? Arrays.stream(relationshipTypes).collect(Collectors.toSet())
                 : Set.of(),
-            QueryUtils.newRelationshipFilter(edgeFilter, relationshipDirection),
+            QueryUtils.newRelationshipFilter(edgeFilter, relationshipDirection));
+
+    // Merge in base filters (e.g. lineage triplets) if provided.
+    if (baseFilters != null && baseFilters.getAllowedEdgeTriplets() != null) {
+      graphFilters.setAllowedEdgeTriplets(baseFilters.getAllowedEdgeTriplets());
+    }
+
+    RelatedEntitiesScrollResult result =
+        graphService.scrollRelatedEntities(
+            opContext,
+            graphFilters,
             Edge.EDGE_SORT_CRITERION,
             scrollId,
             pitKeepAlive != null && pitKeepAlive.isEmpty() ? null : pitKeepAlive,

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/GenericRelationshipController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/GenericRelationshipController.java
@@ -7,13 +7,10 @@ import com.datahub.authentication.Authentication;
 import com.datahub.authentication.AuthenticationContext;
 import com.datahub.authorization.AuthUtil;
 import com.datahub.authorization.AuthorizerChain;
-import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.SetMode;
 import com.linkedin.metadata.aspect.models.graph.Edge;
-import com.linkedin.metadata.aspect.models.graph.RelatedEntities;
 import com.linkedin.metadata.aspect.models.graph.RelatedEntitiesScrollResult;
-import com.linkedin.metadata.graph.GraphFilters;
 import com.linkedin.metadata.graph.GraphService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.query.SliceOptions;
@@ -29,7 +26,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -141,7 +137,7 @@ public abstract class GenericRelationshipController {
 
     return ResponseEntity.ok(
         GenericScrollResult.<GenericRelationship>builder()
-            .results(toGenericRelationships(result.getEntities()))
+            .results(ScrollUtils.toGenericRelationships(result.getEntities()))
             .scrollId(result.getScrollId())
             .build());
   }
@@ -268,7 +264,7 @@ public abstract class GenericRelationshipController {
 
     return ResponseEntity.ok(
         GenericScrollResult.<GenericRelationship>builder()
-            .results(toGenericRelationships(result.getEntities()))
+            .results(ScrollUtils.toGenericRelationships(result.getEntities()))
             .scrollId(result.getScrollId())
             .build());
   }
@@ -303,7 +299,10 @@ public abstract class GenericRelationshipController {
       @RequestParam(value = "pitKeepAlive", required = false, defaultValue = "5m")
           String pitKeepAlive,
       @RequestBody @Nonnull ScrollRelationshipsRequestBody body) {
-    return doScrollRelationships(
+    return ScrollUtils.doScrollRelationships(
+        systemOperationContext,
+        authorizationChain,
+        graphService,
         request,
         "scrollRelationships",
         relationshipTypes,
@@ -318,196 +317,5 @@ public abstract class GenericRelationshipController {
         pitKeepAlive,
         body,
         null);
-  }
-
-  /**
-   * Scrolls lineage relationship edges. Accepts the same parameters as /scroll but additionally
-   * applies a triplet-based lineage filter from the entity registry so that only edges annotated as
-   * lineage are returned. Callers can still layer on source/destination/relationship type filters,
-   * entity filters, and direction as needed.
-   */
-  @PostMapping(value = "/scrollLineage", produces = MediaType.APPLICATION_JSON_VALUE)
-  @Operation(
-      summary =
-          "Scroll lineage relationships with configurable filters on source/destination types and edges.")
-  public ResponseEntity<GenericScrollResult<GenericRelationship>> scrollLineage(
-      HttpServletRequest request,
-      @RequestParam(value = "relationshipTypes", required = false) String[] relationshipTypes,
-      @RequestParam(value = "sourceTypes", required = false) String[] sourceTypes,
-      @RequestParam(value = "destinationTypes", required = false) String[] destinationTypes,
-      @RequestParam(value = "direction", defaultValue = "OUTGOING") String direction,
-      @RequestParam(value = "count", defaultValue = "10") Integer count,
-      @RequestParam(value = "scrollId", required = false) String scrollId,
-      @RequestParam(value = "includeSoftDelete", required = false, defaultValue = "false")
-          Boolean includeSoftDelete,
-      @RequestParam(value = "sliceId", required = false) Integer sliceId,
-      @RequestParam(value = "sliceMax", required = false) Integer sliceMax,
-      @RequestParam(value = "pitKeepAlive", required = false, defaultValue = "5m")
-          String pitKeepAlive,
-      @RequestBody @Nonnull ScrollRelationshipsRequestBody body) {
-    GraphFilters baseFilters = GraphFilters.forLineage(graphService.getLineageRegistry());
-    return doScrollRelationships(
-        request,
-        "scrollLineage",
-        relationshipTypes,
-        sourceTypes,
-        destinationTypes,
-        direction,
-        count,
-        scrollId,
-        includeSoftDelete,
-        sliceId,
-        sliceMax,
-        pitKeepAlive,
-        body,
-        baseFilters);
-  }
-
-  /**
-   * Shared implementation for scrollRelationships and scrollLineage. When {@code baseFilters} is
-   * non-null its filters (e.g. lineage triplets) are applied additively to the filters derived from
-   * the request parameters.
-   */
-  private ResponseEntity<GenericScrollResult<GenericRelationship>> doScrollRelationships(
-      HttpServletRequest request,
-      String operationName,
-      String[] relationshipTypes,
-      String[] sourceTypes,
-      String[] destinationTypes,
-      String direction,
-      Integer count,
-      String scrollId,
-      Boolean includeSoftDelete,
-      Integer sliceId,
-      Integer sliceMax,
-      String pitKeepAlive,
-      ScrollRelationshipsRequestBody body,
-      GraphFilters baseFilters) {
-
-    Authentication authentication = AuthenticationContext.getAuthentication();
-    OperationContext opContext =
-        OperationContext.asSession(
-                systemOperationContext,
-                RequestContext.builder()
-                    .buildOpenapi(
-                        authentication.getActor().toUrnStr(), request, operationName, List.of()),
-                authorizationChain,
-                authentication,
-                true)
-            .withSearchFlags(
-                f ->
-                    f.setIncludeSoftDeleted(includeSoftDelete)
-                        .setSliceOptions(
-                            sliceId != null && sliceMax != null
-                                ? new SliceOptions().setId(sliceId).setMax(sliceMax)
-                                : null,
-                            SetMode.IGNORE_NULL));
-
-    if (!AuthUtil.isAPIAuthorized(opContext, RELATIONSHIP, READ)) {
-      throw new UnauthorizedException(
-          authentication.getActor().toUrnStr()
-              + " is unauthorized to "
-              + READ
-              + " "
-              + RELATIONSHIP);
-    }
-
-    Set<String> sourceTypesSet =
-        sourceTypes != null && sourceTypes.length > 0
-            ? Arrays.stream(sourceTypes).collect(Collectors.toSet())
-            : null;
-    Set<String> destinationTypesSet =
-        destinationTypes != null && destinationTypes.length > 0
-            ? Arrays.stream(destinationTypes).collect(Collectors.toSet())
-            : null;
-
-    com.linkedin.metadata.query.filter.Filter sourceEntityFilter =
-        Optional.ofNullable(body.getSourceFilter())
-            .map(io.datahubproject.openapi.v3.models.Filter::toRecordTemplate)
-            .orElse(QueryUtils.EMPTY_FILTER);
-    com.linkedin.metadata.query.filter.Filter destinationEntityFilter =
-        Optional.ofNullable(body.getDestinationFilter())
-            .map(io.datahubproject.openapi.v3.models.Filter::toRecordTemplate)
-            .orElse(QueryUtils.EMPTY_FILTER);
-    com.linkedin.metadata.query.filter.Filter edgeFilter =
-        Optional.ofNullable(body.getEdgeFilter())
-            .map(io.datahubproject.openapi.v3.models.Filter::toRecordTemplate)
-            .orElse(QueryUtils.EMPTY_FILTER);
-
-    RelationshipDirection relationshipDirection;
-    try {
-      relationshipDirection = RelationshipDirection.valueOf(direction.toUpperCase());
-    } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException(
-          "Direction must be INCOMING, OUTGOING, or UNDIRECTED, got: " + direction);
-    }
-
-    // Build GraphFilters from the request parameters.
-    GraphFilters graphFilters =
-        new GraphFilters(
-            sourceEntityFilter,
-            destinationEntityFilter,
-            sourceTypesSet,
-            destinationTypesSet,
-            relationshipTypes != null
-                ? Arrays.stream(relationshipTypes).collect(Collectors.toSet())
-                : Set.of(),
-            QueryUtils.newRelationshipFilter(edgeFilter, relationshipDirection));
-
-    // Merge in base filters (e.g. lineage triplets) if provided.
-    if (baseFilters != null && baseFilters.getAllowedEdgeTriplets() != null) {
-      graphFilters.setAllowedEdgeTriplets(baseFilters.getAllowedEdgeTriplets());
-    }
-
-    RelatedEntitiesScrollResult result =
-        graphService.scrollRelatedEntities(
-            opContext,
-            graphFilters,
-            Edge.EDGE_SORT_CRITERION,
-            scrollId,
-            pitKeepAlive != null && pitKeepAlive.isEmpty() ? null : pitKeepAlive,
-            count,
-            null,
-            null);
-
-    if (!AuthUtil.isAPIAuthorizedUrns(
-        opContext,
-        RELATIONSHIP,
-        READ,
-        result.getEntities().stream()
-            .flatMap(
-                edge ->
-                    Stream.of(
-                        UrnUtils.getUrn(edge.getSourceUrn()),
-                        UrnUtils.getUrn(edge.getDestinationUrn())))
-            .collect(Collectors.toSet()))) {
-      throw new UnauthorizedException(
-          authentication.getActor().toUrnStr()
-              + " is unauthorized to "
-              + READ
-              + " "
-              + RELATIONSHIP);
-    }
-
-    return ResponseEntity.ok(
-        GenericScrollResult.<GenericRelationship>builder()
-            .results(toGenericRelationships(result.getEntities()))
-            .scrollId(result.getScrollId())
-            .build());
-  }
-
-  private List<GenericRelationship> toGenericRelationships(List<RelatedEntities> relatedEntities) {
-    return relatedEntities.stream()
-        .map(
-            result -> {
-              Urn source = UrnUtils.getUrn(result.getSourceUrn());
-              Urn dest = UrnUtils.getUrn(result.getDestinationUrn());
-              return GenericRelationship.builder()
-                  .relationshipType(result.getRelationshipType())
-                  .source(GenericRelationship.GenericNode.fromUrn(source))
-                  .destination(GenericRelationship.GenericNode.fromUrn(dest))
-                  .build();
-            })
-        .collect(Collectors.toList());
   }
 }

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/ScrollUtils.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/ScrollUtils.java
@@ -1,0 +1,192 @@
+package io.datahubproject.openapi.controller;
+
+import static com.linkedin.metadata.authorization.ApiGroup.RELATIONSHIP;
+import static com.linkedin.metadata.authorization.ApiOperation.READ;
+
+import com.datahub.authentication.Authentication;
+import com.datahub.authentication.AuthenticationContext;
+import com.datahub.authorization.AuthUtil;
+import com.datahub.authorization.AuthorizerChain;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.SetMode;
+import com.linkedin.metadata.aspect.models.graph.Edge;
+import com.linkedin.metadata.aspect.models.graph.RelatedEntities;
+import com.linkedin.metadata.aspect.models.graph.RelatedEntitiesScrollResult;
+import com.linkedin.metadata.graph.GraphFilters;
+import com.linkedin.metadata.graph.GraphService;
+import com.linkedin.metadata.query.SliceOptions;
+import com.linkedin.metadata.query.filter.RelationshipDirection;
+import com.linkedin.metadata.search.utils.QueryUtils;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.RequestContext;
+import io.datahubproject.openapi.exception.UnauthorizedException;
+import io.datahubproject.openapi.models.GenericScrollResult;
+import io.datahubproject.openapi.v2.models.GenericRelationship;
+import io.datahubproject.openapi.v3.models.ScrollRelationshipsRequestBody;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseEntity;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ScrollUtils {
+
+  /**
+   * Shared implementation for scroll endpoints. When {@code baseFilters} is non-null its filters
+   * (e.g. lineage triplets) are applied additively to the filters derived from the request
+   * parameters.
+   */
+  public static ResponseEntity<GenericScrollResult<GenericRelationship>> doScrollRelationships(
+      OperationContext systemOperationContext,
+      AuthorizerChain authorizationChain,
+      GraphService graphService,
+      HttpServletRequest request,
+      String operationName,
+      String[] relationshipTypes,
+      String[] sourceTypes,
+      String[] destinationTypes,
+      String direction,
+      Integer count,
+      String scrollId,
+      Boolean includeSoftDelete,
+      Integer sliceId,
+      Integer sliceMax,
+      String pitKeepAlive,
+      ScrollRelationshipsRequestBody body,
+      @Nullable GraphFilters baseFilters) {
+
+    Authentication authentication = AuthenticationContext.getAuthentication();
+    OperationContext opContext =
+        OperationContext.asSession(
+                systemOperationContext,
+                RequestContext.builder()
+                    .buildOpenapi(
+                        authentication.getActor().toUrnStr(), request, operationName, List.of()),
+                authorizationChain,
+                authentication,
+                true)
+            .withSearchFlags(
+                f ->
+                    f.setIncludeSoftDeleted(includeSoftDelete)
+                        .setSliceOptions(
+                            sliceId != null && sliceMax != null
+                                ? new SliceOptions().setId(sliceId).setMax(sliceMax)
+                                : null,
+                            SetMode.IGNORE_NULL));
+
+    if (!AuthUtil.isAPIAuthorized(opContext, RELATIONSHIP, READ)) {
+      throw new UnauthorizedException(
+          authentication.getActor().toUrnStr()
+              + " is unauthorized to "
+              + READ
+              + " "
+              + RELATIONSHIP);
+    }
+
+    Set<String> sourceTypesSet =
+        sourceTypes != null && sourceTypes.length > 0
+            ? Arrays.stream(sourceTypes).collect(Collectors.toSet())
+            : null;
+    Set<String> destinationTypesSet =
+        destinationTypes != null && destinationTypes.length > 0
+            ? Arrays.stream(destinationTypes).collect(Collectors.toSet())
+            : null;
+
+    com.linkedin.metadata.query.filter.Filter sourceEntityFilter =
+        Optional.ofNullable(body.getSourceFilter())
+            .map(io.datahubproject.openapi.v3.models.Filter::toRecordTemplate)
+            .orElse(QueryUtils.EMPTY_FILTER);
+    com.linkedin.metadata.query.filter.Filter destinationEntityFilter =
+        Optional.ofNullable(body.getDestinationFilter())
+            .map(io.datahubproject.openapi.v3.models.Filter::toRecordTemplate)
+            .orElse(QueryUtils.EMPTY_FILTER);
+    com.linkedin.metadata.query.filter.Filter edgeFilter =
+        Optional.ofNullable(body.getEdgeFilter())
+            .map(io.datahubproject.openapi.v3.models.Filter::toRecordTemplate)
+            .orElse(QueryUtils.EMPTY_FILTER);
+
+    RelationshipDirection relationshipDirection;
+    try {
+      relationshipDirection = RelationshipDirection.valueOf(direction.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Direction must be INCOMING, OUTGOING, or UNDIRECTED, got: " + direction);
+    }
+
+    // Build GraphFilters from the request parameters.
+    GraphFilters graphFilters =
+        new GraphFilters(
+            sourceEntityFilter,
+            destinationEntityFilter,
+            sourceTypesSet,
+            destinationTypesSet,
+            relationshipTypes != null
+                ? Arrays.stream(relationshipTypes).collect(Collectors.toSet())
+                : Set.of(),
+            QueryUtils.newRelationshipFilter(edgeFilter, relationshipDirection));
+
+    // Merge in base filters (e.g. lineage triplets) if provided.
+    if (baseFilters != null && baseFilters.getAllowedEdgeTriplets() != null) {
+      graphFilters.setAllowedEdgeTriplets(baseFilters.getAllowedEdgeTriplets());
+    }
+
+    RelatedEntitiesScrollResult result =
+        graphService.scrollRelatedEntities(
+            opContext,
+            graphFilters,
+            Edge.EDGE_SORT_CRITERION,
+            scrollId,
+            pitKeepAlive != null && pitKeepAlive.isEmpty() ? null : pitKeepAlive,
+            count,
+            null,
+            null);
+
+    if (!AuthUtil.isAPIAuthorizedUrns(
+        opContext,
+        RELATIONSHIP,
+        READ,
+        result.getEntities().stream()
+            .flatMap(
+                edge ->
+                    Stream.of(
+                        UrnUtils.getUrn(edge.getSourceUrn()),
+                        UrnUtils.getUrn(edge.getDestinationUrn())))
+            .collect(Collectors.toSet()))) {
+      throw new UnauthorizedException(
+          authentication.getActor().toUrnStr()
+              + " is unauthorized to "
+              + READ
+              + " "
+              + RELATIONSHIP);
+    }
+
+    return ResponseEntity.ok(
+        GenericScrollResult.<GenericRelationship>builder()
+            .results(toGenericRelationships(result.getEntities()))
+            .scrollId(result.getScrollId())
+            .build());
+  }
+
+  static List<GenericRelationship> toGenericRelationships(List<RelatedEntities> relatedEntities) {
+    return relatedEntities.stream()
+        .map(
+            result -> {
+              Urn source = UrnUtils.getUrn(result.getSourceUrn());
+              Urn dest = UrnUtils.getUrn(result.getDestinationUrn());
+              return GenericRelationship.builder()
+                  .relationshipType(result.getRelationshipType())
+                  .source(GenericRelationship.GenericNode.fromUrn(source))
+                  .destination(GenericRelationship.GenericNode.fromUrn(dest))
+                  .build();
+            })
+        .collect(Collectors.toList());
+  }
+}

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/controller/LineageController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/controller/LineageController.java
@@ -1,0 +1,85 @@
+package io.datahubproject.openapi.v3.controller;
+
+import com.datahub.authorization.AuthorizerChain;
+import com.linkedin.metadata.graph.GraphFilters;
+import com.linkedin.metadata.graph.GraphService;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.openapi.controller.ScrollUtils;
+import io.datahubproject.openapi.models.GenericScrollResult;
+import io.datahubproject.openapi.v2.models.GenericRelationship;
+import io.datahubproject.openapi.v3.models.ScrollRelationshipsRequestBody;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("LineageControllerV3")
+@RequiredArgsConstructor
+@RequestMapping("/openapi/v3/lineage")
+@Slf4j
+@Tag(name = "Generic Lineage", description = "APIs for accessing lineage relationships.")
+public class LineageController {
+
+  @Autowired private GraphService graphService;
+  @Autowired private AuthorizerChain authorizationChain;
+
+  @Qualifier("systemOperationContext")
+  @Autowired
+  private OperationContext systemOperationContext;
+
+  /**
+   * Scrolls lineage relationship edges. Applies a triplet-based lineage filter from the entity
+   * registry so that only edges annotated as lineage are returned. Callers can still layer on
+   * source/destination/relationship type filters, entity filters, and direction as needed.
+   */
+  @PostMapping(value = "/scroll", produces = MediaType.APPLICATION_JSON_VALUE)
+  @Operation(
+      summary =
+          "Scroll lineage relationships with configurable filters on source/destination types and edges.")
+  public ResponseEntity<GenericScrollResult<GenericRelationship>> scrollLineage(
+      HttpServletRequest request,
+      @RequestParam(value = "relationshipTypes", required = false) String[] relationshipTypes,
+      @RequestParam(value = "sourceTypes", required = false) String[] sourceTypes,
+      @RequestParam(value = "destinationTypes", required = false) String[] destinationTypes,
+      @RequestParam(value = "direction", defaultValue = "OUTGOING") String direction,
+      @RequestParam(value = "count", defaultValue = "10") Integer count,
+      @RequestParam(value = "scrollId", required = false) String scrollId,
+      @RequestParam(value = "includeSoftDelete", required = false, defaultValue = "false")
+          Boolean includeSoftDelete,
+      @RequestParam(value = "sliceId", required = false) Integer sliceId,
+      @RequestParam(value = "sliceMax", required = false) Integer sliceMax,
+      @RequestParam(value = "pitKeepAlive", required = false, defaultValue = "5m")
+          String pitKeepAlive,
+      @RequestBody @Nonnull ScrollRelationshipsRequestBody body) {
+    GraphFilters baseFilters = GraphFilters.forLineage(graphService.getLineageRegistry());
+    return ScrollUtils.doScrollRelationships(
+        systemOperationContext,
+        authorizationChain,
+        graphService,
+        request,
+        "scrollLineage",
+        relationshipTypes,
+        sourceTypes,
+        destinationTypes,
+        direction,
+        count,
+        scrollId,
+        includeSoftDelete,
+        sliceId,
+        sliceMax,
+        pitKeepAlive,
+        body,
+        baseFilters);
+  }
+}

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/controller/RelationshipControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/controller/RelationshipControllerTest.java
@@ -14,9 +14,11 @@ import com.datahub.authorization.AuthorizerChain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.aspect.models.graph.RelatedEntitiesScrollResult;
+import com.linkedin.metadata.graph.GraphFilters;
 import com.linkedin.metadata.graph.GraphService;
 import com.linkedin.metadata.graph.elastic.ElasticSearchGraphService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.models.registry.LineageRegistry;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.query.filter.RelationshipFilter;
@@ -158,16 +160,11 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
     assertNotNull(capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getId());
     assertNotNull(capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getMax());
     assertEquals(
-        0,
-        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getId().intValue());
+        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getId().intValue(),
+        0);
     assertEquals(
-        2,
-        capturedOpContext
-            .getSearchContext()
-            .getSearchFlags()
-            .getSliceOptions()
-            .getMax()
-            .intValue());
+        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getMax().intValue(),
+        2);
   }
 
   @Test
@@ -292,16 +289,11 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
     assertNotNull(capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getId());
     assertNotNull(capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getMax());
     assertEquals(
-        1,
-        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getId().intValue());
+        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getId().intValue(),
+        1);
     assertEquals(
-        3,
-        capturedOpContext
-            .getSearchContext()
-            .getSearchFlags()
-            .getSliceOptions()
-            .getMax()
-            .intValue());
+        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getMax().intValue(),
+        3);
   }
 
   @Test
@@ -487,7 +479,7 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
 
     // Verify specific relationship types were passed
     Set capturedTypes = relationshipTypesCaptor.getValue();
-    assertEquals(2, capturedTypes.size());
+    assertEquals(capturedTypes.size(), 2);
     assertTrue(capturedTypes.contains("DownstreamOf"));
     assertTrue(capturedTypes.contains("Consumes"));
   }
@@ -529,7 +521,7 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
 
     // Verify specific relationship type was passed
     Set capturedTypes = relationshipTypesCaptor.getValue();
-    assertEquals(1, capturedTypes.size());
+    assertEquals(capturedTypes.size(), 1);
     assertTrue(capturedTypes.contains("DownstreamOf"));
   }
 
@@ -677,16 +669,11 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
     OperationContext capturedOpContext = opContextCaptor.getValue();
     assertNotNull(capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions());
     assertEquals(
-        2,
-        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getId().intValue());
+        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getId().intValue(),
+        2);
     assertEquals(
-        5,
-        capturedOpContext
-            .getSearchContext()
-            .getSearchFlags()
-            .getSliceOptions()
-            .getMax()
-            .intValue());
+        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getMax().intValue(),
+        5);
     assertTrue(capturedOpContext.getSearchContext().getSearchFlags().isIncludeSoftDeleted());
 
     // Verify INCOMING direction parameters
@@ -695,14 +682,14 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
 
     // Verify relationship types
     Set capturedTypes = relationshipTypesCaptor.getValue();
-    assertEquals(2, capturedTypes.size());
+    assertEquals(capturedTypes.size(), 2);
     assertTrue(capturedTypes.contains("DownstreamOf"));
     assertTrue(capturedTypes.contains("Consumes"));
 
     // Verify other parameters
-    assertEquals("prev-scroll-id", scrollIdCaptor.getValue());
-    assertEquals("15m", pitKeepAliveCaptor.getValue());
-    assertEquals(20, countCaptor.getValue().intValue());
+    assertEquals(scrollIdCaptor.getValue(), "prev-scroll-id");
+    assertEquals(pitKeepAliveCaptor.getValue(), "15m");
+    assertEquals(countCaptor.getValue().intValue(), 20);
   }
 
   @Test
@@ -752,23 +739,18 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
 
     // Verify relationship types
     Set capturedTypes = relationshipTypesCaptor.getValue();
-    assertEquals(1, capturedTypes.size());
+    assertEquals(capturedTypes.size(), 1);
     assertTrue(capturedTypes.contains("Produces"));
 
     // Verify slice options
     OperationContext capturedOpContext = opContextCaptor.getValue();
     assertNotNull(capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions());
     assertEquals(
-        1,
-        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getId().intValue());
+        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getId().intValue(),
+        1);
     assertEquals(
-        4,
-        capturedOpContext
-            .getSearchContext()
-            .getSearchFlags()
-            .getSliceOptions()
-            .getMax()
-            .intValue());
+        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getMax().intValue(),
+        4);
   }
 
   @Test
@@ -821,20 +803,11 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
     RelatedEntitiesScrollResult expectedResult =
         new RelatedEntitiesScrollResult(0, 10, "scroll-1", Arrays.asList());
 
-    ArgumentCaptor<Set> relationshipTypesCaptor = ArgumentCaptor.forClass(Set.class);
-    ArgumentCaptor<Set> sourceTypesCaptor = ArgumentCaptor.forClass(Set.class);
-    ArgumentCaptor<Set> destTypesCaptor = ArgumentCaptor.forClass(Set.class);
-    ArgumentCaptor<Filter> sourceFilterCaptor = ArgumentCaptor.forClass(Filter.class);
-    ArgumentCaptor<Filter> destFilterCaptor = ArgumentCaptor.forClass(Filter.class);
+    ArgumentCaptor<GraphFilters> graphFiltersCaptor = ArgumentCaptor.forClass(GraphFilters.class);
 
     when(mockGraphService.scrollRelatedEntities(
             any(),
-            sourceTypesCaptor.capture(),
-            sourceFilterCaptor.capture(),
-            destTypesCaptor.capture(),
-            destFilterCaptor.capture(),
-            relationshipTypesCaptor.capture(),
-            any(),
+            graphFiltersCaptor.capture(),
             any(),
             isNull(),
             anyString(),
@@ -852,19 +825,21 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
         .andExpect(status().is2xxSuccessful())
         .andExpect(jsonPath("$.scrollId").value("scroll-1"));
 
+    GraphFilters captured = graphFiltersCaptor.getValue();
     // No relationshipTypes param → null → empty set (all types)
-    assertTrue(relationshipTypesCaptor.getValue().isEmpty());
+    assertTrue(captured.getRelationshipTypes().isEmpty());
     // No sourceType / destinationType → null passed through
-    assertNull(sourceTypesCaptor.getValue());
-    assertNull(destTypesCaptor.getValue());
+    assertNull(captured.getSourceTypes());
+    assertNull(captured.getDestinationTypes());
     // No filters in body → EMPTY_FILTER (no criteria)
     assertTrue(
-        sourceFilterCaptor.getValue().getOr().isEmpty()
-            || sourceFilterCaptor.getValue().getOr().stream()
+        captured.getSourceEntityFilter().getOr().isEmpty()
+            || captured.getSourceEntityFilter().getOr().stream()
                 .allMatch(cc -> cc.getAnd().isEmpty()));
     assertTrue(
-        destFilterCaptor.getValue().getOr().isEmpty()
-            || destFilterCaptor.getValue().getOr().stream().allMatch(cc -> cc.getAnd().isEmpty()));
+        captured.getDestinationEntityFilter().getOr().isEmpty()
+            || captured.getDestinationEntityFilter().getOr().stream()
+                .allMatch(cc -> cc.getAnd().isEmpty()));
   }
 
   @Test
@@ -872,16 +847,11 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
     RelatedEntitiesScrollResult expectedResult =
         new RelatedEntitiesScrollResult(0, 10, null, Arrays.asList());
 
-    ArgumentCaptor<Set> relationshipTypesCaptor = ArgumentCaptor.forClass(Set.class);
+    ArgumentCaptor<GraphFilters> graphFiltersCaptor = ArgumentCaptor.forClass(GraphFilters.class);
 
     when(mockGraphService.scrollRelatedEntities(
             any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            relationshipTypesCaptor.capture(),
-            any(),
+            graphFiltersCaptor.capture(),
             any(),
             isNull(),
             anyString(),
@@ -900,8 +870,8 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful());
 
-    Set capturedTypes = relationshipTypesCaptor.getValue();
-    assertEquals(2, capturedTypes.size());
+    Set<String> capturedTypes = graphFiltersCaptor.getValue().getRelationshipTypes();
+    assertEquals(capturedTypes.size(), 2);
     assertTrue(capturedTypes.contains("DownstreamOf"));
     assertTrue(capturedTypes.contains("Consumes"));
   }
@@ -911,17 +881,11 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
     RelatedEntitiesScrollResult expectedResult =
         new RelatedEntitiesScrollResult(0, 10, null, Arrays.asList());
 
-    ArgumentCaptor<Set> sourceTypesCaptor = ArgumentCaptor.forClass(Set.class);
-    ArgumentCaptor<Set> destTypesCaptor = ArgumentCaptor.forClass(Set.class);
+    ArgumentCaptor<GraphFilters> graphFiltersCaptor = ArgumentCaptor.forClass(GraphFilters.class);
 
     when(mockGraphService.scrollRelatedEntities(
             any(),
-            sourceTypesCaptor.capture(),
-            any(),
-            destTypesCaptor.capture(),
-            any(),
-            anySet(),
-            any(),
+            graphFiltersCaptor.capture(),
             any(),
             isNull(),
             anyString(),
@@ -941,12 +905,13 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful());
 
-    Set capturedSrcTypes = sourceTypesCaptor.getValue();
-    assertEquals(1, capturedSrcTypes.size());
+    GraphFilters captured = graphFiltersCaptor.getValue();
+    Set<String> capturedSrcTypes = captured.getSourceTypes();
+    assertEquals(capturedSrcTypes.size(), 1);
     assertTrue(capturedSrcTypes.contains("dataset"));
 
-    Set capturedDstTypes = destTypesCaptor.getValue();
-    assertEquals(2, capturedDstTypes.size());
+    Set<String> capturedDstTypes = captured.getDestinationTypes();
+    assertEquals(capturedDstTypes.size(), 2);
     assertTrue(capturedDstTypes.contains("chart"));
     assertTrue(capturedDstTypes.contains("dashboard"));
   }
@@ -960,17 +925,11 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
     RelatedEntitiesScrollResult expectedResult =
         new RelatedEntitiesScrollResult(0, 10, null, Arrays.asList());
 
-    ArgumentCaptor<Filter> sourceFilterCaptor = ArgumentCaptor.forClass(Filter.class);
-    ArgumentCaptor<Filter> destFilterCaptor = ArgumentCaptor.forClass(Filter.class);
+    ArgumentCaptor<GraphFilters> graphFiltersCaptor = ArgumentCaptor.forClass(GraphFilters.class);
 
     when(mockGraphService.scrollRelatedEntities(
             any(),
-            any(),
-            sourceFilterCaptor.capture(),
-            any(),
-            destFilterCaptor.capture(),
-            anySet(),
-            any(),
+            graphFiltersCaptor.capture(),
             any(),
             isNull(),
             anyString(),
@@ -1022,19 +981,20 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful());
 
+    GraphFilters captured = graphFiltersCaptor.getValue();
     // Source filter should have a non-empty criterion on the "urn" field
-    Filter capturedSrcFilter = sourceFilterCaptor.getValue();
+    Filter capturedSrcFilter = captured.getSourceEntityFilter();
     assertNotNull(capturedSrcFilter);
     assertFalse(capturedSrcFilter.getOr().isEmpty());
-    assertEquals("urn", capturedSrcFilter.getOr().get(0).getAnd().get(0).getField());
+    assertEquals(capturedSrcFilter.getOr().get(0).getAnd().get(0).getField(), "urn");
     assertFalse(capturedSrcFilter.getOr().get(0).getAnd().get(0).getValues().isEmpty());
 
     // Destination filter should have a non-empty criterion on the "urn" field with both URNs
-    Filter capturedDstFilter = destFilterCaptor.getValue();
+    Filter capturedDstFilter = captured.getDestinationEntityFilter();
     assertNotNull(capturedDstFilter);
     assertFalse(capturedDstFilter.getOr().isEmpty());
-    assertEquals("urn", capturedDstFilter.getOr().get(0).getAnd().get(0).getField());
-    assertEquals(2, capturedDstFilter.getOr().get(0).getAnd().get(0).getValues().size());
+    assertEquals(capturedDstFilter.getOr().get(0).getAnd().get(0).getField(), "urn");
+    assertEquals(capturedDstFilter.getOr().get(0).getAnd().get(0).getValues().size(), 2);
   }
 
   @Test
@@ -1047,12 +1007,7 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
 
     when(mockGraphService.scrollRelatedEntities(
             opContextCaptor.capture(),
-            any(),
-            any(),
-            any(),
-            any(),
-            anySet(),
-            any(),
+            any(GraphFilters.class),
             any(),
             isNull(),
             anyString(),
@@ -1074,16 +1029,11 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
     OperationContext capturedOpContext = opContextCaptor.getValue();
     assertNotNull(capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions());
     assertEquals(
-        1,
-        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getId().intValue());
+        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getId().intValue(),
+        1);
     assertEquals(
-        4,
-        capturedOpContext
-            .getSearchContext()
-            .getSearchFlags()
-            .getSliceOptions()
-            .getMax()
-            .intValue());
+        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getMax().intValue(),
+        4);
   }
 
   @Test
@@ -1096,25 +1046,14 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
 
     ArgumentCaptor<OperationContext> opContextCaptor =
         ArgumentCaptor.forClass(OperationContext.class);
-    ArgumentCaptor<Set> sourceTypesCaptor = ArgumentCaptor.forClass(Set.class);
-    ArgumentCaptor<Filter> sourceFilterCaptor = ArgumentCaptor.forClass(Filter.class);
-    ArgumentCaptor<Set> destTypesCaptor = ArgumentCaptor.forClass(Set.class);
-    ArgumentCaptor<Filter> destFilterCaptor = ArgumentCaptor.forClass(Filter.class);
-    ArgumentCaptor<Set> relTypesCaptor = ArgumentCaptor.forClass(Set.class);
-    ArgumentCaptor<RelationshipFilter> relFilterCaptor =
-        ArgumentCaptor.forClass(RelationshipFilter.class);
+    ArgumentCaptor<GraphFilters> graphFiltersCaptor = ArgumentCaptor.forClass(GraphFilters.class);
     ArgumentCaptor<String> scrollIdCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> pitCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Integer> countCaptor = ArgumentCaptor.forClass(Integer.class);
 
     when(mockGraphService.scrollRelatedEntities(
             opContextCaptor.capture(),
-            sourceTypesCaptor.capture(),
-            sourceFilterCaptor.capture(),
-            destTypesCaptor.capture(),
-            destFilterCaptor.capture(),
-            relTypesCaptor.capture(),
-            relFilterCaptor.capture(),
+            graphFiltersCaptor.capture(),
             any(),
             scrollIdCaptor.capture(),
             pitCaptor.capture(),
@@ -1191,46 +1130,46 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
         .andExpect(status().is2xxSuccessful())
         .andExpect(jsonPath("$.scrollId").value("next-scroll"));
 
+    GraphFilters captured = graphFiltersCaptor.getValue();
+
     // Verify relationship types
-    assertEquals(1, relTypesCaptor.getValue().size());
-    assertTrue(relTypesCaptor.getValue().contains("DownstreamOf"));
+    assertEquals(captured.getRelationshipTypes().size(), 1);
+    assertTrue(captured.getRelationshipTypes().contains("DownstreamOf"));
 
     // Verify entity type filters
-    assertEquals(1, sourceTypesCaptor.getValue().size());
-    assertTrue(sourceTypesCaptor.getValue().contains("dataset"));
-    assertEquals(1, destTypesCaptor.getValue().size());
-    assertTrue(destTypesCaptor.getValue().contains("chart"));
+    assertEquals(captured.getSourceTypes().size(), 1);
+    assertTrue(captured.getSourceTypes().contains("dataset"));
+    assertEquals(captured.getDestinationTypes().size(), 1);
+    assertTrue(captured.getDestinationTypes().contains("chart"));
 
     // Verify URN filters from request body
-    assertFalse(sourceFilterCaptor.getValue().getOr().isEmpty());
-    assertFalse(destFilterCaptor.getValue().getOr().isEmpty());
+    assertFalse(captured.getSourceEntityFilter().getOr().isEmpty());
+    assertFalse(captured.getDestinationEntityFilter().getOr().isEmpty());
 
     // Verify edge filter was embedded in the RelationshipFilter
-    RelationshipFilter capturedRelFilter = relFilterCaptor.getValue();
+    RelationshipFilter capturedRelFilter = captured.getRelationshipFilter();
     assertNotNull(capturedRelFilter);
     assertFalse(capturedRelFilter.getOr().isEmpty());
-    assertEquals("relationshipType", capturedRelFilter.getOr().get(0).getAnd().get(0).getField());
+    assertEquals(capturedRelFilter.getOr().get(0).getAnd().get(0).getField(), "relationshipType");
 
     // Verify pagination parameters
-    assertEquals("prev-scroll", scrollIdCaptor.getValue());
-    assertEquals("10m", pitCaptor.getValue());
-    assertEquals(20, countCaptor.getValue().intValue());
+    assertEquals(scrollIdCaptor.getValue(), "prev-scroll");
+    assertEquals(pitCaptor.getValue(), "10m");
+    assertEquals(countCaptor.getValue().intValue(), 20);
 
     // Verify slice options and includeSoftDelete
     OperationContext capturedOpContext = opContextCaptor.getValue();
     assertNotNull(capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions());
     assertEquals(
-        0,
-        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getId().intValue());
+        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getId().intValue(),
+        0);
     assertEquals(
-        3,
-        capturedOpContext
-            .getSearchContext()
-            .getSearchFlags()
-            .getSliceOptions()
-            .getMax()
-            .intValue());
+        capturedOpContext.getSearchContext().getSearchFlags().getSliceOptions().getMax().intValue(),
+        3);
     assertTrue(capturedOpContext.getSearchContext().getSearchFlags().isIncludeSoftDeleted());
+
+    // Verify no lineage triplets on the regular scroll endpoint
+    assertNull(captured.getAllowedEdgeTriplets());
   }
 
   @Test
@@ -1238,17 +1177,11 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
     RelatedEntitiesScrollResult expectedResult =
         new RelatedEntitiesScrollResult(0, 10, "scroll-1", Arrays.asList());
 
-    ArgumentCaptor<RelationshipFilter> relFilterCaptor =
-        ArgumentCaptor.forClass(RelationshipFilter.class);
+    ArgumentCaptor<GraphFilters> graphFiltersCaptor = ArgumentCaptor.forClass(GraphFilters.class);
 
     when(mockGraphService.scrollRelatedEntities(
             any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            anySet(),
-            relFilterCaptor.capture(),
+            graphFiltersCaptor.capture(),
             any(),
             isNull(),
             anyString(),
@@ -1265,7 +1198,9 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful());
 
-    assertEquals(RelationshipDirection.OUTGOING, relFilterCaptor.getValue().getDirection());
+    assertEquals(
+        graphFiltersCaptor.getValue().getRelationshipFilter().getDirection(),
+        RelationshipDirection.OUTGOING);
   }
 
   @Test
@@ -1273,17 +1208,11 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
     RelatedEntitiesScrollResult expectedResult =
         new RelatedEntitiesScrollResult(0, 10, "scroll-out", Arrays.asList());
 
-    ArgumentCaptor<RelationshipFilter> relFilterCaptor =
-        ArgumentCaptor.forClass(RelationshipFilter.class);
+    ArgumentCaptor<GraphFilters> graphFiltersCaptor = ArgumentCaptor.forClass(GraphFilters.class);
 
     when(mockGraphService.scrollRelatedEntities(
             any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            anySet(),
-            relFilterCaptor.capture(),
+            graphFiltersCaptor.capture(),
             any(),
             isNull(),
             anyString(),
@@ -1302,7 +1231,9 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
         .andExpect(status().is2xxSuccessful())
         .andExpect(jsonPath("$.scrollId").value("scroll-out"));
 
-    assertEquals(RelationshipDirection.OUTGOING, relFilterCaptor.getValue().getDirection());
+    assertEquals(
+        graphFiltersCaptor.getValue().getRelationshipFilter().getDirection(),
+        RelationshipDirection.OUTGOING);
   }
 
   @Test
@@ -1310,17 +1241,11 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
     RelatedEntitiesScrollResult expectedResult =
         new RelatedEntitiesScrollResult(0, 10, "scroll-in", Arrays.asList());
 
-    ArgumentCaptor<RelationshipFilter> relFilterCaptor =
-        ArgumentCaptor.forClass(RelationshipFilter.class);
+    ArgumentCaptor<GraphFilters> graphFiltersCaptor = ArgumentCaptor.forClass(GraphFilters.class);
 
     when(mockGraphService.scrollRelatedEntities(
             any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            anySet(),
-            relFilterCaptor.capture(),
+            graphFiltersCaptor.capture(),
             any(),
             isNull(),
             anyString(),
@@ -1339,7 +1264,9 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
         .andExpect(status().is2xxSuccessful())
         .andExpect(jsonPath("$.scrollId").value("scroll-in"));
 
-    assertEquals(RelationshipDirection.INCOMING, relFilterCaptor.getValue().getDirection());
+    assertEquals(
+        graphFiltersCaptor.getValue().getRelationshipFilter().getDirection(),
+        RelationshipDirection.INCOMING);
   }
 
   @Test
@@ -1347,17 +1274,11 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
     RelatedEntitiesScrollResult expectedResult =
         new RelatedEntitiesScrollResult(0, 10, null, Arrays.asList());
 
-    ArgumentCaptor<RelationshipFilter> relFilterCaptor =
-        ArgumentCaptor.forClass(RelationshipFilter.class);
+    ArgumentCaptor<GraphFilters> graphFiltersCaptor = ArgumentCaptor.forClass(GraphFilters.class);
 
     when(mockGraphService.scrollRelatedEntities(
             any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            anySet(),
-            relFilterCaptor.capture(),
+            graphFiltersCaptor.capture(),
             any(),
             isNull(),
             anyString(),
@@ -1375,7 +1296,9 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful());
 
-    assertEquals(RelationshipDirection.OUTGOING, relFilterCaptor.getValue().getDirection());
+    assertEquals(
+        graphFiltersCaptor.getValue().getRelationshipFilter().getDirection(),
+        RelationshipDirection.OUTGOING);
   }
 
   @Test
@@ -1388,5 +1311,122 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
                 .content(objectMapper.writeValueAsString(EMPTY_SCROLL_BODY))
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().is4xxClientError());
+  }
+
+  @Test
+  public void testScrollLineageSetsAllowedEdgeTriplets() throws Exception {
+    RelatedEntitiesScrollResult expectedResult =
+        new RelatedEntitiesScrollResult(0, 10, "lineage-scroll", Arrays.asList());
+
+    // Setup lineage registry on the mock graph service
+    LineageRegistry lineageRegistry =
+        TestOperationContexts.systemContextNoSearchAuthorization().getLineageRegistry();
+    when(mockGraphService.getLineageRegistry()).thenReturn(lineageRegistry);
+
+    ArgumentCaptor<GraphFilters> graphFiltersCaptor = ArgumentCaptor.forClass(GraphFilters.class);
+
+    when(mockGraphService.scrollRelatedEntities(
+            any(),
+            graphFiltersCaptor.capture(),
+            any(),
+            isNull(),
+            anyString(),
+            anyInt(),
+            isNull(),
+            isNull()))
+        .thenReturn(expectedResult);
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/openapi/v3/relationship/scrollLineage")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(EMPTY_SCROLL_BODY))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().is2xxSuccessful())
+        .andExpect(jsonPath("$.scrollId").value("lineage-scroll"));
+
+    GraphFilters captured = graphFiltersCaptor.getValue();
+    // scrollLineage should populate allowedEdgeTriplets from the lineage registry
+    assertNotNull(captured.getAllowedEdgeTriplets());
+    assertFalse(captured.getAllowedEdgeTriplets().isEmpty());
+
+    // Verify a known lineage edge is present (dataset DownstreamOf dataset)
+    boolean hasDownstreamOf =
+        captured.getAllowedEdgeTriplets().stream()
+            .anyMatch(
+                p -> p.getKey().equals("dataset") && p.getValue().getType().equals("DownstreamOf"));
+    assertTrue(hasDownstreamOf, "Expected lineage triplets to include dataset DownstreamOf");
+  }
+
+  @Test
+  public void testScrollLineageWithAdditionalFilters() throws Exception {
+    RelatedEntitiesScrollResult expectedResult =
+        new RelatedEntitiesScrollResult(0, 10, null, Arrays.asList());
+
+    LineageRegistry lineageRegistry =
+        TestOperationContexts.systemContextNoSearchAuthorization().getLineageRegistry();
+    when(mockGraphService.getLineageRegistry()).thenReturn(lineageRegistry);
+
+    ArgumentCaptor<GraphFilters> graphFiltersCaptor = ArgumentCaptor.forClass(GraphFilters.class);
+
+    when(mockGraphService.scrollRelatedEntities(
+            any(),
+            graphFiltersCaptor.capture(),
+            any(),
+            isNull(),
+            anyString(),
+            anyInt(),
+            isNull(),
+            isNull()))
+        .thenReturn(expectedResult);
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/openapi/v3/relationship/scrollLineage")
+                .param("sourceTypes", "dataset")
+                .param("destinationTypes", "chart")
+                .param("relationshipTypes", "Consumes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(EMPTY_SCROLL_BODY))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().is2xxSuccessful());
+
+    GraphFilters captured = graphFiltersCaptor.getValue();
+    // Should have both the request-level filters AND the lineage triplets
+    assertEquals(Set.of("dataset"), captured.getSourceTypes());
+    assertEquals(Set.of("chart"), captured.getDestinationTypes());
+    assertEquals(Set.of("Consumes"), captured.getRelationshipTypes());
+    assertNotNull(captured.getAllowedEdgeTriplets());
+    assertFalse(captured.getAllowedEdgeTriplets().isEmpty());
+  }
+
+  @Test
+  public void testScrollEndpointDoesNotSetTriplets() throws Exception {
+    RelatedEntitiesScrollResult expectedResult =
+        new RelatedEntitiesScrollResult(0, 10, null, Arrays.asList());
+
+    ArgumentCaptor<GraphFilters> graphFiltersCaptor = ArgumentCaptor.forClass(GraphFilters.class);
+
+    when(mockGraphService.scrollRelatedEntities(
+            any(),
+            graphFiltersCaptor.capture(),
+            any(),
+            isNull(),
+            anyString(),
+            anyInt(),
+            isNull(),
+            isNull()))
+        .thenReturn(expectedResult);
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/openapi/v3/relationship/scroll")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(EMPTY_SCROLL_BODY))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().is2xxSuccessful());
+
+    // Regular scroll should NOT set triplets
+    assertNull(graphFiltersCaptor.getValue().getAllowedEdgeTriplets());
   }
 }

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/controller/RelationshipControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/controller/RelationshipControllerTest.java
@@ -58,6 +58,7 @@ import org.testng.annotations.Test;
   SpringWebConfig.class,
   TracingInterceptor.class,
   RelationshipController.class,
+  LineageController.class,
   RelationshipControllerTest.RelationshipControllerTestConfig.class,
   GlobalControllerExceptionHandler.class,
 })
@@ -1338,7 +1339,7 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
 
     mockMvc
         .perform(
-            MockMvcRequestBuilders.post("/openapi/v3/relationship/scrollLineage")
+            MockMvcRequestBuilders.post("/openapi/v3/lineage/scroll")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(EMPTY_SCROLL_BODY))
                 .accept(MediaType.APPLICATION_JSON))
@@ -1382,7 +1383,7 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
 
     mockMvc
         .perform(
-            MockMvcRequestBuilders.post("/openapi/v3/relationship/scrollLineage")
+            MockMvcRequestBuilders.post("/openapi/v3/lineage/scroll")
                 .param("sourceTypes", "dataset")
                 .param("destinationTypes", "chart")
                 .param("relationshipTypes", "Consumes")

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/graph/GraphFilters.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/graph/GraphFilters.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.graph;
 
 import static com.linkedin.metadata.search.utils.QueryUtils.EMPTY_FILTER;
 
+import com.linkedin.metadata.models.registry.LineageRegistry;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.query.filter.RelationshipFilter;
@@ -10,10 +11,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import org.apache.commons.lang3.tuple.Pair;
 
 @Data
 @AllArgsConstructor
@@ -48,6 +51,28 @@ public class GraphFilters {
   public static GraphFilters ALL =
       new GraphFilters(EMPTY_FILTER, EMPTY_FILTER, null, null, null, INCOMING_FILTER);
 
+  /**
+   * Build a GraphFilters that matches all lineage edges across all entity types. The result uses
+   * triplet-based filtering so that only (sourceType, destType, relType) combinations that are
+   * actually annotated as lineage in the registry are matched.
+   */
+  public static GraphFilters forLineage(@Nonnull LineageRegistry lineageRegistry) {
+    Set<Pair<String, LineageRegistry.EdgeInfo>> triplets = new HashSet<>();
+    for (var entry : lineageRegistry.getLineageSpecs().entrySet()) {
+      String entityType = entry.getKey();
+      LineageRegistry.LineageSpec spec = entry.getValue();
+      for (LineageRegistry.EdgeInfo edge :
+          Stream.concat(spec.getUpstreamEdges().stream(), spec.getDownstreamEdges().stream())
+              .collect(Collectors.toSet())) {
+        triplets.add(Pair.of(entityType, edge));
+      }
+    }
+    GraphFilters filters =
+        new GraphFilters(EMPTY_FILTER, EMPTY_FILTER, null, null, Set.of(), INCOMING_FILTER);
+    filters.setAllowedEdgeTriplets(triplets);
+    return filters;
+  }
+
   @Nonnull private Filter sourceEntityFilter;
 
   @Nonnull private Filter destinationEntityFilter;
@@ -61,6 +86,16 @@ public class GraphFilters {
   @Nonnull private RelationshipFilter relationshipFilter;
 
   @Nullable private RelationshipDirection relationshipDirection;
+
+  /**
+   * When set, filters edges by (sourceEntityType, destinationEntityType, relationshipType) triples
+   * using OR logic — an edge matches if it belongs to ANY of the listed triplets. This gets applied
+   * on top of the independent sourceTypes/destinationTypes/relationshipTypes filters, but generally
+   * should not be used in combination with them. This is meant for more precise filters, e.g.
+   * lineage edges where a relationship type may exist across entity types but only some
+   * combinations constitute lineage.
+   */
+  @Nullable private Set<Pair<String, LineageRegistry.EdgeInfo>> allowedEdgeTriplets;
 
   public GraphFilters(
       @Nonnull Filter sourceEntityFilter,

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/graph/GraphFiltersTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/graph/GraphFiltersTest.java
@@ -3,13 +3,17 @@ package com.linkedin.metadata.graph;
 import static com.linkedin.metadata.search.utils.QueryUtils.EMPTY_FILTER;
 import static org.testng.Assert.*;
 
+import com.linkedin.metadata.models.registry.LineageRegistry;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.query.filter.RelationshipFilter;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
 import org.testng.annotations.Test;
 
 public class GraphFiltersTest {
@@ -208,5 +212,75 @@ public class GraphFiltersTest {
             GraphFilters.INCOMING_FILTER);
 
     assertFalse(populatedFilters.noResultsByType());
+  }
+
+  @Test
+  public void testForLineage() {
+    OperationContext opContext = TestOperationContexts.systemContextNoSearchAuthorization();
+    LineageRegistry lineageRegistry = opContext.getLineageRegistry();
+
+    GraphFilters filters = GraphFilters.forLineage(lineageRegistry);
+
+    // Should have empty entity/relationship type filters
+    assertEquals(filters.getSourceEntityFilter(), EMPTY_FILTER);
+    assertEquals(filters.getDestinationEntityFilter(), EMPTY_FILTER);
+    RelationshipFilter emptyRelationshipFilter =
+        new RelationshipFilter().setDirection(RelationshipDirection.INCOMING);
+    assertEquals(filters.getRelationshipFilter(), emptyRelationshipFilter);
+    assertNull(filters.getSourceTypes());
+    assertNull(filters.getDestinationTypes());
+    assertTrue(filters.getRelationshipTypes().isEmpty());
+
+    // Should have triplets populated from the lineage registry
+    Set<Pair<String, LineageRegistry.EdgeInfo>> triplets = filters.getAllowedEdgeTriplets();
+    assertNotNull(triplets);
+    assertFalse(triplets.isEmpty());
+
+    // Verify triplets contains DownstreamOf on datasets
+    boolean hasDownstreamOf =
+        triplets.stream()
+            .anyMatch(
+                p ->
+                    p.getKey().equals("dataset")
+                        && p.getValue().getType().equals("DownstreamOf")
+                        && p.getValue().getDirection().equals(RelationshipDirection.OUTGOING));
+    assertTrue(hasDownstreamOf, "Expected dataset DownstreamOf edge in lineage triplets");
+
+    // Verify every triplet comes from the lineage registry
+    for (Pair<String, LineageRegistry.EdgeInfo> triplet : triplets) {
+      String entityType = triplet.getKey();
+      LineageRegistry.LineageSpec spec = lineageRegistry.getLineageSpecs().get(entityType);
+      assertNotNull(spec, "Entity type " + entityType + " should exist in lineage specs");
+      Set<LineageRegistry.EdgeInfo> allEdges = new HashSet<>();
+      allEdges.addAll(spec.getUpstreamEdges());
+      allEdges.addAll(spec.getDownstreamEdges());
+      assertTrue(
+          allEdges.contains(triplet.getValue()),
+          "Edge " + triplet.getValue() + " should exist in lineage spec for " + entityType);
+    }
+  }
+
+  @Test
+  public void testForLineageCoversAllRegistryEdges() {
+    OperationContext opContext = TestOperationContexts.systemContextNoSearchAuthorization();
+    LineageRegistry lineageRegistry = opContext.getLineageRegistry();
+
+    GraphFilters filters = GraphFilters.forLineage(lineageRegistry);
+    Set<Pair<String, LineageRegistry.EdgeInfo>> triplets = filters.getAllowedEdgeTriplets();
+
+    // Collect all expected triplets from the registry
+    Set<Pair<String, LineageRegistry.EdgeInfo>> expectedTriplets = new HashSet<>();
+    for (var entry : lineageRegistry.getLineageSpecs().entrySet()) {
+      String entityType = entry.getKey();
+      LineageRegistry.LineageSpec spec = entry.getValue();
+      for (LineageRegistry.EdgeInfo edge : spec.getUpstreamEdges()) {
+        expectedTriplets.add(Pair.of(entityType, edge));
+      }
+      for (LineageRegistry.EdgeInfo edge : spec.getDownstreamEdges()) {
+        expectedTriplets.add(Pair.of(entityType, edge));
+      }
+    }
+
+    assertEquals(triplets, expectedTriplets);
   }
 }

--- a/smoke-test/tests/openapi/v3/test_scroll.py
+++ b/smoke-test/tests/openapi/v3/test_scroll.py
@@ -590,3 +590,60 @@ def test_scroll_relationships_pagination(graph_client: DataHubGraph) -> None:
     logger.info(
         f"scroll_relationships pagination: page1={len(first_edges)}, page2={len(second_edges)} distinct edges"
     )
+
+
+# ---------------------------------------------------------------------------
+# scroll_lineage
+# ---------------------------------------------------------------------------
+
+
+def test_scroll_lineage_with_source_urns_filter(
+    graph_client: DataHubGraph,
+) -> None:
+    """scroll_lineage with source_urns should only return lineage edges
+    from the specified source entity."""
+    result = graph_client.scroll_lineage(
+        source_urns=[ZETA],
+        count=100,
+    )
+    assert len(result.relationships) >= 1
+    for rel in result.relationships:
+        assert rel.source_urn == ZETA, (
+            f"Expected source_urn={ZETA}, got '{rel.source_urn}'"
+        )
+    edges = {
+        (r.source_urn, r.destination_urn, r.relationship_type)
+        for r in result.relationships
+    }
+    assert (ZETA, ALPHA, "DownstreamOf") in edges, (
+        f"Expected ZETA->ALPHA DownstreamOf with source_urns filter, got: {edges}"
+    )
+    logger.info(
+        f"scroll_lineage with source_urns filter: {len(result.relationships)} edges"
+    )
+
+
+def test_scroll_lineage_with_relationship_type_filter(
+    graph_client: DataHubGraph,
+) -> None:
+    """scroll_lineage filtered to DerivedFrom should return FEATURE_1->ALPHA
+    but not ZETA->ALPHA (DownstreamOf)."""
+    result = graph_client.scroll_lineage(
+        relationship_types=["DerivedFrom"],
+        count=100,
+    )
+    assert len(result.relationships) >= 1
+    for rel in result.relationships:
+        assert rel.relationship_type == "DerivedFrom", (
+            f"Expected only DerivedFrom edges, got '{rel.relationship_type}'"
+        )
+    edges = {(r.source_urn, r.destination_urn) for r in result.relationships}
+    assert (FEATURE_1, ALPHA) in edges, (
+        f"Expected FEATURE_1->ALPHA DerivedFrom, got: {edges}"
+    )
+    assert (ZETA, ALPHA) not in edges, (
+        "ZETA->ALPHA DownstreamOf should be excluded by DerivedFrom filter"
+    )
+    logger.info(
+        f"scroll_lineage with DerivedFrom filter: {len(result.relationships)} edges"
+    )


### PR DESCRIPTION
Adds a new `/openapi/v3/relationship/scrollLineage` endpoint that automatically adds the lineage filter (based on lineage registry -- creates triplets). To facilitate this, updates `GraphFilters` to have a `allowedEdgeTriplets` that gets read by `GraphQueryUtils`.

Also refactors `RelationshipControllerTest` because calls changed to `scrollRelatedEntities`.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
