### PR TITLE
fix(ingest): matillion connector _include_unpublished_pipelines false…

### DIFF
--- a/datahub-frontend/conf/routes
+++ b/datahub-frontend/conf/routes
@@ -34,7 +34,6 @@ DELETE        /api/*path                                                      co
 PUT           /api/*path                                                      controllers.Application.proxy(path: String, request: Request)
 
 # Proxies API requests to the metadata service api
-GET           /openapi/v3/api-docs                                             controllers.Default.redirect(to = "/openapi/v3/api-docs/openapi-v3")
 GET           /openapi/*path                                                   controllers.Application.proxy(path: String, request: Request)
 POST          /openapi/*path                                                   controllers.Application.proxy(path: String, request: Request)
 DELETE        /openapi/*path                                                   controllers.Application.proxy(path: String, request: Request)

--- a/datahub-frontend/conf/routes
+++ b/datahub-frontend/conf/routes
@@ -34,6 +34,7 @@ DELETE        /api/*path                                                      co
 PUT           /api/*path                                                      controllers.Application.proxy(path: String, request: Request)
 
 # Proxies API requests to the metadata service api
+GET           /openapi/v3/api-docs                                             controllers.Default.redirect(to = "/openapi/v3/api-docs/openapi-v3")
 GET           /openapi/*path                                                   controllers.Application.proxy(path: String, request: Request)
 POST          /openapi/*path                                                   controllers.Application.proxy(path: String, request: Request)
 DELETE        /openapi/*path                                                   controllers.Application.proxy(path: String, request: Request)

--- a/metadata-ingestion/src/datahub/ingestion/source/matillion_dpc/matillion.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/matillion_dpc/matillion.py
@@ -343,6 +343,7 @@ class MatillionSource(StatefulIngestionSourceBase):
             logger.info(
                 "Skipping unpublished pipeline discovery (include_unpublished_pipelines=False)"
             )
+            pipeline_groups = {key: [] for key in published_pipelines_index}
 
         for key in pipeline_groups:
             project_id = key.project_id
@@ -494,6 +495,7 @@ class MatillionSource(StatefulIngestionSourceBase):
 
         if not all_steps_by_name:
             logger.debug(f"No steps found for pipeline {pipeline_name}")
+            self.report.report_pipelines_scanned()
             return
 
         pipeline = MatillionPipeline(

--- a/metadata-ingestion/tests/unit/matillion_dpc/test_matillion_source.py
+++ b/metadata-ingestion/tests/unit/matillion_dpc/test_matillion_source.py
@@ -224,6 +224,43 @@ def test_workunit_processors(
     assert len(processors) > 0
 
 
+def test_published_pipelines_emitted_when_unpublished_disabled(
+    config: MatillionSourceConfig, pipeline_context: PipelineContext
+) -> None:
+    """Published pipelines must be emitted when include_unpublished_pipelines=False."""
+    config.include_unpublished_pipelines = False
+    source = MatillionSource(config, pipeline_context)
+
+    mock_projects = [MatillionProject(id="proj-1", name="Test Project")]
+    mock_environments = [
+        MatillionEnvironment(name="Production", default_agent_id="agent-1")
+    ]
+    mock_pipelines = [
+        MatillionPipeline(name="Pipeline A"),
+        MatillionPipeline(name="Pipeline B"),
+    ]
+
+    with (
+        patch.object(source.api_client, "get_projects", return_value=mock_projects),
+        patch.object(
+            source.api_client, "get_environments", return_value=mock_environments
+        ),
+        patch.object(source.api_client, "get_pipelines", return_value=mock_pipelines),
+        patch.object(source.api_client, "get_streaming_pipelines", return_value=[]),
+        patch.object(source.api_client, "get_schedules", return_value=[]),
+        patch.object(
+            source.api_client, "get_pipeline_execution_steps", return_value=[]
+        ),
+    ):
+        workunits = list(
+            source._discover_and_process_pipelines_from_executions(mock_projects)
+        )
+
+    assert source.report.pipelines_emitted == 2
+    assert source.report.pipelines_scanned == 2
+    assert len(workunits) > 0
+
+
 def test_execution_workunits_with_no_timestamps(
     config: MatillionSourceConfig, pipeline_context: PipelineContext
 ) -> None:


### PR DESCRIPTION
When recipe has `include_unpublished_pipelines: false`, published pipelines were fetched but never emitted because _process_pipeline_from_executions exits early when given empty execution lists, and the emit/scanned counters were placed after that early return. This PR ensures DataFlow entities are always emitted for published pipelines regardless of execution history, and moves the counters to accurately reflect output.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pipeline discovery and reporting accuracy for Matillion ingestion when excluding unpublished pipelines.
  * Optimized OpenAPI documentation endpoint routing for improved API access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->