### PR TITLE
feat(i18n): extract untranslated strings in EntitySidebarTabs

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/EntitySidebarTabs.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/EntitySidebarTabs.tsx
@@ -155,6 +155,7 @@ const TabText = styled.span<{ $isSelected?: boolean }>`
 `;
 
 const TabTextWithTooltip = ({ text, isSelected }: { text: string; isSelected?: boolean }) => {
+    const { t } = useTranslation('entity.shared.containers');
     const textRef = React.useRef<HTMLSpanElement>(null);
     const [isOverflowing, setIsOverflowing] = React.useState(false);
 
@@ -165,8 +166,8 @@ const TabTextWithTooltip = ({ text, isSelected }: { text: string; isSelected?: b
         }
     }, [text]);
 
-    // eslint-disable-next-line i18next/no-literal-string -- (untranslated-text) computed tooltip fallback based on external tab name
-    const tooltipText = text === 'Props' ? 'Structured Properties' : text;
+    const tooltipText =
+        text === t('sidebar.tabs.propsAbbreviation') ? t('sidebar.tabs.structuredPropertiesTooltip') : text;
 
     return (
         <Tooltip title={isOverflowing ? tooltipText : null} placement="right">

--- a/datahub-web-react/src/i18n/locales/en/entity.shared.containers.json
+++ b/datahub-web-react/src/i18n/locales/en/entity.shared.containers.json
@@ -221,6 +221,7 @@
     "sidebar.tabs.columnsLabel": "Columns",
     "sidebar.tabs.lineageLabel": "Lineage",
     "sidebar.tabs.propsAbbreviation": "Props",
+    "sidebar.tabs.structuredPropertiesTooltip": "Structured Properties",
     "sidebar.tabs.summaryLabel": "Summary",
     "sidebar.viewDefinition.languageLabel": "Language",
     "sidebar.viewDefinition.materializedFalse": "False",


### PR DESCRIPTION
Extracts missed untranslated strings in EntitySidebarTabs

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
