### PR TITLE
ci(docker-nightly): Fix tag logic in docker-nightly

### DIFF
--- a/.github/workflows/docker-unified-nightly.yml
+++ b/.github/workflows/docker-unified-nightly.yml
@@ -3,8 +3,8 @@ name: Nightly Docker Test
 # and if tests pass, tags them as nightly and daily for publishing
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 8 * * *" # Run at midnight Pacific time (8 AM UTC) every day
+  # schedule:
+  # - cron: "0 8 * * *" # Run at midnight Pacific time (8 AM UTC) every day
 
 concurrency:
   group: ${{ github.workflow }}
@@ -127,7 +127,7 @@ jobs:
         id: collect-images
         run: |
           # contains full repo/image:tag for all published images (includes all variants)
-          images="$(depot bake -f "${{ github.workspace }}/build/bake-spec-allImages.json" --print |  jq -cr '.target[].tags[]' | grep ':quickstart' | tr '\n' ' ')"
+          images="$(depot bake -f "${{ github.workspace }}/build/bake-spec-allImages.json" --print | jq -cr '.target[].tags[]' | grep ':sha-' | sort -u | tr '\n' ' ')"
 
           echo "datahub_images=$images" >> "$GITHUB_OUTPUT"
 
@@ -376,7 +376,7 @@ jobs:
         id: collect-images
         run: |
           # contains full repo/image:tag for all published images (includes all variants)
-          images="$(depot bake -f "${{ github.workspace }}/build/bake-spec-allImages.json" --print |  jq -cr '.target[].tags[]' | grep ':quickstart' | tr '\n' ' ')"
+          images="$(depot bake -f "${{ github.workspace }}/build/bake-spec-allImages.json" --print | jq -cr '.target[].tags[]' | grep ':sha-' | sort -u | tr '\n' ' ')"
 
           echo "datahub_images=$images" >> "$GITHUB_OUTPUT"
 
@@ -400,8 +400,8 @@ jobs:
                 echo "Failed to pull $image"
                 failed_pulls=$((failed_pulls + 1))
               else
-                # Re-tag the quickstart image with the nightly tag for smoke tests
-                newImage=${image/\:quickstart/\:${{ needs.setup.outputs.tag }}}
+                # Re-tag the sha image with the nightly tag for smoke tests
+                newImage="${image/:sha-???????/:${{ needs.setup.outputs.tag }}}"
                 echo "Tagging $image as $newImage"
                 docker tag "$image" "$newImage"
               fi
@@ -641,7 +641,7 @@ jobs:
         id: collect-images
         run: |
           # contains full repo/image:tag for all published images (includes all variants)
-          images="$(depot bake -f "${{ github.workspace }}/build/bake-spec-allImages.json" --print |  jq -cr '.target[].tags[]' | grep ':quickstart' | tr '\n' ' ')"
+          images="$(depot bake -f "${{ github.workspace }}/build/bake-spec-allImages.json" --print | jq -cr '.target[].tags[]' | grep ':sha-' | sort -u | tr '\n' ' ')"
 
           echo "datahub_images=$images" >> "$GITHUB_OUTPUT"
 
@@ -676,7 +676,7 @@ jobs:
           eval "set -- ${{ steps.collect-images.outputs.datahub_images }}"
           for image do
             if [ -n "$image" ]; then
-              imageWithNightlyTag=${image/\:quickstart/\:${{ needs.setup.outputs.tag }}}
+              imageWithNightlyTag="${image/:sha-???????/:${{ needs.setup.outputs.tag }}}"
               echo "Tagging $image as $imageWithNightlyTag"
               if ! docker tag "$image" "$imageWithNightlyTag"; then
                 echo "Failed to tag $imageWithNightlyTag"
@@ -687,7 +687,7 @@ jobs:
                 failed_pushes=$((failed_pushes + 1))
               fi
               
-              imageWithDateTag=${image/\:quickstart/\:${{ needs.setup.outputs.date_tag }}}
+              imageWithDateTag="${image/:sha-???????/:${{ needs.setup.outputs.date_tag }}}"
               echo "Tagging $image as imageWithDateTag"
               if ! docker tag "$image" "$imageWithDateTag"; then
                 echo "Failed to tag imageWithDateTag"


### PR DESCRIPTION
Docker nightly is failing since it is trying to pull the wrong tag.
https://github.com/datahub-project/datahub/actions/runs/27337341379

Fixing some of the issues. There are more bugs here so disabling the schedule to avoid wasting compute for now. Will re-enable after things are fixed.

relates to PFP-3745
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
