### PR TITLE
fix(dev): make datahub-dev Gradle build timeout configurable via --timeout

### DIFF
--- a/scripts/dev/datahub_dev.py
+++ b/scripts/dev/datahub_dev.py
@@ -1789,7 +1789,7 @@ def cmd_start(args: argparse.Namespace) -> int:
     result = _run(
         ["./gradlew", task],
         capture=False,
-        timeout=1200,
+        timeout=args.timeout,
     )
     if result.returncode != 0:
         _log(f"{task} failed. Check the output above for errors.")
@@ -2089,8 +2089,8 @@ def build_parser() -> argparse.ArgumentParser:
     start_p.add_argument(
         "--timeout",
         type=int,
-        default=DEFAULT_TIMEOUT,
-        help=f"Timeout for readiness wait (default: {DEFAULT_TIMEOUT})",
+        default=1200,
+        help="Timeout in seconds for both the Gradle build and readiness wait (default: 1200)",
     )
 
     # wait


### PR DESCRIPTION
## Summary

- The `quickstartDebug` Gradle build in `datahub-dev start` had a hardcoded 1200s (20min) timeout that couldn't be overridden, causing failures on slower machines.
- Wire the build timeout to the existing `--timeout` flag so users can increase it (e.g. `datahub-dev.sh start --timeout 2400`).
- Default remains 1200s to preserve existing behavior.