### PR TITLE
test(cypress): skip Cypress tests migrated to Playwright

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -432,10 +432,10 @@ jobs:
         # cypress_batch_count is used to split the collection of cypress test specs into batches.
         run: |
           if [[ "${{ env.IS_FORK }}" == "true" ]]; then
-            echo "cypress_batch_count=5" >> "$GITHUB_OUTPUT"
+            echo "cypress_batch_count=3" >> "$GITHUB_OUTPUT"
             echo "python_batch_count=3" >> "$GITHUB_OUTPUT"
           else
-            echo "cypress_batch_count=8" >> "$GITHUB_OUTPUT"
+            echo "cypress_batch_count=4" >> "$GITHUB_OUTPUT"
             echo "python_batch_count=7" >> "$GITHUB_OUTPUT"
           fi
 

--- a/smoke-test/tests/cypress/cypress/e2e/analytics/analytics.js
+++ b/smoke-test/tests/cypress/cypress/e2e/analytics/analytics.js
@@ -1,4 +1,4 @@
-describe("analytics", () => {
+describe.skip("analytics", () => {
   it("can go to a chart and see analytics in tab views", () => {
     cy.login();
 

--- a/smoke-test/tests/cypress/cypress/e2e/analytics/analytics.js
+++ b/smoke-test/tests/cypress/cypress/e2e/analytics/analytics.js
@@ -1,3 +1,4 @@
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("analytics", () => {
   it("can go to a chart and see analytics in tab views", () => {
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/auto_completeV2/v2_auto_complete.js
+++ b/smoke-test/tests/cypress/cypress/e2e/auto_completeV2/v2_auto_complete.js
@@ -1,3 +1,4 @@
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("auto-complete", () => {
   beforeEach(() => {
     cy.setFeatureFlags((res) => {

--- a/smoke-test/tests/cypress/cypress/e2e/auto_completeV2/v2_auto_complete.js
+++ b/smoke-test/tests/cypress/cypress/e2e/auto_completeV2/v2_auto_complete.js
@@ -1,4 +1,4 @@
-describe("auto-complete", () => {
+describe.skip("auto-complete", () => {
   beforeEach(() => {
     cy.setFeatureFlags((res) => {
       res.body.data.appConfig.featureFlags.showHomePageRedesign = false;

--- a/smoke-test/tests/cypress/cypress/e2e/businessAttribute/attribute_mutations.js
+++ b/smoke-test/tests/cypress/cypress/e2e/businessAttribute/attribute_mutations.js
@@ -1,5 +1,6 @@
 import { aliasQuery, hasOperationName } from "../utils";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("attribute list adding tags and terms", () => {
   let businessAttributeEntityEnabled;
 

--- a/smoke-test/tests/cypress/cypress/e2e/businessAttribute/attribute_mutations.js
+++ b/smoke-test/tests/cypress/cypress/e2e/businessAttribute/attribute_mutations.js
@@ -1,6 +1,6 @@
 import { aliasQuery, hasOperationName } from "../utils";
 
-describe("attribute list adding tags and terms", () => {
+describe.skip("attribute list adding tags and terms", () => {
   let businessAttributeEntityEnabled;
 
   beforeEach(() => {

--- a/smoke-test/tests/cypress/cypress/e2e/businessAttribute/businessAttribute.js
+++ b/smoke-test/tests/cypress/cypress/e2e/businessAttribute/businessAttribute.js
@@ -1,6 +1,6 @@
 import { aliasQuery, hasOperationName } from "../utils";
 
-describe("businessAttribute", () => {
+describe.skip("businessAttribute", () => {
   let businessAttributeEntityEnabled;
 
   beforeEach(() => {

--- a/smoke-test/tests/cypress/cypress/e2e/businessAttribute/businessAttribute.js
+++ b/smoke-test/tests/cypress/cypress/e2e/businessAttribute/businessAttribute.js
@@ -1,5 +1,6 @@
 import { aliasQuery, hasOperationName } from "../utils";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("businessAttribute", () => {
   let businessAttributeEntityEnabled;
 

--- a/smoke-test/tests/cypress/cypress/e2e/containersV2/v2_containers.js
+++ b/smoke-test/tests/cypress/cypress/e2e/containersV2/v2_containers.js
@@ -1,3 +1,4 @@
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("containers", () => {
   it("can see elements inside the container", () => {
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/containersV2/v2_containers.js
+++ b/smoke-test/tests/cypress/cypress/e2e/containersV2/v2_containers.js
@@ -1,4 +1,4 @@
-describe("containers", () => {
+describe.skip("containers", () => {
   it("can see elements inside the container", () => {
     cy.login();
     cy.goToContainer("urn:li:container:348c96555971d3f5c1ffd7dd2e7446cb");

--- a/smoke-test/tests/cypress/cypress/e2e/glossaryV2/v2_glossary.js
+++ b/smoke-test/tests/cypress/cypress/e2e/glossaryV2/v2_glossary.js
@@ -30,7 +30,7 @@ const deleteGlossary = (message) => {
   cy.ensureTextNotPresent(message);
 };
 
-describe("glossary", () => {
+describe.skip("glossary", () => {
   beforeEach(() => {
     Cypress.on("uncaught:exception", (err, runnable) => false);
   });

--- a/smoke-test/tests/cypress/cypress/e2e/glossaryV2/v2_glossary.js
+++ b/smoke-test/tests/cypress/cypress/e2e/glossaryV2/v2_glossary.js
@@ -30,6 +30,7 @@ const deleteGlossary = (message) => {
   cy.ensureTextNotPresent(message);
 };
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("glossary", () => {
   beforeEach(() => {
     Cypress.on("uncaught:exception", (err, runnable) => false);

--- a/smoke-test/tests/cypress/cypress/e2e/glossaryV2/v2_glossaryTerm.js
+++ b/smoke-test/tests/cypress/cypress/e2e/glossaryV2/v2_glossaryTerm.js
@@ -57,7 +57,7 @@ const enterKeyInSearchBox = (text) => {
     .type(`${text}{enter}`);
 };
 
-describe("glossaryTerm", () => {
+describe.skip("glossaryTerm", () => {
   beforeEach(() => {
     cy.login();
     cy.skipIntroducePage();

--- a/smoke-test/tests/cypress/cypress/e2e/glossaryV2/v2_glossaryTerm.js
+++ b/smoke-test/tests/cypress/cypress/e2e/glossaryV2/v2_glossaryTerm.js
@@ -57,6 +57,7 @@ const enterKeyInSearchBox = (text) => {
     .type(`${text}{enter}`);
 };
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("glossaryTerm", () => {
   beforeEach(() => {
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/glossaryV2/v2_glossary_navigation.js
+++ b/smoke-test/tests/cypress/cypress/e2e/glossaryV2/v2_glossary_navigation.js
@@ -56,7 +56,7 @@ const deleteGlossary = (message) => {
   cy.waitTextVisible(message);
 };
 
-describe("glossary sidebar navigation test", () => {
+describe.skip("glossary sidebar navigation test", () => {
   beforeEach(() => {
     Cypress.on("uncaught:exception", (err, runnable) => false);
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/glossaryV2/v2_glossary_navigation.js
+++ b/smoke-test/tests/cypress/cypress/e2e/glossaryV2/v2_glossary_navigation.js
@@ -56,6 +56,7 @@ const deleteGlossary = (message) => {
   cy.waitTextVisible(message);
 };
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("glossary sidebar navigation test", () => {
   beforeEach(() => {
     Cypress.on("uncaught:exception", (err, runnable) => false);

--- a/smoke-test/tests/cypress/cypress/e2e/homeV2/v2_home.js
+++ b/smoke-test/tests/cypress/cypress/e2e/homeV2/v2_home.js
@@ -1,4 +1,4 @@
-describe("home", () => {
+describe.skip("home", () => {
   beforeEach(() => {
     cy.setFeatureFlags((res) => {
       res.body.data.appConfig.featureFlags.showHomePageRedesign = false;

--- a/smoke-test/tests/cypress/cypress/e2e/homeV2/v2_home.js
+++ b/smoke-test/tests/cypress/cypress/e2e/homeV2/v2_home.js
@@ -1,3 +1,4 @@
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("home", () => {
   beforeEach(() => {
     cy.setFeatureFlags((res) => {

--- a/smoke-test/tests/cypress/cypress/e2e/incidentsV2/v2_incidents.js
+++ b/smoke-test/tests/cypress/cypress/e2e/incidentsV2/v2_incidents.js
@@ -28,7 +28,7 @@ function expandGroupIfNeeded(group) {
     });
 }
 
-describe("incidents", () => {
+describe.skip("incidents", () => {
   const newIncidentNameWithTimeStamp = `${NEW_INCIDENT_VALUES.NAME}-${Date.now()}`;
   const editedIncidentNameWithTimeStamp = `${newIncidentNameWithTimeStamp}-edited`;
 

--- a/smoke-test/tests/cypress/cypress/e2e/incidentsV2/v2_incidents.js
+++ b/smoke-test/tests/cypress/cypress/e2e/incidentsV2/v2_incidents.js
@@ -28,6 +28,7 @@ function expandGroupIfNeeded(group) {
     });
 }
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("incidents", () => {
   const newIncidentNameWithTimeStamp = `${NEW_INCIDENT_VALUES.NAME}-${Date.now()}`;
   const editedIncidentNameWithTimeStamp = `${newIncidentNameWithTimeStamp}-edited`;

--- a/smoke-test/tests/cypress/cypress/e2e/ingestionV2/run_history.js
+++ b/smoke-test/tests/cypress/cypress/e2e/ingestionV2/run_history.js
@@ -11,6 +11,7 @@ import {
   goToIngestionPage,
 } from "./utils";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("run history tab in manage data sources", () => {
   beforeEach(() => {
     setIngestionRedesignFlags(true);

--- a/smoke-test/tests/cypress/cypress/e2e/ingestionV2/run_history.js
+++ b/smoke-test/tests/cypress/cypress/e2e/ingestionV2/run_history.js
@@ -11,7 +11,7 @@ import {
   goToIngestionPage,
 } from "./utils";
 
-describe("run history tab in manage data sources", () => {
+describe.skip("run history tab in manage data sources", () => {
   beforeEach(() => {
     setIngestionRedesignFlags(true);
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/ingestionV3/run_history_v2.js
+++ b/smoke-test/tests/cypress/cypress/e2e/ingestionV3/run_history_v2.js
@@ -13,6 +13,7 @@ import {
 
 const testId = Math.floor(Math.random() * 100000);
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("run history tab in manage data sources", () => {
   const createdSources = [];
 

--- a/smoke-test/tests/cypress/cypress/e2e/ingestionV3/run_history_v2.js
+++ b/smoke-test/tests/cypress/cypress/e2e/ingestionV3/run_history_v2.js
@@ -13,7 +13,7 @@ import {
 
 const testId = Math.floor(Math.random() * 100000);
 
-describe("run history tab in manage data sources", () => {
+describe.skip("run history tab in manage data sources", () => {
   const createdSources = [];
 
   beforeEach(() => {

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_download_lineage_results.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_download_lineage_results.js
@@ -29,7 +29,7 @@ const downloadCsvFile = (filename) => {
   cy.ensureTextNotPresent("Creating CSV");
 };
 
-describe("download lineage results to .csv file", () => {
+describe.skip("download lineage results to .csv file", () => {
   beforeEach(() => {
     cy.on("uncaught:exception", (err, runnable) => false);
   });

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_download_lineage_results.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_download_lineage_results.js
@@ -29,6 +29,7 @@ const downloadCsvFile = (filename) => {
   cy.ensureTextNotPresent("Creating CSV");
 };
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("download lineage results to .csv file", () => {
   beforeEach(() => {
     cy.on("uncaught:exception", (err, runnable) => false);

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_impact_analysis.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_impact_analysis.js
@@ -20,7 +20,7 @@ const startAtDataSetLineage = () => {
   cy.get('[data-node-key="Lineage"]').first().should("be.visible").click();
 };
 
-describe("impact analysis", () => {
+describe.skip("impact analysis", () => {
   beforeEach(() => {
     cy.on("uncaught:exception", (err, runnable) => false);
   });

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_impact_analysis.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_impact_analysis.js
@@ -20,6 +20,7 @@ const startAtDataSetLineage = () => {
   cy.get('[data-node-key="Lineage"]').first().should("be.visible").click();
 };
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("impact analysis", () => {
   beforeEach(() => {
     cy.on("uncaught:exception", (err, runnable) => false);

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_lineage_column_level.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_lineage_column_level.js
@@ -8,6 +8,7 @@ const expandContractColumns = (asset) => {
     .click({ force: true });
 };
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("column-level lineage graph test", () => {
   it("navigate to lineage graph view and verify that column-level lineage is showing correctly", () => {
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_lineage_column_level.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_lineage_column_level.js
@@ -8,7 +8,7 @@ const expandContractColumns = (asset) => {
     .click({ force: true });
 };
 
-describe("column-level lineage graph test", () => {
+describe.skip("column-level lineage graph test", () => {
   it("navigate to lineage graph view and verify that column-level lineage is showing correctly", () => {
     cy.login();
     cy.goToEntityLineageGraphV2(DATASET_ENTITY_TYPE, DATASET_URN);

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_lineage_column_path.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_lineage_column_path.js
@@ -25,6 +25,7 @@ const clickDownAndUpArrow = (asset) => {
     .click();
 };
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("column-Level lineage and impact analysis path test", () => {
   beforeEach(() => {
     cy.on("uncaught:exception", (err, runnable) => false);

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_lineage_column_path.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_lineage_column_path.js
@@ -25,7 +25,7 @@ const clickDownAndUpArrow = (asset) => {
     .click();
 };
 
-describe("column-Level lineage and impact analysis path test", () => {
+describe.skip("column-Level lineage and impact analysis path test", () => {
   beforeEach(() => {
     cy.on("uncaught:exception", (err, runnable) => false);
     cy.intercept("POST", "/api/v2/graphql", (req) => {

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_lineage_graph.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_lineage_graph.js
@@ -103,7 +103,7 @@ const FILTERING_NODE19_URN =
 const FILTERING_NODE20_URN =
   "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node20,PROD)";
 
-describe("lineage_graph", () => {
+describe.skip("lineage_graph", () => {
   beforeEach(() => {
     cy.setFeatureFlags((res) => {
       res.body.data.appConfig.featureFlags.lineageGraphV3 = false;

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_lineage_graph.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_lineage_graph.js
@@ -103,6 +103,7 @@ const FILTERING_NODE19_URN =
 const FILTERING_NODE20_URN =
   "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node20,PROD)";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("lineage_graph", () => {
   beforeEach(() => {
     cy.setFeatureFlags((res) => {

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_download_lineage_results.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_download_lineage_results.js
@@ -31,7 +31,7 @@ const downloadCsvFile = (filename) => {
   cy.ensureTextNotPresent("Creating CSV");
 };
 
-describe("download lineage results to .csv file", () => {
+describe.skip("download lineage results to .csv file", () => {
   beforeEach(() => {
     setLineageV3FeatureFlags();
     cy.on("uncaught:exception", (err, runnable) => false);

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_download_lineage_results.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_download_lineage_results.js
@@ -31,6 +31,7 @@ const downloadCsvFile = (filename) => {
   cy.ensureTextNotPresent("Creating CSV");
 };
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("download lineage results to .csv file", () => {
   beforeEach(() => {
     setLineageV3FeatureFlags();

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_impact_analysis.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_impact_analysis.js
@@ -19,7 +19,7 @@ const startAtDataSetLineage = () => {
   cy.get('[data-node-key="Lineage"]').first().should("be.visible").click();
 };
 
-describe("impact analysis", () => {
+describe.skip("impact analysis", () => {
   beforeEach(() => {
     setLineageV3FeatureFlags();
   });

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_impact_analysis.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_impact_analysis.js
@@ -19,6 +19,7 @@ const startAtDataSetLineage = () => {
   cy.get('[data-node-key="Lineage"]').first().should("be.visible").click();
 };
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("impact analysis", () => {
   beforeEach(() => {
     setLineageV3FeatureFlags();

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_lineage_column_level.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_lineage_column_level.js
@@ -10,7 +10,7 @@ const expandContractColumns = (asset) => {
     .click({ force: true });
 };
 
-describe("column-level lineage graph test", () => {
+describe.skip("column-level lineage graph test", () => {
   beforeEach(() => {
     setLineageV3FeatureFlags();
   });

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_lineage_column_level.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_lineage_column_level.js
@@ -10,6 +10,7 @@ const expandContractColumns = (asset) => {
     .click({ force: true });
 };
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("column-level lineage graph test", () => {
   beforeEach(() => {
     setLineageV3FeatureFlags();

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_lineage_column_path.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_lineage_column_path.js
@@ -20,6 +20,7 @@ const verifyColumnPathModal = (from, to) => {
     .should("be.visible");
 };
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("column-Level lineage and impact analysis path test", () => {
   beforeEach(() => {
     setLineageV3FeatureFlags();

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_lineage_column_path.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_lineage_column_path.js
@@ -20,7 +20,7 @@ const verifyColumnPathModal = (from, to) => {
     .should("be.visible");
 };
 
-describe("column-Level lineage and impact analysis path test", () => {
+describe.skip("column-Level lineage and impact analysis path test", () => {
   beforeEach(() => {
     setLineageV3FeatureFlags();
   });

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_lineage_graph.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_lineage_graph.js
@@ -104,7 +104,7 @@ const FILTERING_NODE19_URN =
 const FILTERING_NODE20_URN =
   "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node20,PROD)";
 
-describe("lineage_graph", () => {
+describe.skip("lineage_graph", () => {
   beforeEach(() => {
     setLineageV3FeatureFlags();
   });

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_lineage_graph.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV3/v3_lineage_graph.js
@@ -104,6 +104,7 @@ const FILTERING_NODE19_URN =
 const FILTERING_NODE20_URN =
   "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node20,PROD)";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("lineage_graph", () => {
   beforeEach(() => {
     setLineageV3FeatureFlags();

--- a/smoke-test/tests/cypress/cypress/e2e/loginV2/v2_login.js
+++ b/smoke-test/tests/cypress/cypress/e2e/loginV2/v2_login.js
@@ -1,3 +1,4 @@
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("login", () => {
   it("logs in", () => {
     cy.visit("/");

--- a/smoke-test/tests/cypress/cypress/e2e/loginV2/v2_login.js
+++ b/smoke-test/tests/cypress/cypress/e2e/loginV2/v2_login.js
@@ -1,4 +1,4 @@
-describe("login", () => {
+describe.skip("login", () => {
   it("logs in", () => {
     cy.visit("/");
     cy.get("input[data-testid=username]").type(Cypress.env("ADMIN_USERNAME"));

--- a/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/assign_unassign_tags.js
+++ b/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/assign_unassign_tags.js
@@ -7,7 +7,7 @@ const SAMPLE_DATASET_URN =
   "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)";
 const SAMPLE_DATASET_NAME = "SampleCypressHiveDataset";
 
-describe("tags - assign/unassign", () => {
+describe.skip("tags - assign/unassign", () => {
   beforeEach(() => {
     cy.login();
   });

--- a/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/assign_unassign_tags.js
+++ b/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/assign_unassign_tags.js
@@ -7,6 +7,7 @@ const SAMPLE_DATASET_URN =
   "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)";
 const SAMPLE_DATASET_NAME = "SampleCypressHiveDataset";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("tags - assign/unassign", () => {
   beforeEach(() => {
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/create_edit_remove_tags.js
+++ b/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/create_edit_remove_tags.js
@@ -2,7 +2,7 @@ import TagsPageHelper from "./helpers/tags_page_helper";
 
 const test_id = `manage_tagsV2_${new Date().getTime()}`;
 
-describe("tags - create/edit/remove", () => {
+describe.skip("tags - create/edit/remove", () => {
   beforeEach(() => {
     cy.login();
   });

--- a/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/create_edit_remove_tags.js
+++ b/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/create_edit_remove_tags.js
@@ -2,6 +2,7 @@ import TagsPageHelper from "./helpers/tags_page_helper";
 
 const test_id = `manage_tagsV2_${new Date().getTime()}`;
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("tags - create/edit/remove", () => {
   beforeEach(() => {
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/search_bar_placeholder.js
+++ b/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/search_bar_placeholder.js
@@ -1,3 +1,4 @@
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("tags - search bar placeholder", () => {
   beforeEach(() => {
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/search_bar_placeholder.js
+++ b/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/search_bar_placeholder.js
@@ -1,4 +1,4 @@
-describe("tags - search bar placeholder", () => {
+describe.skip("tags - search bar placeholder", () => {
   beforeEach(() => {
     cy.login();
   });

--- a/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/search_not_exists.js
+++ b/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/search_not_exists.js
@@ -1,4 +1,4 @@
-describe("tags - search not exists", () => {
+describe.skip("tags - search not exists", () => {
   beforeEach(() => {
     cy.login();
   });

--- a/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/search_not_exists.js
+++ b/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/search_not_exists.js
@@ -1,3 +1,4 @@
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("tags - search not exists", () => {
   beforeEach(() => {
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/title_search_results.js
+++ b/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/title_search_results.js
@@ -1,3 +1,4 @@
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("tags - title, search, and results", () => {
   beforeEach(() => {
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/title_search_results.js
+++ b/smoke-test/tests/cypress/cypress/e2e/manage_tagsV2/title_search_results.js
@@ -1,4 +1,4 @@
-describe("tags - title, search, and results", () => {
+describe.skip("tags - title, search, and results", () => {
   beforeEach(() => {
     cy.login();
   });

--- a/smoke-test/tests/cypress/cypress/e2e/mfeframework/valid_config_mfe.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mfeframework/valid_config_mfe.js
@@ -1,5 +1,6 @@
 const MFE_CONTAINER_CSS_SELECTOR = '[data-testid="mfe-configurable-container"]';
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("MFE YAML Config - Valid Config", () => {
   beforeEach(() => {
     cy.intercept("GET", "/mfe/config", {

--- a/smoke-test/tests/cypress/cypress/e2e/mfeframework/valid_config_mfe.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mfeframework/valid_config_mfe.js
@@ -1,6 +1,6 @@
 const MFE_CONTAINER_CSS_SELECTOR = '[data-testid="mfe-configurable-container"]';
 
-describe("MFE YAML Config - Valid Config", () => {
+describe.skip("MFE YAML Config - Valid Config", () => {
   beforeEach(() => {
     cy.intercept("GET", "/mfe/config", {
       statusCode: 200,

--- a/smoke-test/tests/cypress/cypress/e2e/ml/experiment.js
+++ b/smoke-test/tests/cypress/cypress/e2e/ml/experiment.js
@@ -1,3 +1,4 @@
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("experiment", () => {
   beforeEach(() => {
     cy.visit("/");

--- a/smoke-test/tests/cypress/cypress/e2e/ml/experiment.js
+++ b/smoke-test/tests/cypress/cypress/e2e/ml/experiment.js
@@ -1,4 +1,4 @@
-describe("experiment", () => {
+describe.skip("experiment", () => {
   beforeEach(() => {
     cy.visit("/");
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/ml/model_mlflow.js
+++ b/smoke-test/tests/cypress/cypress/e2e/ml/model_mlflow.js
@@ -1,3 +1,4 @@
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("models", () => {
   // Add global error handling
   beforeEach(() => {

--- a/smoke-test/tests/cypress/cypress/e2e/ml/model_mlflow.js
+++ b/smoke-test/tests/cypress/cypress/e2e/ml/model_mlflow.js
@@ -1,4 +1,4 @@
-describe("models", () => {
+describe.skip("models", () => {
   // Add global error handling
   beforeEach(() => {
     // This prevents test failures due to unhandled exceptions in the application

--- a/smoke-test/tests/cypress/cypress/e2e/ml/model_sagemaker.js
+++ b/smoke-test/tests/cypress/cypress/e2e/ml/model_sagemaker.js
@@ -1,4 +1,4 @@
-describe("models", () => {
+describe.skip("models", () => {
   it("can visit sagemaker models and groups", () => {
     cy.visitWithLogin(
       "/mlModels/urn:li:mlModel:(urn:li:dataPlatform:sagemaker,cypress-model,PROD)/Summary?is_lineage_mode=false",

--- a/smoke-test/tests/cypress/cypress/e2e/ml/model_sagemaker.js
+++ b/smoke-test/tests/cypress/cypress/e2e/ml/model_sagemaker.js
@@ -1,3 +1,4 @@
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("models", () => {
   it("can visit sagemaker models and groups", () => {
     cy.visitWithLogin(

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/dataset_health.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/dataset_health.js
@@ -2,7 +2,7 @@ const urn =
   "urn:li:dataset:(urn:li:dataPlatform:hive,cypress_health_test,PROD)";
 const datasetName = "cypress_health_test";
 
-describe("dataset health test", () => {
+describe.skip("dataset health test", () => {
   it("go to dataset with failing assertions and active incidents and verify health of dataset", () => {
     cy.login();
     cy.goToDataset(urn, datasetName);

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/dataset_health.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/dataset_health.js
@@ -2,6 +2,7 @@ const urn =
   "urn:li:dataset:(urn:li:dataPlatform:hive,cypress_health_test,PROD)";
 const datasetName = "cypress_health_test";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("dataset health test", () => {
   it("go to dataset with failing assertions and active incidents and verify health of dataset", () => {
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/edit_documentation.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/edit_documentation.js
@@ -3,7 +3,7 @@ const documentation_edited = `This is test${test_id} documentation EDITED`;
 const wrong_url = "https://www.linkedincom";
 const correct_url = "https://www.linkedin.com";
 
-describe("edit documentation and link to dataset", () => {
+describe.skip("edit documentation and link to dataset", () => {
   it("edit field documentation", () => {
     cy.login();
     cy.visit(

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/edit_documentation.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/edit_documentation.js
@@ -3,6 +3,7 @@ const documentation_edited = `This is test${test_id} documentation EDITED`;
 const wrong_url = "https://www.linkedincom";
 const correct_url = "https://www.linkedin.com";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("edit documentation and link to dataset", () => {
   it("edit field documentation", () => {
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_domains.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_domains.js
@@ -4,6 +4,7 @@ const test_domain_id = Math.floor(Math.random() * 100000);
 const test_domain = `CypressDomainTest ${test_domain_id}`;
 const test_domain_urn = `urn:li:domain:${test_domain_id}`;
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("add remove domain", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/v2/graphql", (req) => {

--- a/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_domains.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_domains.js
@@ -4,7 +4,7 @@ const test_domain_id = Math.floor(Math.random() * 100000);
 const test_domain = `CypressDomainTest ${test_domain_id}`;
 const test_domain_urn = `urn:li:domain:${test_domain_id}`;
 
-describe("add remove domain", () => {
+describe.skip("add remove domain", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/v2/graphql", (req) => {
       aliasQuery(req, "appConfig");

--- a/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_edit_documentation.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_edit_documentation.js
@@ -153,6 +153,7 @@ const ensureThatUrlIsNotAvaliableOnSidebar = (url) => {
   });
 };
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("edit documentation and link to dataset", () => {
   // https://github.com/cypress-io/cypress/issues/29277
   Cypress.on(

--- a/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_edit_documentation.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_edit_documentation.js
@@ -153,7 +153,7 @@ const ensureThatUrlIsNotAvaliableOnSidebar = (url) => {
   });
 };
 
-describe("edit documentation and link to dataset", () => {
+describe.skip("edit documentation and link to dataset", () => {
   // https://github.com/cypress-io/cypress/issues/29277
   Cypress.on(
     "uncaught:exception",

--- a/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_ingestion_source.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_ingestion_source.js
@@ -6,6 +6,7 @@ const password = `password${number}`;
 const role = `role${number}`;
 const ingestion_source_name = `ingestion source ${number}`;
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("ingestion source creation flow", () => {
   beforeEach(() => {
     cy.setFeatureFlags((res) => {

--- a/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_ingestion_source.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_ingestion_source.js
@@ -6,7 +6,7 @@ const password = `password${number}`;
 const role = `role${number}`;
 const ingestion_source_name = `ingestion source ${number}`;
 
-describe("ingestion source creation flow", () => {
+describe.skip("ingestion source creation flow", () => {
   beforeEach(() => {
     cy.setFeatureFlags((res) => {
       res.body.data.appConfig.featureFlags.showIngestionPageRedesign = false;

--- a/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_managed_ingestion.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_managed_ingestion.js
@@ -18,6 +18,7 @@ function typeInMonacoEditor(text) {
     .type(text);
 }
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("run managed ingestion", () => {
   beforeEach(() => {
     cy.setFeatureFlags((res) => {

--- a/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_managed_ingestion.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_managed_ingestion.js
@@ -18,7 +18,7 @@ function typeInMonacoEditor(text) {
     .type(text);
 }
 
-describe("run managed ingestion", () => {
+describe.skip("run managed ingestion", () => {
   beforeEach(() => {
     cy.setFeatureFlags((res) => {
       res.body.data.appConfig.featureFlags.showIngestionPageRedesign = false;

--- a/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_managing_secrets.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_managing_secrets.js
@@ -1,4 +1,4 @@
-describe("managing secrets for ingestion creation", () => {
+describe.skip("managing secrets for ingestion creation", () => {
   beforeEach(() => {
     cy.setFeatureFlags((res) => {
       res.body.data.appConfig.featureFlags.showIngestionPageRedesign = false;

--- a/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_managing_secrets.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_managing_secrets.js
@@ -1,3 +1,4 @@
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("managing secrets for ingestion creation", () => {
   beforeEach(() => {
     cy.setFeatureFlags((res) => {

--- a/smoke-test/tests/cypress/cypress/e2e/onboarding/welcome-to-datahub-modal.cy.js
+++ b/smoke-test/tests/cypress/cypress/e2e/onboarding/welcome-to-datahub-modal.cy.js
@@ -1,6 +1,6 @@
 import { aliasQuery, hasOperationName } from "../utils";
 
-describe("WelcomeToDataHubModal", () => {
+describe.skip("WelcomeToDataHubModal", () => {
   const SKIP_WELCOME_MODAL_KEY = "skipWelcomeModal";
 
   beforeEach(() => {

--- a/smoke-test/tests/cypress/cypress/e2e/onboarding/welcome-to-datahub-modal.cy.js
+++ b/smoke-test/tests/cypress/cypress/e2e/onboarding/welcome-to-datahub-modal.cy.js
@@ -1,5 +1,6 @@
 import { aliasQuery, hasOperationName } from "../utils";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("WelcomeToDataHubModal", () => {
   const SKIP_WELCOME_MODAL_KEY = "skipWelcomeModal";
 

--- a/smoke-test/tests/cypress/cypress/e2e/ownershipV2/v2_manage_ownership.js
+++ b/smoke-test/tests/cypress/cypress/e2e/ownershipV2/v2_manage_ownership.js
@@ -1,4 +1,4 @@
-describe("manage ownership", () => {
+describe.skip("manage ownership", () => {
   it("go to ownership types settings page, create, edit, make default, delete a ownership type", () => {
     const testOwnershipType = `Test Ownership Type ${Date.now()}`;
 

--- a/smoke-test/tests/cypress/cypress/e2e/ownershipV2/v2_manage_ownership.js
+++ b/smoke-test/tests/cypress/cypress/e2e/ownershipV2/v2_manage_ownership.js
@@ -1,3 +1,4 @@
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("manage ownership", () => {
   it("go to ownership types settings page, create, edit, make default, delete a ownership type", () => {
     const testOwnershipType = `Test Ownership Type ${Date.now()}`;

--- a/smoke-test/tests/cypress/cypress/e2e/schema_blameV2/v2_schema_blame.js
+++ b/smoke-test/tests/cypress/cypress/e2e/schema_blameV2/v2_schema_blame.js
@@ -1,7 +1,7 @@
 const urn =
   "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)";
 
-describe("schema blame", () => {
+describe.skip("schema blame", () => {
   Cypress.on("uncaught:exception", (err, runnable) => false);
 
   it("can activate the blame view and verify for the latest version of a dataset", () => {

--- a/smoke-test/tests/cypress/cypress/e2e/schema_blameV2/v2_schema_blame.js
+++ b/smoke-test/tests/cypress/cypress/e2e/schema_blameV2/v2_schema_blame.js
@@ -1,6 +1,7 @@
 const urn =
   "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("schema blame", () => {
   Cypress.on("uncaught:exception", (err, runnable) => false);
 

--- a/smoke-test/tests/cypress/cypress/e2e/searchV2/basicSearch.js
+++ b/smoke-test/tests/cypress/cypress/e2e/searchV2/basicSearch.js
@@ -5,6 +5,7 @@ const SAMPLE_ENTITY_NAME = "SampleCypressKafkaDataset";
 const SAMPLE_ENTITY_URN =
   "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleCypressKafkaDataset,PROD)";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("searchBarV2 - Basic Search", () => {
   const helper = new SearchV2Helper();
 

--- a/smoke-test/tests/cypress/cypress/e2e/searchV2/basicSearch.js
+++ b/smoke-test/tests/cypress/cypress/e2e/searchV2/basicSearch.js
@@ -5,7 +5,7 @@ const SAMPLE_ENTITY_NAME = "SampleCypressKafkaDataset";
 const SAMPLE_ENTITY_URN =
   "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleCypressKafkaDataset,PROD)";
 
-describe("searchBarV2 - Basic Search", () => {
+describe.skip("searchBarV2 - Basic Search", () => {
   const helper = new SearchV2Helper();
 
   const setupTest = (searchBarApi = "SEARCH_ACROSS_ENTITIES") => {

--- a/smoke-test/tests/cypress/cypress/e2e/searchV2/entityInteraction.js
+++ b/smoke-test/tests/cypress/cypress/e2e/searchV2/entityInteraction.js
@@ -5,7 +5,7 @@ const SAMPLE_ENTITY_NAME = "SampleCypressKafkaDataset";
 const SAMPLE_ENTITY_URN =
   "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleCypressKafkaDataset,PROD)";
 
-describe("searchBarV2 - Entity Interaction", () => {
+describe.skip("searchBarV2 - Entity Interaction", () => {
   const helper = new SearchV2Helper();
 
   const setupTest = (searchBarApi = "SEARCH_ACROSS_ENTITIES") => {

--- a/smoke-test/tests/cypress/cypress/e2e/searchV2/entityInteraction.js
+++ b/smoke-test/tests/cypress/cypress/e2e/searchV2/entityInteraction.js
@@ -5,6 +5,7 @@ const SAMPLE_ENTITY_NAME = "SampleCypressKafkaDataset";
 const SAMPLE_ENTITY_URN =
   "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleCypressKafkaDataset,PROD)";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("searchBarV2 - Entity Interaction", () => {
   const helper = new SearchV2Helper();
 

--- a/smoke-test/tests/cypress/cypress/e2e/searchV2/filterApplication.js
+++ b/smoke-test/tests/cypress/cypress/e2e/searchV2/filterApplication.js
@@ -5,6 +5,7 @@ const SAMPLE_ENTITY_NAME = "SampleCypressKafkaDataset";
 const SAMPLE_ENTITY_URN =
   "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleCypressKafkaDataset,PROD)";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("searchBarV2 - Filter Application", () => {
   const helper = new SearchV2Helper();
 

--- a/smoke-test/tests/cypress/cypress/e2e/searchV2/filterApplication.js
+++ b/smoke-test/tests/cypress/cypress/e2e/searchV2/filterApplication.js
@@ -5,7 +5,7 @@ const SAMPLE_ENTITY_NAME = "SampleCypressKafkaDataset";
 const SAMPLE_ENTITY_URN =
   "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleCypressKafkaDataset,PROD)";
 
-describe("searchBarV2 - Filter Application", () => {
+describe.skip("searchBarV2 - Filter Application", () => {
   const helper = new SearchV2Helper();
 
   const setupTest = (searchBarApi = "SEARCH_ACROSS_ENTITIES") => {

--- a/smoke-test/tests/cypress/cypress/e2e/searchV2/filterFunctionality.js
+++ b/smoke-test/tests/cypress/cypress/e2e/searchV2/filterFunctionality.js
@@ -3,6 +3,7 @@ import { SearchV2Helper } from "./helpers/searchV2Helper";
 
 const SAMPLE_ENTITY_NAME = "SampleCypressKafkaDataset";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("searchBarV2 - Filter Functionality", () => {
   const helper = new SearchV2Helper();
 

--- a/smoke-test/tests/cypress/cypress/e2e/searchV2/filterFunctionality.js
+++ b/smoke-test/tests/cypress/cypress/e2e/searchV2/filterFunctionality.js
@@ -3,7 +3,7 @@ import { SearchV2Helper } from "./helpers/searchV2Helper";
 
 const SAMPLE_ENTITY_NAME = "SampleCypressKafkaDataset";
 
-describe("searchBarV2 - Filter Functionality", () => {
+describe.skip("searchBarV2 - Filter Functionality", () => {
   const helper = new SearchV2Helper();
 
   const setupTest = (searchBarApi = "SEARCH_ACROSS_ENTITIES") => {

--- a/smoke-test/tests/cypress/cypress/e2e/searchV2/keyboardInteraction.js
+++ b/smoke-test/tests/cypress/cypress/e2e/searchV2/keyboardInteraction.js
@@ -3,7 +3,7 @@ import { SearchV2Helper } from "./helpers/searchV2Helper";
 
 const SAMPLE_ENTITY_NAME = "SampleCypressKafkaDataset";
 
-describe("searchBarV2 - Keyboard Interaction", () => {
+describe.skip("searchBarV2 - Keyboard Interaction", () => {
   const helper = new SearchV2Helper();
 
   const setupTest = (searchBarApi = "SEARCH_ACROSS_ENTITIES") => {

--- a/smoke-test/tests/cypress/cypress/e2e/searchV2/keyboardInteraction.js
+++ b/smoke-test/tests/cypress/cypress/e2e/searchV2/keyboardInteraction.js
@@ -3,6 +3,7 @@ import { SearchV2Helper } from "./helpers/searchV2Helper";
 
 const SAMPLE_ENTITY_NAME = "SampleCypressKafkaDataset";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("searchBarV2 - Keyboard Interaction", () => {
   const helper = new SearchV2Helper();
 

--- a/smoke-test/tests/cypress/cypress/e2e/searchV2/matchedFields.js
+++ b/smoke-test/tests/cypress/cypress/e2e/searchV2/matchedFields.js
@@ -4,6 +4,7 @@ import { SearchV2Helper } from "./helpers/searchV2Helper";
 const SAMPLE_ENTITY_URN =
   "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleCypressKafkaDataset,PROD)";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("searchBarV2 - Matched Fields", () => {
   const helper = new SearchV2Helper();
 

--- a/smoke-test/tests/cypress/cypress/e2e/searchV2/matchedFields.js
+++ b/smoke-test/tests/cypress/cypress/e2e/searchV2/matchedFields.js
@@ -4,7 +4,7 @@ import { SearchV2Helper } from "./helpers/searchV2Helper";
 const SAMPLE_ENTITY_URN =
   "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleCypressKafkaDataset,PROD)";
 
-describe("searchBarV2 - Matched Fields", () => {
+describe.skip("searchBarV2 - Matched Fields", () => {
   const helper = new SearchV2Helper();
 
   const setupTest = (searchBarApi = "SEARCH_ACROSS_ENTITIES") => {

--- a/smoke-test/tests/cypress/cypress/e2e/searchV2/urlInitialization.js
+++ b/smoke-test/tests/cypress/cypress/e2e/searchV2/urlInitialization.js
@@ -3,7 +3,7 @@ import { SearchV2Helper } from "./helpers/searchV2Helper";
 
 const SAMPLE_ENTITY_NAME = "SampleCypressKafkaDataset";
 
-describe("searchBarV2 - URL Initialization", () => {
+describe.skip("searchBarV2 - URL Initialization", () => {
   const helper = new SearchV2Helper();
 
   const setupTest = (searchBarApi = "SEARCH_ACROSS_ENTITIES") => {

--- a/smoke-test/tests/cypress/cypress/e2e/searchV2/urlInitialization.js
+++ b/smoke-test/tests/cypress/cypress/e2e/searchV2/urlInitialization.js
@@ -3,6 +3,7 @@ import { SearchV2Helper } from "./helpers/searchV2Helper";
 
 const SAMPLE_ENTITY_NAME = "SampleCypressKafkaDataset";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("searchBarV2 - URL Initialization", () => {
   const helper = new SearchV2Helper();
 

--- a/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_homePagePost.js
+++ b/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_homePagePost.js
@@ -30,7 +30,7 @@ const clickOnMoreOption = () => {
   cy.get('[data-testid="dropdown-menu-item"]').first().click();
 };
 
-describe("create announcement and link post", () => {
+describe.skip("create announcement and link post", () => {
   beforeEach(() => {
     cy.setFeatureFlags((res) => {
       res.body.data.appConfig.featureFlags.showHomePageRedesign = false;

--- a/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_homePagePost.js
+++ b/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_homePagePost.js
@@ -30,6 +30,7 @@ const clickOnMoreOption = () => {
   cy.get('[data-testid="dropdown-menu-item"]').first().click();
 };
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("create announcement and link post", () => {
   beforeEach(() => {
     cy.setFeatureFlags((res) => {

--- a/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_manage_access_tokens.js
+++ b/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_manage_access_tokens.js
@@ -2,7 +2,7 @@ import { aliasQuery, hasOperationName } from "../utils";
 
 const test_id = Math.floor(Math.random() * 100000);
 
-describe("manage access tokens", () => {
+describe.skip("manage access tokens", () => {
   before(() => {
     cy.intercept("POST", "/api/v2/graphql", (req) => {
       aliasQuery(req, "appConfig");

--- a/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_manage_access_tokens.js
+++ b/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_manage_access_tokens.js
@@ -2,6 +2,7 @@ import { aliasQuery, hasOperationName } from "../utils";
 
 const test_id = Math.floor(Math.random() * 100000);
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("manage access tokens", () => {
   before(() => {
     cy.intercept("POST", "/api/v2/graphql", (req) => {

--- a/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_manage_policies.js
+++ b/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_manage_policies.js
@@ -124,6 +124,7 @@ function deletePolicy(policyEdited, deletePolicyTitle) {
   cy.ensureTextNotPresent(policyEdited);
 }
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("create and manage platform and metadata policies", () => {
   beforeEach(() => {
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_manage_policies.js
+++ b/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_manage_policies.js
@@ -124,7 +124,7 @@ function deletePolicy(policyEdited, deletePolicyTitle) {
   cy.ensureTextNotPresent(policyEdited);
 }
 
-describe("create and manage platform and metadata policies", () => {
+describe.skip("create and manage platform and metadata policies", () => {
   beforeEach(() => {
     cy.login();
     cy.visit("/settings/permissions/policies");

--- a/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_manage_service_accounts.js
+++ b/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_manage_service_accounts.js
@@ -1,6 +1,6 @@
 import { aliasQuery, hasOperationName, getUniqueTestId } from "../utils";
 
-describe("manage service accounts", () => {
+describe.skip("manage service accounts", () => {
   before(() => {
     cy.intercept("POST", "/api/v2/graphql", (req) => {
       aliasQuery(req, "appConfig");

--- a/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_manage_service_accounts.js
+++ b/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_manage_service_accounts.js
@@ -1,5 +1,6 @@
 import { aliasQuery, hasOperationName, getUniqueTestId } from "../utils";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("manage service accounts", () => {
   before(() => {
     cy.intercept("POST", "/api/v2/graphql", (req) => {

--- a/smoke-test/tests/cypress/cypress/e2e/siblingsV2/v2_siblings.js
+++ b/smoke-test/tests/cypress/cypress/e2e/siblingsV2/v2_siblings.js
@@ -1,4 +1,4 @@
-describe("siblings", () => {
+describe.skip("siblings", () => {
   it("will merge metadata to non-primary sibling", () => {
     cy.login();
     cy.visit("/");

--- a/smoke-test/tests/cypress/cypress/e2e/siblingsV2/v2_siblings.js
+++ b/smoke-test/tests/cypress/cypress/e2e/siblingsV2/v2_siblings.js
@@ -1,3 +1,4 @@
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("siblings", () => {
   it("will merge metadata to non-primary sibling", () => {
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/summaryTab/domainSummary.js
+++ b/smoke-test/tests/cypress/cypress/e2e/summaryTab/domainSummary.js
@@ -6,6 +6,7 @@ const TEST_DOMAIN_URN = "urn:li:domain:testing";
 const TEST_SUBDOMAIN_NAME = "Subdomain";
 const TEST_DATA_PRODUCT_NAME = "Testing";
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("summary tab - domain", () => {
   beforeEach(() => {
     utils.setSummaryTabFlags(true);

--- a/smoke-test/tests/cypress/cypress/e2e/summaryTab/domainSummary.js
+++ b/smoke-test/tests/cypress/cypress/e2e/summaryTab/domainSummary.js
@@ -6,7 +6,7 @@ const TEST_DOMAIN_URN = "urn:li:domain:testing";
 const TEST_SUBDOMAIN_NAME = "Subdomain";
 const TEST_DATA_PRODUCT_NAME = "Testing";
 
-describe("summary tab - domain", () => {
+describe.skip("summary tab - domain", () => {
   beforeEach(() => {
     utils.setSummaryTabFlags(true);
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/task_runV2/v2_task_runs.js
+++ b/smoke-test/tests/cypress/cypress/e2e/task_runV2/v2_task_runs.js
@@ -1,3 +1,4 @@
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("task runs", () => {
   it("can visit dataset with runs aspect and verify the task run is present", () => {
     cy.visit("/");

--- a/smoke-test/tests/cypress/cypress/e2e/task_runV2/v2_task_runs.js
+++ b/smoke-test/tests/cypress/cypress/e2e/task_runV2/v2_task_runs.js
@@ -1,4 +1,4 @@
-describe("task runs", () => {
+describe.skip("task runs", () => {
   it("can visit dataset with runs aspect and verify the task run is present", () => {
     cy.visit("/");
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/uploadFiles/uploadFiles.js
+++ b/smoke-test/tests/cypress/cypress/e2e/uploadFiles/uploadFiles.js
@@ -22,7 +22,7 @@ function getSetRequiredFeatureFlagsInterceptor() {
 
 // const testId = getUniqueTestId();
 
-describe("uploadFiles", () => {
+describe.skip("uploadFiles", () => {
   const setupInterceptors = (testId) => {
     cy.intercept("POST", "/api/v2/graphql", (req) => {
       if (hasOperationName(req, "getPresignedUploadUrl")) {

--- a/smoke-test/tests/cypress/cypress/e2e/uploadFiles/uploadFiles.js
+++ b/smoke-test/tests/cypress/cypress/e2e/uploadFiles/uploadFiles.js
@@ -22,6 +22,7 @@ function getSetRequiredFeatureFlagsInterceptor() {
 
 // const testId = getUniqueTestId();
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("uploadFiles", () => {
   const setupInterceptors = (testId) => {
     cy.intercept("POST", "/api/v2/graphql", (req) => {

--- a/smoke-test/tests/cypress/cypress/e2e/viewV2/v2_manage_views.js
+++ b/smoke-test/tests/cypress/cypress/e2e/viewV2/v2_manage_views.js
@@ -1,3 +1,4 @@
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("manage views", () => {
   it("go to views settings page, create, edit, make default, delete a view", () => {
     const viewName = "Test View";

--- a/smoke-test/tests/cypress/cypress/e2e/viewV2/v2_manage_views.js
+++ b/smoke-test/tests/cypress/cypress/e2e/viewV2/v2_manage_views.js
@@ -1,4 +1,4 @@
-describe("manage views", () => {
+describe.skip("manage views", () => {
   it("go to views settings page, create, edit, make default, delete a view", () => {
     const viewName = "Test View";
 

--- a/smoke-test/tests/cypress/cypress/e2e/viewV2/v2_view_select.js
+++ b/smoke-test/tests/cypress/cypress/e2e/viewV2/v2_view_select.js
@@ -3,6 +3,7 @@ function openViewEditDropDownAndClickId(data_id) {
   cy.clickOptionWithTestId(data_id);
 }
 
+// Migrated to Playwright — see e2e-test/ui/playwright/tests/
 describe.skip("view select", () => {
   it("click view select, create view, clear view, make defaults, clear view", () => {
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/viewV2/v2_view_select.js
+++ b/smoke-test/tests/cypress/cypress/e2e/viewV2/v2_view_select.js
@@ -3,7 +3,7 @@ function openViewEditDropDownAndClickId(data_id) {
   cy.clickOptionWithTestId(data_id);
 }
 
-describe("view select", () => {
+describe.skip("view select", () => {
   it("click view select, create view, clear view, make defaults, clear view", () => {
     cy.login();
     const randomNumber = Math.floor(Math.random() * 100000);


### PR DESCRIPTION
## Summary

* Marks 59 Cypress `describe` blocks with `describe.skip` for all test domains that have been fully migrated to Playwright
* Leaves partial and not-yet-migrated domains (Stats Tab V2, Application, Documents, Summary Tab, Settings groups gaps, etc.) untouched
* Prevents double-execution of the same test scenarios in CI

## Domains skippedog

Analytics, Auto-Complete V2, Business Attributes, Containers V2, Glossary V2, Home Page V2, Incidents V2, Ingestion V2/V3 (run history + secrets + managed ingestion), Lineage V2/V3 (all 5 files each), Login V2, Manage Tags V2, MFE Framework, ML Entities, Mutations V1/V2, Onboarding, Ownership V2, Schema Blame V2, Search V2, Settings V2 (home posts, access tokens, policies, service accounts), Siblings V2, Summary Tab (domain), Task Runs V2, Upload Files, Views V2

## Test plan

- [ ] Confirm Cypress CI run reports these suites as skipped (0 tests executed per domain)
- [ ] Confirm the remaining non-skipped Cypress suites (Stats Tab V2, Application, Documents, etc.) still run normally
- [ ] Confirm Playwright suite continues to pass for all migrated domains

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)