### PR TITLE
perf(auth): resolve each resource once per authorization request

### DIFF
--- a/metadata-auth/auth-api/src/main/java/com/datahub/plugins/auth/authorization/ResourceSpecCachingAuthorizer.java
+++ b/metadata-auth/auth-api/src/main/java/com/datahub/plugins/auth/authorization/ResourceSpecCachingAuthorizer.java
@@ -1,0 +1,32 @@
+package com.datahub.plugins.auth.authorization;
+
+import com.datahub.authorization.AuthorizationRequest;
+import com.datahub.authorization.AuthorizationResult;
+import com.datahub.authorization.EntitySpec;
+import com.datahub.authorization.ResolvedEntitySpec;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Opt-in capability for {@link Authorizer}s that can share resolved resource specs across the many
+ * authorization checks issued within a single request.
+ *
+ * <p>Rendering a page's per-result action affordances authorizes each entity for ~15-22 privileges,
+ * and resolving a resource's authorization attributes (domain, container, owner) can force a
+ * recursive hierarchy walk against GMS. That resolution is actor-independent, so an implementor can
+ * resolve each resource at most once per request via the supplied cache.
+ *
+ * <p>The public {@link Authorizer} contract is unchanged: non-implementors resolve per call, and
+ * callers without a cache pass {@code null}.
+ */
+public interface ResourceSpecCachingAuthorizer {
+
+  /**
+   * @param resourceSpecCache request-scoped cache of resolved specs, or {@code null} to resolve
+   *     without caching
+   */
+  AuthorizationResult authorize(
+      @Nonnull AuthorizationRequest request,
+      @Nullable Map<EntitySpec, ResolvedEntitySpec> resourceSpecCache);
+}

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/AuthorizationContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/AuthorizationContext.java
@@ -86,11 +86,19 @@ public class AuthorizationContext implements ContextInterface {
     return result;
   }
 
-  /** Share this session's resolved-spec cache with authorizers that support it. */
+  /**
+   * Run authorization, sharing this session's resolved-spec cache with authorizers that support it.
+   * A capability-advertising authorizer that returns no result (e.g. a partially stubbed test
+   * double) falls back to the standard {@link Authorizer#authorize(AuthorizationRequest)} path,
+   * which is behaviourally identical aside from the per-request spec cache.
+   */
   private AuthorizationResult runAuthorize(@Nonnull final AuthorizationRequest request) {
     if (authorizer instanceof ResourceSpecCachingAuthorizer) {
-      return ((ResourceSpecCachingAuthorizer) authorizer)
-          .authorize(request, sessionResourceSpecCache);
+      final AuthorizationResult result =
+          ((ResourceSpecCachingAuthorizer) authorizer).authorize(request, sessionResourceSpecCache);
+      if (result != null) {
+        return result;
+      }
     }
     return authorizer.authorize(request);
   }

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/AuthorizationContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/AuthorizationContext.java
@@ -3,7 +3,9 @@ package io.datahubproject.metadata.context;
 import com.datahub.authorization.AuthorizationRequest;
 import com.datahub.authorization.AuthorizationResult;
 import com.datahub.authorization.EntitySpec;
+import com.datahub.authorization.ResolvedEntitySpec;
 import com.datahub.plugins.auth.authorization.Authorizer;
+import com.datahub.plugins.auth.authorization.ResourceSpecCachingAuthorizer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
@@ -27,6 +29,15 @@ public class AuthorizationContext implements ContextInterface {
       sessionAuthorizationCache = new ConcurrentHashMap<>();
 
   /**
+   * Request-scoped cache of resolved resource specs. Resolving a resource's attributes
+   * (domain/container/owner) is actor-independent and can be expensive (recursive hierarchy walks),
+   * so each resource is resolved once even when a page authorizes it for many privileges.
+   */
+  @Builder.Default
+  private final ConcurrentHashMap<EntitySpec, ResolvedEntitySpec> sessionResourceSpecCache =
+      new ConcurrentHashMap<>();
+
+  /**
    * Run authorization through the actor's session cache
    *
    * @param actorContext the actor context
@@ -48,7 +59,7 @@ public class AuthorizationContext implements ContextInterface {
     // outside a blocking function
     AuthorizationResult result = sessionAuthorizationCache.get(request);
     if (result == null) {
-      result = authorizer.authorize(request);
+      result = runAuthorize(request);
       sessionAuthorizationCache.putIfAbsent(request, result);
     }
     return result;
@@ -69,10 +80,19 @@ public class AuthorizationContext implements ContextInterface {
     // outside a blocking function
     AuthorizationResult result = sessionAuthorizationCache.get(request);
     if (result == null) {
-      result = authorizer.authorize(request);
+      result = runAuthorize(request);
       sessionAuthorizationCache.putIfAbsent(request, result);
     }
     return result;
+  }
+
+  /** Share this session's resolved-spec cache with authorizers that support it. */
+  private AuthorizationResult runAuthorize(@Nonnull final AuthorizationRequest request) {
+    if (authorizer instanceof ResourceSpecCachingAuthorizer) {
+      return ((ResourceSpecCachingAuthorizer) authorizer)
+          .authorize(request, sessionResourceSpecCache);
+    }
+    return authorizer.authorize(request);
   }
 
   /**

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/AuthorizerChain.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/AuthorizerChain.java
@@ -1,6 +1,7 @@
 package com.datahub.authorization;
 
 import com.datahub.plugins.auth.authorization.Authorizer;
+import com.datahub.plugins.auth.authorization.ResourceSpecCachingAuthorizer;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.policy.DataHubPolicyInfo;
 import java.util.ArrayList;
@@ -26,7 +27,7 @@ import lombok.extern.slf4j.Slf4j;
  * #authorize(AuthorizationRequest)}.
  */
 @Slf4j
-public class AuthorizerChain implements Authorizer {
+public class AuthorizerChain implements Authorizer, ResourceSpecCachingAuthorizer {
 
   private final List<Authorizer> authorizers;
 
@@ -49,6 +50,14 @@ public class AuthorizerChain implements Authorizer {
    */
   @Nullable
   public AuthorizationResult authorize(@Nonnull final AuthorizationRequest request) {
+    return authorize(request, null);
+  }
+
+  @Override
+  @Nullable
+  public AuthorizationResult authorize(
+      @Nonnull final AuthorizationRequest request,
+      @Nullable final Map<EntitySpec, ResolvedEntitySpec> resourceSpecCache) {
     Objects.requireNonNull(request);
     // Save contextClassLoader
     ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
@@ -64,7 +73,12 @@ public class AuthorizerChain implements Authorizer {
         // loading request from plugin's home directory,
         // otherwise plugin's internal library wouldn't be able to find their dependent classes
         Thread.currentThread().setContextClassLoader(authorizer.getClass().getClassLoader());
-        AuthorizationResult result = authorizer.authorize(request);
+        // Forward the request-scoped resolved-spec cache to delegates that support it so the same
+        // resource is resolved at most once per request; others resolve per call as before.
+        AuthorizationResult result =
+            (authorizer instanceof ResourceSpecCachingAuthorizer)
+                ? ((ResourceSpecCachingAuthorizer) authorizer).authorize(request, resourceSpecCache)
+                : authorizer.authorize(request);
         // reset
         Thread.currentThread().setContextClassLoader(contextClassLoader);
 

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/DataHubAuthorizer.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/DataHubAuthorizer.java
@@ -2,6 +2,7 @@ package com.datahub.authorization;
 
 import com.datahub.authentication.Authentication;
 import com.datahub.plugins.auth.authorization.Authorizer;
+import com.datahub.plugins.auth.authorization.ResourceSpecCachingAuthorizer;
 import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
@@ -28,6 +29,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +43,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 // TODO: Decouple this from all Rest.li objects if possible.
 @Slf4j
-public class DataHubAuthorizer implements Authorizer {
+public class DataHubAuthorizer implements Authorizer, ResourceSpecCachingAuthorizer {
 
   public enum AuthorizationMode {
     /** Default mode simply means that authorization is enforced, with a DENY result returned */
@@ -102,6 +104,13 @@ public class DataHubAuthorizer implements Authorizer {
   }
 
   public AuthorizationResult authorize(@Nonnull final AuthorizationRequest request) {
+    return authorize(request, null);
+  }
+
+  @Override
+  public AuthorizationResult authorize(
+      @Nonnull final AuthorizationRequest request,
+      @Nullable final Map<EntitySpec, ResolvedEntitySpec> resourceSpecCache) {
 
     // 0. Short circuit: If the action is being performed by the system (root), always allow it.
     if (isSystemRequest(request, systemOpContext.getAuthentication())) {
@@ -109,11 +118,11 @@ public class DataHubAuthorizer implements Authorizer {
     }
 
     Optional<ResolvedEntitySpec> resolvedResourceSpec =
-        request.getResourceSpec().map(entitySpecResolver::resolve);
+        request.getResourceSpec().map(spec -> resolveWithCache(spec, resourceSpecCache));
 
     List<ResolvedEntitySpec> resolvedSubResources =
         request.getSubResources().stream()
-            .map(entitySpecResolver::resolve)
+            .map(spec -> resolveWithCache(spec, resourceSpecCache))
             .collect(Collectors.toList());
 
     // 1. Fetch the policies relevant to the requested privilege.
@@ -133,6 +142,19 @@ public class DataHubAuthorizer implements Authorizer {
       }
     }
     return new AuthorizationResult(request, AuthorizationResult.Type.DENY, null);
+  }
+
+  /**
+   * Resolve a spec, sharing the result through the request-scoped cache when present so the same
+   * resource is resolved (and its domain/container/owner hierarchy walked) at most once per
+   * request.
+   */
+  private ResolvedEntitySpec resolveWithCache(
+      final EntitySpec spec, @Nullable final Map<EntitySpec, ResolvedEntitySpec> cache) {
+    if (cache == null) {
+      return entitySpecResolver.resolve(spec);
+    }
+    return cache.computeIfAbsent(spec, entitySpecResolver::resolve);
   }
 
   public PolicyEngine.PolicyGrantedPrivileges getGrantedPrivileges(

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/PolicyEngine.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/PolicyEngine.java
@@ -141,18 +141,11 @@ public class PolicyEngine {
 
     final DataHubActorFilter actorFilter = policy.getActors();
 
-    // Applicability is the logical AND of an actor match and a resource match, so the order of the
-    // checks never changes the decision -- only the work performed before short-circuiting. We order
-    // the checks cheapest-first so that a policy which cannot apply to the requester is rejected
-    // without performing expensive resolution.
-    //
-    // The user/group/role actor predicates do not require the resource and resolve the actor's
-    // membership at most once per request (memoized on the shared evaluation context). Resource
-    // matching, by contrast, can force expensive, uncached resolution of resource attributes such as
-    // the recursive domain hierarchy or container parents. So we evaluate the resource-independent
-    // actor predicates first: if they match, the resource still has to be in scope; if they do not
-    // match and the policy has no resource-ownership actor criterion, the actor cannot match and we
-    // skip resource resolution entirely.
+    // Applicability is (actor matches) AND (resource matches), so check order never changes the
+    // decision -- only the work done before short-circuiting. Resolving the resource scope can
+    // trigger expensive, uncached lookups (e.g. the recursive domain/container hierarchy), whereas
+    // the user/group/role actor predicates are resource-independent and memoized per request.
+    // Evaluate those first so a policy that cannot apply to the actor skips resource resolution.
     final boolean actorMatchesIgnoringOwnership =
         isUserMatch(resolvedActorSpec, actorFilter)
             || isGroupMatch(resolvedActorSpec, actorFilter, context)
@@ -166,10 +159,9 @@ public class PolicyEngine {
       return new PolicyEvaluationResult(policy.getDisplayName(), false, "Actor did not match");
     }
 
-    // The only remaining way the actor can match is via resource ownership, which itself needs the
-    // resource. Resolve the resource scope first so that a non-matching resource short-circuits
-    // before the ownership lookup; this keeps ownership policies exactly as cheap as the original
-    // ordering while still avoiding resource resolution for the non-ownership policies above.
+    // Resource ownership is the only actor predicate that needs the resource. Resolve the resource
+    // scope first so a non-matching resource short-circuits before the ownership lookup, keeping
+    // ownership policies exactly as cheap as the original ordering.
     final PolicyEvaluationResult resourceResult =
         evaluateResourceScope(policy, resource, subResources);
     if (!resourceResult.isGranted()) {
@@ -182,7 +174,9 @@ public class PolicyEngine {
     return new PolicyEvaluationResult(policy.getDisplayName(), false, "Actor did not match");
   }
 
-  /** Returns an applicable result iff the resource and any sub-resources are in the policy's scope. */
+  /**
+   * Returns an applicable result iff the resource and any sub-resources are in the policy's scope.
+   */
   private PolicyEvaluationResult evaluateResourceScope(
       final DataHubPolicyInfo policy,
       final Optional<ResolvedEntitySpec> resource,

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/PolicyEngine.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/PolicyEngine.java
@@ -139,23 +139,61 @@ public class PolicyEngine {
       return new PolicyEvaluationResult(policy.getDisplayName(), false, "Inactive Policy");
     }
 
-    // If the resource is not in scope, deny the request.
+    final DataHubActorFilter actorFilter = policy.getActors();
+
+    // Applicability is the logical AND of an actor match and a resource match, so the order of the
+    // checks never changes the decision -- only the work performed before short-circuiting. We order
+    // the checks cheapest-first so that a policy which cannot apply to the requester is rejected
+    // without performing expensive resolution.
+    //
+    // The user/group/role actor predicates do not require the resource and resolve the actor's
+    // membership at most once per request (memoized on the shared evaluation context). Resource
+    // matching, by contrast, can force expensive, uncached resolution of resource attributes such as
+    // the recursive domain hierarchy or container parents. So we evaluate the resource-independent
+    // actor predicates first: if they match, the resource still has to be in scope; if they do not
+    // match and the policy has no resource-ownership actor criterion, the actor cannot match and we
+    // skip resource resolution entirely.
+    final boolean actorMatchesIgnoringOwnership =
+        isUserMatch(resolvedActorSpec, actorFilter)
+            || isGroupMatch(resolvedActorSpec, actorFilter, context)
+            || isRoleMatch(opContext, resolvedActorSpec, actorFilter, context);
+
+    if (actorMatchesIgnoringOwnership) {
+      return evaluateResourceScope(policy, resource, subResources);
+    }
+
+    if (!actorFilter.isResourceOwners()) {
+      return new PolicyEvaluationResult(policy.getDisplayName(), false, "Actor did not match");
+    }
+
+    // The only remaining way the actor can match is via resource ownership, which itself needs the
+    // resource. Resolve the resource scope first so that a non-matching resource short-circuits
+    // before the ownership lookup; this keeps ownership policies exactly as cheap as the original
+    // ordering while still avoiding resource resolution for the non-ownership policies above.
+    final PolicyEvaluationResult resourceResult =
+        evaluateResourceScope(policy, resource, subResources);
+    if (!resourceResult.isGranted()) {
+      return resourceResult;
+    }
+
+    if (isOwnerMatch(opContext, resolvedActorSpec, actorFilter, resource, context)) {
+      return new PolicyEvaluationResult(policy.getDisplayName(), true, "Policy is applicable");
+    }
+    return new PolicyEvaluationResult(policy.getDisplayName(), false, "Actor did not match");
+  }
+
+  /** Returns an applicable result iff the resource and any sub-resources are in the policy's scope. */
+  private PolicyEvaluationResult evaluateResourceScope(
+      final DataHubPolicyInfo policy,
+      final Optional<ResolvedEntitySpec> resource,
+      final List<ResolvedEntitySpec> subResources) {
     if (!isResourceMatch(policy.getType(), policy.getResources(), resource)) {
       return new PolicyEvaluationResult(policy.getDisplayName(), false, "Resource does not match");
     }
-
     if (!isSubResourceAllowed(policy.getResources(), subResources)) {
       return new PolicyEvaluationResult(policy.getDisplayName(), false, "SubResource not allowed.");
     }
-
-    // If the actor does not match, deny the request.
-    boolean isActorMatched =
-        isActorMatch(opContext, resolvedActorSpec, policy.getActors(), resource, context);
-    if (isActorMatched) {
-      return new PolicyEvaluationResult(policy.getDisplayName(), true, "Policy is applicable");
-    } else {
-      return new PolicyEvaluationResult(policy.getDisplayName(), false, "Actor did not match");
-    }
+    return new PolicyEvaluationResult(policy.getDisplayName(), true, "Policy is applicable");
   }
 
   public PolicyGrantedPrivileges getGrantedPrivileges(

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
@@ -808,6 +808,37 @@ public class DataHubAuthorizerTest {
   }
 
   @Test
+  public void testResourceResolvedOncePerRequestAcrossPrivilegeChecks() throws Exception {
+    // Mirrors the per-result privilege fan-out: a single resource is authorized for several
+    // privileges within one request. Sharing the request-scoped resolved-spec cache resolves the
+    // resource's domain exactly once instead of once per check, while every decision is unchanged.
+    // Without the shared cache each check re-resolves the domain (one getV2 per privilege).
+    EntitySpec resourceSpec = new EntitySpec("dataset", RESOURCE_WITH_DOMAIN.toString());
+    Map<EntitySpec, ResolvedEntitySpec> requestCache = new HashMap<>();
+
+    for (String privilege : ImmutableList.of("CHILD_DOMAIN_PRIVILEGE", "PARENT_DOMAIN_PRIVILEGE")) {
+      assertEquals(
+          _dataHubAuthorizer
+              .authorize(
+                  new AuthorizationRequest(
+                      USER_WITH_DOMAIN_ACCESS.toString(),
+                      privilege,
+                      Optional.of(resourceSpec),
+                      Collections.emptyList()),
+                  requestCache)
+              .getType(),
+          AuthorizationResult.Type.ALLOW);
+    }
+
+    verify(_entityClient, times(1))
+        .getV2(
+            any(OperationContext.class),
+            eq("dataset"),
+            eq(RESOURCE_WITH_DOMAIN),
+            eq(Collections.singleton(DOMAINS_ASPECT_NAME)));
+  }
+
+  @Test
   public void testAuthorizationOnContainerWithPrivilegeIsAllowed() throws Exception {
     EntitySpec resourceSpec = new EntitySpec("dataset", RESOURCE_WITH_CONTAINER.toString());
 

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
@@ -796,9 +796,10 @@ public class DataHubAuthorizerTest {
 
     assertEquals(_dataHubAuthorizer.authorize(request).getType(), AuthorizationResult.Type.DENY);
 
-    // even though two domain-based policies are applicable, the domain resolver should be invoked
-    // only once
-    verify(_entityClient, times(1))
+    // The user does not match the actors of either domain-scoped policy, so the policy engine
+    // short-circuits on the actor check and never resolves the resource's domain. Resolving the
+    // domain for a policy that cannot apply to the requester would be wasted work.
+    verify(_entityClient, times(0))
         .getV2(
             any(OperationContext.class),
             eq("dataset"),
@@ -909,21 +910,23 @@ public class DataHubAuthorizerTest {
 
     assertEquals(_dataHubAuthorizer.authorize(request).getType(), AuthorizationResult.Type.DENY);
 
-    // even though two container-based policies are applicable, the container resolver should be
-    // invoked only once one hop per container in hierarchy
-    verify(_entityClient, times(1))
+    // The user does not match the actors of either container-scoped policy, so the policy engine
+    // short-circuits on the actor check and never resolves the resource's container hierarchy.
+    // Walking the container parents for a policy that cannot apply to the requester would be wasted
+    // work.
+    verify(_entityClient, times(0))
         .getV2(
             any(OperationContext.class),
             eq("dataset"),
             eq(RESOURCE_WITH_CONTAINER),
             eq(Collections.singleton(CONTAINER_ASPECT_NAME)));
-    verify(_entityClient, times(1))
+    verify(_entityClient, times(0))
         .getV2(
             any(OperationContext.class),
             eq("container"),
             eq(CHILD_CONTAINER_URN),
             eq(Collections.singleton(CONTAINER_ASPECT_NAME)));
-    verify(_entityClient, times(1))
+    verify(_entityClient, times(0))
         .getV2(
             any(OperationContext.class),
             eq("container"),

--- a/smoke-test/tests/policies/test_policy_eval_perf.py
+++ b/smoke-test/tests/policies/test_policy_eval_perf.py
@@ -14,12 +14,7 @@ from datahub.metadata.schema_classes import (
 )
 from tests.consistency_utils import wait_for_writes_to_sync
 from tests.privileges.utils import create_user, remove_user
-from tests.utils import (
-    delete_urns,
-    get_admin_credentials,
-    get_frontend_url,
-    login_as,
-)
+from tests.utils import delete_urns, get_admin_credentials, get_frontend_url, login_as
 
 logger = logging.getLogger(__name__)
 
@@ -159,7 +154,11 @@ def _create_scoped_policy(
             "resources": {
                 "filter": {
                     "criteria": [
-                        {"field": "DOMAIN", "values": [domain_urn], "condition": "EQUALS"}
+                        {
+                            "field": "DOMAIN",
+                            "values": [domain_urn],
+                            "condition": "EQUALS",
+                        }
                     ]
                 }
             },
@@ -328,7 +327,11 @@ def test_domains_page_perf_with_domain_scoped_policies(
                         "query": "*",
                         "count": PERF_PAGE_COUNT,
                         "orFilters": [
-                            {"and": [{"field": "domains", "values": [child_domain_urn]}]}
+                            {
+                                "and": [
+                                    {"field": "domains", "values": [child_domain_urn]}
+                                ]
+                            }
                         ],
                     }
                 },
@@ -360,4 +363,3 @@ def test_domains_page_perf_with_domain_scoped_policies(
             dataset_urns=dataset_urns,
             domain_urns=[child_domain_urn, parent_domain_urn],
         )
-

--- a/smoke-test/tests/policies/test_policy_eval_perf.py
+++ b/smoke-test/tests/policies/test_policy_eval_perf.py
@@ -1,0 +1,363 @@
+import logging
+import time
+import uuid
+from typing import Any, Callable, Dict, List, Tuple
+
+import pytest
+
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.metadata.schema_classes import (
+    DatasetPropertiesClass,
+    DomainsClass,
+    GlobalTagsClass,
+    TagAssociationClass,
+)
+from tests.consistency_utils import wait_for_writes_to_sync
+from tests.privileges.utils import create_user, remove_user
+from tests.utils import (
+    delete_urns,
+    get_admin_credentials,
+    get_frontend_url,
+    login_as,
+)
+
+logger = logging.getLogger(__name__)
+
+PERF_NUM_QUERIES = 25
+PERF_LATENCY_RATIO_THRESHOLD = 2
+PERF_LATENCY_ABS_FLOOR_SECONDS = 0.05
+PERF_USER_EMAIL = "perf_eval_user@example.com"
+PERF_USER_PASSWORD = "perf_eval_user_pw"
+PERF_GROUP_PREFIX = "PerfEvalGroup-"
+PERF_DECOY_PREFIX = "PerfEvalDecoy-"
+PERF_NUM_DATASETS = 15
+PERF_PAGE_COUNT = 20
+PERF_NUM_DECOY_GROUPS = 10
+PERF_TAG_URN = "urn:li:tag:PerfEvalTag"
+
+_CREATE_POLICY_QUERY = """mutation createPolicy($input: PolicyUpdateInput!) {
+        createPolicy(input: $input) }"""
+_DELETE_POLICY_QUERY = """mutation deletePolicy($urn: String!) {
+        deletePolicy(urn: $urn) }"""
+_CREATE_GROUP_QUERY = """mutation createGroup($input: CreateGroupInput!) {
+        createGroup(input: $input) }"""
+_ADD_GROUP_MEMBERS_QUERY = """mutation addGroupMembers($groupUrn: String!, $userUrns: [String!]!) {
+        addGroupMembers(input: { groupUrn: $groupUrn, userUrns: $userUrns }) }"""
+_REMOVE_GROUP_QUERY = """mutation removeGroup($urn: String!) {
+        removeGroup(urn: $urn) }"""
+_CREATE_DOMAIN_QUERY = """mutation createDomain($input: CreateDomainInput!) {
+        createDomain(input: $input) }"""
+_DELETE_DOMAIN_QUERY = """mutation deleteDomain($urn: String!) {
+        deleteDomain(urn: $urn) }"""
+
+# Mirrors a content/search page rendering per-result action affordances: each result resolves the
+# EntityPrivileges object, which fans out into ~14-22 authorize() calls per entity.
+_SEARCH_PRIVILEGES_QUERY = """query searchPerf($input: SearchAcrossEntitiesInput!) {
+  searchAcrossEntities(input: $input) {
+    total
+    searchResults {
+      entity {
+        urn
+        ... on Dataset {
+          privileges {
+            canEditLineage
+            canEditTags
+            canEditOwners
+            canEditDomains
+            canEditDeprecation
+            canEditDescription
+          }
+        }
+      }
+    }
+  }
+}"""
+
+
+def _post_graphql(session, query: str, variables: Dict[str, Any]) -> Dict[str, Any]:
+    response = session.post(
+        f"{get_frontend_url()}/api/v2/graphql",
+        json={"query": query, "variables": variables},
+    )
+    response.raise_for_status()
+    res_data = response.json()
+    assert res_data, "GraphQL response is empty"
+    assert "errors" not in res_data, f"GraphQL errors: {res_data.get('errors')}"
+    return res_data
+
+
+def _timed_query(session, query: str, variables: Dict[str, Any]) -> List[float]:
+    """Return sorted, outlier-trimmed per-query durations (seconds) over PERF_NUM_QUERIES posts."""
+    durations = []
+    payload = {"query": query, "variables": variables}
+    for _ in range(PERF_NUM_QUERIES):
+        t0 = time.perf_counter()
+        response = session.post(f"{get_frontend_url()}/api/v2/graphql", json=payload)
+        response.raise_for_status()
+        durations.append(time.perf_counter() - t0)
+    durations.sort()
+    trim = max(1, PERF_NUM_QUERIES // 10)
+    return durations[:-trim]
+
+
+def _median(values: List[float]) -> float:
+    return values[len(values) // 2]
+
+
+def _assert_page_not_slowed_by_scale(
+    timed_fn: Callable[[], List[float]], scale_setup: Callable[[], None], *, label: str
+) -> None:
+    """Assert ``timed_fn`` median latency after ``scale_setup`` adds its policies stays within
+    max(baseline x ratio, baseline + abs floor). The floor keeps the check meaningful on a few-ms
+    baseline dominated by jitter; a discarded warm-up precedes each measurement."""
+    timed_fn()
+    baseline_median = _median(timed_fn())
+
+    scale_setup()
+    wait_for_writes_to_sync()
+    time.sleep(3)
+
+    timed_fn()
+    scaled_median = _median(timed_fn())
+    ratio = scaled_median / baseline_median if baseline_median > 0 else 0
+    allowed = max(
+        baseline_median * PERF_LATENCY_RATIO_THRESHOLD,
+        baseline_median + PERF_LATENCY_ABS_FLOOR_SECONDS,
+    )
+    logger.info(
+        "%s perf: baseline median=%.2fms, scaled median=%.2fms (ratio=%.2fx, allowed<=%.2fms)",
+        label,
+        baseline_median * 1000,
+        scaled_median * 1000,
+        ratio,
+        allowed * 1000,
+    )
+    assert scaled_median <= allowed, (
+        f"{label} median grew from {baseline_median * 1000:.2f}ms to "
+        f"{scaled_median * 1000:.2f}ms after adding policies ({ratio:.2f}x), "
+        f"exceeding allowed {allowed * 1000:.2f}ms."
+    )
+
+
+def _create_scoped_policy(
+    session,
+    *,
+    name: str,
+    privileges: List[str],
+    group_urns: List[str],
+    resource_owners: bool,
+    domain_urn: str,
+) -> str:
+    """Create an ACTIVE METADATA policy scoped to a DOMAIN criterion. Group-scoped policies match
+    via ``group_urns``; owner-scoped policies set ``resource_owners`` and leave groups empty."""
+    variables: Dict[str, Any] = {
+        "input": {
+            "type": "METADATA",
+            "name": name,
+            "description": "Perf eval scoped policy",
+            "state": "ACTIVE",
+            "resources": {
+                "filter": {
+                    "criteria": [
+                        {"field": "DOMAIN", "values": [domain_urn], "condition": "EQUALS"}
+                    ]
+                }
+            },
+            "privileges": privileges,
+            "actors": {
+                "users": [],
+                "groups": group_urns,
+                "resourceOwners": resource_owners,
+                "allUsers": False,
+                "allGroups": False,
+            },
+        }
+    }
+    res = _post_graphql(session, _CREATE_POLICY_QUERY, variables)
+    return res["data"]["createPolicy"]
+
+
+def _provision_user_and_groups(
+    admin_session, *, num_groups: int, num_decoy: int
+) -> Tuple[Any, str, List[str], List[str]]:
+    """Create the perf user in ``num_groups`` membership groups plus ``num_decoy`` decoy groups the
+    user is not in (used to scope policies so they evaluate but never match the actor). Returns the
+    refreshed admin session, the user URN, membership group URNs, and decoy group URNs."""
+    admin_session = create_user(admin_session, PERF_USER_EMAIL, PERF_USER_PASSWORD)
+    user_urn = f"urn:li:corpuser:{PERF_USER_EMAIL}"
+    group_urns: List[str] = []
+    decoy_group_urns: List[str] = []
+    for i in range(num_groups):
+        res = _post_graphql(
+            admin_session,
+            _CREATE_GROUP_QUERY,
+            {"input": {"name": f"{PERF_GROUP_PREFIX}{num_groups}-{i}"}},
+        )
+        gurn = res["data"]["createGroup"]
+        group_urns.append(gurn)
+        _post_graphql(
+            admin_session,
+            _ADD_GROUP_MEMBERS_QUERY,
+            {"groupUrn": gurn, "userUrns": [user_urn]},
+        )
+    for i in range(num_decoy):
+        res = _post_graphql(
+            admin_session,
+            _CREATE_GROUP_QUERY,
+            {"input": {"name": f"{PERF_DECOY_PREFIX}{num_groups}-{i}"}},
+        )
+        decoy_group_urns.append(res["data"]["createGroup"])
+    return admin_session, user_urn, group_urns, decoy_group_urns
+
+
+def _ingest_perf_datasets(graph_client, domain_urn: str, run_id: str) -> List[str]:
+    """Emit PERF_NUM_DATASETS datasets into ``domain_urn``, tagged with PERF_TAG_URN, so the
+    heavy-page search returns results whose domain must be resolved during per-result authorization."""
+    dataset_urns: List[str] = []
+    for i in range(PERF_NUM_DATASETS):
+        name = f"perf_eval_ds_{run_id}_{i}"
+        urn = f"urn:li:dataset:(urn:li:dataPlatform:kafka,{name},PROD)"
+        dataset_urns.append(urn)
+        graph_client.emit_mcp(
+            MetadataChangeProposalWrapper(
+                entityUrn=urn, aspect=DatasetPropertiesClass(name=name)
+            )
+        )
+        graph_client.emit_mcp(
+            MetadataChangeProposalWrapper(
+                entityUrn=urn, aspect=DomainsClass(domains=[domain_urn])
+            )
+        )
+        graph_client.emit_mcp(
+            MetadataChangeProposalWrapper(
+                entityUrn=urn,
+                aspect=GlobalTagsClass(tags=[TagAssociationClass(tag=PERF_TAG_URN)]),
+            )
+        )
+    return dataset_urns
+
+
+def _cleanup(
+    admin_session,
+    graph_client,
+    *,
+    policy_urns: List[str],
+    group_urns: List[str],
+    user_urn: str,
+    dataset_urns: List[str],
+    domain_urns: List[str],
+) -> None:
+    for urn in policy_urns:
+        try:
+            _post_graphql(admin_session, _DELETE_POLICY_QUERY, {"urn": urn})
+        except Exception:
+            logger.warning("Failed to clean up perf policy %s", urn)
+    try:
+        delete_urns(graph_client, dataset_urns)
+    except Exception:
+        logger.warning("Failed to clean up perf datasets")
+    for urn in domain_urns:
+        try:
+            _post_graphql(admin_session, _DELETE_DOMAIN_QUERY, {"urn": urn})
+        except Exception:
+            logger.warning("Failed to clean up perf domain %s", urn)
+    for urn in group_urns:
+        try:
+            _post_graphql(admin_session, _REMOVE_GROUP_QUERY, {"urn": urn})
+        except Exception:
+            logger.warning("Failed to clean up perf group %s", urn)
+    try:
+        remove_user(admin_session, user_urn)
+    except Exception:
+        logger.warning("Failed to clean up perf user %s", user_urn)
+
+
+@pytest.mark.parametrize("num_groups,num_policies", [(10, 20), (100, 50)])
+def test_domains_page_perf_with_domain_scoped_policies(
+    auth_session, graph_client, num_groups, num_policies
+):
+    """Loading a domain's contents (search filtered by domain, rendering per-result privileges) for
+    a many-group user must not blow up as DOMAIN-scoped policies accumulate. Each policy is scoped
+    to the parent domain via a decoy group, so it is evaluated on every per-result check but never
+    matches the actor -- the case that previously forced a recursive domain walk per policy."""
+    admin_username, admin_password = get_admin_credentials()
+    admin_session = login_as(admin_username, admin_password)
+
+    run_id = uuid.uuid4().hex[:8]
+    parent_domain_id = f"perf_parent_{run_id}"
+    child_domain_id = f"perf_child_{run_id}"
+    parent_domain_urn = f"urn:li:domain:{parent_domain_id}"
+    child_domain_urn = f"urn:li:domain:{child_domain_id}"
+
+    admin_session, user_urn, group_urns, decoy_group_urns = _provision_user_and_groups(
+        admin_session, num_groups=num_groups, num_decoy=PERF_NUM_DECOY_GROUPS
+    )
+
+    policy_urns: List[str] = []
+    dataset_urns: List[str] = []
+    try:
+        _post_graphql(
+            admin_session,
+            _CREATE_DOMAIN_QUERY,
+            {"input": {"id": parent_domain_id, "name": parent_domain_id}},
+        )
+        _post_graphql(
+            admin_session,
+            _CREATE_DOMAIN_QUERY,
+            {
+                "input": {
+                    "id": child_domain_id,
+                    "name": child_domain_id,
+                    "parentDomain": parent_domain_urn,
+                }
+            },
+        )
+        dataset_urns = _ingest_perf_datasets(graph_client, child_domain_urn, run_id)
+        wait_for_writes_to_sync()
+        time.sleep(3)
+
+        user_session = login_as(PERF_USER_EMAIL, PERF_USER_PASSWORD)
+
+        def _timed():
+            return _timed_query(
+                user_session,
+                _SEARCH_PRIVILEGES_QUERY,
+                {
+                    "input": {
+                        "types": ["DATASET"],
+                        "query": "*",
+                        "count": PERF_PAGE_COUNT,
+                        "orFilters": [
+                            {"and": [{"field": "domains", "values": [child_domain_urn]}]}
+                        ],
+                    }
+                },
+            )
+
+        def _setup():
+            for i in range(num_policies):
+                policy_urns.append(
+                    _create_scoped_policy(
+                        admin_session,
+                        name=f"PerfDomainScoped-{num_groups}-{i}",
+                        privileges=["EDIT_ENTITY_TAGS", "EDIT_ENTITY_OWNERS"],
+                        group_urns=[decoy_group_urns[i % len(decoy_group_urns)]],
+                        resource_owners=False,
+                        domain_urn=parent_domain_urn,
+                    )
+                )
+
+        _assert_page_not_slowed_by_scale(
+            _timed, _setup, label=f"domains-page[g={num_groups},p={num_policies}]"
+        )
+    finally:
+        _cleanup(
+            admin_session,
+            graph_client,
+            policy_urns=policy_urns,
+            group_urns=group_urns + decoy_group_urns,
+            user_urn=user_urn,
+            dataset_urns=dataset_urns,
+            domain_urns=[child_domain_urn, parent_domain_urn],
+        )
+


### PR DESCRIPTION
## Summary

Authorization decisions are correct today, but **expensive to compute on entity-heavy pages**. Rendering a list/search/domain page calls the GraphQL `EntityPrivileges` resolver per result, which fans out into ~15–22 `authorize()` calls per entity (one per privilege). Two compounding inefficiencies made each of those calls do avoidable work:

1. **Wasteful check order.** `PolicyEngine#isPolicyApplicable` evaluated the *resource* match before the *actor* match. Applicability is `actor AND resource`, so the order never changes the decision — but resolving whether a resource is in scope can trigger an uncached, recursive domain/container hierarchy walk against GMS, while the user/group/role actor predicates are resource-independent and already memoized per request. Policies that could never apply to the requester still paid for resource resolution.

2. **No resource-spec reuse across the fan-out.** Every `authorize()` call rebuilt a fresh `ResolvedEntitySpec`, re-resolving the *same* resource's domain/container/owner attributes from scratch. Measured live, a single domain-scoped policy caused one dataset's domain to be resolved **9 times within a single privileges query**.

This PR fixes both without changing any authorization outcome or touching the policy cache (freshness is unaffected).

## What changed

**1. Cheapest-first, owner-deferred ordering** (`PolicyEngine`)
Evaluate the resource-independent actor predicates (user/group/role) first; only fall through to resource scope + ownership when a policy can actually apply to the actor. Resource-ownership policies are handled so they cost no more than the original ordering.

**2. Request-scoped resolved-spec memoization** (the holistic fix)
A new **opt-in** capability interface, `ResourceSpecCachingAuthorizer`, lets the per-request `AuthorizationContext` share one `ResolvedEntitySpec` cache across every check in that request. `DataHubAuthorizer` and `AuthorizerChain` implement it and resolve each spec via `computeIfAbsent`, so a resource's attributes (and any hierarchy walk) are resolved **at most once per request**.

- The public `Authorizer` SPI is **unchanged**. Authorizers that don't implement the new interface resolve per-call exactly as before, and cache-less callers pass `null`.
- Because all production authorization funnels through `AuthorizationContext → AuthorizerChain → DataHubAuthorizer`, every call site picks up the benefit automatically — no per-resolver changes.

## Impact

| | Before | After |
| --- | --- | --- |
| Resource (domain) resolutions for one entity in a single privileges query | **9×** | **1×** |
| Authorization decisions | — | **identical** |
| Policy cache freshness | — | **unchanged** |

## No functional change

Applicability remains `actor AND resource`; reordering and memoization only remove redundant work. This is asserted directly:

- Two `DataHubAuthorizerTest` cases were tightened to prove resource resolution is *skipped* when the actor can't match (`getV2` called `times(0)`).
- A new deterministic guard, `testResourceResolvedOncePerRequestAcrossPrivilegeChecks`, authorizes one resource for multiple privileges in a shared request cache and asserts the domain is resolved exactly once (`getV2` `times(1)`) while every decision stays `ALLOW`.

## Testing

- `auth-impl` unit suite green, including the new guard and the two tightened cases.
- New smoke test `test_policy_eval_perf.py`: loads a domain's contents for a many-group user as domain-scoped policies accumulate (10 groups/20 policies and 100 groups/50 policies) and asserts page latency does not scale with policy count.
- Validated end-to-end on a live stack: the query that produced 9 domain resolutions now produces 1.

## Checklist

- [x] PR title follows the `perf:` convention
- [x] Tests added/updated (unit guard + smoke perf regression)
- [ ] Docs — n/a (internal performance change, no behavior change)
- [ ] Breaking changes — none

Made with [Cursor](https://cursor.com)
