### PR TITLE
fix(ingest/sql-parsing): guard against sqlglot LATERAL FLATTEN resolver crash (SIGSEGV)

### DIFF
--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -855,6 +855,46 @@ class _ColumnResolver:
             return default_col_name
 
 
+def _statement_risks_unnest_resolver_recursion(
+    statement: sqlglot.exp.Expression, schema: sqlglot.MappingSchema
+) -> bool:
+    """Detect the sqlglot resolver infinite-recursion trigger (sqlglot >= 30.7.0).
+
+    sqlglot's column Resolver recurses without a re-entrancy guard when it tries
+    to type a ``LATERAL FLATTEN`` / ``UNNEST`` of an *unqualified* column whose
+    base table is absent from the schema, while a schema is otherwise present:
+    typing the unnested column disambiguates it via ``get_table``, which
+    enumerates every source's columns, which re-enters the same lateral source.
+    In the compiled ``sqlglot[c]`` build this overflows the native C stack into
+    an uncatchable SIGSEGV that kills the whole ingest process. We cannot
+    monkeypatch the compiled resolver (mypyc dispatches its internal calls
+    natively), so we detect the trigger here and skip column-level lineage,
+    keeping table-level lineage.
+
+    The conditions mirror the confirmed trigger, so safe LATERAL FLATTENs
+    (qualified column, base table schema'd, or no schema at all) are unaffected.
+    """
+    mapping = getattr(schema, "mapping", None) or {}
+    if not mapping:
+        # No schema -> sqlglot skips the type-resolution path; safe.
+        return False
+
+    def _is_known(table: sqlglot.exp.Table) -> bool:
+        try:
+            return bool(schema.column_names(table))
+        except Exception:
+            return False
+
+    if not any(not _is_known(table) for table in statement.find_all(sqlglot.exp.Table)):
+        # Every referenced table is schema'd -> type resolves directly; safe.
+        return False
+
+    for unnest in statement.find_all(sqlglot.exp.Lateral, sqlglot.exp.Unnest):
+        if any(not col.table for col in unnest.find_all(sqlglot.exp.Column)):
+            return True
+    return False
+
+
 def _prepare_query_columns(
     statement: sqlglot.exp.Expression,
     dialect: sqlglot.Dialect,
@@ -931,6 +971,17 @@ def _prepare_query_columns(
         # )
 
     if not is_create_ddl:
+        # Guard against a sqlglot resolver infinite recursion (>= 30.7.0) that
+        # SIGSEGVs the compiled build. We can't catch a native crash, so we must
+        # refuse the statement before handing it to optimize().
+        if _statement_risks_unnest_resolver_recursion(statement, sqlglot_db_schema):
+            raise SqlUnderstandingError(
+                "Skipping column-level lineage: LATERAL FLATTEN/UNNEST of an "
+                "unqualified column over a table missing from the schema triggers "
+                "a sqlglot optimizer stack overflow (sqlglot>=30.7.0). Table-level "
+                "lineage is unaffected."
+            )
+
         # Optimize the statement + qualify column references.
         if logger.getEffectiveLevel() <= logging.DEBUG:
             logger.debug(

--- a/metadata-ingestion/tests/unit/sql_parsing/test_unnest_resolver_guard.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_unnest_resolver_guard.py
@@ -1,0 +1,83 @@
+import sqlglot
+
+from datahub.sql_parsing.schema_resolver import SchemaResolver
+from datahub.sql_parsing.sqlglot_lineage import (
+    _statement_risks_unnest_resolver_recursion,
+    sqlglot_lineage,
+)
+
+# A LATERAL FLATTEN of an *unqualified* column (`items`) whose base table
+# (`my_db.raw_schema.events`) is not in the schema. With a schema otherwise
+# present, this triggers an infinite recursion in sqlglot's resolver (>= 30.7.0)
+# that SIGSEGVs the compiled sqlglot[c] build. See the guard for details.
+_SELECT = (
+    "SELECT GET_PATH(f.value, 'id') AS obj_id, COUNT(*) AS cnt "
+    "FROM my_db.raw_schema.events AS e, "
+    "LATERAL FLATTEN(items) AS f "
+    "WHERE CAST(GET_PATH(f.value, 'kind') AS VARCHAR) = 'X' "
+    "GROUP BY obj_id"
+)
+_CREATE_VIEW = f"CREATE OR REPLACE VIEW my_db.analytics.usage_view AS {_SELECT}"
+
+
+def _parse(sql: str) -> sqlglot.exp.Expression:
+    statement = sqlglot.parse_one(sql, dialect="snowflake")
+    assert isinstance(statement, sqlglot.exp.Expression)
+    return statement
+
+
+def _schema(mapping: dict) -> sqlglot.MappingSchema:
+    return sqlglot.MappingSchema(mapping, dialect="snowflake", normalize=False)
+
+
+def test_detector_flags_unqualified_unnest_over_unschemad_table() -> None:
+    schema = _schema({"MY_DB": {"ANALYTICS": {"USAGE_VIEW": {"OBJ_ID": "VARIANT"}}}})
+    assert _statement_risks_unnest_resolver_recursion(_parse(_SELECT), schema) is True
+
+
+def test_detector_allows_safe_cases() -> None:
+    schema = _schema({"MY_DB": {"ANALYTICS": {"USAGE_VIEW": {"OBJ_ID": "VARIANT"}}}})
+    # qualified flatten column -> safe
+    qualified = _parse(_SELECT.replace("FLATTEN(items)", "FLATTEN(e.items)"))
+    assert _statement_risks_unnest_resolver_recursion(qualified, schema) is False
+
+    # no schema at all -> safe
+    assert (
+        _statement_risks_unnest_resolver_recursion(_parse(_SELECT), _schema({}))
+        is False
+    )
+
+    # base table fully schema'd (case matching the statement) -> safe
+    base_schema = _schema({"my_db": {"raw_schema": {"events": {"items": "ARRAY"}}}})
+    assert (
+        _statement_risks_unnest_resolver_recursion(_parse(_SELECT), base_schema)
+        is False
+    )
+
+    # ordinary query, no unnest -> safe
+    plain = _parse("SELECT a, b FROM db.s.t")
+    assert _statement_risks_unnest_resolver_recursion(plain, schema) is False
+
+
+def test_risky_unnest_skips_cll_without_crashing() -> None:
+    # End-to-end on the CREATE VIEW shape that crashes: the view target's schema
+    # is present while the source table is not. The guard must keep table-level
+    # lineage and report a column error instead of crashing the process (which it
+    # otherwise would on the compiled sqlglot[c] build).
+    resolver = SchemaResolver(platform="snowflake")
+    resolver.add_raw_schema_info(
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.analytics.usage_view,PROD)",
+        {"OBJ_ID": "VARIANT", "CNT": "NUMBER(18,0)"},
+    )
+    result = sqlglot_lineage(
+        _CREATE_VIEW,
+        schema_resolver=resolver,
+        default_db="my_db",
+        default_schema="analytics",
+    )
+    assert any("raw_schema.events" in t.lower() for t in result.in_tables), (
+        result.in_tables
+    )
+    assert any("usage_view" in t.lower() for t in result.out_tables), result.out_tables
+    assert result.debug_info.table_error is None
+    assert "LATERAL FLATTEN" in str(result.debug_info.column_error)


### PR DESCRIPTION
## Summary

Snowflake (and other) ingestion can crash hard — an **uncatchable `SIGSEGV`** that kills the whole `datahub ingest` process — while generating column-level lineage for certain views. This adds a targeted guard that turns the crash into a graceful, reported skip (table-level lineage is retained).

## Root cause

It's a bug in **sqlglot's column `Resolver`** (regression in `sqlglot 30.7.0`, still unfixed in `30.10.0`). When `qualify`/`optimize` types a `LATERAL FLATTEN` / `UNNEST` of an **unqualified** column whose **base table is absent from the provided schema** (while a schema is otherwise present), the resolver recurses without a re-entrancy guard:

```
get_source_columns (lateral source)
 -> _get_unnest_column_type        # column unqualified -> disambiguate
   -> get_table -> _get_table_name_from_sources -> _get_all_source_columns
     -> get_source_columns          # re-enters the same lateral source -> ∞
```

In the **compiled `sqlglot[c]`** build used in production, this recurses in mypyc-native frames that don't honor Python's recursion limit, so it overflows the C stack into a `SIGSEGV` — no `try/except` can recover it.

Minimal standalone reproducer (only `sqlglot[c]==30.8.0`):

```python
import sqlglot
from sqlglot.optimizer import optimize
sql = "SELECT f.value AS v FROM my_db.raw.events, LATERAL FLATTEN(items) AS f"
schema = {"my_db": {"other": {"some_table": {"c": "INT"}}}}  # present, lacks my_db.raw.events
optimize(sqlglot.parse_one(sql, dialect="snowflake"), dialect="snowflake", schema=schema)
# sqlglot[c] -> SIGSEGV ; pure Python -> RecursionError
```

## The fix

A monkeypatch of the resolver doesn't work here — mypyc dispatches the compiled resolver's internal calls natively, so reassigning the method is ignored. Instead, `_prepare_query_columns` now detects the trigger **before** calling `optimize()` and raises `SqlUnderstandingError`, which the existing handler turns into a skipped-CLL with a reported `column_error`. Table-level lineage is unaffected.

The detection mirrors the confirmed trigger conditions, so safe `LATERAL FLATTEN`s are not affected:

| Flattened column | Schema state | Behavior |
| --- | --- | --- |
| unqualified, base table not in schema | schema present | **CLL skipped (guarded)** |
| qualified | — | CLL runs |
| unqualified, base table in schema | — | CLL runs |
| any | no schema | CLL runs |

Upstream sqlglot issue: https://github.com/tobymao/sqlglot/issues/7732 — once sqlglot ships a fix this guard can be removed.

## Testing

`tests/unit/sql_parsing/test_unnest_resolver_guard.py`: detector precision across the matrix above, plus an end-to-end test that the crashing view shape now keeps table-level lineage and reports a column error instead of crashing. Full `sql_parsing` suite passes (440 tests); `mypy`/`ruff` clean.

## Checklist

- [x] PR conforms to the Contributing Guideline (Commit Message Format)
- [x] Tests added
- [ ] Docs added/updated (n/a — internal crash guard)
- [ ] Breaking changes documented (n/a)

