### PR TITLE
feat(tags): surface deprecation on tag profile and manage tags list

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/tag/mappers/TagMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/tag/mappers/TagMapper.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.types.tag.mappers;
 
 import static com.linkedin.metadata.Constants.*;
 
+import com.linkedin.common.Deprecation;
 import com.linkedin.common.Ownership;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.DataMap;
@@ -10,6 +11,7 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.Tag;
+import com.linkedin.datahub.graphql.types.common.mappers.DeprecationMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.OwnershipMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.util.MappingHelper;
 import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
@@ -53,6 +55,10 @@ public class TagMapper implements ModelMapper<EntityResponse, Tag> {
         OWNERSHIP_ASPECT_NAME,
         (tag, dataMap) ->
             tag.setOwnership(OwnershipMapper.map(context, new Ownership(dataMap), entityUrn)));
+    mappingHelper.mapToResult(
+        DEPRECATION_ASPECT_NAME,
+        (tag, dataMap) ->
+            tag.setDeprecation(DeprecationMapper.map(context, new Deprecation(dataMap))));
 
     if (result.getProperties() != null && result.getProperties().getName() == null) {
       result.getProperties().setName(legacyName);

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -5142,6 +5142,11 @@ type Tag implements Entity {
   ownership: Ownership
 
   """
+  The deprecation status of the Tag
+  """
+  deprecation: Deprecation
+
+  """
   Granular API for querying edges extending from this entity
   """
   relationships(input: RelationshipsInput!): EntityRelationshipsResult

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/tag/mappers/TagMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/tag/mappers/TagMapperTest.java
@@ -1,0 +1,66 @@
+package com.linkedin.datahub.graphql.types.tag.mappers;
+
+import static com.linkedin.metadata.Constants.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.common.Deprecation;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.Tag;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+public class TagMapperTest {
+
+  private static final String TEST_TAG_URN = "urn:li:tag:SomeTag";
+  private static final String TEST_ACTOR_URN = "urn:li:corpuser:datahub";
+
+  @Test
+  public void testMapTagBasic() throws Exception {
+    Urn tagUrn = Urn.createFromString(TEST_TAG_URN);
+
+    EntityResponse entityResponse = new EntityResponse();
+    entityResponse.setUrn(tagUrn);
+    entityResponse.setAspects(new EnvelopedAspectMap(new HashMap<>()));
+
+    Tag result = TagMapper.map(null, entityResponse);
+
+    assertNotNull(result);
+    assertEquals(result.getUrn(), TEST_TAG_URN);
+    assertEquals(result.getType(), EntityType.TAG);
+    assertNull(result.getDeprecation());
+  }
+
+  @Test
+  public void testMapTagWithDeprecation() throws Exception {
+    Urn tagUrn = Urn.createFromString(TEST_TAG_URN);
+    Urn actorUrn = Urn.createFromString(TEST_ACTOR_URN);
+
+    Deprecation deprecation = new Deprecation();
+    deprecation.setDeprecated(true);
+    deprecation.setNote("This tag is deprecated.");
+    deprecation.setActor(actorUrn);
+
+    Map<String, EnvelopedAspect> aspects = new HashMap<>();
+    aspects.put(
+        DEPRECATION_ASPECT_NAME, new EnvelopedAspect().setValue(new Aspect(deprecation.data())));
+
+    EntityResponse entityResponse = new EntityResponse();
+    entityResponse.setUrn(tagUrn);
+    entityResponse.setAspects(new EnvelopedAspectMap(aspects));
+
+    Tag result = TagMapper.map(null, entityResponse);
+
+    assertNotNull(result);
+    assertEquals(result.getUrn(), TEST_TAG_URN);
+    assertNotNull(result.getDeprecation());
+    assertTrue(result.getDeprecation().getDeprecated());
+    assertEquals(result.getDeprecation().getNote(), "This tag is deprecated.");
+    assertEquals(result.getDeprecation().getActor(), TEST_ACTOR_URN);
+  }
+}

--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -1138,6 +1138,7 @@ export const sampleTag = {
         description: 'sample tag description',
         colorHex: 'sample tag color',
     },
+    deprecation: null,
     autoRenderAspects: [],
 };
 

--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/UpdateDeprecationModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/UpdateDeprecationModal.tsx
@@ -1,11 +1,10 @@
-import { Button, Form, Modal, message } from 'antd';
-import React from 'react';
+import { DatePicker, Modal, TextArea, toast } from '@components';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { handleBatchError } from '@app/entity/shared/utils';
-import { Editor } from '@src/alchemy-components/components/Editor/Editor';
-import DatePicker from '@utils/DayjsDatePicker';
+import type { Dayjs } from '@utils/dayjs';
 
 import { useBatchUpdateDeprecationMutation } from '@graphql/mutations.generated';
 
@@ -15,8 +14,10 @@ type Props = {
     refetch?: () => void;
 };
 
-const StyledEditor = styled(Editor)`
-    border: 1px solid ${(props) => props.theme.colors.border};
+const FieldGroup = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
 `;
 
 export const UpdateDeprecationModal = ({ urns, onClose, refetch }: Props) => {
@@ -24,69 +25,71 @@ export const UpdateDeprecationModal = ({ urns, onClose, refetch }: Props) => {
     const { t: tc } = useTranslation('common.actions');
     const { t: tf } = useTranslation('common.feedback');
     const [batchUpdateDeprecation] = useBatchUpdateDeprecationMutation();
-    const [form] = Form.useForm();
 
-    const handleClose = () => {
-        form.resetFields();
-        onClose();
-    };
+    const [note, setNote] = useState<string>('');
+    const [decommissionTime, setDecommissionTime] = useState<Dayjs | null | undefined>(undefined);
 
-    const handleOk = async (formData: any) => {
-        message.loading({ content: tf('updating') });
+    const handleSubmit = async () => {
+        toast.loading(tf('updating'));
         try {
             await batchUpdateDeprecation({
                 variables: {
                     input: {
-                        resources: [...urns.map((urn) => ({ resourceUrn: urn }))],
+                        resources: urns.map((urn) => ({ resourceUrn: urn })),
                         deprecated: true,
-                        note: formData.note,
-                        decommissionTime: formData.decommissionTime && formData.decommissionTime.unix() * 1000,
+                        note,
+                        decommissionTime: decommissionTime ? decommissionTime.unix() * 1000 : null,
                     },
                 },
             });
-            message.destroy();
-            message.success({ content: t('deprecation.updated'), duration: 2 });
+            toast.destroy();
+            toast.success(t('deprecation.updated'), { duration: 2 });
         } catch (e: unknown) {
-            message.destroy();
+            toast.destroy();
             if (e instanceof Error) {
-                message.error(
-                    handleBatchError(urns, e, {
-                        content: t('deprecation.updateError', { errorMessage: e.message || '' }),
-                        duration: 2,
-                    }),
-                );
+                const fallback = {
+                    content: t('deprecation.updateError', { errorMessage: e.message || '' }),
+                    duration: 2,
+                };
+                const { content, duration } = handleBatchError(urns, e, fallback);
+                toast.error(content, { duration });
             }
         }
         refetch?.();
-        handleClose();
+        onClose();
     };
 
     return (
         <Modal
             title={t('deprecation.addDetailsTitle')}
-            open
-            onCancel={handleClose}
-            keyboard
-            footer={
-                <>
-                    <Button onClick={handleClose} type="text">
-                        {tc('cancel')}
-                    </Button>
-                    <Button form="addDeprecationForm" key="submit" htmlType="submit">
-                        {t('deprecation.ok')}
-                    </Button>
-                </>
-            }
-            width="40%"
+            onCancel={onClose}
+            buttons={[
+                {
+                    text: tc('cancel'),
+                    variant: 'text',
+                    onClick: onClose,
+                },
+                {
+                    buttonDataTestId: 'add-deprecation-submit',
+                    text: t('deprecation.ok'),
+                    onClick: handleSubmit,
+                },
+            ]}
         >
-            <Form form={form} name="addDeprecationForm" onFinish={handleOk} layout="vertical">
-                <Form.Item name="note" label={t('deprecation.noteLabel')} rules={[{ whitespace: true }]}>
-                    <StyledEditor />
-                </Form.Item>
-                <Form.Item name="decommissionTime" label={t('deprecation.decommissionDateLabel')}>
-                    <DatePicker style={{ width: '100%' }} />
-                </Form.Item>
-            </Form>
+            <FieldGroup>
+                <TextArea
+                    label={t('deprecation.noteLabel')}
+                    value={note}
+                    onChange={(e) => setNote(e.target.value)}
+                    rows={4}
+                    autoFocus
+                />
+                <DatePicker
+                    placeholder={t('deprecation.decommissionDateLabel')}
+                    value={decommissionTime}
+                    onChange={(v) => setDecommissionTime(v)}
+                />
+            </FieldGroup>
         </Modal>
     );
 };

--- a/datahub-web-react/src/app/entityV2/tag/Tag.tsx
+++ b/datahub-web-react/src/app/entityV2/tag/Tag.tsx
@@ -59,6 +59,7 @@ export class TagEntity implements Entity<Tag> {
                 entityType={EntityType.Tag}
                 typeIcon={this.icon(14, IconStyleType.ACCENT)}
                 previewType={previewType}
+                deprecation={data.deprecation}
                 propagationDetails={extraContext?.propagationDetails}
             />
         );
@@ -77,6 +78,6 @@ export class TagEntity implements Entity<Tag> {
     };
 
     supportedCapabilities = () => {
-        return new Set([EntityCapabilityType.OWNERS]);
+        return new Set([EntityCapabilityType.OWNERS, EntityCapabilityType.DEPRECATION]);
     };
 }

--- a/datahub-web-react/src/app/shared/TagStyleEntity.tsx
+++ b/datahub-web-react/src/app/shared/TagStyleEntity.tsx
@@ -20,6 +20,7 @@ import { EditOwnersModal } from '@app/entity/shared/containers/profile/sidebar/O
 import { ENTITY_FILTER_NAME, UnionType } from '@app/search/utils/constants';
 import { generateOrFilters } from '@app/search/utils/generateOrFilters';
 import { navigateToSearchUrl } from '@app/search/utils/navigateToSearchUrl';
+import { DeprecationIcon } from '@app/entityV2/shared/components/styled/DeprecationIcon';
 import CopyUrn from '@app/shared/CopyUrn';
 import { ErrorSection } from '@app/shared/error/ErrorSection';
 import { useEntityRegistry } from '@app/useEntityRegistry';
@@ -343,6 +344,15 @@ export default function TagStyleEntity({
                         <TitleText>
                             {(data?.tag && entityRegistry.getDisplayName(EntityType.Tag, data?.tag)) || ''}
                         </TitleText>
+                        {data?.tag?.deprecation?.deprecated && (
+                            <DeprecationIcon
+                                urn={urn}
+                                deprecation={data.tag.deprecation}
+                                showUndeprecate
+                                refetch={refetch}
+                                showText={false}
+                            />
+                        )}
                     </TagName>
                 </div>
                 <ActionButtons>
@@ -352,7 +362,7 @@ export default function TagStyleEntity({
                             urn={urn}
                             entityType={EntityType.Tag}
                             entityData={data?.tag}
-                            menuItems={new Set([EntityMenuItems.DELETE])}
+                            menuItems={new Set([EntityMenuItems.UPDATE_DEPRECATION, EntityMenuItems.DELETE])}
                         />
                     )}
                 </ActionButtons>

--- a/datahub-web-react/src/app/shared/TagStyleEntity.tsx
+++ b/datahub-web-react/src/app/shared/TagStyleEntity.tsx
@@ -17,10 +17,10 @@ import { ExpandedOwner } from '@app/entity/shared/components/styled/ExpandedOwne
 import { GetSearchResultsParams, SearchResultInterface } from '@app/entity/shared/components/styled/search/types';
 import { EMPTY_MESSAGES } from '@app/entity/shared/constants';
 import { EditOwnersModal } from '@app/entity/shared/containers/profile/sidebar/Ownership/EditOwnersModal';
+import { DeprecationIcon } from '@app/entityV2/shared/components/styled/DeprecationIcon';
 import { ENTITY_FILTER_NAME, UnionType } from '@app/search/utils/constants';
 import { generateOrFilters } from '@app/search/utils/generateOrFilters';
 import { navigateToSearchUrl } from '@app/search/utils/navigateToSearchUrl';
-import { DeprecationIcon } from '@app/entityV2/shared/components/styled/DeprecationIcon';
 import CopyUrn from '@app/shared/CopyUrn';
 import { ErrorSection } from '@app/shared/error/ErrorSection';
 import { useEntityRegistry } from '@app/useEntityRegistry';

--- a/datahub-web-react/src/app/sharedV2/tags/tag/Tag.tsx
+++ b/datahub-web-react/src/app/sharedV2/tags/tag/Tag.tsx
@@ -35,6 +35,18 @@ const StyledHighlight = styled(Highlight)<{ $maxWidth?: number }>`
     max-width: ${(props) => (props.$maxWidth ? `${props.$maxWidth}px` : '120px')};
 `;
 
+// The DeprecationIcon renders a 16x16 SVG by default. Inside a tag pill it sits next to the
+// 12px PillRemoveIcon (X), so we constrain its SVG size to match for visual balance. Popover
+// content is portalled to document.body, so this selector only affects the inline trigger SVG.
+const PillDeprecationSlot = styled.span`
+    display: inline-flex;
+    align-items: center;
+    & svg {
+        width: 12px;
+        height: 12px;
+    }
+`;
+
 interface Props {
     tag: TagAssociation;
     entityUrn?: string;
@@ -150,12 +162,14 @@ export default function Tag({
                         dataTestId={`tag-${displayName}-pill`}
                         rightAdornment={
                             tag.tag.deprecation && tag.tag.deprecation.deprecated ? (
-                                <DeprecationIcon
-                                    urn={tag.tag.urn}
-                                    deprecation={tag.tag.deprecation}
-                                    showUndeprecate={false}
-                                    showText={false}
-                                />
+                                <PillDeprecationSlot>
+                                    <DeprecationIcon
+                                        urn={tag.tag.urn}
+                                        deprecation={tag.tag.deprecation}
+                                        showUndeprecate={false}
+                                        showText={false}
+                                    />
+                                </PillDeprecationSlot>
                             ) : undefined
                         }
                         onRemove={

--- a/datahub-web-react/src/app/sharedV2/tags/tag/Tag.tsx
+++ b/datahub-web-react/src/app/sharedV2/tags/tag/Tag.tsx
@@ -4,6 +4,7 @@ import Highlight from 'react-highlighter';
 import { useTranslation } from 'react-i18next';
 import styled, { useTheme } from 'styled-components';
 
+import { DeprecationIcon } from '@app/entityV2/shared/components/styled/DeprecationIcon';
 import { HoverEntityTooltip } from '@app/recommendations/renderer/component/HoverEntityTooltip';
 import { useHasMatchedFieldByUrn } from '@app/search/context/SearchResultContext';
 import { TagProfileDrawer } from '@app/shared/tags/TagProfileDrawer';
@@ -147,6 +148,16 @@ export default function Tag({
                         variant={highlightTag ? 'highlighted' : 'default'}
                         size={fontSize && fontSize <= 10 ? 'sm' : 'md'}
                         dataTestId={`tag-${displayName}-pill`}
+                        rightAdornment={
+                            tag.tag.deprecation && tag.tag.deprecation.deprecated ? (
+                                <DeprecationIcon
+                                    urn={tag.tag.urn}
+                                    deprecation={tag.tag.deprecation}
+                                    showUndeprecate={false}
+                                    showText={false}
+                                />
+                            ) : undefined
+                        }
                         onRemove={
                             canRemove && !readOnly
                                 ? (e) => {

--- a/datahub-web-react/src/app/sharedV2/tags/tag/__tests__/Tag.test.tsx
+++ b/datahub-web-react/src/app/sharedV2/tags/tag/__tests__/Tag.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+import Tag from '@app/sharedV2/tags/tag/Tag';
+import themeV2 from '@conf/theme/themeV2';
+
+import { EntityType } from '@types';
+
+vi.mock('@app/entityV2/shared/components/styled/DeprecationIcon', () => ({
+    DeprecationIcon: () => <div data-testid="deprecation-icon" />,
+}));
+
+vi.mock('@app/recommendations/renderer/component/HoverEntityTooltip', () => ({
+    HoverEntityTooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@app/shared/tags/TagProfileDrawer', () => ({
+    TagProfileDrawer: () => null,
+}));
+
+vi.mock('@app/sharedV2/modals/ConfirmationModal', () => ({
+    ConfirmationModal: () => null,
+}));
+
+vi.mock('@app/useEntityRegistry', () => ({
+    useEntityRegistry: () => ({ getDisplayName: vi.fn(() => 'TestTag') }),
+}));
+
+vi.mock('@app/search/context/SearchResultContext', () => ({
+    useHasMatchedFieldByUrn: vi.fn(() => false),
+}));
+
+vi.mock('@app/shared/useEmbeddedProfileLinkProps', () => ({
+    useIsEmbeddedProfile: vi.fn(() => false),
+}));
+
+vi.mock('@graphql/mutations.generated', () => ({
+    useRemoveTagMutation: vi.fn(() => [vi.fn()]),
+}));
+
+vi.mock('@utils/runtimeBasePath', () => ({
+    resolveRuntimePath: (p: string) => p,
+}));
+
+vi.mock('@components', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@components')>();
+    return { ...actual, toast: { success: vi.fn(), error: vi.fn() } };
+});
+
+const baseTag = {
+    tag: {
+        urn: 'urn:li:tag:TestTag',
+        type: EntityType.Tag,
+        name: 'TestTag',
+        properties: { colorHex: null },
+        deprecation: null,
+    },
+    associatedUrn: 'urn:li:dataset:test',
+} as any;
+
+const renderTag = (tag: any) =>
+    render(
+        <ThemeProvider theme={themeV2}>
+            <Tag tag={tag} />
+        </ThemeProvider>,
+    );
+
+describe('Tag (sharedV2)', () => {
+    it('renders deprecation icon when tag is deprecated', () => {
+        renderTag({
+            ...baseTag,
+            tag: { ...baseTag.tag, deprecation: { deprecated: true, note: null, actor: null, decommissionTime: null } },
+        });
+        expect(screen.getByTestId('deprecation-icon')).toBeInTheDocument();
+    });
+
+    it('does not render deprecation icon when deprecated=false', () => {
+        renderTag({
+            ...baseTag,
+            tag: { ...baseTag.tag, deprecation: { deprecated: false, note: null, actor: null, decommissionTime: null } },
+        });
+        expect(screen.queryByTestId('deprecation-icon')).not.toBeInTheDocument();
+    });
+
+    it('does not render deprecation icon when deprecation is null', () => {
+        renderTag(baseTag);
+        expect(screen.queryByTestId('deprecation-icon')).not.toBeInTheDocument();
+    });
+});

--- a/datahub-web-react/src/app/sharedV2/tags/tag/__tests__/Tag.test.tsx
+++ b/datahub-web-react/src/app/sharedV2/tags/tag/__tests__/Tag.test.tsx
@@ -78,7 +78,10 @@ describe('Tag (sharedV2)', () => {
     it('does not render deprecation icon when deprecated=false', () => {
         renderTag({
             ...baseTag,
-            tag: { ...baseTag.tag, deprecation: { deprecated: false, note: null, actor: null, decommissionTime: null } },
+            tag: {
+                ...baseTag.tag,
+                deprecation: { deprecated: false, note: null, actor: null, decommissionTime: null },
+            },
         });
         expect(screen.queryByTestId('deprecation-icon')).not.toBeInTheDocument();
     });

--- a/datahub-web-react/src/app/tags/TagsTable.tsx
+++ b/datahub-web-react/src/app/tags/TagsTable.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useUserContext } from '@app/context/useUserContext';
 import { ManageTag } from '@app/tags/ManageTag';
+import { UpdateDeprecationModal } from '@app/entity/shared/EntityDropdown/UpdateDeprecationModal';
 import {
     TagActionsColumn,
     TagAppliedToColumn,
@@ -47,6 +48,9 @@ const TagsTable = ({ searchQuery, searchData, loading: propLoading, networkStatu
 
     const [showEdit, setShowEdit] = useState(false);
     const [editingTag, setEditingTag] = useState('');
+
+    const [showDeprecationModal, setShowDeprecationModal] = useState(false);
+    const [deprecationTagUrn, setDeprecationTagUrn] = useState('');
 
     // Simplified state for delete confirmation modal
     const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -182,6 +186,10 @@ const TagsTable = ({ searchQuery, searchData, loading: propLoading, networkStatu
                                     message.error(t('tags.noDeletePermissionError'));
                                 }
                             }}
+                            onDeprecate={() => {
+                                setDeprecationTagUrn(record.entity.urn);
+                                setShowDeprecationModal(true);
+                            }}
                             canManageTags={canManageTags}
                         />
                     );
@@ -216,6 +224,14 @@ const TagsTable = ({ searchQuery, searchData, loading: propLoading, networkStatu
                     onClose={() => setShowEdit(false)}
                     onSave={refetch}
                     isModalOpen={showEdit}
+                />
+            )}
+
+            {showDeprecationModal && (
+                <UpdateDeprecationModal
+                    urns={[deprecationTagUrn]}
+                    onClose={() => setShowDeprecationModal(false)}
+                    refetch={refetch}
                 />
             )}
 

--- a/datahub-web-react/src/app/tags/TagsTable.tsx
+++ b/datahub-web-react/src/app/tags/TagsTable.tsx
@@ -5,8 +5,8 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useUserContext } from '@app/context/useUserContext';
-import { ManageTag } from '@app/tags/ManageTag';
 import { UpdateDeprecationModal } from '@app/entity/shared/EntityDropdown/UpdateDeprecationModal';
+import { ManageTag } from '@app/tags/ManageTag';
 import {
     TagActionsColumn,
     TagAppliedToColumn,
@@ -55,8 +55,8 @@ const TagsTable = ({ searchQuery, searchData, loading: propLoading, networkStatu
 
     const handleDeprecationComplete = useCallback(() => {
         refetch();
-        client.refetchQueries({ include: [{ query: GetTagDocument, variables: { urn: deprecationTagUrn } }] });
-    }, [client, deprecationTagUrn, refetch]);
+        client.refetchQueries({ include: [GetTagDocument] });
+    }, [client, refetch]);
 
     // Simplified state for delete confirmation modal
     const [showDeleteModal, setShowDeleteModal] = useState(false);

--- a/datahub-web-react/src/app/tags/TagsTable.tsx
+++ b/datahub-web-react/src/app/tags/TagsTable.tsx
@@ -1,4 +1,4 @@
-import { NetworkStatus } from '@apollo/client';
+import { NetworkStatus, useApolloClient } from '@apollo/client';
 import { Modal, Table } from '@components';
 import { message } from 'antd';
 import React, { useCallback, useMemo, useState } from 'react';
@@ -20,7 +20,7 @@ import { useEntityRegistry } from '@src/app/useEntityRegistry';
 import { GetSearchResultsForMultipleQuery } from '@src/graphql/search.generated';
 import { EntityType } from '@src/types.generated';
 
-import { useDeleteTagMutation } from '@graphql/tag.generated';
+import { GetTagDocument, useDeleteTagMutation } from '@graphql/tag.generated';
 
 interface Props {
     searchQuery: string;
@@ -36,6 +36,7 @@ const TagsTable = ({ searchQuery, searchData, loading: propLoading, networkStatu
     const { t: tl } = useTranslation('common.labels');
     const entityRegistry = useEntityRegistry();
     const userContext = useUserContext();
+    const client = useApolloClient();
     const [deleteTagMutation] = useDeleteTagMutation();
 
     // Check if user has permission to manage or delete tags
@@ -51,6 +52,11 @@ const TagsTable = ({ searchQuery, searchData, loading: propLoading, networkStatu
 
     const [showDeprecationModal, setShowDeprecationModal] = useState(false);
     const [deprecationTagUrn, setDeprecationTagUrn] = useState('');
+
+    const handleDeprecationComplete = useCallback(() => {
+        refetch();
+        client.refetchQueries({ include: [{ query: GetTagDocument, variables: { urn: deprecationTagUrn } }] });
+    }, [client, deprecationTagUrn, refetch]);
 
     // Simplified state for delete confirmation modal
     const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -231,7 +237,7 @@ const TagsTable = ({ searchQuery, searchData, loading: propLoading, networkStatu
                 <UpdateDeprecationModal
                     urns={[deprecationTagUrn]}
                     onClose={() => setShowDeprecationModal(false)}
-                    refetch={refetch}
+                    refetch={handleDeprecationComplete}
                 />
             )}
 

--- a/datahub-web-react/src/app/tags/TagsTableColumns.tsx
+++ b/datahub-web-react/src/app/tags/TagsTableColumns.tsx
@@ -3,6 +3,8 @@ import { Copy } from '@phosphor-icons/react/dist/csr/Copy';
 import { DotsThreeVertical } from '@phosphor-icons/react/dist/csr/DotsThreeVertical';
 import { PencilSimple } from '@phosphor-icons/react/dist/csr/PencilSimple';
 import { Trash } from '@phosphor-icons/react/dist/csr/Trash';
+import { WarningCircle } from '@phosphor-icons/react/dist/csr/WarningCircle';
+import { message } from 'antd';
 import React from 'react';
 import Highlight from 'react-highlighter';
 import { useTranslation } from 'react-i18next';
@@ -16,6 +18,7 @@ import { UnionType } from '@src/app/search/utils/constants';
 import { generateOrFilters } from '@src/app/search/utils/generateOrFilters';
 import { navigateToSearchUrl } from '@src/app/search/utils/navigateToSearchUrl';
 import { useEntityRegistry, useEntityRegistryV2 } from '@src/app/useEntityRegistry';
+import { useBatchUpdateDeprecationMutation } from '@graphql/mutations.generated';
 import { useGetSearchResultsForMultipleQuery } from '@src/graphql/search.generated';
 import { useGetTagQuery } from '@src/graphql/tag.generated';
 import { Entity, EntityType } from '@src/types.generated';
@@ -220,15 +223,50 @@ export const TagActionsColumn = React.memo(
         tagUrn,
         onEdit,
         onDelete,
+        onDeprecate,
         canManageTags,
     }: {
         tagUrn: string;
         onEdit: () => void;
         onDelete: () => void;
+        onDeprecate: () => void;
         canManageTags: boolean;
     }) => {
         const { t } = useTranslation('misc');
         const { t: tc } = useTranslation('common.actions');
+        const { t: te } = useTranslation('entity.shared.entityDropdown');
+        const { t: tf } = useTranslation('common.feedback');
+
+        const { data: tagData, refetch } = useGetTagQuery({
+            variables: { urn: tagUrn },
+            fetchPolicy: 'cache-first',
+        });
+        const isDeprecated = tagData?.tag?.deprecation?.deprecated ?? false;
+
+        const [batchUpdateDeprecation] = useBatchUpdateDeprecationMutation();
+
+        const handleUndeprecate = async () => {
+            message.loading({ content: tf('updating') });
+            try {
+                await batchUpdateDeprecation({
+                    variables: {
+                        input: {
+                            resources: [{ resourceUrn: tagUrn }],
+                            deprecated: false,
+                        },
+                    },
+                });
+                message.destroy();
+                message.success({ content: te('deprecation.updated'), duration: 2 });
+                refetch();
+            } catch (e: unknown) {
+                message.destroy();
+                if (e instanceof Error) {
+                    message.error({ content: te('deprecation.updateError', { errorMessage: e.message || '' }), duration: 2 });
+                }
+            }
+        };
+
         const menuItems = [
             {
                 type: 'item' as const,
@@ -249,6 +287,14 @@ export const TagActionsColumn = React.memo(
             },
             ...(canManageTags
                 ? [
+                      {
+                          type: 'item' as const,
+                          key: 'deprecate',
+                          title: isDeprecated ? te('deprecation.markUnDeprecated') : te('deprecation.markDeprecated'),
+                          icon: WarningCircle,
+                          onClick: isDeprecated ? handleUndeprecate : onDeprecate,
+                          'data-testid': 'action-deprecate',
+                      },
                       {
                           type: 'item' as const,
                           key: 'delete',

--- a/datahub-web-react/src/app/tags/TagsTableColumns.tsx
+++ b/datahub-web-react/src/app/tags/TagsTableColumns.tsx
@@ -12,6 +12,7 @@ import { useHistory } from 'react-router';
 import styled from 'styled-components';
 
 import { CardIcons } from '@app/govern/structuredProperties/styledComponents';
+import { DeprecationIcon } from '@app/entityV2/shared/components/styled/DeprecationIcon';
 import { OwnerAvatarGroup } from '@app/sharedV2/owners/OwnerAvatarGroup';
 import { getTagColor } from '@app/tags/utils';
 import { UnionType } from '@src/app/search/utils/constants';
@@ -52,6 +53,12 @@ const ColorDotContainer = styled.div`
     align-items: center;
 `;
 
+const TagNameRow = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+`;
+
 const ColorDot = styled.div`
     width: 20px;
     height: 20px;
@@ -61,11 +68,19 @@ const ColorDot = styled.div`
 
 export const TagNameColumn = React.memo(
     ({ tagUrn, displayName, searchQuery }: { tagUrn: string; displayName: string; searchQuery?: string }) => {
+        const { data } = useGetTagQuery({ variables: { urn: tagUrn }, fetchPolicy: 'cache-first' });
+        const deprecation = data?.tag?.deprecation ?? null;
+
         return (
             <ColumnContainer>
-                <TagName data-testid={`${tagUrn}-name`}>
-                    <Highlight search={searchQuery}>{displayName}</Highlight>
-                </TagName>
+                <TagNameRow>
+                    <TagName data-testid={`${tagUrn}-name`}>
+                        <Highlight search={searchQuery}>{displayName}</Highlight>
+                    </TagName>
+                    {deprecation && deprecation.deprecated && (
+                        <DeprecationIcon urn={tagUrn} deprecation={deprecation} showUndeprecate={false} showText={false} />
+                    )}
+                </TagNameRow>
             </ColumnContainer>
         );
     },

--- a/datahub-web-react/src/app/tags/TagsTableColumns.tsx
+++ b/datahub-web-react/src/app/tags/TagsTableColumns.tsx
@@ -1,9 +1,8 @@
-import { Icon, Menu, Text } from '@components';
+import { Button, Menu, Text } from '@components';
 import { Copy } from '@phosphor-icons/react/dist/csr/Copy';
 import { DotsThreeVertical } from '@phosphor-icons/react/dist/csr/DotsThreeVertical';
 import { PencilSimple } from '@phosphor-icons/react/dist/csr/PencilSimple';
 import { Trash } from '@phosphor-icons/react/dist/csr/Trash';
-import { WarningCircle } from '@phosphor-icons/react/dist/csr/WarningCircle';
 import { message } from 'antd';
 import React from 'react';
 import Highlight from 'react-highlighter';
@@ -11,7 +10,6 @@ import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router';
 import styled from 'styled-components';
 
-import { CardIcons } from '@app/govern/structuredProperties/styledComponents';
 import { DeprecationIcon } from '@app/entityV2/shared/components/styled/DeprecationIcon';
 import { OwnerAvatarGroup } from '@app/sharedV2/owners/OwnerAvatarGroup';
 import { getTagColor } from '@app/tags/utils';
@@ -19,10 +17,24 @@ import { UnionType } from '@src/app/search/utils/constants';
 import { generateOrFilters } from '@src/app/search/utils/generateOrFilters';
 import { navigateToSearchUrl } from '@src/app/search/utils/navigateToSearchUrl';
 import { useEntityRegistry, useEntityRegistryV2 } from '@src/app/useEntityRegistry';
-import { useBatchUpdateDeprecationMutation } from '@graphql/mutations.generated';
 import { useGetSearchResultsForMultipleQuery } from '@src/graphql/search.generated';
 import { useGetTagQuery } from '@src/graphql/tag.generated';
 import { Entity, EntityType } from '@src/types.generated';
+
+import { useBatchUpdateDeprecationMutation } from '@graphql/mutations.generated';
+
+import DeprecatedIcon from '@images/deprecated-status.svg?react';
+
+// The raw deprecated-status SVG has a 16x16 viewBox with artwork filling 100%, while phosphor
+// icons used elsewhere in the menu reserve ~20% padding inside their viewBox. Without scaling,
+// this icon appears visibly larger than its peers in the row action menu.
+interface DeprecatedMenuIconProps extends React.SVGProps<SVGSVGElement> {
+    style?: React.CSSProperties;
+}
+
+const DeprecatedMenuIcon = ({ style, ...rest }: DeprecatedMenuIconProps) => (
+    <DeprecatedIcon {...rest} style={{ ...style, width: '80%', height: '80%' }} />
+);
 
 const TagName = styled.div`
     font-size: 14px;
@@ -31,6 +43,13 @@ const TagName = styled.div`
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+`;
+
+// Matches the Groups table's ActionsContainer pattern so the action button hugs the right edge
+// of its column cell (parent column has alignment: 'right' which only affects text alignment).
+const ActionsContainer = styled.div`
+    display: flex;
+    justify-content: flex-end;
 `;
 
 const TagDescription = styled.div`
@@ -78,7 +97,12 @@ export const TagNameColumn = React.memo(
                         <Highlight search={searchQuery}>{displayName}</Highlight>
                     </TagName>
                     {deprecation && deprecation.deprecated && (
-                        <DeprecationIcon urn={tagUrn} deprecation={deprecation} showUndeprecate={false} showText={false} />
+                        <DeprecationIcon
+                            urn={tagUrn}
+                            deprecation={deprecation}
+                            showUndeprecate={false}
+                            showText={false}
+                        />
                     )}
                 </TagNameRow>
             </ColumnContainer>
@@ -277,7 +301,10 @@ export const TagActionsColumn = React.memo(
             } catch (e: unknown) {
                 message.destroy();
                 if (e instanceof Error) {
-                    message.error({ content: te('deprecation.updateError', { errorMessage: e.message || '' }), duration: 2 });
+                    message.error({
+                        content: te('deprecation.updateError', { errorMessage: e.message || '' }),
+                        duration: 2,
+                    });
                 }
             }
         };
@@ -306,7 +333,7 @@ export const TagActionsColumn = React.memo(
                           type: 'item' as const,
                           key: 'deprecate',
                           title: isDeprecated ? te('deprecation.markUnDeprecated') : te('deprecation.markDeprecated'),
-                          icon: WarningCircle,
+                          icon: DeprecatedMenuIcon,
                           onClick: isDeprecated ? handleUndeprecate : onDeprecate,
                           'data-testid': 'action-deprecate',
                       },
@@ -324,11 +351,16 @@ export const TagActionsColumn = React.memo(
         ];
 
         return (
-            <CardIcons>
+            <ActionsContainer>
                 <Menu items={menuItems} trigger={['click']} data-testid={`${tagUrn}-actions-dropdown`}>
-                    <Icon icon={DotsThreeVertical} size="md" data-testid={`${tagUrn}-actions`} />
+                    <Button
+                        variant="text"
+                        icon={{ icon: DotsThreeVertical, weight: 'bold', size: '2xl', color: 'gray' }}
+                        isCircle
+                        data-testid={`${tagUrn}-actions`}
+                    />
                 </Menu>
-            </CardIcons>
+            </ActionsContainer>
         );
     },
 );

--- a/datahub-web-react/src/app/tags/__tests__/TagActionsColumn.test.tsx
+++ b/datahub-web-react/src/app/tags/__tests__/TagActionsColumn.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TagActionsColumn } from '@app/tags/TagsTableColumns';
+import themeV2 from '@conf/theme/themeV2';
+
+vi.mock('@components', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@components')>();
+    return {
+        ...actual,
+        Icon: React.forwardRef(({ 'data-testid': testId, ...props }: any, ref: any) => (
+            <div ref={ref} data-testid={testId} {...props} />
+        )),
+        Menu: ({ items, children }: any) => (
+            <div>
+                {children}
+                {items?.map((item: any) => (
+                    <button
+                        key={item.key}
+                        data-testid={item['data-testid'] || item.key}
+                        onClick={item.onClick}
+                        type="button"
+                    >
+                        {item.title}
+                    </button>
+                ))}
+            </div>
+        ),
+        Text: (props: any) => <p {...props} />,
+    };
+});
+
+
+const TAG_URN = 'urn:li:tag:TestTag';
+
+const defaultProps = {
+    tagUrn: TAG_URN,
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+    onDeprecate: vi.fn(),
+    canManageTags: true,
+};
+
+const renderWithTheme = (ui: React.ReactElement) => render(<ThemeProvider theme={themeV2}>{ui}</ThemeProvider>);
+
+describe('TagActionsColumn', () => {
+    it('shows edit, copy URN, deprecate, and delete when canManageTags is true', () => {
+        renderWithTheme(<TagActionsColumn {...defaultProps} canManageTags />);
+
+        expect(screen.getByTestId('action-edit')).toBeInTheDocument();
+        expect(screen.getByTestId('copy-urn')).toBeInTheDocument();
+        expect(screen.getByTestId('action-deprecate')).toBeInTheDocument();
+        expect(screen.getByTestId('action-delete')).toBeInTheDocument();
+    });
+
+    it('hides deprecate and delete when canManageTags is false', () => {
+        renderWithTheme(<TagActionsColumn {...defaultProps} canManageTags={false} />);
+
+        expect(screen.getByTestId('action-edit')).toBeInTheDocument();
+        expect(screen.getByTestId('copy-urn')).toBeInTheDocument();
+        expect(screen.queryByTestId('action-deprecate')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('action-delete')).not.toBeInTheDocument();
+    });
+
+    it('calls onEdit when the edit item is clicked', () => {
+        const onEdit = vi.fn();
+        renderWithTheme(<TagActionsColumn {...defaultProps} onEdit={onEdit} />);
+
+        fireEvent.click(screen.getByTestId('action-edit'));
+        expect(onEdit).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onDeprecate when the deprecate item is clicked', () => {
+        const onDeprecate = vi.fn();
+        renderWithTheme(<TagActionsColumn {...defaultProps} onDeprecate={onDeprecate} />);
+
+        fireEvent.click(screen.getByTestId('action-deprecate'));
+        expect(onDeprecate).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onDelete when the delete item is clicked', () => {
+        const onDelete = vi.fn();
+        renderWithTheme(<TagActionsColumn {...defaultProps} onDelete={onDelete} />);
+
+        fireEvent.click(screen.getByTestId('action-delete'));
+        expect(onDelete).toHaveBeenCalledTimes(1);
+    });
+});

--- a/datahub-web-react/src/app/tags/__tests__/TagActionsColumn.test.tsx
+++ b/datahub-web-react/src/app/tags/__tests__/TagActionsColumn.test.tsx
@@ -6,6 +6,18 @@ import { describe, expect, it, vi } from 'vitest';
 import { TagActionsColumn } from '@app/tags/TagsTableColumns';
 import themeV2 from '@conf/theme/themeV2';
 
+// Mock Apollo hooks so no ApolloProvider is needed
+vi.mock('@src/graphql/tag.generated', () => ({
+    useGetTagQuery: vi.fn(() => ({
+        data: { tag: { deprecation: { deprecated: false } } },
+        refetch: vi.fn(),
+    })),
+}));
+
+vi.mock('@graphql/mutations.generated', () => ({
+    useBatchUpdateDeprecationMutation: vi.fn(() => [vi.fn()]),
+}));
+
 vi.mock('@components', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@components')>();
     return {

--- a/datahub-web-react/src/app/tags/__tests__/TagActionsColumn.test.tsx
+++ b/datahub-web-react/src/app/tags/__tests__/TagActionsColumn.test.tsx
@@ -5,7 +5,6 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { TagActionsColumn } from '@app/tags/TagsTableColumns';
 import themeV2 from '@conf/theme/themeV2';
-
 import { useGetTagQuery } from '@src/graphql/tag.generated';
 
 // Mock Apollo hooks so no ApolloProvider is needed
@@ -45,7 +44,6 @@ vi.mock('@components', async (importOriginal) => {
         Text: (props: any) => <p {...props} />,
     };
 });
-
 
 const TAG_URN = 'urn:li:tag:TestTag';
 

--- a/datahub-web-react/src/app/tags/__tests__/TagActionsColumn.test.tsx
+++ b/datahub-web-react/src/app/tags/__tests__/TagActionsColumn.test.tsx
@@ -6,6 +6,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { TagActionsColumn } from '@app/tags/TagsTableColumns';
 import themeV2 from '@conf/theme/themeV2';
 
+import { useGetTagQuery } from '@src/graphql/tag.generated';
+
 // Mock Apollo hooks so no ApolloProvider is needed
 vi.mock('@src/graphql/tag.generated', () => ({
     useGetTagQuery: vi.fn(() => ({
@@ -98,5 +100,17 @@ describe('TagActionsColumn', () => {
 
         fireEvent.click(screen.getByTestId('action-delete'));
         expect(onDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows "Mark as un-deprecated" when the tag is already deprecated', () => {
+        vi.mocked(useGetTagQuery).mockReturnValueOnce({
+            data: { tag: { deprecation: { deprecated: true } } },
+            refetch: vi.fn(),
+        } as any);
+
+        renderWithTheme(<TagActionsColumn {...defaultProps} />);
+
+        const btn = screen.getByTestId('action-deprecate');
+        expect(btn.textContent).toMatch(/un-deprecat/i);
     });
 });

--- a/datahub-web-react/src/app/tags/__tests__/TagNameColumn.test.tsx
+++ b/datahub-web-react/src/app/tags/__tests__/TagNameColumn.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+import { TagNameColumn } from '@app/tags/TagsTableColumns';
+import themeV2 from '@conf/theme/themeV2';
+
+import { useGetTagQuery } from '@src/graphql/tag.generated';
+
+vi.mock('@src/graphql/tag.generated', () => ({
+    useGetTagQuery: vi.fn(() => ({ data: null })),
+}));
+
+vi.mock('@app/entityV2/shared/components/styled/DeprecationIcon', () => ({
+    DeprecationIcon: () => <div data-testid="deprecation-icon" />,
+}));
+
+vi.mock('react-highlighter', () => ({
+    default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const TAG_URN = 'urn:li:tag:TestTag';
+
+const renderColumn = (mockData: any) => {
+    vi.mocked(useGetTagQuery).mockReturnValue(mockData);
+    return render(
+        <ThemeProvider theme={themeV2}>
+            <TagNameColumn tagUrn={TAG_URN} displayName="TestTag" />
+        </ThemeProvider>,
+    );
+};
+
+describe('TagNameColumn', () => {
+    afterEach(() => vi.clearAllMocks());
+
+    it('renders deprecation icon when tag is deprecated', () => {
+        renderColumn({ data: { tag: { deprecation: { deprecated: true } } } });
+        expect(screen.getByTestId('deprecation-icon')).toBeInTheDocument();
+    });
+
+    it('does not render deprecation icon when deprecated=false', () => {
+        renderColumn({ data: { tag: { deprecation: { deprecated: false } } } });
+        expect(screen.queryByTestId('deprecation-icon')).not.toBeInTheDocument();
+    });
+
+    it('does not render deprecation icon when deprecation is null', () => {
+        renderColumn({ data: { tag: { deprecation: null } } });
+        expect(screen.queryByTestId('deprecation-icon')).not.toBeInTheDocument();
+    });
+
+    it('does not render deprecation icon when data is absent', () => {
+        renderColumn({ data: null });
+        expect(screen.queryByTestId('deprecation-icon')).not.toBeInTheDocument();
+    });
+
+    it('always renders the tag display name', () => {
+        renderColumn({ data: null });
+        expect(screen.getByText('TestTag')).toBeInTheDocument();
+    });
+});

--- a/datahub-web-react/src/app/tags/__tests__/TagNameColumn.test.tsx
+++ b/datahub-web-react/src/app/tags/__tests__/TagNameColumn.test.tsx
@@ -4,7 +4,6 @@ import { ThemeProvider } from 'styled-components';
 
 import { TagNameColumn } from '@app/tags/TagsTableColumns';
 import themeV2 from '@conf/theme/themeV2';
-
 import { useGetTagQuery } from '@src/graphql/tag.generated';
 
 vi.mock('@src/graphql/tag.generated', () => ({

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -9,6 +9,9 @@ fragment globalTagsFields on GlobalTags {
                 name
                 colorHex
             }
+            deprecation {
+                ...deprecationFields
+            }
         }
         associatedUrn
         attribution {

--- a/datahub-web-react/src/graphql/tag.graphql
+++ b/datahub-web-react/src/graphql/tag.graphql
@@ -12,6 +12,9 @@ query getTag($urn: String!) {
         ownership {
             ...ownershipFields
         }
+        deprecation {
+            ...deprecationFields
+        }
         autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
             ...autoRenderAspectFields
         }

--- a/datahub-web-react/src/i18n/locales/de/entity.shared.entityDropdown.json
+++ b/datahub-web-react/src/i18n/locales/de/entity.shared.entityDropdown.json
@@ -34,7 +34,7 @@
     "deprecation.markUnTooltip": "Veraltungsmarkierung dieser {{entityName}} entfernen",
     "deprecation.modalTitle": "Als veraltet markieren",
     "deprecation.noteLabel": "Notiz",
-    "deprecation.ok": "OK",
+    "deprecation.ok": "Verwerfen",
     "deprecation.reasonLabel": "Grund",
     "deprecation.reasonPlaceholder": "Grund hinzufügen",
     "deprecation.replacementLabel": "Nachfolger",

--- a/datahub-web-react/src/i18n/locales/en/entity.shared.entityDropdown.json
+++ b/datahub-web-react/src/i18n/locales/en/entity.shared.entityDropdown.json
@@ -34,7 +34,7 @@
     "deprecation.markUnTooltip": "Mark this {{entityName}} as un-deprecated",
     "deprecation.modalTitle": "Set as Deprecated",
     "deprecation.noteLabel": "Note",
-    "deprecation.ok": "Ok",
+    "deprecation.ok": "Deprecate",
     "deprecation.reasonLabel": "Reason",
     "deprecation.reasonPlaceholder": "Add Reason",
     "deprecation.replacementLabel": "Replacement",

--- a/datahub-web-react/src/i18n/locales/es/entity.shared.entityDropdown.json
+++ b/datahub-web-react/src/i18n/locales/es/entity.shared.entityDropdown.json
@@ -34,7 +34,7 @@
     "deprecation.markUnTooltip": "Marcar este {{entityName}} como no obsoleto",
     "deprecation.modalTitle": "Establecer como obsoleto",
     "deprecation.noteLabel": "Nota",
-    "deprecation.ok": "Aceptar",
+    "deprecation.ok": "Descontinuar",
     "deprecation.reasonLabel": "Motivo",
     "deprecation.reasonPlaceholder": "Añadir motivo",
     "deprecation.replacementLabel": "Reemplazo",

--- a/datahub-web-react/src/i18n/locales/pt-BR/entity.shared.entityDropdown.json
+++ b/datahub-web-react/src/i18n/locales/pt-BR/entity.shared.entityDropdown.json
@@ -34,7 +34,7 @@
     "deprecation.markUnTooltip": "Marcar este(a) {{entityName}} como não descontinuado(a)",
     "deprecation.modalTitle": "Definir como Descontinuado",
     "deprecation.noteLabel": "Nota",
-    "deprecation.ok": "Ok",
+    "deprecation.ok": "Descontinuar",
     "deprecation.reasonLabel": "Motivo",
     "deprecation.reasonPlaceholder": "Adicionar Motivo",
     "deprecation.replacementLabel": "Substituto",


### PR DESCRIPTION

<img width="1840" height="1196" alt="Screenshot 2026-06-17 at 10 17 08 AM" src="https://github.com/user-attachments/assets/689fc6d8-be16-406d-bb2b-339c47e8e92f" />
<img width="1840" height="1196" alt="Screenshot 2026-06-17 at 10 17 22 AM" src="https://github.com/user-attachments/assets/9e20dd32-b78a-4aac-ad5f-51f292c4f2d4" />
<img width="1840" height="1196" alt="Screenshot 2026-06-17 at 10 17 10 AM" src="https://github.com/user-attachments/assets/274aca08-ba7f-44ae-92de-6dd7c0abd1a8" />
## Summary

Tags have always supported the `deprecation` GMS aspect, but the UI never exposed it. This PR wires up deprecation end-to-end for tag entities across three surfaces:

- **Tag profile header**: shows `DeprecationIcon` when the tag is deprecated, using the same component already used by datasets and other entity types
- **Tag profile three-dot menu**: adds "Mark as Deprecated" / "Mark as un-deprecated" via `EntityMenuItems.UPDATE_DEPRECATION` in `EntityDropdown`
- **Manage Tags table row menu**: adds deprecate/un-deprecate inline action using `batchUpdateDeprecation`; reads current state from Apollo cache (`useGetTagQuery` with `cache-first`) to toggle the label without an extra round-trip

### Backend

- `TagMapper.java`: maps `DEPRECATION_ASPECT_NAME` using `DeprecationMapper.map()`, identical pattern to `DatasetMapper`
- `entity.graphql`: adds nullable `deprecation: Deprecation` field to the `Tag` type

### Frontend

- `Tag.tsx`: adds `EntityCapabilityType.DEPRECATION` to `supportedCapabilities()` and wires `deprecation` prop to `EntityPreview`
- `TagStyleEntity.tsx`: renders `DeprecationIcon` and `EntityMenuItems.UPDATE_DEPRECATION`
- `TagsTable.tsx` + `TagsTableColumns.tsx`: adds deprecate/un-deprecate row action with direct `batchUpdateDeprecation` mutation (no modal for un-deprecate; modal reused from `UpdateDeprecationModal` for deprecate)
- `tag.graphql`: adds `deprecation { ...deprecationFields }` to the `getTag` query

### Tests

- `TagMapperTest.java` (new): covers null-deprecation and populated-deprecation mapping cases
- `TagActionsColumn.test.tsx` (new): covers permission gating (`canManageTags=false` hides the action), menu item rendering, and callback invocation for both deprecate and un-deprecate paths

## Test plan

- [ ] Navigate to a tag profile; verify deprecation icon appears in header and three-dot menu shows "Mark as Deprecated"
- [ ] Mark the tag as deprecated via the profile menu; verify icon updates and menu switches to "Mark as un-deprecated"
- [ ] Open Manage Tags (`/tags`); verify row menu shows "Mark as Deprecated" / "Mark as un-deprecated" depending on current state
- [ ] Verify clicking "Mark as un-deprecated" in the row menu fires the mutation without a modal
- [ ] Log in as a user without `manageTags` or `createTags`; verify the deprecation action is absent from row menus and the page route is gated
- [ ] Run `./gradlew :datahub-graphql-core:test --tests "*.TagMapperTest"` — all tests pass
- [ ] Run `yarn test TagActionsColumn.test.tsx --watchAll=false` — all 5 tests pass

Linear Ticket: CUS-8010