### PR TITLE
fix: catch jakarta.json.JsonException in Template.applyPatch

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/Template.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/Template.java
@@ -67,6 +67,12 @@ public interface Template<T extends RecordTemplate> {
               "Error performing JSON PATCH on aspect %s. Patch: %s Target: %s",
               recordTemplate.schema().getName(), jsonPatch, transformed.toString()),
           e);
+    } catch (jakarta.json.JsonException e) {
+      throw new RuntimeException(
+          String.format(
+              "Error performing JSON PATCH on aspect %s. Patch: %s Target: %s",
+              recordTemplate.schema().getName(), jsonPatch, transformed.toString()),
+          e);
     }
   }
 

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/Template.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/Template.java
@@ -61,13 +61,7 @@ public interface Template<T extends RecordTemplate> {
                   .readObject());
       JsonNode postProcessed = rebaseFields(OBJECT_MAPPER.readTree(patched.toString()));
       return RecordUtils.toRecordTemplate(getTemplateType(), postProcessed.toString());
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(
-          String.format(
-              "Error performing JSON PATCH on aspect %s. Patch: %s Target: %s",
-              recordTemplate.schema().getName(), jsonPatch, transformed.toString()),
-          e);
-    } catch (jakarta.json.JsonException e) {
+    } catch (JsonProcessingException | jakarta.json.JsonException e) {
       throw new RuntimeException(
           String.format(
               "Error performing JSON PATCH on aspect %s. Patch: %s Target: %s",


### PR DESCRIPTION
## Summary

```
BatchMetadataChangeProposalsProcessor: MCP Processor Error with jakarta.json.JsonException: Illegal integer format, was ...
```

- `JsonPatch.apply()` (Parsson library) throws `jakarta.json.JsonException` when a JSON Pointer segment cannot be parsed as an integer array index — e.g. when a domain URN (`urn:li:domain:...`) is used as a path token in a `domains` PATCH MCP
- This exception is not a subclass of Jackson's `JsonProcessingException`, so it escaped the existing `catch` block in `Template.applyPatch`, bypassed the Kafka consumer's error handler, and prevented Kafka offset commit
- Result: MCE consumer retried the same bad message indefinitely, eventually causing CrashLoopBackOff
- Fix: add `catch (jakarta.json.JsonException e)` mirroring the existing handler so the exception is wrapped as a `RuntimeException` with full context and caught cleanly by `BatchMetadataChangeProposalsProcessor`

## Test plan

- [ ] Existing unit tests for `Template`/`PatchItemImpl` pass
- [ ] Manually verify a domain PATCH MCP with a malformed JSON Pointer no longer crashes the consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)