### PR TITLE
fix(scripts): comment-only changes no longer trigger spurious transitive bumps (cherry-pick #10249)

### DIFF
--- a/.github/scripts/report_aspect_changes.py
+++ b/.github/scripts/report_aspect_changes.py
@@ -1429,6 +1429,26 @@ def _render_mutator_section(mutators: list[dict]) -> list[str]:
     return out
 
 
+def _is_comment_only_change(path: str, base: str, head: str) -> bool:
+    """True if path's only diff between base and head is comments/whitespace.
+
+    Mirrors bump_schema_versions.is_comment_only_change so the report and the
+    actual bumper agree on which non-aspect edits cascade a schemaVersion bump.
+    The only difference is that this compares two git refs (the report's base
+    and head) rather than the working tree, reusing bsv.normalize_pdl_for_compare
+    (strip comments + collapse whitespace) for the canonical form.
+
+    A created or deleted file (one side empty) is a real change, not
+    comment-only — consistent with the bumper, which never silently drops
+    new/removed files.
+    """
+    old = file_at(base, path)
+    new = file_at(head, path)
+    if not old or not new:
+        return False
+    return bsv.normalize_pdl_for_compare(old) == bsv.normalize_pdl_for_compare(new)
+
+
 def _classify_window(base: str, head: str) -> list[FileFinding]:
     """Run the full classification for a single base..head window.
 
@@ -1440,7 +1460,17 @@ def _classify_window(base: str, head: str) -> list[FileFinding]:
     findings = [analyze_file(p_, base, head) for p_ in paths]
 
     direct_set = set(paths)
-    non_aspect_changed = [f.path for f in findings if not f.is_aspect]
+    # Drop non-aspect records whose only change is comments/whitespace from the
+    # transitive BFS seed: a doc-comment edit carries no schema semantics, so it
+    # must not cascade a schemaVersion bump into aspects that reference it. This
+    # reuses bump_schema_versions' normalize-and-compare so the report classifies
+    # comment-only edits exactly as the bumper does — a real (non-comment) change
+    # to a field default, includes clause, annotation, etc. still seeds the BFS.
+    non_aspect_changed = [
+        f.path
+        for f in findings
+        if not f.is_aspect and not _is_comment_only_change(f.path, base, head)
+    ]
     if not non_aspect_changed:
         return findings
 

--- a/.github/scripts/report_aspect_changes.py
+++ b/.github/scripts/report_aspect_changes.py
@@ -1790,14 +1790,23 @@ def _aggregate_per_pr_verdict(entries: list[dict]) -> str:
     """Reduce a list of per-PR-slice verdicts to a single cumulative status,
     honoring catch-up reconciliation.
 
-    Priority order (highest wins): bump_spurious > bump_needed > bump_done >
+    Priority order (highest wins): bump_needed > bump_spurious > bump_done >
     bump_not_needed. A BUMP_NEEDED entry is **ignored** when its PR appears
     in any later slice's `catch_up_for_prs` — that NEEDED slice has already
     been reconciled by a catch-up bump and is no longer an unpaid debt.
 
-    The cumulative bucket therefore follows the per-PR truth: a file lands
-    in `bump_spurious` whenever any slice has an unreconciled spurious bump,
-    even if cumulative-diff math would call the window `bump_done`.
+    An *unreconciled* BUMP_NEEDED outranks BUMP_SPURIOUS: a needed bump is a
+    release-blocking, silent-migration hazard, whereas a spurious bump is only
+    informational. Catch-up reconciliation flows oldest→newest, so a slice that
+    is still BUMP_SPURIOUS after reclassification paid no debt — it cannot have
+    covered the unreconciled change (a bump only pays for changes that preceded
+    it). Surfacing the file as bump_needed is therefore both correct and the
+    safe failure mode; the spurious slice is still listed in the per-PR
+    breakdown for the reviewer. This avoids the false-negative where a duplicate
+    release bump landing inside the window (e.g. the same v1.1.0 bump shipped on
+    both the cloud branch and acryl-main) masks a later transitive bump_needed.
+
+    The cumulative bucket therefore follows the per-PR truth.
     """
     paid_prs: set[str] = set()
     for e in entries:
@@ -1808,10 +1817,10 @@ def _aggregate_per_pr_verdict(entries: list[dict]) -> str:
         e["bump_status"] == BUMP_NEEDED and e.get("pr") not in paid_prs for e in entries
     )
     has_done = any(e["bump_status"] == BUMP_DONE for e in entries)
-    if has_spurious:
-        return BUMP_SPURIOUS
     if has_unreconciled_needed:
         return BUMP_NEEDED
+    if has_spurious:
+        return BUMP_SPURIOUS
     if has_done:
         return BUMP_DONE
     return BUMP_NOT_NEEDED

--- a/.github/scripts/report_pdl_aspect_changes.md
+++ b/.github/scripts/report_pdl_aspect_changes.md
@@ -314,9 +314,11 @@ Without reclassification, both #9534 and #9579 would be `bump_spurious`. With it
 
 ### Effect on the file's cumulative bucket
 
-The reclassified slice verdicts feed the per-PR aggregator that drives each file's bucket in the cumulative report. The aggregator honors catch-up reconciliation: a `bump_needed` slice whose PR appears in any later slice's `catch_up_for_prs` is no longer treated as an unpaid debt and does not push the file into `bump_needed`. Priority order (highest wins): `bump_spurious > bump_needed > bump_done > bump_not_needed`.
+The reclassified slice verdicts feed the per-PR aggregator that drives each file's bucket in the cumulative report. The aggregator honors catch-up reconciliation: a `bump_needed` slice whose PR appears in any later slice's `catch_up_for_prs` is no longer treated as an unpaid debt and does not push the file into `bump_needed`. Priority order (highest wins): `bump_needed > bump_spurious > bump_done > bump_not_needed`.
 
-**Per-PR truth drives the bucket** — when an unreconciled spurious slice exists in the window, the file lands in `bump_spurious` even if cumulative-diff math would call the window `bump_done`. Reviewers see the per-PR breakdown table for the file to identify which specific PR was at fault.
+**An unreconciled `bump_needed` outranks `bump_spurious`.** A needed bump is a release-blocking, silent-migration hazard; a spurious bump is only informational. Because catch-up reconciliation flows oldest→newest, a slice that is _still_ `bump_spurious` after reclassification paid no debt — it cannot have covered a later change (a bump only pays for changes that preceded it). So when a file has both an unreconciled needed slice and a spurious slice, the file lands in `bump_needed` (the safe failure mode); the spurious slice is still listed in the per-PR breakdown for the reviewer. This prevents a false negative where a **duplicated release bump** landing inside the window masks a later real change — e.g. the v1.1.0 catch-up bump shipped as separate commits on both the cloud branch (#9687) and acryl-main (#9684), so the acryl-main copy falls inside a `v1.1.2-cloud..acryl-main` window as a spurious slice and would otherwise have hidden a later transitive `bump_needed` on the same aspect (`MonitorSuiteInfo` via `EntityChangeType`; `AssertionRunEvent`'s added `executedQuery` field).
+
+**Per-PR truth drives the bucket** — when an unreconciled spurious slice exists in the window (and no unreconciled needed slice outranks it), the file lands in `bump_spurious` even if cumulative-diff math would call the window `bump_done`. Reviewers see the per-PR breakdown table for the file to identify which specific PR was at fault.
 
 For `Status.pdl`:
 

--- a/.github/scripts/test/test_report_aspect_changes.py
+++ b/.github/scripts/test/test_report_aspect_changes.py
@@ -1249,6 +1249,135 @@ def test_main_routes_two_hop_transitive_aspect_to_transitive_section(
     assert "bumped with NO structural change" not in text
 
 
+# ---------------------------------------------------------------------------
+# Transitive BFS seed filtering — must match bump_schema_versions semantics:
+# a non-aspect edit seeds the transitive bump BFS iff it is NOT comment-only
+# (comments/whitespace stripped via bsv.normalize_pdl_for_compare). Created and
+# deleted files count as real changes.
+# ---------------------------------------------------------------------------
+
+
+def _seed_window(monkeypatch, changed, contents, reached):
+    """Drive _classify_window with mocked git/file plumbing.
+
+    changed:   list of changed paths (changed_pdls return)
+    contents:  {path: (base_text, head_text)} — "" means absent at that ref
+    reached:   {source_path: {aspect_path, ...}} for the transitive BFS spy
+    Returns (findings_by_basename, captured_seed_sources).
+    """
+    captured: dict[str, list[str]] = {}
+
+    def fake_file_at(ref, path):
+        pair = contents.get(path)
+        if pair is None:
+            return None
+        return pair[0] if ref == "BASE" else pair[1]
+
+    def spy_per_source(sources):
+        captured["sources"] = list(sources)
+        return {s: set(reached.get(s, set())) for s in sources if s in reached}
+
+    monkeypatch.setattr(rac, "changed_pdls", lambda base, head: list(changed))
+    monkeypatch.setattr(rac, "file_at", fake_file_at)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+    monkeypatch.setattr(rac, "pr_numbers_for_file", lambda *a: [])
+    monkeypatch.setattr(rac, "last_author_for_file", lambda *a: None)
+    monkeypatch.setattr(rac, "latest_commit_date_for_file", lambda *a: None)
+    monkeypatch.setattr(rac, "find_transitive_aspects_per_source", spy_per_source)
+    monkeypatch.setattr(
+        rac, "upstream_attribution_for_transitive", lambda sources, head, base: ([], None, None)
+    )
+    findings = rac._classify_window("BASE", "HEAD")
+    import os
+    return {os.path.basename(f.path): f for f in findings}, captured.get("sources", [])
+
+
+_D = "metadata-models/src/main/pegasus/com/linkedin/x"
+
+
+def test_comment_only_nonaspect_does_not_seed_transitive_bump(monkeypatch):
+    """A comment/doc-only edit to a non-aspect record must NOT seed the BFS,
+    while a real structural change to a sibling still does.
+
+    Matches bump_schema_versions.is_comment_only_change: the canonical form
+    (comments stripped, whitespace collapsed) is unchanged, so the edit is
+    dropped from the seed and the aspect that references it is not flagged.
+    """
+    comment = f"{_D}/CommentOnly.pdl"
+    real = f"{_D}/RealChange.pdl"
+    aspect_c = f"{_D}/AspectViaComment.pdl"
+    aspect_r = f"{_D}/AspectViaReal.pdl"
+    by, sources = _seed_window(
+        monkeypatch,
+        changed=[comment, real],
+        contents={
+            comment: (
+                "record CommentOnly {\n  x: string\n}",
+                "record CommentOnly {\n  /** new doc */\n  x: string\n}",
+            ),
+            real: (
+                "record RealChange {\n  y: string\n}",
+                "record RealChange {\n  y: string\n  z: optional string\n}",
+            ),
+            aspect_c: ('@Aspect = {"name": "c", "schemaVersion": 3}\nrecord A { a: string }',) * 2,
+            aspect_r: ('@Aspect = {"name": "r", "schemaVersion": 3}\nrecord B { b: string }',) * 2,
+        },
+        reached={comment: {aspect_c}, real: {aspect_r}},
+    )
+    # Comment-only excluded from the seed; structural sibling kept.
+    assert sources == [real]
+    assert "AspectViaComment.pdl" not in by
+    assert by["AspectViaReal.pdl"].bump_status == rac.BUMP_NEEDED
+
+
+def test_noncomment_nonstructural_change_seeds_transitive_bump(monkeypatch):
+    """Parity guard with the bumper: a NON-comment change that analyze_file does
+    not model as structural (here, a field default-value change) must STILL seed
+    the BFS, because bsv.normalize_pdl_for_compare sees a real diff.
+
+    This is the case the previous has_structural-based filter got wrong: it
+    dropped default/includes/annotation changes that the actual bumper bumps on.
+    """
+    default = f"{_D}/DefaultChange.pdl"
+    aspect = f"{_D}/AspectViaDefault.pdl"
+    by, sources = _seed_window(
+        monkeypatch,
+        changed=[default],
+        contents={
+            default: (
+                'record DefaultChange {\n  mode: string = "ENABLED"\n}',
+                'record DefaultChange {\n  mode: string = "DISABLED"\n}',
+            ),
+            aspect: ('@Aspect = {"name": "d", "schemaVersion": 5}\nrecord D { d: string }',) * 2,
+        },
+        reached={default: {aspect}},
+    )
+    # has_structural is False (analyze_file doesn't model defaults), but the
+    # change is NOT comment-only, so it must still seed the BFS like the bumper.
+    assert by["DefaultChange.pdl"].has_structural is False
+    assert sources == [default]
+    assert by["AspectViaDefault.pdl"].bump_status == rac.BUMP_NEEDED
+
+
+def test_deleted_nonaspect_seeds_transitive_bump(monkeypatch):
+    """A deleted non-aspect record is a real change (one ref empty), so it is
+    NOT comment-only and still seeds the BFS — consistent with the bumper, which
+    never silently drops removed files."""
+    deleted = f"{_D}/Deleted.pdl"
+    aspect = f"{_D}/AspectViaDeleted.pdl"
+    by, sources = _seed_window(
+        monkeypatch,
+        changed=[deleted],
+        contents={
+            deleted: ("record Deleted {\n  z: string\n}", ""),  # gone at head
+            aspect: ('@Aspect = {"name": "dl", "schemaVersion": 4}\nrecord E { e: string }',) * 2,
+        },
+        reached={deleted: {aspect}},
+    )
+    assert sources == [deleted]
+    assert by["AspectViaDeleted.pdl"].bump_status == rac.BUMP_NEEDED
+
+
 def test_pr_numbers_for_file_returns_all_prs_in_window(monkeypatch):
     """When multiple PRs touch a file in base..head, ALL get returned."""
     log_output = (

--- a/.github/scripts/test/test_report_aspect_changes.py
+++ b/.github/scripts/test/test_report_aspect_changes.py
@@ -629,7 +629,12 @@ def test_upstream_attribution_dedupes_prs_across_sources(monkeypatch):
 
 
 def test_aggregate_per_pr_verdict_priority_order():
-    """Highest-priority verdict wins: spurious > needed > done > bump_not_needed."""
+    """Highest-priority verdict wins: needed > spurious > done > bump_not_needed.
+
+    An *unreconciled* bump_needed outranks bump_spurious: a needed bump is a
+    release-blocking, silent-migration hazard, while a spurious bump is merely
+    informational. A coexisting spurious slice must never mask the blocker.
+    """
     assert (
             rac._aggregate_per_pr_verdict(
                 [
@@ -638,7 +643,7 @@ def test_aggregate_per_pr_verdict_priority_order():
                     {"bump_status": rac.BUMP_NEEDED},
                 ]
             )
-            == rac.BUMP_SPURIOUS
+            == rac.BUMP_NEEDED
     )
     assert (
             rac._aggregate_per_pr_verdict(
@@ -712,6 +717,54 @@ def test_aggregator_returns_needed_when_some_needed_slices_unreconciled():
         },
         {"pr": "C", "bump_status": rac.BUMP_NEEDED},  # not in catch_up_for_prs
     ]
+    assert rac._aggregate_per_pr_verdict(entries) == rac.BUMP_NEEDED
+
+
+def test_aggregator_unreconciled_needed_outranks_earlier_spurious_bump():
+    """Regression (MonitorSuiteInfo): an EARLIER spurious bump must not mask a
+    LATER, genuinely-unreconciled bump_needed.
+
+    Real case behind this test: a v1.1.0 release catch-up bump (no schema
+    change in its own commit) landed as a duplicate commit inside the report
+    window — because the same bump shipped on both the cloud release branch
+    (#9687) and acryl-main (#9684) — so it surfaces as a BUMP_SPURIOUS slice.
+    A *later* PR (#9814) then made a real transitive change (the
+    EntityChangeType enum grew) with no accompanying bump → BUMP_NEEDED.
+
+    A bump can only pay debt for changes that preceded it (catch-up flows
+    oldest→newest), so the earlier spurious bump cannot pre-pay #9814's change.
+    The file therefore genuinely needs a bump and must land in bump_needed, not
+    bump_spurious.
+    """
+    entries = [
+        {"pr": "9684", "date": "2026-05-19", "bump_status": rac.BUMP_SPURIOUS},
+        {"pr": "9814", "date": "2026-05-26", "bump_status": rac.BUMP_NEEDED},
+    ]
+    # Run the real reconciliation pipeline: catch-up must NOT reconcile the
+    # later needed against the earlier spurious bump.
+    rac._apply_catchup_reclassification(entries)
+    assert rac._aggregate_per_pr_verdict(entries) == rac.BUMP_NEEDED
+
+
+def test_aggregator_direct_change_needed_not_masked_by_earlier_spurious_bump():
+    """Regression (AssertionRunEvent): a later DIRECT schema change shipped
+    without a bump must not be hidden by an earlier spurious bump.
+
+    Real slices behind this test: an earlier spurious schemaVersion bump
+    (#9658, 4→5, no change in that commit) precedes PR #9696, which ADDED an
+    optional field (`executedQuery`) to the aspect without bumping. The added
+    field is a genuine, unreconciled bump_needed and must surface — a bump only
+    pays debt for changes that preceded it, so the earlier spurious bump cannot
+    cover #9696's later change. This is the higher-stakes variant of the masking
+    bug: a direct, unbumped field addition is exactly the silent-migration
+    hazard the report exists to flag.
+    """
+    entries = [
+        {"pr": None, "date": "2026-05-21", "bump_status": rac.BUMP_NEEDED},  # transitive via BoundsValueSpace
+        {"pr": "9658", "date": "2026-05-21", "bump_status": rac.BUMP_SPURIOUS},  # 4→5, no change in slice
+        {"pr": "9696", "date": "2026-05-28", "bump_status": rac.BUMP_NEEDED},  # added executedQuery, no bump
+    ]
+    rac._apply_catchup_reclassification(entries)
     assert rac._aggregate_per_pr_verdict(entries) == rac.BUMP_NEEDED
 
 


### PR DESCRIPTION
Cherry-pick of acryldata/datahub-fork#10249 onto `master`.

## Summary

Two fixes to the `@Aspect` PDL change report (`report_aspect_changes.py`) so its bump classification stays aligned with the actual bumper (`bump_schema_versions.py`) and never masks a release-blocking `bump_needed`.

## Fix 1 — comment-only edits no longer trigger spurious transitive bumps

`_classify_window` seeded the transitive-dependency BFS with **every** changed non-aspect record, so a comment-only edit to an upstream record forced a `bump_needed` on every aspect referencing it. The BFS seed now drops a non-aspect record iff its base→head diff is comments/whitespace only, reusing the bumper's own `normalize_pdl_for_compare` (strip comments + collapse whitespace). Real changes (field add/remove, type, enum value, default value, `includes`, annotation) still seed the BFS; created/deleted files count as real changes.

## Fix 2 — surface unreconciled `bump_needed` over coexisting `bump_spurious`

The per-PR aggregator (`_aggregate_per_pr_verdict`) ranked `bump_spurious` above `bump_needed`, masking a release-blocking `bump_needed` when a file's slices contained both. Priority is reordered to `bump_needed` > `bump_spurious` > `bump_done` > `bump_not_needed`. Since catch-up reconciliation flows oldest→newest, a slice still `bump_spurious` after reclassification cannot have covered the later change, so reporting `bump_needed` is both correct and the safe failure mode.

## Tests

- Full suite: `126 passed`.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [ ] Docs — n/a (internal CI/reporting script; debt-model docs updated in-tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
