### PR TITLE
fix(ui): Display all group relationships on user profile page

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/sidebarSection/UserGroupSidebarSection.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/sidebarSection/UserGroupSidebarSection.tsx
@@ -27,19 +27,14 @@ export const UserGroupSideBarSection = ({ groupsDetails }: Props) => {
     const entityRegistry = useEntityRegistryV2();
     const [entityCount, setEntityCount] = useState(DEFAULT_MAX_ENTITIES_TO_SHOW);
 
-    // Filter out soft-deleted or orphaned groups that lack both info and editableProperties
-    const validGroups = groupsDetails.filter((detail) => {
-        const group = detail?.entity as CorpGroup | undefined;
-        return group && (group.info || group.editableProperties);
-    });
-    const groupsDetailsCount = validGroups.length;
+    const groupsDetailsCount = groupsDetails.length;
     return (
         <SidebarSection
             title={t('sidebar.groupsTitle')}
             content={
                 <>
                     <GroupsContainer>
-                        {validGroups.map((groupDetail, index) => {
+                        {groupsDetails.map((groupDetail, index) => {
                             const group = groupDetail.entity as CorpGroup;
                             return (
                                 group &&

--- a/datahub-web-react/src/app/entityV2/user/UserGroups.tsx
+++ b/datahub-web-react/src/app/entityV2/user/UserGroups.tsx
@@ -15,6 +15,7 @@ type Props = {
     urn: string;
     initialRelationships?: Array<EntityRelationship> | null;
     pageSize: number;
+    totalRelationships: number;
 };
 
 const GroupsViewWrapper = styled.div`
@@ -84,7 +85,7 @@ const GroupDescription = styled.span`
     max-width: 100%;
 `;
 
-export default function UserGroups({ urn, initialRelationships, pageSize }: Props) {
+export default function UserGroups({ urn, initialRelationships, pageSize, totalRelationships }: Props) {
     const { t } = useTranslation('entity.types');
     const [page, setPage] = useState(1);
     const entityRegistry = useEntityRegistry();
@@ -99,14 +100,7 @@ export default function UserGroups({ urn, initialRelationships, pageSize }: Prop
     };
 
     const relationships = groupsData ? groupsData.corpUser?.relationships?.relationships : initialRelationships;
-    const userGroups = [...(relationships || [])]
-        .filter((rel) => {
-            const group = rel?.entity as CorpGroup;
-            return group?.info || group?.editableProperties;
-        })
-        .map((rel) => rel.entity as CorpGroup);
-    const total = userGroups.length;
-
+    const userGroups = [...(relationships || [])].map((rel) => rel.entity as CorpGroup);
     return (
         <GroupsViewWrapper>
             <Row justify="start">
@@ -139,7 +133,7 @@ export default function UserGroups({ urn, initialRelationships, pageSize }: Prop
                 <Pagination
                     current={page}
                     pageSize={pageSize}
-                    total={total}
+                    total={totalRelationships}
                     showLessItems
                     onChange={onChangeGroupsPage}
                     showSizeChanger={false}

--- a/datahub-web-react/src/app/entityV2/user/UserProfile.tsx
+++ b/datahub-web-react/src/app/entityV2/user/UserProfile.tsx
@@ -29,7 +29,7 @@ import { PageRoutes } from '@conf/Global';
 import { useShowNavBarRedesign } from '@src/app/useShowNavBarRedesign';
 
 import { useGetUserOwnedAssetsQuery, useGetUserQuery } from '@graphql/user.generated';
-import { CorpGroup, EntityRelationship, EntityType } from '@types';
+import { EntityRelationship, EntityType } from '@types';
 
 interface Props {
     urn: string;
@@ -106,14 +106,9 @@ export default function UserProfile({ urn }: Props) {
 
     const corpUser = data?.corpUser;
 
-    // Filter out soft-deleted or orphaned groups that lack both info and editableProperties
     const userGroups: Array<EntityRelationship> =
-        corpUser?.groups?.relationships
-            ?.filter((relationship) => {
-                const group = relationship?.entity as CorpGroup | undefined;
-                return group?.info || group?.editableProperties;
-            })
-            ?.map((relationship) => relationship as EntityRelationship) || [];
+        corpUser?.groups?.relationships?.map((relationship) => relationship as EntityRelationship) || [];
+    const totalRelationships = corpUser?.groups?.total || 0;
     const userRoles: Array<EntityRelationship> =
         corpUser?.roles?.relationships?.map((relationship) => relationship as EntityRelationship) || [];
 
@@ -134,7 +129,14 @@ export default function UserProfile({ urn }: Props) {
             {
                 name: t('user.tab.groups'),
                 path: TabType.Groups.toLocaleLowerCase(),
-                content: <UserGroups urn={urn} initialRelationships={userGroups} pageSize={GROUP_PAGE_SIZE} />,
+                content: (
+                    <UserGroups
+                        urn={urn}
+                        initialRelationships={userGroups}
+                        pageSize={GROUP_PAGE_SIZE}
+                        totalRelationships={totalRelationships}
+                    />
+                ),
                 display: {
                     enabled: () => userGroups?.length > 0,
                 },


### PR DESCRIPTION
Fixes a bug where we were unnecessarily filtering out groups when displaying them in the user UI. We were hiding groups that didn't appear to exist in the database, however that breaks out pagination logic so you can't get to page 2 if users were part of more than 20 groups.

On top of that, these ghost groups could still "exist" in that they could be referenced by policies and user's could still be part of these groups, inheriting their permissions. While it's a little odd, I think we should lean towards showing a little too much in this situation as it's already caused confusion for users who didn't know why they couldn't see all of their groups.

If a group doesn't exist in the DB, we show the name as the `id` of the group from the end of its urn. If you try to go to the group profile page you just get a "Not Found" message and you can go back.


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
