### PR TITLE
ci(playwright): increase job timeout to 60 minutes

### DIFF
--- a/.github/workflows/resusable-playwright-tests.yml
+++ b/.github/workflows/resusable-playwright-tests.yml
@@ -50,8 +50,7 @@ jobs:
   playwright_test:
     name: Playwright E2E Tests (Shard ${{ inputs.shard }}/${{ inputs.shard_count }})
     runs-on: ${{ inputs.test_runner_type }}
-    # Increase timeout when docker build needs to be done within the job
-    timeout-minutes: ${{ (github.event_name == 'workflow_dispatch' || inputs.depot_build_id != '') && 20 || 45 }}
+    timeout-minutes: 60
     steps:
       - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:


### PR DESCRIPTION
## Summary

- Increases the Playwright E2E job `timeout-minutes` from a conditional `20 || 45` to a flat `60` for all trigger paths
- Fixes the issue where multiple test failures (each waiting up to 90s on element-not-found) pushed SaaS shards past the old 20-min cap, causing GitHub to cancel the job before HTML/JUnit reports were uploaded

## Test plan

- [ ] Verify existing Playwright CI runs complete within 60 minutes
- [ ] Confirm reports are uploaded even when tests fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)