### PR TITLE
feat(domains): Add attribution to domains; add domains to glossary nodes

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/builder/DomainsPatchBuilder.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/builder/DomainsPatchBuilder.java
@@ -3,44 +3,163 @@ package com.linkedin.metadata.aspect.patch.builder;
 import static com.fasterxml.jackson.databind.node.JsonNodeFactory.instance;
 import static com.linkedin.metadata.Constants.DOMAINS_ASPECT_NAME;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.data.ByteString;
+import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.metadata.aspect.patch.PatchOperationType;
+import com.linkedin.mxe.GenericAspect;
+import com.linkedin.mxe.MetadataChangeProposal;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 
 public class DomainsPatchBuilder extends AbstractMultiFieldPatchBuilder<DomainsPatchBuilder> {
 
-  private static final String BASE_PATH = "/domains";
+  private static final String BASE_PATH = "/domainAssociations/";
+  private static final String DOMAIN_KEY = "domain";
+  private static final String CONTEXT_KEY = "context";
+  private static final String ATTRIBUTION_SOURCE_KEY = "attribution\u241fsource";
 
-  public DomainsPatchBuilder setDomain(@Nonnull Urn urn) {
-    // remove existing list of domains to set the new one
-    this.pathValues.add(ImmutableTriple.of(PatchOperationType.REMOVE.getValue(), BASE_PATH, null));
-    // add empty domains array
+  private final List<ImmutableTriple<String, String, JsonNode>> wildcardRemoveOps =
+      new ArrayList<>();
+
+  private static final Map<String, List<String>> WILDCARD_REMOVE_APK =
+      Collections.singletonMap(
+          "domainAssociations",
+          Collections.unmodifiableList(Arrays.asList(DOMAIN_KEY, ATTRIBUTION_SOURCE_KEY)));
+
+  public DomainsPatchBuilder addDomain(@Nonnull Urn domainUrn, @Nullable String context) {
+    ObjectNode value = instance.objectNode();
+    value.put(DOMAIN_KEY, domainUrn.toString());
+
+    if (context != null) {
+      value.put(CONTEXT_KEY, context);
+    }
+
     pathValues.add(
-        ImmutableTriple.of(PatchOperationType.ADD.getValue(), BASE_PATH, instance.arrayNode()));
-    // set the new domain
+        ImmutableTriple.of(
+            PatchOperationType.ADD.getValue(), BASE_PATH + "/" + encodeValueUrn(domainUrn), value));
+    return this;
+  }
+
+  public DomainsPatchBuilder addDomain(
+      @Nonnull Urn domainUrn, @Nullable String context, @Nonnull Urn attributionSource) {
+    ObjectNode value = instance.objectNode();
+    value.put(DOMAIN_KEY, domainUrn.toString());
+
+    if (context != null) {
+      value.put(CONTEXT_KEY, context);
+    }
+
     pathValues.add(
         ImmutableTriple.of(
             PatchOperationType.ADD.getValue(),
-            BASE_PATH + "/" + urn,
-            instance.textNode(urn.toString())));
+            BASE_PATH + encodeValue(attributionSource.toString()) + "/" + encodeValueUrn(domainUrn),
+            value));
     return this;
   }
 
-  public DomainsPatchBuilder removeDomain(@Nonnull Urn urn) {
+  public DomainsPatchBuilder removeDomain(@Nonnull Urn domainUrn) {
+    wildcardRemoveOps.add(
+        ImmutableTriple.of(
+            PatchOperationType.REMOVE.getValue(), BASE_PATH + encodeValueUrn(domainUrn), null));
+    return this;
+  }
+
+  public DomainsPatchBuilder removeDomain(@Nonnull Urn domainUrn, @Nonnull Urn attributionSource) {
     pathValues.add(
-        ImmutableTriple.of(PatchOperationType.REMOVE.getValue(), BASE_PATH + "/" + urn, null));
+        ImmutableTriple.of(
+            PatchOperationType.REMOVE.getValue(),
+            BASE_PATH + encodeValue(attributionSource.toString()) + "/" + encodeValueUrn(domainUrn),
+            null));
     return this;
   }
 
-  /**
-   * Clears all domains from the entity.
-   *
-   * @return this builder
-   */
-  public DomainsPatchBuilder clearDomains() {
-    pathValues.add(ImmutableTriple.of(PatchOperationType.REMOVE.getValue(), BASE_PATH, null));
-    return this;
+  @Override
+  public MetadataChangeProposal build() {
+    if (!pathValues.isEmpty() && !wildcardRemoveOps.isEmpty()) {
+      throw new IllegalStateException(
+          "Cannot build a single patch for mixed add/attributed-remove and unattributed-remove "
+              + "operations — each requires a different arrayPrimaryKeys ordering. "
+              + "Use buildAll() to emit separate MCPs.");
+    }
+    if (pathValues.isEmpty() && !wildcardRemoveOps.isEmpty()) {
+      return buildMcpForOps(wildcardRemoveOps, WILDCARD_REMOVE_APK);
+    }
+    return super.build();
+  }
+
+  @Override
+  public List<MetadataChangeProposal> buildAll() {
+    if (pathValues.isEmpty() && wildcardRemoveOps.isEmpty()) {
+      throw new IllegalArgumentException("No patches specified.");
+    }
+    List<MetadataChangeProposal> result = new ArrayList<>();
+    if (!pathValues.isEmpty()) {
+      result.add(super.build());
+    }
+    if (!wildcardRemoveOps.isEmpty()) {
+      result.add(buildMcpForOps(wildcardRemoveOps, WILDCARD_REMOVE_APK));
+    }
+    return result;
+  }
+
+  private MetadataChangeProposal buildMcpForOps(
+      List<ImmutableTriple<String, String, JsonNode>> ops,
+      @Nullable Map<String, List<String>> apk) {
+    ArrayNode patches = instance.arrayNode();
+    ops.forEach(
+        triple ->
+            patches.add(
+                instance
+                    .objectNode()
+                    .put(OP_KEY, triple.left)
+                    .put(PATH_KEY, triple.middle)
+                    .set(VALUE_KEY, triple.right)));
+
+    JsonNode payload;
+    if (apk != null) {
+      ObjectNode apkNode = instance.objectNode();
+      for (Map.Entry<String, List<String>> entry : apk.entrySet()) {
+        ArrayNode keys = instance.arrayNode();
+        entry.getValue().forEach(keys::add);
+        apkNode.set(entry.getKey(), keys);
+      }
+      ObjectNode envelope = instance.objectNode();
+      envelope.set("arrayPrimaryKeys", apkNode);
+      envelope.set("patch", patches);
+      payload = envelope;
+    } else {
+      payload = patches;
+    }
+
+    GenericAspect genericAspect = new GenericAspect();
+    genericAspect.setContentType("application/json-patch+json");
+    genericAspect.setValue(ByteString.copyString(payload.toString(), StandardCharsets.UTF_8));
+
+    MetadataChangeProposal proposal = new MetadataChangeProposal();
+    proposal.setChangeType(ChangeType.PATCH);
+    proposal.setEntityType(getEntityType());
+    proposal.setEntityUrn(this.targetEntityUrn);
+    proposal.setAspectName(getAspectName());
+    proposal.setAspect(genericAspect);
+    return proposal;
+  }
+
+  @Override
+  protected Map<String, List<String>> getArrayPrimaryKeys() {
+    return Collections.singletonMap(
+        "domainAssociations",
+        Collections.unmodifiableList(Arrays.asList(ATTRIBUTION_SOURCE_KEY, DOMAIN_KEY)));
   }
 
   @Override

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/builder/PatchBuilderParityTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/builder/PatchBuilderParityTest.java
@@ -396,4 +396,60 @@ public class PatchBuilderParityTest {
             .build();
     assertPayloadMatches("structuredProperties_remove", mcp);
   }
+
+  // ---- Domains ----
+
+  private static final String DOMAIN_URN = "urn:li:domain:testDomain";
+
+  @Test
+  public void testDomainsAdd() throws Exception {
+    MetadataChangeProposal mcp =
+        new DomainsPatchBuilder()
+            .urn(Urn.createFromString(DATASET_URN))
+            .addDomain(Urn.createFromString(DOMAIN_URN), null)
+            .build();
+    assertPayloadMatches("domains_add", mcp);
+  }
+
+  @Test
+  public void testDomainsAddWithContext() throws Exception {
+    MetadataChangeProposal mcp =
+        new DomainsPatchBuilder()
+            .urn(Urn.createFromString(DATASET_URN))
+            .addDomain(Urn.createFromString(DOMAIN_URN), "testContext")
+            .build();
+    assertPayloadMatches("domains_add_with_context", mcp);
+  }
+
+  @Test
+  public void testDomainsAddAttributed() throws Exception {
+    MetadataChangeProposal mcp =
+        new DomainsPatchBuilder()
+            .urn(Urn.createFromString(DATASET_URN))
+            .addDomain(
+                Urn.createFromString(DOMAIN_URN), null, Urn.createFromString(ATTRIBUTION_SOURCE))
+            .build();
+    assertPayloadMatches("domains_add_attributed", mcp);
+  }
+
+  @Test
+  public void testDomainsRemove() throws Exception {
+    MetadataChangeProposal mcp =
+        new DomainsPatchBuilder()
+            .urn(Urn.createFromString(DATASET_URN))
+            .removeDomain(Urn.createFromString(DOMAIN_URN))
+            .build();
+    assertPayloadMatches("domains_remove", mcp);
+  }
+
+  @Test
+  public void testDomainsRemoveAttributed() throws Exception {
+    MetadataChangeProposal mcp =
+        new DomainsPatchBuilder()
+            .urn(Urn.createFromString(DATASET_URN))
+            .removeDomain(
+                Urn.createFromString(DOMAIN_URN), Urn.createFromString(ATTRIBUTION_SOURCE))
+            .build();
+    assertPayloadMatches("domains_remove_attributed", mcp);
+  }
 }

--- a/entity-registry/src/test/resources/patch_builder_parity.json
+++ b/entity-registry/src/test/resources/patch_builder_parity.json
@@ -65,6 +65,94 @@
       }
     ]
   },
+  "domains_add": {
+    "arrayPrimaryKeys": {
+      "domainAssociations": [
+        "attribution\u241fsource",
+        "domain"
+      ]
+    },
+    "patch": [
+      {
+        "op": "add",
+        "path": "/domainAssociations//urn:li:domain:testDomain",
+        "value": {
+          "domain": "urn:li:domain:testDomain"
+        }
+      }
+    ]
+  },
+  "domains_add_attributed": {
+    "arrayPrimaryKeys": {
+      "domainAssociations": [
+        "attribution\u241fsource",
+        "domain"
+      ]
+    },
+    "patch": [
+      {
+        "op": "add",
+        "path": "/domainAssociations/urn:li:dataHubAction:testSource/urn:li:domain:testDomain",
+        "value": {
+          "attribution": {
+            "actor": "urn:li:corpuser:datahub",
+            "source": "urn:li:dataHubAction:testSource",
+            "sourceDetail": {},
+            "time": 0
+          },
+          "domain": "urn:li:domain:testDomain"
+        }
+      }
+    ]
+  },
+  "domains_add_with_context": {
+    "arrayPrimaryKeys": {
+      "domainAssociations": [
+        "attribution\u241fsource",
+        "domain"
+      ]
+    },
+    "patch": [
+      {
+        "op": "add",
+        "path": "/domainAssociations//urn:li:domain:testDomain",
+        "value": {
+          "context": "testContext",
+          "domain": "urn:li:domain:testDomain"
+        }
+      }
+    ]
+  },
+  "domains_remove": {
+    "arrayPrimaryKeys": {
+      "domainAssociations": [
+        "domain",
+        "attribution\u241fsource"
+      ]
+    },
+    "patch": [
+      {
+        "op": "remove",
+        "path": "/domainAssociations/urn:li:domain:testDomain",
+        "value": {}
+      }
+    ]
+  },
+  "domains_remove_attributed": {
+    "arrayPrimaryKeys": {
+      "domainAssociations": [
+        "attribution\u241fsource",
+        "domain"
+      ]
+    },
+    "patch": [
+      {
+        "op": "remove",
+        "path": "/domainAssociations/urn:li:dataHubAction:testSource/urn:li:domain:testDomain",
+        "value": {}
+      }
+    ]
+  },
   "globalTags_add": {
     "arrayPrimaryKeys": {
       "tags": [

--- a/metadata-ingestion/scripts/generate_patch_parity_golden.py
+++ b/metadata-ingestion/scripts/generate_patch_parity_golden.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from datahub.metadata.schema_classes import (
     DocumentationAssociationClass,
+    DomainAssociationClass,
     GlossaryTermAssociationClass,
     MetadataAttributionClass,
     OwnerClass,
@@ -24,16 +25,25 @@ from datahub.specific.dataset import DatasetPatchBuilder
 DATASET_URN = "urn:li:dataset:(urn:li:dataPlatform:hive,SampleTable,PROD)"
 ATTRIBUTION_SOURCE = "urn:li:dataHubAction:testSource"
 TYPE_URN = "urn:li:ownershipType:__system__technical_owner"
+DOMAIN_URN = "urn:li:domain:testDomain"
 
 
-def extract_patch_payload(builder: DatasetPatchBuilder, aspect_name: str) -> dict:
-    """Build MCPs and return the parsed JSON payload for the given aspect."""
+def extract_patch_payload(
+    builder: DatasetPatchBuilder, aspect_name: str, index: int = 0
+) -> dict:
+    """Build MCPs and return the parsed JSON payload for the given aspect.
+
+    When multiple MCPs share the same aspect name (e.g. different APK orderings),
+    use ``index`` to select which one (0-based among matches).
+    """
     mcps = builder.build()
-    for mcp in mcps:
-        if mcp.aspectName == aspect_name:
-            raw = mcp.aspect.value
-            return json.loads(raw)
-    raise ValueError(f"No MCP found for aspect {aspect_name}")
+    matches = [mcp for mcp in mcps if mcp.aspectName == aspect_name]
+    if index >= len(matches):
+        raise ValueError(
+            f"No MCP at index {index} for aspect {aspect_name} "
+            f"(found {len(matches)} match(es))"
+        )
+    return json.loads(matches[index].aspect.value)
 
 
 def main() -> None:
@@ -268,6 +278,37 @@ def main() -> None:
     result["structuredProperties_remove_attributed"] = extract_patch_payload(
         builder, "structuredProperties"
     )
+
+    # =========================================================================
+    # Domains
+    # =========================================================================
+
+    # --- Domains: add (no context, no attribution) ---
+    builder = DatasetPatchBuilder(DATASET_URN)
+    builder.add_domain(DomainAssociationClass(domain=DOMAIN_URN))
+    result["domains_add"] = extract_patch_payload(builder, "domains")
+
+    # --- Domains: add with context ---
+    builder = DatasetPatchBuilder(DATASET_URN)
+    builder.add_domain(DomainAssociationClass(domain=DOMAIN_URN, context="testContext"))
+    result["domains_add_with_context"] = extract_patch_payload(builder, "domains")
+
+    # --- Domains: add with attribution ---
+    builder = DatasetPatchBuilder(DATASET_URN)
+    builder.add_domain(
+        DomainAssociationClass(domain=DOMAIN_URN, attribution=attribution)
+    )
+    result["domains_add_attributed"] = extract_patch_payload(builder, "domains")
+
+    # --- Domains: remove (wildcard — all sources for this domain) ---
+    builder = DatasetPatchBuilder(DATASET_URN)
+    builder.remove_domain(DOMAIN_URN)
+    result["domains_remove"] = extract_patch_payload(builder, "domains")
+
+    # --- Domains: remove with attribution source ---
+    builder = DatasetPatchBuilder(DATASET_URN)
+    builder.remove_domain(DOMAIN_URN, attribution_source=ATTRIBUTION_SOURCE)
+    result["domains_remove_attributed"] = extract_patch_payload(builder, "domains")
 
     out_path = (
         Path(__file__).resolve().parents[2]

--- a/metadata-ingestion/src/datahub/specific/aspect_helpers/domains.py
+++ b/metadata-ingestion/src/datahub/specific/aspect_helpers/domains.py
@@ -57,9 +57,7 @@ class HasDomainsPatch(MetadataPatchProposal):
         Args:
             domain: The domain to remove, specified as a string or Urn object.
             attribution_source: When set, only the entry for that specific source is
-                removed.  When omitted, ``*`` is used as the source component, which
-                the backend expands to every source in the stored map — removing all
-                entries for this domain URN without affecting other domain URNs.
+                removed. When omitted, all entries for the specified domain urn are removed.
 
         Returns:
             The patch builder instance.

--- a/metadata-ingestion/src/datahub/specific/aspect_helpers/domains.py
+++ b/metadata-ingestion/src/datahub/specific/aspect_helpers/domains.py
@@ -1,0 +1,83 @@
+from typing import Optional, Union
+
+from typing_extensions import Self
+
+from datahub.emitter.mcp_patch_builder import (
+    UNIT_SEPARATOR,
+    MetadataPatchProposal,
+    determine_array_primary_keys,
+)
+from datahub.metadata.schema_classes import (
+    DomainAssociationClass as DomainAssociation,
+    DomainsClass as Domains,
+)
+from datahub.metadata.urns import DomainUrn, Urn
+
+DEFAULT_DOMAIN_ASSOCIATIONS_KEY_FIELDS = [
+    f"attribution{UNIT_SEPARATOR}source",
+    "domain",
+]
+_DOMAINS_APK = {"domainAssociations": DEFAULT_DOMAIN_ASSOCIATIONS_KEY_FIELDS}
+
+
+class HasDomainsPatch(MetadataPatchProposal):
+    def add_domain(self, domain: DomainAssociation) -> Self:
+        """Adds a domain association to the entity.
+
+        Uses compound-key semantics keyed by ``(attribution.source, domain)``.
+        Unattributed domains use ``source=""``; attributed domains use the actual source.
+
+        Args:
+            domain: The DomainAssociation object to add.
+
+        Returns:
+            The patch builder instance.
+        """
+        source = (
+            domain.attribution.source
+            if domain.attribution and domain.attribution.source
+            else ""
+        )
+        self._add_patch(
+            Domains.ASPECT_NAME,
+            "add",
+            path=("domainAssociations", source, domain.domain),
+            value=domain,
+            array_primary_keys=_DOMAINS_APK,
+        )
+        return self
+
+    def remove_domain(
+        self,
+        domain: Union[str, Urn],
+        attribution_source: Optional[Union[str, Urn]] = None,
+    ) -> Self:
+        """Removes a domain association from the entity.
+
+        Args:
+            domain: The domain to remove, specified as a string or Urn object.
+            attribution_source: When set, only the entry for that specific source is
+                removed.  When omitted, ``*`` is used as the source component, which
+                the backend expands to every source in the stored map — removing all
+                entries for this domain URN without affecting other domain URNs.
+
+        Returns:
+            The patch builder instance.
+        """
+        if isinstance(domain, str) and not domain.startswith("urn:li:domain:"):
+            domain = DomainUrn(domain)
+        source = str(attribution_source) if attribution_source is not None else None
+        path, array_primary_keys = determine_array_primary_keys(
+            field_name="domainAssociations",
+            default_key_fields=DEFAULT_DOMAIN_ASSOCIATIONS_KEY_FIELDS,
+            path=[source, str(domain)],
+        )
+        self._add_patch(
+            Domains.ASPECT_NAME,
+            "remove",
+            path=("domainAssociations", *path),
+            value={},
+            array_primary_keys=array_primary_keys,
+        )
+
+        return self

--- a/metadata-ingestion/src/datahub/specific/chart.py
+++ b/metadata-ingestion/src/datahub/specific/chart.py
@@ -11,6 +11,7 @@ from datahub.metadata.schema_classes import (
     SystemMetadataClass,
 )
 from datahub.specific.aspect_helpers.custom_properties import HasCustomPropertiesPatch
+from datahub.specific.aspect_helpers.domains import HasDomainsPatch
 from datahub.specific.aspect_helpers.ownership import HasOwnershipPatch
 from datahub.specific.aspect_helpers.tags import HasTagsPatch
 from datahub.specific.aspect_helpers.terms import HasTermsPatch
@@ -22,6 +23,7 @@ class ChartPatchBuilder(
     HasCustomPropertiesPatch,
     HasTagsPatch,
     HasTermsPatch,
+    HasDomainsPatch,
     MetadataPatchProposal,
 ):
     def __init__(

--- a/metadata-ingestion/src/datahub/specific/dashboard.py
+++ b/metadata-ingestion/src/datahub/specific/dashboard.py
@@ -10,6 +10,7 @@ from datahub.metadata.schema_classes import (
     SystemMetadataClass,
 )
 from datahub.specific.aspect_helpers.custom_properties import HasCustomPropertiesPatch
+from datahub.specific.aspect_helpers.domains import HasDomainsPatch
 from datahub.specific.aspect_helpers.ownership import HasOwnershipPatch
 from datahub.specific.aspect_helpers.tags import HasTagsPatch
 from datahub.specific.aspect_helpers.terms import HasTermsPatch
@@ -21,6 +22,7 @@ class DashboardPatchBuilder(
     HasCustomPropertiesPatch,
     HasTagsPatch,
     HasTermsPatch,
+    HasDomainsPatch,
     MetadataPatchProposal,
 ):
     def __init__(

--- a/metadata-ingestion/src/datahub/specific/datajob.py
+++ b/metadata-ingestion/src/datahub/specific/datajob.py
@@ -11,6 +11,7 @@ from datahub.metadata.schema_classes import (
 )
 from datahub.metadata.urns import SchemaFieldUrn, Urn
 from datahub.specific.aspect_helpers.custom_properties import HasCustomPropertiesPatch
+from datahub.specific.aspect_helpers.domains import HasDomainsPatch
 from datahub.specific.aspect_helpers.fine_grained_lineage import (
     HasFineGrainedLineagePatch,
 )
@@ -24,6 +25,7 @@ class DataJobPatchBuilder(
     HasCustomPropertiesPatch,
     HasTagsPatch,
     HasTermsPatch,
+    HasDomainsPatch,
     HasFineGrainedLineagePatch,
     MetadataPatchProposal,
 ):

--- a/metadata-ingestion/src/datahub/specific/dataproduct.py
+++ b/metadata-ingestion/src/datahub/specific/dataproduct.py
@@ -8,6 +8,7 @@ from datahub.metadata.schema_classes import (
     SystemMetadataClass,
 )
 from datahub.specific.aspect_helpers.custom_properties import HasCustomPropertiesPatch
+from datahub.specific.aspect_helpers.domains import HasDomainsPatch
 from datahub.specific.aspect_helpers.institutional_memory import (
     HasInstitutionalMemoryPatch,
 )
@@ -25,6 +26,7 @@ class DataProductPatchBuilder(
     HasStructuredPropertiesPatch,
     HasTagsPatch,
     HasTermsPatch,
+    HasDomainsPatch,
     HasInstitutionalMemoryPatch,
     MetadataPatchProposal,
 ):

--- a/metadata-ingestion/src/datahub/specific/dataset.py
+++ b/metadata-ingestion/src/datahub/specific/dataset.py
@@ -22,6 +22,7 @@ from datahub.metadata.schema_classes import (
 from datahub.metadata.urns import DatasetUrn, TagUrn, Urn
 from datahub.specific.aspect_helpers.custom_properties import HasCustomPropertiesPatch
 from datahub.specific.aspect_helpers.documentation import HasDocumentationPatch
+from datahub.specific.aspect_helpers.domains import HasDomainsPatch
 from datahub.specific.aspect_helpers.fine_grained_lineage import (
     HasFineGrainedLineagePatch,
 )
@@ -130,6 +131,7 @@ class DatasetPatchBuilder(
     HasStructuredPropertiesPatch,
     HasTagsPatch,
     HasTermsPatch,
+    HasDomainsPatch,
     HasFineGrainedLineagePatch,
     HasSiblingsPatch,
     HasDocumentationPatch,

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/hooks/DomainsSyncMutationHook.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/hooks/DomainsSyncMutationHook.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -34,10 +33,10 @@ import lombok.extern.slf4j.Slf4j;
  * <p>Write path:
  *
  * <ul>
- *   <li>If both fields are present and inconsistent (non-propagated URNs from associations ≠
- *       domains) AND domains changed from previous → reject with 400.
- *   <li>If {@code domainAssociations} is provided → derive {@code domains} from non-propagated
- *       entries.
+ *   <li>If both fields are present and inconsistent (all URNs from associations ≠ domains) AND
+ *       domains changed from previous → reject with 400.
+ *   <li>If {@code domainAssociations} is provided → derive {@code domains} from all entries;
+ *       reorder so manual associations (and their URNs) precede propagated ones.
  *   <li>If only {@code domains} is provided (legacy path) → diff against previous and update {@code
  *       domainAssociations}.
  * </ul>
@@ -80,11 +79,12 @@ public class DomainsSyncMutationHook extends MutationHook {
 
     if (associationsProvided) {
       // Both fields present — only allowed if they are already in sync.
-      // "In sync" means the non-propagated URNs from associations equal the domains set.
-      Set<Urn> nonPropagatedUrns = getNonPropagatedUrns(proposed.getDomainAssociations());
-      Set<Urn> domainUrns = new LinkedHashSet<>(proposed.getDomains());
+      // "In sync" means the full set of URNs from associations equals the domains set.
+      Set<Urn> allAssociationUrns = getAllUrns(proposed.getDomainAssociations());
+      Set<Urn> domainUrns = toSet(proposed.getDomains());
 
-      if (!nonPropagatedUrns.equals(domainUrns)) {
+      // When domains is empty, the caller relies on domainAssociations alone — no conflict.
+      if (!domainUrns.isEmpty() && !allAssociationUrns.equals(domainUrns)) {
         boolean domainsChanged = didDomainsChange(proposed, previous);
         if (domainsChanged) {
           throw new ValidationException(
@@ -97,30 +97,39 @@ public class DomainsSyncMutationHook extends MutationHook {
 
       // domainAssociations is the source of truth; derive domains from non-propagated entries
       deriveDomainsFromAssociations(proposed);
+      sortAssociations(proposed);
       return true;
     }
 
     // Legacy path: caller only set domains. Sync domainAssociations.
     deriveAssociationsFromDomains(proposed, previous);
+    sortAssociations(proposed);
     return true;
   }
 
   /**
-   * Derives the {@code domains} array from {@code domainAssociations}, excluding propagated
-   * entries. An association is considered propagated if {@code
-   * attribution.sourceDetail["propagated"]} is {@code "true"} (case-insensitive).
+   * Derives the {@code domains} array from all entries in {@code domainAssociations}. Manual
+   * (non-propagated) URNs are listed first, followed by propagated URNs, mirroring the association
+   * order.
    */
   private void deriveDomainsFromAssociations(Domains proposed) {
     DomainAssociationArray associations = proposed.getDomainAssociations();
-    Set<Urn> domainUrns = new LinkedHashSet<>();
+    Set<Urn> manualUrns = new LinkedHashSet<>();
+    Set<Urn> propagatedUrns = new LinkedHashSet<>();
     if (associations != null) {
       for (DomainAssociation assoc : associations) {
-        if (!isPropagated(assoc)) {
-          domainUrns.add(assoc.getDomain());
+        if (isPropagated(assoc)) {
+          propagatedUrns.add(assoc.getDomain());
+        } else {
+          manualUrns.add(assoc.getDomain());
         }
       }
     }
-    proposed.setDomains(new UrnArray(new ArrayList<>(domainUrns)));
+    // Remove any propagated URN that also has a manual association
+    propagatedUrns.removeAll(manualUrns);
+    List<Urn> ordered = new ArrayList<>(manualUrns);
+    ordered.addAll(propagatedUrns);
+    proposed.setDomains(new UrnArray(ordered));
   }
 
   /**
@@ -160,6 +169,43 @@ public class DomainsSyncMutationHook extends MutationHook {
     proposed.setDomainAssociations(newAssociations);
   }
 
+  /** Reorders associations so that manual (non-propagated) entries come before propagated ones. */
+  private static void sortAssociations(Domains domains) {
+    if (!domains.hasDomainAssociations()) {
+      return;
+    }
+    DomainAssociationArray associations = domains.getDomainAssociations();
+    if (associations == null || associations.size() <= 1) {
+      return;
+    }
+    List<DomainAssociation> manual = new ArrayList<>();
+    List<DomainAssociation> propagated = new ArrayList<>();
+    for (DomainAssociation assoc : associations) {
+      if (isPropagated(assoc)) {
+        propagated.add(assoc);
+      } else {
+        manual.add(assoc);
+      }
+    }
+    if (propagated.isEmpty()) {
+      return;
+    }
+    DomainAssociationArray sorted = new DomainAssociationArray();
+    sorted.addAll(manual);
+    sorted.addAll(propagated);
+    domains.setDomainAssociations(sorted);
+  }
+
+  private static Set<Urn> getAllUrns(DomainAssociationArray associations) {
+    Set<Urn> urns = new LinkedHashSet<>();
+    if (associations != null) {
+      for (DomainAssociation assoc : associations) {
+        urns.add(assoc.getDomain());
+      }
+    }
+    return urns;
+  }
+
   private static Set<Urn> getNonPropagatedUrns(DomainAssociationArray associations) {
     Set<Urn> urns = new LinkedHashSet<>();
     if (associations != null) {
@@ -172,7 +218,7 @@ public class DomainsSyncMutationHook extends MutationHook {
     return urns;
   }
 
-  private static boolean isPropagated(DomainAssociation assoc) {
+  static boolean isPropagated(DomainAssociation assoc) {
     if (!assoc.hasAttribution()) {
       return false;
     }
@@ -184,9 +230,17 @@ public class DomainsSyncMutationHook extends MutationHook {
     return propagated != null && propagated.equalsIgnoreCase("true");
   }
 
+  private static Set<Urn> toSet(@Nullable UrnArray array) {
+    if (array == null || array.isEmpty()) {
+      return new LinkedHashSet<>();
+    }
+    return new LinkedHashSet<>(array);
+  }
+
   private static boolean didDomainsChange(Domains proposed, @Nullable Domains previous) {
-    UrnArray proposedDomains = proposed.getDomains();
-    UrnArray previousDomains = previous != null ? previous.getDomains() : null;
-    return !Objects.equals(proposedDomains, previousDomains);
+    Set<Urn> proposedDomains = toSet(proposed.getDomains());
+    Set<Urn> previousDomains =
+        previous != null ? toSet(previous.getDomains()) : new LinkedHashSet<>();
+    return !proposedDomains.equals(previousDomains);
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/hooks/DomainsSyncMutationHook.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/hooks/DomainsSyncMutationHook.java
@@ -16,6 +16,7 @@ import com.linkedin.metadata.entity.validation.ValidationException;
 import com.linkedin.util.Pair;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -163,31 +164,15 @@ public class DomainsSyncMutationHook extends MutationHook {
     proposed.setDomainAssociations(newAssociations);
   }
 
-  /** Reorders associations so that manual (non-propagated) entries come before propagated ones. */
+  /** Sorts associations so that manual (non-propagated) entries come before propagated ones. */
   private static void sortAssociations(Domains domains) {
-    if (!domains.hasDomainAssociations()) {
-      return;
-    }
     DomainAssociationArray associations = domains.getDomainAssociations();
     if (associations == null || associations.size() <= 1) {
       return;
     }
-    List<DomainAssociation> manual = new ArrayList<>();
-    List<DomainAssociation> propagated = new ArrayList<>();
-    for (DomainAssociation assoc : associations) {
-      if (isPropagated(assoc)) {
-        propagated.add(assoc);
-      } else {
-        manual.add(assoc);
-      }
-    }
-    if (propagated.isEmpty()) {
-      return;
-    }
-    DomainAssociationArray sorted = new DomainAssociationArray();
-    sorted.addAll(manual);
-    sorted.addAll(propagated);
-    domains.setDomainAssociations(sorted);
+    List<DomainAssociation> sorted = new ArrayList<>(associations);
+    sorted.sort(Comparator.comparing(DomainsSyncMutationHook::isPropagated));
+    domains.setDomainAssociations(new DomainAssociationArray(sorted));
   }
 
   static boolean isPropagated(DomainAssociation assoc) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/hooks/DomainsSyncMutationHook.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/hooks/DomainsSyncMutationHook.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -30,15 +31,13 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Keeps the {@code domains} and {@code domainAssociations} fields of the Domains aspect in sync.
  *
- * <p>Write path:
+ * <p>Write path — based on which field(s) actually <em>changed</em> relative to the previous value:
  *
  * <ul>
- *   <li>If both fields are present and inconsistent (all URNs from associations ≠ domains) AND
- *       domains changed from previous → reject with 400.
- *   <li>If {@code domainAssociations} is provided → derive {@code domains} from all entries;
- *       reorder so manual associations (and their URNs) precede propagated ones.
- *   <li>If only {@code domains} is provided (legacy path) → diff against previous and update {@code
- *       domainAssociations}.
+ *   <li>If both fields changed and the URN sets are inconsistent → reject with 400.
+ *   <li>If only {@code domainAssociations} changed → derive {@code domains} from associations.
+ *   <li>If only {@code domains} changed → derive {@code domainAssociations} from domains.
+ *   <li>If {@code domainAssociations} is not present → derive associations from {@code domains}.
  * </ul>
  */
 @Slf4j
@@ -75,61 +74,56 @@ public class DomainsSyncMutationHook extends MutationHook {
 
     Domains previous = item.getPreviousAspect(Domains.class);
 
-    boolean associationsProvided = proposed.hasDomainAssociations();
+    @Nullable DomainAssociationArray associations = proposed.getDomainAssociations();
 
-    if (associationsProvided) {
-      // Both fields present — only allowed if they are already in sync.
-      // "In sync" means the full set of URNs from associations equals the domains set.
-      Set<Urn> allAssociationUrns = getAllUrns(proposed.getDomainAssociations());
-      Set<Urn> domainUrns = toSet(proposed.getDomains());
+    if (associations == null) {
+      // Caller only set domains. Sync domainAssociations.
+      deriveAssociationsFromDomains(proposed, previous);
+    } else {
+      // Both fields present — determine which actually changed to decide source of truth.
+      boolean domainsChanged = didDomainsChange(proposed, previous);
+      boolean associationsChanged = didAssociationsChange(proposed, previous);
 
-      // When domains is empty, the caller relies on domainAssociations alone — no conflict.
-      if (!domainUrns.isEmpty() && !allAssociationUrns.equals(domainUrns)) {
-        boolean domainsChanged = didDomainsChange(proposed, previous);
-        if (domainsChanged) {
+      if (domainsChanged && associationsChanged) {
+        // Both changed — only allowed if they are consistent.
+        Set<Urn> allAssociationUrns =
+            associations.stream()
+                .map(DomainAssociation::getDomain)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        Set<Urn> domainUrns = new LinkedHashSet<>(proposed.getDomains());
+        if (!domainUrns.isEmpty() && !allAssociationUrns.equals(domainUrns)) {
           throw new ValidationException(
               "Cannot update both 'domains' and 'domainAssociations' in the same write. "
                   + "Use 'domainAssociations' for rich metadata or 'domains' for legacy "
                   + "compatibility, but not both. Entity: "
                   + item.getUrn());
         }
+      } else if (domainsChanged) {
+        // Only domains changed (e.g. read-modify-write that updated only domains).
+        deriveAssociationsFromDomains(proposed, previous);
       }
-
-      // domainAssociations is the source of truth; derive domains from non-propagated entries
-      deriveDomainsFromAssociations(proposed);
-      sortAssociations(proposed);
-      return true;
+      // else: only associations changed or neither — associations are already correct.
     }
 
-    // Legacy path: caller only set domains. Sync domainAssociations.
-    deriveAssociationsFromDomains(proposed, previous);
+    // Sort associations (manual before propagated), then derive domains to match.
     sortAssociations(proposed);
+    deriveDomainsFromAssociations(proposed);
     return true;
   }
 
   /**
-   * Derives the {@code domains} array from all entries in {@code domainAssociations}. Manual
-   * (non-propagated) URNs are listed first, followed by propagated URNs, mirroring the association
-   * order.
+   * Derives the {@code domains} array from {@code domainAssociations}, preserving the association
+   * order and deduplicating. Call after {@link #sortAssociations} so manual URNs come first.
    */
-  private void deriveDomainsFromAssociations(Domains proposed) {
+  private static void deriveDomainsFromAssociations(Domains proposed) {
     DomainAssociationArray associations = proposed.getDomainAssociations();
-    Set<Urn> manualUrns = new LinkedHashSet<>();
-    Set<Urn> propagatedUrns = new LinkedHashSet<>();
+    Set<Urn> urns = new LinkedHashSet<>();
     if (associations != null) {
       for (DomainAssociation assoc : associations) {
-        if (isPropagated(assoc)) {
-          propagatedUrns.add(assoc.getDomain());
-        } else {
-          manualUrns.add(assoc.getDomain());
-        }
+        urns.add(assoc.getDomain());
       }
     }
-    // Remove any propagated URN that also has a manual association
-    propagatedUrns.removeAll(manualUrns);
-    List<Urn> ordered = new ArrayList<>(manualUrns);
-    ordered.addAll(propagatedUrns);
-    proposed.setDomains(new UrnArray(ordered));
+    proposed.setDomains(new UrnArray(new ArrayList<>(urns)));
   }
 
   /**
@@ -196,28 +190,6 @@ public class DomainsSyncMutationHook extends MutationHook {
     domains.setDomainAssociations(sorted);
   }
 
-  private static Set<Urn> getAllUrns(DomainAssociationArray associations) {
-    Set<Urn> urns = new LinkedHashSet<>();
-    if (associations != null) {
-      for (DomainAssociation assoc : associations) {
-        urns.add(assoc.getDomain());
-      }
-    }
-    return urns;
-  }
-
-  private static Set<Urn> getNonPropagatedUrns(DomainAssociationArray associations) {
-    Set<Urn> urns = new LinkedHashSet<>();
-    if (associations != null) {
-      for (DomainAssociation assoc : associations) {
-        if (!isPropagated(assoc)) {
-          urns.add(assoc.getDomain());
-        }
-      }
-    }
-    return urns;
-  }
-
   static boolean isPropagated(DomainAssociation assoc) {
     if (!assoc.hasAttribution()) {
       return false;
@@ -230,17 +202,27 @@ public class DomainsSyncMutationHook extends MutationHook {
     return propagated != null && propagated.equalsIgnoreCase("true");
   }
 
-  private static Set<Urn> toSet(@Nullable UrnArray array) {
-    if (array == null || array.isEmpty()) {
-      return new LinkedHashSet<>();
-    }
-    return new LinkedHashSet<>(array);
+  private static boolean didDomainsChange(Domains proposed, @Nullable Domains previous) {
+    UrnArray proposedDomains = proposed.getDomains();
+    UrnArray previousDomains = previous != null ? previous.getDomains() : new UrnArray();
+    return !proposedDomains.equals(previousDomains);
   }
 
-  private static boolean didDomainsChange(Domains proposed, @Nullable Domains previous) {
-    Set<Urn> proposedDomains = toSet(proposed.getDomains());
-    Set<Urn> previousDomains =
-        previous != null ? toSet(previous.getDomains()) : new LinkedHashSet<>();
-    return !proposedDomains.equals(previousDomains);
+  private static boolean didAssociationsChange(Domains proposed, @Nullable Domains previous) {
+    DomainAssociationArray proposedAssociations =
+        proposed.getDomainAssociations() != null
+            ? proposed.getDomainAssociations()
+            : new DomainAssociationArray();
+    DomainAssociationArray previousAssociations =
+        previous != null && previous.getDomainAssociations() != null
+            ? previous.getDomainAssociations()
+            : new DomainAssociationArray();
+    if (proposedAssociations == null && previousAssociations == null) {
+      return false;
+    }
+    if (proposedAssociations == null || previousAssociations == null) {
+      return true;
+    }
+    return !proposedAssociations.equals(previousAssociations);
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/hooks/DomainsSyncMutationHook.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/hooks/DomainsSyncMutationHook.java
@@ -1,0 +1,192 @@
+package com.linkedin.metadata.aspect.hooks;
+
+import com.datahub.context.OperationFingerprint;
+import com.linkedin.common.MetadataAttribution;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.domain.DomainAssociation;
+import com.linkedin.domain.DomainAssociationArray;
+import com.linkedin.domain.Domains;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.aspect.RetrieverContext;
+import com.linkedin.metadata.aspect.batch.ChangeMCP;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.aspect.plugins.hooks.MutationHook;
+import com.linkedin.metadata.entity.validation.ValidationException;
+import com.linkedin.util.Pair;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Keeps the {@code domains} and {@code domainAssociations} fields of the Domains aspect in sync.
+ *
+ * <p>Write path:
+ *
+ * <ul>
+ *   <li>If both fields are present and inconsistent (non-propagated URNs from associations ≠
+ *       domains) AND domains changed from previous → reject with 400.
+ *   <li>If {@code domainAssociations} is provided → derive {@code domains} from non-propagated
+ *       entries.
+ *   <li>If only {@code domains} is provided (legacy path) → diff against previous and update {@code
+ *       domainAssociations}.
+ * </ul>
+ */
+@Slf4j
+@Getter
+@Setter
+@Accessors(chain = true)
+public class DomainsSyncMutationHook extends MutationHook {
+
+  private static final String PROPAGATED_KEY = "propagated";
+
+  @Nonnull private AspectPluginConfig config;
+
+  @Override
+  protected Stream<Pair<ChangeMCP, Boolean>> writeMutation(
+      @Nonnull OperationFingerprint operationContext,
+      @Nonnull Collection<ChangeMCP> changeMCPS,
+      @Nonnull RetrieverContext retrieverContext) {
+    List<Pair<ChangeMCP, Boolean>> results = new ArrayList<>();
+    for (ChangeMCP item : changeMCPS) {
+      if (!Constants.DOMAINS_ASPECT_NAME.equals(item.getAspectName())) {
+        results.add(Pair.of(item, false));
+        continue;
+      }
+      results.add(Pair.of(item, syncDomains(item)));
+    }
+    return results.stream();
+  }
+
+  private boolean syncDomains(ChangeMCP item) {
+    Domains proposed = item.getAspect(Domains.class);
+    if (proposed == null) {
+      return false;
+    }
+
+    Domains previous = item.getPreviousAspect(Domains.class);
+
+    boolean associationsProvided = proposed.hasDomainAssociations();
+
+    if (associationsProvided) {
+      // Both fields present — only allowed if they are already in sync.
+      // "In sync" means the non-propagated URNs from associations equal the domains set.
+      Set<Urn> nonPropagatedUrns = getNonPropagatedUrns(proposed.getDomainAssociations());
+      Set<Urn> domainUrns = new LinkedHashSet<>(proposed.getDomains());
+
+      if (!nonPropagatedUrns.equals(domainUrns)) {
+        boolean domainsChanged = didDomainsChange(proposed, previous);
+        if (domainsChanged) {
+          throw new ValidationException(
+              "Cannot update both 'domains' and 'domainAssociations' in the same write. "
+                  + "Use 'domainAssociations' for rich metadata or 'domains' for legacy "
+                  + "compatibility, but not both. Entity: "
+                  + item.getUrn());
+        }
+      }
+
+      // domainAssociations is the source of truth; derive domains from non-propagated entries
+      deriveDomainsFromAssociations(proposed);
+      return true;
+    }
+
+    // Legacy path: caller only set domains. Sync domainAssociations.
+    deriveAssociationsFromDomains(proposed, previous);
+    return true;
+  }
+
+  /**
+   * Derives the {@code domains} array from {@code domainAssociations}, excluding propagated
+   * entries. An association is considered propagated if {@code
+   * attribution.sourceDetail["propagated"]} is {@code "true"} (case-insensitive).
+   */
+  private void deriveDomainsFromAssociations(Domains proposed) {
+    DomainAssociationArray associations = proposed.getDomainAssociations();
+    Set<Urn> domainUrns = new LinkedHashSet<>();
+    if (associations != null) {
+      for (DomainAssociation assoc : associations) {
+        if (!isPropagated(assoc)) {
+          domainUrns.add(assoc.getDomain());
+        }
+      }
+    }
+    proposed.setDomains(new UrnArray(new ArrayList<>(domainUrns)));
+  }
+
+  /**
+   * Derives {@code domainAssociations} from a diff between previous and proposed {@code domains}.
+   * New URNs get empty-attribution entries; removed URNs have all their associations deleted.
+   */
+  private void deriveAssociationsFromDomains(Domains proposed, @Nullable Domains previous) {
+    Set<Urn> proposedUrns = new LinkedHashSet<>(proposed.getDomains());
+
+    // Start from previous associations if available
+    DomainAssociationArray newAssociations = new DomainAssociationArray();
+
+    if (previous != null
+        && previous.hasDomainAssociations()
+        && previous.getDomainAssociations() != null) {
+      // Keep associations whose domain is still in the proposed set
+      for (DomainAssociation assoc : previous.getDomainAssociations()) {
+        if (proposedUrns.contains(assoc.getDomain())) {
+          newAssociations.add(assoc);
+        }
+      }
+    }
+
+    // Add new entries for URNs not in previous
+    Set<Urn> existingUrns = new LinkedHashSet<>();
+    for (DomainAssociation assoc : newAssociations) {
+      existingUrns.add(assoc.getDomain());
+    }
+    for (Urn urn : proposedUrns) {
+      if (!existingUrns.contains(urn)) {
+        DomainAssociation assoc = new DomainAssociation();
+        assoc.setDomain(urn);
+        newAssociations.add(assoc);
+      }
+    }
+
+    proposed.setDomainAssociations(newAssociations);
+  }
+
+  private static Set<Urn> getNonPropagatedUrns(DomainAssociationArray associations) {
+    Set<Urn> urns = new LinkedHashSet<>();
+    if (associations != null) {
+      for (DomainAssociation assoc : associations) {
+        if (!isPropagated(assoc)) {
+          urns.add(assoc.getDomain());
+        }
+      }
+    }
+    return urns;
+  }
+
+  private static boolean isPropagated(DomainAssociation assoc) {
+    if (!assoc.hasAttribution()) {
+      return false;
+    }
+    MetadataAttribution attribution = assoc.getAttribution();
+    if (!attribution.hasSourceDetail()) {
+      return false;
+    }
+    String propagated = attribution.getSourceDetail().get(PROPAGATED_KEY);
+    return propagated != null && propagated.equalsIgnoreCase("true");
+  }
+
+  private static boolean didDomainsChange(Domains proposed, @Nullable Domains previous) {
+    UrnArray proposedDomains = proposed.getDomains();
+    UrnArray previousDomains = previous != null ? previous.getDomains() : null;
+    return !Objects.equals(proposedDomains, previousDomains);
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/DomainChangeEvent.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/DomainChangeEvent.java
@@ -1,19 +1,20 @@
 package com.linkedin.metadata.timeline.data.entity;
 
-import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.AuditStamp;
-import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.timeline.data.ChangeCategory;
 import com.linkedin.metadata.timeline.data.ChangeEvent;
 import com.linkedin.metadata.timeline.data.ChangeOperation;
 import com.linkedin.metadata.timeline.data.SemanticChangeType;
+import java.util.Map;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Value;
+import lombok.experimental.NonFinal;
 
 @EqualsAndHashCode(callSuper = true)
 @Value
+@NonFinal
 @Getter
 public class DomainChangeEvent extends ChangeEvent {
   @Builder(builderMethodName = "entityDomainChangeEventBuilder")
@@ -22,16 +23,16 @@ public class DomainChangeEvent extends ChangeEvent {
       ChangeCategory category,
       ChangeOperation operation,
       String modifier,
+      Map<String, Object> parameters,
       AuditStamp auditStamp,
       SemanticChangeType semVerChange,
-      String description,
-      Urn domainUrn) {
+      String description) {
     super(
         entityUrn,
         category,
         operation,
         modifier,
-        ImmutableMap.of("domainUrn", domainUrn.toString()),
+        parameters,
         auditStamp,
         semVerChange,
         description);

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SingleDomainChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SingleDomainChangeEventGenerator.java
@@ -4,8 +4,10 @@ import static com.linkedin.metadata.Constants.*;
 
 import com.datahub.util.RecordUtils;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.domain.DomainAssociation;
 import com.linkedin.domain.Domains;
 import com.linkedin.metadata.aspect.EntityAspect;
 import com.linkedin.metadata.timeline.data.ChangeCategory;
@@ -19,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -98,7 +101,7 @@ public class SingleDomainChangeEventGenerator extends EntityChangeEventGenerator
               .operation(ChangeOperation.ADD)
               .entityUrn(entityUrn)
               .modifier(domainUrn.toString())
-              .domainUrn(domainUrn)
+              .parameters(buildParameters(domainUrn, getContext(targetDomains, domainUrn)))
               .description(String.format(DOMAIN_ADDED_FORMAT, domainUrn.getId(), entityUrn))
               .auditStamp(auditStamp)
               .build());
@@ -113,7 +116,7 @@ public class SingleDomainChangeEventGenerator extends EntityChangeEventGenerator
               .operation(ChangeOperation.REMOVE)
               .entityUrn(entityUrn)
               .modifier(domainUrn.toString())
-              .domainUrn(domainUrn)
+              .parameters(buildParameters(domainUrn, getContext(baseDomains, domainUrn)))
               .description(String.format(DOMAIN_REMOVED_FORMAT, domainUrn.getId(), entityUrn))
               .auditStamp(auditStamp)
               .build());
@@ -130,7 +133,8 @@ public class SingleDomainChangeEventGenerator extends EntityChangeEventGenerator
               .operation(ChangeOperation.REMOVE)
               .entityUrn(entityUrn)
               .modifier(removedDomainUrn.toString())
-              .domainUrn(removedDomainUrn)
+              .parameters(
+                  buildParameters(removedDomainUrn, getContext(baseDomains, removedDomainUrn)))
               .description(
                   String.format(DOMAIN_REMOVED_FORMAT, removedDomainUrn.getId(), entityUrn))
               .auditStamp(auditStamp)
@@ -141,7 +145,8 @@ public class SingleDomainChangeEventGenerator extends EntityChangeEventGenerator
               .operation(ChangeOperation.ADD)
               .entityUrn(entityUrn)
               .modifier(addedDomainUrn.toString())
-              .domainUrn(addedDomainUrn)
+              .parameters(
+                  buildParameters(addedDomainUrn, getContext(targetDomains, addedDomainUrn)))
               .description(String.format(DOMAIN_ADDED_FORMAT, addedDomainUrn.getId(), entityUrn))
               .auditStamp(auditStamp)
               .build());
@@ -166,5 +171,23 @@ public class SingleDomainChangeEventGenerator extends EntityChangeEventGenerator
 
   private boolean isDomainEmpty(@Nullable final Domains domains) {
     return domains == null || domains.getDomains().size() == 0;
+  }
+
+  private static Map<String, Object> buildParameters(
+      @Nonnull Urn domainUrn, @Nullable String context) {
+    return ImmutableMap.of(
+        "domainUrn", domainUrn.toString(), "context", context != null ? context : "{}");
+  }
+
+  @Nullable
+  private static String getContext(@Nonnull final Domains domains, @Nonnull final Urn domainUrn) {
+    if (!domains.hasDomainAssociations()) {
+      return null;
+    }
+    return domains.getDomainAssociations().stream()
+        .filter(da -> da.getDomain().equals(domainUrn) && da.hasContext())
+        .findFirst()
+        .map(DomainAssociation::getContext)
+        .orElse(null);
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/hooks/DomainsSyncMutationHookTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/hooks/DomainsSyncMutationHookTest.java
@@ -1,0 +1,489 @@
+package com.linkedin.metadata.aspect.hooks;
+
+import static com.linkedin.metadata.Constants.DOMAINS_ASPECT_NAME;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.datahub.context.OperationFingerprint;
+import com.linkedin.common.MetadataAttribution;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.StringMap;
+import com.linkedin.domain.DomainAssociation;
+import com.linkedin.domain.DomainAssociationArray;
+import com.linkedin.domain.Domains;
+import com.linkedin.metadata.aspect.RetrieverContext;
+import com.linkedin.metadata.aspect.batch.ChangeMCP;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.entity.validation.ValidationException;
+import com.linkedin.util.Pair;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class DomainsSyncMutationHookTest {
+
+  private static final Urn TEST_ENTITY_URN =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:postgres,test.table,PROD)");
+  private static final Urn DOMAIN_A = UrnUtils.getUrn("urn:li:domain:a");
+  private static final Urn DOMAIN_B = UrnUtils.getUrn("urn:li:domain:b");
+  private static final Urn DOMAIN_C = UrnUtils.getUrn("urn:li:domain:c");
+
+  private static final AspectPluginConfig HOOK_CONFIG =
+      AspectPluginConfig.builder()
+          .className(DomainsSyncMutationHook.class.getName())
+          .enabled(true)
+          .supportedOperations(List.of("UPSERT"))
+          .supportedEntityAspectNames(
+              List.of(
+                  AspectPluginConfig.EntityAspectName.builder()
+                      .entityName("*")
+                      .aspectName(DOMAINS_ASPECT_NAME)
+                      .build()))
+          .build();
+
+  private RetrieverContext retrieverContext;
+
+  @BeforeMethod
+  public void setup() {
+    retrieverContext = mock(RetrieverContext.class);
+  }
+
+  // ── Legacy path: only domains provided ─────────────────────────────────────
+
+  @Test
+  public void testLegacyWrite_newEntity_createsAssociations() {
+    Domains proposed = makeDomains(DOMAIN_A, DOMAIN_B);
+    ChangeMCP item = makeChangeMCP(proposed, null);
+
+    List<Pair<ChangeMCP, Boolean>> result = applyHook(item);
+
+    assertEquals(result.size(), 1);
+    assertTrue(result.get(0).getSecond());
+    assertTrue(proposed.hasDomainAssociations());
+    DomainAssociationArray assocs = proposed.getDomainAssociations();
+    assertEquals(assocs.size(), 2);
+    assertEquals(assocs.get(0).getDomain(), DOMAIN_A);
+    assertEquals(assocs.get(1).getDomain(), DOMAIN_B);
+    assertFalse(assocs.get(0).hasAttribution());
+  }
+
+  @Test
+  public void testLegacyWrite_addDomain_preservesExistingAttribution() {
+    MetadataAttribution attr = makeAttribution();
+    DomainAssociation existingAssoc = new DomainAssociation();
+    existingAssoc.setDomain(DOMAIN_A);
+    existingAssoc.setAttribution(attr);
+
+    Domains previous = makeDomains(DOMAIN_A);
+    previous.setDomainAssociations(new DomainAssociationArray(List.of(existingAssoc)));
+
+    Domains proposed = makeDomains(DOMAIN_A, DOMAIN_B);
+    // No domainAssociations on proposed → legacy path
+    ChangeMCP item = makeChangeMCP(proposed, previous);
+
+    applyHook(item);
+
+    DomainAssociationArray assocs = proposed.getDomainAssociations();
+    assertEquals(assocs.size(), 2);
+    // Existing attribution for DOMAIN_A is preserved
+    assertEquals(assocs.get(0).getDomain(), DOMAIN_A);
+    assertTrue(assocs.get(0).hasAttribution());
+    assertEquals(assocs.get(0).getAttribution(), attr);
+    // New domain B gets empty attribution
+    assertEquals(assocs.get(1).getDomain(), DOMAIN_B);
+    assertFalse(assocs.get(1).hasAttribution());
+  }
+
+  @Test
+  public void testLegacyWrite_removeDomain_removesAllAssociations() {
+    DomainAssociation assocA = new DomainAssociation();
+    assocA.setDomain(DOMAIN_A);
+    DomainAssociation assocB = new DomainAssociation();
+    assocB.setDomain(DOMAIN_B);
+    // Propagated association for B
+    DomainAssociation assocBPropagated = new DomainAssociation();
+    assocBPropagated.setDomain(DOMAIN_B);
+    assocBPropagated.setAttribution(makePropagatedAttribution());
+
+    Domains previous = makeDomains(DOMAIN_A, DOMAIN_B);
+    previous.setDomainAssociations(
+        new DomainAssociationArray(List.of(assocA, assocB, assocBPropagated)));
+
+    // Remove DOMAIN_B
+    Domains proposed = makeDomains(DOMAIN_A);
+    ChangeMCP item = makeChangeMCP(proposed, previous);
+
+    applyHook(item);
+
+    DomainAssociationArray assocs = proposed.getDomainAssociations();
+    assertEquals(assocs.size(), 1);
+    assertEquals(assocs.get(0).getDomain(), DOMAIN_A);
+  }
+
+  // ── New path: domainAssociations provided ──────────────────────────────────
+
+  @Test
+  public void testNewPathWrite_derivesDomainsFromAssociations() {
+    DomainAssociation assocA = new DomainAssociation();
+    assocA.setDomain(DOMAIN_A);
+    DomainAssociation assocB = new DomainAssociation();
+    assocB.setDomain(DOMAIN_B);
+
+    Domains proposed = new Domains();
+    // Domains set consistently with associations (well-behaved new-path client)
+    proposed.setDomains(new UrnArray(List.of(DOMAIN_A, DOMAIN_B)));
+    proposed.setDomainAssociations(new DomainAssociationArray(List.of(assocA, assocB)));
+
+    ChangeMCP item = makeChangeMCP(proposed, null);
+
+    applyHook(item);
+
+    // domains derived from non-propagated associations
+    assertEquals(proposed.getDomains().size(), 2);
+    assertTrue(proposed.getDomains().contains(DOMAIN_A));
+    assertTrue(proposed.getDomains().contains(DOMAIN_B));
+  }
+
+  @Test
+  public void testNewPathWrite_propagatedEntriesIncludedInDomainsAfterManual() {
+    DomainAssociation assocA = new DomainAssociation();
+    assocA.setDomain(DOMAIN_A);
+
+    DomainAssociation propagatedB = new DomainAssociation();
+    propagatedB.setDomain(DOMAIN_B);
+    propagatedB.setAttribution(makePropagatedAttribution());
+
+    Domains proposed = new Domains();
+    proposed.setDomains(new UrnArray(List.of(DOMAIN_A, DOMAIN_B)));
+    proposed.setDomainAssociations(new DomainAssociationArray(List.of(assocA, propagatedB)));
+
+    ChangeMCP item = makeChangeMCP(proposed, null);
+
+    applyHook(item);
+
+    // All URNs appear in domains, manual first then propagated
+    assertEquals(proposed.getDomains().size(), 2);
+    assertEquals(proposed.getDomains().get(0), DOMAIN_A);
+    assertEquals(proposed.getDomains().get(1), DOMAIN_B);
+    // Both associations are preserved
+    assertEquals(proposed.getDomainAssociations().size(), 2);
+  }
+
+  @Test
+  public void testNewPathWrite_deduplicatesDomains() {
+    // Two non-propagated associations for the same domain
+    DomainAssociation assocA1 = new DomainAssociation();
+    assocA1.setDomain(DOMAIN_A);
+    DomainAssociation assocA2 = new DomainAssociation();
+    assocA2.setDomain(DOMAIN_A);
+    assocA2.setAttribution(makeAttribution());
+
+    Domains proposed = new Domains();
+    proposed.setDomains(new UrnArray(List.of(DOMAIN_A)));
+    proposed.setDomainAssociations(new DomainAssociationArray(List.of(assocA1, assocA2)));
+
+    ChangeMCP item = makeChangeMCP(proposed, null);
+
+    applyHook(item);
+
+    // Deduplicated in domains
+    assertEquals(proposed.getDomains().size(), 1);
+    assertEquals(proposed.getDomains().get(0), DOMAIN_A);
+  }
+
+  // ── Conflict detection ─────────────────────────────────────────────────────
+
+  @Test
+  public void testBothFieldsInSync_allowed() {
+    // domains and associations are consistent → no error
+    DomainAssociation assocA = new DomainAssociation();
+    assocA.setDomain(DOMAIN_A);
+
+    Domains proposed = new Domains();
+    proposed.setDomains(new UrnArray(List.of(DOMAIN_A)));
+    proposed.setDomainAssociations(new DomainAssociationArray(List.of(assocA)));
+
+    Domains previous = makeDomains(DOMAIN_B);
+    ChangeMCP item = makeChangeMCP(proposed, previous);
+
+    // Should not throw
+    List<Pair<ChangeMCP, Boolean>> result = applyHook(item);
+    assertTrue(result.get(0).getSecond());
+  }
+
+  @Test
+  public void testBothFieldsInSyncWithPropagated_allowed() {
+    // All URNs (including propagated) match domains → allowed
+    DomainAssociation assocA = new DomainAssociation();
+    assocA.setDomain(DOMAIN_A);
+    DomainAssociation propagatedB = new DomainAssociation();
+    propagatedB.setDomain(DOMAIN_B);
+    propagatedB.setAttribution(makePropagatedAttribution());
+
+    Domains proposed = new Domains();
+    proposed.setDomains(new UrnArray(List.of(DOMAIN_A, DOMAIN_B)));
+    proposed.setDomainAssociations(new DomainAssociationArray(List.of(assocA, propagatedB)));
+
+    Domains previous = makeDomains(DOMAIN_C);
+    ChangeMCP item = makeChangeMCP(proposed, previous);
+
+    // Should not throw despite both fields changing from previous
+    List<Pair<ChangeMCP, Boolean>> result = applyHook(item);
+    assertTrue(result.get(0).getSecond());
+  }
+
+  @Test(expectedExceptions = ValidationException.class)
+  public void testBothFieldsInconsistentAndDomainsChanged_throws() {
+    DomainAssociation assocB = new DomainAssociation();
+    assocB.setDomain(DOMAIN_B);
+
+    Domains proposed = new Domains();
+    proposed.setDomains(new UrnArray(List.of(DOMAIN_A))); // inconsistent with associations
+    proposed.setDomainAssociations(new DomainAssociationArray(List.of(assocB)));
+
+    Domains previous = makeDomains(DOMAIN_C); // domains changed from previous
+    ChangeMCP item = makeChangeMCP(proposed, previous);
+
+    applyHook(item);
+  }
+
+  @Test
+  public void testBothFieldsInconsistentButDomainsUnchanged_allowed() {
+    // Associations differ from domains but domains didn't change from previous
+    // → associations win (caller updated only associations)
+    DomainAssociation assocB = new DomainAssociation();
+    assocB.setDomain(DOMAIN_B);
+
+    Domains proposed = new Domains();
+    proposed.setDomains(new UrnArray(List.of(DOMAIN_A))); // same as previous
+    proposed.setDomainAssociations(new DomainAssociationArray(List.of(assocB)));
+
+    Domains previous = makeDomains(DOMAIN_A); // domains unchanged
+    ChangeMCP item = makeChangeMCP(proposed, previous);
+
+    applyHook(item);
+
+    // Domains derived from associations
+    assertEquals(proposed.getDomains().size(), 1);
+    assertEquals(proposed.getDomains().get(0), DOMAIN_B);
+  }
+
+  // ── Edge cases ─────────────────────────────────────────────────────────────
+
+  @Test
+  public void testNullProposedAspect_noOp() {
+    ChangeMCP item = mock(ChangeMCP.class);
+    when(item.getAspectName()).thenReturn(DOMAINS_ASPECT_NAME);
+    when(item.getUrn()).thenReturn(TEST_ENTITY_URN);
+    when(item.getAspect(Domains.class)).thenReturn(null);
+
+    List<Pair<ChangeMCP, Boolean>> result = applyHook(item);
+    assertFalse(result.get(0).getSecond());
+  }
+
+  @Test
+  public void testNonDomainsAspect_passThrough() {
+    ChangeMCP item = mock(ChangeMCP.class);
+    when(item.getAspectName()).thenReturn("glossaryTermInfo");
+
+    List<Pair<ChangeMCP, Boolean>> result = applyHook(item);
+    assertFalse(result.get(0).getSecond());
+  }
+
+  @Test
+  public void testEmptyDomainsAndEmptyAssociations() {
+    Domains proposed = new Domains();
+    proposed.setDomains(new UrnArray());
+    proposed.setDomainAssociations(new DomainAssociationArray());
+
+    ChangeMCP item = makeChangeMCP(proposed, null);
+
+    applyHook(item);
+
+    assertEquals(proposed.getDomains().size(), 0);
+    assertEquals(proposed.getDomainAssociations().size(), 0);
+  }
+
+  @Test
+  public void testLegacyWrite_noPreviousAssociations_createsFromScratch() {
+    // Previous aspect exists but has no domainAssociations (v1 data)
+    Domains previous = makeDomains(DOMAIN_A);
+    // No domainAssociations on previous
+
+    Domains proposed = makeDomains(DOMAIN_A, DOMAIN_B);
+    ChangeMCP item = makeChangeMCP(proposed, previous);
+
+    applyHook(item);
+
+    DomainAssociationArray assocs = proposed.getDomainAssociations();
+    assertEquals(assocs.size(), 2);
+    Set<Urn> assocUrns =
+        assocs.stream().map(DomainAssociation::getDomain).collect(Collectors.toSet());
+    assertEquals(assocUrns, Set.of(DOMAIN_A, DOMAIN_B));
+  }
+
+  // ── Ordering: manual before propagated ───────────────────────────────────
+
+  @Test
+  public void testNewPath_manualBeforePropagatedInAssociations() {
+    // Propagated entry listed first in input; after sync it should come last
+    DomainAssociation propagatedA = new DomainAssociation();
+    propagatedA.setDomain(DOMAIN_A);
+    propagatedA.setAttribution(makePropagatedAttribution());
+
+    DomainAssociation manualB = new DomainAssociation();
+    manualB.setDomain(DOMAIN_B);
+
+    DomainAssociation manualC = new DomainAssociation();
+    manualC.setDomain(DOMAIN_C);
+
+    Domains proposed = new Domains();
+    proposed.setDomains(new UrnArray(List.of(DOMAIN_A, DOMAIN_B, DOMAIN_C)));
+    proposed.setDomainAssociations(
+        new DomainAssociationArray(List.of(propagatedA, manualB, manualC)));
+
+    ChangeMCP item = makeChangeMCP(proposed, null);
+
+    applyHook(item);
+
+    DomainAssociationArray assocs = proposed.getDomainAssociations();
+    assertEquals(assocs.size(), 3);
+    // Manual entries first
+    assertEquals(assocs.get(0).getDomain(), DOMAIN_B);
+    assertFalse(DomainsSyncMutationHook.isPropagated(assocs.get(0)));
+    assertEquals(assocs.get(1).getDomain(), DOMAIN_C);
+    assertFalse(DomainsSyncMutationHook.isPropagated(assocs.get(1)));
+    // Propagated entry last
+    assertEquals(assocs.get(2).getDomain(), DOMAIN_A);
+    assertTrue(DomainsSyncMutationHook.isPropagated(assocs.get(2)));
+
+    // domains reordered: manual first, then propagated
+    assertEquals(proposed.getDomains().size(), 3);
+    assertEquals(proposed.getDomains().get(0), DOMAIN_B);
+    assertEquals(proposed.getDomains().get(1), DOMAIN_C);
+    assertEquals(proposed.getDomains().get(2), DOMAIN_A);
+  }
+
+  @Test
+  public void testLegacyPath_preservedPropagatedAssociationsMovedToEnd() {
+    // Previous has: manual A, propagated B, manual C (B is propagated but in the middle)
+    DomainAssociation assocA = new DomainAssociation();
+    assocA.setDomain(DOMAIN_A);
+    DomainAssociation propagatedB = new DomainAssociation();
+    propagatedB.setDomain(DOMAIN_B);
+    propagatedB.setAttribution(makePropagatedAttribution());
+    DomainAssociation assocC = new DomainAssociation();
+    assocC.setDomain(DOMAIN_C);
+
+    Domains previous = makeDomains(DOMAIN_A, DOMAIN_B, DOMAIN_C);
+    previous.setDomainAssociations(
+        new DomainAssociationArray(List.of(assocA, propagatedB, assocC)));
+
+    // Legacy write keeps all three domains
+    Domains proposed = makeDomains(DOMAIN_A, DOMAIN_B, DOMAIN_C);
+    ChangeMCP item = makeChangeMCP(proposed, previous);
+
+    applyHook(item);
+
+    DomainAssociationArray assocs = proposed.getDomainAssociations();
+    assertEquals(assocs.size(), 3);
+    // Manual entries first (A, C), then propagated (B)
+    assertFalse(DomainsSyncMutationHook.isPropagated(assocs.get(0)));
+    assertFalse(DomainsSyncMutationHook.isPropagated(assocs.get(1)));
+    assertTrue(DomainsSyncMutationHook.isPropagated(assocs.get(2)));
+    assertEquals(assocs.get(2).getDomain(), DOMAIN_B);
+  }
+
+  @Test
+  public void testAllManual_orderUnchanged() {
+    DomainAssociation assocA = new DomainAssociation();
+    assocA.setDomain(DOMAIN_A);
+    DomainAssociation assocB = new DomainAssociation();
+    assocB.setDomain(DOMAIN_B);
+
+    Domains proposed = new Domains();
+    proposed.setDomains(new UrnArray(List.of(DOMAIN_A, DOMAIN_B)));
+    proposed.setDomainAssociations(new DomainAssociationArray(List.of(assocA, assocB)));
+
+    ChangeMCP item = makeChangeMCP(proposed, null);
+
+    applyHook(item);
+
+    DomainAssociationArray assocs = proposed.getDomainAssociations();
+    assertEquals(assocs.size(), 2);
+    assertEquals(assocs.get(0).getDomain(), DOMAIN_A);
+    assertEquals(assocs.get(1).getDomain(), DOMAIN_B);
+  }
+
+  @Test
+  public void testAllPropagated_orderUnchanged() {
+    DomainAssociation propagatedA = new DomainAssociation();
+    propagatedA.setDomain(DOMAIN_A);
+    propagatedA.setAttribution(makePropagatedAttribution());
+
+    DomainAssociation propagatedB = new DomainAssociation();
+    propagatedB.setDomain(DOMAIN_B);
+    propagatedB.setAttribution(makePropagatedAttribution());
+
+    Domains proposed = new Domains();
+    proposed.setDomains(new UrnArray(List.of(DOMAIN_A, DOMAIN_B)));
+    proposed.setDomainAssociations(new DomainAssociationArray(List.of(propagatedA, propagatedB)));
+
+    ChangeMCP item = makeChangeMCP(proposed, null);
+
+    applyHook(item);
+
+    DomainAssociationArray assocs = proposed.getDomainAssociations();
+    assertEquals(assocs.size(), 2);
+    assertEquals(assocs.get(0).getDomain(), DOMAIN_A);
+    assertEquals(assocs.get(1).getDomain(), DOMAIN_B);
+    // domains includes all URNs (propagated included)
+    assertEquals(proposed.getDomains().size(), 2);
+    assertEquals(proposed.getDomains().get(0), DOMAIN_A);
+    assertEquals(proposed.getDomains().get(1), DOMAIN_B);
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private List<Pair<ChangeMCP, Boolean>> applyHook(ChangeMCP item) {
+    DomainsSyncMutationHook hook = new DomainsSyncMutationHook();
+    hook.setConfig(HOOK_CONFIG);
+    return hook.writeMutation(OperationFingerprint.EMPTY, List.of(item), retrieverContext).toList();
+  }
+
+  private static Domains makeDomains(Urn... urns) {
+    Domains domains = new Domains();
+    domains.setDomains(new UrnArray(List.of(urns)));
+    return domains;
+  }
+
+  private static ChangeMCP makeChangeMCP(Domains proposed, Domains previous) {
+    ChangeMCP item = mock(ChangeMCP.class);
+    when(item.getAspectName()).thenReturn(DOMAINS_ASPECT_NAME);
+    when(item.getUrn()).thenReturn(TEST_ENTITY_URN);
+    when(item.getAspect(Domains.class)).thenReturn(proposed);
+    when(item.getPreviousAspect(Domains.class)).thenReturn(previous);
+    return item;
+  }
+
+  private static MetadataAttribution makeAttribution() {
+    MetadataAttribution attr = new MetadataAttribution();
+    attr.setTime(System.currentTimeMillis());
+    attr.setActor(UrnUtils.getUrn("urn:li:corpuser:testUser"));
+    return attr;
+  }
+
+  private static MetadataAttribution makePropagatedAttribution() {
+    MetadataAttribution attr = makeAttribution();
+    attr.setSourceDetail(new StringMap(Map.of("propagated", "true")));
+    return attr;
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/hooks/DomainsSyncMutationHookTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/hooks/DomainsSyncMutationHookTest.java
@@ -276,6 +276,61 @@ public class DomainsSyncMutationHookTest {
     assertEquals(proposed.getDomains().get(0), DOMAIN_B);
   }
 
+  // ── Read-modify-write scenarios ───────────────────────────────────────────
+
+  @Test
+  public void testReadModifyWrite_onlyDomainsChanged_syncsAssociations() {
+    // Previous has both fields in sync (as if written by the hook previously)
+    DomainAssociation assocA = new DomainAssociation();
+    assocA.setDomain(DOMAIN_A);
+
+    Domains previous = makeDomains(DOMAIN_A);
+    previous.setDomainAssociations(new DomainAssociationArray(List.of(assocA)));
+
+    // Read-modify-write: caller read the full aspect, changed only domains, left associations stale
+    Domains proposed = new Domains();
+    proposed.setDomains(new UrnArray(List.of(DOMAIN_A, DOMAIN_B)));
+    proposed.setDomainAssociations(new DomainAssociationArray(List.of(assocA))); // stale from read
+
+    ChangeMCP item = makeChangeMCP(proposed, previous);
+
+    applyHook(item);
+
+    // Associations should be derived from domains (not left stale)
+    DomainAssociationArray assocs = proposed.getDomainAssociations();
+    assertEquals(assocs.size(), 2);
+    Set<Urn> assocUrns =
+        assocs.stream().map(DomainAssociation::getDomain).collect(Collectors.toSet());
+    assertEquals(assocUrns, Set.of(DOMAIN_A, DOMAIN_B));
+  }
+
+  @Test
+  public void testReadModifyWrite_onlyAssociationsChanged_syncsDomains() {
+    // Previous has both fields in sync
+    DomainAssociation assocA = new DomainAssociation();
+    assocA.setDomain(DOMAIN_A);
+
+    Domains previous = makeDomains(DOMAIN_A);
+    previous.setDomainAssociations(new DomainAssociationArray(List.of(assocA)));
+
+    // Read-modify-write: caller changed only associations, left domains stale
+    DomainAssociation newAssocB = new DomainAssociation();
+    newAssocB.setDomain(DOMAIN_B);
+
+    Domains proposed = new Domains();
+    proposed.setDomains(new UrnArray(List.of(DOMAIN_A))); // stale from read
+    proposed.setDomainAssociations(new DomainAssociationArray(List.of(assocA, newAssocB)));
+
+    ChangeMCP item = makeChangeMCP(proposed, previous);
+
+    applyHook(item);
+
+    // Domains should be derived from associations
+    assertEquals(proposed.getDomains().size(), 2);
+    assertTrue(proposed.getDomains().contains(DOMAIN_A));
+    assertTrue(proposed.getDomains().contains(DOMAIN_B));
+  }
+
   // ── Edge cases ─────────────────────────────────────────────────────────────
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/SingleDomainChangeEventGeneratorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/SingleDomainChangeEventGeneratorTest.java
@@ -1,128 +1,215 @@
 package com.linkedin.metadata.timeline.eventgenerator;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
-import com.linkedin.metadata.aspect.EntityAspect;
-import com.linkedin.metadata.timeline.data.ChangeCategory;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.domain.DomainAssociation;
+import com.linkedin.domain.DomainAssociationArray;
+import com.linkedin.domain.Domains;
 import com.linkedin.metadata.timeline.data.ChangeEvent;
 import com.linkedin.metadata.timeline.data.ChangeOperation;
-import com.linkedin.metadata.timeline.data.ChangeTransaction;
-import com.linkedin.metadata.timeline.data.SemanticChangeType;
-import java.sql.Timestamp;
+import com.linkedin.metadata.timeline.data.entity.DomainChangeEvent;
+import com.linkedin.mxe.SystemMetadata;
+import java.net.URISyntaxException;
+import java.util.List;
 import org.testng.annotations.Test;
 
-/**
- * Tests that {@link SingleDomainChangeEventGenerator} correctly implements {@code getSemanticDiff}
- * (the legacy API still called by the timeline pipeline). Before the fix, the generator only
- * implemented the new {@code getChangeEvents} API, so {@code getSemanticDiff} fell through to the
- * base class and threw {@link UnsupportedOperationException}.
- */
 public class SingleDomainChangeEventGeneratorTest {
 
-  private static final String ENTITY_URN =
+  private static final String TEST_ENTITY_URN =
       "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.table,PROD)";
   private static final String DOMAIN_URN_1 = "urn:li:domain:engineering";
   private static final String DOMAIN_URN_2 = "urn:li:domain:marketing";
+  private static final String TEST_CONTEXT =
+      "{\"origin\":\"urn:li:dataset:(urn:li:dataPlatform:hive,OriginTable,PROD)\",\"propagated\":\"true\",\"actor\":\"urn:li:corpuser:test\"}";
 
-  private static EntityAspect makeDomainAspect(String entityUrn, String domainUrn, long version) {
-    String json =
-        domainUrn != null
-            ? String.format("{\"domains\": [\"%s\"]}", domainUrn)
-            : "{\"domains\": []}";
-    EntityAspect aspect = new EntityAspect();
-    aspect.setUrn(entityUrn);
-    aspect.setAspect("domains");
-    aspect.setVersion(version);
-    aspect.setMetadata(json);
-    aspect.setCreatedOn(new Timestamp(1000L * (version + 1)));
-    aspect.setCreatedBy("urn:li:corpuser:tester");
-    return aspect;
+  private static Urn getTestUrn() throws URISyntaxException {
+    return Urn.createFromString(TEST_ENTITY_URN);
   }
 
-  @Test
-  public void testGetSemanticDiffDoesNotThrow() {
-    SingleDomainChangeEventGenerator generator = new SingleDomainChangeEventGenerator();
-
-    EntityAspect previous = makeDomainAspect(ENTITY_URN, null, 0);
-    EntityAspect current = makeDomainAspect(ENTITY_URN, DOMAIN_URN_1, 1);
-
-    // This must NOT throw UnsupportedOperationException
-    ChangeTransaction tx =
-        generator.getSemanticDiff(previous, current, ChangeCategory.DOMAIN, null, false);
-
-    assertNotNull(tx);
-    assertNotNull(tx.getChangeEvents());
-    assertEquals(tx.getChangeEvents().size(), 1);
-
-    ChangeEvent event = tx.getChangeEvents().get(0);
-    assertEquals(event.getCategory(), ChangeCategory.DOMAIN);
-    assertEquals(event.getOperation(), ChangeOperation.ADD);
-    assertEquals(event.getEntityUrn(), ENTITY_URN);
-    assertNotNull(event.getDescription(), "Domain ADD events must have a description");
-    assertTrue(event.getDescription().contains("engineering"));
-    assertTrue(event.getDescription().contains(ENTITY_URN));
+  private static AuditStamp getTestAuditStamp() throws URISyntaxException {
+    return new AuditStamp()
+        .setActor(Urn.createFromString("urn:li:corpuser:__datahub_system"))
+        .setTime(1683829509553L);
   }
 
-  @Test
-  public void testDomainChanged() {
-    SingleDomainChangeEventGenerator generator = new SingleDomainChangeEventGenerator();
-
-    EntityAspect previous = makeDomainAspect(ENTITY_URN, DOMAIN_URN_1, 0);
-    EntityAspect current = makeDomainAspect(ENTITY_URN, DOMAIN_URN_2, 1);
-
-    ChangeTransaction tx =
-        generator.getSemanticDiff(previous, current, ChangeCategory.DOMAIN, null, false);
-
-    assertNotNull(tx);
-    // Domain change emits a REMOVE + ADD pair
-    assertEquals(tx.getChangeEvents().size(), 2);
-
-    long addCount =
-        tx.getChangeEvents().stream().filter(e -> e.getOperation() == ChangeOperation.ADD).count();
-    long removeCount =
-        tx.getChangeEvents().stream()
-            .filter(e -> e.getOperation() == ChangeOperation.REMOVE)
-            .count();
-    assertEquals(addCount, 1);
-    assertEquals(removeCount, 1);
-
-    // Both events must have descriptions
-    for (ChangeEvent event : tx.getChangeEvents()) {
-      assertNotNull(event.getDescription(), "Domain change events must have descriptions");
+  private static Aspect<Domains> createDomainsAspect(String domainUrn, String context)
+      throws URISyntaxException {
+    Domains domains = new Domains();
+    if (domainUrn != null) {
+      Urn urn = Urn.createFromString(domainUrn);
+      domains.setDomains(new UrnArray(urn));
+      if (context != null) {
+        DomainAssociation association = new DomainAssociation();
+        association.setDomain(urn);
+        association.setContext(context);
+        domains.setDomainAssociations(new DomainAssociationArray(association));
+      }
+    } else {
+      domains.setDomains(new UrnArray());
     }
+    return new Aspect<>(domains, new SystemMetadata());
+  }
+
+  private static void validateChangeEvent(
+      ChangeEvent changeEvent,
+      ChangeOperation expectedOperation,
+      String expectedDomainUrn,
+      String expectedContext) {
+    assertNotNull(changeEvent);
+    assertEquals(changeEvent.getOperation(), expectedOperation);
+    assertEquals(changeEvent.getModifier(), expectedDomainUrn);
+    assertEquals(changeEvent.getEntityUrn(), TEST_ENTITY_URN);
+
+    assertNotNull(changeEvent.getParameters());
+    assertEquals(changeEvent.getParameters().get("domainUrn"), expectedDomainUrn);
+    assertEquals(
+        changeEvent.getParameters().get("context"),
+        expectedContext != null ? expectedContext : "{}");
   }
 
   @Test
-  public void testDomainRemoved() {
+  public void testAddDomainWithContext() throws Exception {
     SingleDomainChangeEventGenerator generator = new SingleDomainChangeEventGenerator();
 
-    EntityAspect previous = makeDomainAspect(ENTITY_URN, DOMAIN_URN_1, 0);
-    EntityAspect current = makeDomainAspect(ENTITY_URN, null, 1);
+    Aspect<Domains> from = createDomainsAspect(null, null);
+    Aspect<Domains> to = createDomainsAspect(DOMAIN_URN_1, TEST_CONTEXT);
 
-    ChangeTransaction tx =
-        generator.getSemanticDiff(previous, current, ChangeCategory.DOMAIN, null, false);
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(
+            getTestUrn(), "dataset", "domains", from, to, getTestAuditStamp());
 
-    assertNotNull(tx);
-    assertEquals(tx.getChangeEvents().size(), 1);
-    assertNotNull(
-        tx.getChangeEvents().get(0).getDescription(),
-        "Domain REMOVE events must have a description");
-    assertTrue(tx.getChangeEvents().get(0).getDescription().contains("engineering"));
-    assertEquals(tx.getChangeEvents().get(0).getOperation(), ChangeOperation.REMOVE);
+    assertEquals(actual.size(), 1);
+    validateChangeEvent(actual.get(0), ChangeOperation.ADD, DOMAIN_URN_1, TEST_CONTEXT);
   }
 
   @Test
-  public void testNoDomainChange() {
+  public void testAddDomainWithoutContext() throws Exception {
     SingleDomainChangeEventGenerator generator = new SingleDomainChangeEventGenerator();
 
-    EntityAspect previous = makeDomainAspect(ENTITY_URN, DOMAIN_URN_1, 0);
-    EntityAspect current = makeDomainAspect(ENTITY_URN, DOMAIN_URN_1, 1);
+    Aspect<Domains> from = createDomainsAspect(null, null);
+    Aspect<Domains> to = createDomainsAspect(DOMAIN_URN_1, null);
 
-    ChangeTransaction tx =
-        generator.getSemanticDiff(previous, current, ChangeCategory.DOMAIN, null, false);
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(
+            getTestUrn(), "dataset", "domains", from, to, getTestAuditStamp());
 
-    assertNotNull(tx);
-    assertTrue(tx.getChangeEvents().isEmpty());
-    assertEquals(tx.getSemVerChange(), SemanticChangeType.NONE);
+    assertEquals(actual.size(), 1);
+    validateChangeEvent(actual.get(0), ChangeOperation.ADD, DOMAIN_URN_1, null);
+  }
+
+  @Test
+  public void testRemoveDomainWithContext() throws Exception {
+    SingleDomainChangeEventGenerator generator = new SingleDomainChangeEventGenerator();
+
+    Aspect<Domains> from = createDomainsAspect(DOMAIN_URN_1, TEST_CONTEXT);
+    Aspect<Domains> to = createDomainsAspect(null, null);
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(
+            getTestUrn(), "dataset", "domains", from, to, getTestAuditStamp());
+
+    assertEquals(actual.size(), 1);
+    validateChangeEvent(actual.get(0), ChangeOperation.REMOVE, DOMAIN_URN_1, TEST_CONTEXT);
+  }
+
+  @Test
+  public void testRemoveDomainWithoutContext() throws Exception {
+    SingleDomainChangeEventGenerator generator = new SingleDomainChangeEventGenerator();
+
+    Aspect<Domains> from = createDomainsAspect(DOMAIN_URN_1, null);
+    Aspect<Domains> to = createDomainsAspect(null, null);
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(
+            getTestUrn(), "dataset", "domains", from, to, getTestAuditStamp());
+
+    assertEquals(actual.size(), 1);
+    validateChangeEvent(actual.get(0), ChangeOperation.REMOVE, DOMAIN_URN_1, null);
+  }
+
+  @Test
+  public void testDomainChanged() throws Exception {
+    SingleDomainChangeEventGenerator generator = new SingleDomainChangeEventGenerator();
+
+    Aspect<Domains> from = createDomainsAspect(DOMAIN_URN_1, TEST_CONTEXT);
+    Aspect<Domains> to = createDomainsAspect(DOMAIN_URN_2, null);
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(
+            getTestUrn(), "dataset", "domains", from, to, getTestAuditStamp());
+
+    assertEquals(actual.size(), 2);
+
+    ChangeEvent removeEvent =
+        actual.stream()
+            .filter(e -> e.getOperation() == ChangeOperation.REMOVE)
+            .findFirst()
+            .orElse(null);
+    ChangeEvent addEvent =
+        actual.stream()
+            .filter(e -> e.getOperation() == ChangeOperation.ADD)
+            .findFirst()
+            .orElse(null);
+
+    validateChangeEvent(removeEvent, ChangeOperation.REMOVE, DOMAIN_URN_1, TEST_CONTEXT);
+    validateChangeEvent(addEvent, ChangeOperation.ADD, DOMAIN_URN_2, null);
+  }
+
+  @Test
+  public void testNoChanges() throws Exception {
+    SingleDomainChangeEventGenerator generator = new SingleDomainChangeEventGenerator();
+
+    Aspect<Domains> from = createDomainsAspect(DOMAIN_URN_1, TEST_CONTEXT);
+    Aspect<Domains> to = createDomainsAspect(DOMAIN_URN_1, TEST_CONTEXT);
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(
+            getTestUrn(), "dataset", "domains", from, to, getTestAuditStamp());
+
+    assertEquals(actual.size(), 0);
+  }
+
+  @Test
+  public void testChangeEventIsDomainChangeEvent() throws Exception {
+    SingleDomainChangeEventGenerator generator = new SingleDomainChangeEventGenerator();
+
+    Aspect<Domains> from = createDomainsAspect(null, null);
+    Aspect<Domains> to = createDomainsAspect(DOMAIN_URN_1, TEST_CONTEXT);
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(
+            getTestUrn(), "dataset", "domains", from, to, getTestAuditStamp());
+
+    assertEquals(actual.size(), 1);
+
+    ChangeEvent changeEvent = actual.get(0);
+    assertEquals(changeEvent.getClass(), DomainChangeEvent.class);
+
+    DomainChangeEvent domainChangeEvent = (DomainChangeEvent) changeEvent;
+    assertNotNull(domainChangeEvent.getParameters());
+    assertEquals(domainChangeEvent.getParameters().get("domainUrn"), DOMAIN_URN_1);
+    assertEquals(domainChangeEvent.getParameters().get("context"), TEST_CONTEXT);
+  }
+
+  @Test
+  public void testDescriptionContainsDomainAndEntity() throws Exception {
+    SingleDomainChangeEventGenerator generator = new SingleDomainChangeEventGenerator();
+
+    Aspect<Domains> from = createDomainsAspect(null, null);
+    Aspect<Domains> to = createDomainsAspect(DOMAIN_URN_1, null);
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(
+            getTestUrn(), "dataset", "domains", from, to, getTestAuditStamp());
+
+    assertEquals(actual.size(), 1);
+    assertNotNull(actual.get(0).getDescription());
+    assertTrue(actual.get(0).getDescription().contains("engineering"));
+    assertTrue(actual.get(0).getDescription().contains(TEST_ENTITY_URN));
   }
 }

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHookTest.java
@@ -279,7 +279,7 @@ public class PlatformEventGeneratorHookTest {
             ChangeCategory.DOMAIN,
             ChangeOperation.ADD,
             domainUrn.toString(),
-            ImmutableMap.of("domainUrn", domainUrn.toString()),
+            ImmutableMap.of("domainUrn", domainUrn.toString(), "context", "{}"),
             actorUrn);
 
     verifyProducePlatformEvent(mockProducer, platformEvent);
@@ -310,7 +310,7 @@ public class PlatformEventGeneratorHookTest {
             ChangeCategory.DOMAIN,
             ChangeOperation.REMOVE,
             domainUrn.toString(),
-            ImmutableMap.of("domainUrn", domainUrn.toString()),
+            ImmutableMap.of("domainUrn", domainUrn.toString(), "context", "{}"),
             actorUrn);
 
     verifyProducePlatformEvent(mockProducer, platformEvent);

--- a/metadata-models/src/main/pegasus/com/linkedin/domain/DomainAssociation.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/domain/DomainAssociation.pdl
@@ -1,0 +1,42 @@
+namespace com.linkedin.domain
+
+import com.linkedin.common.MetadataAttribution
+import com.linkedin.common.Urn
+
+/**
+ * Properties of an applied domain association.
+ */
+record DomainAssociation {
+  /**
+   * Urn of the associated domain. Corresponds to an entry in the parallel domains array.
+   */
+  domain: Urn
+
+  /**
+   * Additional context about the association
+   */
+  context: optional string
+
+  /**
+   * Information about who, why, and how this domain was applied.
+   * sourceDetail may carry flags such as 'propagated'='true' when set via glossary tree propagation.
+   */
+  @Searchable = {
+    "/time": {
+      "fieldName": "domainAttributionDates",
+      "fieldType": "DATETIME",
+      "queryByDefault": false
+    },
+    "/actor": {
+      "fieldName": "domainAttributionActors",
+      "fieldType": "URN",
+      "queryByDefault": false
+    },
+    "/source": {
+      "fieldName": "domainAttributionSources",
+      "fieldType": "URN",
+      "queryByDefault": false
+    }
+  }
+  attribution: optional MetadataAttribution
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/domain/Domains.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/domain/Domains.pdl
@@ -28,4 +28,12 @@ record Domains {
     }
   }
   domains: array[Urn]
+
+  /**
+   * Additional per-domain association metadata such as attribution and propagation source.
+   * A superset of the domains field; entries correspond by domain URN.
+   * Initial migration handled by the DomainsMigrationMutator;
+   * the two fields are kept in sync via the DomainsSyncMutationHook.
+   */
+  domainAssociations: optional array[DomainAssociation]
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/domain/Domains.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/domain/Domains.pdl
@@ -6,7 +6,8 @@ import com.linkedin.common.Urn
  * Links from an Asset to its Domains
  */
 @Aspect = {
-  "name": "domains"
+  "name": "domains",
+  "schemaVersion": 2
 }
 record Domains {
   /**

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -338,6 +338,7 @@ entities:
       - subTypes
       - displayProperties
       - assetSettings
+      - domains
   - name: document
     category: core
     keyAspect: documentKey

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
@@ -9,6 +9,7 @@ import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.aspect.hooks.AspectMigrationMutator;
 import com.linkedin.metadata.aspect.hooks.AspectMigrationMutatorChain;
+import com.linkedin.metadata.aspect.hooks.DomainsSyncMutationHook;
 import com.linkedin.metadata.aspect.hooks.FieldPathMutator;
 import com.linkedin.metadata.aspect.hooks.IgnoreUnknownMutator;
 import com.linkedin.metadata.aspect.hooks.LifecycleStageTransitionHook;
@@ -703,6 +704,23 @@ public class SpringStandardPluginConfiguration {
                         AspectPluginConfig.EntityAspectName.builder()
                             .entityName("*")
                             .aspectName(STATUS_ASPECT_NAME)
+                            .build()))
+                .build());
+  }
+
+  @Bean
+  public MutationHook domainsSyncMutationHook() {
+    return new DomainsSyncMutationHook()
+        .setConfig(
+            AspectPluginConfig.builder()
+                .className(DomainsSyncMutationHook.class.getName())
+                .enabled(true)
+                .supportedOperations(List.of(CREATE, CREATE_ENTITY, UPSERT, UPDATE, RESTATE, PATCH))
+                .supportedEntityAspectNames(
+                    List.of(
+                        AspectPluginConfig.EntityAspectName.builder()
+                            .entityName(ALL)
+                            .aspectName(DOMAINS_ASPECT_NAME)
                             .build()))
                 .build());
   }

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/aspect/hooks/migrations/DomainsMigrationMutator.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/aspect/hooks/migrations/DomainsMigrationMutator.java
@@ -1,0 +1,72 @@
+package com.linkedin.metadata.aspect.hooks.migrations;
+
+import static com.linkedin.metadata.Constants.DOMAINS_ASPECT_NAME;
+
+import com.linkedin.common.UrnArray;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.domain.DomainAssociation;
+import com.linkedin.domain.DomainAssociationArray;
+import com.linkedin.domain.Domains;
+import com.linkedin.metadata.aspect.RetrieverContext;
+import com.linkedin.metadata.aspect.hooks.AspectMigrationMutator;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * v1 → v2 migration: backfills {@code domainAssociations} from the {@code domains} array when the
+ * field is absent. Always returns a copy for v1 aspects so the schema version gets bumped to v2,
+ * even if associations are already present (e.g. set by a new-path client writing to a v1 entity).
+ */
+@Slf4j
+@Component
+public class DomainsMigrationMutator extends AspectMigrationMutator {
+
+  @Nonnull
+  @Override
+  public String getAspectName() {
+    return DOMAINS_ASPECT_NAME;
+  }
+
+  @Override
+  public long getSourceVersion() {
+    return 1L;
+  }
+
+  @Override
+  public long getTargetVersion() {
+    return 2L;
+  }
+
+  @Nullable
+  @Override
+  protected RecordTemplate transform(
+      @Nonnull RecordTemplate sourceAspect, @Nonnull RetrieverContext context) {
+    Domains domains = new Domains(sourceAspect.data());
+
+    try {
+      Domains copy = domains.copy();
+
+      // Only backfill when associations are missing; if a new-path client already set them, keep
+      // as-is
+      if (!copy.hasDomainAssociations() || copy.getDomainAssociations().isEmpty()) {
+        UrnArray domainUrns = copy.getDomains();
+        if (domainUrns != null && !domainUrns.isEmpty()) {
+          DomainAssociationArray associations = new DomainAssociationArray();
+          for (var urn : domainUrns) {
+            DomainAssociation assoc = new DomainAssociation();
+            assoc.setDomain(urn);
+            associations.add(assoc);
+          }
+          copy.setDomainAssociations(associations);
+        }
+      }
+
+      // Always return copy so schema version gets bumped from v1 → v2
+      return copy;
+    } catch (CloneNotSupportedException e) {
+      throw new IllegalStateException("Failed to copy Domains aspect for migration", e);
+    }
+  }
+}

--- a/metadata-service/factories/src/test/java/com/linkedin/metadata/aspect/hooks/migrations/DomainsMigrationMutatorTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/metadata/aspect/hooks/migrations/DomainsMigrationMutatorTest.java
@@ -1,0 +1,116 @@
+package com.linkedin.metadata.aspect.hooks.migrations;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.domain.DomainAssociation;
+import com.linkedin.domain.DomainAssociationArray;
+import com.linkedin.domain.Domains;
+import com.linkedin.metadata.aspect.AspectRetriever;
+import com.linkedin.metadata.aspect.RetrieverContext;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import java.util.List;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class DomainsMigrationMutatorTest {
+
+  private static final Urn DOMAIN_A = UrnUtils.getUrn("urn:li:domain:a");
+  private static final Urn DOMAIN_B = UrnUtils.getUrn("urn:li:domain:b");
+
+  private RetrieverContext retrieverContext;
+
+  @BeforeMethod
+  public void setUp() {
+    EntityRegistry entityRegistry = mock(EntityRegistry.class);
+    AspectRetriever mockAspectRetriever = mock(AspectRetriever.class);
+    when(mockAspectRetriever.getEntityRegistry()).thenReturn(entityRegistry);
+    retrieverContext = mock(RetrieverContext.class);
+    when(retrieverContext.getAspectRetriever()).thenReturn(mockAspectRetriever);
+  }
+
+  @Test
+  public void testTransform_backfillsAssociationsFromDomains() {
+    DomainsMigrationMutator mutator = new DomainsMigrationMutator();
+
+    Domains original = makeDomains(DOMAIN_A, DOMAIN_B);
+
+    RecordTemplate result = mutator.transform(original, retrieverContext);
+
+    assertNotNull(result);
+    Domains migrated = new Domains(result.data());
+    assertTrue(migrated.hasDomainAssociations());
+    DomainAssociationArray assocs = migrated.getDomainAssociations();
+    assertEquals(assocs.size(), 2);
+    assertEquals(assocs.get(0).getDomain(), DOMAIN_A);
+    assertEquals(assocs.get(1).getDomain(), DOMAIN_B);
+    // Empty attribution
+    assertTrue(!assocs.get(0).hasAttribution());
+  }
+
+  @Test
+  public void testTransform_emptyDomains_returnsCopy() {
+    DomainsMigrationMutator mutator = new DomainsMigrationMutator();
+
+    Domains original = makeDomains();
+
+    RecordTemplate result = mutator.transform(original, retrieverContext);
+
+    // Still returns a copy so version gets bumped
+    assertNotNull(result);
+    Domains migrated = new Domains(result.data());
+    assertTrue(!migrated.hasDomainAssociations() || migrated.getDomainAssociations().isEmpty());
+  }
+
+  @Test
+  public void testTransform_associationsAlreadyPresent_keepsThem() {
+    DomainsMigrationMutator mutator = new DomainsMigrationMutator();
+
+    DomainAssociation existingAssoc = new DomainAssociation();
+    existingAssoc.setDomain(DOMAIN_A);
+    existingAssoc.setContext("user-set");
+
+    Domains original = makeDomains(DOMAIN_A);
+    original.setDomainAssociations(new DomainAssociationArray(List.of(existingAssoc)));
+
+    RecordTemplate result = mutator.transform(original, retrieverContext);
+
+    assertNotNull(result);
+    Domains migrated = new Domains(result.data());
+    assertEquals(migrated.getDomainAssociations().size(), 1);
+    assertEquals(migrated.getDomainAssociations().get(0).getContext(), "user-set");
+  }
+
+  @Test
+  public void testTransform_doesNotMutateOriginal() {
+    DomainsMigrationMutator mutator = new DomainsMigrationMutator();
+
+    Domains original = makeDomains(DOMAIN_A);
+
+    mutator.transform(original, retrieverContext);
+
+    // Original should not have domainAssociations set
+    assertTrue(!original.hasDomainAssociations());
+  }
+
+  @Test
+  public void testAspectNameAndVersions() {
+    DomainsMigrationMutator mutator = new DomainsMigrationMutator();
+    assertEquals(mutator.getAspectName(), "domains");
+    assertEquals(mutator.getSourceVersion(), 1L);
+    assertEquals(mutator.getTargetVersion(), 2L);
+  }
+
+  private static Domains makeDomains(Urn... urns) {
+    Domains domains = new Domains();
+    domains.setDomains(new UrnArray(List.of(urns)));
+    return domains;
+  }
+}

--- a/smoke-test/tests/patch/test_domain_patches.py
+++ b/smoke-test/tests/patch/test_domain_patches.py
@@ -1,0 +1,299 @@
+import logging
+import time
+import uuid
+from typing import Generator, cast
+
+import pytest
+
+from datahub.configuration.common import OperationalError
+from datahub.emitter.mce_builder import make_dataset_urn
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.graph.client import DataHubGraph
+from datahub.metadata.schema_classes import (
+    DomainAssociationClass,
+    DomainsClass,
+    MetadataAttributionClass,
+)
+from datahub.specific.dataset import DatasetPatchBuilder
+
+logger = logging.getLogger(__name__)
+
+
+def _make_domain_urn() -> str:
+    return f"urn:li:domain:{uuid.uuid4()}"
+
+
+def _make_domain_association(
+    domain_urn: str,
+    source: str = "",
+    propagated: bool = False,
+) -> DomainAssociationClass:
+    now_ms = int(time.time() * 1000)
+    source_detail = {"propagated": "true"} if propagated else None
+    attribution = MetadataAttributionClass(
+        time=now_ms,
+        actor="urn:li:corpuser:datahub",
+        source=source if source else "urn:li:dataHubAction:default",
+        sourceDetail=source_detail,
+    )
+    if not source and not propagated:
+        return DomainAssociationClass(domain=domain_urn)
+    return DomainAssociationClass(
+        domain=domain_urn, context="context", attribution=attribution
+    )
+
+
+def _get_domains(graph_client: DataHubGraph, entity_urn: str) -> DomainsClass:
+    aspect = graph_client.get_aspect(
+        entity_urn=entity_urn,
+        aspect_type=DomainsClass,
+    )
+    assert aspect is not None
+    return aspect
+
+
+@pytest.fixture(params=["graph_client", "openapi_graph_client"])
+def patch_dataset(request) -> Generator[tuple[DataHubGraph, str], None, None]:
+    """Yields (graph_client, dataset_urn). The dataset is hard-deleted after the test."""
+    graph_client = cast(DataHubGraph, request.getfixturevalue(request.param))
+    dataset_urn = make_dataset_urn(
+        platform="hive", name=f"SampleHiveDataset-{uuid.uuid4()}", env="PROD"
+    )
+    yield graph_client, dataset_urn
+    graph_client.hard_delete_entity(dataset_urn)
+
+
+def test_add_remove_via_domains_updates_domain_associations(patch_dataset):
+    """Adding/removing entries in `domains` (legacy field) should sync to domainAssociations."""
+    graph_client, dataset_urn = patch_dataset
+
+    domain_a = _make_domain_urn()
+    domain_b = _make_domain_urn()
+
+    # Seed with one domain.
+    graph_client.emit_mcp(
+        MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=DomainsClass(domains=[domain_a]),
+        )
+    )
+
+    aspect = _get_domains(graph_client, dataset_urn)
+    assert aspect.domains == [domain_a]
+    assert aspect.domainAssociations is not None
+    assoc_domains = {a.domain for a in aspect.domainAssociations}
+    assert assoc_domains == {domain_a}
+
+    # Add a second domain via full-replace of the domains field.
+    graph_client.emit_mcp(
+        MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=DomainsClass(domains=[domain_a, domain_b]),
+        )
+    )
+
+    aspect = _get_domains(graph_client, dataset_urn)
+    assert aspect.domains == [domain_a, domain_b]
+    assert aspect.domainAssociations is not None
+    assoc_domains = {a.domain for a in aspect.domainAssociations}
+    assert assoc_domains == {domain_a, domain_b}
+
+    # Remove domain_a by writing only domain_b.
+    graph_client.emit_mcp(
+        MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=DomainsClass(domains=[domain_b]),
+        )
+    )
+
+    aspect = _get_domains(graph_client, dataset_urn)
+    assert aspect.domains == [domain_b]
+    assert aspect.domainAssociations is not None
+    assoc_domains = {a.domain for a in aspect.domainAssociations}
+    assert assoc_domains == {domain_b}
+
+
+def test_add_remove_via_domain_associations_patch_updates_domains(patch_dataset):
+    """Adding/removing entries via domainAssociations patch
+    should sync to the domains field and preserve attribution."""
+    graph_client, dataset_urn = patch_dataset
+
+    source = "urn:li:dataHubAction:testSource"
+    domain_a = _make_domain_urn()
+    domain_b = _make_domain_urn()
+
+    # Add domain_a via patch with a source.
+    for mcp in (
+        DatasetPatchBuilder(dataset_urn)
+        .add_domain(_make_domain_association(domain_a, source=source))
+        .build()
+    ):
+        graph_client.emit_mcp(mcp)
+
+    aspect = _get_domains(graph_client, dataset_urn)
+    assert aspect.domains == [domain_a]
+    assert aspect.domainAssociations is not None and len(aspect.domainAssociations) == 1
+    assoc_a = aspect.domainAssociations[0]
+    assert assoc_a.domain == domain_a
+    assert assoc_a.attribution is not None
+    assert assoc_a.attribution.source == source
+    assert assoc_a.context == "context"
+
+    # Add domain_b via patch
+    for mcp in (
+        DatasetPatchBuilder(dataset_urn)
+        .add_domain(_make_domain_association(domain_b))
+        .build()
+    ):
+        graph_client.emit_mcp(mcp)
+
+    aspect = _get_domains(graph_client, dataset_urn)
+    expected_domains = [domain_a, domain_b]
+    assert aspect.domains == expected_domains
+    assert {a.domain for a in (aspect.domainAssociations or [])} == set(
+        expected_domains
+    )
+
+    # Remove domain_a via patch.
+    for mcp in (
+        DatasetPatchBuilder(dataset_urn)
+        .remove_domain(domain_a, attribution_source=source)
+        .build()
+    ):
+        graph_client.emit_mcp(mcp)
+
+    aspect = _get_domains(graph_client, dataset_urn)
+    assert aspect.domains == [domain_b]
+    assert aspect.domainAssociations is not None
+    assert {a.domain for a in (aspect.domainAssociations or [])} == {domain_b}
+
+
+def test_add_remove_via_domain_associations_upsert_updates_domains(patch_dataset):
+    """Adding/removing entries via full-replace domainAssociations
+    should sync to the domains field and preserve attribution."""
+    graph_client, dataset_urn = patch_dataset
+
+    source = "urn:li:dataHubAction:testSource"
+    domain_a = _make_domain_urn()
+    domain_b = _make_domain_urn()
+
+    assoc_a = _make_domain_association(domain_a, source=source)
+
+    # Write domain_a via full-replace with domainAssociations.
+    graph_client.emit_mcp(
+        MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=DomainsClass(domains=[], domainAssociations=[assoc_a]),
+        )
+    )
+
+    aspect = _get_domains(graph_client, dataset_urn)
+    assert aspect.domains == [domain_a]
+    assert aspect.domainAssociations is not None and len(aspect.domainAssociations) == 1
+    read_assoc = aspect.domainAssociations[0]
+    assert read_assoc.domain == domain_a
+    assert read_assoc.attribution is not None
+    assert read_assoc.attribution.source == source
+    assert read_assoc.context == "context"
+
+    # Add domain_b via full-replace, keeping domain_a.
+    assoc_b = _make_domain_association(domain_b)
+    graph_client.emit_mcp(
+        MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=DomainsClass(domains=[], domainAssociations=[assoc_a, assoc_b]),
+        )
+    )
+
+    aspect = _get_domains(graph_client, dataset_urn)
+    expected_domains = [domain_a, domain_b]
+    assert aspect.domains == expected_domains
+    assert {a.domain for a in (aspect.domainAssociations or [])} == set(
+        expected_domains
+    )
+
+    # Remove domain_a by writing only domain_b.
+    graph_client.emit_mcp(
+        MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=DomainsClass(domains=[], domainAssociations=[assoc_b]),
+        )
+    )
+
+    aspect = _get_domains(graph_client, dataset_urn)
+    assert aspect.domains == [domain_b]
+    assert aspect.domainAssociations is not None
+    assert {a.domain for a in (aspect.domainAssociations or [])} == {domain_b}
+
+
+def test_updating_both_domains_and_domain_associations_errors(patch_dataset):
+    """Writing a Domains aspect where both `domains` and `domainAssociations`
+    are present with inconsistent URNs AND the domains field changed from
+    the previous value should result in an error."""
+    graph_client, dataset_urn = patch_dataset
+
+    domain_a = _make_domain_urn()
+    domain_b = _make_domain_urn()
+
+    # Seed with domain_a.
+    graph_client.emit_mcp(
+        MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=DomainsClass(domains=[domain_a]),
+        )
+    )
+
+    # Attempt to write inconsistent domains and domainAssociations:
+    # domains says [domain_b] but domainAssociations says [domain_a].
+    inconsistent_aspect = DomainsClass(
+        domains=[domain_b],
+        domainAssociations=[DomainAssociationClass(domain=domain_a)],
+    )
+
+    with pytest.raises(OperationalError, match="Cannot update both"):
+        graph_client.emit_mcp(
+            MetadataChangeProposalWrapper(
+                entityUrn=dataset_urn, aspect=inconsistent_aspect
+            )
+        )
+
+
+def test_propagated_domains_ordered_after_manual(patch_dataset):
+    """Propagated domain associations should always appear after manual ones
+    in both domainAssociations and domains."""
+    graph_client, dataset_urn = patch_dataset
+
+    domain_manual = _make_domain_urn()
+    domain_propagated = _make_domain_urn()
+
+    # Write both a propagated and manual association via full-replace.
+    # Intentionally put the propagated one first to verify reordering.
+    assoc_propagated = _make_domain_association(domain_propagated, propagated=True)
+    assoc_manual = _make_domain_association(domain_manual)
+
+    graph_client.emit_mcp(
+        MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=DomainsClass(
+                domains=[domain_manual, domain_propagated],
+                domainAssociations=[assoc_propagated, assoc_manual],
+            ),
+        )
+    )
+
+    aspect = _get_domains(graph_client, dataset_urn)
+
+    # domains field should have manual first, then propagated
+    assert aspect.domains == [domain_manual, domain_propagated]
+
+    # domainAssociations should have both, with manual first
+    assert aspect.domainAssociations is not None
+    assert len(aspect.domainAssociations) == 2
+    assert aspect.domainAssociations[0].domain == domain_manual
+    assert aspect.domainAssociations[1].domain == domain_propagated
+    assert (
+        aspect.domainAssociations[1].attribution is not None
+        and aspect.domainAssociations[1].attribution.sourceDetail is not None
+        and aspect.domainAssociations[1].attribution.sourceDetail.get("propagated")
+        == "true"
+    )

--- a/smoke-test/tests/patch/test_domain_patches.py
+++ b/smoke-test/tests/patch/test_domain_patches.py
@@ -228,8 +228,7 @@ def test_add_remove_via_domain_associations_upsert_updates_domains(patch_dataset
 
 def test_updating_both_domains_and_domain_associations_errors(patch_dataset):
     """Writing a Domains aspect where both `domains` and `domainAssociations`
-    are present with inconsistent URNs AND the domains field changed from
-    the previous value should result in an error."""
+    actually changed from previous and are inconsistent should result in an error."""
     graph_client, dataset_urn = patch_dataset
 
     domain_a = _make_domain_urn()
@@ -243,11 +242,11 @@ def test_updating_both_domains_and_domain_associations_errors(patch_dataset):
         )
     )
 
-    # Attempt to write inconsistent domains and domainAssociations:
-    # domains says [domain_b] but domainAssociations says [domain_a].
+    # Both fields differ from previous and are inconsistent with each other:
+    # domains says [domain_b] but domainAssociations says [domain_c].
     inconsistent_aspect = DomainsClass(
         domains=[domain_b],
-        domainAssociations=[DomainAssociationClass(domain=domain_a)],
+        domainAssociations=[],
     )
 
     with pytest.raises(OperationalError, match="Cannot update both"):
@@ -256,6 +255,86 @@ def test_updating_both_domains_and_domain_associations_errors(patch_dataset):
                 entityUrn=dataset_urn, aspect=inconsistent_aspect
             )
         )
+
+
+def test_read_modify_write_domains_updates_associations(patch_dataset):
+    """Read-modify-write on `domains` should sync domainAssociations,
+    even though the read-back aspect has domainAssociations populated."""
+    graph_client, dataset_urn = patch_dataset
+
+    domain_a = _make_domain_urn()
+    domain_b = _make_domain_urn()
+
+    # Seed with domain_a.
+    graph_client.emit_mcp(
+        MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=DomainsClass(domains=[domain_a]),
+        )
+    )
+
+    # Read back the full aspect — both fields are now populated.
+    aspect = _get_domains(graph_client, dataset_urn)
+    assert aspect.domains == [domain_a]
+    assert aspect.domainAssociations is not None
+    assert len(aspect.domainAssociations) == 1
+
+    # Simulate read-modify-write: change only domains, leave domainAssociations stale.
+    aspect.domains = [domain_a, domain_b]
+
+    graph_client.emit_mcp(
+        MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=aspect,
+        )
+    )
+
+    result = _get_domains(graph_client, dataset_urn)
+    assert set(result.domains) == {domain_a, domain_b}
+    assert result.domainAssociations is not None
+    assoc_domains = {a.domain for a in result.domainAssociations}
+    assert assoc_domains == {domain_a, domain_b}
+
+
+def test_read_modify_write_associations_updates_domains(patch_dataset):
+    """Read-modify-write on `domainAssociations` should sync domains,
+    even though the read-back aspect has domains populated."""
+    graph_client, dataset_urn = patch_dataset
+
+    domain_a = _make_domain_urn()
+    domain_b = _make_domain_urn()
+
+    # Seed with domain_a.
+    graph_client.emit_mcp(
+        MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=DomainsClass(domains=[domain_a]),
+        )
+    )
+
+    # Read back the full aspect — both fields are now populated.
+    aspect = _get_domains(graph_client, dataset_urn)
+    assert aspect.domains == [domain_a]
+    assert aspect.domainAssociations is not None
+
+    # Simulate read-modify-write: change only domainAssociations, leave domains stale.
+    aspect.domainAssociations = [
+        DomainAssociationClass(domain=domain_a),
+        DomainAssociationClass(domain=domain_b),
+    ]
+
+    graph_client.emit_mcp(
+        MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=aspect,
+        )
+    )
+
+    result = _get_domains(graph_client, dataset_urn)
+    assert set(result.domains) == {domain_a, domain_b}
+    assert result.domainAssociations is not None
+    assoc_domains = {a.domain for a in result.domainAssociations}
+    assert assoc_domains == {domain_a, domain_b}
 
 
 def test_propagated_domains_ordered_after_manual(patch_dataset):


### PR DESCRIPTION
Add attribution info to domains just like tags, terms, ownership, structured properties, etc. Because we have the existing `domains` field, this is done by adding a new `domainAssociations` field that is kept in sync with the existing field via a mutation hook (and migration mutator to handle migrating old data).  Also updates change event generator to pass context and patching logic to operate on domainAssociations.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
