### PR TITLE
feat(i18n): extract keys from embed

### DIFF
--- a/datahub-web-react/translated-files.txt
+++ b/datahub-web-react/translated-files.txt
@@ -2,6 +2,7 @@ src/alchemy-components/components/**/*.{ts,tsx}
 src/app/analyticsDashboardV2/**/*.{ts,tsx}
 src/app/domain/**/*.{ts,tsx}
 src/app/domainV2/**/*.{ts,tsx}
+src/app/embed/**/*.{ts,tsx}
 src/app/entityV2/**/*.{ts,tsx}
 src/app/glossary/**/*.{ts,tsx}
 src/app/glossaryV2/**/*.{ts,tsx}


### PR DESCRIPTION
embed/ folder doesn't have extractable strings so this folder just added to translated-files.txt

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
