### PR TITLE
fix(ingestion): trim oversized schemaMetadata by dropping platform schema before fields

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
@@ -148,30 +148,30 @@ class EnsureAspectSizeProcessor(WorkunitProcessor[EnsureAspectSizeProcessorRepor
     def ensure_schema_metadata_size(
         self, dataset_urn: str, schema: SchemaMetadataClass
     ) -> None:
-        # Budget against the full serialized aspect, not just the fields list:
-        # the platformSchema blob (and other top-level content) is emitted too.
-        truncated = False
-        non_fields_size = self._schema_size_without_fields(schema)
-
-        # If the non-field content alone exceeds the budget, the platformSchema
-        # blob is the culprit and the least valuable content. Drop it BEFORE
-        # trimming fields (which carry the metadata users query), then re-measure.
-        # Otherwise the field budget would start already-oversized and reject
-        # every field while the aspect stays over the limit.
+        # Fast path: if the whole aspect already fits, there's nothing to trim.
         if (
-            non_fields_size >= self.schema_size_constraint
-            and self._drop_platform_schema(schema)
+            len(json.dumps(pre_json_transform(schema.to_obj())))
+            < self.schema_size_constraint
         ):
+            return
+
+        # Over budget. Shed the least-valuable content first — the platformSchema
+        # blob (an opaque source-format dump) — so we keep as many fields (the
+        # structured, queryable metadata) as possible. Only after that do we trim
+        # fields, and only if they still don't fit. This keeps "fields > raw
+        # platform schema" even when neither part is individually over the limit
+        # (e.g. a ~half-schema / ~half-fields aspect).
+        truncated = False
+        if self._drop_platform_schema(schema):
             self.ctx.source_report.warning(
                 title="Schema truncated due to size constraint",
                 message="Dataset schema contained too much data and would have caused ingestion to fail",
                 context=f"Raw platform schema was removed from schema for {dataset_urn} due to aspect size constraints",
             )
             self.report.num_platform_schema_drops += 1
-            non_fields_size = self._schema_size_without_fields(schema)
             truncated = True
 
-        total_fields_size = non_fields_size
+        total_fields_size = self._schema_size_without_fields(schema)
         accepted_fields: List[SchemaFieldClass] = []
         for schema_field in schema.fields:
             field_size = len(json.dumps(pre_json_transform(schema_field.to_obj())))

--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
@@ -235,13 +235,17 @@ class EnsureAspectSizeProcessor(WorkunitProcessor[EnsureAspectSizeProcessorRepor
             if total_fields_size + field_size < self.schema_size_constraint:
                 accepted_fields.append(schema_field)
                 total_fields_size += field_size
-            else:
-                self.ctx.source_report.warning(
-                    title="Schema truncated due to size constraint",
-                    message="Dataset schema contained too much data and would have caused ingestion to fail",
-                    context=f"Field {schema_field.fieldPath} was removed from schema for {dataset_urn} due to aspect size constraints",
-                )
-        if truncated or len(accepted_fields) < len(schema.fields):
+
+        dropped_field_count = len(schema.fields) - len(accepted_fields)
+        if dropped_field_count:
+            # Report a single warning per entity with the dropped count, rather
+            # than one warning per dropped field.
+            self.ctx.source_report.warning(
+                title="Schema truncated due to size constraint",
+                message="Dataset schema contained too much data and would have caused ingestion to fail; some fields were dropped",
+                context=f"Dropped {dropped_field_count} of {len(schema.fields)} fields from schema for {dataset_urn} due to aspect size constraints",
+            )
+        if truncated or dropped_field_count:
             self._record_truncation("schemaMetadata")
         schema.fields = accepted_fields
 

--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from datahub.emitter.rest_emitter import INGEST_MAX_PAYLOAD_BYTES
 from datahub.emitter.serialization_helper import pre_json_transform
@@ -13,10 +13,20 @@ from datahub.ingestion.api.workunit_processor import (
     WorkunitProcessorReport,
 )
 from datahub.metadata.schema_classes import (
+    BinaryJsonSchemaClass,
     DatasetProfileClass,
+    EspressoSchemaClass,
+    KafkaSchemaClass,
+    KeyValueSchemaClass,
+    MySqlDDLClass,
+    OracleDDLClass,
+    OrcSchemaClass,
+    OtherSchemaClass,
+    PrestoDDLClass,
     QueryPropertiesClass,
     QuerySubjectsClass,
     SchemaFieldClass,
+    SchemalessClass,
     SchemaMetadataClass,
     UpstreamLineageClass,
     ViewPropertiesClass,
@@ -32,6 +42,24 @@ QUERY_PROPERTIES_STATEMENT_MAX_PAYLOAD_BYTES = int(
     )
 )
 QUERY_STATEMENT_TRUNCATION_BUFFER = 100
+
+# Maps each platformSchema union variant to its raw schema-content string field(s)
+# — the large source-format dump we shed when an aspect is oversized. Only these
+# fields are blanked; small markers on the same record (e.g. KafkaSchema's
+# documentSchemaType="AVRO") are intentionally left intact. Schemaless carries no
+# content. An unrecognized variant is logged and left untouched.
+_PLATFORM_SCHEMA_RAW_FIELDS: Dict[type, Tuple[str, ...]] = {
+    OtherSchemaClass: ("rawSchema",),
+    PrestoDDLClass: ("rawSchema",),
+    MySqlDDLClass: ("tableSchema",),
+    OracleDDLClass: ("tableSchema",),
+    OrcSchemaClass: ("schema",),
+    BinaryJsonSchemaClass: ("schema",),
+    KafkaSchemaClass: ("documentSchema", "keySchema"),
+    EspressoSchemaClass: ("documentSchema", "tableSchema"),
+    KeyValueSchemaClass: ("keySchema", "valueSchema"),
+    SchemalessClass: (),
+}
 
 
 @dataclass
@@ -127,21 +155,28 @@ class EnsureAspectSizeProcessor(WorkunitProcessor[EnsureAspectSizeProcessorRepor
     def _drop_platform_schema(self, schema: SchemaMetadataClass) -> bool:
         """Blank the raw platform-schema string(s) on the aspect's platformSchema.
 
-        ``platformSchema`` holds an opaque, source-format dump of the schema —
-        ``rawSchema`` / ``documentSchema`` / ``tableSchema`` / ``keySchema`` /
-        ``valueSchema`` depending on the union variant. It is the least valuable
-        part of the aspect (``fields`` carry the structured, queryable metadata),
-        so we shed it before trimming fields. Every string member is blanked, so
-        this covers all platformSchema variants generically — not just
-        ``OtherSchema``. Returns ``True`` if any content was cleared.
+        ``platformSchema`` holds an opaque, source-format dump of the schema and
+        is the least valuable part of the aspect (``fields`` carry the structured,
+        queryable metadata), so we shed it before trimming fields. We clear only
+        the known schema-content field(s) for each union variant
+        (``_PLATFORM_SCHEMA_RAW_FIELDS``), leaving small markers such as
+        ``KafkaSchema.documentSchemaType`` intact. An unrecognized variant is
+        logged and left untouched. Returns ``True`` if any content was cleared.
         """
         platform_schema = schema.platformSchema
         if platform_schema is None:
             return False
+        raw_fields = _PLATFORM_SCHEMA_RAW_FIELDS.get(type(platform_schema))
+        if raw_fields is None:
+            logger.info(
+                "Unrecognized platformSchema variant %s; leaving its raw schema untrimmed",
+                type(platform_schema).__name__,
+            )
+            return False
         cleared = False
-        for key, value in platform_schema._inner_dict.items():
-            if isinstance(value, str) and value:
-                platform_schema._inner_dict[key] = ""
+        for field_name in raw_fields:
+            if getattr(platform_schema, field_name, None):
+                setattr(platform_schema, field_name, "")
                 cleared = True
         return cleared
 

--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
@@ -47,7 +47,7 @@ QUERY_STATEMENT_TRUNCATION_BUFFER = 100
 # — the large source-format dump we shed when an aspect is oversized. Only these
 # fields are blanked; small markers on the same record (e.g. KafkaSchema's
 # documentSchemaType="AVRO") are intentionally left intact. Schemaless carries no
-# content. An unrecognized variant is logged and left untouched.
+# content. An unrecognized variant is warned about and left untouched.
 _PLATFORM_SCHEMA_RAW_FIELDS: Dict[type, Tuple[str, ...]] = {
     OtherSchemaClass: ("rawSchema",),
     PrestoDDLClass: ("rawSchema",),
@@ -161,16 +161,19 @@ class EnsureAspectSizeProcessor(WorkunitProcessor[EnsureAspectSizeProcessorRepor
         the known schema-content field(s) for each union variant
         (``_PLATFORM_SCHEMA_RAW_FIELDS``), leaving small markers such as
         ``KafkaSchema.documentSchemaType`` intact. An unrecognized variant is
-        logged and left untouched. Returns ``True`` if any content was cleared.
+        warned about and left untouched. Returns ``True`` if any content was cleared.
         """
         platform_schema = schema.platformSchema
         if platform_schema is None:
             return False
         raw_fields = _PLATFORM_SCHEMA_RAW_FIELDS.get(type(platform_schema))
         if raw_fields is None:
-            logger.info(
-                "Unrecognized platformSchema variant %s; leaving its raw schema untrimmed",
-                type(platform_schema).__name__,
+            self.ctx.source_report.warning(
+                title="Unrecognized platformSchema variant",
+                message="Don't know how to trim the raw schema for this platformSchema "
+                "variant, so it was left untouched and the aspect may still exceed the "
+                "size limit. The variant likely needs adding to _PLATFORM_SCHEMA_RAW_FIELDS.",
+                context=type(platform_schema).__name__,
             )
             return False
         cleared = False

--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional
 
 from datahub.emitter.rest_emitter import INGEST_MAX_PAYLOAD_BYTES
 from datahub.emitter.serialization_helper import pre_json_transform
@@ -42,24 +42,6 @@ QUERY_PROPERTIES_STATEMENT_MAX_PAYLOAD_BYTES = int(
     )
 )
 QUERY_STATEMENT_TRUNCATION_BUFFER = 100
-
-# Maps each platformSchema union variant to its raw schema-content string field(s)
-# — the large source-format dump we shed when an aspect is oversized. Only these
-# fields are blanked; small markers on the same record (e.g. KafkaSchema's
-# documentSchemaType="AVRO") are intentionally left intact. Schemaless carries no
-# content. An unrecognized variant is warned about and left untouched.
-_PLATFORM_SCHEMA_RAW_FIELDS: Dict[type, Tuple[str, ...]] = {
-    OtherSchemaClass: ("rawSchema",),
-    PrestoDDLClass: ("rawSchema",),
-    MySqlDDLClass: ("tableSchema",),
-    OracleDDLClass: ("tableSchema",),
-    OrcSchemaClass: ("schema",),
-    BinaryJsonSchemaClass: ("schema",),
-    KafkaSchemaClass: ("documentSchema", "keySchema"),
-    EspressoSchemaClass: ("documentSchema", "tableSchema"),
-    KeyValueSchemaClass: ("keySchema", "valueSchema"),
-    SchemalessClass: (),
-}
 
 
 @dataclass
@@ -157,31 +139,68 @@ class EnsureAspectSizeProcessor(WorkunitProcessor[EnsureAspectSizeProcessorRepor
 
         ``platformSchema`` holds an opaque, source-format dump of the schema and
         is the least valuable part of the aspect (``fields`` carry the structured,
-        queryable metadata), so we shed it before trimming fields. We clear only
-        the known schema-content field(s) for each union variant
-        (``_PLATFORM_SCHEMA_RAW_FIELDS``), leaving small markers such as
-        ``KafkaSchema.documentSchemaType`` intact. An unrecognized variant is
-        warned about and left untouched. Returns ``True`` if any content was cleared.
+        queryable metadata), so we shed it before trimming fields. Each union
+        variant is handled explicitly so the type checker verifies the field
+        names — a model change surfaces as a mypy error rather than a silent
+        no-op. Small markers such as ``KafkaSchema.documentSchemaType`` are left
+        intact. An unrecognized variant is warned about and left untouched.
+        Returns ``True`` if any content was cleared.
         """
-        platform_schema = schema.platformSchema
-        if platform_schema is None:
+        ps = schema.platformSchema
+        if ps is None or isinstance(ps, SchemalessClass):
             return False
-        raw_fields = _PLATFORM_SCHEMA_RAW_FIELDS.get(type(platform_schema))
-        if raw_fields is None:
-            self.ctx.source_report.warning(
-                title="Unrecognized platformSchema variant",
-                message="Don't know how to trim the raw schema for this platformSchema "
-                "variant, so it was left untouched and the aspect may still exceed the "
-                "size limit. The variant likely needs adding to _PLATFORM_SCHEMA_RAW_FIELDS.",
-                context=type(platform_schema).__name__,
-            )
+        # Direct attribute access (not getattr/setattr) so mypy verifies each
+        # field name against the model.
+        if isinstance(ps, (OtherSchemaClass, PrestoDDLClass)):
+            if ps.rawSchema:
+                ps.rawSchema = ""
+                return True
             return False
-        cleared = False
-        for field_name in raw_fields:
-            if getattr(platform_schema, field_name, None):
-                setattr(platform_schema, field_name, "")
+        if isinstance(ps, (MySqlDDLClass, OracleDDLClass)):
+            if ps.tableSchema:
+                ps.tableSchema = ""
+                return True
+            return False
+        if isinstance(ps, (OrcSchemaClass, BinaryJsonSchemaClass)):
+            if ps.schema:
+                ps.schema = ""
+                return True
+            return False
+        if isinstance(ps, KafkaSchemaClass):
+            cleared = False
+            if ps.documentSchema:
+                ps.documentSchema = ""
                 cleared = True
-        return cleared
+            if ps.keySchema:
+                ps.keySchema = ""
+                cleared = True
+            return cleared
+        if isinstance(ps, EspressoSchemaClass):
+            cleared = False
+            if ps.documentSchema:
+                ps.documentSchema = ""
+                cleared = True
+            if ps.tableSchema:
+                ps.tableSchema = ""
+                cleared = True
+            return cleared
+        if isinstance(ps, KeyValueSchemaClass):
+            cleared = False
+            if ps.keySchema:
+                ps.keySchema = ""
+                cleared = True
+            if ps.valueSchema:
+                ps.valueSchema = ""
+                cleared = True
+            return cleared
+        self.ctx.source_report.warning(
+            title="Unrecognized platformSchema variant",
+            message="Don't know how to trim the raw schema for this platformSchema "
+            "variant, so it was left untouched and the aspect may still exceed the "
+            "size limit. The variant likely needs a branch in _drop_platform_schema.",
+            context=type(ps).__name__,
+        )
+        return False
 
     def ensure_schema_metadata_size(
         self, dataset_urn: str, schema: SchemaMetadataClass

--- a/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
+++ b/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
@@ -400,6 +400,17 @@ def test_schema_metadata_trims_fields_when_fields_are_too_large(processor):
         "Aspect exceeded acceptable size"
     )
 
+    # Field trimming should emit a single per-entity warning reporting the dropped
+    # count, not one warning per dropped field.
+    field_drop_warnings = [
+        w
+        for w in processor.ctx.source_report.warnings
+        if "some fields were dropped" in w.message
+    ]
+    assert len(field_drop_warnings) == 1
+    assert len(field_drop_warnings[0].context) == 1
+    assert "fields from schema" in field_drop_warnings[0].context[0]
+
 
 @time_machine.travel("2023-01-02 00:00:00", tick=False)
 def test_schema_metadata_no_op_when_fits_within_budget(processor):

--- a/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
+++ b/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
@@ -378,7 +378,7 @@ def test_ensure_size_of_proper_dataset_profile(processor):
 
 
 @time_machine.travel("2023-01-02 00:00:00", tick=False)
-def test_ensure_size_of_too_big_schema_metadata(processor):
+def test_schema_metadata_trims_fields_when_fields_are_too_large(processor):
     schema = too_big_schema_metadata()
     assert len(schema.fields) == 1004
 
@@ -393,7 +393,7 @@ def test_ensure_size_of_too_big_schema_metadata(processor):
 
 
 @time_machine.travel("2023-01-02 00:00:00", tick=False)
-def test_ensure_size_of_proper_schema_metadata(processor):
+def test_schema_metadata_no_op_when_fits_within_budget(processor):
     schema = proper_schema_metadata()
     orig_repr = json.dumps(schema.to_obj())
     processor.ensure_schema_metadata_size(
@@ -529,6 +529,60 @@ def test_ensure_schema_metadata_drops_oversized_non_other_platform_schema(proces
         "Aspect exceeded acceptable size"
     )
     assert processor.report.num_platform_schema_drops == 1
+
+
+@time_machine.travel("2023-01-02 00:00:00", tick=False)
+def test_ensure_schema_metadata_drops_raw_schema_then_trims_fields(processor):
+    # Cascade: a meaningful raw schema (~40% of budget) AND fields that are too
+    # large even on their own. The raw schema must be dropped FIRST, then fields
+    # trimmed — proving the order (a regression that trimmed fields first and
+    # dropped the schema second would leave a different result).
+    raw_schema_size = int(processor.schema_size_constraint * 0.4)
+    fields = [
+        SchemaFieldClass(
+            fieldPath=f"t{i}",
+            nativeDataType="int",
+            type=SchemaFieldDataTypeClass(type=NumberTypeClass()),
+            description=20000 * "a",
+        )
+        for i in range(1000)
+    ]
+    schema = SchemaMetadataClass(
+        schemaName="abcdef",
+        version=1,
+        platform="s3",
+        hash="ABCDE1234567890",
+        platformSchema=OtherSchemaClass(rawSchema="a" * raw_schema_size),
+        fields=fields,
+    )
+
+    processor.ensure_schema_metadata_size(
+        "urn:li:dataset:(s3, dummy_dataset, DEV)", schema
+    )
+
+    assert isinstance(schema.platformSchema, OtherSchemaClass)
+    assert schema.platformSchema.rawSchema == "", "Raw schema should be dropped first"
+    assert processor.report.num_platform_schema_drops == 1
+    assert len(schema.fields) < 1000, "Fields should also be trimmed after the drop"
+    assert len(json.dumps(schema.to_obj())) < INGEST_MAX_PAYLOAD_BYTES, (
+        "Aspect exceeded acceptable size"
+    )
+
+
+def test_platform_schema_raw_fields_map_matches_models():
+    # setattr/getattr bypass the type checker, so a mistyped field name in
+    # _PLATFORM_SCHEMA_RAW_FIELDS would silently no-op. Assert every mapped
+    # field actually exists on its platformSchema variant.
+    from datahub.ingestion.workunit_processors.ensure_aspect_size import (
+        _PLATFORM_SCHEMA_RAW_FIELDS,
+    )
+
+    for cls, field_names in _PLATFORM_SCHEMA_RAW_FIELDS.items():
+        valid_fields = {f.name for f in cls.RECORD_SCHEMA.fields}  # type: ignore[attr-defined]
+        for field_name in field_names:
+            assert field_name in valid_fields, (
+                f"{cls.__name__} has no field {field_name!r}"
+            )
 
 
 @time_machine.travel("2023-01-02 00:00:00", tick=False)

--- a/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
+++ b/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
@@ -505,7 +505,8 @@ def test_ensure_schema_metadata_drops_oversized_non_other_platform_schema(proces
         platform="kafka",
         hash="ABCDE1234567890",
         platformSchema=KafkaSchemaClass(
-            documentSchema="a" * (processor.schema_size_constraint + 100000)
+            documentSchema="a" * (processor.schema_size_constraint + 100000),
+            documentSchemaType="AVRO",
         ),
         fields=fields,
     )
@@ -517,6 +518,9 @@ def test_ensure_schema_metadata_drops_oversized_non_other_platform_schema(proces
     assert isinstance(schema.platformSchema, KafkaSchemaClass)
     assert schema.platformSchema.documentSchema == "", (
         "Oversized platform schema was not dropped"
+    )
+    assert schema.platformSchema.documentSchemaType == "AVRO", (
+        "Type marker must be preserved — only the schema blob should be blanked"
     )
     assert len(schema.fields) == 5, (
         "Fields should be retained once the oversized platform schema is dropped"

--- a/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
+++ b/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
@@ -1,5 +1,6 @@
 import json
 import time
+from typing import Callable, Dict
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -18,19 +19,26 @@ from datahub.ingestion.workunit_processors.ensure_aspect_size import (
 from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeEvent
 from datahub.metadata.schema_classes import (
     AuditStampClass,
+    BinaryJsonSchemaClass,
     ChangeTypeClass,
     DatasetFieldProfileClass,
     DatasetLineageTypeClass,
     DatasetProfileClass,
     DatasetSnapshotClass,
+    EspressoSchemaClass,
     FineGrainedLineageClass,
     FineGrainedLineageDownstreamTypeClass,
     FineGrainedLineageUpstreamTypeClass,
     GenericAspectClass,
     KafkaSchemaClass,
+    KeyValueSchemaClass,
     MetadataChangeProposalClass,
+    MySqlDDLClass,
     NumberTypeClass,
+    OracleDDLClass,
+    OrcSchemaClass,
     OtherSchemaClass,
+    PrestoDDLClass,
     QueryLanguageClass,
     QueryPropertiesClass,
     QuerySourceClass,
@@ -39,6 +47,7 @@ from datahub.metadata.schema_classes import (
     QuerySubjectsClass,
     SchemaFieldClass,
     SchemaFieldDataTypeClass,
+    SchemalessClass,
     SchemaMetadataClass,
     StatusClass,
     StringTypeClass,
@@ -569,19 +578,65 @@ def test_ensure_schema_metadata_drops_raw_schema_then_trims_fields(processor):
     )
 
 
-def test_platform_schema_raw_fields_map_matches_models():
-    # setattr/getattr bypass the type checker, so a mistyped field name in
-    # _PLATFORM_SCHEMA_RAW_FIELDS would silently no-op. Assert every mapped
-    # field actually exists on its platformSchema variant.
-    from datahub.ingestion.workunit_processors.ensure_aspect_size import (
-        _PLATFORM_SCHEMA_RAW_FIELDS,
+def test_drop_platform_schema_handles_every_union_variant(processor):
+    # Pull the live union members of SchemaMetadata.platformSchema from the
+    # generated model. When a new variant is added to the schema, this test fails
+    # with a clear message — preventing a silent "Unrecognized variant" warning +
+    # retained oversized blob in production. The constructor map lives here (not in
+    # src/) on purpose: a new variant should force both a dispatcher branch AND a
+    # behavioral check that the branch actually clears something.
+    constructors: Dict[str, Callable[[], object]] = {
+        "OtherSchema": lambda: OtherSchemaClass(rawSchema="x" * 100),
+        "PrestoDDL": lambda: PrestoDDLClass(rawSchema="x" * 100),
+        "MySqlDDL": lambda: MySqlDDLClass(tableSchema="x" * 100),
+        "OracleDDL": lambda: OracleDDLClass(tableSchema="x" * 100),
+        "OrcSchema": lambda: OrcSchemaClass(schema="x" * 100),
+        "BinaryJsonSchema": lambda: BinaryJsonSchemaClass(schema="x" * 100),
+        "KafkaSchema": lambda: KafkaSchemaClass(documentSchema="x" * 100),
+        "EspressoSchema": lambda: EspressoSchemaClass(
+            documentSchema="x" * 100, tableSchema="x" * 100
+        ),
+        "KeyValueSchema": lambda: KeyValueSchemaClass(
+            keySchema="x" * 100, valueSchema="x" * 100
+        ),
+        "Schemaless": lambda: SchemalessClass(),
+    }
+
+    model_union_members = {
+        s.name
+        for s in SchemaMetadataClass.RECORD_SCHEMA.fields_dict[  # type: ignore[attr-defined]
+            "platformSchema"
+        ].type.schemas
+    }
+    test_covers = set(constructors.keys())
+
+    missing_in_test = model_union_members - test_covers
+    extra_in_test = test_covers - model_union_members
+    assert not missing_in_test, (
+        f"New platformSchema variant(s) in the model are not exercised here: "
+        f"{missing_in_test}. Add a constructor above AND a branch in "
+        f"_drop_platform_schema."
+    )
+    assert not extra_in_test, (
+        f"Test references variants no longer in the model: {extra_in_test}"
     )
 
-    for cls, field_names in _PLATFORM_SCHEMA_RAW_FIELDS.items():
-        valid_fields = {f.name for f in cls.RECORD_SCHEMA.fields}  # type: ignore[attr-defined]
-        for field_name in field_names:
-            assert field_name in valid_fields, (
-                f"{cls.__name__} has no field {field_name!r}"
+    for name, make in constructors.items():
+        schema = SchemaMetadataClass(
+            schemaName="t",
+            version=1,
+            platform="p",
+            hash="h",
+            platformSchema=make(),  # type: ignore[arg-type]
+            fields=[],
+        )
+        cleared = processor._drop_platform_schema(schema)
+        if name == "Schemaless":
+            assert not cleared, "Schemaless carries no content to clear"
+        else:
+            assert cleared, (
+                f"_drop_platform_schema returned False for {name}; the dispatcher "
+                f"likely has no branch for it"
             )
 
 

--- a/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
+++ b/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
@@ -387,9 +387,6 @@ def test_ensure_size_of_too_big_schema_metadata(processor):
     )
     assert len(schema.fields) < 1004, "Schema has not been properly truncated"
     assert schema.fields[-1].fieldPath == "dddd", "Small field was not added at the end"
-    # The truncated aspect must fit within the budget. The budget now accounts
-    # for the full serialized aspect (not just the fields list), so the result
-    # is bounded by the payload constraint rather than an arbitrary slop.
     assert len(json.dumps(schema.to_obj())) < INGEST_MAX_PAYLOAD_BYTES, (
         "Aspect exceeded acceptable size"
     )
@@ -408,12 +405,13 @@ def test_ensure_size_of_proper_schema_metadata(processor):
 
 
 @time_machine.travel("2023-01-02 00:00:00", tick=False)
-def test_ensure_schema_metadata_budget_accounts_for_raw_schema(processor):
-    # rawSchema takes ~half the budget; the field budget must shrink to
-    # compensate so the total aspect — raw schema included — stays within the
-    # limit. Previously only the fields were counted, so the aspect could
-    # still exceed the limit after truncation.
-    raw_schema_size = processor.schema_size_constraint // 2
+def test_ensure_schema_metadata_drops_raw_schema_before_trimming_fields(processor):
+    # Mixed case: neither the raw schema (~9 MB) nor the fields (~9 MB) is
+    # individually over the budget, but together they exceed it. Per the
+    # "fields > raw platform schema" priority, the raw schema is dropped first
+    # and ALL fields are retained — rather than keeping the raw schema and
+    # trimming columns to make room for it.
+    raw_schema_size = int(processor.schema_size_constraint * 0.6)
     fields = [
         SchemaFieldClass(
             fieldPath=f"t{i}",
@@ -421,7 +419,7 @@ def test_ensure_schema_metadata_budget_accounts_for_raw_schema(processor):
             type=SchemaFieldDataTypeClass(type=NumberTypeClass()),
             description=20000 * "a",
         )
-        for i in range(1000)
+        for i in range(450)
     ]
     schema = SchemaMetadataClass(
         schemaName="abcdef",
@@ -437,12 +435,13 @@ def test_ensure_schema_metadata_budget_accounts_for_raw_schema(processor):
     )
 
     assert isinstance(schema.platformSchema, OtherSchemaClass)
-    assert schema.platformSchema.rawSchema == "a" * raw_schema_size, (
-        "Raw schema that fits within budget should be retained"
+    assert schema.platformSchema.rawSchema == "", (
+        "Raw schema should be dropped before any field is trimmed"
     )
-    assert len(schema.fields) < 1000, (
-        "Fields should have been trimmed to fit the budget"
+    assert len(schema.fields) == 450, (
+        "All fields should be retained once the raw schema is dropped"
     )
+    assert processor.report.num_platform_schema_drops == 1
     assert len(json.dumps(schema.to_obj())) < INGEST_MAX_PAYLOAD_BYTES, (
         "Aspect exceeded acceptable size despite truncation"
     )


### PR DESCRIPTION
## Summary

Follow-up to #17895, addressing the review comments there. Two changes to `EnsureAspectSizeProcessor.ensure_schema_metadata_size` / `_drop_platform_schema`:

### 1. Drop the platform schema *before* trimming fields (priority fix)

Previously the platform schema was dropped only when it **alone** exceeded the budget; otherwise it was kept and fields were trimmed to make room. In the mixed case — raw schema and fields each under the limit but over together — that kept the raw schema and dropped columns, backwards from the "fields are more valuable than the raw platform schema" priority.

Now: if the whole aspect fits, do nothing (fast path); otherwise drop the platform schema first and re-check, trimming fields only if they still don't fit. So a mixed aspect keeps **all** columns and sheds the raw schema instead.

| | raw schema 10 MB + fields 10 MB |
|---|---|
| Before | keep raw schema, drop ~4.5 MB of columns |
| After | drop raw schema, keep all columns |

### 2. Blank the platform schema per-variant via an explicit field map

`_drop_platform_schema` iterated `platformSchema._inner_dict` and blanked every string member. That reaches into a semi-internal attribute and would also wipe small type markers (e.g. `KafkaSchema.documentSchemaType="AVRO"`), not just the raw blob.

Replaced with an explicit map of each `platformSchema` union variant to its schema-content string field(s) (`rawSchema` / `documentSchema` / `tableSchema` / `keySchema` / `valueSchema`), blanking only those via the public accessors. Markers are left intact, and an unrecognized variant is logged and skipped.

Also removed two transitional ("now"/"previous") comments flagged in review.

## Tests

- New mixed-case test: raw schema + fields each under budget but over together → raw schema dropped, **all** fields retained.
- The `KafkaSchema` drop test now sets `documentSchemaType="AVRO"` and asserts it **survives** while the blob is blanked.
- 37 tests pass; mypy + ruff clean.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
