### PR TITLE
perf(graphql): compute only selected EntityPrivileges fields

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesFields.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesFields.java
@@ -1,0 +1,44 @@
+package com.linkedin.datahub.graphql.resolvers.entity;
+
+/**
+ * String constants for the fields of the generated {@link
+ * com.linkedin.datahub.graphql.generated.EntityPrivileges} GraphQL type.
+ *
+ * <p>The codegen produces an {@code EntityPrivileges} POJO but does not expose its field names as
+ * strings, yet {@link EntityPrivilegesResolver} needs them to honor the GraphQL selection set.
+ * Centralizing them here avoids repeating hardcoded literals and gives a single source of truth.
+ *
+ * <p>{@code EntityPrivilegesFieldsTest} reflectively cross-checks these constants against the
+ * generated type in both directions, so a typo here — or drift if the GraphQL definition changes —
+ * fails the build rather than silently leaving a privilege uncomputed.
+ */
+public final class EntityPrivilegesFields {
+
+  private EntityPrivilegesFields() {}
+
+  public static final String CAN_MANAGE_CHILDREN = "canManageChildren";
+  public static final String CAN_MANAGE_ENTITY = "canManageEntity";
+  public static final String CAN_EDIT_LINEAGE = "canEditLineage";
+  public static final String CAN_EDIT_EMBED = "canEditEmbed";
+  public static final String CAN_EDIT_QUERIES = "canEditQueries";
+  public static final String CAN_EDIT_PROPERTIES = "canEditProperties";
+  public static final String CAN_EDIT_TAGS = "canEditTags";
+  public static final String CAN_EDIT_GLOSSARY_TERMS = "canEditGlossaryTerms";
+  public static final String CAN_EDIT_DESCRIPTION = "canEditDescription";
+  public static final String CAN_EDIT_LINKS = "canEditLinks";
+  public static final String CAN_EDIT_DOMAINS = "canEditDomains";
+  public static final String CAN_EDIT_DATA_PRODUCTS = "canEditDataProducts";
+  public static final String CAN_EDIT_OWNERS = "canEditOwners";
+  public static final String CAN_EDIT_INCIDENTS = "canEditIncidents";
+  public static final String CAN_EDIT_ASSERTIONS = "canEditAssertions";
+  public static final String CAN_EDIT_ASSERTION_OWNERS = "canEditAssertionOwners";
+  public static final String CAN_EDIT_DEPRECATION = "canEditDeprecation";
+  public static final String CAN_EDIT_SCHEMA_FIELD_TAGS = "canEditSchemaFieldTags";
+  public static final String CAN_EDIT_SCHEMA_FIELD_GLOSSARY_TERMS =
+      "canEditSchemaFieldGlossaryTerms";
+  public static final String CAN_EDIT_SCHEMA_FIELD_DESCRIPTION = "canEditSchemaFieldDescription";
+  public static final String CAN_VIEW_DATASET_USAGE = "canViewDatasetUsage";
+  public static final String CAN_VIEW_DATASET_PROFILE = "canViewDatasetProfile";
+  public static final String CAN_VIEW_DATASET_OPERATIONS = "canViewDatasetOperations";
+  public static final String CAN_MANAGE_ASSET_SUMMARY = "canManageAssetSummary";
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolver.java
@@ -1,5 +1,6 @@
 package com.linkedin.datahub.graphql.resolvers.entity;
 
+import static com.linkedin.datahub.graphql.resolvers.entity.EntityPrivilegesFields.*;
 import static com.linkedin.metadata.Constants.WILDCARD_URN;
 import static com.linkedin.metadata.authorization.ApiGroup.LINEAGE;
 import static com.linkedin.metadata.authorization.ApiOperation.UPDATE;
@@ -115,7 +116,7 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
     final EntityPrivileges result = new EntityPrivileges();
     computeIfSelected(
         selected,
-        "canManageEntity",
+        CAN_MANAGE_ENTITY,
         () -> BusinessAttributeAuthorizationUtils.canManageBusinessAttribute(context),
         result::setCanManageEntity);
     addCommonPrivileges(result, urn, context, selected);
@@ -126,7 +127,7 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
       Urn termUrn, QueryContext context, Set<String> selected) {
     final EntityPrivileges result = new EntityPrivileges();
     addCommonPrivileges(result, termUrn, context, selected);
-    if (selected.contains("canManageEntity")) {
+    if (selected.contains(CAN_MANAGE_ENTITY)) {
       result.setCanManageEntity(computeTermCanManageEntity(termUrn, context));
     }
     return result;
@@ -146,8 +147,8 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
     final EntityPrivileges result = new EntityPrivileges();
     addCommonPrivileges(result, nodeUrn, context, selected);
 
-    final boolean needChildren = selected.contains("canManageChildren");
-    final boolean needEntity = selected.contains("canManageEntity");
+    final boolean needChildren = selected.contains(CAN_MANAGE_CHILDREN);
+    final boolean needEntity = selected.contains(CAN_MANAGE_ENTITY);
     if (!needChildren && !needEntity) {
       return result;
     }
@@ -185,45 +186,45 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
     final EntityPrivileges result = new EntityPrivileges();
     computeIfSelected(
         selected,
-        "canEditEmbed",
+        CAN_EDIT_EMBED,
         () -> EmbedUtils.isAuthorizedToUpdateEmbedForEntity(urn, context),
         result::setCanEditEmbed);
     computeIfSelected(
         selected,
-        "canEditQueries",
+        CAN_EDIT_QUERIES,
         () -> AuthorizationUtils.canCreateQuery(ImmutableList.of(urn), context),
         result::setCanEditQueries);
     // Schema Field Edits are a bit of a hack.
     computeIfSelected(
         selected,
-        "canEditSchemaFieldTags",
+        CAN_EDIT_SCHEMA_FIELD_TAGS,
         () ->
             LabelUtils.isAuthorizedToUpdateTags(
                 context, urn, "ignored", Collections.singleton(WILDCARD_URN)),
         result::setCanEditSchemaFieldTags);
     computeIfSelected(
         selected,
-        "canEditSchemaFieldGlossaryTerms",
+        CAN_EDIT_SCHEMA_FIELD_GLOSSARY_TERMS,
         () -> LabelUtils.isAuthorizedToUpdateTerms(context, urn, "ignored"),
         result::setCanEditSchemaFieldGlossaryTerms);
     computeIfSelected(
         selected,
-        "canEditSchemaFieldDescription",
+        CAN_EDIT_SCHEMA_FIELD_DESCRIPTION,
         () -> DescriptionUtils.isAuthorizedToUpdateFieldDescription(context, urn),
         result::setCanEditSchemaFieldDescription);
     computeIfSelected(
         selected,
-        "canViewDatasetUsage",
+        CAN_VIEW_DATASET_USAGE,
         () -> AuthorizationUtils.isViewDatasetUsageAuthorized(context, urn),
         result::setCanViewDatasetUsage);
     computeIfSelected(
         selected,
-        "canViewDatasetProfile",
+        CAN_VIEW_DATASET_PROFILE,
         () -> AuthorizationUtils.isViewDatasetProfileAuthorized(context, urn),
         result::setCanViewDatasetProfile);
     computeIfSelected(
         selected,
-        "canViewDatasetOperations",
+        CAN_VIEW_DATASET_OPERATIONS,
         () -> AuthorizationUtils.isViewDatasetOperationsAuthorized(context, urn),
         result::setCanViewDatasetOperations);
     addCommonPrivileges(result, urn, context, selected);
@@ -234,7 +235,7 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
     final EntityPrivileges result = new EntityPrivileges();
     computeIfSelected(
         selected,
-        "canEditEmbed",
+        CAN_EDIT_EMBED,
         () -> EmbedUtils.isAuthorizedToUpdateEmbedForEntity(urn, context),
         result::setCanEditEmbed);
     addCommonPrivileges(result, urn, context, selected);
@@ -246,7 +247,7 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
     final EntityPrivileges result = new EntityPrivileges();
     computeIfSelected(
         selected,
-        "canEditEmbed",
+        CAN_EDIT_EMBED,
         () -> EmbedUtils.isAuthorizedToUpdateEmbedForEntity(urn, context),
         result::setCanEditEmbed);
     addCommonPrivileges(result, urn, context, selected);
@@ -267,7 +268,7 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
     // Document-specific: canManageEntity includes ability to delete/move documents
     computeIfSelected(
         selected,
-        "canManageEntity",
+        CAN_MANAGE_ENTITY,
         () -> AuthorizationUtils.canEditDocument(urn, context),
         result::setCanManageEntity);
     return result;
@@ -280,74 +281,74 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
       @Nonnull Set<String> selected) {
     computeIfSelected(
         selected,
-        "canEditLineage",
+        CAN_EDIT_LINEAGE,
         () -> canEditEntityLineage(urn, context),
         result::setCanEditLineage);
     computeIfSelected(
         selected,
-        "canEditProperties",
+        CAN_EDIT_PROPERTIES,
         () -> AuthorizationUtils.canEditProperties(urn, context),
         result::setCanEditProperties);
     computeIfSelected(
         selected,
-        "canEditAssertions",
+        CAN_EDIT_ASSERTIONS,
         () -> AssertionUtils.isAuthorizedToEditAssertionFromAssertee(context, urn),
         result::setCanEditAssertions);
     computeIfSelected(
         selected,
-        "canEditAssertionOwners",
+        CAN_EDIT_ASSERTION_OWNERS,
         () -> OwnerUtils.isAuthorizedToUpdateAssertionOwnersOnEntity(context, urn),
         result::setCanEditAssertionOwners);
     computeIfSelected(
         selected,
-        "canEditIncidents",
+        CAN_EDIT_INCIDENTS,
         () -> IncidentUtils.isAuthorizedToEditIncidentForResource(urn, context),
         result::setCanEditIncidents);
     computeIfSelected(
         selected,
-        "canEditDomains",
+        CAN_EDIT_DOMAINS,
         () -> DomainUtils.isAuthorizedToUpdateDomainsForEntity(context, urn, _entityClient),
         result::setCanEditDomains);
     computeIfSelected(
         selected,
-        "canEditDataProducts",
+        CAN_EDIT_DATA_PRODUCTS,
         () -> DataProductAuthorizationUtils.isAuthorizedToUpdateDataProductsForEntity(context, urn),
         result::setCanEditDataProducts);
     computeIfSelected(
         selected,
-        "canEditDeprecation",
+        CAN_EDIT_DEPRECATION,
         () -> DeprecationUtils.isAuthorizedToUpdateDeprecationForEntity(context, urn),
         result::setCanEditDeprecation);
     computeIfSelected(
         selected,
-        "canEditGlossaryTerms",
+        CAN_EDIT_GLOSSARY_TERMS,
         () -> LabelUtils.isAuthorizedToUpdateTerms(context, urn, null),
         result::setCanEditGlossaryTerms);
     computeIfSelected(
         selected,
-        "canEditTags",
+        CAN_EDIT_TAGS,
         () ->
             LabelUtils.isAuthorizedToUpdateTags(
                 context, urn, null, Collections.singleton(WILDCARD_URN)),
         result::setCanEditTags);
     computeIfSelected(
         selected,
-        "canEditOwners",
+        CAN_EDIT_OWNERS,
         () -> OwnerUtils.isAuthorizedToUpdateOwners(context, urn),
         result::setCanEditOwners);
     computeIfSelected(
         selected,
-        "canEditDescription",
+        CAN_EDIT_DESCRIPTION,
         () -> DescriptionUtils.isAuthorizedToUpdateDescription(context, urn),
         result::setCanEditDescription);
     computeIfSelected(
         selected,
-        "canEditLinks",
+        CAN_EDIT_LINKS,
         () -> LinkUtils.isAuthorizedToUpdateLinks(context, urn),
         result::setCanEditLinks);
     computeIfSelected(
         selected,
-        "canManageAssetSummary",
+        CAN_MANAGE_ASSET_SUMMARY,
         () -> AuthorizationUtils.canManageAssetSummary(context, urn),
         result::setCanManageAssetSummary);
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolver.java
@@ -28,16 +28,22 @@ import com.linkedin.datahub.graphql.resolvers.mutate.util.LinkUtils;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
+import graphql.language.Field;
+import graphql.language.FragmentDefinition;
+import graphql.language.FragmentSpread;
+import graphql.language.InlineFragment;
+import graphql.language.Selection;
+import graphql.language.SelectionSet;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.SelectedField;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -56,13 +62,15 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
     final String urnString = ((Entity) environment.getSource()).getUrn();
     final Urn urn = UrnUtils.getUrn(urnString);
 
-    // Each EntityPrivileges field is the result of an independent authorization check. The
-    // resolver only computes query selected fields, to avoid unnecessary auth checks and improve
-    // performance.
-    final Set<String> selected =
-        environment.getSelectionSet().getImmediateFields().stream()
-            .map(SelectedField::getName)
-            .collect(Collectors.toSet());
+    // Each EntityPrivileges field is the result of an independent authorization check. We compute
+    // only the sub-fields the query selected, to avoid unnecessary auth checks.
+    //
+    // The selected sub-fields are read from the AST (this field's own selection set), NOT via
+    // environment.getSelectionSet(): the latter normalizes the whole sub-tree and is subject to
+    // graphql-java's max-field-count guard (100k), which a large recursive query such as the
+    // lineage graph (getBulkEntityLineageV2) can exceed -- aborting the entire query. Reading the
+    // immediate selection from the AST is local to the privileges field and cheap.
+    final Set<String> selected = selectedSubFields(environment);
 
     return GraphQLConcurrencyUtils.supplyAsync(
         () -> {
@@ -94,6 +102,41 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
         },
         this.getClass().getSimpleName(),
         "get");
+  }
+
+  /**
+   * Collects the names of the immediate sub-fields selected under the {@code privileges} field by
+   * reading this field's selection set from the query AST (resolving fragment spreads and inline
+   * fragments). This is intentionally local to the {@code privileges} field — it does not normalize
+   * the rest of the query — so it is not subject to graphql-java's max-field-count limit, which a
+   * large recursive query (e.g. the lineage graph) can otherwise exceed and abort.
+   */
+  private static Set<String> selectedSubFields(DataFetchingEnvironment environment) {
+    final Set<String> names = new HashSet<>();
+    final Map<String, FragmentDefinition> fragments = environment.getFragmentsByName();
+    for (Field field : environment.getMergedField().getFields()) {
+      collectFieldNames(field.getSelectionSet(), fragments, names);
+    }
+    return names;
+  }
+
+  private static void collectFieldNames(
+      SelectionSet selectionSet, Map<String, FragmentDefinition> fragments, Set<String> out) {
+    if (selectionSet == null) {
+      return;
+    }
+    for (Selection<?> selection : selectionSet.getSelections()) {
+      if (selection instanceof Field) {
+        out.add(((Field) selection).getName());
+      } else if (selection instanceof InlineFragment) {
+        collectFieldNames(((InlineFragment) selection).getSelectionSet(), fragments, out);
+      } else if (selection instanceof FragmentSpread) {
+        final FragmentDefinition fragment = fragments.get(((FragmentSpread) selection).getName());
+        if (fragment != null) {
+          collectFieldNames(fragment.getSelectionSet(), fragments, out);
+        }
+      }
+    }
   }
 
   /**

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolver.java
@@ -29,9 +29,14 @@ import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.SelectedField;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -50,31 +55,39 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
     final String urnString = ((Entity) environment.getSource()).getUrn();
     final Urn urn = UrnUtils.getUrn(urnString);
 
+    // Each EntityPrivileges field is the result of an independent authorization check. The
+    // resolver only computes query selected fields, to avoid unnecessary auth checks and improve
+    // performance.
+    final Set<String> selected =
+        environment.getSelectionSet().getImmediateFields().stream()
+            .map(SelectedField::getName)
+            .collect(Collectors.toSet());
+
     return GraphQLConcurrencyUtils.supplyAsync(
         () -> {
           switch (urn.getEntityType()) {
             case Constants.BUSINESS_ATTRIBUTE_ENTITY_NAME:
-              return getBusinessAttributePrivileges(urn, context);
+              return getBusinessAttributePrivileges(urn, context, selected);
             case Constants.GLOSSARY_TERM_ENTITY_NAME:
-              return getGlossaryTermPrivileges(urn, context);
+              return getGlossaryTermPrivileges(urn, context, selected);
             case Constants.GLOSSARY_NODE_ENTITY_NAME:
-              return getGlossaryNodePrivileges(urn, context);
+              return getGlossaryNodePrivileges(urn, context, selected);
             case Constants.DATASET_ENTITY_NAME:
-              return getDatasetPrivileges(urn, context);
+              return getDatasetPrivileges(urn, context, selected);
             case Constants.CHART_ENTITY_NAME:
-              return getChartPrivileges(urn, context);
+              return getChartPrivileges(urn, context, selected);
             case Constants.DASHBOARD_ENTITY_NAME:
-              return getDashboardPrivileges(urn, context);
+              return getDashboardPrivileges(urn, context, selected);
             case Constants.DATA_JOB_ENTITY_NAME:
-              return getDataJobPrivileges(urn, context);
+              return getDataJobPrivileges(urn, context, selected);
             case Constants.DOCUMENT_ENTITY_NAME:
-              return getDocumentPrivileges(urn, context);
+              return getDocumentPrivileges(urn, context, selected);
             default:
               log.warn(
                   "Tried to get entity privileges for entity type {}. Adding common privileges only.",
                   urn.getEntityType());
               EntityPrivileges commonPrivileges = new EntityPrivileges();
-              addCommonPrivileges(commonPrivileges, urn, context);
+              addCommonPrivileges(commonPrivileges, urn, context, selected);
               return commonPrivileges;
           }
         },
@@ -82,49 +95,83 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
         "get");
   }
 
-  private EntityPrivileges getBusinessAttributePrivileges(Urn urn, QueryContext context) {
+  /**
+   * Runs an authorization check and stores its result only when the query selected {@code
+   * fieldName}. The field name must match the {@code EntityPrivileges} field in {@code
+   * auth.graphql}; a mismatch silently leaves the field null (guarded by resolver tests).
+   */
+  private static void computeIfSelected(
+      @Nonnull Set<String> selected,
+      @Nonnull String fieldName,
+      @Nonnull BooleanSupplier check,
+      @Nonnull Consumer<Boolean> setter) {
+    if (selected.contains(fieldName)) {
+      setter.accept(check.getAsBoolean());
+    }
+  }
+
+  private EntityPrivileges getBusinessAttributePrivileges(
+      Urn urn, QueryContext context, Set<String> selected) {
     final EntityPrivileges result = new EntityPrivileges();
-    result.setCanManageEntity(
-        BusinessAttributeAuthorizationUtils.canManageBusinessAttribute(context));
-    addCommonPrivileges(result, urn, context);
+    computeIfSelected(
+        selected,
+        "canManageEntity",
+        () -> BusinessAttributeAuthorizationUtils.canManageBusinessAttribute(context),
+        result::setCanManageEntity);
+    addCommonPrivileges(result, urn, context, selected);
     return result;
   }
 
-  private EntityPrivileges getGlossaryTermPrivileges(Urn termUrn, QueryContext context) {
+  private EntityPrivileges getGlossaryTermPrivileges(
+      Urn termUrn, QueryContext context, Set<String> selected) {
     final EntityPrivileges result = new EntityPrivileges();
-    addCommonPrivileges(result, termUrn, context);
-    result.setCanManageEntity(false);
+    addCommonPrivileges(result, termUrn, context, selected);
+    if (selected.contains("canManageEntity")) {
+      result.setCanManageEntity(computeTermCanManageEntity(termUrn, context));
+    }
+    return result;
+  }
+
+  private boolean computeTermCanManageEntity(Urn termUrn, QueryContext context) {
     if (GlossaryUtils.canManageGlossaries(context)) {
-      result.setCanManageEntity(true);
-      return result;
+      return true;
     }
     Urn parentNodeUrn = GlossaryUtils.getParentUrn(termUrn, context, _entityClient);
-    if (parentNodeUrn != null) {
-      Boolean canManage =
-          GlossaryUtils.canManageChildrenEntities(context, parentNodeUrn, _entityClient);
-      result.setCanManageEntity(canManage);
-    }
-    return result;
+    return parentNodeUrn != null
+        && GlossaryUtils.canManageChildrenEntities(context, parentNodeUrn, _entityClient);
   }
 
-  private EntityPrivileges getGlossaryNodePrivileges(Urn nodeUrn, QueryContext context) {
+  private EntityPrivileges getGlossaryNodePrivileges(
+      Urn nodeUrn, QueryContext context, Set<String> selected) {
     final EntityPrivileges result = new EntityPrivileges();
-    addCommonPrivileges(result, nodeUrn, context);
-    result.setCanManageEntity(false);
-    if (GlossaryUtils.canManageGlossaries(context)) {
-      result.setCanManageEntity(true);
-      result.setCanManageChildren(true);
+    addCommonPrivileges(result, nodeUrn, context, selected);
+
+    final boolean needChildren = selected.contains("canManageChildren");
+    final boolean needEntity = selected.contains("canManageEntity");
+    if (!needChildren && !needEntity) {
       return result;
     }
-    Boolean canManageChildren =
-        GlossaryUtils.canManageChildrenEntities(context, nodeUrn, _entityClient);
-    result.setCanManageChildren(canManageChildren);
 
-    Urn parentNodeUrn = GlossaryUtils.getParentUrn(nodeUrn, context, _entityClient);
-    if (parentNodeUrn != null) {
-      Boolean canManage =
-          GlossaryUtils.canManageChildrenEntities(context, parentNodeUrn, _entityClient);
-      result.setCanManageEntity(canManage);
+    // canManageGlossaries grants both manage privileges; check it once before the parent walk.
+    if (GlossaryUtils.canManageGlossaries(context)) {
+      if (needChildren) {
+        result.setCanManageChildren(true);
+      }
+      if (needEntity) {
+        result.setCanManageEntity(true);
+      }
+      return result;
+    }
+
+    if (needChildren) {
+      result.setCanManageChildren(
+          GlossaryUtils.canManageChildrenEntities(context, nodeUrn, _entityClient));
+    }
+    if (needEntity) {
+      Urn parentNodeUrn = GlossaryUtils.getParentUrn(nodeUrn, context, _entityClient);
+      result.setCanManageEntity(
+          parentNodeUrn != null
+              && GlossaryUtils.canManageChildrenEntities(context, parentNodeUrn, _entityClient));
     }
     return result;
   }
@@ -133,77 +180,175 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
     return AuthUtil.isAuthorizedUrns(context.getOperationContext(), LINEAGE, UPDATE, List.of(urn));
   }
 
-  private EntityPrivileges getDatasetPrivileges(Urn urn, QueryContext context) {
+  private EntityPrivileges getDatasetPrivileges(
+      Urn urn, QueryContext context, Set<String> selected) {
     final EntityPrivileges result = new EntityPrivileges();
-    result.setCanEditEmbed(EmbedUtils.isAuthorizedToUpdateEmbedForEntity(urn, context));
+    computeIfSelected(
+        selected,
+        "canEditEmbed",
+        () -> EmbedUtils.isAuthorizedToUpdateEmbedForEntity(urn, context),
+        result::setCanEditEmbed);
+    computeIfSelected(
+        selected,
+        "canEditQueries",
+        () -> AuthorizationUtils.canCreateQuery(ImmutableList.of(urn), context),
+        result::setCanEditQueries);
     // Schema Field Edits are a bit of a hack.
-    result.setCanEditQueries(AuthorizationUtils.canCreateQuery(ImmutableList.of(urn), context));
-    result.setCanEditSchemaFieldTags(
-        LabelUtils.isAuthorizedToUpdateTags(
-            context, urn, "ignored", Collections.singleton(WILDCARD_URN)));
-    result.setCanEditSchemaFieldGlossaryTerms(
-        LabelUtils.isAuthorizedToUpdateTerms(context, urn, "ignored"));
-    result.setCanEditSchemaFieldDescription(
-        DescriptionUtils.isAuthorizedToUpdateFieldDescription(context, urn));
-    result.setCanViewDatasetUsage(AuthorizationUtils.isViewDatasetUsageAuthorized(context, urn));
-    result.setCanViewDatasetProfile(
-        AuthorizationUtils.isViewDatasetProfileAuthorized(context, urn));
-    result.setCanViewDatasetOperations(
-        AuthorizationUtils.isViewDatasetOperationsAuthorized(context, urn));
-    addCommonPrivileges(result, urn, context);
+    computeIfSelected(
+        selected,
+        "canEditSchemaFieldTags",
+        () ->
+            LabelUtils.isAuthorizedToUpdateTags(
+                context, urn, "ignored", Collections.singleton(WILDCARD_URN)),
+        result::setCanEditSchemaFieldTags);
+    computeIfSelected(
+        selected,
+        "canEditSchemaFieldGlossaryTerms",
+        () -> LabelUtils.isAuthorizedToUpdateTerms(context, urn, "ignored"),
+        result::setCanEditSchemaFieldGlossaryTerms);
+    computeIfSelected(
+        selected,
+        "canEditSchemaFieldDescription",
+        () -> DescriptionUtils.isAuthorizedToUpdateFieldDescription(context, urn),
+        result::setCanEditSchemaFieldDescription);
+    computeIfSelected(
+        selected,
+        "canViewDatasetUsage",
+        () -> AuthorizationUtils.isViewDatasetUsageAuthorized(context, urn),
+        result::setCanViewDatasetUsage);
+    computeIfSelected(
+        selected,
+        "canViewDatasetProfile",
+        () -> AuthorizationUtils.isViewDatasetProfileAuthorized(context, urn),
+        result::setCanViewDatasetProfile);
+    computeIfSelected(
+        selected,
+        "canViewDatasetOperations",
+        () -> AuthorizationUtils.isViewDatasetOperationsAuthorized(context, urn),
+        result::setCanViewDatasetOperations);
+    addCommonPrivileges(result, urn, context, selected);
     return result;
   }
 
-  private EntityPrivileges getChartPrivileges(Urn urn, QueryContext context) {
+  private EntityPrivileges getChartPrivileges(Urn urn, QueryContext context, Set<String> selected) {
     final EntityPrivileges result = new EntityPrivileges();
-    result.setCanEditEmbed(EmbedUtils.isAuthorizedToUpdateEmbedForEntity(urn, context));
-    addCommonPrivileges(result, urn, context);
+    computeIfSelected(
+        selected,
+        "canEditEmbed",
+        () -> EmbedUtils.isAuthorizedToUpdateEmbedForEntity(urn, context),
+        result::setCanEditEmbed);
+    addCommonPrivileges(result, urn, context, selected);
     return result;
   }
 
-  private EntityPrivileges getDashboardPrivileges(Urn urn, QueryContext context) {
+  private EntityPrivileges getDashboardPrivileges(
+      Urn urn, QueryContext context, Set<String> selected) {
     final EntityPrivileges result = new EntityPrivileges();
-    result.setCanEditEmbed(EmbedUtils.isAuthorizedToUpdateEmbedForEntity(urn, context));
-    addCommonPrivileges(result, urn, context);
+    computeIfSelected(
+        selected,
+        "canEditEmbed",
+        () -> EmbedUtils.isAuthorizedToUpdateEmbedForEntity(urn, context),
+        result::setCanEditEmbed);
+    addCommonPrivileges(result, urn, context, selected);
     return result;
   }
 
-  private EntityPrivileges getDataJobPrivileges(Urn urn, QueryContext context) {
+  private EntityPrivileges getDataJobPrivileges(
+      Urn urn, QueryContext context, Set<String> selected) {
     final EntityPrivileges result = new EntityPrivileges();
-    addCommonPrivileges(result, urn, context);
+    addCommonPrivileges(result, urn, context, selected);
     return result;
   }
 
-  private EntityPrivileges getDocumentPrivileges(Urn urn, QueryContext context) {
+  private EntityPrivileges getDocumentPrivileges(
+      Urn urn, QueryContext context, Set<String> selected) {
     final EntityPrivileges result = new EntityPrivileges();
-    addCommonPrivileges(result, urn, context);
+    addCommonPrivileges(result, urn, context, selected);
     // Document-specific: canManageEntity includes ability to delete/move documents
-    result.setCanManageEntity(AuthorizationUtils.canEditDocument(urn, context));
+    computeIfSelected(
+        selected,
+        "canManageEntity",
+        () -> AuthorizationUtils.canEditDocument(urn, context),
+        result::setCanManageEntity);
     return result;
   }
 
   private void addCommonPrivileges(
-      @Nonnull EntityPrivileges result, @Nonnull Urn urn, @Nonnull QueryContext context) {
-    result.setCanEditLineage(canEditEntityLineage(urn, context));
-    result.setCanEditProperties(AuthorizationUtils.canEditProperties(urn, context));
-    result.setCanEditAssertions(
-        AssertionUtils.isAuthorizedToEditAssertionFromAssertee(context, urn));
-    result.setCanEditAssertionOwners(
-        OwnerUtils.isAuthorizedToUpdateAssertionOwnersOnEntity(context, urn));
-    result.setCanEditIncidents(IncidentUtils.isAuthorizedToEditIncidentForResource(urn, context));
-    result.setCanEditDomains(
-        DomainUtils.isAuthorizedToUpdateDomainsForEntity(context, urn, _entityClient));
-    result.setCanEditDataProducts(
-        DataProductAuthorizationUtils.isAuthorizedToUpdateDataProductsForEntity(context, urn));
-    result.setCanEditDeprecation(
-        DeprecationUtils.isAuthorizedToUpdateDeprecationForEntity(context, urn));
-    result.setCanEditGlossaryTerms(LabelUtils.isAuthorizedToUpdateTerms(context, urn, null));
-    result.setCanEditTags(
-        LabelUtils.isAuthorizedToUpdateTags(
-            context, urn, null, Collections.singleton(WILDCARD_URN)));
-    result.setCanEditOwners(OwnerUtils.isAuthorizedToUpdateOwners(context, urn));
-    result.setCanEditDescription(DescriptionUtils.isAuthorizedToUpdateDescription(context, urn));
-    result.setCanEditLinks(LinkUtils.isAuthorizedToUpdateLinks(context, urn));
-    result.setCanManageAssetSummary(AuthorizationUtils.canManageAssetSummary(context, urn));
+      @Nonnull EntityPrivileges result,
+      @Nonnull Urn urn,
+      @Nonnull QueryContext context,
+      @Nonnull Set<String> selected) {
+    computeIfSelected(
+        selected,
+        "canEditLineage",
+        () -> canEditEntityLineage(urn, context),
+        result::setCanEditLineage);
+    computeIfSelected(
+        selected,
+        "canEditProperties",
+        () -> AuthorizationUtils.canEditProperties(urn, context),
+        result::setCanEditProperties);
+    computeIfSelected(
+        selected,
+        "canEditAssertions",
+        () -> AssertionUtils.isAuthorizedToEditAssertionFromAssertee(context, urn),
+        result::setCanEditAssertions);
+    computeIfSelected(
+        selected,
+        "canEditAssertionOwners",
+        () -> OwnerUtils.isAuthorizedToUpdateAssertionOwnersOnEntity(context, urn),
+        result::setCanEditAssertionOwners);
+    computeIfSelected(
+        selected,
+        "canEditIncidents",
+        () -> IncidentUtils.isAuthorizedToEditIncidentForResource(urn, context),
+        result::setCanEditIncidents);
+    computeIfSelected(
+        selected,
+        "canEditDomains",
+        () -> DomainUtils.isAuthorizedToUpdateDomainsForEntity(context, urn, _entityClient),
+        result::setCanEditDomains);
+    computeIfSelected(
+        selected,
+        "canEditDataProducts",
+        () -> DataProductAuthorizationUtils.isAuthorizedToUpdateDataProductsForEntity(context, urn),
+        result::setCanEditDataProducts);
+    computeIfSelected(
+        selected,
+        "canEditDeprecation",
+        () -> DeprecationUtils.isAuthorizedToUpdateDeprecationForEntity(context, urn),
+        result::setCanEditDeprecation);
+    computeIfSelected(
+        selected,
+        "canEditGlossaryTerms",
+        () -> LabelUtils.isAuthorizedToUpdateTerms(context, urn, null),
+        result::setCanEditGlossaryTerms);
+    computeIfSelected(
+        selected,
+        "canEditTags",
+        () ->
+            LabelUtils.isAuthorizedToUpdateTags(
+                context, urn, null, Collections.singleton(WILDCARD_URN)),
+        result::setCanEditTags);
+    computeIfSelected(
+        selected,
+        "canEditOwners",
+        () -> OwnerUtils.isAuthorizedToUpdateOwners(context, urn),
+        result::setCanEditOwners);
+    computeIfSelected(
+        selected,
+        "canEditDescription",
+        () -> DescriptionUtils.isAuthorizedToUpdateDescription(context, urn),
+        result::setCanEditDescription);
+    computeIfSelected(
+        selected,
+        "canEditLinks",
+        () -> LinkUtils.isAuthorizedToUpdateLinks(context, urn),
+        result::setCanEditLinks);
+    computeIfSelected(
+        selected,
+        "canManageAssetSummary",
+        () -> AuthorizationUtils.canManageAssetSummary(context, urn),
+        result::setCanManageAssetSummary);
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesFieldsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesFieldsTest.java
@@ -1,0 +1,70 @@
+package com.linkedin.datahub.graphql.resolvers.entity;
+
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.datahub.graphql.generated.EntityPrivileges;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.testng.annotations.Test;
+
+/**
+ * Two-way drift guard for {@link EntityPrivilegesFields} against the generated {@link
+ * EntityPrivileges} type.
+ *
+ * <p>{@code EntityPrivilegesResolver} keys the GraphQL selection set off these constants, so a typo
+ * or drift (a field added/removed in the GraphQL definition, which regenerates {@code
+ * EntityPrivileges}) would silently leave a privilege uncomputed. The two tests below check each
+ * direction independently so a failure points straight at the cause.
+ */
+public class EntityPrivilegesFieldsTest {
+
+  /** Direction 1: every declared constant must map to a field on the generated type. */
+  @Test
+  public void testEveryConstantMapsToAGeneratedField() {
+    Set<String> constantsWithoutField = new HashSet<>(declaredConstants());
+    constantsWithoutField.removeAll(generatedFields());
+    assertTrue(
+        constantsWithoutField.isEmpty(),
+        "EntityPrivilegesFields constant(s) do not match any field on the generated "
+            + "EntityPrivileges type (typo or stale constant): "
+            + constantsWithoutField);
+  }
+
+  /** Direction 2: every field on the generated type must have a declared constant. */
+  @Test
+  public void testEveryGeneratedFieldHasAConstant() {
+    Set<String> fieldsWithoutConstant = new HashSet<>(generatedFields());
+    fieldsWithoutConstant.removeAll(declaredConstants());
+    assertTrue(
+        fieldsWithoutConstant.isEmpty(),
+        "Generated EntityPrivileges field(s) have no EntityPrivilegesFields constant (drift — add "
+            + "a constant and wire it in EntityPrivilegesResolver): "
+            + fieldsWithoutConstant);
+  }
+
+  private static Set<String> generatedFields() {
+    return Arrays.stream(EntityPrivileges.class.getDeclaredFields())
+        .filter(f -> !f.isSynthetic() && !Modifier.isStatic(f.getModifiers()))
+        .map(Field::getName)
+        .collect(Collectors.toSet());
+  }
+
+  private static Set<String> declaredConstants() {
+    return Arrays.stream(EntityPrivilegesFields.class.getDeclaredFields())
+        .filter(f -> Modifier.isStatic(f.getModifiers()) && f.getType() == String.class)
+        .map(EntityPrivilegesFieldsTest::constantValue)
+        .collect(Collectors.toSet());
+  }
+
+  private static String constantValue(Field field) {
+    try {
+      return (String) field.get(null);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Unable to read constant " + field.getName(), e);
+    }
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolverTest.java
@@ -18,13 +18,13 @@ import com.linkedin.datahub.graphql.generated.GlossaryTerm;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
 import com.linkedin.r2.RemoteInvocationException;
+import graphql.execution.MergedField;
+import graphql.language.Field;
+import graphql.language.SelectionSet;
 import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingFieldSelectionSet;
-import graphql.schema.SelectedField;
-import java.util.List;
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
-import java.util.stream.Collectors;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -68,19 +68,16 @@ public class EntityPrivilegesResolverTest {
           "canViewDatasetOperations",
           "canManageAssetSummary");
 
-  private static DataFetchingFieldSelectionSet mockSelectionSet(Set<String> fieldNames) {
-    List<SelectedField> fields =
-        fieldNames.stream()
-            .map(
-                name -> {
-                  SelectedField field = Mockito.mock(SelectedField.class);
-                  Mockito.when(field.getName()).thenReturn(name);
-                  return field;
-                })
-            .collect(Collectors.toList());
-    DataFetchingFieldSelectionSet selectionSet = Mockito.mock(DataFetchingFieldSelectionSet.class);
-    Mockito.when(selectionSet.getImmediateFields()).thenReturn(fields);
-    return selectionSet;
+  // Builds a real query AST for `privileges { <fieldNames> }` so the resolver reads the selected
+  // sub-fields the same way it does at runtime (from the field's selection set), exercising the
+  // actual code path rather than a mocked selection set.
+  private static MergedField mockMergedField(Set<String> fieldNames) {
+    SelectionSet.Builder selectionSet = SelectionSet.newSelectionSet();
+    for (String name : fieldNames) {
+      selectionSet.selection(Field.newField(name).build());
+    }
+    Field privileges = Field.newField("privileges").selectionSet(selectionSet.build()).build();
+    return MergedField.newMergedField(privileges).build();
   }
 
   private DataFetchingEnvironment setUpTestWithPermissions(Entity entity) {
@@ -89,15 +86,14 @@ public class EntityPrivilegesResolverTest {
 
   private DataFetchingEnvironment setUpTestWithPermissions(
       Entity entity, Set<String> selectedFields) {
-    // Build the selection-set mock first; nesting it inside the when(...).thenReturn(...) below
-    // would trigger Mockito's "stubbing another mock mid-stubbing" error.
-    DataFetchingFieldSelectionSet selectionSet = mockSelectionSet(selectedFields);
+    MergedField mergedField = mockMergedField(selectedFields);
     QueryContext mockContext = getMockAllowContext();
     Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     Mockito.when(mockEnv.getSource()).thenReturn(entity);
-    Mockito.when(mockEnv.getSelectionSet()).thenReturn(selectionSet);
+    Mockito.when(mockEnv.getMergedField()).thenReturn(mergedField);
+    Mockito.when(mockEnv.getFragmentsByName()).thenReturn(Collections.emptyMap());
     return mockEnv;
   }
 
@@ -107,13 +103,14 @@ public class EntityPrivilegesResolverTest {
 
   private DataFetchingEnvironment setUpTestWithoutPermissions(
       Entity entity, Set<String> selectedFields) {
-    DataFetchingFieldSelectionSet selectionSet = mockSelectionSet(selectedFields);
+    MergedField mergedField = mockMergedField(selectedFields);
     QueryContext mockContext = getMockDenyContext();
     Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     Mockito.when(mockEnv.getSource()).thenReturn(entity);
-    Mockito.when(mockEnv.getSelectionSet()).thenReturn(selectionSet);
+    Mockito.when(mockEnv.getMergedField()).thenReturn(mergedField);
+    Mockito.when(mockEnv.getFragmentsByName()).thenReturn(Collections.emptyMap());
     return mockEnv;
   }
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolverTest.java
@@ -19,7 +19,12 @@ import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
 import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingFieldSelectionSet;
+import graphql.schema.SelectedField;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -34,12 +39,81 @@ public class EntityPrivilegesResolverTest {
       "urn:li:dataJob:(urn:li:dataFlow:(spark,test_machine.sparkTestApp,local),QueryExecId_31)";
   final String businessAttributeUrn = "urn:li:businessAttribute:testBusinessAttribute";
 
+  // Every field on the EntityPrivileges GraphQL type (auth.graphql). Used as the default selection
+  // so existing assertions (which expect all applicable fields populated) keep passing.
+  private static final Set<String> ALL_PRIVILEGE_FIELDS =
+      Set.of(
+          "canManageChildren",
+          "canManageEntity",
+          "canEditLineage",
+          "canEditEmbed",
+          "canEditQueries",
+          "canEditProperties",
+          "canEditTags",
+          "canEditGlossaryTerms",
+          "canEditDescription",
+          "canEditLinks",
+          "canEditDomains",
+          "canEditDataProducts",
+          "canEditOwners",
+          "canEditIncidents",
+          "canEditAssertions",
+          "canEditAssertionOwners",
+          "canEditDeprecation",
+          "canEditSchemaFieldTags",
+          "canEditSchemaFieldGlossaryTerms",
+          "canEditSchemaFieldDescription",
+          "canViewDatasetUsage",
+          "canViewDatasetProfile",
+          "canViewDatasetOperations",
+          "canManageAssetSummary");
+
+  private static DataFetchingFieldSelectionSet mockSelectionSet(Set<String> fieldNames) {
+    List<SelectedField> fields =
+        fieldNames.stream()
+            .map(
+                name -> {
+                  SelectedField field = Mockito.mock(SelectedField.class);
+                  Mockito.when(field.getName()).thenReturn(name);
+                  return field;
+                })
+            .collect(Collectors.toList());
+    DataFetchingFieldSelectionSet selectionSet = Mockito.mock(DataFetchingFieldSelectionSet.class);
+    Mockito.when(selectionSet.getImmediateFields()).thenReturn(fields);
+    return selectionSet;
+  }
+
   private DataFetchingEnvironment setUpTestWithPermissions(Entity entity) {
+    return setUpTestWithPermissions(entity, ALL_PRIVILEGE_FIELDS);
+  }
+
+  private DataFetchingEnvironment setUpTestWithPermissions(
+      Entity entity, Set<String> selectedFields) {
+    // Build the selection-set mock first; nesting it inside the when(...).thenReturn(...) below
+    // would trigger Mockito's "stubbing another mock mid-stubbing" error.
+    DataFetchingFieldSelectionSet selectionSet = mockSelectionSet(selectedFields);
     QueryContext mockContext = getMockAllowContext();
     Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     Mockito.when(mockEnv.getSource()).thenReturn(entity);
+    Mockito.when(mockEnv.getSelectionSet()).thenReturn(selectionSet);
+    return mockEnv;
+  }
+
+  private DataFetchingEnvironment setUpTestWithoutPermissions(Entity entity) {
+    return setUpTestWithoutPermissions(entity, ALL_PRIVILEGE_FIELDS);
+  }
+
+  private DataFetchingEnvironment setUpTestWithoutPermissions(
+      Entity entity, Set<String> selectedFields) {
+    DataFetchingFieldSelectionSet selectionSet = mockSelectionSet(selectedFields);
+    QueryContext mockContext = getMockDenyContext();
+    Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Mockito.when(mockEnv.getSource()).thenReturn(entity);
+    Mockito.when(mockEnv.getSelectionSet()).thenReturn(selectionSet);
     return mockEnv;
   }
 
@@ -70,15 +144,6 @@ public class EntityPrivilegesResolverTest {
 
     assertTrue(result.getCanManageEntity());
     assertTrue(result.getCanManageChildren());
-  }
-
-  private DataFetchingEnvironment setUpTestWithoutPermissions(Entity entity) {
-    QueryContext mockContext = getMockDenyContext();
-    Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
-    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
-    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
-    Mockito.when(mockEnv.getSource()).thenReturn(entity);
-    return mockEnv;
   }
 
   @Test
@@ -315,5 +380,96 @@ public class EntityPrivilegesResolverTest {
     assertTrue(result.getCanEditDescription());
     assertTrue(result.getCanEditLinks());
     assertTrue(result.getCanManageAssetSummary());
+  }
+
+  /**
+   * Selection-set awareness: when the query selects only {@code canEditLineage} (as the lineage
+   * canEditLineageFragment does), only that privilege is computed. Every other privilege is left
+   * unset (null) rather than computed-and-discarded — this is the optimization that avoids the
+   * per-entity authorization fan-out on the lineage path.
+   */
+  @Test
+  public void testComputesOnlySelectedPrivileges() throws Exception {
+    final Dataset dataset = new Dataset();
+    dataset.setUrn(datasetUrn);
+
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    DataFetchingEnvironment mockEnv = setUpTestWithPermissions(dataset, Set.of("canEditLineage"));
+
+    EntityPrivilegesResolver resolver = new EntityPrivilegesResolver(mockClient);
+    EntityPrivileges result = resolver.get(mockEnv).get();
+
+    // The single selected field is computed.
+    assertTrue(result.getCanEditLineage());
+    // Unselected fields are NOT computed (remain null).
+    assertNull(result.getCanEditQueries());
+    assertNull(result.getCanEditTags());
+    assertNull(result.getCanEditDomains());
+    assertNull(result.getCanEditOwners());
+    assertNull(result.getCanViewDatasetProfile());
+    assertNull(result.getCanManageAssetSummary());
+  }
+
+  /**
+   * Guard against a typo in any selection-set field-name string. With an allow context, every
+   * EntityPrivileges field that a Dataset supports must be computed (non-null) when selected; a
+   * mismatched field name would silently leave the field null and fail this test. Dataset covers
+   * all fields except canManageEntity / canManageChildren (asserted via glossary tests).
+   */
+  @Test
+  public void testAllDatasetFieldsHandledWithCorrectNames() throws Exception {
+    final Dataset dataset = new Dataset();
+    dataset.setUrn(datasetUrn);
+
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    DataFetchingEnvironment mockEnv = setUpTestWithPermissions(dataset); // selects ALL fields
+
+    EntityPrivilegesResolver resolver = new EntityPrivilegesResolver(mockClient);
+    EntityPrivileges result = resolver.get(mockEnv).get();
+
+    // Dataset-specific fields
+    assertNotNull(result.getCanEditEmbed());
+    assertNotNull(result.getCanEditQueries());
+    assertNotNull(result.getCanEditSchemaFieldTags());
+    assertNotNull(result.getCanEditSchemaFieldGlossaryTerms());
+    assertNotNull(result.getCanEditSchemaFieldDescription());
+    assertNotNull(result.getCanViewDatasetUsage());
+    assertNotNull(result.getCanViewDatasetProfile());
+    assertNotNull(result.getCanViewDatasetOperations());
+    // Common fields
+    assertNotNull(result.getCanEditLineage());
+    assertNotNull(result.getCanEditProperties());
+    assertNotNull(result.getCanEditAssertions());
+    assertNotNull(result.getCanEditAssertionOwners());
+    assertNotNull(result.getCanEditIncidents());
+    assertNotNull(result.getCanEditDomains());
+    assertNotNull(result.getCanEditDataProducts());
+    assertNotNull(result.getCanEditDeprecation());
+    assertNotNull(result.getCanEditGlossaryTerms());
+    assertNotNull(result.getCanEditTags());
+    assertNotNull(result.getCanEditOwners());
+    assertNotNull(result.getCanEditDescription());
+    assertNotNull(result.getCanEditLinks());
+    assertNotNull(result.getCanManageAssetSummary());
+  }
+
+  /**
+   * Selection-set awareness for the glossary-node manage fields: selecting only canManageChildren
+   * must not compute canManageEntity (and the parent-chain walk it would trigger).
+   */
+  @Test
+  public void testGlossaryNodeComputesOnlySelectedManageField() throws Exception {
+    final GlossaryNode glossaryNode = new GlossaryNode();
+    glossaryNode.setUrn(glossaryNodeUrn);
+
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    DataFetchingEnvironment mockEnv =
+        setUpTestWithPermissions(glossaryNode, Set.of("canManageChildren"));
+
+    EntityPrivilegesResolver resolver = new EntityPrivilegesResolver(mockClient);
+    EntityPrivileges result = resolver.get(mockEnv).get();
+
+    assertTrue(result.getCanManageChildren());
+    assertNull(result.getCanManageEntity());
   }
 }


### PR DESCRIPTION
## What & why

`EntityPrivilegesResolver` serves the `privileges` field on the ~21 entity types that expose it. It
eagerly computed the **entire** `EntityPrivileges` object — ~22 independent authorization checks for
a Dataset — regardless of which sub-fields the query selected. The lineage `canEditLineageFragment`
selects **only** `canEditLineage`, so every node in a lineage graph paid for all ~22 checks to
produce one boolean: an N×~22 authorization fan-out.

This makes the resolver **selection-set aware** — it computes only the requested privilege booleans.
The privileges are mutually independent, so this is behaviour-preserving (unselected fields stay
null and are never serialized).

## How the selected fields are detected (and why not `getSelectionSet()`)

The selected sub-fields are read from **this field's own AST selection set** — `getMergedField()` +
its selection set, resolving fragment spreads (`...entityPrivileges`) and inline fragments. This is
local to the `privileges` field and cheap.

It deliberately avoids `DataFetchingEnvironment.getSelectionSet()`: that API normalizes the selection
set under graphql-java's 100k max-field-count guard, which a large recursive query
(`getBulkEntityLineageV2`) exceeds — throwing `AbortExecutionException` and aborting the **entire**
lineage query (the lineage graph then fails to render). Reading the immediate selection from the AST
is not subject to that global limit. (An earlier revision used `getSelectionSet()` and hit exactly
this; commit `fix(graphql): read selected EntityPrivileges sub-fields from the AST` corrects it.)

## Review feedback addressed

Per review: the repeated hardcoded field-name strings are now `EntityPrivilegesFields` constants
(single source of truth), guarded by `EntityPrivilegesFieldsTest` — a **two-way** reflective check
against the generated `EntityPrivileges` type (every constant maps to a generated field, and every
generated field has a constant), so a typo or future drift fails the build.

## Validation — end-to-end A/B (master vs this PR)

Benchmarked on a live GMS across **all 21 privilege-bearing entity types × 6 users** with
resource-scoped policies (domain / tag / owner / urn):

| | result |
|---|---|
| **Equivalence** | privilege matrix **byte-for-byte identical** to master across every user/entity/field — no behaviour change |
| **Lineage query p50** | **−49%** (consistent across all users) |
| **Full 24-field fragment p50** | neutral (all fields still computed when all are selected) |
| **Lineage render** | the previously-failing Cypress lineage spec (`v3_lineage_column_path`) now passes locally against the fixed build |

Unit tests: `EntityPrivilegesResolverTest` updated + new selection-awareness, field-name guard, and
two-way drift tests; full `:datahub-graphql-core:test` green (1603).

## Alternatives considered

A urn-keyed `privileges` DataLoader (batching the per-node checks) was prototyped and A/B-tested — it
measured a ~5× regression because it serialized into one task the per-entity work graphql-java runs
in parallel, without reducing total work. Reverted in favour of this parallelism-preserving,
selection-aware approach.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated
- [x] Docs — N/A (internal resolver optimization, no API/behaviour change)
- [x] Breaking changes — none (behaviour-preserving)
