### PR TITLE
refactor(ingest/dremio): drop unused query classification + comment stripping

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_entities.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_entities.py
@@ -1,10 +1,7 @@
 import logging
-import re
 import uuid
 from datetime import datetime
 from typing import Any, ClassVar, Dict, Iterator, List, Optional
-
-from sqlglot import parse_one
 
 from datahub.emitter.mce_builder import make_term_urn
 from datahub.ingestion.source.common.subtypes import DatasetContainerSubTypes
@@ -20,69 +17,8 @@ from datahub.ingestion.source.dremio.dremio_models import (
     DremioDatasetType,
     DremioEntityContainerType,
 )
-from datahub.utilities.str_enum import StrEnum
 
 logger = logging.getLogger(__name__)
-
-
-class DremioQueryType(StrEnum):
-    """Query classification returned by DremioQuery._get_query_type()."""
-
-    SELECT = "SELECT"
-    DML = "DML"
-    DDL = "DDL"
-
-
-# Internal lookup table mapping query type categories to their leading SQL operators.
-_QUERY_OPERATORS: Dict[str, List[str]] = {
-    DremioQueryType.DML: ["CREATE", "DELETE", "INSERT", "MERGE", "UPDATE"],
-    DremioQueryType.DDL: [
-        "ALTER BRANCH",
-        "ALTER PIPE",
-        "ALTER SOURCE",
-        "ALTER TABLE",
-        "ALTER TAG",
-        "ALTER VIEW",
-        "ANALYZE TABLE",
-        "COPY INTO",
-        "CREATE BRANCH",
-        "CREATE FOLDER",
-        "CREATE PIPE",
-        "CREATE ROLE",
-        "CREATE TABLE",
-        "CREATE TAG",
-        "CREATE USER",
-        "CREATE VIEW",
-        "DESCRIBE PIPE",
-        "DESCRIBE TABLE",
-        "DROP BRANCH",
-        "DROP FOLDER",
-        "DROP PIPE",
-        "DROP ROLE",
-        "DROP TABLE",
-        "DROP TAG",
-        "DROP USER",
-        "DROP VIEW",
-        "GRANT ROLE",
-        "GRANT TO ROLE",
-        "GRANT TO USER",
-        "MERGE BRANCH",
-        "REVOKE FROM ROLE",
-        "REVOKE FROM USER",
-        "REVOKE ROLE",
-        "SHOW BRANCHES",
-        "SHOW CREATE TABLE",
-        "SHOW CREATE VIEW",
-        "SHOW LOGS",
-        "SHOW TABLES",
-        "SHOW TAGS",
-        "SHOW VIEWS",
-        "USE",
-        "VACUUM CATALOG",
-        "VACUUM TABLE",
-    ],
-    DremioQueryType.SELECT: ["SELECT", "WITH"],
-}
 
 
 class DremioGlossaryTerm:
@@ -102,9 +38,6 @@ class DremioGlossaryTerm:
 
 
 class DremioQuery:
-    query_without_comments: str
-    query_type: DremioQueryType
-    query_subtype: str
     affected_dataset: str
 
     def __init__(
@@ -120,9 +53,6 @@ class DremioQuery:
         self.username = username
         self.submitted_ts = self._get_submitted_ts(submitted_ts)
         self.query = self._get_query(query)
-        self.query_without_comments = self.get_raw_query(query)
-        self.query_type = self._get_query_type()
-        self.query_subtype = self._get_query_subtype()
         self.queried_datasets = self._get_queried_datasets(queried_datasets)
         if affected_datasets:
             self.affected_dataset = affected_datasets
@@ -138,49 +68,13 @@ class DremioQuery:
     def _get_query(self, query: str) -> str:
         return str(query).replace("'", "'")
 
-    def _get_query_type(self) -> DremioQueryType:
-        query_operator = re.split(
-            pattern=r"\s+",
-            string=self.query_without_comments.strip(),
-            maxsplit=1,
-        )[0]
-
-        if query_operator in _QUERY_OPERATORS[DremioQueryType.SELECT]:
-            return DremioQueryType.SELECT
-        if query_operator in _QUERY_OPERATORS[DremioQueryType.DML]:
-            return DremioQueryType.DML
-        return DremioQueryType.DDL
-
-    def _get_query_subtype(self) -> str:
-        for query_operator in (
-            _QUERY_OPERATORS[DremioQueryType.SELECT]
-            + _QUERY_OPERATORS[DremioQueryType.DML]
-            + _QUERY_OPERATORS[DremioQueryType.DDL]
-        ):
-            if self.query_without_comments.upper().startswith(query_operator):
-                return query_operator
-        return "UNDEFINED"
-
     def _get_queried_datasets(self, queried_datasets: str) -> List[str]:
         return list(
             {dataset.strip() for dataset in queried_datasets.strip("[]").split(",")}
         )
 
     def _get_affected_tables(self) -> str:
-        # TO DO
-        # for manipulation_operator in _data_manipulation_queries:
-        #     if self.query_without_comments.upper().startswith(manipulation_operator):
-
         return ""
-
-    def get_raw_query(self, sql_query: str) -> str:
-        """Remove comments from SQL query using sqlglot parser."""
-        try:
-            parsed = parse_one(sql_query)
-            return parsed.sql(comments=False)
-        except Exception as e:
-            logger.warning(e)
-            return sql_query
 
 
 class DremioDataset:

--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_source.py
@@ -295,6 +295,7 @@ class DremioSource(StatefulIngestionSourceBase):
             usage_config=self.config.usage,
             # Gate SQL-discovered URNs through the catalog-walk filters.
             is_allowed_table=self._is_allowed_table,
+            format_queries=False,
         )
         self.report.sql_aggregator = self.sql_parsing_aggregator.report
 

--- a/metadata-ingestion/tests/unit/dremio/test_dremio_entities.py
+++ b/metadata-ingestion/tests/unit/dremio/test_dremio_entities.py
@@ -13,70 +13,7 @@ from datahub.ingestion.source.dremio.dremio_entities import (
 VALID_TS = "2024-01-15 10:30:00.000"
 
 
-class TestDremioQueryClassification:
-    """Tests for DremioQuery._get_query_type() and _get_query_subtype()."""
-
-    def _make_query(self, sql: str) -> DremioQuery:
-        return DremioQuery(
-            job_id="test-job",
-            username="user",
-            submitted_ts=VALID_TS,
-            query=sql,
-            queried_datasets="[myspace.mytable]",
-        )
-
-    @pytest.mark.parametrize(
-        "sql, expected_type",
-        [
-            ("SELECT col FROM table1", "SELECT"),
-            ("WITH cte AS (SELECT 1) SELECT * FROM cte", "SELECT"),
-            ("INSERT INTO t SELECT * FROM s", "DML"),
-            ("DELETE FROM t WHERE id = 1", "DML"),
-            ("UPDATE t SET x = 1 WHERE id = 1", "DML"),
-            # NOTE: CREATE* is classified as DML because the type check is first-word only
-            # and "CREATE" appears in QUERY_TYPES["DML"] — "CREATE VIEW" in DDL is never reached.
-            ("CREATE VIEW v AS SELECT 1", "DML"),
-            ("DROP TABLE t", "DDL"),
-            ("ALTER TABLE t ADD COLUMN x INT", "DDL"),
-        ],
-    )
-    def test_query_type_classification(self, sql, expected_type):
-        q = self._make_query(sql)
-        assert q.query_type == expected_type
-
-    def test_subtype_is_first_operator(self):
-        q = self._make_query("SELECT * FROM t")
-        assert q.query_subtype == "SELECT"
-
-    def test_subtype_for_create_view(self):
-        # DML list is iterated before DDL, so "CREATE" (DML) matches before "CREATE VIEW" (DDL).
-        q = self._make_query("CREATE VIEW v AS SELECT 1")
-        assert q.query_subtype == "CREATE"
-
-    @pytest.mark.parametrize(
-        "sql, expected_subtype",
-        [
-            # _get_query_subtype only walks SELECT + DML + DDL; the
-            # DATA_MANIPULATION bucket master removed was never iterated.
-            # Pin that the single-word DML entries are still the first hit.
-            ("INSERT INTO foo SELECT * FROM bar", "INSERT"),
-            (
-                "MERGE INTO target USING src ON src.id = target.id WHEN MATCHED THEN UPDATE SET x = 1",
-                "MERGE",
-            ),
-            ("CREATE TABLE foo AS SELECT 1", "CREATE"),
-        ],
-    )
-    def test_subtype_for_data_manipulation_unchanged_after_bucket_removal(
-        self, sql, expected_subtype
-    ):
-        q = self._make_query(sql)
-        assert q.query_subtype == expected_subtype
-
-    def test_subtype_for_with_cte(self):
-        q = self._make_query("WITH cte AS (SELECT 1) SELECT * FROM cte")
-        assert q.query_subtype == "WITH"
-
+class TestDremioQueryParsing:
     def test_queried_datasets_parsed_from_brackets(self):
         q = DremioQuery(
             job_id="j1",


### PR DESCRIPTION
## Summary

`DremioQuery` computed three attributes on every construction — `query_without_comments`, `query_type`, `query_subtype` — but **nothing in the connector ever reads them** (only the unit tests did). They are not used for filtering, emission, lineage, or operation types.

The comment-stripping that fed them (`get_raw_query`) ran a **full sqlglot parse + regenerate per query**. Because it passed no dialect, it used sqlglot's **base** dialect, which:
- mis-tokenizes Dremio-specific SQL → `Invalid expression / Unexpected token` warnings, and
- drops unsupported args — e.g. rewrites `TO_CHAR(ts, 'YYYY-MM-DD')` to `CAST(ts AS TEXT)` and logs `Argument 'format' is not supported for expression 'ToChar' when targeting Dialect`.

Since the outputs are dead, this PR removes the whole chain rather than just fixing the dialect:
- `get_raw_query`, `_get_query_type`, `_get_query_subtype`
- the `DremioQueryType` enum and the operator lookup table
- the now-unused `re` / `parse_one` / `StrEnum` imports
- the corresponding unit tests

This eliminates the warning **and** the per-query sqlglot parse on large Dremio query histories.

Separately, sets `format_queries=False` on the Dremio `SqlParsingAggregator` (mirroring `snowflake-queries`) to skip the per-query reformatting step, reducing CPU/memory pressure.

No user-facing/emitted behavior changes, so no `updating-datahub.md` entry.

## Test plan

- [x] `pytest tests/unit/dremio/` — 238 passed.
- [x] `./gradlew :metadata-ingestion:lintFix` — clean.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline
- [ ] Links to related issues (if applicable)
- [x] Tests added/updated (if applicable)
- [ ] Documentation update (if applicable)