### PR TITLE
test(playwright/mfe-framework): migrate mfe-framework tests to playwright

### DIFF
--- a/e2e-test/ui/playwright/pages/mfe-framework.page.ts
+++ b/e2e-test/ui/playwright/pages/mfe-framework.page.ts
@@ -1,0 +1,131 @@
+import { Page } from '@playwright/test';
+import { TIMEOUTS, LOAD_STATES } from '../utils/constants';
+
+/**
+ * MFE Framework page object — encapsulates all MFE-related selectors and interactions
+ *
+ * Handles:
+ * - Navigation to MFE sidebar items
+ * - MFE configuration mocking
+ * - Remote entry response mocking
+ * - MFE content verification
+ */
+export class MFEFrameworkPage {
+  readonly page: Page;
+
+  // Selectors
+  readonly navBarItemHome = () => this.page.getByTestId('nav-bar-item-home');
+  readonly mfeContainer = () => this.page.getByTestId('mfe-configurable-container');
+  readonly mfeItemByName = (name: string) => this.page.getByText(name);
+  readonly errorMessage = (mfeName: string) => this.page.getByText(`${mfeName} is not available`);
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  /**
+   * Mock fetch requests at browser level to intercept /mfe/config
+   * Must be called BEFORE navigation
+   */
+  async mockFetchForMFEConfig(yamlConfig: string): Promise<void> {
+    await this.page.addInitScript((configYaml: string) => {
+      const originalFetch = window.fetch;
+      window.fetch = ((resource: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        let url = '';
+        if (typeof resource === 'string') {
+          url = resource;
+        } else if (resource instanceof URL) {
+          url = resource.toString();
+        } else {
+          url = resource.url;
+        }
+        if (url.includes('/mfe/config')) {
+          return Promise.resolve(
+            new Response(configYaml, {
+              status: 200,
+              headers: { 'Content-Type': 'text/plain' },
+            }),
+          );
+        }
+        return originalFetch(resource, init);
+      }) as typeof window.fetch;
+    }, yamlConfig);
+  }
+
+  /**
+   * Setup mock response for remote entry (success or failure)
+   */
+  async mockRemoteEntry(status: number, body: string): Promise<void> {
+    await this.page.route('**/remoteEntry.js', async (route) => {
+      await route.fulfill({
+        status,
+        contentType: status === 200 ? 'application/javascript' : 'text/plain',
+        body,
+      });
+    });
+  }
+
+  /**
+   * Navigate to home page and setup initial state
+   */
+  async navigateToHome(): Promise<void> {
+    await this.page.goto('/');
+  }
+
+  /**
+   * Skip intro page by setting localStorage
+   */
+  async skipIntroPage(): Promise<void> {
+    await this.page.evaluate(() => {
+      localStorage.setItem('skipAcrylIntroducePage', 'true');
+    });
+  }
+
+  /**
+   * Wait for initial page load and MFE config to be fetched
+   */
+  async waitForPageLoad(): Promise<void> {
+    await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
+  }
+
+  /**
+   * Wait for sidebar navigation to be visible
+   */
+  async waitForSidebar(): Promise<void> {
+    await this.navBarItemHome().waitFor({ state: 'visible', timeout: TIMEOUTS.LONG });
+  }
+
+  /**
+   * Wait for MFE item to appear in sidebar
+   */
+  async waitForMFEItem(mfeName: string): Promise<void> {
+    await this.mfeItemByName(mfeName).waitFor({
+      state: 'visible',
+      timeout: TIMEOUTS.LONG,
+    });
+  }
+
+  /**
+   * Click on MFE item in sidebar to navigate
+   */
+  async clickMFEItem(mfeName: string): Promise<void> {
+    await this.mfeItemByName(mfeName).click();
+  }
+
+  /**
+   * Wait for navigation to MFE route
+   */
+  async waitForMFENavigation(mfePath: string): Promise<void> {
+    await this.page.waitForURL(`**${mfePath}`);
+  }
+
+  /**
+   * Complete setup flow: mock config, navigate, wait for load
+   */
+  async setupMFEFramework(yamlConfig: string): Promise<void> {
+    await this.mockFetchForMFEConfig(yamlConfig);
+    await this.navigateToHome();
+    await this.skipIntroPage();
+    await this.waitForPageLoad();
+  }
+}

--- a/e2e-test/ui/playwright/tests/mfeframework/valid-config-mfe.spec.ts
+++ b/e2e-test/ui/playwright/tests/mfeframework/valid-config-mfe.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '../../fixtures/base-test';
+import { MFEFrameworkPage } from '../../pages/mfe-framework.page';
+import { TIMEOUTS } from '../../utils/constants';
+
+const MFE_CONFIG_YAML = `subNavigationMode: false
+microFrontends:
+  - id: HelloWorld
+    label: HelloWorld Cypress
+    path: /helloworld-mfe
+    remoteEntry: http://localhost:3002/remoteEntry.js
+    module: helloWorldMFE/mount
+    flags:
+      enabled: true
+      showInNav: true
+    navIcon: HandWaving`;
+
+const REMOTE_ENTRY_SUCCESS = `
+window.helloWorldMFE = {
+  init: function(shared) {
+    console.log('helloWorldMFE.init() called');
+  },
+  get: function(module) {
+    console.log('helloWorldMFE.get() called for:', module);
+    return Promise.resolve(() => {
+      return function mount(containerElement, props) {
+        if (containerElement) {
+          containerElement.innerHTML = '<h1>HelloWorld Cypress MFE Mounted</h1>';
+        }
+        return () => console.log('cleanup called');
+      };
+    });
+  }
+};`;
+
+const MFE_NAME = 'HelloWorld Cypress';
+const MFE_PATH = '/helloworld-mfe';
+const MFE_CONTENT = 'HelloWorld Cypress MFE Mounted';
+
+test.describe('MFE Framework Configuration', () => {
+  test.beforeEach(async ({ page }) => {
+    const mfePage = new MFEFrameworkPage(page);
+    await mfePage.setupMFEFramework(MFE_CONFIG_YAML);
+  });
+
+  test('shows all MFE items from YAML in the sidebar', async ({ page }) => {
+    const mfePage = new MFEFrameworkPage(page);
+
+    await mfePage.waitForSidebar();
+    await mfePage.waitForPageLoad();
+    await expect(mfePage.mfeItemByName(MFE_NAME)).toBeVisible({ timeout: TIMEOUTS.LONG });
+  });
+
+  test('navigates to MFE route when sidebar item is clicked and shows error if mounting fails', async ({ page }) => {
+    const mfePage = new MFEFrameworkPage(page);
+
+    await mfePage.mockRemoteEntry(503, 'Service Unavailable');
+    await mfePage.waitForSidebar();
+    await mfePage.clickMFEItem(MFE_NAME);
+    await mfePage.waitForMFENavigation(MFE_PATH);
+    await expect(mfePage.errorMessage(MFE_NAME)).toBeVisible({ timeout: TIMEOUTS.LONG });
+  });
+
+  test('navigates to MFE route when sidebar item is clicked and shows MFE container on success', async ({ page }) => {
+    const mfePage = new MFEFrameworkPage(page);
+
+    await mfePage.mockRemoteEntry(200, REMOTE_ENTRY_SUCCESS);
+    await mfePage.waitForSidebar();
+    await mfePage.clickMFEItem(MFE_NAME);
+    await mfePage.waitForMFENavigation(MFE_PATH);
+    await expect(mfePage.mfeContainer()).toBeVisible({ timeout: TIMEOUTS.LONG });
+    await expect(mfePage.mfeContainer().getByText(MFE_CONTENT)).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
+  });
+});


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/PFP-4096/migrate-tests-in-mfeframework-folder

**Description:**

This PR migrates MFE Framework tests from cypress to playwright.

**New Page Object Model**

- mfe-framework.page.ts

**New Test Files**

Tests in tests/mfeframework/:
- valid-config-mfe.spec.ts (3 tests covering config loading, error handling, and content rendering)

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
