### PR TITLE
fix(ingest/sql-parsing): preserve case-sensitive column lineage, drop the `lineage()` normalization patch

### DIFF
--- a/metadata-ingestion/src/datahub/sql_parsing/_sqlglot_patch.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/_sqlglot_patch.py
@@ -149,20 +149,6 @@ def _patch_lineage() -> None:
     lineage_py.Node = Node  # type: ignore
     sqlglot.lineage.Node = Node  # type: ignore
 
-    patchy.patch(
-        lineage_py.lineage,
-        """\
-@@ -68,4 +68,6 @@
-     if column is not None:
--        column_name = normalize_identifiers.normalize_identifiers(column, dialect=dialect).name
-+        # column_name = normalize_identifiers.normalize_identifiers(column, dialect=dialect).name
-+        assert isinstance(column, str)
-+        column_name = column
-         if not any(select.alias_or_name == column_name for select in selectable.selects):
-             raise SqlglotError(f"Cannot find column '{column_name}' in query.")
-""",
-    )
-
     # Patch 1: Change set to list for source_columns (preserve column order)
     patchy.patch(
         lineage_py.to_node,

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -22,6 +22,7 @@ from typing import (
 import pydantic.dataclasses
 import sqlglot
 import sqlglot.errors
+import sqlglot.expressions
 import sqlglot.lineage
 import sqlglot.optimizer
 import sqlglot.optimizer.annotate_types
@@ -1119,7 +1120,12 @@ def _select_statement_cll(
 
             try:
                 lineage_node = sqlglot.lineage.lineage(
-                    output_col,
+                    # Pass the already-resolved output column as a quoted identifier so
+                    # sqlglot's normalize_identifiers preserves its casing instead of
+                    # case-folding it (which would break the lookup for case-sensitive
+                    # columns). identify=True during qualification makes every projection
+                    # a quoted identifier, so quoted=True is uniformly correct here.
+                    sqlglot.expressions.column(output_col, quoted=True),
                     statement,
                     dialect=dialect,
                     scope=root_scope,

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -1119,13 +1119,19 @@ def _select_statement_cll(
                 continue
 
             try:
+                # output_col was resolved by our qualify pass (schema built with
+                # normalize=False), so it already holds the column's real casing.
+                # sqlglot.lineage re-normalizes the lookup name using dialect rules
+                # only -- on case-insensitive dialects (Databricks, Spark, Hive,
+                # Redshift, Trino, ...) that folds the identifier (quoting does not
+                # exempt it), so the lookup no longer matches and lineage is silently
+                # dropped for mixed-case columns. Marking the identifier case_sensitive
+                # makes that normalization a no-op on every dialect (sqlglot's
+                # documented hook); lineage() matches on the identifier name only.
+                output_col_expr = sqlglot.expressions.column(output_col)
+                output_col_expr.this.meta["case_sensitive"] = True
                 lineage_node = sqlglot.lineage.lineage(
-                    # Pass the already-resolved output column as a quoted identifier so
-                    # sqlglot's normalize_identifiers preserves its casing instead of
-                    # case-folding it (which would break the lookup for case-sensitive
-                    # columns). identify=True during qualification makes every projection
-                    # a quoted identifier, so quoted=True is uniformly correct here.
-                    sqlglot.expressions.column(output_col, quoted=True),
+                    output_col_expr,
                     statement,
                     dialect=dialect,
                     scope=root_scope,

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -1119,15 +1119,12 @@ def _select_statement_cll(
                 continue
 
             try:
-                # output_col was resolved by our qualify pass (schema built with
-                # normalize=False), so it already holds the column's real casing.
-                # sqlglot.lineage re-normalizes the lookup name using dialect rules
-                # only -- on case-insensitive dialects (Databricks, Spark, Hive,
-                # Redshift, Trino, ...) that folds the identifier (quoting does not
-                # exempt it), so the lookup no longer matches and lineage is silently
-                # dropped for mixed-case columns. Marking the identifier case_sensitive
-                # makes that normalization a no-op on every dialect (sqlglot's
-                # documented hook); lineage() matches on the identifier name only.
+                # output_col already holds the column's real casing (qualified with
+                # normalize=False). sqlglot.lineage would re-normalize the lookup name
+                # per dialect (upper for Snowflake, lower for case-insensitive ones),
+                # breaking the match and silently dropping lineage for mixed-case
+                # columns. case_sensitive marks the identifier so normalization skips
+                # it on every dialect and lineage() matches the name verbatim.
                 output_col_expr = sqlglot.expressions.column(output_col)
                 output_col_expr.this.meta["case_sensitive"] = True
                 lineage_node = sqlglot.lineage.lineage(

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_databricks_case_sensitive_column_lineage.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_databricks_case_sensitive_column_lineage.json
@@ -1,0 +1,60 @@
+{
+    "query_type": "SELECT",
+    "query_type_props": {},
+    "query_fingerprint": "bab6830e987279585f6223e83750593a9254ac92df310f4e9502094f9fdecc2b",
+    "in_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:databricks,hive_metastore.bronze_kambi.bet,PROD)"
+    ],
+    "out_tables": [],
+    "column_lineage": [
+        {
+            "downstream": {
+                "table": null,
+                "column": "betStatusId",
+                "column_type": {
+                    "type": {
+                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                    }
+                },
+                "native_column_type": "BIGINT"
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:databricks,hive_metastore.bronze_kambi.bet,PROD)",
+                    "column": "betStatusId"
+                }
+            ],
+            "logic": {
+                "is_direct_copy": true,
+                "column_logic": "`bet`.`betStatusId` AS `betStatusId`"
+            }
+        },
+        {
+            "downstream": {
+                "table": null,
+                "column": "channelId",
+                "column_type": {
+                    "type": {
+                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                    }
+                },
+                "native_column_type": "BIGINT"
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:databricks,hive_metastore.bronze_kambi.bet,PROD)",
+                    "column": "channelId"
+                }
+            ],
+            "logic": {
+                "is_direct_copy": true,
+                "column_logic": "`bet`.`channelId` AS `channelId`"
+            }
+        }
+    ],
+    "joins": [],
+    "debug_info": {
+        "confidence": 0.9,
+        "generalized_statement": "SELECT * FROM hive_metastore.bronze_kambi.bet"
+    }
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_case_sensitive_column_through_cte.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_case_sensitive_column_through_cte.json
@@ -1,0 +1,38 @@
+{
+    "query_type": "SELECT",
+    "query_type_props": {},
+    "query_fingerprint": "cff4a16758d09afd2d7285a8b7eecd6653b8846e21de6d95458ee51570e34601",
+    "in_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.sch.tbl,PROD)"
+    ],
+    "out_tables": [],
+    "column_lineage": [
+        {
+            "downstream": {
+                "table": null,
+                "column": "fullname",
+                "column_type": {
+                    "type": {
+                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                },
+                "native_column_type": "VARCHAR"
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.sch.tbl,PROD)",
+                    "column": "CustomerName"
+                }
+            ],
+            "logic": {
+                "is_direct_copy": true,
+                "column_logic": "\"TBL\".\"CUSTOMERNAME\" AS \"CUSTOMERNAME\""
+            }
+        }
+    ],
+    "joins": [],
+    "debug_info": {
+        "confidence": 0.9,
+        "generalized_statement": "WITH staged AS (SELECT \"CustomerName\" FROM db.sch.tbl) SELECT \"CustomerName\" AS \"FullName\" FROM staged"
+    }
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_case_sensitive_quoted_column_lineage.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_case_sensitive_quoted_column_lineage.json
@@ -1,0 +1,38 @@
+{
+    "query_type": "SELECT",
+    "query_type_props": {},
+    "query_fingerprint": "43233c4a4be7d52ab7723ee797991487d756bd67accbf8eee5fc16c08d49c610",
+    "in_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.sch.tbl,PROD)"
+    ],
+    "out_tables": [],
+    "column_lineage": [
+        {
+            "downstream": {
+                "table": null,
+                "column": "fullname",
+                "column_type": {
+                    "type": {
+                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                },
+                "native_column_type": "VARCHAR"
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.sch.tbl,PROD)",
+                    "column": "CustomerName"
+                }
+            ],
+            "logic": {
+                "is_direct_copy": true,
+                "column_logic": "\"TBL\".\"CUSTOMERNAME\" AS \"FullName\""
+            }
+        }
+    ],
+    "joins": [],
+    "debug_info": {
+        "confidence": 0.9,
+        "generalized_statement": "SELECT \"CustomerName\" AS \"FullName\" FROM db.sch.tbl"
+    }
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
@@ -563,6 +563,58 @@ FROM snowflake_sample_data.tpch_sf1.orders o
     )
 
 
+def test_snowflake_case_sensitive_quoted_column_lineage() -> None:
+    # Regression guard for the case-sensitive column lineage fix.
+    #
+    # The output column is handed to sqlglot.lineage.lineage() as a quoted
+    # identifier (exp.column(output_col, quoted=True)) so that sqlglot's
+    # normalize_identifiers preserves its casing. If that is reverted to passing
+    # the raw string, Snowflake (UPPERCASE strategy) case-folds "CustomerName" to
+    # CUSTOMERNAME, the column can no longer be found in the query, and the
+    # upstream edge is silently dropped -- i.e. this assertion would see an empty
+    # column_lineage. See https://github.com/tobymao/sqlglot/issues/7733.
+    assert_sql_result(
+        """
+SELECT "CustomerName" AS "FullName"
+FROM db.sch.tbl
+""",
+        dialect="snowflake",
+        schemas={
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.sch.tbl,PROD)": {
+                "CustomerName": "VARCHAR",
+            },
+        },
+        expected_file=RESOURCE_DIR
+        / "test_snowflake_case_sensitive_quoted_column_lineage.json",
+    )
+
+
+def test_snowflake_case_sensitive_column_through_cte() -> None:
+    # Regression guard for the case-sensitive column lineage fix, this time with
+    # the quoted column "CustomerName" flowing through a CTE. Its casing must
+    # survive the full multi-hop lineage walk (CTE -> outer SELECT), not just the
+    # top-level projection lookup. As with the non-CTE case, reverting to a raw
+    # (non-quoted) column lets Snowflake case-fold the name so the upstream edge
+    # is silently dropped. See https://github.com/tobymao/sqlglot/issues/7733.
+    assert_sql_result(
+        """
+WITH staged AS (
+    SELECT "CustomerName" FROM db.sch.tbl
+)
+SELECT "CustomerName" AS "FullName"
+FROM staged
+""",
+        dialect="snowflake",
+        schemas={
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.sch.tbl,PROD)": {
+                "CustomerName": "VARCHAR",
+            },
+        },
+        expected_file=RESOURCE_DIR
+        / "test_snowflake_case_sensitive_column_through_cte.json",
+    )
+
+
 def test_snowflake_case_statement() -> None:
     assert_sql_result(
         """

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
@@ -566,13 +566,12 @@ FROM snowflake_sample_data.tpch_sf1.orders o
 def test_snowflake_case_sensitive_quoted_column_lineage() -> None:
     # Regression guard for the case-sensitive column lineage fix.
     #
-    # The output column is handed to sqlglot.lineage.lineage() as a quoted
-    # identifier (exp.column(output_col, quoted=True)) so that sqlglot's
-    # normalize_identifiers preserves its casing. If that is reverted to passing
-    # the raw string, Snowflake (UPPERCASE strategy) case-folds "CustomerName" to
-    # CUSTOMERNAME, the column can no longer be found in the query, and the
-    # upstream edge is silently dropped -- i.e. this assertion would see an empty
-    # column_lineage. See https://github.com/tobymao/sqlglot/issues/7733.
+    # The output column is handed to sqlglot.lineage.lineage() with its identifier
+    # marked case_sensitive so sqlglot's normalize_identifiers leaves the casing
+    # alone. If that marker is dropped, Snowflake (UPPERCASE strategy) case-folds
+    # "CustomerName" to CUSTOMERNAME, the column can no longer be found in the query,
+    # and the upstream edge is silently dropped -- i.e. this assertion would see an
+    # empty column_lineage. See https://github.com/tobymao/sqlglot/issues/7733.
     assert_sql_result(
         """
 SELECT "CustomerName" AS "FullName"
@@ -593,8 +592,8 @@ def test_snowflake_case_sensitive_column_through_cte() -> None:
     # Regression guard for the case-sensitive column lineage fix, this time with
     # the quoted column "CustomerName" flowing through a CTE. Its casing must
     # survive the full multi-hop lineage walk (CTE -> outer SELECT), not just the
-    # top-level projection lookup. As with the non-CTE case, reverting to a raw
-    # (non-quoted) column lets Snowflake case-fold the name so the upstream edge
+    # top-level projection lookup. As with the non-CTE case, dropping the
+    # case_sensitive marker lets Snowflake case-fold the name so the upstream edge
     # is silently dropped. See https://github.com/tobymao/sqlglot/issues/7733.
     assert_sql_result(
         """
@@ -612,6 +611,32 @@ FROM staged
         },
         expected_file=RESOURCE_DIR
         / "test_snowflake_case_sensitive_column_through_cte.json",
+    )
+
+
+def test_databricks_case_sensitive_column_lineage() -> None:
+    # Regression guard for case-insensitive dialects (Databricks/Spark/Hive/Redshift/
+    # Trino/...). Unlike Snowflake, these fold identifiers *even when quoted*. A
+    # SELECT * over a schema with mixed-case columns expands to the columns' real
+    # casing (betStatusId), so the lineage lookup must not be re-folded. Passing the
+    # lookup column as quoted=True alone is not enough here -- it case-folds
+    # "betStatusId" to "betstatusid", the column is no longer found, and the upstream
+    # edge is silently dropped. Marking the identifier case_sensitive keeps it
+    # verbatim. This mirrors the Unity Catalog view-lineage path. See
+    # https://github.com/tobymao/sqlglot/issues/7733.
+    assert_sql_result(
+        "SELECT * FROM hive_metastore.bronze_kambi.bet",
+        dialect="databricks",
+        default_db="hive_metastore",
+        default_schema="bronze_kambi",
+        schemas={
+            "urn:li:dataset:(urn:li:dataPlatform:databricks,hive_metastore.bronze_kambi.bet,PROD)": {
+                "betStatusId": "BIGINT",
+                "channelId": "BIGINT",
+            },
+        },
+        expected_file=RESOURCE_DIR
+        / "test_databricks_case_sensitive_column_lineage.json",
     )
 
 

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
@@ -590,11 +590,11 @@ FROM db.sch.tbl
 
 def test_snowflake_case_sensitive_column_through_cte() -> None:
     # Regression guard for the case-sensitive column lineage fix, this time with
-    # the quoted column "CustomerName" flowing through a CTE. Its casing must
-    # survive the full multi-hop lineage walk (CTE -> outer SELECT), not just the
-    # top-level projection lookup. As with the non-CTE case, dropping the
-    # case_sensitive marker lets Snowflake case-fold the name so the upstream edge
-    # is silently dropped. See https://github.com/tobymao/sqlglot/issues/7733.
+    # the quoted column "CustomerName" flowing through a CTE, exercising scope
+    # resolution across the CTE -> outer SELECT hop. As with the non-CTE case,
+    # dropping the case_sensitive marker lets Snowflake case-fold the projection
+    # lookup so the upstream edge is silently dropped.
+    # See https://github.com/tobymao/sqlglot/issues/7733.
     assert_sql_result(
         """
 WITH staged AS (


### PR DESCRIPTION

## Summary

Column-level lineage was silently dropped for mixed-case columns whenever DataHub preserved the column's real casing (case-sensitive/quoted columns on Snowflake, and mixed-case columns on Databricks/Spark/etc.). The old workaround monkey-patched `sqlglot.lineage.lineage` at import time to globally disable its identifier-normalization step. This PR deletes that patch and instead fixes our one call site: we hand the output column to `lineage()` with its identifier marked **case-sensitive**, so sqlglot leaves the name verbatim. Emitted lineage is preserved across all dialects; we just stop hacking a third-party function. Regression tests lock it in.

## Why the patch existed

`lineage(column, sql, ...)` re-normalizes the lookup `column` before matching it against the query's projections, and raises if nothing matches ([`lineage.py#L156`](https://github.com/tobymao/sqlglot/blob/v30.8.0/sqlglot/lineage.py#L156)):

```python
column_name = normalize_identifiers.normalize_identifiers(column, dialect=dialect).name
if not any(select.alias_or_name == column_name for select in selectable.selects):
    raise SqlglotError(f"Cannot find column '{column_name}' in query.")
```

That normalization folds the identifier's case based on its **quoted** flag and the dialect's strategy ([`Dialect.normalize_identifier`](https://github.com/tobymao/sqlglot/blob/v30.8.0/sqlglot/dialects/dialect.py#L1001)):

- **Unquoted** identifier → folded on every case-folding dialect (Snowflake → `UPPER`, Postgres → `lower`).
- **Quoted** identifier → preserved on `UPPERCASE` / `LOWERCASE` / `CASE_SENSITIVE`, but **still folded** on `CASE_INSENSITIVE`.

| Strategy | Examples | Folds a **quoted** identifier? |
| --- | --- | --- |
| `UPPERCASE` | Snowflake, Oracle | No (preserved) |
| `LOWERCASE` | Postgres, default (no dialect) | No (preserved) |
| `CASE_SENSITIVE` | MySQL | No (never folds) |
| `CASE_INSENSITIVE` | Databricks, Spark, Hive, Redshift, Trino/Presto, DuckDB, BigQuery | **Yes — folds even when quoted** |

DataHub does its own normalization **with** schema context — it builds the scope with `MappingSchema(normalize=False)`, so its projections keep real casing (`betStatusId`, `CustomerName`). This lookup is the exception: it gets only a `dialect`, never the schema, so it folds by the dialect default and disagrees with those verbatim projections:

- Snowflake `"FullName"` (quoted, mixed-case) → `FULLNAME` → no match.
- Databricks `betStatusId` (mixed-case, from `SELECT *`) → `betstatusid` → no match.

Either way the raise fires, the call site catches it, and the edge is silently dropped. The patch deleted that fold for every caller.

## The fix

At our single call site in [`sqlglot_lineage.py`](metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py):

```python
output_col_expr = sqlglot.expressions.column(output_col)
output_col_expr.this.meta["case_sensitive"] = True
lineage_node = sqlglot.lineage.lineage(
    output_col_expr,
    statement, dialect=dialect, scope=root_scope, trim_selects=False, copy=False,
)
```

`meta["case_sensitive"]` is sqlglot's opt-out: `normalize_identifiers` prunes and skips any node carrying it ([`normalize_identifiers.py#L66-L67`](https://github.com/tobymao/sqlglot/blob/v30.8.0/sqlglot/optimizer/normalize_identifiers.py#L66)), so the lookup name is matched verbatim on every dialect — the same result the deleted patch produced.

Why it's safe:

- The marker sits on a **throwaway** expression we build only for the lookup; it never enters the AST/scope `lineage()` walks. `to_node` then receives the verbatim string `column_name` — identical to what the old `column_name = column` patch produced — so downstream lineage is unchanged.

## Why the maintainer's "just quote it" is not enough

The sqlglot maintainer's suggested workaround ([#7733](https://github.com/tobymao/sqlglot/issues/7733)) is to pass the column as a quoted identifier — `exp.column(output_col, quoted=True)`. That works on dialects that **exempt quoted identifiers** from folding (`UPPERCASE`/`LOWERCASE`/`CASE_SENSITIVE`/default): on Snowflake, `"CustomerName"` is preserved and the lookup matches.

It is **not** enough on `CASE_INSENSITIVE` dialects (Databricks, Spark, Hive, Redshift, Trino, DuckDB), which fold identifiers **even when quoted** (last table row above). The failure surfaces precisely when the resolved output column is still mixed-case — and that is the `SELECT *` path: DataHub expands `*` from its schema (built `normalize=False`), so the projection keeps its real casing `betStatusId`. `quoted=True` then folds the lookup name to `betstatusid`, which no longer matches the projection `betStatusId` → `Cannot find column` → the edge is dropped. The Unity Catalog view `CREATE VIEW view1 AS SELECT * FROM bet` is exactly this case, and `view1` lost its `fineGrainedLineages` under `quoted=True`.

(BigQuery is also `CASE_INSENSITIVE` but did **not** break: it is in DataHub's `DIALECTS_WITH_CASE_INSENSITIVE_COLS`, so DataHub pre-folds its names to a canonical case and both sides agree. Explicit references like `SELECT betStatusId` also survive `quoted=True`, because qualify already folded the written name — so the fold lands on the same value. Only the schema-expanded mixed-case `*` projection diverges.)

The `case_sensitive` marker suppresses the fold on **every** dialect, so the resolved name is matched verbatim regardless — Snowflake and Databricks alike.

| Resolved column (after qualify) | `quoted=True` alone | `case_sensitive` marker |
| --- | --- | --- |
| `"CustomerName"` on Snowflake — `UPPERCASE` | preserved ✅ | preserved ✅ |
| `betStatusId` via `SELECT *` on Databricks — `CASE_INSENSITIVE` | folded → **dropped** ❌ | preserved ✅ |
| already-folded / lowercase names | unchanged ✅ | unchanged ✅ |

## Tests

Added in `tests/unit/sql_parsing/test_sqlglot_lineage.py` (with goldens):

- `test_snowflake_case_sensitive_quoted_column_lineage` — single projection; asserts the upstream edge keeps casing (`CustomerName`).
- `test_snowflake_case_sensitive_column_through_cte` — same column through a CTE, so casing must survive a multi-hop walk, not just the top-level lookup.
- `test_databricks_case_sensitive_column_lineage` — `SELECT *` over a mixed-case schema on a `CASE_INSENSITIVE` dialect (the Unity Catalog view path). This is the case `quoted=True` silently dropped; it fails if the `case_sensitive` marker is removed.

All three were verified to **fail** without the marker (the revert reproduces `Cannot find column '…'` and empties `column_lineage`) and to pass once restored, so they guard the mechanism, not just the happy path. The Unity Catalog integration tests (`test_ingestion`, `test_ml_model_with_signature_and_run_details`) pass with goldens unchanged.