### PR TITLE
fix(patch/domains): Add back setDomain method on Java patch builder for backwards compatibility

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/builder/DomainsPatchBuilder.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/builder/DomainsPatchBuilder.java
@@ -37,6 +37,17 @@ public class DomainsPatchBuilder extends AbstractMultiFieldPatchBuilder<DomainsP
           "domainAssociations",
           Collections.unmodifiableList(Arrays.asList(DOMAIN_KEY, ATTRIBUTION_SOURCE_KEY)));
 
+  public DomainsPatchBuilder setDomain(@Nonnull Urn urn) {
+    // remove existing list of domains to set the new one
+    this.pathValues.add(ImmutableTriple.of(PatchOperationType.REMOVE.getValue(), BASE_PATH, null));
+    // add empty domains object node
+    pathValues.add(
+        ImmutableTriple.of(PatchOperationType.ADD.getValue(), BASE_PATH, instance.objectNode()));
+    // set the new domain
+    addDomain(urn, null);
+    return this;
+  }
+
   public DomainsPatchBuilder addDomain(@Nonnull Urn domainUrn, @Nullable String context) {
     ObjectNode value = instance.objectNode();
     value.put(DOMAIN_KEY, domainUrn.toString());


### PR DESCRIPTION
Accidentally removed this in a previous PR. This adds it back, but with the new base path.
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
