### PR TITLE
docs(cloud): remove Actions version from v1.0.0+ release notes

### DIFF
--- a/docs/managed-datahub/release-notes/next.md
+++ b/docs/managed-datahub/release-notes/next.md
@@ -21,7 +21,6 @@ TBD
 - **On-Prem Versions**:
   - **Helm**: TBD
   - **API Gateway**: TBD
-  - **Actions**: TBD
 
 ## Release Changelog
 

--- a/docs/managed-datahub/release-notes/v_1_0_0.md
+++ b/docs/managed-datahub/release-notes/v_1_0_0.md
@@ -135,7 +135,6 @@ This release rolls up hotfixes on top of v1.0.0. There are no breaking changes o
 - **On-Prem Versions**:
   - **Helm**: v1.6.111
   - **API Gateway**: v0.7.0
-  - **Actions**: v0.0.3
 
 ## Known Issues
 

--- a/docs/managed-datahub/release-notes/v_1_1_0.md
+++ b/docs/managed-datahub/release-notes/v_1_1_0.md
@@ -77,7 +77,6 @@ Includes all upstream OSS changes through DataHub Core [v1.6.0](https://github.c
 - **On-Prem Versions**:
   - **Helm**: 1.6.129
   - **API Gateway**: v0.7.0
-  - **Actions**: v0.0.3
 
 #### New Feature Highlights
 


### PR DESCRIPTION
## Summary

- Removes the **Actions** entry from the Recommended Versions / On-Prem Versions section in DataHub Cloud release notes for v1.0.0 and later.
- Updated files: `v_1_0_0.md`, `v_1_1_0.md`, and `next.md`.
- Pre-v1.0.0 release notes (e.g. v0.3.x) are unchanged.

## Test plan

- [x] Verified only v1.0.0+ release note files contained standalone Actions version entries
- [x] Confirmed markdown lint passed via pre-commit hook
- [ ] Spot-check rendered docs site sidebar entries for v1.0.0 and v1.1.0 release notes


Made with [Cursor](https://cursor.com)