### PR TITLE
chore(ingest/sql-parsing): remove redundant scope-traverse cycle-detection patch

### DIFF
--- a/metadata-ingestion/src/datahub/sql_parsing/_sqlglot_patch.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/_sqlglot_patch.py
@@ -7,7 +7,6 @@ import patchy.api
 import sqlglot
 import sqlglot.expressions
 import sqlglot.lineage
-import sqlglot.optimizer.scope
 
 from datahub.utilities.is_pytest import is_pytest_running
 from datahub.utilities.unified_diff import apply_diff
@@ -25,7 +24,6 @@ from datahub.utilities.unified_diff import apply_diff
 # With sqlglot[c] (C tokenizer), patchy works for pure-Python functions but fails on those
 # compiled by mypyc to .so extensions. For compiled targets we use alternative strategies:
 # - __deepcopy__ in expression_core.py: wrapper function
-# - Scope.traverse in optimizer/scope.py: full Python reimplementation
 # - lineage.lineage / lineage.to_node: load lineage.py as a pure-Python module and patch that
 
 _DEBUG_PATCHER = is_pytest_running()
@@ -73,47 +71,6 @@ def _deepcopy_wrapper(
 
     datahub.utilities.cooperative_timeout.cooperate()
     return _original_deepcopy(self, memo)
-
-
-def _patch_scope_traverse() -> None:
-    # Circular scope dependencies can happen in somewhat specific circumstances
-    # due to our usage of sqlglot.
-    # See https://github.com/tobymao/sqlglot/pull/4244
-    #
-    # In sqlglot[c] v30+, Scope.traverse is mypyc-compiled and cannot be patched
-    # with patchy. We reimplement it entirely in pure Python with cycle detection.
-    import itertools
-
-    from sqlglot.errors import OptimizeError
-    from sqlglot.optimizer.scope import Scope
-
-    def _traverse_with_cycle_detection(
-        self: Scope,
-    ) -> t.Iterator[Scope]:
-        stack = [self]
-        seen_scopes: t.Set[int] = set()
-        result = []
-        while stack:
-            scope = stack.pop()
-
-            # Scopes aren't hashable, so we use id(scope) instead.
-            if id(scope) in seen_scopes:
-                raise OptimizeError(f"Scope {scope} has a circular scope dependency")
-            seen_scopes.add(id(scope))
-
-            result.append(scope)
-            stack.extend(
-                itertools.chain(
-                    scope.cte_scopes,
-                    scope.union_scopes,
-                    scope.table_scopes,
-                    scope.subquery_scopes,
-                )
-            )
-
-        yield from reversed(result)
-
-    sqlglot.optimizer.scope.Scope.traverse = _traverse_with_cycle_detection  # type: ignore
 
 
 def _patch_lineage() -> None:
@@ -220,7 +177,6 @@ def _patch_lineage() -> None:
 # Apply patches
 
 sqlglot.expressions.Expression.__deepcopy__ = _deepcopy_wrapper  # type: ignore
-_patch_scope_traverse()
 _patch_lineage()
 
 SQLGLOT_PATCHED = True

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_patch.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_patch.py
@@ -4,9 +4,7 @@ import time
 
 import pytest
 import sqlglot
-import sqlglot.errors
 import sqlglot.lineage
-import sqlglot.optimizer
 import sqlglot.optimizer.unnest_subqueries
 from sqlglot import exp
 
@@ -33,19 +31,6 @@ def test_cooperative_timeout_sql() -> None:
             time.sleep(0.0001)
 
     assert 0.6 <= timer.elapsed_seconds() <= 1.2
-
-
-def test_scope_circular_dependency() -> None:
-    scope = sqlglot.optimizer.build_scope(
-        sqlglot.parse_one("WITH w AS (SELECT * FROM q) SELECT * FROM w")
-    )
-    assert scope is not None
-
-    cte_scope = scope.cte_scopes[0]
-    cte_scope.cte_scopes.append(cte_scope)
-
-    with pytest.raises(sqlglot.errors.OptimizeError, match="circular scope dependency"):
-        list(scope.traverse())
 
 
 def test_lineage_node_subfield() -> None:


### PR DESCRIPTION
## Summary

Removes DataHub's `_patch_scope_traverse()` monkey-patch from `_sqlglot_patch.py`. It reimplemented sqlglot's `Scope.traverse()` in pure Python with cycle detection to turn an infinite loop into a raised `OptimizeError`. The hang it guarded against is now fixed at its root cause upstream [sqlglot](https://github.com/tobymao/sqlglot/issues/7295), present in our pinned 30.8.0), so the patch is dead code for any known input.

## What caused the hang

DataHub runs sqlglot's optimizer with `validate_qualify_columns=False`. On certain `UNION ALL` queries (repro: sqlglot [#4244](https://github.com/tobymao/sqlglot/pull/4244#issuecomment-2415249989), unresolved columns made `unnest_subqueries.decorrelate()` treat a `UNION` branch as a correlated subquery and run [`select.parent.replace(alias)`](https://github.com/tobymao/sqlglot/blob/v30.8.0/sqlglot/optimizer/unnest_subqueries.py#L273) — replacing a whole `SELECT` branch with a bare column `_u_0.user_id`. That single line is what led to the infinite loop, via this chain:

1. The `UNION`'s left operand is now a `Column` where a `SELECT` must be.
2. In [`scope._traverse_union`](https://github.com/tobymao/sqlglot/blob/v30.8.0/sqlglot/optimizer/scope.py#L702-L738), building the scope for that branch calls `_traverse_scope`, which has no case for a `Column`: it [logs `Cannot traverse scope … with type Column` and returns **without yielding**](https://github.com/tobymao/sqlglot/blob/v30.8.0/sqlglot/optimizer/scope.py#L689-L691).
3. Because nothing is yielded, the loop variable in `_traverse_union` is never reassigned and still points at the **parent union scope**. The next branch then runs [`union_scope.union_scopes = [prev_scope, scope]`](https://github.com/tobymao/sqlglot/blob/v30.8.0/sqlglot/optimizer/scope.py#L732), recording the union scope **as its own child**.
4. [`Scope.traverse()`](https://github.com/tobymao/sqlglot/blob/v30.8.0/sqlglot/optimizer/scope.py#L568-L589) is a DFS over `union_scopes`; it steps into the scope that contains itself and loops forever.

So the cycle was never a `traverse()` problem — it was a corrupted AST from `decorrelate()`.

## Why DataHub's earlier fix did NOT fix this

DataHub previously carried a second patch, `_patch_unnest_subqueries()` (removed in [#17772](https://github.com/datahub-project/datahub/pull/17772)), which guarded `decorrelate()`'s later `_replace(parent_predicate, …)` calls with `if parent_predicate:`. We verified that guard, applied alone to pre-fix sqlglot, **still hangs** on the [4244 query](https://github.com/tobymao/sqlglot/pull/4244#issuecomment-2415249989) — because the corrupting line is `select.parent.replace(alias)`, which runs *before* the guarded calls and doesn't touch `parent_predicate`. That guard only ever fixed a *crash* sibling of the same defect, not this hang — which is why the separate `_patch_scope_traverse()` net existed at all.