### PR TITLE
feat(ingestion/iceberg): add ingest_empty_namespaces to skip namespaces with no selected tables

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
@@ -3,7 +3,7 @@ import logging
 import threading
 import uuid
 from functools import partial
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Generator, Iterable, List, Optional, Tuple
 
 from dateutil import parser as dateutil_parser
 from pyiceberg.catalog import Catalog
@@ -160,7 +160,6 @@ class IcebergSource(StatefulIngestionSourceBase):
         self.stamping_processor = AutoSystemMetadata(
             self.ctx
         )  # single instance used only when processing namespaces
-        self.namespaces: List[Tuple[Identifier, str]] = []
 
     @classmethod
     def create(cls, config_dict: Dict, ctx: PipelineContext) -> "IcebergSource":
@@ -230,43 +229,57 @@ class IcebergSource(StatefulIngestionSourceBase):
                 continue
             yield namespace
 
-    def _get_datasets(
-        self, catalog: Catalog, namespaces: Iterable[Tuple[Identifier, str]]
-    ) -> Iterable[Tuple[Identifier, str]]:
-        LOGGER.debug("Starting to retrieve tables")
-        tables_count = 0
-        for namespace, namespace_urn in namespaces:
-            try:
-                tables = catalog.list_tables(namespace)
-                tables_count += len(tables)
+    def _list_allowed_tables(
+        self, catalog: Catalog, namespace: Identifier
+    ) -> Optional[List[Identifier]]:
+        """List the tables in a namespace that pass ``table_pattern``.
+
+        Returns ``None`` if the namespace's tables could not be listed (the
+        failure is reported); otherwise returns the allowed table identifiers
+        (possibly empty). Tables rejected by ``table_pattern`` are reported as
+        dropped here, so they never reach dataset processing — and an empty
+        result lets the caller skip emitting an otherwise-empty namespace.
+        """
+        namespace_repr = ".".join(namespace)
+        try:
+            tables = catalog.list_tables(namespace)
+        except NoSuchNamespaceError as e:
+            self.report.warning(
+                title="No such namespace",
+                message="Skipping the missing namespace.",
+                context=namespace_repr,
+                exc=e,
+            )
+            return None
+        except RESTError as e:
+            self.report.warning(
+                title="Iceberg REST Server Error",
+                message="Iceberg REST Server returned error status when trying to list tables for a namespace, skipping it.",
+                context=namespace_repr,
+                exc=e,
+            )
+            return None
+        except Exception as e:
+            self.report.report_failure(
+                title="Error when processing a namespace",
+                message="Skipping the namespace due to errors while processing it.",
+                context=namespace_repr,
+                exc=e,
+            )
+            return None
+
+        self.report.report_listed_tables_for_namespace(namespace_repr, len(tables))
+        allowed_tables: List[Identifier] = []
+        for table in tables:
+            table_name = ".".join(table)
+            if self.config.table_pattern.allowed(table_name):
+                allowed_tables.append(table)
+            else:
+                self.report.report_dropped(table_name)
                 LOGGER.debug(
-                    f"Retrieved {len(tables)} tables for namespace: {namespace}, in total retrieved {tables_count}, first 10: {tables[:10]}"
+                    f"Skipping table {table_name} due to not being allowed by the config pattern"
                 )
-                self.report.report_listed_tables_for_namespace(
-                    ".".join(namespace), len(tables)
-                )
-                yield from [(table, namespace_urn) for table in tables]
-            except NoSuchNamespaceError as e:
-                self.report.warning(
-                    title="No such namespace",
-                    message="Skipping the missing namespace.",
-                    context=str(namespace),
-                    exc=e,
-                )
-            except RESTError as e:
-                self.report.warning(
-                    title="Iceberg REST Server Error",
-                    message="Iceberg REST Server returned error status when trying to list tables for a namespace, skipping it.",
-                    context=str(namespace),
-                    exc=e,
-                )
-            except Exception as e:
-                self.report.report_failure(
-                    title="Error when processing a namespace",
-                    message="Skipping the namespace due to errors while processing it.",
-                    context=str(namespace),
-                    exc=e,
-                )
+        return allowed_tables
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         thread_local = threading.local()
@@ -365,15 +378,9 @@ class IcebergSource(StatefulIngestionSourceBase):
         ) -> Iterable[MetadataWorkUnit]:
             try:
                 LOGGER.debug(f"Processing dataset for path {dataset_path}")
+                # table_pattern filtering already happened in _list_allowed_tables,
+                # so every dataset reaching here is one we intend to ingest.
                 dataset_name = ".".join(dataset_path)
-                if not self.config.table_pattern.allowed(dataset_name):
-                    # Dataset name is rejected by pattern, report as dropped.
-                    self.report.report_dropped(dataset_name)
-                    LOGGER.debug(
-                        f"Skipping table {dataset_name} due to not being allowed by the config pattern"
-                    )
-                    return
-
                 yield from _try_processing_dataset(
                     dataset_path, dataset_name, namespace_urn
                 )
@@ -396,7 +403,7 @@ class IcebergSource(StatefulIngestionSourceBase):
             return
 
         try:
-            yield from self._process_namespaces()
+            dataset_args = yield from self._process_namespaces_and_collect_datasets()
         except Exception as e:
             self.report.report_failure(
                 title="Failed to list namespaces",
@@ -407,19 +414,55 @@ class IcebergSource(StatefulIngestionSourceBase):
 
         for wu in ThreadedIteratorExecutor.process(
             worker_func=_process_dataset,
-            args_list=[
-                (dataset_path, namespace_urn)
-                for dataset_path, namespace_urn in self._get_datasets(
-                    self.catalog, self.namespaces
-                )
-            ],
+            args_list=dataset_args,
             max_workers=self.config.processing_threads,
         ):
             yield wu
 
+    def _process_namespaces_and_collect_datasets(
+        self,
+    ) -> Generator[MetadataWorkUnit, None, List[Tuple[Identifier, str]]]:
+        """Emit namespace containers and collect the datasets to ingest.
+
+        A namespace container is emitted only when the namespace has at least one
+        table matching ``table_pattern`` (or ``ingest_empty_namespaces`` is set).
+        This prevents emitting metadata for thousands of unrelated namespaces when
+        ``table_pattern`` is narrow. Returns the ``(table, namespace_urn)`` pairs
+        whose datasets should be processed.
+        """
+        dataset_args: List[Tuple[Identifier, str]] = []
+        for namespace in self._get_namespaces(self.catalog):
+            allowed_tables = self._list_allowed_tables(self.catalog, namespace)
+            if (
+                allowed_tables is not None
+                and not allowed_tables
+                and not self.config.ingest_empty_namespaces
+            ):
+                # Successfully listed the namespace but none of its tables match
+                # table_pattern — skip it so we don't emit metadata for thousands
+                # of unrelated namespaces. (A listing failure, allowed_tables is
+                # None, still emits the container as before.)
+                LOGGER.debug(
+                    f"Skipping namespace {'.'.join(namespace)}: no tables match "
+                    "table_pattern and ingest_empty_namespaces is disabled"
+                )
+                continue
+            namespace_urn = yield from self._try_processing_namespace(namespace)
+            if namespace_urn is None:
+                # Namespace container emission failed; skip its datasets.
+                continue
+            if allowed_tables:
+                dataset_args.extend((table, namespace_urn) for table in allowed_tables)
+        return dataset_args
+
     def _try_processing_namespace(
         self, namespace: Identifier
-    ) -> Iterable[MetadataWorkUnit]:
+    ) -> Generator[MetadataWorkUnit, None, Optional[str]]:
+        """Emit a namespace's container aspects and return its container URN.
+
+        Returns the namespace container URN on success, or ``None`` if the
+        namespace could not be processed (the failure is reported).
+        """
         namespace_repr = ".".join(namespace)
         try:
             LOGGER.debug(f"Processing namespace {namespace_repr}")
@@ -443,7 +486,7 @@ class IcebergSource(StatefulIngestionSourceBase):
                         entityUrn=namespace_urn, aspect=aspect
                     ).as_workunit()
                 )
-            self.namespaces.append((namespace, namespace_urn))
+            return namespace_urn
         except NoSuchNamespaceError as e:
             self.report.report_warning(
                 title="Failed to retrieve namespace properties",
@@ -451,7 +494,7 @@ class IcebergSource(StatefulIngestionSourceBase):
                 context=namespace_repr,
                 exc=e,
             )
-            return
+            return None
         except RESTError as e:
             self.report.warning(
                 title="Iceberg REST Server Error",
@@ -459,6 +502,7 @@ class IcebergSource(StatefulIngestionSourceBase):
                 context=str(namespace),
                 exc=e,
             )
+            return None
         except Exception as e:
             self.report.report_failure(
                 title="Failed to process namespace",
@@ -466,13 +510,7 @@ class IcebergSource(StatefulIngestionSourceBase):
                 context=namespace_repr,
                 exc=e,
             )
-
-    def _process_namespaces(self) -> Iterable[MetadataWorkUnit]:
-        namespace_ids = self._get_namespaces(self.catalog)
-        for namespace in namespace_ids:
-            yield from self._try_processing_namespace(namespace)
-
-        LOGGER.debug("Namespaces ingestion completed")
+            return None
 
     def _create_iceberg_table_aspects(
         self, dataset_name: str, table: Table, namespace_urn: str

--- a/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg_common.py
@@ -113,6 +113,18 @@ class IcebergSourceConfig(StatefulIngestionConfigBase, DatasetSourceConfigMixin)
         default=AllowDenyPattern.allow_all(),
         description="Regex patterns for namespaces to filter in ingestion.",
     )
+    ingest_empty_namespaces: bool = Field(
+        default=True,
+        description=(
+            "Whether to emit container entities for namespaces that contain no "
+            "tables matching `table_pattern`. When `True` (default), every namespace "
+            "allowed by `namespace_pattern` is cataloged, consistent with how the "
+            "SQL sources emit schema/database containers. Set to `False` to skip "
+            "namespaces that have no selected tables — useful for catalogs with "
+            "thousands of namespaces where a narrow `table_pattern` would otherwise "
+            "emit metadata for many unrelated namespaces."
+        ),
+    )
     user_ownership_property: Optional[str] = Field(
         default="owner",
         description="Iceberg table property to look for a `CorpUser` owner.  Can only hold a single user value.  If property has no value, no owner information will be emitted.",

--- a/metadata-ingestion/tests/unit/test_iceberg.py
+++ b/metadata-ingestion/tests/unit/test_iceberg.py
@@ -1240,7 +1240,8 @@ def test_proper_run_with_multiple_namespaces() -> None:
     ) as get_catalog:
         get_catalog.return_value = mock_catalog
         wu: List[MetadataWorkUnit] = [*source.get_workunits_internal()]
-        # ingested 1 table (6 MCPs) and 2 namespaces (4 MCPs each), despite exception
+        # ingested 1 table (6 MCPs) and 2 namespaces (4 MCPs each) — the empty
+        # namespaceB is still cataloged by default (ingest_empty_namespaces=True)
         expected_wu_urns = [
             "urn:li:dataset:(urn:li:dataPlatform:iceberg,namespaceA.table1,PROD)",
         ] * MCPS_PER_TABLE + [
@@ -1256,6 +1257,59 @@ def test_proper_run_with_multiple_namespaces() -> None:
             urns,
             expected_wu_urns,
         )
+
+
+def test_empty_namespaces_skipped_when_opted_out() -> None:
+    # namespaceA has a matching table; namespaceB is empty. By default both are
+    # emitted (consistent with the SQL sources); setting ingest_empty_namespaces
+    # to False skips the empty namespaceB to avoid fan-out on large catalogs.
+    def _catalog() -> MockCatalog:
+        return MockCatalog(
+            {
+                "namespaceA": {
+                    "table1": lambda catalog: Table(
+                        identifier=("namespaceA", "table1"),
+                        metadata=TableMetadataV2(
+                            partition_specs=[PartitionSpec(spec_id=0)],
+                            location="s3://abcdefg/namespaceA/table1",
+                            last_column_id=0,
+                            schemas=[Schema(schema_id=0)],
+                            current_schema_id=0,
+                        ),
+                        metadata_location="s3://abcdefg/namespaceA/table1",
+                        io=PyArrowFileIO(),
+                        catalog=catalog,
+                    )
+                },
+                "namespaceB": {},
+            }
+        )
+
+    namespace_a_urn = "urn:li:container:390e031441265aae5b7b7ae8d51b0c1f"
+    namespace_b_urn = "urn:li:container:74727446a56420d80ff3b1abf2a18087"
+
+    def _emitted_urns(source: IcebergSource) -> set:
+        with patch(
+            "datahub.ingestion.source.iceberg.iceberg.IcebergSourceConfig.get_catalog"
+        ) as get_catalog:
+            get_catalog.return_value = _catalog()
+            return {
+                wu.metadata.entityUrn
+                for wu in source.get_workunits_internal()
+                if isinstance(wu.metadata, MetadataChangeProposalWrapper)
+            }
+
+    # Default (ingest_empty_namespaces=True): both namespaces are emitted.
+    default_urns = _emitted_urns(with_iceberg_source(processing_threads=1))
+    assert namespace_a_urn in default_urns
+    assert namespace_b_urn in default_urns
+
+    # Opt-out: the empty namespaceB is skipped.
+    opted_out_urns = _emitted_urns(
+        with_iceberg_source(processing_threads=1, ingest_empty_namespaces=False)
+    )
+    assert namespace_a_urn in opted_out_urns
+    assert namespace_b_urn not in opted_out_urns
 
 
 def test_filtering() -> None:


### PR DESCRIPTION
## Summary

Iceberg REST catalogs can expose a very large number of namespaces. Because namespace emission is gated only by `namespace_pattern` (not `table_pattern`), a recipe that selects a single table via `table_pattern` still emits a container — 5 aspects (status / containerProperties / subTypes / dataPlatformInstance / browsePathsV2) — for **every** namespace allowed by `namespace_pattern`, plus a `list_tables` + `load_namespace_properties` round-trip each. For a catalog with thousands of namespaces that is tens of thousands of MCPs (and a lot of wasted catalog calls) for a single ingested table, and it adds payload pressure on size-limited emit paths.

This is the same behavior the SQL sources have today — `sql_common` emits schema/database containers per `schema_pattern`/`database_pattern`, not `table_pattern`. The difference is scale: SQL schemas number in the tens, while Iceberg REST namespaces can be in the thousands.

## Change

Adds an `ingest_empty_namespaces` config, **default `True`** — so the default behavior is unchanged and stays consistent with the SQL sources. Set it to `False` to emit a namespace container only when at least one of its tables matches `table_pattern`:

- `table_pattern` filtering moves up into table listing (rejected tables are reported as dropped there), so namespaces with no selected tables are skipped before their container is built.
- A namespace whose table listing *fails* still emits its container, as before.

## Notes

- This is **opt-out**: no behavior change for existing users; high-cardinality catalogs can set `ingest_empty_namespaces: false`.
- Not a cosmetic fix — the UI already hides childless browse containers. The point is to avoid emitting / storing / indexing (and making per-namespace catalog calls for) thousands of unrelated namespace entities on a narrow ingestion, and to ease payload pressure on size-capped emit paths.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
