### PR TITLE
feat(ingest/glue): classify views and extract view lineage

### DIFF
--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -619,6 +619,7 @@ glue = [
     "cachetools<6.0.0",
     "patchy==2.8.0",
     "sqlglot[c]==30.8.0",
+    "sqlparse<0.6.0",
     "urllib3>=1.26,<3.0",
 ]
 

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -679,7 +679,8 @@ plugins: Dict[str, Set[str]] = {
     "flink": {"requests<3.0.0", "tenacity>=8.0.1,<9.0.0"},
     "grafana": {"requests<3.0.0", *sqlglot_lib},
     "omni": {"requests<3.0.0", "PyYAML>=5.4"},
-    "glue": aws_common | cachetools_lib | sqlglot_lib,
+    # usage_common (sqlparse) is required by SqlParsingAggregator, used for view lineage.
+    "glue": aws_common | cachetools_lib | sqlglot_lib | usage_common,
     # hdbcli is supported officially by SAP, sqlalchemy-hana is built on top but not officially supported
     "hana": sql_common
     | {

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -75,6 +75,10 @@ from datahub.ingestion.source.aws.s3_util import (
 from datahub.ingestion.source.aws.tag_entities import (
     LakeFormationTagPlatformResourceId,
 )
+from datahub.ingestion.source.common.presto_view_decoder import (
+    decode_presto_view,
+    is_presto_view,
+)
 from datahub.ingestion.source.common.subtypes import (
     DatasetContainerSubTypes,
     DatasetSubTypes,
@@ -135,6 +139,11 @@ from datahub.metadata.schema_classes import (
     TimeStampClass,
     UpstreamClass,
     UpstreamLineageClass,
+    ViewPropertiesClass,
+)
+from datahub.sql_parsing.sql_parsing_aggregator import (
+    SqlAggregatorReport,
+    SqlParsingAggregator,
 )
 from datahub.sql_parsing.sqlglot_lineage import create_lineage_sql_parsed_result
 from datahub.utilities.delta import delta_type_to_hive_type
@@ -293,6 +302,16 @@ class GlueSourceConfig(
         description="When enabled, column-level lineage will be extracted between Glue table columns and storage location fields.",
     )
 
+    include_view_lineage: bool = Field(
+        default=True,
+        description=(
+            "When enabled, the SQL definition of each Glue view (TableType "
+            "VIRTUAL_VIEW, e.g. Athena/Presto views) is parsed to extract upstream "
+            "table/view lineage, including column-level lineage. Referenced tables "
+            "must also be ingested for the lineage to resolve to DataHub entities."
+        ),
+    )
+
     extract_column_parameters: bool = Field(
         default=False,
         description=(
@@ -363,8 +382,13 @@ class GlueSourceConfig(
 class GlueSourceReport(StaleEntityRemovalSourceReport):
     catalog_id: Optional[str] = None
     tables_scanned = 0
+    views_scanned = 0
     filtered: LossyList[str] = dataclass_field(default_factory=LossyList)
     databases: EntityFilterReport = EntityFilterReport.field(type="database")
+
+    # Surfaces SQL-parsing metrics/warnings (e.g. view definitions that failed to
+    # parse) when view lineage is enabled; None otherwise.
+    sql_aggregator: Optional[SqlAggregatorReport] = None
 
     num_job_script_location_missing: int = 0
     num_job_script_location_invalid: int = 0
@@ -377,6 +401,9 @@ class GlueSourceReport(StaleEntityRemovalSourceReport):
 
     def report_table_scanned(self) -> None:
         self.tables_scanned += 1
+
+    def report_view_scanned(self) -> None:
+        self.views_scanned += 1
 
     def report_table_dropped(self, table: str) -> None:
         self.filtered.append(table)
@@ -408,6 +435,19 @@ class ResolvedLakeFormationTags:
 
     direct: List[LakeFormationTag]
     propagated: List[LakeFormationTag]
+
+
+@dataclass
+class GlueViewDefinition:
+    """SQL definition of a Glue view and the SQL dialect it is written in.
+
+    Glue catalogs hold views from two engines: Athena/Presto views (base64-encoded
+    Trino SQL) and raw Spark/Hive views (Spark SQL). Lineage parsing must use the
+    matching dialect, so we carry it alongside the SQL.
+    """
+
+    sql: str
+    dialect: str
 
 
 @platform_name("Glue")
@@ -450,6 +490,17 @@ class GlueSource(StatefulIngestionSourceBase):
 
     lf_tag_cache: Dict[str, Dict[str, List[str]]] = {}
 
+    # Glue marks views (Athena/Presto or Spark/Hive views registered in the
+    # catalog) with this TableType. Everything else is a table.
+    _VIRTUAL_VIEW_TABLE_TYPE = "VIRTUAL_VIEW"
+
+    # sqlglot dialects for the two kinds of Glue view SQL. Presto/Athena views are
+    # Trino SQL; raw views are authored by Spark (Glue ETL/EMR) or Hive. sqlglot's
+    # "spark" dialect extends "hive", so it parses both Spark and Hive SQL — the
+    # safer default for raw views than "hive" alone.
+    _PRESTO_VIEW_DIALECT = "trino"
+    _RAW_VIEW_DIALECT = "spark"
+
     def __init__(self, config: GlueSourceConfig, ctx: PipelineContext):
         super().__init__(config, ctx)
         self.ctx = ctx
@@ -477,6 +528,26 @@ class GlueSource(StatefulIngestionSourceBase):
                 platform_instance=self.source_config.platform_instance,
                 catalog=self.source_config.catalog_id,
             )
+
+        # Parses VIRTUAL_VIEW SQL definitions into view->upstream lineage. View
+        # parsing is deferred to gen_metadata(), by which point every table and
+        # view schema has been registered.
+        self.aggregator: Optional[SqlParsingAggregator] = None
+        if self.source_config.include_view_lineage:
+            self.aggregator = SqlParsingAggregator(
+                platform=self.platform,
+                platform_instance=self.source_config.platform_instance,
+                env=self.env,
+                graph=self.ctx.graph,
+                eager_graph_load=False,
+            )
+            # Surface the aggregator's parse metrics/warnings in the source report.
+            self.report.sql_aggregator = self.aggregator.report
+
+    def close(self) -> None:
+        if self.aggregator:
+            self.aggregator.close()
+        super().close()
 
     def get_database_lf_tags(
         self,
@@ -1726,6 +1797,21 @@ class GlueSource(StatefulIngestionSourceBase):
         if self.extract_transforms:
             yield from self._transform_extraction()
 
+        # Flush view lineage parsed from VIRTUAL_VIEW definitions. Deferred to here
+        # so all table/view schemas are registered before the SQL is parsed.
+        # This is the single funnel for view lineage, so a failure here must be
+        # reported rather than aborting the run after tables/views were emitted.
+        if self.aggregator:
+            try:
+                for mcp in self.aggregator.gen_metadata():
+                    yield mcp.as_workunit()
+            except Exception as e:
+                self.report.report_failure(
+                    message="Failed to generate view lineage from SQL parsing",
+                    context="SqlParsingAggregator.gen_metadata",
+                    exc=e,
+                )
+
     def _gen_table_wu(self, table: Dict) -> Iterable[MetadataWorkUnit]:
         database_name = table["DatabaseName"]
         table_name = table["Name"]
@@ -1745,13 +1831,42 @@ class GlueSource(StatefulIngestionSourceBase):
         )
 
         yield from self._extract_record(dataset_urn, table, full_table_name)
-        # generate a Dataset snapshot
-        # We also want to assign "table" subType to the dataset representing glue table - unfortunately it is not
-        # possible via Dataset snapshot embedded in a mce, so we have to generate a mcp.
+
+        is_view = table.get("TableType") == self._VIRTUAL_VIEW_TABLE_TYPE
+
+        # We assign the "Table"/"View" subType to the dataset representing the glue
+        # table - unfortunately it is not possible via the Dataset snapshot embedded
+        # in an mce, so we have to generate a separate mcp.
         yield MetadataChangeProposalWrapper(
             entityUrn=dataset_urn,
-            aspect=SubTypes(typeNames=[DatasetSubTypes.TABLE]),
+            aspect=SubTypes(
+                typeNames=[DatasetSubTypes.VIEW if is_view else DatasetSubTypes.TABLE]
+            ),
         ).as_workunit()
+
+        if is_view:
+            self.report.report_view_scanned()
+            view_definition = self._get_view_definition(table, full_table_name)
+            yield MetadataChangeProposalWrapper(
+                entityUrn=dataset_urn,
+                aspect=ViewPropertiesClass(
+                    materialized=False,
+                    viewLanguage="SQL",
+                    viewLogic=view_definition.sql if view_definition else "",
+                ),
+            ).as_workunit()
+            if view_definition and self.aggregator:
+                # Glue is a two-level namespace (database.table); the view's Glue
+                # database is the default schema for resolving unqualified tables.
+                # Parse with the view's own dialect (Trino for Athena/Presto views,
+                # Spark for raw Spark/Hive views) rather than the platform default.
+                self.aggregator.add_view_definition(
+                    view_urn=dataset_urn,
+                    view_definition=view_definition.sql,
+                    default_db=None,
+                    default_schema=database_name,
+                    override_dialect=view_definition.dialect,
+                )
 
         yield from self._get_domain_wu(
             dataset_name=full_table_name,
@@ -1760,6 +1875,48 @@ class GlueSource(StatefulIngestionSourceBase):
         yield from self.add_table_to_database_container(
             dataset_urn=dataset_urn, db_name=database_name
         )
+
+    def _get_view_definition(
+        self, table: Dict, full_table_name: str
+    ) -> Optional[GlueViewDefinition]:
+        """Extract the SQL definition (and dialect) of a Glue VIRTUAL_VIEW table.
+
+        Decodes the Presto/Athena base64 encoding when present (Trino dialect),
+        otherwise returns the raw text as a Spark view, falling back to
+        ViewExpandedText. Returns ``None`` (and reports a warning) when no usable
+        SQL can be extracted, so the caller never persists an unusable encoded blob
+        as the view definition.
+        """
+        view_text = table.get("ViewOriginalText") or table.get("ViewExpandedText")
+        if not isinstance(view_text, str) or not view_text:
+            self.report.report_warning(
+                message="View has no SQL definition",
+                context=f"table={full_table_name}",
+            )
+            return None
+
+        if is_presto_view(view_text):
+            # A failed decode leaves only the encoded marker, which is not usable
+            # SQL, so we return None rather than store the raw blob as viewLogic.
+            try:
+                original_sql = decode_presto_view(view_text).get("originalSql")
+            except Exception as e:
+                self.report.report_warning(
+                    message="Failed to decode Presto view definition",
+                    context=f"table={full_table_name}: {e}",
+                )
+                return None
+            if isinstance(original_sql, str) and original_sql:
+                return GlueViewDefinition(
+                    sql=original_sql, dialect=self._PRESTO_VIEW_DIALECT
+                )
+            self.report.report_warning(
+                message="Presto view definition missing 'originalSql'",
+                context=f"table={full_table_name}",
+            )
+            return None
+
+        return GlueViewDefinition(sql=view_text, dialect=self._RAW_VIEW_DIALECT)
 
     def _transform_extraction(self) -> Iterable[MetadataWorkUnit]:
         for job in self.get_all_jobs():
@@ -1882,6 +2039,10 @@ class GlueSource(StatefulIngestionSourceBase):
         )
         if schema_metadata:
             dataset_snapshot.aspects.append(schema_metadata)
+            # Register every table/view schema so the aggregator can resolve
+            # column-level lineage when it parses view definitions.
+            if self.aggregator:
+                self.aggregator.register_schema(dataset_urn, schema_metadata)
 
         # Add platform instance
         dataset_snapshot.aspects.append(self._get_data_platform_instance())

--- a/metadata-ingestion/src/datahub/ingestion/source/common/presto_view_decoder.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/common/presto_view_decoder.py
@@ -1,0 +1,54 @@
+"""Helpers for decoding Presto/Athena view definitions.
+
+Presto, Trino and Athena register catalog views whose stored "view text" is a
+base64-encoded JSON document wrapped in a marker comment, e.g.::
+
+    /* Presto View: <base64-of-json> */
+
+The decoded JSON carries ``originalSql`` (the view's SQL), ``columns`` and other
+fields. Several connectors (Hive Metastore, Glue) encounter this same encoding, so
+the decode logic lives here to avoid duplication.
+"""
+
+import base64
+import json
+from typing import Any, Dict, List, TypedDict, cast
+
+# Markers wrapping the base64-encoded payload of a Presto/Athena view.
+PRESTO_VIEW_PREFIX = "/* Presto View: "
+PRESTO_VIEW_SUFFIX = " */"
+
+
+class PrestoViewDefinition(TypedDict, total=False):
+    """Decoded payload of a Presto/Athena view.
+
+    ``total=False`` because the decoder does not guarantee these keys are present
+    (a malformed payload may omit them); only the documented subset that consumers
+    rely on is declared.
+    """
+
+    originalSql: str
+    columns: List[Dict[str, Any]]
+
+
+def is_presto_view(view_text: str) -> bool:
+    """Return True if ``view_text`` is a Presto/Athena base64-encoded view."""
+    return view_text.startswith(PRESTO_VIEW_PREFIX)
+
+
+def decode_presto_view(view_text: str) -> PrestoViewDefinition:
+    """Decode a Presto/Athena view envelope into its JSON payload.
+
+    Expects text of the form ``/* Presto View: <base64> */`` and returns the parsed
+    JSON object (typically with ``originalSql`` and ``columns`` keys).
+
+    Raises on malformed input (invalid base64, non-JSON, or a non-object payload).
+    Callers that want best-effort behaviour should catch the exception.
+    """
+    encoded = view_text.split(PRESTO_VIEW_PREFIX, 1)[-1].rsplit(PRESTO_VIEW_SUFFIX, 1)[
+        0
+    ]
+    payload = json.loads(base64.b64decode(encoded))
+    if not isinstance(payload, dict):
+        raise ValueError("Presto view payload is not a JSON object")
+    return cast(PrestoViewDefinition, payload)

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/hive/hive_metadata_processor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/hive/hive_metadata_processor.py
@@ -13,9 +13,7 @@ The processor handles:
 - View lineage integration via SqlParsingAggregator
 """
 
-import base64
 import dataclasses
-import json
 import logging
 from collections import namedtuple
 from itertools import groupby
@@ -38,6 +36,7 @@ from datahub.emitter.mce_builder import (
 )
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.source.common.presto_view_decoder import decode_presto_view
 from datahub.ingestion.source.common.subtypes import (
     DatasetContainerSubTypes,
     DatasetSubTypes,
@@ -100,10 +99,6 @@ class HiveMetadataProcessor:
     It extracts shared metadata processing logic from HiveMetastoreSource
     to enable composition-based design.
     """
-
-    # Presto view markers for base64-encoded view definitions
-    _PRESTO_VIEW_PREFIX = "/* Presto View: "
-    _PRESTO_VIEW_SUFFIX = " */"
 
     def __init__(
         self,
@@ -288,14 +283,10 @@ class HiveMetadataProcessor:
         self, view_original_text: str
     ) -> Tuple[List[Dict[str, Any]], str]:
         """Extract column metadata from base64-encoded Presto view definition."""
-        encoded_view_info = view_original_text.split(self._PRESTO_VIEW_PREFIX, 1)[
-            -1
-        ].rsplit(self._PRESTO_VIEW_SUFFIX, 1)[0]
+        decoded_view_info = decode_presto_view(view_original_text)
+        view_definition = decoded_view_info["originalSql"]
 
-        decoded_view_info = base64.b64decode(encoded_view_info)
-        view_definition = json.loads(decoded_view_info).get("originalSql")
-
-        columns = json.loads(decoded_view_info).get("columns")
+        columns = decoded_view_info["columns"]
         for col in columns:
             col["col_name"], col["col_type"] = col["name"], col["type"]
 
@@ -632,9 +623,16 @@ class HiveMetadataProcessor:
             )
             dataset_name = self._get_identifier(schema=schema_name, entity=row["name"])
 
-            columns, view_definition = self._get_presto_view_column_metadata(
-                row["view_original_text"]
-            )
+            try:
+                columns, view_definition = self._get_presto_view_column_metadata(
+                    row["view_original_text"]
+                )
+            except Exception as e:
+                # A single malformed Presto view must not abort the whole database.
+                self.report.report_warning(
+                    dataset_name, f"Failed to decode Presto view definition: {e}"
+                )
+                continue
 
             if len(columns) == 0:
                 self.report.report_warning(dataset_name, "missing column information")

--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
@@ -127,6 +127,7 @@ class ViewDefinition:
     view_definition: str
     default_db: Optional[str] = None
     default_schema: Optional[str] = None
+    override_dialect: Optional[DialectOrStr] = None
 
 
 @dataclasses.dataclass
@@ -843,6 +844,7 @@ class SqlParsingAggregator(Closeable):
         view_definition: str,
         default_db: Optional[str] = None,
         default_schema: Optional[str] = None,
+        override_dialect: Optional[DialectOrStr] = None,
     ) -> None:
         """Add a view definition to the aggregator.
 
@@ -851,6 +853,11 @@ class SqlParsingAggregator(Closeable):
 
         The actual processing of view definitions is deferred until output time,
         since all schemas will be registered at that point.
+
+        ``override_dialect`` parses this view's SQL with a specific dialect instead
+        of the aggregator's platform default — useful for catalogs whose views span
+        multiple dialects (e.g. Glue/Hive catalogs holding both Presto/Trino and
+        Hive views).
         """
 
         self.report.num_view_definitions += 1
@@ -859,6 +866,7 @@ class SqlParsingAggregator(Closeable):
             view_definition=view_definition,
             default_db=default_db,
             default_schema=default_schema,
+            override_dialect=override_dialect,
         )
 
     def add_observed_query(
@@ -1193,6 +1201,7 @@ class SqlParsingAggregator(Closeable):
             default_db=view_definition.default_db,
             default_schema=view_definition.default_schema,
             schema_resolver=self._schema_resolver,
+            override_dialect=view_definition.override_dialect,
         )
         if parsed.debug_info.error:
             self.report.views_parse_failures[view_urn] = (

--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_common.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_common.py
@@ -32,7 +32,8 @@ def get_dialect_str(platform: str) -> str:
     elif platform_lower == "fabric-onelake":
         # Fabric SQL Analytics Endpoint speaks T-SQL.
         return "tsql"
-    elif platform_lower == "athena":
+    elif platform_lower in {"athena", "glue"}:
+        # Glue catalog views are Athena/Presto views, which speak Trino SQL.
         return "trino"
     elif platform_lower == "hana":
         # sqlglot does not ship a dedicated SAP HANA dialect. HANA SQL is

--- a/metadata-ingestion/tests/unit/glue/glue_views_mces_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_views_mces_golden.json
@@ -1,0 +1,1227 @@
+[
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:4287d7310125c8abed376e1f6009a59b",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "glue",
+                "env": "PROD",
+                "database": "my_db",
+                "CreateTime": "June 01, 2021 at 14:55:02"
+            },
+            "name": "my_db",
+            "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/my_db",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:4287d7310125c8abed376e1f6009a59b",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:4287d7310125c8abed376e1f6009a59b",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:glue"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:4287d7310125c8abed376e1f6009a59b",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Database"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:4287d7310125c8abed376e1f6009a59b",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1622559302000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "operationType": "CREATE",
+            "lastUpdatedTimestamp": 1622559302000
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "Location": "s3://my-bucket/base_table"
+                        },
+                        "name": "base_table",
+                        "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/my_db/base_table",
+                        "created": {
+                            "time": 1622559302000
+                        },
+                        "lastModified": {
+                            "time": 1622559302000
+                        },
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "my_db.base_table",
+                        "platform": "urn:li:dataPlatform:glue",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "[version=2.0].[type=string].id",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "[version=2.0].[type=string].name",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.DataPlatformInstance": {
+                        "platform": "urn:li:dataPlatform:glue"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Table"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:4287d7310125c8abed376e1f6009a59b"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:4287d7310125c8abed376e1f6009a59b",
+                    "urn": "urn:li:container:4287d7310125c8abed376e1f6009a59b"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_from_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1622559302000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "operationType": "CREATE",
+            "lastUpdatedTimestamp": 1622559302000
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_from_table,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {},
+                        "name": "view_from_table",
+                        "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/my_db/view_from_table",
+                        "created": {
+                            "time": 1622559302000
+                        },
+                        "lastModified": {
+                            "time": 1622559302000
+                        },
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "my_db.view_from_table",
+                        "platform": "urn:li:dataPlatform:glue",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "[version=2.0].[type=string].id",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "[version=2.0].[type=string].name",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.DataPlatformInstance": {
+                        "platform": "urn:li:dataPlatform:glue"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_from_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "View"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_from_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "json": {
+            "materialized": false,
+            "viewLogic": "SELECT id, name FROM base_table",
+            "viewLanguage": "SQL"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_from_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:4287d7310125c8abed376e1f6009a59b"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_from_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:4287d7310125c8abed376e1f6009a59b",
+                    "urn": "urn:li:container:4287d7310125c8abed376e1f6009a59b"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_on_view,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1622559302000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "operationType": "CREATE",
+            "lastUpdatedTimestamp": 1622559302000
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_on_view,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {},
+                        "name": "view_on_view",
+                        "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/my_db/view_on_view",
+                        "created": {
+                            "time": 1622559302000
+                        },
+                        "lastModified": {
+                            "time": 1622559302000
+                        },
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "my_db.view_on_view",
+                        "platform": "urn:li:dataPlatform:glue",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "[version=2.0].[type=string].id",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.DataPlatformInstance": {
+                        "platform": "urn:li:dataPlatform:glue"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_on_view,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "View"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_on_view,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "json": {
+            "materialized": false,
+            "viewLogic": "SELECT id FROM view_from_table",
+            "viewLanguage": "SQL"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_on_view,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:4287d7310125c8abed376e1f6009a59b"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_on_view,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:4287d7310125c8abed376e1f6009a59b",
+                    "urn": "urn:li:container:4287d7310125c8abed376e1f6009a59b"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.spark_view,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1622559302000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "operationType": "CREATE",
+            "lastUpdatedTimestamp": 1622559302000
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.spark_view,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {},
+                        "name": "spark_view",
+                        "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/my_db/spark_view",
+                        "created": {
+                            "time": 1622559302000
+                        },
+                        "lastModified": {
+                            "time": 1622559302000
+                        },
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "my_db.spark_view",
+                        "platform": "urn:li:dataPlatform:glue",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "[version=2.0].[type=string].id",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "[version=2.0].[type=string].name",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.DataPlatformInstance": {
+                        "platform": "urn:li:dataPlatform:glue"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.spark_view,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "View"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.spark_view,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "json": {
+            "materialized": false,
+            "viewLogic": "SELECT `id`, `name` FROM `base_table`",
+            "viewLanguage": "SQL"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.spark_view,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:4287d7310125c8abed376e1f6009a59b"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.spark_view,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 1586840400000,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "created": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD)",
+                    "type": "VIEW",
+                    "query": "urn:li:query:view_5712fec9a65a69b33b7c875fabc8676a659cd805cde1422511208554b031e5ff"
+                }
+            ],
+            "fineGrainedLineages": [
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD),id)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.spark_view,PROD),id)"
+                    ],
+                    "transformOperation": "COPY: `base_table`.`id` AS `id`",
+                    "confidenceScore": 0.9,
+                    "query": "urn:li:query:view_5712fec9a65a69b33b7c875fabc8676a659cd805cde1422511208554b031e5ff"
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD),name)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.spark_view,PROD),name)"
+                    ],
+                    "transformOperation": "COPY: `base_table`.`name` AS `name`",
+                    "confidenceScore": 0.9,
+                    "query": "urn:li:query:view_5712fec9a65a69b33b7c875fabc8676a659cd805cde1422511208554b031e5ff"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.spark_view,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:4287d7310125c8abed376e1f6009a59b",
+                    "urn": "urn:li:container:4287d7310125c8abed376e1f6009a59b"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_5712fec9a65a69b33b7c875fabc8676a659cd805cde1422511208554b031e5ff",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "SELECT `id`, `name` FROM `base_table`",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:_ingestion"
+            },
+            "lastModified": {
+                "time": 1586840400000,
+                "actor": "urn:li:corpuser:_ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_5712fec9a65a69b33b7c875fabc8676a659cd805cde1422511208554b031e5ff",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.spark_view,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD),id)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD),name)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.spark_view,PROD),id)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.spark_view,PROD),name)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_5712fec9a65a69b33b7c875fabc8676a659cd805cde1422511208554b031e5ff",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:glue"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_from_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 1586840400000,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "created": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD)",
+                    "type": "VIEW",
+                    "query": "urn:li:query:view_1e3f88099262929fffda79a63d447d37bdfe5a632be9bc077fb18b13bcad3e81"
+                }
+            ],
+            "fineGrainedLineages": [
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD),id)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_from_table,PROD),id)"
+                    ],
+                    "transformOperation": "COPY: \"base_table\".\"id\" AS \"id\"",
+                    "confidenceScore": 0.9,
+                    "query": "urn:li:query:view_1e3f88099262929fffda79a63d447d37bdfe5a632be9bc077fb18b13bcad3e81"
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD),name)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_from_table,PROD),name)"
+                    ],
+                    "transformOperation": "COPY: \"base_table\".\"name\" AS \"name\"",
+                    "confidenceScore": 0.9,
+                    "query": "urn:li:query:view_1e3f88099262929fffda79a63d447d37bdfe5a632be9bc077fb18b13bcad3e81"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_1e3f88099262929fffda79a63d447d37bdfe5a632be9bc077fb18b13bcad3e81",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "SELECT\n  id,\n  name\nFROM base_table",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:_ingestion"
+            },
+            "lastModified": {
+                "time": 1586840400000,
+                "actor": "urn:li:corpuser:_ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_1e3f88099262929fffda79a63d447d37bdfe5a632be9bc077fb18b13bcad3e81",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_from_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD),id)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD),name)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_from_table,PROD),id)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_from_table,PROD),name)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_1e3f88099262929fffda79a63d447d37bdfe5a632be9bc077fb18b13bcad3e81",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:glue"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_on_view,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 1586840400000,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "created": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_from_table,PROD)",
+                    "type": "VIEW",
+                    "query": "urn:li:query:view_b1b6c80f0f728d081e92c655198ef1ce5a59a9621c58bbcc2b20e9b52bfef9c1"
+                }
+            ],
+            "fineGrainedLineages": [
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_from_table,PROD),id)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_on_view,PROD),id)"
+                    ],
+                    "transformOperation": "COPY: \"view_from_table\".\"id\" AS \"id\"",
+                    "confidenceScore": 0.9,
+                    "query": "urn:li:query:view_b1b6c80f0f728d081e92c655198ef1ce5a59a9621c58bbcc2b20e9b52bfef9c1"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_b1b6c80f0f728d081e92c655198ef1ce5a59a9621c58bbcc2b20e9b52bfef9c1",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "SELECT\n  id\nFROM view_from_table",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:_ingestion"
+            },
+            "lastModified": {
+                "time": 1586840400000,
+                "actor": "urn:li:corpuser:_ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_b1b6c80f0f728d081e92c655198ef1ce5a59a9621c58bbcc2b20e9b52bfef9c1",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_from_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_on_view,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_from_table,PROD),id)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:glue,my_db.view_on_view,PROD),id)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_b1b6c80f0f728d081e92c655198ef1ce5a59a9621c58bbcc2b20e9b52bfef9c1",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:glue"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_1e3f88099262929fffda79a63d447d37bdfe5a632be9bc077fb18b13bcad3e81",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_5712fec9a65a69b33b7c875fabc8676a659cd805cde1422511208554b031e5ff",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_b1b6c80f0f728d081e92c655198ef1ce5a59a9621c58bbcc2b20e9b52bfef9c1",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586840400000,
+        "runId": "glue-source-tes",
+        "lastRunId": "no-run-id-provided"
+    }
+}
+]

--- a/metadata-ingestion/tests/unit/glue/test_glue_source.py
+++ b/metadata-ingestion/tests/unit/glue/test_glue_source.py
@@ -1,3 +1,4 @@
+import base64
 import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple, Type, cast
@@ -26,6 +27,7 @@ from datahub.ingestion.source.aws.glue import (
     _redact_secret_fields_in_dataflow_script,
     _sanitize_jdbc_url,
 )
+from datahub.ingestion.source.common.subtypes import DatasetSubTypes
 from datahub.ingestion.source.state.sql_common_state import (
     BaseSQLAlchemyCheckpointState,
 )
@@ -50,6 +52,7 @@ from tests.unit.glue.test_glue_source_stubs import (
     get_databases_response,
     get_databases_response_for_lineage,
     get_databases_response_profiling,
+    get_databases_response_views,
     get_databases_response_with_mixed_database,
     get_databases_response_with_resource_link,
     get_dataflow_graph_response_1,
@@ -72,6 +75,7 @@ from tests.unit.glue.test_glue_source_stubs import (
     get_tables_response_for_mixed_database,
     get_tables_response_for_target_database,
     get_tables_response_profiling_1,
+    get_tables_response_views,
     mixed_database,
     normal_table_in_mixed_database,
     resource_link_database,
@@ -102,6 +106,7 @@ def glue_source(
     extract_lakeformation_tags: bool = False,
     incremental_properties: bool = False,
     propagate_lakeformation_tags: bool = False,
+    include_view_lineage: bool = False,
 ) -> GlueSource:
     pipeline_context = PipelineContext(run_id="glue-source-tes")
     if mock_datahub_graph_instance:
@@ -121,6 +126,7 @@ def glue_source(
             extract_lakeformation_tags=extract_lakeformation_tags,
             incremental_properties=incremental_properties,
             propagate_lakeformation_tags=propagate_lakeformation_tags,
+            include_view_lineage=include_view_lineage,
         ),
     )
 
@@ -290,6 +296,41 @@ def test_glue_ingest(
         pytestconfig,
         output_path=tmp_path / mce_file,
         golden_path=test_resources_dir / mce_golden_file,
+    )
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def test_glue_view_lineage_ingest(
+    tmp_path: Path,
+    pytestconfig: pytest.Config,
+) -> None:
+    # End-to-end golden test for the VIRTUAL_VIEW path: exercises View subtype +
+    # ViewProperties emission and the full register-schemas-then-flush ordering
+    # that produces view->table and view->view (column-level) lineage.
+    glue_source_instance = glue_source(
+        include_view_lineage=True,
+        use_s3_bucket_tags=False,
+        use_s3_object_tags=False,
+        extract_transforms=False,
+    )
+
+    with Stubber(glue_source_instance.glue_client) as glue_stubber:
+        glue_stubber.add_response("get_databases", get_databases_response_views, {})
+        glue_stubber.add_response(
+            "get_tables",
+            get_tables_response_views,
+            {"DatabaseName": "my_db"},
+        )
+
+        mce_objects = [wu.metadata for wu in glue_source_instance.get_workunits()]
+        glue_stubber.assert_no_pending_responses()
+
+        write_metadata_file(tmp_path / "glue_views_mces.json", mce_objects)
+
+    mce_helpers.check_golden_file(
+        pytestconfig,
+        output_path=tmp_path / "glue_views_mces.json",
+        golden_path=test_resources_dir / "glue_views_mces_golden.json",
     )
 
 
@@ -2310,3 +2351,241 @@ def test_get_column_param_definitions_emitted_via_graph() -> None:
         if wu.get_aspect_of_type(models.StructuredPropertiesClass) is not None
     ]
     assert len(assignment_wus) > 0
+
+
+def _subtypes_and_view_props(
+    workunits: List[Any],
+) -> Tuple[Optional[List[str]], Optional[models.ViewPropertiesClass]]:
+    sub_types: Optional[List[str]] = None
+    view_props: Optional[models.ViewPropertiesClass] = None
+    for wu in workunits:
+        sub_type_aspect = wu.get_aspect_of_type(models.SubTypesClass)
+        if sub_type_aspect is not None:
+            sub_types = sub_type_aspect.typeNames
+        view_props_aspect = wu.get_aspect_of_type(models.ViewPropertiesClass)
+        if view_props_aspect is not None:
+            view_props = view_props_aspect
+    return sub_types, view_props
+
+
+def test_glue_virtual_view_classified_as_view_with_presto_definition() -> None:
+    # Athena/Presto views are stored in Glue as VIRTUAL_VIEW tables whose
+    # ViewOriginalText is a base64-encoded JSON blob wrapped in a Presto marker.
+    source = glue_source(use_s3_bucket_tags=False, use_s3_object_tags=False)
+    original_sql = "SELECT id, name FROM my_db.my_schema.events"
+    encoded = base64.b64encode(
+        json.dumps({"originalSql": original_sql, "columns": []}).encode()
+    ).decode()
+    table = {
+        "Name": "events_view",
+        "DatabaseName": "my_db",
+        "CatalogId": "123412341234",
+        "TableType": "VIRTUAL_VIEW",
+        "ViewOriginalText": f"/* Presto View: {encoded} */",
+        "StorageDescriptor": {"Columns": [{"Name": "id", "Type": "int"}]},
+    }
+
+    sub_types, view_props = _subtypes_and_view_props(list(source._gen_table_wu(table)))
+
+    assert sub_types == [DatasetSubTypes.VIEW]
+    assert view_props is not None
+    assert view_props.viewLogic == original_sql
+    assert view_props.materialized is False
+    assert view_props.viewLanguage == "SQL"
+
+
+def test_glue_virtual_view_with_raw_sql_definition() -> None:
+    # Spark/Hive views registered in the catalog keep the raw SQL in
+    # ViewOriginalText without the Presto encoding.
+    source = glue_source(use_s3_bucket_tags=False, use_s3_object_tags=False)
+    raw_sql = "SELECT * FROM my_db.my_schema.orders"
+    table = {
+        "Name": "orders_view",
+        "DatabaseName": "my_db",
+        "CatalogId": "123412341234",
+        "TableType": "VIRTUAL_VIEW",
+        "ViewOriginalText": raw_sql,
+        "StorageDescriptor": {"Columns": [{"Name": "id", "Type": "int"}]},
+    }
+
+    sub_types, view_props = _subtypes_and_view_props(list(source._gen_table_wu(table)))
+
+    assert sub_types == [DatasetSubTypes.VIEW]
+    assert view_props is not None
+    assert view_props.viewLogic == raw_sql
+
+
+def test_glue_view_definition_falls_back_to_view_expanded_text() -> None:
+    # When ViewOriginalText is absent, the raw SQL in ViewExpandedText is used.
+    source = glue_source(use_s3_bucket_tags=False, use_s3_object_tags=False)
+    raw_sql = "SELECT * FROM my_db.my_schema.orders"
+    table = {
+        "Name": "orders_view",
+        "DatabaseName": "my_db",
+        "CatalogId": "123412341234",
+        "TableType": "VIRTUAL_VIEW",
+        "ViewExpandedText": raw_sql,
+        "StorageDescriptor": {"Columns": [{"Name": "id", "Type": "int"}]},
+    }
+
+    sub_types, view_props = _subtypes_and_view_props(list(source._gen_table_wu(table)))
+
+    assert sub_types == [DatasetSubTypes.VIEW]
+    assert view_props is not None
+    assert view_props.viewLogic == raw_sql
+
+
+def test_glue_view_with_undecodable_presto_text_warns_and_drops_blob() -> None:
+    # A view whose Presto marker wraps invalid base64 must NOT persist the encoded
+    # blob as viewLogic; it falls back to empty and surfaces a warning.
+    source = glue_source(use_s3_bucket_tags=False, use_s3_object_tags=False)
+    table = {
+        "Name": "broken_view",
+        "DatabaseName": "my_db",
+        "CatalogId": "123412341234",
+        "TableType": "VIRTUAL_VIEW",
+        "ViewOriginalText": "/* Presto View: not!valid!base64 */",
+        "StorageDescriptor": {"Columns": [{"Name": "id", "Type": "int"}]},
+    }
+
+    sub_types, view_props = _subtypes_and_view_props(list(source._gen_table_wu(table)))
+
+    assert sub_types == [DatasetSubTypes.VIEW]
+    assert view_props is not None
+    assert view_props.viewLogic == ""
+    assert len(list(source.report.warnings)) >= 1
+
+
+def test_glue_view_without_sql_definition_warns_and_emits_empty_logic() -> None:
+    # A VIRTUAL_VIEW carrying neither ViewOriginalText nor ViewExpandedText is still
+    # classified as a view, with empty viewLogic and a warning (not silent).
+    source = glue_source(use_s3_bucket_tags=False, use_s3_object_tags=False)
+    table = {
+        "Name": "empty_view",
+        "DatabaseName": "my_db",
+        "CatalogId": "123412341234",
+        "TableType": "VIRTUAL_VIEW",
+        "StorageDescriptor": {"Columns": [{"Name": "id", "Type": "int"}]},
+    }
+
+    sub_types, view_props = _subtypes_and_view_props(list(source._gen_table_wu(table)))
+
+    assert sub_types == [DatasetSubTypes.VIEW]
+    assert view_props is not None
+    assert view_props.viewLogic == ""
+    assert len(list(source.report.warnings)) >= 1
+
+
+def test_glue_view_lineage_links_view_to_upstream_table() -> None:
+    # A VIRTUAL_VIEW whose SQL selects from a base table should yield an
+    # upstreamLineage edge from the view to that table, parsed from the view SQL.
+    source = glue_source(
+        use_s3_bucket_tags=False,
+        use_s3_object_tags=False,
+        include_view_lineage=True,
+    )
+    assert source.aggregator is not None
+
+    base_table = {
+        "Name": "base_table",
+        "DatabaseName": "my_db",
+        "CatalogId": "123412341234",
+        "TableType": "EXTERNAL_TABLE",
+        "StorageDescriptor": {
+            "Columns": [
+                {"Name": "id", "Type": "int"},
+                {"Name": "name", "Type": "string"},
+            ]
+        },
+    }
+    original_sql = "SELECT id, name FROM base_table"
+    encoded = base64.b64encode(
+        json.dumps({"originalSql": original_sql, "columns": []}).encode()
+    ).decode()
+    view = {
+        "Name": "events_view",
+        "DatabaseName": "my_db",
+        "CatalogId": "123412341234",
+        "TableType": "VIRTUAL_VIEW",
+        "ViewOriginalText": f"/* Presto View: {encoded} */",
+        "StorageDescriptor": {
+            "Columns": [
+                {"Name": "id", "Type": "int"},
+                {"Name": "name", "Type": "string"},
+            ]
+        },
+    }
+
+    # Drive both the base table (registers its schema) and the view (registers
+    # schema + view definition), then flush the aggregator.
+    list(source._gen_table_wu(base_table))
+    list(source._gen_table_wu(view))
+    mcps = list(source.aggregator.gen_metadata())
+
+    view_urn = "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.events_view,PROD)"
+    base_urn = "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.base_table,PROD)"
+    upstream_lineages = [
+        mcp.aspect
+        for mcp in mcps
+        if mcp.entityUrn == view_urn
+        and isinstance(mcp.aspect, models.UpstreamLineageClass)
+    ]
+    assert upstream_lineages, "no upstreamLineage emitted for the view"
+    lineage = upstream_lineages[0]
+    upstream_urns = {u.dataset for u in lineage.upstreams}
+    assert base_urn in upstream_urns
+
+    # Schemas were registered (via _extract_record), so column-level lineage
+    # should resolve the view's columns back to the base table's columns.
+    assert lineage.fineGrainedLineages, "no column-level lineage emitted"
+    column_edges = {
+        (
+            up.split(",")[-1].rstrip(")"),
+            down.split(",")[-1].rstrip(")"),
+        )
+        for fgl in lineage.fineGrainedLineages
+        for up in (fgl.upstreams or [])
+        for down in (fgl.downstreams or [])
+    }
+    assert ("id", "id") in column_edges
+    assert ("name", "name") in column_edges
+
+
+def test_glue_view_lineage_disabled_creates_no_aggregator() -> None:
+    source = glue_source(use_s3_bucket_tags=False, use_s3_object_tags=False)
+    assert source.aggregator is None
+
+
+def test_glue_view_definition_dialect_detection() -> None:
+    # Presto/Athena views are Trino SQL; raw (Spark/Hive) views are parsed as Spark
+    # (sqlglot's spark dialect is a superset of hive). The detected dialect drives
+    # per-view SQL parsing for lineage.
+    source = glue_source(use_s3_bucket_tags=False, use_s3_object_tags=False)
+    encoded = base64.b64encode(
+        json.dumps({"originalSql": "SELECT id FROM base_table", "columns": []}).encode()
+    ).decode()
+    presto = source._get_view_definition(
+        {"ViewOriginalText": f"/* Presto View: {encoded} */"}, "my_db.presto_view"
+    )
+    raw = source._get_view_definition(
+        {"ViewOriginalText": "SELECT id FROM base_table"}, "my_db.raw_view"
+    )
+
+    assert presto is not None and presto.dialect == "trino"
+    assert raw is not None and raw.dialect == "spark"
+
+
+def test_glue_external_table_remains_table_without_view_properties() -> None:
+    source = glue_source(use_s3_bucket_tags=False, use_s3_object_tags=False)
+    table = {
+        "Name": "events",
+        "DatabaseName": "my_db",
+        "CatalogId": "123412341234",
+        "TableType": "EXTERNAL_TABLE",
+        "StorageDescriptor": {"Columns": [{"Name": "id", "Type": "int"}]},
+    }
+
+    sub_types, view_props = _subtypes_and_view_props(list(source._gen_table_wu(table)))
+
+    assert sub_types == [DatasetSubTypes.TABLE]
+    assert view_props is None

--- a/metadata-ingestion/tests/unit/glue/test_glue_source_stubs.py
+++ b/metadata-ingestion/tests/unit/glue/test_glue_source_stubs.py
@@ -1,6 +1,8 @@
+import base64
 import datetime
 import io
-from typing import Any, Dict
+import json
+from typing import Any, Dict, List
 
 from botocore.response import StreamingBody
 
@@ -1320,3 +1322,110 @@ def get_bucket_tagging() -> Dict[str, Any]:
 
 def get_object_tagging() -> Dict[str, Any]:
     return {"TagSet": [{"Key": "baz", "Value": "bob"}]}
+
+
+def _presto_view_text(original_sql: str, columns: List[Dict[str, str]]) -> str:
+    """Build an Athena/Presto-encoded ViewOriginalText for test fixtures."""
+    payload = json.dumps(
+        {
+            "originalSql": original_sql,
+            "catalog": "awsdatacatalog",
+            "schema": "my_db",
+            "columns": columns,
+        }
+    )
+    encoded = base64.b64encode(payload.encode()).decode()
+    return f"/* Presto View: {encoded} */"
+
+
+# Single database with a base table, a view over it, and a view over that view —
+# exercises the end-to-end VIRTUAL_VIEW path: View subtype, ViewProperties, and
+# (table + column-level) view lineage via the SqlParsingAggregator.
+get_databases_response_views = {
+    "DatabaseList": [
+        {
+            "Name": "my_db",
+            "CreateTime": datetime.datetime(2021, 6, 1, 14, 55, 2),
+            "CatalogId": "123412341234",
+        },
+    ]
+}
+
+get_tables_response_views = {
+    "TableList": [
+        {
+            "Name": "base_table",
+            "DatabaseName": "my_db",
+            "CatalogId": "123412341234",
+            "CreateTime": datetime.datetime(2021, 6, 1, 14, 55, 2),
+            "UpdateTime": datetime.datetime(2021, 6, 1, 14, 55, 2),
+            "TableType": "EXTERNAL_TABLE",
+            "StorageDescriptor": {
+                "Columns": [
+                    {"Name": "id", "Type": "string"},
+                    {"Name": "name", "Type": "string"},
+                ],
+                "Location": "s3://my-bucket/base_table",
+            },
+        },
+        {
+            "Name": "view_from_table",
+            "DatabaseName": "my_db",
+            "CatalogId": "123412341234",
+            "CreateTime": datetime.datetime(2021, 6, 1, 14, 55, 2),
+            "UpdateTime": datetime.datetime(2021, 6, 1, 14, 55, 2),
+            "TableType": "VIRTUAL_VIEW",
+            "ViewOriginalText": _presto_view_text(
+                "SELECT id, name FROM base_table",
+                [
+                    {"name": "id", "type": "varchar"},
+                    {"name": "name", "type": "varchar"},
+                ],
+            ),
+            "ViewExpandedText": "/* Presto View */",
+            "StorageDescriptor": {
+                "Columns": [
+                    {"Name": "id", "Type": "string"},
+                    {"Name": "name", "Type": "string"},
+                ],
+            },
+        },
+        {
+            "Name": "view_on_view",
+            "DatabaseName": "my_db",
+            "CatalogId": "123412341234",
+            "CreateTime": datetime.datetime(2021, 6, 1, 14, 55, 2),
+            "UpdateTime": datetime.datetime(2021, 6, 1, 14, 55, 2),
+            "TableType": "VIRTUAL_VIEW",
+            "ViewOriginalText": _presto_view_text(
+                "SELECT id FROM view_from_table",
+                [{"name": "id", "type": "varchar"}],
+            ),
+            "ViewExpandedText": "/* Presto View */",
+            "StorageDescriptor": {
+                "Columns": [
+                    {"Name": "id", "Type": "string"},
+                ],
+            },
+        },
+        {
+            # Raw (non-Presto) view authored by Spark/Hive: SQL is stored verbatim
+            # with backtick-quoted identifiers, which parse under the Spark/Hive
+            # dialect but NOT under Trino — so resolving its lineage proves per-view
+            # dialect detection works end-to-end.
+            "Name": "spark_view",
+            "DatabaseName": "my_db",
+            "CatalogId": "123412341234",
+            "CreateTime": datetime.datetime(2021, 6, 1, 14, 55, 2),
+            "UpdateTime": datetime.datetime(2021, 6, 1, 14, 55, 2),
+            "TableType": "VIRTUAL_VIEW",
+            "ViewOriginalText": "SELECT `id`, `name` FROM `base_table`",
+            "StorageDescriptor": {
+                "Columns": [
+                    {"Name": "id", "Type": "string"},
+                    {"Name": "name", "Type": "string"},
+                ],
+            },
+        },
+    ]
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_utils.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_utils.py
@@ -7,7 +7,7 @@ import sqlglot
 
 from datahub.sql_parsing.query_types import get_query_type_of_sql
 from datahub.sql_parsing.schema_resolver import SchemaResolver
-from datahub.sql_parsing.sql_parsing_common import QueryType
+from datahub.sql_parsing.sql_parsing_common import QueryType, get_dialect_str
 from datahub.sql_parsing.sqlglot_lineage import (
     _UPDATE_ARGS_NOT_SUPPORTED_BY_SELECT,
     sqlglot_lineage,
@@ -26,6 +26,14 @@ from datahub.sql_parsing.sqlglot_utils import (
 
 def test_update_from_select():
     assert {"returning", "this"} == _UPDATE_ARGS_NOT_SUPPORTED_BY_SELECT
+
+
+def test_glue_and_athena_use_trino_dialect():
+    # Glue catalog views are Athena/Presto views (Trino SQL). Without this mapping,
+    # Glue/Athena view-SQL parsing silently fails and no lineage is produced.
+    assert get_dialect_str("glue") == "trino"
+    assert get_dialect_str("athena") == "trino"
+    assert is_dialect_instance(get_dialect("glue"), "trino")
 
 
 def test_is_dialect_instance():

--- a/metadata-ingestion/tests/unit/test_presto_view_decoder.py
+++ b/metadata-ingestion/tests/unit/test_presto_view_decoder.py
@@ -1,0 +1,42 @@
+import base64
+import json
+
+import pytest
+
+from datahub.ingestion.source.common.presto_view_decoder import (
+    decode_presto_view,
+    is_presto_view,
+)
+
+
+def _presto_envelope(payload: dict) -> str:
+    encoded = base64.b64encode(json.dumps(payload).encode()).decode()
+    return f"/* Presto View: {encoded} */"
+
+
+def test_is_presto_view_distinguishes_encoded_from_raw_sql() -> None:
+    assert is_presto_view(_presto_envelope({"originalSql": "SELECT 1"}))
+    assert not is_presto_view("SELECT * FROM my_db.my_schema.orders")
+
+
+def test_decode_presto_view_returns_payload() -> None:
+    payload = {
+        "originalSql": "SELECT id FROM my_db.my_schema.events",
+        "columns": [{"name": "id", "type": "integer"}],
+    }
+    decoded = decode_presto_view(_presto_envelope(payload))
+    assert decoded["originalSql"] == payload["originalSql"]
+    assert decoded["columns"] == payload["columns"]
+
+
+def test_decode_presto_view_raises_on_invalid_base64() -> None:
+    # binascii.Error (bad base64) and json.JSONDecodeError both subclass ValueError.
+    with pytest.raises(ValueError):
+        decode_presto_view("/* Presto View: not!valid!base64 */")
+
+
+def test_decode_presto_view_raises_when_payload_not_object() -> None:
+    # A JSON array (not an object) is not a valid view payload.
+    encoded = base64.b64encode(json.dumps([1, 2, 3]).encode()).decode()
+    with pytest.raises(ValueError):
+        decode_presto_view(f"/* Presto View: {encoded} */")

--- a/metadata-ingestion/uv.lock
+++ b/metadata-ingestion/uv.lock
@@ -1071,6 +1071,7 @@ glue = [
     { name = "cachetools" },
     { name = "patchy" },
     { name = "sqlglot", extra = ["c"] },
+    { name = "sqlparse" },
     { name = "urllib3" },
 ]
 grafana = [
@@ -3157,6 +3158,7 @@ requires-dist = [
     { name = "sqlparse", marker = "extra == 'dremio'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'druid'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'fabric-onelake'", specifier = "<0.6.0" },
+    { name = "sqlparse", marker = "extra == 'glue'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'hana'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'hive'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'hive-metastore'", specifier = "<0.6.0" },


### PR DESCRIPTION
## Summary

The Glue connector classified every catalog object as a **Table**, even AWS Glue
views (`TableType=VIRTUAL_VIEW`) — contradicting the docs, which promise
datasets/tables/views. This PR fixes the classification and adds view lineage.

For each `VIRTUAL_VIEW` the connector now:

- emits the **`View`** subtype and a **`ViewProperties`** aspect with the decoded
  view SQL (Athena/Presto views store SQL base64-encoded inside a
  `/* Presto View: … */` envelope; raw Spark/Hive views store it verbatim);
- parses the view SQL into **table- and column-level lineage** via
  `SqlParsingAggregator` (new `include_view_lineage` config, default `true`);
- **detects the SQL dialect per view** — Trino for Athena/Presto-encoded views,
  Spark for raw Spark/Hive views (sqlglot's `spark` dialect is a superset of
  `hive`, so it parses both) — via a new `override_dialect` option on
  `SqlParsingAggregator.add_view_definition`.

Supporting changes:

- Extracts the Presto-view decoder (previously duplicated in the Hive Metastore
  source) into `datahub.ingestion.source.common.presto_view_decoder` and reuses
  it in both connectors.
- Maps the `glue` platform to the `trino` sqlglot dialect (the default; per-view
  detection overrides it where needed).
- Surfaces the aggregator's parse report as a sub-report, guards the lineage
  flush, and closes the aggregator on source `close()`.

## Testing

- Unit tests for view classification, the shared decoder, dialect detection, and
  the `glue→trino` mapping.
- An end-to-end golden test (`glue_views_mces_golden.json`) covering a base
  table, a Presto view, a view-on-view, and a raw Spark view (backtick-quoted —
  resolves only under the Spark/Hive dialect, proving per-view detection).
- Verified against a live AWS Glue catalog: views correctly classified with
  table- and column-level lineage, including cross-database and view-on-view.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing/#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)