### PR TITLE
fix(i18n): localize relative timestamps, profile tabs, and search placeholder

### DIFF
--- a/datahub-web-react/src/app/entityV2/user/UserProfile.tsx
+++ b/datahub-web-react/src/app/entityV2/user/UserProfile.tsx
@@ -124,7 +124,7 @@ export default function UserProfile({ urn }: Props) {
     const getTabs = () => {
         return [
             {
-                name: TabType.Assets,
+                name: t('user.tab.ownerOf'),
                 path: TabType.Assets.toLocaleLowerCase(),
                 content: <UserAssets urn={urn} />,
                 display: {
@@ -132,14 +132,14 @@ export default function UserProfile({ urn }: Props) {
                 },
             },
             {
-                name: TabType.Groups,
+                name: t('user.tab.groups'),
                 path: TabType.Groups.toLocaleLowerCase(),
                 content: <UserGroups urn={urn} initialRelationships={userGroups} pageSize={GROUP_PAGE_SIZE} />,
                 display: {
                     enabled: () => userGroups?.length > 0,
                 },
             },
-        ].filter((tab) => ENABLED_TAB_TYPES.includes(tab.name));
+        ].filter((tab) => ENABLED_TAB_TYPES.some((tabType) => tabType.toLocaleLowerCase() === tab.path));
     };
     const defaultTabPath = getTabs() && getTabs()?.length > 0 ? getTabs()[0].path : '';
     const onTabChange = () => null;

--- a/datahub-web-react/src/app/searchV2/SearchablePage.tsx
+++ b/datahub-web-react/src/app/searchV2/SearchablePage.tsx
@@ -1,5 +1,6 @@
 import { debounce } from 'lodash';
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import styled, { useTheme } from 'styled-components';
 
 import { useUserContext } from '@app/context/useUserContext';
@@ -81,6 +82,7 @@ export const SearchablePage = ({ children, hideSearchBar }: Props) => {
 
     const entityRegistry = useEntityRegistry();
     const themeConfig = useTheme();
+    const { t } = useTranslation('search');
     const { selectedQuickFilter } = useQuickFiltersContext();
 
     const [getAutoCompleteResults, { data: suggestionsData }] = useGetAutoCompleteMultipleResultsLazyQuery();
@@ -130,7 +132,9 @@ export const SearchablePage = ({ children, hideSearchBar }: Props) => {
         <>
             <SearchHeader
                 initialQuery={currentQuery as string}
-                placeholderText={themeConfig.content.search.searchbarMessage}
+                placeholderText={t('searchBar.placeholder', {
+                    defaultValue: themeConfig.content.search.searchbarMessage,
+                })}
                 suggestions={
                     (newSuggestionData &&
                         newSuggestionData?.autoCompleteForMultiple &&

--- a/datahub-web-react/src/app/shared/time/timeUtils.tsx
+++ b/datahub-web-react/src/app/shared/time/timeUtils.tsx
@@ -143,7 +143,7 @@ export const getSupportedTimezones = () => {
 };
 
 export const toRelativeTimeString = (timeMs: number | undefined) => {
-    const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+    const rtf = new Intl.RelativeTimeFormat(i18next.language || 'en', { numeric: 'auto' });
 
     if (!timeMs) return null;
     const diffInMs = timeMs - new Date().getTime();

--- a/datahub-web-react/src/i18n/locales/de/misc.json
+++ b/datahub-web-react/src/i18n/locales/de/misc.json
@@ -75,7 +75,7 @@
     "tags.appliedToEntityCount_other": "{{count}} Entitäten",
     "tags.color": "Farbe",
     "tags.columnAppliedTo": "Angewendet auf",
-    "tags.columnOwners": "Owners",
+    "tags.columnOwners": "Owner",
     "tags.columnTag": "Tag",
     "tags.copyUrn": "URN kopieren",
     "tags.createButton": "Tag erstellen",

--- a/datahub-web-react/src/i18n/locales/en/entity.types.json
+++ b/datahub-web-react/src/i18n/locales/en/entity.types.json
@@ -310,6 +310,8 @@
     "user.namePlural": "People",
     "user.slackMemberIdHelp": "Find your member ID from the <icon></icon> menu in your Slack profile. More info <anchor>here.</anchor>",
     "user.slackMemberIdLabel": "Slack Member ID",
+    "user.tab.groups": "Groups",
+    "user.tab.ownerOf": "Owner Of",
     "user.teamLabel": "Team",
     "user.teamsHeading": "Teams",
     "user.titleRoleLabel": "Title/Role"


### PR DESCRIPTION
## Summary

Several i18n fixes for UI strings that rendered in English regardless of the selected language:

- **Relative timestamps** — `toRelativeTimeString` constructed `Intl.RelativeTimeFormat` with a hardcoded `'en'` locale, so "4 days ago" / "yesterday" always rendered in English. Now uses `i18next.language`, so relative times follow the active locale. One-line change that fixes ~35 call sites (entity sidebars, structured properties, lineage, dataset/chart previews, etc.). The dayjs-based path is already locale-synced and unaffected.
- **User-profile tabs** — the routed-tab labels (Owner Of, Groups) were the raw `TabType` enum values. Wrapped in `t()` (`entity.types`) while keeping the enum as the stable route path; the enabled-filter now keys off `path`, matching the existing `GroupProfile` pattern. Adds `user.tab.ownerOf` / `user.tab.groups`.
- **Main search bar** — the placeholder came straight from the theme's `searchbarMessage`. Routed `SearchablePage` through `t('search:searchBar.placeholder')` with that theme value as the i18next `defaultValue`, so it's translatable while custom-theme overrides still win when no translation key is present.
- **de** — tags column header "Owners" → "Owner" (idiomatic uninflected plural).

## Checklist
- [x] PR title follows Conventional Commits
- [x] Verified locally: `yarn type-check` and lint pass on changed files