### PR TITLE
feat(i18n): add lazy loading for remirror and dayjs translations

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Editor/RemirrorLocaleProvider.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Editor/RemirrorLocaleProvider.tsx
@@ -1,26 +1,32 @@
 import { i18n as remirrorI18n } from '@remirror/i18n';
 import * as remirrorPlurals from '@remirror/i18n/plurals';
 import { I18nProvider } from '@remirror/react';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { REMIRROR_LOCALE_MESSAGES } from '@src/i18n/remirror';
+import { REMIRROR_LOCALE_LOADERS } from '@src/i18n/remirror';
+
+// Languages whose Remirror built-in labels we localize. Any other app language falls back
+// to English (Remirror's built-in) so its labels never render as raw message ids.
+const REMIRROR_SUPPORTED_LOCALES = ['en', ...Object.keys(REMIRROR_LOCALE_LOADERS)];
 
 // Remirror's built-in labels use its own Lingui i18n, which ships English only. Load our
-// supplementary locale bundles (e.g. German) into that shared instance once — values may
-// be plain strings or ICU messages, which Lingui compiles at render time. Plural messages
-// also need the locale's plural rules.
-Object.entries(REMIRROR_LOCALE_MESSAGES).forEach(([locale, messages]) => {
+// supplementary locale bundle (e.g. German) into that shared instance the first time its
+// language is activated — values may be plain strings or ICU messages, which Lingui compiles
+// at render time. Plural messages also need the locale's plural rules.
+async function loadRemirrorLocale(locale: string): Promise<void> {
+    const loader = REMIRROR_LOCALE_LOADERS[locale];
+    // `en` has no loader (built in); a bundle is loaded at most once.
+    if (!loader || remirrorI18n.messages[locale]) {
+        return;
+    }
+    const { default: messages } = await loader();
     const plurals = (remirrorPlurals as Record<string, ((n: number, ord?: boolean) => string) | undefined>)[locale];
     if (plurals) {
         remirrorI18n.loadLocaleData(locale, { plurals });
     }
     remirrorI18n.load(locale, messages);
-});
-
-// Languages whose Remirror built-in labels we localize. Any other app language falls back
-// to English (Remirror's built-in) so its labels never render as raw message ids.
-const REMIRROR_SUPPORTED_LOCALES = ['en', ...Object.keys(REMIRROR_LOCALE_MESSAGES)];
+}
 
 type Props = {
     children: React.ReactNode;
@@ -35,12 +41,26 @@ export default function RemirrorLocaleProvider({ children }: Props) {
     const { i18n: appI18n } = useTranslation();
     const appLanguage = (appI18n.resolvedLanguage || appI18n.language || 'en').split('-')[0];
     const locale = REMIRROR_SUPPORTED_LOCALES.includes(appLanguage) ? appLanguage : 'en';
+    // Only activate once the bundle is loaded, so labels never flash raw message ids. Until then
+    // the provider stays on English (Remirror's built-in).
+    const [activeLocale, setActiveLocale] = useState('en');
+
     useEffect(() => {
-        remirrorI18n.activate(locale);
+        let cancelled = false;
+        loadRemirrorLocale(locale).then(() => {
+            if (cancelled) {
+                return;
+            }
+            remirrorI18n.activate(locale);
+            setActiveLocale(locale);
+        });
+        return () => {
+            cancelled = true;
+        };
     }, [locale]);
 
     return (
-        <I18nProvider i18n={remirrorI18n} locale={locale}>
+        <I18nProvider i18n={remirrorI18n} locale={activeLocale}>
             {children}
         </I18nProvider>
     );

--- a/datahub-web-react/src/app/i18n/hooks/__tests__/useChangeLocale.test.ts
+++ b/datahub-web-react/src/app/i18n/hooks/__tests__/useChangeLocale.test.ts
@@ -5,10 +5,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_LANGUAGE } from '@app/i18n/constants';
 import { useChangeLocale } from '@app/i18n/hooks/useChangeLocale';
 import { useUpdateUserLocaleSettings } from '@app/i18n/hooks/useUpdateUserLocaleSettings';
-import dayjs from '@utils/dayjs';
+import { setDayjsLocale } from '@utils/dayjs';
 
 vi.mock('@app/i18n/hooks/useUpdateUserLocaleSettings');
-vi.mock('@utils/dayjs', () => ({ default: { locale: vi.fn() } }));
+vi.mock('@utils/dayjs', () => ({ setDayjsLocale: vi.fn().mockResolvedValue(undefined) }));
 
 const mockUpdateUserLocaleSettings = vi.fn().mockResolvedValue({});
 vi.mocked(useUpdateUserLocaleSettings).mockReturnValue(mockUpdateUserLocaleSettings);
@@ -29,7 +29,7 @@ describe('useChangeLocale', () => {
 
         expect(mockUpdateUserLocaleSettings).toHaveBeenCalledWith('en');
         expect(i18next.changeLanguage).toHaveBeenCalledWith('en');
-        expect(dayjs.locale).toHaveBeenCalledWith('en');
+        expect(setDayjsLocale).toHaveBeenCalledWith('en');
     });
 
     it('falls back to DEFAULT_LANGUAGE for unsupported language', async () => {
@@ -41,7 +41,7 @@ describe('useChangeLocale', () => {
 
         expect(mockUpdateUserLocaleSettings).toHaveBeenCalledWith('unsupported');
         expect(i18next.changeLanguage).toHaveBeenCalledWith(DEFAULT_LANGUAGE);
-        expect(dayjs.locale).toHaveBeenCalledWith(DEFAULT_LANGUAGE);
+        expect(setDayjsLocale).toHaveBeenCalledWith(DEFAULT_LANGUAGE);
     });
 
     it('falls back to DEFAULT_LANGUAGE for null', async () => {

--- a/datahub-web-react/src/app/i18n/hooks/__tests__/useLanguageSync.test.ts
+++ b/datahub-web-react/src/app/i18n/hooks/__tests__/useLanguageSync.test.ts
@@ -5,11 +5,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { LOCALE_MAP } from '@app/i18n/constants';
 import { useLanguageSync } from '@app/i18n/hooks/useLanguageSync';
 import { useLocaleConfig } from '@app/i18n/hooks/useLocaleConfig';
-import dayjs from '@utils/dayjs';
+import { setDayjsLocale } from '@utils/dayjs';
 
 vi.mock('@app/i18n/hooks/useLocaleConfig');
 vi.mock('i18next', () => ({ default: { changeLanguage: vi.fn() } }));
-vi.mock('@utils/dayjs', () => ({ default: { locale: vi.fn() } }));
+vi.mock('@utils/dayjs', () => ({ setDayjsLocale: vi.fn().mockResolvedValue(undefined) }));
 
 const mockUseLocaleConfig = vi.mocked(useLocaleConfig);
 
@@ -24,7 +24,7 @@ describe('useLanguageSync', () => {
         renderHook(() => useLanguageSync());
 
         expect(i18next.changeLanguage).toHaveBeenCalledWith('en');
-        expect(dayjs.locale).toHaveBeenCalledWith('en');
+        expect(setDayjsLocale).toHaveBeenCalledWith('en');
     });
 
     it('re-syncs when locale config changes', () => {
@@ -37,6 +37,6 @@ describe('useLanguageSync', () => {
         rerender();
 
         expect(i18next.changeLanguage).toHaveBeenCalledWith('de');
-        expect(dayjs.locale).toHaveBeenCalledWith('de');
+        expect(setDayjsLocale).toHaveBeenCalledWith('de');
     });
 });

--- a/datahub-web-react/src/app/i18n/hooks/useChangeLocale.ts
+++ b/datahub-web-react/src/app/i18n/hooks/useChangeLocale.ts
@@ -5,7 +5,7 @@ import { DEFAULT_LANGUAGE, LOCALE_MAP } from '@app/i18n/constants';
 import { useUpdateUserLocaleSettings } from '@app/i18n/hooks/useUpdateUserLocaleSettings';
 import { SupportedLanguage } from '@app/i18n/types';
 import { isSupportedLanguage } from '@app/i18n/utils';
-import dayjs from '@utils/dayjs';
+import { setDayjsLocale } from '@utils/dayjs';
 
 export function useChangeLocale() {
     const updateUserLocaleSettings = useUpdateUserLocaleSettings();
@@ -19,7 +19,7 @@ export function useChangeLocale() {
             await i18next.loadLanguages(localeConfig.lang);
             await updateUserLocaleSettings(language);
             i18next.changeLanguage(localeConfig.lang);
-            dayjs.locale(localeConfig.dayjs);
+            await setDayjsLocale(localeConfig.dayjs);
         },
         [updateUserLocaleSettings],
     );

--- a/datahub-web-react/src/app/i18n/hooks/useLanguageSync.ts
+++ b/datahub-web-react/src/app/i18n/hooks/useLanguageSync.ts
@@ -2,13 +2,15 @@ import i18next from 'i18next';
 import { useEffect } from 'react';
 
 import { useLocaleConfig } from '@app/i18n/hooks/useLocaleConfig';
-import dayjs from '@utils/dayjs';
+import { setDayjsLocale } from '@utils/dayjs';
 
 export function useLanguageSync(): void {
     const localeConfig = useLocaleConfig();
 
     useEffect(() => {
         i18next.changeLanguage(localeConfig.lang);
-        dayjs.locale(localeConfig.dayjs);
+        // setDayjsLocale resolves after the locale chunk loads; ignore the promise — dayjs falls
+        // back to its current locale until then, and a later language change supersedes this one.
+        setDayjsLocale(localeConfig.dayjs);
     }, [localeConfig.lang, localeConfig.dayjs]);
 }

--- a/datahub-web-react/src/app/i18n/hooks/useLanguageSync.ts
+++ b/datahub-web-react/src/app/i18n/hooks/useLanguageSync.ts
@@ -11,6 +11,6 @@ export function useLanguageSync(): void {
         i18next.changeLanguage(localeConfig.lang);
         // setDayjsLocale resolves after the locale chunk loads; ignore the promise — dayjs falls
         // back to its current locale until then, and a later language change supersedes this one.
-        setDayjsLocale(localeConfig.dayjs);
+        void setDayjsLocale(localeConfig.dayjs);
     }, [localeConfig.lang, localeConfig.dayjs]);
 }

--- a/datahub-web-react/src/app/i18n/hooks/useLanguageSync.ts
+++ b/datahub-web-react/src/app/i18n/hooks/useLanguageSync.ts
@@ -11,6 +11,7 @@ export function useLanguageSync(): void {
         i18next.changeLanguage(localeConfig.lang);
         // setDayjsLocale resolves after the locale chunk loads; ignore the promise — dayjs falls
         // back to its current locale until then, and a later language change supersedes this one.
+        // eslint-disable-next-line no-void
         void setDayjsLocale(localeConfig.dayjs);
     }, [localeConfig.lang, localeConfig.dayjs]);
 }

--- a/datahub-web-react/src/i18n/remirror/__tests__/remirror.test.ts
+++ b/datahub-web-react/src/i18n/remirror/__tests__/remirror.test.ts
@@ -1,6 +1,6 @@
 import { messages as remirrorEnMessages } from '@remirror/i18n/en';
 
-import { REMIRROR_LOCALE_MESSAGES } from '@src/i18n/remirror';
+import { REMIRROR_LOCALE_LOADERS } from '@src/i18n/remirror';
 
 // Remirror renders the raw message id for any key missing from the active locale's bundle,
 // so each supplementary locale must cover every message id Remirror ships for English.
@@ -8,8 +8,12 @@ import { REMIRROR_LOCALE_MESSAGES } from '@src/i18n/remirror';
 describe('Remirror locale bundles', () => {
     const enKeys = Object.keys(remirrorEnMessages);
 
-    it.each(Object.entries(REMIRROR_LOCALE_MESSAGES))('"%s" covers every Remirror message id', (_locale, messages) => {
-        const missing = enKeys.filter((key) => !(key in messages));
-        expect(missing).toEqual([]);
-    });
+    it.each(Object.entries(REMIRROR_LOCALE_LOADERS))(
+        '"%s" covers every Remirror message id',
+        async (_locale, loader) => {
+            const { default: messages } = await loader();
+            const missing = enKeys.filter((key) => !(key in messages));
+            expect(missing).toEqual([]);
+        },
+    );
 });

--- a/datahub-web-react/src/i18n/remirror/index.ts
+++ b/datahub-web-react/src/i18n/remirror/index.ts
@@ -1,17 +1,20 @@
 import type { Messages } from '@remirror/i18n';
 
-import de from '@src/i18n/remirror/de.json';
-import es from '@src/i18n/remirror/es.json';
-import ptBR from '@src/i18n/remirror/pt-BR.json';
-
 // Supplementary locale bundles for Remirror's built-in labels (command/table/keyboard),
 // keyed by language code and loaded directly into Remirror's own Lingui i18n (see
 // `RemirrorLocaleProvider`). English ships with `@remirror/i18n`, so it is intentionally
 // not duplicated here. Values may be plain strings or ICU strings (plural/select, e.g.
 // `{count, plural, one {# Zeile} other {# Zeilen}}`) that Lingui compiles at render time.
 //
+// These are dynamic imports so a bundle's JSON is fetched only when its language is activated,
+// keeping non-English locale data out of the main chunk.
+//
 // NOTE: This is a Lingui catalog for Remirror, NOT an i18next namespace — keep it out of
 // `src/i18n/locales/`, which is reserved for i18next resources. Each bundle MUST cover
 // every key Remirror defines for `en` (Lingui renders the raw message id for a missing
 // key); this is enforced by `__tests__/remirror.test.ts`.
-export const REMIRROR_LOCALE_MESSAGES: Record<string, Messages> = { de, es, 'pt-BR': ptBR };
+export const REMIRROR_LOCALE_LOADERS: Record<string, () => Promise<{ default: Messages }>> = {
+    de: () => import('@src/i18n/remirror/de.json'),
+    es: () => import('@src/i18n/remirror/es.json'),
+    'pt-BR': () => import('@src/i18n/remirror/pt-BR.json'),
+};

--- a/datahub-web-react/src/utils/dayjs.ts
+++ b/datahub-web-react/src/utils/dayjs.ts
@@ -1,7 +1,4 @@
 import dayjs from 'dayjs';
-import 'dayjs/locale/de';
-import 'dayjs/locale/es';
-import 'dayjs/locale/pt-br';
 import advancedFormat from 'dayjs/plugin/advancedFormat';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import duration from 'dayjs/plugin/duration';
@@ -27,6 +24,24 @@ dayjs.extend(utc);
 dayjs.extend(weekOfYear);
 dayjs.extend(weekYear);
 dayjs.extend(weekday);
+
+// dayjs ships English built in; other locales are registered by a side-effecting import. Splitting
+// them into dynamic imports keeps non-English locale data out of the main chunk — each is fetched
+// only when that language is selected. Keep keys in sync with `LOCALE_MAP` in `app/i18n/constants`.
+const DAYJS_LOCALE_LOADERS: Record<string, () => Promise<unknown>> = {
+    de: () => import('dayjs/locale/de'),
+    es: () => import('dayjs/locale/es'),
+    'pt-br': () => import('dayjs/locale/pt-br'),
+};
+
+/**
+ * Loads the locale's data chunk (if any) and then activates it. `en` is built in, so it has no
+ * loader and resolves immediately. Always `await` before relying on locale-dependent formatting.
+ */
+export async function setDayjsLocale(code: string): Promise<void> {
+    await DAYJS_LOCALE_LOADERS[code]?.();
+    dayjs.locale(code);
+}
 
 export default dayjs;
 export type { Dayjs, ManipulateType } from 'dayjs';


### PR DESCRIPTION
This PR adds lazy loading for remirror and dayjs translations 

Depends on https://github.com/datahub-project/datahub/pull/17874


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
