### PR TITLE
fix(ingestion/openlineage): avoid NPE when SchemaDatasetFacet fields omit type

### DIFF
--- a/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/converter/OpenLineageToDataHub.java
+++ b/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/converter/OpenLineageToDataHub.java
@@ -1330,6 +1330,9 @@ public class OpenLineageToDataHub {
 
   public static SchemaFieldDataType.Type convertOlFieldTypeToDHFieldType(
       String openLineageFieldType) {
+    if (openLineageFieldType == null) {
+      return SchemaFieldDataType.Type.create(new NullType());
+    }
     switch (openLineageFieldType) {
       case "string":
         return SchemaFieldDataType.Type.create(new StringType());
@@ -1368,7 +1371,7 @@ public class OpenLineageToDataHub {
             field -> {
               SchemaField schemaField = new SchemaField();
               schemaField.setFieldPath(field.getName());
-              schemaField.setNativeDataType(field.getType());
+              schemaField.setNativeDataType(field.getType() == null ? "" : field.getType());
               schemaField.setType(
                   new SchemaFieldDataType()
                       .setType(convertOlFieldTypeToDHFieldType(field.getType())));

--- a/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/TrinoNullFieldsTest.java
+++ b/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/TrinoNullFieldsTest.java
@@ -315,6 +315,59 @@ public class TrinoNullFieldsTest {
     }
   }
 
+  /** Test that SchemaDatasetFacet fields can omit "type" without failing conversion. */
+  @Test
+  public void testSchemaFacetWithFieldsMissingType() throws Exception {
+    DatahubOpenlineageConfig config =
+        DatahubOpenlineageConfig.builder()
+            .fabricType(FabricType.PROD)
+            .orchestrator("trino")
+            .materializeDataset(true)
+            .captureColumnLevelLineage(false)
+            .build();
+
+    OpenLineage openLineage = new OpenLineage(TRINO_PRODUCER_URI);
+
+    OpenLineage.SchemaDatasetFacetFields fieldA =
+        openLineage.newSchemaDatasetFacetFieldsBuilder().name("col_a").build();
+    OpenLineage.SchemaDatasetFacetFields fieldB =
+        openLineage.newSchemaDatasetFacetFieldsBuilder().name("col_b").build();
+
+    OpenLineage.SchemaDatasetFacet schemaFacet =
+        openLineage.newSchemaDatasetFacetBuilder().fields(Arrays.asList(fieldA, fieldB)).build();
+
+    OpenLineage.DatasetFacets datasetFacets =
+        openLineage.newDatasetFacetsBuilder().schema(schemaFacet).build();
+
+    OpenLineage.InputDataset inputDataset =
+        openLineage
+            .newInputDatasetBuilder()
+            .namespace("trino://example-host:443")
+            .name("schema.table.source")
+            .facets(datasetFacets)
+            .build();
+
+    OpenLineage.RunEvent runEvent =
+        openLineage
+            .newRunEventBuilder()
+            .eventTime(ZonedDateTime.now())
+            .eventType(OpenLineage.RunEvent.EventType.COMPLETE)
+            .run(openLineage.newRunBuilder().runId(UUID.randomUUID()).build())
+            .job(
+                openLineage
+                    .newJobBuilder()
+                    .namespace("trino-ci")
+                    .name("repro-missing-type")
+                    .facets(openLineage.newJobFacetsBuilder().build())
+                    .build())
+            .inputs(Arrays.asList(inputDataset))
+            .outputs(Collections.emptyList())
+            .build();
+
+    DatahubJob datahubJob = OpenLineageToDataHub.convertRunEventToJob(runEvent, config);
+    assertNotNull(datahubJob, "Should handle SchemaDatasetFacet fields without a type gracefully");
+  }
+
   /**
    * Test handling of SchemaDatasetFacet with empty fields list.
    *


### PR DESCRIPTION
## Summary
- Fix a null-handling bug in OpenLineage schema conversion where `SchemaDatasetFacet.fields[].type` can be omitted.
- Make `convertOlFieldTypeToDHFieldType` null-safe and default to `NullType` when OpenLineage type is absent.
- Prevent `SchemaField.nativeDataType` from receiving null by using an empty-string fallback.
- Add regression coverage for Trino-style events where schema fields include `name` but omit `type`.

## Why
OpenLineage spec allows field `type` to be optional, but conversion previously threw NPE and caused ingestion failures (HTTP 500) for valid payloads.

## Test plan
- [x] `./gradlew :metadata-integration:java:openlineage-converter:check`
- [x] Module tests pass (`21 passing`)
- [x] Spotless check passes
- [x] Jacoco report task runs
- [x] New regression test in `TrinoNullFieldsTest` validates missing-type scenario