### PR TITLE
feat(ingest/tableau): log Initial SQL + lineage and warn when none parses

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
@@ -943,6 +943,14 @@ class TableauSourceReport(
     # Download succeeded but the archive carried no .tds/.twb definition to parse.
     num_initial_sql_definitions_missing: int = 0
     num_initial_sql_embedded_datasources_unmatched: int = 0
+    # Diagnostics: total statements split out across all Initial SQL connections, and
+    # the count of non-empty Initial SQL values that split into ZERO statements. The
+    # latter is the signal that the SQL lost its line breaks (e.g. `--` line comments
+    # with no terminating newline collapse the whole script into one comment), so
+    # split_statements produced nothing to parse -- an otherwise-silent zero-lineage
+    # outcome. See _initial_sql_result_from_connections for the per-datasource warning.
+    num_initial_sql_statements_parsed: int = 0
+    num_initial_sql_connections_without_statements: int = 0
     num_hidden_assets_skipped: int = 0
     logged_in_user: LossyList[UserInfo] = dataclass_field(default_factory=LossyList)
 
@@ -3018,11 +3026,17 @@ class TableauSiteSource:
             # semicolons (idiomatic T-SQL). split_statements handles both. The parser
             # handles one statement at a time; statements that reference no tables
             # (e.g. SET) contribute no lineage.
-            for statement in split_statements(
-                conn.initial_sql, dialect=get_dialect_str(platform)
-            ):
-                if not statement.strip():
-                    continue
+            statements = [
+                statement
+                for statement in split_statements(
+                    conn.initial_sql, dialect=get_dialect_str(platform)
+                )
+                if statement.strip()
+            ]
+            self.report.num_initial_sql_statements_parsed += len(statements)
+
+            conn_upstreams: List[Upstream] = []
+            for statement in statements:
                 # Resolve Tableau parameter templating + neutralize T-SQL @variables
                 # before parsing (the raw SQL is preserved for the custom property).
                 # Temp-table (#/##) upstreams are dropped in make_upstream_class.
@@ -3059,10 +3073,42 @@ class TableauSiteSource:
                     continue
                 # platform_instance is the overridden upstream instance so over-qualified
                 # names (e.g. a SQL Server linked-server prefix) are trimmed correctly.
-                upstreams.extend(
+                conn_upstreams.extend(
                     make_upstream_class(
                         parsed_result, platform_instance=platform_instance
                     )
+                )
+
+            upstreams.extend(conn_upstreams)
+
+            # Log the datasource, its raw Initial SQL, and the lineage produced so a
+            # missing-lineage run can be debugged directly. repr() keeps newline
+            # boundaries visible. At DEBUG so SQL stays out of normal logs -- run
+            # ingestion with --debug to see it.
+            logger.debug(
+                "Initial SQL for %s:\n  sql=%r\n  lineage upstreams (%d): %s",
+                datasource_urn,
+                conn.initial_sql,
+                len(conn_upstreams),
+                [u.dataset for u in conn_upstreams],
+            )
+
+            # A non-empty Initial SQL that split into zero statements yields no lineage
+            # (e.g. `--` line comments with no terminating newline collapse the whole
+            # script into a single comment). Surface it instead of failing silently.
+            if not statements:
+                has_newline = "\n" in conn.initial_sql or "\r" in conn.initial_sql
+                has_line_comment = "--" in conn.initial_sql
+                self.report.num_initial_sql_connections_without_statements += 1
+                self.report.warning(
+                    title="Initial SQL produced no parseable statements",
+                    message="Initial SQL was present but split into zero statements, so "
+                    "no lineage was extracted from it. This commonly happens when the "
+                    "stored SQL has lost its line breaks and contains `--` line comments: "
+                    "the script collapses into a single comment. Run with --debug to see "
+                    "the raw Initial SQL.",
+                    context=f"{datasource_urn} (chars={len(conn.initial_sql)}, "
+                    f"has_newline={has_newline}, has_line_comment={has_line_comment})",
                 )
 
         self.report.num_initial_sql_lineage_upstreams += len(upstreams)

--- a/metadata-ingestion/tests/unit/tableau/test_tableau_initial_sql.py
+++ b/metadata-ingestion/tests/unit/tableau/test_tableau_initial_sql.py
@@ -67,6 +67,16 @@ TDS_PARAM_INITIAL_SQL = TDS_WITH_INITIAL_SQL.replace(
     b" WHERE REGION = &lt;[Parameters].[Region]&gt;'",
 )
 
+# Initial SQL whose line breaks were lost: a leading `--` line comment with no
+# terminating newline swallows the whole script, so split_statements yields zero
+# statements and no lineage. The connector must surface this (warning + counter)
+# rather than fail silently.
+TDS_FLATTENED_COMMENT_INITIAL_SQL = TDS_WITH_INITIAL_SQL.replace(
+    b"one-time-sql='CREATE TEMPORARY TABLE TMP AS SELECT * FROM ANALYTICS_DB.PUBLIC.SOURCE_TABLE'",
+    b"one-time-sql='-- build temp stage CREATE TEMPORARY TABLE TMP AS "
+    b"SELECT * FROM ANALYTICS_DB.PUBLIC.SOURCE_TABLE'",
+)
+
 
 def _make_tdsx(tds_bytes: bytes) -> bytes:
     buf = io.BytesIO()
@@ -291,6 +301,38 @@ def test_get_initial_sql_lineage_multi_statement():
         and "SOURCE_TWO" in result.raw_sql
     )
     assert site_source.report.num_initial_sql_parse_failures == 0
+    assert site_source.report.num_initial_sql_statements_parsed == 2
+    assert site_source.report.num_initial_sql_connections_without_statements == 0
+
+
+def test_get_initial_sql_lineage_flattened_comment_warns_and_counts():
+    # Stored Initial SQL that has lost its line breaks: a leading `--` comment with no
+    # newline swallows the whole script, so zero statements split out and no lineage is
+    # produced. This must be surfaced (warning + counter), NOT treated as a parse
+    # failure and NOT left silent.
+    site_source = _make_site_source()
+    tdsx = _make_tdsx(TDS_FLATTENED_COMMENT_INITIAL_SQL)
+
+    def fake_download(luid, filepath=None, include_extract=True):
+        path = Path(filepath) / "ds.tdsx"
+        path.write_bytes(tdsx)
+        return str(path)
+
+    with mock.patch.object(
+        site_source.server.datasources, "download", side_effect=fake_download
+    ):
+        result = site_source.get_initial_sql_lineage(
+            datasource={"luid": "abc-123", "id": "dsid"},
+            datasource_urn="urn:li:dataset:(urn:li:dataPlatform:tableau,dsid,PROD)",
+        )
+
+    # Raw SQL is still captured for the custom property, but yields no lineage.
+    assert result.upstreams == []
+    assert result.raw_sql is not None
+    assert site_source.report.num_initial_sql_connections_found == 1
+    assert site_source.report.num_initial_sql_statements_parsed == 0
+    assert site_source.report.num_initial_sql_parse_failures == 0
+    assert site_source.report.num_initial_sql_connections_without_statements == 1
 
 
 def test_emit_datasource_upstream_lineage_merges_and_dedups_initial_sql():


### PR DESCRIPTION
## Summary

Adds diagnostics to the Tableau **Initial SQL** lineage path so a run that produces no Initial-SQL lineage can be debugged directly from the ingestion output, and so the most common silent-failure mode becomes visible.

Motivation: investigating a case where a data source's Initial SQL was captured as the `initialSql` custom property but produced **no upstream lineage**, with nothing in the report explaining why. The cause turned out to be Initial SQL whose line breaks were lost: a leading `--` line comment with no terminating newline collapses the entire script into a single comment, so `split_statements` yields zero statements. This is not a parse failure, so it incremented no counter and emitted no warning — completely silent.

## Changes

- **Per-data-source DEBUG log** of the dataset URN, the raw Initial SQL (via `repr()`, so newline boundaries are visible), and the upstream URNs it produced. Run ingestion with `--debug` to see exactly what the connector received and what lineage it derived.
- **Structured report warning + counter** (`num_initial_sql_connections_without_statements`) when a non-empty Initial SQL splits into zero statements. The warning context reports `has_newline` / `has_line_comment`, which immediately tells you whether the SQL arrived with its line breaks intact.
- **New counter** `num_initial_sql_statements_parsed` for visibility into how many statements were extracted across all connections.

No change to lineage emission behavior.

## Testing

- New unit test `test_get_initial_sql_lineage_flattened_comment_warns_and_counts` covers the zero-statements case (raw SQL still captured, no upstreams, counter incremented, *not* counted as a parse failure).
- Strengthened the existing multi-statement test to assert `num_initial_sql_statements_parsed` and that the zero-statements counter stays 0.
- `metadata-ingestion:lintFix` and targeted `mypy` pass on the changed files; full `tests/unit/tableau/test_tableau_initial_sql.py` suite passes (47 tests).

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added
- [ ] Docs (none required — observability only)
- [ ] Breaking changes (none)