### PR TITLE
fix(ingest/fivetran): map Managed Data Lake Glue destinations to <schema>.<table> URNs

### DIFF
--- a/metadata-ingestion/docs/sources/fivetran/fivetran_pre.md
+++ b/metadata-ingestion/docs/sources/fivetran/fivetran_pre.md
@@ -128,6 +128,35 @@ destination_to_platform_instance:
 
 The user override always wins; REST destination discovery still runs in the background to fill in any fields the user didn't pin (e.g. `database` from the discovered config when not overridden). Glue routing needs no `database` — the destination schema is the Glue database (see the Glue section above).
 
+**When you must set `platform` yourself.** Discovery only knows how to map the destination services DataHub recognizes (Snowflake, BigQuery, Databricks, and the Managed Data Lake variants). If a REST call succeeds but reports a service the connector doesn't map — or if you run without `api_config` and the recipe-level `destination_platform` doesn't fit a particular destination — the connector cannot guess a platform. It then skips that destination's lineage edges with a one-time structured warning, and you must pin `destination_to_platform_instance.<id>.platform` explicitly to resolve it.
+
+##### Dropping the schema segment from URNs (`include_schema_in_urn`)
+
+Fivetran reports every table as `<schema>.<table>`, and by default the connector keeps that schema segment in the dataset URN. Some platforms, however, have no schema layer in their natural URN — for example a Kafka topic is addressed as just `kafka.<topic>`, but Fivetran still slots a synthetic schema in front of it.
+
+**Set `include_schema_in_urn: false` when** the source or destination platform addresses tables with **no schema/namespace level** and DataHub's own source for that platform emits a URN _without_ a leading schema. Concretely, set it to `false` for:
+
+- **Streaming/message platforms** whose URN is a single name — e.g. Kafka (`kafka.<topic>`).
+- **File / object / SaaS sources** where Fivetran injects a synthetic schema (often the connector or source name) that isn't part of the real platform's identifier.
+
+The tell-tale symptom is a Fivetran-emitted URN that carries one **extra** leading segment compared to the URN the platform's native DataHub source produces, so lineage fails to stitch. Leave it at the default (`true`) for everything that does have a real schema — relational warehouses, and `iceberg`/`glue`.
+
+Set it on the matching `sources_to_platform_instance` or `destination_to_platform_instance` entry to strip the leading schema segment:
+
+```yaml
+config:
+  sources_to_platform_instance:
+    my_kafka_connector_id:
+      platform: kafka
+      include_schema_in_urn: false # emit `kafka.<topic>`, not `kafka.<schema>.<topic>`
+  destination_to_platform_instance:
+    my_kafka_connector_id:
+      platform: kafka
+      include_schema_in_urn: false
+```
+
+This is an independent knob from `database`/platform routing: `database` controls whether a database segment is **prepended**, while `include_schema_in_urn` controls whether the schema segment is **stripped**. (For `glue` specifically, never set it to `false` — the schema _is_ the Glue database, so dropping it would produce a wrong single-part URN.)
+
 #### Hybrid deployments and destination discovery
 
 If your Fivetran setup has a single account-level Fivetran Platform Connector delivering log data to one destination (typically Snowflake) but actual data is spread across destinations of different types (e.g., Snowflake for some connectors, Managed Data Lake for others), the per-recipe `destination_platform` field can only describe one destination's type at a time.

--- a/metadata-ingestion/docs/sources/fivetran/fivetran_pre.md
+++ b/metadata-ingestion/docs/sources/fivetran/fivetran_pre.md
@@ -71,8 +71,7 @@ config:
     polaris_warehouse_a:
       platform: iceberg # default; emit `iceberg.<schema>.<table>` URNs
     glue_warehouse_b:
-      platform: glue # emit `glue.<database>.<schema>.<table>` URNs
-      database: <actual Glue database name from your AWS Glue console>
+      platform: glue # emit `glue.<schema>.<table>` URNs (schema == Glue database)
       platform_instance: "glue_us_west" # match the Glue source recipe
       env: PROD
     s3_lake_c:
@@ -85,25 +84,23 @@ config:
 
 **Iceberg (default, or `platform: iceberg`).** Emits `urn:li:dataset:(iceberg, <schema>.<table>, env)`. No extra config needed for Polaris / Iceberg-REST destinations — this is the fallback default for any MDL destination whose config doesn't trigger another auto-detect rule.
 
-**Glue (`platform: glue`, or auto-detected).** Emits `urn:li:dataset:(glue, <database>.<schema>.<table>, env)` aligned with DataHub's [Glue source](https://docs.datahub.com/docs/generated/ingestion/sources/glue). **Auto-detected** in two cases — no explicit `platform: glue` needed in either:
+**Glue (`platform: glue`, or auto-detected).** Emits `urn:li:dataset:(glue, <schema>.<table>, env)` aligned with DataHub's [Glue source](https://docs.datahub.com/docs/generated/ingestion/sources/glue). **Auto-detected** in two cases — no explicit `platform: glue` needed in either:
 
 - The destination has Fivetran's `should_maintain_tables_in_glue: true` toggle set (visible via `/v1/destinations/{id}`), OR
-- The user supplied `database` on the destination entry (a database name only makes sense for Glue among MDL platforms, so the connector treats it as a glue-intent signal and avoids silently dropping it on an iceberg/s3/gcs/abs route).
+- The user supplied `database` on the destination entry (a backward-compatible glue-intent signal — the connector routes to glue rather than the iceberg default).
 
-**You must supply `database` yourself for Glue routing.** Fivetran's REST API does not expose the actual Glue database name it creates, and the Fivetran docs do not document the Glue-table-naming convention (Fivetran shares one Glue database per region across all destinations in that region). Inspect your AWS Glue console to find the actual database name and configure it on the destination entry:
+**No `database` config is needed for Glue.** Fivetran's Managed Data Lake registers each destination **schema** as its own AWS Glue **database** and each table as a Glue table. So the URN is the two-part `<schema>.<table>` — where the schema _is_ the Glue database — exactly matching DataHub's Glue source (which builds `<glue_db>.<table>`). The schema comes from each lineage record, so a destination spanning many schemas (one Glue database per connector) is handled automatically:
 
 ```yaml
 destination_to_platform_instance:
   glue_warehouse_a:
-    # platform: glue can be auto-detected from the MDL toggle, but you can
-    # also pin it explicitly.
-    database: fivetran_managed_data_lake_us_west_2 # actual Glue database name
+    # platform: glue is auto-detected from the `should_maintain_tables_in_glue`
+    # toggle, but you can pin it explicitly. No `database` required.
     platform_instance: "glue_us_west" # match the Glue source recipe
+    env: PROD
 ```
 
-The connector then composes `urn:li:dataset:(glue, <database>.<schema>.<table>, env)` using the `<schema>.<table>` from Fivetran's lineage record verbatim as the Glue table name. **Verify against your Glue catalog** that Fivetran's table names are formatted this way; if they aren't, the URN won't align with DataHub's Glue source URNs and lineage won't render.
-
-Until `database` is set, Glue lineage edges are skipped with a structured warning (one per destination, not per edge — repeated edges on a misconfigured destination are silently skipped after the first warning).
+For example, a Glue destination with the `sales` and `marketing` schemas emits `urn:li:dataset:(glue, sales.orders, PROD)` and `urn:li:dataset:(glue, marketing.campaigns, PROD)` — each schema mapping to its own Glue database. To align with a DataHub Glue ingestion, give both recipes the same `platform_instance` and `env` (a plain Glue source uses none by default). Any `database` set on a glue destination entry is ignored for URN construction.
 
 **Object-storage routing (`platform: s3`, `gcs`, or `abs`).** Emits a path-style URN aligned with DataHub's [S3](https://docs.datahub.com/docs/generated/ingestion/sources/s3), [GCS](https://docs.datahub.com/docs/generated/ingestion/sources/gcs), or [Azure Blob / ADLS](https://docs.datahub.com/docs/generated/ingestion/sources/abs) sources. The path prefix is composed from fields in the Fivetran destination response (`/v1/destinations/{id}`) — no extra recipe configuration required:
 
@@ -129,7 +126,7 @@ destination_to_platform_instance:
     env: PROD
 ```
 
-The user override always wins; REST destination discovery still runs in the background to fill in any fields the user didn't pin (e.g. `database` from the discovered config when not overridden). For Glue routing, also set `destination_to_platform_instance.<destination_id>.database` to the actual Glue database name from your AWS Glue console.
+The user override always wins; REST destination discovery still runs in the background to fill in any fields the user didn't pin (e.g. `database` from the discovered config when not overridden). Glue routing needs no `database` — the destination schema is the Glue database (see the Glue section above).
 
 #### Hybrid deployments and destination discovery
 

--- a/metadata-ingestion/src/datahub/ingestion/source/fivetran/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fivetran/config.py
@@ -241,11 +241,19 @@ class PlatformDetail(ConfigModel):
     database: Optional[str] = pydantic.Field(
         default=None,
         description="The database that all assets produced by this connector belong to. "
-        "For destinations, this defaults to the fivetran log config's database.",
+        "For destinations, this defaults to the fivetran log config's database. "
+        "Honored only for relational warehouses (`<platform>.<database>.<schema>.<table>`); "
+        "ignored for `iceberg`/`glue`, where the schema is the namespace (for `glue` a set "
+        "value is treated only as a legacy routing hint, not a URN segment).",
     )
     include_schema_in_urn: bool = pydantic.Field(
         default=True,
-        description="Include schema in the dataset URN. In some cases, the schema is not relevant to the dataset URN and Fivetran sets it to the source and destination table names in the connector.",
+        description="Whether to keep the schema segment in the dataset URN. Fivetran "
+        "reports every table as `<schema>.<table>`, but some target platforms have no "
+        "schema layer in their URN (e.g. Kafka, whose URN is just `<topic>`). Set False "
+        "to strip the leading schema segment so the emitted URN matches that platform's "
+        "naming. Leave True (the default) for warehouses and for `iceberg`/`glue`, where "
+        "the schema is a meaningful namespace.",
     )
     database_lowercase: bool = pydantic.Field(
         default=True,
@@ -255,7 +263,8 @@ class PlatformDetail(ConfigModel):
             "convention (and to preserve the long-standing Fivetran connector "
             "behaviour). Set False to keep the case Fivetran reports — useful "
             "when aligning with another DataHub source whose URN preserves "
-            "the database casing (e.g. some Glue or Iceberg setups). "
+            "the database casing. Only affects relational warehouses; "
+            "`iceberg`/`glue` carry no `database` segment. "
             "Schema and table segments are always passed through unchanged."
         ),
     )

--- a/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran.py
@@ -137,6 +137,15 @@ class FivetranSource(StatefulIngestionSourceBase):
         {"s3", "gcs", "abs"}
     )
 
+    # URN platforms whose namespace is the two-part `<schema>.<table>` with no
+    # `database` prefix — `build_destination_urn` emits these verbatim. The set
+    # is `_NON_RELATIONAL_DESTINATION_PLATFORMS - _PATH_STYLE_DESTINATION_PLATFORMS`;
+    # for `glue`, the destination schema *is* the Glue database (see the branch
+    # in `build_destination_urn` for the Fivetran MDL→Glue rationale).
+    _TWO_PART_NAMESPACE_DESTINATION_PLATFORMS: ClassVar[FrozenSet[str]] = frozenset(
+        {"iceberg", "glue"}
+    )
+
     def __init__(self, config: FivetranSourceConfig, ctx: PipelineContext):
         super().__init__(config, ctx)
         self.config = config
@@ -311,11 +320,13 @@ class FivetranSource(StatefulIngestionSourceBase):
             except ValueError as e:
                 # Most common causes: (a) no platform discovered for this
                 # destination (REST call failed and no declarative
-                # override); (b) auto-detected `platform: glue` but no
-                # user-supplied `database`. Skip the lineage edge for this
-                # connector and keep the ingest going. Dedup the warning
-                # per destination — every connector on a misconfigured
-                # destination would otherwise emit its own copy.
+                # override), so `platform` is unset; (b) a path-style
+                # destination (`s3`/`gcs`/`abs`) whose `database` (the
+                # bucket-or-container prefix) couldn't be discovered or
+                # pinned. Skip the lineage edge for this connector and keep
+                # the ingest going. Dedup the warning per destination —
+                # every connector on a misconfigured destination would
+                # otherwise emit its own copy.
                 if connector.destination_id not in self._destinations_with_urn_warning:
                     self._destinations_with_urn_warning.add(connector.destination_id)
                     self.report.warning(
@@ -323,8 +334,10 @@ class FivetranSource(StatefulIngestionSourceBase):
                         message=(
                             "Skipping all lineage edges for this destination. "
                             "Subsequent edges will be skipped silently. Set "
-                            "`destination_to_platform_instance.<id>.database` "
-                            "(and `platform` if not auto-detected) to fix."
+                            "`destination_to_platform_instance.<id>.platform` "
+                            "if it wasn't auto-detected, and (for s3/gcs/abs "
+                            "destinations only) `.database` with the path "
+                            "prefix, to fix."
                         ),
                         context=(
                             f"connector_id={connector.connector_id}, "
@@ -396,17 +409,13 @@ class FivetranSource(StatefulIngestionSourceBase):
         DataHub's iceberg source convention so URNs align if the same
         catalog is also ingested directly.
 
-        Glue-routed Managed Data Lake destinations are treated as
-        relational: the URN is composed as
-        `glue.<destination_details.database>.<schema>.<table>`. The user
-        is responsible for setting `database` to the actual Glue database
-        name observed in their Glue console (Fivetran shares one Glue
-        database per region across all destinations and the REST API
-        does not expose this name) and for verifying that Fivetran's
-        Glue tables are literally named `<schema>.<table>` so the URN
-        aligns with DataHub's Glue source. If the Glue catalog uses a
-        different table-name convention, the URN won't match and the
-        customer must configure their Glue source accordingly.
+        Glue-routed Managed Data Lake destinations use the same two-part
+        `<schema>.<table>` shape: Fivetran's MDL registers each
+        destination schema as its own Glue database and each table as a
+        Glue table, so `<schema>.<table>` already equals
+        `<glue_db>.<table>` — matching DataHub's Glue source. No
+        user-supplied `database` is required or used for Glue (see the
+        inline comment on the two-part branch below).
 
         For path-style routed Managed Data Lake destinations
         (`platform: s3 | gcs | abs`), the URN follows DataHub's
@@ -437,11 +446,12 @@ class FivetranSource(StatefulIngestionSourceBase):
         #     matching DataHub's Glue source (which builds `<glue_db>.<table>`).
         #     A single destination spans many schemas (one per connector), each
         #     its own Glue database, so the per-row schema — not a single
-        #     user-supplied `database` — must lead the URN. (Verified against a
-        #     live Fivetran MDL→Glue catalog: Glue db `fivetran_log`, table
-        #     `account`.) `database` is therefore neither required nor used for
-        #     Glue.
-        if destination_details.platform in ("iceberg", "glue"):
+        #     user-supplied `database` — must lead the URN. `database` is
+        #     therefore neither required nor used for Glue.
+        if (
+            destination_details.platform
+            in FivetranSource._TWO_PART_NAMESPACE_DESTINATION_PLATFORMS
+        ):
             return DatasetUrn.create_from_ids(
                 platform_id=destination_details.platform,
                 table_name=table_name,

--- a/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran.py
@@ -428,11 +428,22 @@ class FivetranSource(StatefulIngestionSourceBase):
             if destination_details.include_schema_in_urn
             else destination_table.split(".", 1)[1]
         )
-        # Iceberg-family platforms have a two-part namespace; no `database`
+        # Two-part `<schema>.<table>` namespace platforms; no `database`
         # prefix in the URN. REST-discovered MDL destinations land here.
-        if destination_details.platform == "iceberg":
+        #   - iceberg: the namespace is the destination schema.
+        #   - glue: Fivetran's Managed Data Lake registers each destination
+        #     SCHEMA as its own Glue database and each table as a Glue table,
+        #     so `<schema>.<table>` already equals `<glue_db>.<glue_table>` —
+        #     matching DataHub's Glue source (which builds `<glue_db>.<table>`).
+        #     A single destination spans many schemas (one per connector), each
+        #     its own Glue database, so the per-row schema — not a single
+        #     user-supplied `database` — must lead the URN. (Verified against a
+        #     live Fivetran MDL→Glue catalog: Glue db `fivetran_log`, table
+        #     `account`.) `database` is therefore neither required nor used for
+        #     Glue.
+        if destination_details.platform in ("iceberg", "glue"):
             return DatasetUrn.create_from_ids(
-                platform_id="iceberg",
+                platform_id=destination_details.platform,
                 table_name=table_name,
                 env=destination_details.env,
                 platform_instance=destination_details.platform_instance,
@@ -464,15 +475,12 @@ class FivetranSource(StatefulIngestionSourceBase):
                 env=destination_details.env,
                 platform_instance=destination_details.platform_instance,
             )
-        # Glue (and any other URN platform that ends up here): fall through
-        # to the relational `<platform>.<database>.<schema>.<table>` shape.
-        # For Glue specifically, this is the honest minimum: Fivetran's REST
-        # API doesn't expose the Glue database name and the Fivetran docs
-        # don't document the Glue-table-name convention, so we let the user
-        # supply `database` explicitly and trust Fivetran's lineage record's
-        # `<schema>.<table>` matches the Glue table name verbatim. If the
-        # customer's Glue catalog uses a different table-name convention,
-        # the URN won't align — they must override per-destination.
+        # Relational warehouses (snowflake / bigquery / databricks / redshift
+        # / …): `<platform>.<database>.<schema>.<table>`. `database` is always
+        # populated here — from REST discovery or the DB-mode log database
+        # fallback — so the guard below is a defensive invariant, not a
+        # user-facing failure mode (the two-part lakehouse platforms above
+        # never reach this point).
         destination_database_for_urn = destination_details.database_for_urn
         if destination_database_for_urn is None:
             raise ValueError(
@@ -586,20 +594,19 @@ class FivetranSource(StatefulIngestionSourceBase):
           from the discovered config.
         - For Managed Data Lake destinations, the platform is resolved as:
           (1) user override on `base.platform` (always wins) →
-          (2) `glue` if the user supplied `base.database` (a database
-          name only makes sense for Glue routing among MDL platforms;
-          iceberg/s3/gcs/abs would silently drop it) →
+          (2) `glue` if the user supplied `base.database` (a backward-compatible
+          glue-intent signal — see the heuristic comment below) →
           (3) auto-detect from MDL config toggles (`glue` when
           `should_maintain_tables_in_glue` is set) →
           (4) `iceberg` fallback (the modern Polaris / Iceberg REST
-          default). For `glue`, the user must still supply `database`
-          themselves — the Fivetran REST API doesn't expose the actual
-          Glue database name, so auto-detect picks the platform but the
-          customer pins the database. When the resolved platform is
-          path-style (`s3` / `gcs` / `abs`), `database` is auto-populated
-          from the appropriate fields in the discovered MDL config; the
-          same `service: managed_data_lake` covers AWS, GCS, and ADLS
-          Gen2, distinguished by which fields are populated. The user's
+          default). `glue` needs no `database`: Fivetran's MDL registers each
+          destination schema as its own Glue database, so the URN is the
+          two-part `<schema>.<table>` (schema == Glue database) and `database`
+          is ignored for glue (see `build_destination_urn`). When the resolved
+          platform is path-style (`s3` / `gcs` / `abs`), `database` is
+          auto-populated from the appropriate fields in the discovered MDL
+          config; the same `service: managed_data_lake` covers AWS, GCS, and
+          ADLS Gen2, distinguished by which fields are populated. The user's
           `database` override always wins.
         - For services we don't know about, return `base` unchanged. The caller
           should log a structured warning so the user knows discovery didn't
@@ -607,12 +614,13 @@ class FivetranSource(StatefulIngestionSourceBase):
         """
         if discovered.service == "managed_data_lake":
             # Precedence: user override → user-database-implies-glue →
-            # MDL-toggle auto-detect → iceberg fallback. Treating
-            # `base.database` as a glue-intent signal protects users from
-            # the silent foot-gun where they set `database` (intending
-            # Glue routing) on a destination whose `should_maintain_tables_in_glue`
-            # toggle isn't set — without this, we'd fall through to
-            # iceberg and quietly drop their `database`.
+            # MDL-toggle auto-detect → iceberg fallback. `base.database` is
+            # kept as a backward-compatible glue-intent signal: a user who set
+            # `database` on an MDL destination clearly meant Glue routing (the
+            # only MDL platform for which a database name was ever meaningful),
+            # so route to glue rather than the iceberg fallback. Note the glue
+            # URN itself no longer uses `database` — the schema is the Glue
+            # database — so the value is only a routing hint here.
             resolved_platform = (
                 base.platform
                 or ("glue" if base.database is not None else None)
@@ -675,12 +683,10 @@ class FivetranSource(StatefulIngestionSourceBase):
         through to the generic `iceberg` default.
 
         `should_maintain_tables_in_glue` triggers an auto-default to
-        `glue`. The auto-detect picks the URN platform; the customer
-        still must supply `database` (the actual Glue database name from
-        their AWS Glue console — the REST API doesn't expose it). Until
-        they do, `build_destination_urn` raises a structured ValueError
-        and the caller skips the lineage edge with a once-per-destination
-        warning.
+        `glue`. No further config is needed: Fivetran's MDL registers each
+        destination schema as its own Glue database, so the URN is the
+        two-part `<schema>.<table>` (schema == Glue database) — matching
+        DataHub's Glue source — and no user-supplied `database` is required.
 
         The other catalog toggles (`should_maintain_tables_in_bqms` for
         BigQuery Metastore, `should_maintain_tables_in_one_lake` for

--- a/metadata-ingestion/tests/unit/fivetran/test_fivetran_destination_discovery.py
+++ b/metadata-ingestion/tests/unit/fivetran/test_fivetran_destination_discovery.py
@@ -634,75 +634,75 @@ class TestResolveDestinationDetails:
 
 
 class TestBuildDestinationUrnGlueMdl:
-    """Glue-routed Managed Data Lake destinations are treated as relational:
-    URN shape `glue.<database>.<schema>.<table>` where `<database>` is the
-    user-supplied actual Glue database name (Fivetran shares one Glue
-    database per region; the REST API does not expose its name). The
-    customer is responsible for verifying that Fivetran's Glue tables are
-    literally named `<schema>.<table>` so this URN aligns with DataHub's
-    Glue source.
+    """Fivetran's Managed Data Lake → Glue registers each destination SCHEMA
+    as its own Glue database and each table as a Glue table. So the dataset
+    URN is the two-part ``<schema>.<table>`` (schema == Glue database) —
+    matching DataHub's Glue source, which builds ``<glue_db>.<table>``. No
+    separate ``database`` segment is prepended, and a user-supplied
+    ``database`` is neither required nor used for Glue. Verified against a
+    live Fivetran MDL→Glue catalog: Glue database ``fivetran_log``, table
+    ``account``.
     """
 
-    def test_glue_requires_user_supplied_database(self):
-        # No `database` set → ValueError. Caller catches and skips the
-        # lineage edge with a structured warning. Pin this so the
-        # failure mode stays well-defined.
-        with pytest.raises(ValueError, match="database must be set"):
-            FivetranSource.build_destination_urn(
-                destination_table="public.employee",
-                destination_details=PlatformDetail(platform="glue"),
-            )
+    def test_glue_urn_is_two_part_schema_table(self):
+        urn = FivetranSource.build_destination_urn(
+            destination_table="fivetran_log.account",
+            destination_details=PlatformDetail(platform="glue"),
+        )
+        assert (
+            str(urn)
+            == "urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_log.account,PROD)"
+        )
 
-    def test_glue_with_user_supplied_database(self):
-        # Customer inspects their Glue console, finds the actual database
-        # (e.g., `fivetran_managed_data_lake_us_west_2`), and pins it on
-        # `destination_to_platform_instance.<id>.database`. URN follows
-        # the relational shape with `<schema>.<table>` as the literal
-        # Glue table name.
+    def test_glue_does_not_require_database(self):
+        # The schema already IS the Glue database, so no user `database` is
+        # needed. Must not raise (the previous design raised ValueError here).
         urn = FivetranSource.build_destination_urn(
             destination_table="public.employee",
+            destination_details=PlatformDetail(platform="glue"),
+        )
+        assert (
+            str(urn) == "urn:li:dataset:(urn:li:dataPlatform:glue,public.employee,PROD)"
+        )
+
+    def test_glue_multi_schema_each_table_uses_its_own_schema(self):
+        # One destination holds many connectors, each writing its own schema
+        # → its own Glue database. A single `database` scalar cannot express
+        # this; the per-row schema must drive the URN.
+        details = PlatformDetail(platform="glue")
+        a = FivetranSource.build_destination_urn("fivetran_log.account", details)
+        b = FivetranSource.build_destination_urn("salesforce.opportunity", details)
+        assert (
+            str(a)
+            == "urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_log.account,PROD)"
+        )
+        assert (
+            str(b)
+            == "urn:li:dataset:(urn:li:dataPlatform:glue,salesforce.opportunity,PROD)"
+        )
+
+    def test_glue_respects_platform_instance(self):
+        urn = FivetranSource.build_destination_urn(
+            destination_table="fivetran_log.account",
             destination_details=PlatformDetail(
-                platform="glue",
-                database="fivetran_managed_data_lake_us_west_2",
+                platform="glue", platform_instance="glue_us_east"
             ),
         )
         assert (
             str(urn)
-            == "urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_managed_data_lake_us_west_2.public.employee,PROD)"
+            == "urn:li:dataset:(urn:li:dataPlatform:glue,glue_us_east.fivetran_log.account,PROD)"
         )
 
-    def test_glue_database_is_lowercased(self):
-        # Same as the relational platforms: `database` is lowercased to
-        # match DataHub's Glue source URN convention. AWS Glue itself
-        # normalises database names to lowercase, so this is safe.
+    def test_glue_ignores_database_config(self):
+        # Guard against regressing to the old 3-part shape: a stray
+        # `database` must not prepend a segment.
         urn = FivetranSource.build_destination_urn(
-            destination_table="public.employee",
-            destination_details=PlatformDetail(
-                platform="glue",
-                database="Fivetran_DataLake",
-            ),
+            destination_table="fivetran_log.account",
+            destination_details=PlatformDetail(platform="glue", database="some_db"),
         )
         assert (
             str(urn)
-            == "urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_datalake.public.employee,PROD)"
-        )
-
-    def test_glue_database_case_preserved_when_opted_out(self):
-        # `database_lowercase=False` is the per-destination opt-out for
-        # users whose paired DataHub Glue source URN preserves database
-        # casing. Default (True) keeps the long-standing behaviour
-        # exercised by `test_glue_database_is_lowercased`.
-        urn = FivetranSource.build_destination_urn(
-            destination_table="public.employee",
-            destination_details=PlatformDetail(
-                platform="glue",
-                database="Fivetran_DataLake",
-                database_lowercase=False,
-            ),
-        )
-        assert (
-            str(urn)
-            == "urn:li:dataset:(urn:li:dataPlatform:glue,Fivetran_DataLake.public.employee,PROD)"
+            == "urn:li:dataset:(urn:li:dataPlatform:glue,fivetran_log.account,PROD)"
         )
 
 


### PR DESCRIPTION
## Summary

Fivetran's Managed Data Lake → Glue integration registers **each destination schema as its own AWS Glue database** and each table as a Glue table. The connector previously modeled Glue as a relational warehouse and emitted a three-part `glue.<database>.<schema>.<table>` URN that:

- required a user-supplied `database` (which the REST API can't discover), and
- **never matched** the URNs that DataHub's own Glue source produces (`<glue_db>.<table>`), so Fivetran→Glue lineage silently failed to render.

This routes `glue` through the same two-part `<schema>.<table>` path as `iceberg` — the schema *is* the Glue database. `database` is no longer required or used for Glue, and **multi-schema destinations** (one Glue database per connector — the normal case) now resolve correctly because each lineage row's own schema leads the URN.

### Before / after

| | URN |
|---|---|
| Before | `urn:li:dataset:(glue, <database>.<schema>.<table>, env)` |
| After | `urn:li:dataset:(glue, <schema>.<table>, env)` |

### Verified end-to-end

Against a live Fivetran MDL→Glue destination (Glue database `fivetran_log`, table `account`): the connector now emits `glue,fivetran_log.account,PROD` — byte-identical to a DataHub Glue source ingestion of the same catalog — and lineage stitches automatically (the Glue dataset shows the Fivetran sync job as its upstream).

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated — `TestBuildDestinationUrnGlueMdl` rewritten to assert the two-part shape, including a multi-schema case that config alone cannot express
- [x] Docs updated — `fivetran_pre.md` Glue routing section
- [ ] Breaking changes — n/a (the Glue MDL routing shipped in 1.6.0; this corrects its URN shape before broad adoption)