### PR TITLE
fix(ingestion): budget full schemaMetadata aspect when trimming, not just fields

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
@@ -14,6 +14,7 @@ from datahub.ingestion.api.workunit_processor import (
 )
 from datahub.metadata.schema_classes import (
     DatasetProfileClass,
+    OtherSchemaClass,
     QueryPropertiesClass,
     QuerySubjectsClass,
     SchemaFieldClass,
@@ -100,10 +101,48 @@ class EnsureAspectSizeProcessor(WorkunitProcessor[EnsureAspectSizeProcessorRepor
         if truncated:
             self._record_truncation("datasetProfile")
 
+    def _schema_size_without_fields(self, schema: SchemaMetadataClass) -> int:
+        """Serialized size of the aspect excluding the ``fields`` list.
+
+        The ``fields`` list is the part we trim, but the rest of the aspect is
+        emitted too and must count against the budget — in particular
+        ``platformSchema.rawSchema``, which for deeply-nested schemas can be
+        several MB on its own. Budgeting fields alone lets the final aspect
+        exceed the limit even after truncation.
+        """
+        original_fields = schema.fields
+        try:
+            schema.fields = []
+            return len(json.dumps(pre_json_transform(schema.to_obj())))
+        finally:
+            schema.fields = original_fields
+
     def ensure_schema_metadata_size(
         self, dataset_urn: str, schema: SchemaMetadataClass
     ) -> None:
-        total_fields_size = 0
+        # Budget against the full serialized aspect, not just the fields list.
+        # Top-level keys and especially platformSchema.rawSchema are emitted as
+        # well; ignoring them lets the aspect exceed the limit.
+        raw_schema_dropped = False
+        non_fields_size = self._schema_size_without_fields(schema)
+        if (
+            non_fields_size >= self.schema_size_constraint
+            and isinstance(schema.platformSchema, OtherSchemaClass)
+            and schema.platformSchema.rawSchema
+        ):
+            # The raw schema blob alone exceeds the budget. Drop it so the
+            # structured fields can still be retained instead of failing the
+            # whole aspect.
+            self.ctx.source_report.warning(
+                title="Schema truncated due to size constraint",
+                message="Dataset schema contained too much data and would have caused ingestion to fail",
+                context=f"Raw schema was removed from schema for {dataset_urn} due to aspect size constraints",
+            )
+            schema.platformSchema.rawSchema = ""
+            non_fields_size = self._schema_size_without_fields(schema)
+            raw_schema_dropped = True
+
+        total_fields_size = non_fields_size
         accepted_fields: List[SchemaFieldClass] = []
         for schema_field in schema.fields:
             field_size = len(json.dumps(pre_json_transform(schema_field.to_obj())))
@@ -116,7 +155,7 @@ class EnsureAspectSizeProcessor(WorkunitProcessor[EnsureAspectSizeProcessorRepor
                     message="Dataset schema contained too much data and would have caused ingestion to fail",
                     context=f"Field {schema_field.fieldPath} was removed from schema for {dataset_urn} due to aspect size constraints",
                 )
-        if len(accepted_fields) < len(schema.fields):
+        if raw_schema_dropped or len(accepted_fields) < len(schema.fields):
             self._record_truncation("schemaMetadata")
         schema.fields = accepted_fields
 

--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
@@ -14,7 +14,6 @@ from datahub.ingestion.api.workunit_processor import (
 )
 from datahub.metadata.schema_classes import (
     DatasetProfileClass,
-    OtherSchemaClass,
     QueryPropertiesClass,
     QuerySubjectsClass,
     SchemaFieldClass,
@@ -105,10 +104,15 @@ class EnsureAspectSizeProcessor(WorkunitProcessor[EnsureAspectSizeProcessorRepor
         """Serialized size of the aspect excluding the ``fields`` list.
 
         The ``fields`` list is the part we trim, but the rest of the aspect is
-        emitted too and must count against the budget — in particular
-        ``platformSchema.rawSchema``, which for deeply-nested schemas can be
-        several MB on its own. Budgeting fields alone lets the final aspect
-        exceed the limit even after truncation.
+        emitted too and must count against the budget — chiefly the
+        ``platformSchema`` blob, which for deeply-nested schemas can be several
+        MB on its own, plus top-level scalars (``hash``, ``schemaName``, …).
+
+        We measure by temporarily clearing ``fields`` and serializing the whole
+        aspect, rather than sizing ``platformSchema`` alone, so the budget
+        reflects *all* non-field content the server will parse (nothing is missed
+        if new top-level fields are added later). The mutation is local and
+        restored in the ``finally``.
         """
         original_fields = schema.fields
         try:
@@ -117,30 +121,51 @@ class EnsureAspectSizeProcessor(WorkunitProcessor[EnsureAspectSizeProcessorRepor
         finally:
             schema.fields = original_fields
 
+    def _drop_platform_schema(self, schema: SchemaMetadataClass) -> bool:
+        """Blank the raw platform-schema string(s) on the aspect's platformSchema.
+
+        ``platformSchema`` holds an opaque, source-format dump of the schema —
+        ``rawSchema`` / ``documentSchema`` / ``tableSchema`` / ``keySchema`` /
+        ``valueSchema`` depending on the union variant. It is the least valuable
+        part of the aspect (``fields`` carry the structured, queryable metadata),
+        so we shed it before trimming fields. Every string member is blanked, so
+        this covers all platformSchema variants generically — not just
+        ``OtherSchema``. Returns ``True`` if any content was cleared.
+        """
+        platform_schema = schema.platformSchema
+        if platform_schema is None:
+            return False
+        cleared = False
+        for key, value in platform_schema._inner_dict.items():
+            if isinstance(value, str) and value:
+                platform_schema._inner_dict[key] = ""
+                cleared = True
+        return cleared
+
     def ensure_schema_metadata_size(
         self, dataset_urn: str, schema: SchemaMetadataClass
     ) -> None:
-        # Budget against the full serialized aspect, not just the fields list.
-        # Top-level keys and especially platformSchema.rawSchema are emitted as
-        # well; ignoring them lets the aspect exceed the limit.
-        raw_schema_dropped = False
+        # Budget against the full serialized aspect, not just the fields list:
+        # the platformSchema blob (and other top-level content) is emitted too.
+        truncated = False
         non_fields_size = self._schema_size_without_fields(schema)
+
+        # If the non-field content alone exceeds the budget, the platformSchema
+        # blob is the culprit and the least valuable content. Drop it BEFORE
+        # trimming fields (which carry the metadata users query), then re-measure.
+        # Otherwise the field budget would start already-oversized and reject
+        # every field while the aspect stays over the limit.
         if (
             non_fields_size >= self.schema_size_constraint
-            and isinstance(schema.platformSchema, OtherSchemaClass)
-            and schema.platformSchema.rawSchema
+            and self._drop_platform_schema(schema)
         ):
-            # The raw schema blob alone exceeds the budget. Drop it so the
-            # structured fields can still be retained instead of failing the
-            # whole aspect.
             self.ctx.source_report.warning(
                 title="Schema truncated due to size constraint",
                 message="Dataset schema contained too much data and would have caused ingestion to fail",
-                context=f"Raw schema was removed from schema for {dataset_urn} due to aspect size constraints",
+                context=f"Raw platform schema was removed from schema for {dataset_urn} due to aspect size constraints",
             )
-            schema.platformSchema.rawSchema = ""
             non_fields_size = self._schema_size_without_fields(schema)
-            raw_schema_dropped = True
+            truncated = True
 
         total_fields_size = non_fields_size
         accepted_fields: List[SchemaFieldClass] = []
@@ -155,7 +180,7 @@ class EnsureAspectSizeProcessor(WorkunitProcessor[EnsureAspectSizeProcessorRepor
                     message="Dataset schema contained too much data and would have caused ingestion to fail",
                     context=f"Field {schema_field.fieldPath} was removed from schema for {dataset_urn} due to aspect size constraints",
                 )
-        if raw_schema_dropped or len(accepted_fields) < len(schema.fields):
+        if truncated or len(accepted_fields) < len(schema.fields):
             self._record_truncation("schemaMetadata")
         schema.fields = accepted_fields
 

--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
@@ -46,6 +46,9 @@ class EnsureAspectSizeProcessorReport(WorkunitProcessorReport):
     """Tracks how many workunits had each aspect type truncated."""
 
     num_truncations_by_aspect: Dict[str, int] = field(default_factory=dict)
+    # Number of schemaMetadata aspects whose platformSchema blob was dropped
+    # wholesale (a coarser, more drastic truncation than dropping fields).
+    num_platform_schema_drops: int = 0
 
 
 class EnsureAspectSizeProcessor(WorkunitProcessor[EnsureAspectSizeProcessorReport]):
@@ -164,6 +167,7 @@ class EnsureAspectSizeProcessor(WorkunitProcessor[EnsureAspectSizeProcessorRepor
                 message="Dataset schema contained too much data and would have caused ingestion to fail",
                 context=f"Raw platform schema was removed from schema for {dataset_urn} due to aspect size constraints",
             )
+            self.report.num_platform_schema_drops += 1
             non_fields_size = self._schema_size_without_fields(schema)
             truncated = True
 

--- a/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
+++ b/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
@@ -386,10 +386,10 @@ def test_ensure_size_of_too_big_schema_metadata(processor):
     )
     assert len(schema.fields) < 1004, "Schema has not been properly truncated"
     assert schema.fields[-1].fieldPath == "dddd", "Small field was not added at the end"
-    # +100kb is completely arbitrary, but we are truncating the aspect based on schema fields size only, not total taken
-    # by other parameters of the aspect - it is reasonable approach though - schema fields is the only field in schema
-    # metadata which can be expected to grow out of control
-    assert len(json.dumps(schema.to_obj())) < INGEST_MAX_PAYLOAD_BYTES + 100000, (
+    # The truncated aspect must fit within the budget. The budget now accounts
+    # for the full serialized aspect (not just the fields list), so the result
+    # is bounded by the payload constraint rather than an arbitrary slop.
+    assert len(json.dumps(schema.to_obj())) < INGEST_MAX_PAYLOAD_BYTES, (
         "Aspect exceeded acceptable size"
     )
 
@@ -403,6 +403,84 @@ def test_ensure_size_of_proper_schema_metadata(processor):
     )
     assert orig_repr == json.dumps(schema.to_obj()), (
         "Aspect was modified in case where workunit processor should have been no-op"
+    )
+
+
+@time_machine.travel("2023-01-02 00:00:00", tick=False)
+def test_ensure_schema_metadata_budget_accounts_for_raw_schema(processor):
+    # rawSchema takes ~half the budget; the field budget must shrink to
+    # compensate so the total aspect — raw schema included — stays within the
+    # limit. Previously only the fields were counted, so the aspect could
+    # still exceed the limit after truncation.
+    raw_schema_size = processor.schema_size_constraint // 2
+    fields = [
+        SchemaFieldClass(
+            fieldPath=f"t{i}",
+            nativeDataType="int",
+            type=SchemaFieldDataTypeClass(type=NumberTypeClass()),
+            description=20000 * "a",
+        )
+        for i in range(1000)
+    ]
+    schema = SchemaMetadataClass(
+        schemaName="abcdef",
+        version=1,
+        platform="s3",
+        hash="ABCDE1234567890",
+        platformSchema=OtherSchemaClass(rawSchema="a" * raw_schema_size),
+        fields=fields,
+    )
+
+    processor.ensure_schema_metadata_size(
+        "urn:li:dataset:(s3, dummy_dataset, DEV)", schema
+    )
+
+    assert isinstance(schema.platformSchema, OtherSchemaClass)
+    assert schema.platformSchema.rawSchema == "a" * raw_schema_size, (
+        "Raw schema that fits within budget should be retained"
+    )
+    assert len(schema.fields) < 1000, (
+        "Fields should have been trimmed to fit the budget"
+    )
+    assert len(json.dumps(schema.to_obj())) < INGEST_MAX_PAYLOAD_BYTES, (
+        "Aspect exceeded acceptable size despite truncation"
+    )
+
+
+@time_machine.travel("2023-01-02 00:00:00", tick=False)
+def test_ensure_schema_metadata_drops_oversized_raw_schema(processor):
+    # When rawSchema alone exceeds the budget, it is dropped so the structured
+    # fields can still be retained rather than failing the whole aspect.
+    fields = [
+        SchemaFieldClass(
+            f"f{i}",
+            nativeDataType="int",
+            type=SchemaFieldDataTypeClass(type=NumberTypeClass()),
+        )
+        for i in range(5)
+    ]
+    schema = SchemaMetadataClass(
+        schemaName="abcdef",
+        version=1,
+        platform="s3",
+        hash="ABCDE1234567890",
+        platformSchema=OtherSchemaClass(
+            rawSchema="a" * (processor.schema_size_constraint + 100000)
+        ),
+        fields=fields,
+    )
+
+    processor.ensure_schema_metadata_size(
+        "urn:li:dataset:(s3, dummy_dataset, DEV)", schema
+    )
+
+    assert isinstance(schema.platformSchema, OtherSchemaClass)
+    assert schema.platformSchema.rawSchema == "", "Oversized raw schema was not dropped"
+    assert len(schema.fields) == 5, (
+        "Fields should be retained once the oversized raw schema is dropped"
+    )
+    assert len(json.dumps(schema.to_obj())) < INGEST_MAX_PAYLOAD_BYTES, (
+        "Aspect exceeded acceptable size"
     )
 
 

--- a/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
+++ b/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
@@ -483,6 +483,7 @@ def test_ensure_schema_metadata_drops_oversized_raw_schema(processor):
     assert len(json.dumps(schema.to_obj())) < INGEST_MAX_PAYLOAD_BYTES, (
         "Aspect exceeded acceptable size"
     )
+    assert processor.report.num_platform_schema_drops == 1
 
 
 @time_machine.travel("2023-01-02 00:00:00", tick=False)
@@ -524,6 +525,7 @@ def test_ensure_schema_metadata_drops_oversized_non_other_platform_schema(proces
     assert len(json.dumps(schema.to_obj())) < INGEST_MAX_PAYLOAD_BYTES, (
         "Aspect exceeded acceptable size"
     )
+    assert processor.report.num_platform_schema_drops == 1
 
 
 @time_machine.travel("2023-01-02 00:00:00", tick=False)

--- a/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
+++ b/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
@@ -27,6 +27,7 @@ from datahub.metadata.schema_classes import (
     FineGrainedLineageDownstreamTypeClass,
     FineGrainedLineageUpstreamTypeClass,
     GenericAspectClass,
+    KafkaSchemaClass,
     MetadataChangeProposalClass,
     NumberTypeClass,
     OtherSchemaClass,
@@ -478,6 +479,47 @@ def test_ensure_schema_metadata_drops_oversized_raw_schema(processor):
     assert schema.platformSchema.rawSchema == "", "Oversized raw schema was not dropped"
     assert len(schema.fields) == 5, (
         "Fields should be retained once the oversized raw schema is dropped"
+    )
+    assert len(json.dumps(schema.to_obj())) < INGEST_MAX_PAYLOAD_BYTES, (
+        "Aspect exceeded acceptable size"
+    )
+
+
+@time_machine.travel("2023-01-02 00:00:00", tick=False)
+def test_ensure_schema_metadata_drops_oversized_non_other_platform_schema(processor):
+    # The platform-schema blob must be dropped before fields for ANY union
+    # variant, not just OtherSchema. Here a KafkaSchema documentSchema alone
+    # exceeds the budget; without generic handling the field loop would reject
+    # every field and still leave the aspect oversized.
+    fields = [
+        SchemaFieldClass(
+            f"f{i}",
+            nativeDataType="int",
+            type=SchemaFieldDataTypeClass(type=NumberTypeClass()),
+        )
+        for i in range(5)
+    ]
+    schema = SchemaMetadataClass(
+        schemaName="abcdef",
+        version=1,
+        platform="kafka",
+        hash="ABCDE1234567890",
+        platformSchema=KafkaSchemaClass(
+            documentSchema="a" * (processor.schema_size_constraint + 100000)
+        ),
+        fields=fields,
+    )
+
+    processor.ensure_schema_metadata_size(
+        "urn:li:dataset:(kafka, dummy_dataset, DEV)", schema
+    )
+
+    assert isinstance(schema.platformSchema, KafkaSchemaClass)
+    assert schema.platformSchema.documentSchema == "", (
+        "Oversized platform schema was not dropped"
+    )
+    assert len(schema.fields) == 5, (
+        "Fields should be retained once the oversized platform schema is dropped"
     )
     assert len(json.dumps(schema.to_obj())) < INGEST_MAX_PAYLOAD_BYTES, (
         "Aspect exceeded acceptable size"


### PR DESCRIPTION
## Summary

`EnsureAspectSizeProcessor.ensure_schema_metadata_size` trims schema fields to fit the payload limit, but it only summed `schema.fields` and ignored the rest of the aspect — notably `platformSchema.rawSchema`, plus top-level keys and JSON-escaping overhead. So it trimmed fields to ~the limit, and then the non-field content pushed the serialized aspect back over and GMS rejected it:

```
com.fasterxml.jackson.core.exc.StreamConstraintsException:
String value length (16033303) exceeds the maximum allowed (16000000, from `StreamReadConstraints.getMaxStringLength()`)
```

Observed in the field on a deeply-nested Iceberg schema: the existing truncation removed 497 fields but the aspect was still 16,033,303 chars — **33 KB over** the 16 MB limit — purely because ~540 KB of non-field content was never charged against the budget.

## Change

- `ensure_schema_metadata_size` now budgets the **full serialized aspect**, not just the fields list. A new `_schema_size_without_fields` helper measures the non-field content (top-level keys + `platformSchema.rawSchema`), and the field-trimming loop starts from that baseline — so accepted fields **plus** non-field content stay within the constraint.
- When `rawSchema` alone exceeds the budget, it is dropped (with a warning) so the structured fields can still be retained rather than failing the whole aspect.
- Regression tests covering both the budget accounting and the oversized-`rawSchema` case.

## Example

With `schema_size_constraint ≈ 15,492,710` and ~540 KB of non-field content:

```
Before: budget for fields = 15,492,710 (non-field ignored)
        final aspect = 15,492,710 (fields) + 540,593 (non-field) = 16,033,303  → REJECTED (33 KB over 16 M)

After:  field budget starts at 540,593 (non-field charged first)
        final aspect = 15,492,710  → ACCEPTED
```

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
