### PR TITLE
feat(openapi): expose schemaVersion and searchGroup in entity registry API

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/models/AspectSpec.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/AspectSpec.java
@@ -107,6 +107,11 @@ public class AspectSpec {
     return _aspectAnnotation.getSchemaVersion();
   }
 
+  @Nonnull
+  public AspectAnnotation getAspectAnnotation() {
+    return _aspectAnnotation;
+  }
+
   public Map<String, SearchableFieldSpec> getSearchableFieldSpecMap() {
     return _searchableFieldSpecs;
   }

--- a/entity-registry/src/test/java/com/linkedin/metadata/models/ConfigEntitySpecTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/models/ConfigEntitySpecTest.java
@@ -113,6 +113,14 @@ public class ConfigEntitySpecTest {
     assertEquals(annotation.getSearchGroup(), "primary");
   }
 
+  @Test
+  public void testAspectSpecGetAspectAnnotation() {
+    AspectSpec aspectSpec = createMockAspectSpec("domains");
+
+    assertEquals(aspectSpec.getAspectAnnotation().getName(), "domains");
+    assertEquals(aspectSpec.getAspectAnnotation().getSchemaVersion(), 1L);
+  }
+
   private AspectSpec createMockAspectSpec(String name) {
     return new AspectSpec(
         new com.linkedin.metadata.models.annotation.AspectAnnotation(name, false, false, null, 1L),

--- a/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/v1/models/registry/AspectAnnotationDto.java
+++ b/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/v1/models/registry/AspectAnnotationDto.java
@@ -1,5 +1,8 @@
 package io.datahubproject.openapi.v1.models.registry;
 
+import com.linkedin.data.DataMap;
+import com.linkedin.metadata.models.annotation.AspectAnnotation;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.Builder;
 import lombok.Data;
@@ -11,4 +14,28 @@ public class AspectAnnotationDto {
   private boolean timeseries;
   private boolean autoRender;
   private Map<String, Object> renderSpec;
+  private long schemaVersion;
+
+  public static AspectAnnotationDto fromAspectAnnotation(AspectAnnotation annotation) {
+    if (annotation == null) {
+      return null;
+    }
+
+    return AspectAnnotationDto.builder()
+        .name(annotation.getName())
+        .timeseries(annotation.isTimeseries())
+        .autoRender(annotation.isAutoRender())
+        .renderSpec(convertDataMap(annotation.getRenderSpec()))
+        .schemaVersion(annotation.getSchemaVersion())
+        .build();
+  }
+
+  private static Map<String, Object> convertDataMap(DataMap dataMap) {
+    if (dataMap == null) {
+      return null;
+    }
+    Map<String, Object> result = new HashMap<>();
+    dataMap.forEach(result::put);
+    return result;
+  }
 }

--- a/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/v1/models/registry/AspectSpecDto.java
+++ b/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/v1/models/registry/AspectSpecDto.java
@@ -7,9 +7,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.Builder;
 import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Data
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -41,24 +39,9 @@ public class AspectSpecDto {
   private String registryVersion;
 
   public static AspectSpecDto fromAspectSpec(AspectSpec aspectSpec) {
-    // Get the aspect annotation - need to use reflection since it's private
-    AspectAnnotationDto aspectAnnotationDto = null;
-    try {
-      // The AspectSpec class has getName(), isTimeseries(), isAutoRender(), getRenderSpec() methods
-      // that delegate to the AspectAnnotation
-      aspectAnnotationDto =
-          AspectAnnotationDto.builder()
-              .name(aspectSpec.getName())
-              .timeseries(aspectSpec.isTimeseries())
-              .autoRender(aspectSpec.isAutoRender())
-              .renderSpec(convertDataMap(aspectSpec.getRenderSpec()))
-              .build();
-    } catch (Exception e) {
-      log.error("Error extracting aspect annotation: {}", e.getMessage());
-    }
-
     return AspectSpecDto.builder()
-        .aspectAnnotation(aspectAnnotationDto)
+        .aspectAnnotation(
+            AspectAnnotationDto.fromAspectAnnotation(aspectSpec.getAspectAnnotation()))
 
         // Convert Maps using the generic approach
         .searchableFieldSpec(convertFieldSpecMap(aspectSpec.getSearchableFieldSpecMap()))
@@ -105,14 +88,5 @@ public class AspectSpecDto {
       }
     }
     return result.isEmpty() ? null : result; // Return null if result is empty
-  }
-
-  private static Map<String, Object> convertDataMap(com.linkedin.data.DataMap dataMap) {
-    if (dataMap == null) {
-      return null;
-    }
-    Map<String, Object> result = new HashMap<>();
-    dataMap.forEach(result::put);
-    return result;
   }
 }

--- a/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/v1/models/registry/EntityAnnotationDto.java
+++ b/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/v1/models/registry/EntityAnnotationDto.java
@@ -9,6 +9,7 @@ import lombok.Data;
 public class EntityAnnotationDto {
   private String name;
   private String keyAspect;
+  private String searchGroup;
 
   public static EntityAnnotationDto fromEntityAnnotation(EntityAnnotation annotation) {
     if (annotation == null) {
@@ -18,6 +19,7 @@ public class EntityAnnotationDto {
     return EntityAnnotationDto.builder()
         .name(annotation.getName())
         .keyAspect(annotation.getKeyAspect())
+        .searchGroup(annotation.getSearchGroup())
         .build();
   }
 }

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v1/registry/EntityRegistryControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v1/registry/EntityRegistryControllerTest.java
@@ -2,6 +2,7 @@ package io.datahubproject.openapi.v1.registry;
 
 import static io.datahubproject.test.metadata.context.TestOperationContexts.TEST_USER_AUTH;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -127,7 +128,7 @@ public class EntityRegistryControllerTest {
         .perform(
             get("/openapi/v1/registry/models/entity/specifications")
                 .param("start", "0")
-                .param("count", "100")
+                .param("count", "1000")
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.start", is(0)))
@@ -352,7 +353,47 @@ public class EntityRegistryControllerTest {
             get("/openapi/v1/registry/models/aspect/specifications/{aspectName}", TEST_ASPECT_NAME)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.aspectAnnotation.name", is(TEST_ASPECT_NAME)));
+        .andExpect(jsonPath("$.aspectAnnotation.name", is(TEST_ASPECT_NAME)))
+        .andExpect(jsonPath("$.aspectAnnotation.schemaVersion", is(1)));
+  }
+
+  @Test
+  public void testGetAspectSpecByNameExposesSchemaVersion() throws Exception {
+    authUtilMock
+        .when(
+            () ->
+                AuthUtil.isAPIOperationsAuthorized(
+                    any(OperationContext.class), any(PoliciesConfig.Privilege.class)))
+        .thenReturn(true);
+
+    mockMvc
+        .perform(
+            get("/openapi/v1/registry/models/aspect/specifications/{aspectName}", "domains")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.aspectAnnotation.name", is("domains")))
+        .andExpect(jsonPath("$.aspectAnnotation.schemaVersion", is(2)));
+  }
+
+  @Test
+  public void testGetEntitySpecsExposesSearchGroup() throws Exception {
+    authUtilMock
+        .when(
+            () ->
+                AuthUtil.isAPIOperationsAuthorized(
+                    any(OperationContext.class), any(PoliciesConfig.Privilege.class)))
+        .thenReturn(true);
+
+    mockMvc
+        .perform(
+            get("/openapi/v1/registry/models/entity/specifications")
+                .param("count", "1000")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            jsonPath(
+                "$.elements[?(@.name=='dataset')].entityAnnotation.searchGroup",
+                hasItem("primary")));
   }
 
   @Test

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v1/registry/RegistryDtoMappingTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v1/registry/RegistryDtoMappingTest.java
@@ -1,0 +1,90 @@
+package io.datahubproject.openapi.v1.registry;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import com.linkedin.data.schema.annotation.PathSpecBasedSchemaAnnotationVisitor;
+import com.linkedin.metadata.models.AspectSpec;
+import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.models.annotation.AspectAnnotation;
+import com.linkedin.metadata.models.annotation.EntityAnnotation;
+import io.datahubproject.openapi.v1.models.registry.AspectAnnotationDto;
+import io.datahubproject.openapi.v1.models.registry.AspectSpecDto;
+import io.datahubproject.openapi.v1.models.registry.EntityAnnotationDto;
+import io.datahubproject.openapi.v1.models.registry.EntitySpecDto;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class RegistryDtoMappingTest {
+
+  @BeforeTest
+  public void disableAssert() {
+    PathSpecBasedSchemaAnnotationVisitor.class
+        .getClassLoader()
+        .setClassAssertionStatus(PathSpecBasedSchemaAnnotationVisitor.class.getName(), false);
+  }
+
+  @Test
+  public void testAspectAnnotationDtoMapsSchemaVersion() {
+    AspectAnnotation annotation = new AspectAnnotation("domains", false, false, null, 2L);
+
+    AspectAnnotationDto dto = AspectAnnotationDto.fromAspectAnnotation(annotation);
+
+    assertEquals(dto.getName(), "domains");
+    assertEquals(dto.getSchemaVersion(), 2L);
+  }
+
+  @Test
+  public void testAspectAnnotationDtoMapsDefaultSchemaVersion() {
+    AspectAnnotation annotation = new AspectAnnotation("status", false, false, null, 1L);
+
+    AspectAnnotationDto dto = AspectAnnotationDto.fromAspectAnnotation(annotation);
+
+    assertEquals(dto.getSchemaVersion(), 1L);
+  }
+
+  @Test
+  public void testEntityAnnotationDtoMapsSearchGroup() {
+    EntityAnnotation annotation = new EntityAnnotation("dataset", "datasetKey", "primary");
+
+    EntityAnnotationDto dto = EntityAnnotationDto.fromEntityAnnotation(annotation);
+
+    assertEquals(dto.getName(), "dataset");
+    assertEquals(dto.getKeyAspect(), "datasetKey");
+    assertEquals(dto.getSearchGroup(), "primary");
+  }
+
+  @Test
+  public void testEntityAnnotationDtoMapsDefaultSearchGroup() {
+    EntityAnnotation annotation = new EntityAnnotation("chart", "chartKey");
+
+    EntityAnnotationDto dto = EntityAnnotationDto.fromEntityAnnotation(annotation);
+
+    assertEquals(dto.getSearchGroup(), "default");
+  }
+
+  @Test
+  public void testAspectSpecDtoFromRealRegistryIncludesSchemaVersion() {
+    AspectSpec domains =
+        TestOperationContexts.defaultEntityRegistry().getAspectSpecs().get("domains");
+    assertNotNull(domains);
+
+    AspectSpecDto dto = AspectSpecDto.fromAspectSpec(domains);
+
+    assertNotNull(dto.getAspectAnnotation());
+    assertEquals(dto.getAspectAnnotation().getName(), "domains");
+    assertEquals(dto.getAspectAnnotation().getSchemaVersion(), 2L);
+  }
+
+  @Test
+  public void testEntitySpecDtoFromRealRegistryIncludesSearchGroup() {
+    EntitySpec dataset = TestOperationContexts.defaultEntityRegistry().getEntitySpec("dataset");
+    assertNotNull(dataset);
+
+    EntitySpecDto dto = EntitySpecDto.fromEntitySpec(dataset);
+
+    assertNotNull(dto.getEntityAnnotation());
+    assertEquals(dto.getEntityAnnotation().getSearchGroup(), "primary");
+  }
+}


### PR DESCRIPTION
## Summary
- Expose `@Aspect.schemaVersion` on `AspectAnnotationDto` in the Entity Registry OpenAPI v1 responses
- Expose `@Entity.searchGroup` on `EntityAnnotationDto` in entity specification responses
- Refactor `AspectSpecDto` to map annotations via a shared factory and add `AspectSpec.getAspectAnnotation()` to avoid future field drift
- Add unit tests (`RegistryDtoMappingTest`) and controller assertions for both fields

## Test plan
- [x] `./gradlew spotlessApply`
- [x] `./gradlew :metadata-service:openapi-servlet:test --tests "io.datahubproject.openapi.v1.registry.*"` (38 passing)
- [x] Verified `domains` aspect returns `schemaVersion: 2` and `dataset` entity returns `searchGroup: primary`


Made with [Cursor](https://cursor.com)