### PR TITLE
fix(test): fix flaky smoke tests caused by missing ES sync waits

### DIFF
--- a/smoke-test/tests/openapi/v3/test_scroll.py
+++ b/smoke-test/tests/openapi/v3/test_scroll.py
@@ -10,6 +10,7 @@ from datahub.ingestion.graph.client import DataHubGraph
 from datahub.ingestion.graph.filters import RawSearchFilter
 from datahub.ingestion.graph.openapi import RelationshipDirection, SortCriterionDict
 from datahub.metadata.schema_classes import DatasetKeyClass
+from tests.utils import with_test_retry
 
 logger = logging.getLogger(__name__)
 
@@ -198,20 +199,26 @@ def test_scroll_entities_with_sort_criteria(graph_client: DataHubGraph) -> None:
 def test_scroll_entities_with_query(graph_client: DataHubGraph) -> None:
     """query= narrows results by full-text search; searching for "alpha" within the
     scrolltest platform should include ALPHA and exclude unrelated datasets."""
-    result = graph_client.scroll_entities(
-        entity_names=["dataset"],
-        filter=SCROLLTEST_FILTER,
-        aspects=["datasetKey"],
-        query="alpha",
-        count=10,
-    )
-    assert result.total_count > 0
-    assert ALPHA in result.entities, (
-        f"ALPHA should appear in query='alpha' results, got: {set(result.entities)}"
-    )
-    logger.info(
-        f"scroll_entities with_query: query='alpha' returned {result.total_count} result(s)"
-    )
+
+    @with_test_retry(max_attempts=10)
+    def _assert() -> None:
+        result = graph_client.scroll_entities(
+            entity_names=["dataset"],
+            filter=SCROLLTEST_FILTER,
+            aspects=["datasetKey"],
+            query="alpha",
+            count=10,
+        )
+        assert result.total_count > 0
+        assert ALPHA in result.entities, (
+            f"ALPHA should appear in query='alpha' results, got: {set(result.entities)}"
+            f"\ntotal_count={result.total_count}"
+        )
+        logger.info(
+            f"scroll_entities with_query: query='alpha' returned {result.total_count} result(s)"
+        )
+
+    _assert()
 
 
 def test_scroll_entities_with_system_metadata(graph_client: DataHubGraph) -> None:

--- a/smoke-test/tests/structured_properties/test_structured_properties.py
+++ b/smoke-test/tests/structured_properties/test_structured_properties.py
@@ -28,7 +28,12 @@ from datahub.utilities.urns.structured_properties_urn import StructuredPropertyU
 from datahub.utilities.urns.urn import Urn
 from tests.consistency_utils import wait_for_writes_to_sync
 from tests.utilities.file_emitter import FileEmitter
-from tests.utils import delete_urns, delete_urns_from_file, ingest_file_via_rest
+from tests.utils import (
+    delete_urns,
+    delete_urns_from_file,
+    ingest_file_via_rest,
+    with_test_retry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -394,20 +399,25 @@ def test_structured_property_search(
         dataset_urns[0], dataset_property_name, [property_value], graph=graph_client
     )
 
-    # [] = default entities which includes datasets, does not include fields
-    entity_urns = list(
-        graph_client.get_urns_by_filter(
-            extraFilters=[
-                {
-                    "field": to_es_filter_name(dataset_property_name),
-                    "negated": False,
-                    "condition": "EXISTS",
-                }
-            ]
+    @with_test_retry(max_attempts=15)
+    def _assert_dataset_property_indexed() -> None:
+        entity_urns = list(
+            graph_client.get_urns_by_filter(
+                extraFilters=[
+                    {
+                        "field": to_es_filter_name(dataset_property_name),
+                        "negated": False,
+                        "condition": "EXISTS",
+                    }
+                ],
+                skip_cache=True,
+            )
         )
-    )
-    assert len(entity_urns) == 1
-    assert entity_urns[0] == dataset_urns[0]
+        assert len(entity_urns) == 1
+        assert entity_urns[0] == dataset_urns[0]
+
+    # [] = default entities which includes datasets, does not include fields
+    _assert_dataset_property_indexed()
 
     # Search over schema field specifically
     field_structured_prop = graph_client.get_aspect(
@@ -422,38 +432,48 @@ def test_structured_property_search(
         ]
     )
 
-    # Search over entities that do not include the field
-    field_urns = list(
-        graph_client.get_urns_by_filter(
-            entity_types=["tag"],
-            extraFilters=[
-                {
-                    "field": to_es_filter_name(
-                        field_property_name, namespace="io.datahubproject.test"
-                    ),
-                    "negated": False,
-                    "condition": "EXISTS",
-                }
-            ],
+    @with_test_retry(max_attempts=15)
+    def _assert_field_property_not_in_tags() -> None:
+        field_urns = list(
+            graph_client.get_urns_by_filter(
+                entity_types=["tag"],
+                extraFilters=[
+                    {
+                        "field": to_es_filter_name(
+                            field_property_name, namespace="io.datahubproject.test"
+                        ),
+                        "negated": False,
+                        "condition": "EXISTS",
+                    }
+                ],
+                skip_cache=True,
+            )
         )
-    )
-    assert len(field_urns) == 0
+        assert len(field_urns) == 0
+
+    # Search over entities that do not include the field
+    _assert_field_property_not_in_tags()
+
+    @with_test_retry(max_attempts=15)
+    def _assert_dataset_property_in_mixed_types() -> None:
+        field_urns = list(
+            graph_client.get_urns_by_filter(
+                entity_types=["dataset", "tag"],
+                extraFilters=[
+                    {
+                        "field": to_es_filter_name(dataset_property_name),
+                        "negated": False,
+                        "condition": "EXISTS",
+                    }
+                ],
+                skip_cache=True,
+            )
+        )
+        assert len(field_urns) == 1
+        assert dataset_urns[0] in field_urns
 
     # OR the two properties together to return both results
-    field_urns = list(
-        graph_client.get_urns_by_filter(
-            entity_types=["dataset", "tag"],
-            extraFilters=[
-                {
-                    "field": to_es_filter_name(dataset_property_name),
-                    "negated": False,
-                    "condition": "EXISTS",
-                }
-            ],
-        )
-    )
-    assert len(field_urns) == 1
-    assert dataset_urns[0] in field_urns
+    _assert_dataset_property_in_mixed_types()
 
 
 def test_dataset_structured_property_patch(ingest_cleanup_data, graph_client, caplog):


### PR DESCRIPTION
## Summary

* `test_scroll.py`: Wrap `test_scroll_entities_with_query` search assertion in `with_test_retry(max_attempts=10)` — ZETA's lineage aspect contains the string "alpha" in its upstream URN, so ES can return ZETA before ALPHA is indexed; retry handles the race
* `test_structured_properties.py`: Wrap all three `get_urns_by_filter` calls in `test_structured_property_search` in `with_test_retry(max_attempts=15)` and add `skip_cache=True` — a fixed sleep isn't sufficient for ES indexing in slow CI environments

Backport of [acryldata/datahub-fork#10229](https://github.com/acryldata/datahub-fork/pull/10229) which was merged to the fork.

## Test plan

- [ ] `test_scroll_entities_with_query` — passes reliably (ALPHA indexed before search, retry covers any lag)
- [ ] `test_structured_property_search` — passes reliably (retry + skip_cache covers ES indexing lag after property write)
- [ ] No regression in other scroll or structured-property tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)