### PR TITLE
fix(ci): add --paginate to gh api artifact list calls to avoid 30-item page limit

### DIFF
--- a/.github/actions/smoke-test-retry/action.yml
+++ b/.github/actions/smoke-test-retry/action.yml
@@ -53,7 +53,7 @@ runs:
         ARTIFACT_NAME="Test Results (smoke tests) ${TEST_STRATEGY} ${BATCH}"
         echo "Looking for artifact: ${ARTIFACT_NAME}"
 
-        ARTIFACT_ID=$(gh api "repos/${REPOSITORY}/actions/runs/${RUN_ID}/artifacts" \
+        ARTIFACT_ID=$(gh api --paginate "repos/${REPOSITORY}/actions/runs/${RUN_ID}/artifacts" \
           --jq ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -1)
 
         if [[ -z "$ARTIFACT_ID" ]]; then

--- a/.github/scripts/download_test_artifacts.sh
+++ b/.github/scripts/download_test_artifacts.sh
@@ -149,7 +149,7 @@ for run_id in "${RUN_ID_ARRAY[@]}"; do
 
     # List all artifacts for this run
     echo "Fetching artifact list..."
-    ARTIFACTS=$(gh api "repos/$REPOSITORY/actions/runs/$run_id/artifacts" --jq '.artifacts[] | select(.name | startswith("Test Results (smoke tests)")) | {name: .name, id: .id}')
+    ARTIFACTS=$(gh api --paginate "repos/$REPOSITORY/actions/runs/$run_id/artifacts" --jq '.artifacts[] | select(.name | startswith("Test Results (smoke tests)")) | {name: .name, id: .id}')
 
     if [[ -z "$ARTIFACTS" ]]; then
         echo "Warning: No test result artifacts found for run $run_id"

--- a/.github/workflows/docker-unified-nightly.yml
+++ b/.github/workflows/docker-unified-nightly.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           run_id=$(gh run list  --workflow="docker-unified.yml" --branch master --event push --status success --limit 1 --json=databaseId  | jq '.[].databaseId')
           mkdir -p "${{ github.workspace }}/build"
-          artifact_id=$(gh api "repos/datahub-project/datahub/actions/runs/$run_id/artifacts" --jq '[.artifacts[] | select(.name | startswith("build-metadata-sha-"))] | last | .id')
+          artifact_id=$(gh api --paginate "repos/datahub-project/datahub/actions/runs/$run_id/artifacts" --jq '[.artifacts[] | select(.name | startswith("build-metadata-sha-"))] | last | .id')
           gh api "repos/datahub-project/datahub/actions/artifacts/${artifact_id}/zip" >"${{ github.workspace }}/build/build-metadata.zip"
           unzip "${{ github.workspace }}/build/build-metadata.zip" -d "${{ github.workspace }}/build/"
           ls -l "${{ github.workspace }}/build/"
@@ -225,7 +225,7 @@ jobs:
           echo "Looking for artifact: ${ARTIFACT_NAME}"
 
           # Query artifacts for this workflow run
-          ARTIFACT_ID=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+          ARTIFACT_ID=$(gh api --paginate "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
             --jq ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .id" | head -1)
 
           if [[ -z "$ARTIFACT_ID" ]]; then
@@ -367,7 +367,7 @@ jobs:
         run: |
           run_id=$(gh run list  --workflow="docker-unified.yml" --branch master --event push --status success --limit 1 --json=databaseId  | jq '.[].databaseId')
           mkdir -p "${{ github.workspace }}/build"
-          artifact_id=$(gh api "repos/datahub-project/datahub/actions/runs/$run_id/artifacts" --jq '[.artifacts[] | select(.name | startswith("build-metadata-sha-"))] | last | .id')
+          artifact_id=$(gh api --paginate "repos/datahub-project/datahub/actions/runs/$run_id/artifacts" --jq '[.artifacts[] | select(.name | startswith("build-metadata-sha-"))] | last | .id')
           gh api "repos/datahub-project/datahub/actions/artifacts/${artifact_id}/zip" >"${{ github.workspace }}/build/build-metadata.zip"
           unzip "${{ github.workspace }}/build/build-metadata.zip" -d "${{ github.workspace }}/build/"
           ls -l "${{ github.workspace }}/build/"
@@ -632,7 +632,7 @@ jobs:
         run: |
           run_id=$(gh run list  --workflow="docker-unified.yml" --branch master --event push --status success --limit 1 --json=databaseId  | jq '.[].databaseId')
           mkdir -p "${{ github.workspace }}/build"
-          artifact_id=$(gh api "repos/datahub-project/datahub/actions/runs/$run_id/artifacts" --jq '[.artifacts[] | select(.name | startswith("build-metadata-sha-"))] | last | .id')
+          artifact_id=$(gh api --paginate "repos/datahub-project/datahub/actions/runs/$run_id/artifacts" --jq '[.artifacts[] | select(.name | startswith("build-metadata-sha-"))] | last | .id')
           gh api "repos/datahub-project/datahub/actions/artifacts/${artifact_id}/zip" >"${{ github.workspace }}/build/build-metadata.zip"
           unzip "${{ github.workspace }}/build/build-metadata.zip" -d "${{ github.workspace }}/build/"
           ls -l "${{ github.workspace }}/build/"


### PR DESCRIPTION
## Summary

Our docker-unified.yml workflow has a lot of atifacts > 30. With the addition of Playwright jobs that number has further increased.

- `gh api` without `--paginate` only returns the first 30 artifacts per run. Runs with 40+ artifacts (13 cypress + 7 pytest batches + Playwright) silently miss artifacts on page 2+, causing retry jobs to report `no_artifacts` and fall back to running the full test suite instead of only failed tests.
- Added `--paginate` to all four affected `gh api` calls that list run artifacts:
  - `.github/actions/smoke-test-retry/action.yml` — retry artifact lookup for cypress/pytest batches
  - `.github/workflows/docker-unified-nightly.yml` — retry artifact lookup + 3× `build-metadata-sha-*` lookups
  - `.github/scripts/download_test_artifacts.sh` — bulk test result artifact fetch

## Test plan

- [ ] Trigger a retry (attempt 2) on a run with >30 artifacts and verify the parse step finds the expected artifacts and runs only failed tests instead of falling back to the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)