### PR TITLE
feat(auth): wire actor-scoped policies into authorize()

### DIFF
--- a/li-utils/src/main/java/com/datahub/authorization/AuthorizationRequest.java
+++ b/li-utils/src/main/java/com/datahub/authorization/AuthorizationRequest.java
@@ -1,7 +1,11 @@
 package com.datahub.authorization;
 
+import com.linkedin.data.template.RecordTemplate;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import lombok.Value;
 
 /** A request to authorize a user for a specific privilege. */
@@ -21,4 +25,31 @@ public class AuthorizationRequest {
 
   /** The sub-resources that are being applied as a modification to the target resource */
   Collection<EntitySpec> subResources;
+
+  /**
+   * Session-scoped actor-applicable policies indexed by privilege, or {@code null} when callers do
+   * not supply session policy scope (direct authorizer invocations, test mocks).
+   */
+  @Nullable Map<String, List<RecordTemplate>> actorPoliciesByPrivilege;
+
+  public AuthorizationRequest(
+      String actorUrn,
+      String privilege,
+      Optional<EntitySpec> resourceSpec,
+      Collection<EntitySpec> subResources,
+      @Nullable Map<String, List<RecordTemplate>> actorPoliciesByPrivilege) {
+    this.actorUrn = actorUrn;
+    this.privilege = privilege;
+    this.resourceSpec = resourceSpec;
+    this.subResources = subResources;
+    this.actorPoliciesByPrivilege = actorPoliciesByPrivilege;
+  }
+
+  public AuthorizationRequest(
+      String actorUrn,
+      String privilege,
+      Optional<EntitySpec> resourceSpec,
+      Collection<EntitySpec> subResources) {
+    this(actorUrn, privilege, resourceSpec, subResources, null);
+  }
 }

--- a/li-utils/src/test/java/com/datahub/authorization/AuthorizationRequestTest.java
+++ b/li-utils/src/test/java/com/datahub/authorization/AuthorizationRequestTest.java
@@ -1,0 +1,44 @@
+package com.datahub.authorization;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import com.linkedin.data.template.RecordTemplate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.testng.annotations.Test;
+
+public class AuthorizationRequestTest {
+
+  @Test
+  public void fiveArgConstructorSetsAllFields() {
+    EntitySpec resource = new EntitySpec("dataset", "urn:li:dataset:test");
+    Map<String, List<RecordTemplate>> actorPolicies =
+        Map.of("VIEW", Collections.<RecordTemplate>emptyList());
+
+    AuthorizationRequest request =
+        new AuthorizationRequest(
+            "urn:li:corpuser:testuser",
+            "VIEW",
+            Optional.of(resource),
+            List.of(resource),
+            actorPolicies);
+
+    assertEquals(request.getActorUrn(), "urn:li:corpuser:testuser");
+    assertEquals(request.getPrivilege(), "VIEW");
+    assertEquals(request.getResourceSpec(), Optional.of(resource));
+    assertEquals(request.getSubResources(), List.of(resource));
+    assertEquals(request.getActorPoliciesByPrivilege(), actorPolicies);
+  }
+
+  @Test
+  public void fourArgConstructorLeavesActorPoliciesByPrivilegeNull() {
+    AuthorizationRequest request =
+        new AuthorizationRequest(
+            "urn:li:corpuser:testuser", "VIEW", Optional.empty(), Collections.emptyList());
+
+    assertNull(request.getActorPoliciesByPrivilege());
+  }
+}

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/ActorContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/ActorContext.java
@@ -10,15 +10,21 @@ import com.datahub.authentication.Authentication;
 import com.linkedin.common.Status;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.entity.Aspect;
 import com.linkedin.identity.CorpUserStatus;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.policy.DataHubPolicyInfo;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -46,6 +52,7 @@ public class ActorContext implements ContextInterface {
         .systemAuth(false)
         .authentication(authentication)
         .policyInfoSet(dataHubPolicySet)
+        .actorPoliciesByPrivilege(indexPoliciesByPrivilege(dataHubPolicySet))
         .groupMembership(groupMembership)
         .enforceExistenceEnabled(enforceExistenceEnabled)
         .build();
@@ -57,6 +64,13 @@ public class ActorContext implements ContextInterface {
   @EqualsAndHashCode.Exclude @Builder.Default
   private final Set<DataHubPolicyInfo> policyInfoSet = Collections.emptySet();
 
+  /**
+   * Derived once per session from {@link #policyInfoSet} so authorize() can look up candidates for
+   * a privilege in O(1) without scanning the full actor-applicable set on every check.
+   */
+  @EqualsAndHashCode.Exclude @Builder.Default
+  private final Map<String, List<RecordTemplate>> actorPoliciesByPrivilege = Collections.emptyMap();
+
   @EqualsAndHashCode.Exclude @Builder.Default
   private final Collection<Urn> groupMembership = Collections.emptyList();
 
@@ -64,6 +78,28 @@ public class ActorContext implements ContextInterface {
 
   public Urn getActorUrn() {
     return UrnUtils.getUrn(authentication.getActor().toUrnStr());
+  }
+
+  /**
+   * Groups actor-applicable policies by privilege. Uses the same {@link DataHubPolicyInfo}
+   * references as the policy cache.
+   */
+  @Nonnull
+  public static Map<String, List<RecordTemplate>> indexPoliciesByPrivilege(
+      @Nullable final Set<DataHubPolicyInfo> policyInfoSet) {
+    if (policyInfoSet == null || policyInfoSet.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    final Map<String, List<RecordTemplate>> byPrivilege = new HashMap<>();
+    for (final DataHubPolicyInfo policy : policyInfoSet) {
+      if (policy.getPrivileges() == null) {
+        continue;
+      }
+      for (final String privilege : policy.getPrivileges()) {
+        byPrivilege.computeIfAbsent(privilege, ignored -> new ArrayList<>()).add(policy);
+      }
+    }
+    return Collections.unmodifiableMap(byPrivilege);
   }
 
   /**

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/AuthorizationContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/AuthorizationContext.java
@@ -54,7 +54,8 @@ public class AuthorizationContext implements ContextInterface {
             actorContext.getActorUrn().toString(),
             privilege,
             Optional.ofNullable(resourceSpec),
-            Collections.emptyList());
+            Collections.emptyList(),
+            actorContext.getActorPoliciesByPrivilege());
     // Graphql CompletableFutures causes a recursive exception, we avoid computeIfAbsent and do work
     // outside a blocking function
     AuthorizationResult result = sessionAuthorizationCache.get(request);
@@ -75,7 +76,8 @@ public class AuthorizationContext implements ContextInterface {
             actorContext.getActorUrn().toString(),
             privilege,
             Optional.ofNullable(resourceSpec),
-            subResources);
+            subResources,
+            actorContext.getActorPoliciesByPrivilege());
     // Graphql CompletableFutures causes a recursive exception, we avoid computeIfAbsent and do work
     // outside a blocking function
     AuthorizationResult result = sessionAuthorizationCache.get(request);

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContext.java
@@ -20,6 +20,7 @@ import com.linkedin.metadata.query.SearchFlags;
 import com.linkedin.metadata.utils.AuditStampUtils;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.mxe.SystemMetadata;
+import com.linkedin.policy.DataHubPolicyInfo;
 import io.datahubproject.metadata.exception.ActorAccessException;
 import io.datahubproject.metadata.exception.OperationContextException;
 import io.datahubproject.metadata.exception.TraceException;
@@ -688,6 +689,8 @@ public class OperationContext implements AuthorizationSession, OperationFingerpr
         boolean skipCache,
         boolean enforceExistenceEnabled) {
       final Urn actorUrn = UrnUtils.getUrn(sessionAuthentication.getActor().toUrnStr());
+      final Set<DataHubPolicyInfo> policyInfoSet =
+          this.authorizationContext.getAuthorizer().getActorPolicies(actorUrn);
       final ActorContext sessionActor =
           ActorContext.builder()
               .authentication(sessionAuthentication)
@@ -697,7 +700,8 @@ public class OperationContext implements AuthorizationSession, OperationFingerpr
                           .getAuthentication()
                           .getActor()
                           .equals(sessionAuthentication.getActor()))
-              .policyInfoSet(this.authorizationContext.getAuthorizer().getActorPolicies(actorUrn))
+              .policyInfoSet(policyInfoSet)
+              .actorPoliciesByPrivilege(ActorContext.indexPoliciesByPrivilege(policyInfoSet))
               .groupMembership(this.authorizationContext.getAuthorizer().getActorGroups(actorUrn))
               .enforceExistenceEnabled(enforceExistenceEnabled)
               .build();

--- a/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/ActorContextTest.java
+++ b/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/ActorContextTest.java
@@ -18,6 +18,7 @@ import com.linkedin.common.Status;
 import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.entity.Aspect;
 import com.linkedin.identity.CorpUserStatus;
@@ -31,6 +32,7 @@ import com.linkedin.policy.PolicyMatchCondition;
 import com.linkedin.policy.PolicyMatchCriterion;
 import com.linkedin.policy.PolicyMatchCriterionArray;
 import com.linkedin.policy.PolicyMatchFilter;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -141,6 +143,33 @@ public class ActorContextTest {
         ActorContext.asSessionRestricted(userAuth, Set.of(POLICY_D), Set.of(), true)
             .getCacheKeyComponent(),
         "Expected differences with ownership type policy");
+  }
+
+  @Test
+  public void indexPoliciesByPrivilegeGroupsPoliciesByPrivilege() {
+    Map<String, List<RecordTemplate>> indexed =
+        ActorContext.indexPoliciesByPrivilege(Set.of(POLICY_ABC, POLICY_D));
+
+    assertEquals(indexed.get("a"), List.of(POLICY_ABC));
+    assertEquals(indexed.get("b"), List.of(POLICY_ABC));
+    assertEquals(indexed.get("c"), List.of(POLICY_ABC));
+    assertEquals(indexed.get("d"), List.of(POLICY_D));
+    assertEquals(ActorContext.indexPoliciesByPrivilege(Set.of()).size(), 0);
+    assertEquals(ActorContext.indexPoliciesByPrivilege(null).size(), 0);
+  }
+
+  @Test
+  public void indexPoliciesByPrivilegeSkipsPoliciesWithNullPrivileges() {
+    DataHubPolicyInfo policyWithoutPrivileges = mock(DataHubPolicyInfo.class);
+    when(policyWithoutPrivileges.getPrivileges()).thenReturn(null);
+    Set<DataHubPolicyInfo> policies = new HashSet<>();
+    policies.add(POLICY_ABC);
+    policies.add(policyWithoutPrivileges);
+
+    Map<String, List<RecordTemplate>> indexed = ActorContext.indexPoliciesByPrivilege(policies);
+
+    assertEquals(indexed.get("a"), List.of(POLICY_ABC));
+    assertEquals(indexed.size(), 3);
   }
 
   @Test

--- a/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/AuthorizationContextTest.java
+++ b/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/AuthorizationContextTest.java
@@ -1,0 +1,104 @@
+package io.datahubproject.metadata.context;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.datahub.authentication.Actor;
+import com.datahub.authentication.ActorType;
+import com.datahub.authentication.Authentication;
+import com.datahub.authorization.AuthorizationRequest;
+import com.datahub.authorization.AuthorizationResult;
+import com.datahub.authorization.EntitySpec;
+import com.datahub.plugins.auth.authorization.Authorizer;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.metadata.authorization.PoliciesConfig;
+import com.linkedin.policy.DataHubActorFilter;
+import com.linkedin.policy.DataHubPolicyInfo;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.Test;
+
+public class AuthorizationContextTest {
+
+  private static final DataHubPolicyInfo POLICY =
+      new DataHubPolicyInfo()
+          .setState(PoliciesConfig.ACTIVE_POLICY_STATE)
+          .setActors(
+              new DataHubActorFilter()
+                  .setUsers(new UrnArray(UrnUtils.getUrn("urn:li:corpuser:testuser"))))
+          .setPrivileges(new StringArray(List.of("VIEW", "EDIT")));
+
+  @Test
+  public void authorizePassesActorPoliciesByPrivilegeForResourceOnly() {
+    Authorizer authorizer = mock(Authorizer.class);
+    ArgumentCaptor<AuthorizationRequest> captor =
+        ArgumentCaptor.forClass(AuthorizationRequest.class);
+    when(authorizer.authorize(captor.capture()))
+        .thenAnswer(
+            invocation ->
+                new AuthorizationResult(
+                    invocation.getArgument(0), AuthorizationResult.Type.DENY, null));
+
+    Map<String, List<RecordTemplate>> actorPoliciesByPrivilege =
+        ActorContext.indexPoliciesByPrivilege(Set.of(POLICY));
+    ActorContext actorContext = sessionActor(actorPoliciesByPrivilege);
+    AuthorizationContext authorizationContext =
+        AuthorizationContext.builder().authorizer(authorizer).build();
+    EntitySpec resource = new EntitySpec("dataset", "urn:li:dataset:test");
+
+    authorizationContext.authorize(actorContext, "VIEW", resource);
+
+    AuthorizationRequest request = captor.getValue();
+    assertEquals(request.getActorPoliciesByPrivilege(), actorPoliciesByPrivilege);
+    assertEquals(request.getPrivilege(), "VIEW");
+    assertEquals(request.getResourceSpec().orElse(null), resource);
+  }
+
+  @Test
+  public void authorizePassesActorPoliciesByPrivilegeWithSubResources() {
+    Authorizer authorizer = mock(Authorizer.class);
+    ArgumentCaptor<AuthorizationRequest> captor =
+        ArgumentCaptor.forClass(AuthorizationRequest.class);
+    when(authorizer.authorize(captor.capture()))
+        .thenAnswer(
+            invocation ->
+                new AuthorizationResult(
+                    invocation.getArgument(0), AuthorizationResult.Type.DENY, null));
+
+    Map<String, List<RecordTemplate>> actorPoliciesByPrivilege =
+        ActorContext.indexPoliciesByPrivilege(Set.of(POLICY));
+    ActorContext actorContext = sessionActor(actorPoliciesByPrivilege);
+    AuthorizationContext authorizationContext =
+        AuthorizationContext.builder().authorizer(authorizer).build();
+    EntitySpec resource = new EntitySpec("dataset", "urn:li:dataset:test");
+    EntitySpec subResource = new EntitySpec("tag", "urn:li:tag:test");
+
+    authorizationContext.authorize(actorContext, "EDIT", resource, List.of(subResource));
+
+    AuthorizationRequest request = captor.getValue();
+    assertEquals(request.getActorPoliciesByPrivilege(), actorPoliciesByPrivilege);
+    assertEquals(request.getSubResources(), List.of(subResource));
+    verify(authorizer, times(1)).authorize(any());
+  }
+
+  private static ActorContext sessionActor(
+      Map<String, List<RecordTemplate>> actorPoliciesByPrivilege) {
+    Authentication authentication = new Authentication(new Actor(ActorType.USER, "testuser"), "");
+    return ActorContext.builder()
+        .authentication(authentication)
+        .policyInfoSet(Set.of(POLICY))
+        .actorPoliciesByPrivilege(actorPoliciesByPrivilege)
+        .groupMembership(Collections.emptyList())
+        .build();
+  }
+}

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/DataHubAuthorizer.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/DataHubAuthorizer.java
@@ -6,6 +6,7 @@ import com.datahub.plugins.auth.authorization.ResourceSpecCachingAuthorizer;
 import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.policy.DataHubPolicyInfo;
@@ -126,10 +127,23 @@ public class DataHubAuthorizer implements Authorizer, ResourceSpecCachingAuthori
             .collect(Collectors.toList());
 
     // 1. Fetch the policies relevant to the requested privilege.
-    final List<DataHubPolicyInfo> policiesToEvaluate =
-        new LinkedList<>(getOrDefault(request.getPrivilege(), new ArrayList<>()));
-    policiesToEvaluate.addAll(
-        PoliciesConfig.getDefaultPolicies(UrnUtils.getUrn(request.getActorUrn())));
+    final List<DataHubPolicyInfo> policiesToEvaluate = new LinkedList<>();
+    if (request.getActorPoliciesByPrivilege() != null) {
+      for (final RecordTemplate policy :
+          request
+              .getActorPoliciesByPrivilege()
+              .getOrDefault(request.getPrivilege(), Collections.emptyList())) {
+        policiesToEvaluate.add((DataHubPolicyInfo) policy);
+      }
+    } else {
+      policiesToEvaluate.addAll(getOrDefault(request.getPrivilege(), new ArrayList<>()));
+    }
+    for (final DataHubPolicyInfo defaultPolicy :
+        PoliciesConfig.getDefaultPolicies(UrnUtils.getUrn(request.getActorUrn()))) {
+      if (policiesToEvaluate.stream().noneMatch(existing -> existing == defaultPolicy)) {
+        policiesToEvaluate.add(defaultPolicy);
+      }
+    }
 
     // 2. Evaluate each policy.
     for (DataHubPolicyInfo policy : policiesToEvaluate) {

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
@@ -46,6 +46,7 @@ import com.linkedin.metadata.search.SearchEntityArray;
 import com.linkedin.policy.DataHubActorFilter;
 import com.linkedin.policy.DataHubPolicyInfo;
 import com.linkedin.policy.DataHubResourceFilter;
+import io.datahubproject.metadata.context.ActorContext;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.OperationContextConfig;
 import io.datahubproject.metadata.context.RetrieverContext;
@@ -800,6 +801,58 @@ public class DataHubAuthorizerTest {
     // short-circuits on the actor check and never resolves the resource's domain. Resolving the
     // domain for a policy that cannot apply to the requester would be wasted work.
     verify(_entityClient, times(0))
+        .getV2(
+            any(OperationContext.class),
+            eq("dataset"),
+            eq(RESOURCE_WITH_DOMAIN),
+            eq(Collections.singleton(DOMAINS_ASPECT_NAME)));
+  }
+
+  @Test
+  public void testAuthorizationWithActorScopedPolicyMapExcludesDecoyPolicies() throws Exception {
+    // Session actor policies exclude domain-scoped policies for users not on the actor filter.
+    // Passing that index on the request must skip evaluating decoy policies that remain in the
+    // global privilege index.
+    EntitySpec resourceSpec = new EntitySpec("dataset", RESOURCE_WITH_DOMAIN.toString());
+    Urn unauthorizedUser = UrnUtils.getUrn("urn:li:corpuser:unauthorizedUser");
+    Map<String, List<RecordTemplate>> actorPoliciesByPrivilege =
+        ActorContext.indexPoliciesByPrivilege(
+            _dataHubAuthorizer.getActorPolicies(unauthorizedUser));
+
+    AuthorizationRequest request =
+        new AuthorizationRequest(
+            unauthorizedUser.toString(),
+            "PARENT_DOMAIN_PRIVILEGE",
+            Optional.of(resourceSpec),
+            Collections.emptyList(),
+            actorPoliciesByPrivilege);
+
+    assertEquals(_dataHubAuthorizer.authorize(request).getType(), AuthorizationResult.Type.DENY);
+    verify(_entityClient, times(0))
+        .getV2(
+            any(OperationContext.class),
+            eq("dataset"),
+            eq(RESOURCE_WITH_DOMAIN),
+            eq(Collections.singleton(DOMAINS_ASPECT_NAME)));
+  }
+
+  @Test
+  public void testAuthorizationWithActorScopedPolicyMapAllowsMatchingPolicy() throws Exception {
+    EntitySpec resourceSpec = new EntitySpec("dataset", RESOURCE_WITH_DOMAIN.toString());
+    Map<String, List<RecordTemplate>> actorPoliciesByPrivilege =
+        ActorContext.indexPoliciesByPrivilege(
+            _dataHubAuthorizer.getActorPolicies(USER_WITH_DOMAIN_ACCESS));
+
+    AuthorizationRequest request =
+        new AuthorizationRequest(
+            USER_WITH_DOMAIN_ACCESS.toString(),
+            "CHILD_DOMAIN_PRIVILEGE",
+            Optional.of(resourceSpec),
+            Collections.emptyList(),
+            actorPoliciesByPrivilege);
+
+    assertEquals(_dataHubAuthorizer.authorize(request).getType(), AuthorizationResult.Type.ALLOW);
+    verify(_entityClient, times(1))
         .getV2(
             any(OperationContext.class),
             eq("dataset"),


### PR DESCRIPTION
## Summary

- Build `actorPoliciesByPrivilege` once at session init from `ActorContext.policyInfoSet` and pass it through `AuthorizationRequest` into `DataHubAuthorizer.authorize()`.
- When the scoped map is present, `authorize()` evaluates only session actor-applicable policies for the requested privilege (skipping decoy policies still in the global privilege index), then appends default policies with reference dedupe.
- `null` map preserves existing unscoped behavior for direct authorizer callers and test mocks.

Stacks on #17908 (merged): complements resource-spec memoization and actor-first policy evaluation by removing decoy policies from the evaluation loop entirely.

## Test plan

- [x] `./gradlew spotlessCheck`
- [x] `./gradlew :metadata-service:auth-impl:test --tests "com.datahub.authorization.DataHubAuthorizerTest"`
- [x] `./gradlew :metadata-operation-context:test --tests "io.datahubproject.metadata.context.ActorContextTest"`
- [x] New tests: scoped map excludes decoy policies (DENY, no domain resolution), scoped ALLOW for matching domain policy, `indexPoliciesByPrivilege` grouping
- [x] Existing unscoped authorize tests unchanged (null map path)


Made with [Cursor](https://cursor.com)