### PR TITLE
docs(docker): fix misleading username in Cloudsmith .netrc example

### DIFF
--- a/docker/snippets/uv/.netrc.example
+++ b/docker/snippets/uv/.netrc.example
@@ -17,6 +17,6 @@
 #   machine <hostname> login <username> password <token-or-password>
 #
 # Examples:
-machine dl.cloudsmith.io      login api-key    password <your-cloudsmith-api-key>
+machine dl.cloudsmith.io      login <your-cloudsmith-username> password <your-cloudsmith-api-key>
 machine cgr.dev               login <your-user> password <your-chainguard-token>
 machine my-nexus.example.com  login <user>     password <password>


### PR DESCRIPTION
## Summary

The Cloudsmith entry in `docker/snippets/uv/.netrc.example` used the literal string `api-key` as the `login` field. This implies the username should literally be `api-key`, when in fact Cloudsmith requires a real account username in that field (the API key goes in the `password` field).

Replaces `api-key` with a `<your-cloudsmith-username>` placeholder, consistent with the pattern used by the other entries in the file.

## Checklist

- [x] PR conforms to the Contributing Guideline
- [ ] Links to related issues (N/A - doc-only fix)
- [ ] Tests added/updated (N/A - example file only)
- [ ] Docs added/updated (this is the doc fix)