### PR TITLE
feat(auth): request-scoped session actor identity and authorization

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -980,7 +980,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher(
                     "relatedDocuments",
                     new com.linkedin.datahub.graphql.resolvers.knowledge.RelatedDocumentsResolver(
-                        documentService, entityClient, groupService))
+                        documentService, entityClient))
                 .dataFetcher("entities", new ContainerEntitiesResolver(entityClient))
                 .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
                 .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
@@ -1502,8 +1502,7 @@ public class GmsGraphQLEngine {
               .dataFetcher(
                   "createDynamicFormAssignment",
                   new CreateDynamicFormAssignmentResolver(this.formService))
-              .dataFetcher(
-                  "verifyForm", new VerifyFormResolver(this.formService, this.groupService))
+              .dataFetcher("verifyForm", new VerifyFormResolver(this.formService))
               .dataFetcher("batchRemoveForm", new BatchRemoveFormResolver(this.formService))
               .dataFetcher(
                   "upsertStructuredProperties",
@@ -1833,7 +1832,7 @@ public class GmsGraphQLEngine {
                     .dataFetcher(
                         "relatedDocuments",
                         new com.linkedin.datahub.graphql.resolvers.knowledge
-                            .RelatedDocumentsResolver(documentService, entityClient, groupService))
+                            .RelatedDocumentsResolver(documentService, entityClient))
                     .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.datasetType))
                     .dataFetcher(
                         "lineage",
@@ -2077,7 +2076,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher(
                     "relatedDocuments",
                     new com.linkedin.datahub.graphql.resolvers.knowledge.RelatedDocumentsResolver(
-                        documentService, entityClient, groupService)));
+                        documentService, entityClient)));
   }
 
   private void configureGlossaryNodeResolvers(final RuntimeWiring.Builder builder) {
@@ -2096,7 +2095,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher(
                     "relatedDocuments",
                     new com.linkedin.datahub.graphql.resolvers.knowledge.RelatedDocumentsResolver(
-                        documentService, entityClient, groupService)));
+                        documentService, entityClient)));
   }
 
   private void configureSchemaFieldResolvers(final RuntimeWiring.Builder builder) {
@@ -2343,7 +2342,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher(
                     "relatedDocuments",
                     new com.linkedin.datahub.graphql.resolvers.knowledge.RelatedDocumentsResolver(
-                        documentService, entityClient, groupService))
+                        documentService, entityClient))
                 .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.dashboardType))
                 .dataFetcher(
                     "lineage",
@@ -2477,7 +2476,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher(
                     "relatedDocuments",
                     new com.linkedin.datahub.graphql.resolvers.knowledge.RelatedDocumentsResolver(
-                        documentService, entityClient, groupService))
+                        documentService, entityClient))
                 .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.chartType))
                 .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                 .dataFetcher(
@@ -2689,7 +2688,7 @@ public class GmsGraphQLEngine {
                     .dataFetcher(
                         "relatedDocuments",
                         new com.linkedin.datahub.graphql.resolvers.knowledge
-                            .RelatedDocumentsResolver(documentService, entityClient, groupService))
+                            .RelatedDocumentsResolver(documentService, entityClient))
                     .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.dataJobType))
                     .dataFetcher(
                         "lineage",
@@ -2795,7 +2794,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher(
                     "relatedDocuments",
                     new com.linkedin.datahub.graphql.resolvers.knowledge.RelatedDocumentsResolver(
-                        documentService, entityClient, groupService))
+                        documentService, entityClient))
                 .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.dataFlowType))
                 .dataFetcher(
                     "lineage",
@@ -2855,7 +2854,7 @@ public class GmsGraphQLEngine {
                     .dataFetcher(
                         "relatedDocuments",
                         new com.linkedin.datahub.graphql.resolvers.knowledge
-                            .RelatedDocumentsResolver(documentService, entityClient, groupService))
+                            .RelatedDocumentsResolver(documentService, entityClient))
                     .dataFetcher(
                         "browsePaths", new EntityBrowsePathsResolver(this.mlFeatureTableType))
                     .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
@@ -2950,7 +2949,7 @@ public class GmsGraphQLEngine {
                     .dataFetcher(
                         "relatedDocuments",
                         new com.linkedin.datahub.graphql.resolvers.knowledge
-                            .RelatedDocumentsResolver(documentService, entityClient, groupService))
+                            .RelatedDocumentsResolver(documentService, entityClient))
                     .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.mlModelType))
                     .dataFetcher(
                         "lineage",
@@ -3001,7 +3000,7 @@ public class GmsGraphQLEngine {
                     .dataFetcher(
                         "relatedDocuments",
                         new com.linkedin.datahub.graphql.resolvers.knowledge
-                            .RelatedDocumentsResolver(documentService, entityClient, groupService))
+                            .RelatedDocumentsResolver(documentService, entityClient))
                     .dataFetcher(
                         "browsePaths", new EntityBrowsePathsResolver(this.mlModelGroupType))
                     .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
@@ -3037,7 +3036,7 @@ public class GmsGraphQLEngine {
                     .dataFetcher(
                         "relatedDocuments",
                         new com.linkedin.datahub.graphql.resolvers.knowledge
-                            .RelatedDocumentsResolver(documentService, entityClient, groupService))
+                            .RelatedDocumentsResolver(documentService, entityClient))
                     .dataFetcher(
                         "lineage",
                         new EntityLineageResultResolver(
@@ -3066,7 +3065,7 @@ public class GmsGraphQLEngine {
                     .dataFetcher(
                         "relatedDocuments",
                         new com.linkedin.datahub.graphql.resolvers.knowledge
-                            .RelatedDocumentsResolver(documentService, entityClient, groupService))
+                            .RelatedDocumentsResolver(documentService, entityClient))
                     .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
                     .dataFetcher(
                         "lineage",
@@ -3115,7 +3114,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher(
                     "relatedDocuments",
                     new com.linkedin.datahub.graphql.resolvers.knowledge.RelatedDocumentsResolver(
-                        documentService, entityClient, groupService)));
+                        documentService, entityClient)));
     builder.type(
         "DomainAssociation",
         typeWiring ->
@@ -3141,8 +3140,7 @@ public class GmsGraphQLEngine {
             this.entityService,
             this.graphClient,
             entityRegistry,
-            this.timelineService,
-            this.groupService)
+            this.timelineService)
         .configureResolvers(builder);
   }
 
@@ -3197,7 +3195,7 @@ public class GmsGraphQLEngine {
                                   .collect(Collectors.toList())
                               : null;
                         }))
-                .dataFetcher("isAssignedToMe", new IsFormAssignedToMeResolver(groupService)));
+                .dataFetcher("isAssignedToMe", new IsFormAssignedToMeResolver()));
   }
 
   private void configureDataProductResolvers(final RuntimeWiring.Builder builder) {
@@ -3212,7 +3210,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher(
                     "relatedDocuments",
                     new com.linkedin.datahub.graphql.resolvers.knowledge.RelatedDocumentsResolver(
-                        documentService, entityClient, groupService)));
+                        documentService, entityClient)));
   }
 
   private void configureApplicationResolvers(final RuntimeWiring.Builder builder) {
@@ -3226,7 +3224,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher(
                     "relatedDocuments",
                     new com.linkedin.datahub.graphql.resolvers.knowledge.RelatedDocumentsResolver(
-                        documentService, entityClient, groupService)));
+                        documentService, entityClient)));
     builder.type(
         "ApplicationAssociation",
         typeWiring ->
@@ -3730,8 +3728,7 @@ public class GmsGraphQLEngine {
   private void configureRoleResolvers(final RuntimeWiring.Builder builder) {
     builder.type(
         "Role",
-        typeWiring ->
-            typeWiring.dataFetcher("isAssignedToMe", new IsAssignedToMeResolver(groupService)));
+        typeWiring -> typeWiring.dataFetcher("isAssignedToMe", new IsAssignedToMeResolver()));
   }
 
   private void configureBusinessAttributeResolver(final RuntimeWiring.Builder builder) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataset/IsAssignedToMeResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataset/IsAssignedToMeResolver.java
@@ -1,6 +1,5 @@
 package com.linkedin.datahub.graphql.resolvers.dataset;
 
-import com.datahub.authentication.group.GroupService;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
@@ -13,21 +12,13 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class IsAssignedToMeResolver implements DataFetcher<CompletableFuture<Boolean>> {
-
-  private final GroupService _groupService;
-
-  public IsAssignedToMeResolver(@Nonnull final GroupService groupService) {
-    _groupService = Objects.requireNonNull(groupService, "groupService must not be null");
-  }
 
   @Override
   public CompletableFuture<Boolean> get(final DataFetchingEnvironment environment)
@@ -68,7 +59,8 @@ public class IsAssignedToMeResolver implements DataFetcher<CompletableFuture<Boo
             // Next check whether the user is assigned indirectly, by group.
             if (assignedGroupUrns.size() > 0) {
               final List<Urn> groupUrns =
-                  _groupService.getGroupsForUser(context.getOperationContext(), userUrn);
+                  List.copyOf(
+                      context.getOperationContext().getSessionActorContext().getGroupMembership());
               boolean isUserGroupAssigned =
                   groupUrns.stream()
                       .anyMatch(groupUrn -> assignedGroupUrns.contains(groupUrn.toString()));

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/form/IsFormAssignedToMeResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/form/IsFormAssignedToMeResolver.java
@@ -1,6 +1,5 @@
 package com.linkedin.datahub.graphql.resolvers.form;
 
-import com.datahub.authentication.group.GroupService;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
@@ -11,21 +10,13 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class IsFormAssignedToMeResolver implements DataFetcher<CompletableFuture<Boolean>> {
-
-  private final GroupService _groupService;
-
-  public IsFormAssignedToMeResolver(@Nonnull final GroupService groupService) {
-    _groupService = Objects.requireNonNull(groupService, "groupService must not be null");
-  }
 
   @Override
   public CompletableFuture<Boolean> get(DataFetchingEnvironment environment) {
@@ -60,7 +51,8 @@ public class IsFormAssignedToMeResolver implements DataFetcher<CompletableFuture
             // Next check whether the user is assigned indirectly, by group.
             if (assignedGroupUrns.size() > 0) {
               final List<Urn> groupUrns =
-                  _groupService.getGroupsForUser(context.getOperationContext(), userUrn);
+                  List.copyOf(
+                      context.getOperationContext().getSessionActorContext().getGroupMembership());
               boolean isUserGroupAssigned =
                   groupUrns.stream()
                       .anyMatch(groupUrn -> assignedGroupUrns.contains(groupUrn.toString()));

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/form/VerifyFormResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/form/VerifyFormResolver.java
@@ -3,7 +3,6 @@ package com.linkedin.datahub.graphql.resolvers.form;
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
 
 import com.datahub.authentication.Authentication;
-import com.datahub.authentication.group.GroupService;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
@@ -21,12 +20,9 @@ import javax.annotation.Nonnull;
 public class VerifyFormResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
   private final FormService _formService;
-  private final GroupService _groupService;
 
-  public VerifyFormResolver(
-      @Nonnull final FormService formService, @Nonnull final GroupService groupService) {
+  public VerifyFormResolver(@Nonnull final FormService formService) {
     _formService = Objects.requireNonNull(formService, "formService must not be null");
-    _groupService = Objects.requireNonNull(groupService, "groupService must not be null");
   }
 
   @Override
@@ -45,7 +41,8 @@ public class VerifyFormResolver implements DataFetcher<CompletableFuture<Boolean
         () -> {
           try {
             final List<Urn> groupsForUser =
-                _groupService.getGroupsForUser(context.getOperationContext(), actorUrn);
+                List.copyOf(
+                    context.getOperationContext().getSessionActorContext().getGroupMembership());
             if (!_formService.isFormAssignedToUser(
                 context.getOperationContext(), formUrn, entityUrn, actorUrn, groupsForUser)) {
               throw new AuthorizationException(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentResolvers.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentResolvers.java
@@ -1,6 +1,5 @@
 package com.linkedin.datahub.graphql.resolvers.knowledge;
 
-import com.datahub.authentication.group.GroupService;
 import com.linkedin.datahub.graphql.generated.Document;
 import com.linkedin.datahub.graphql.resolvers.load.EntityRelationshipsResultResolver;
 import com.linkedin.datahub.graphql.resolvers.load.EntityTypeResolver;
@@ -32,7 +31,6 @@ public class DocumentResolvers {
   private final com.linkedin.metadata.graph.GraphClient graphClient;
   private final EntityRegistry entityRegistry;
   private final TimelineService timelineService;
-  private final GroupService groupService;
 
   public DocumentResolvers(
       @Nonnull DocumentService documentService,
@@ -44,8 +42,7 @@ public class DocumentResolvers {
       @Nonnull EntityService entityService,
       @Nonnull com.linkedin.metadata.graph.GraphClient graphClient,
       @Nonnull EntityRegistry entityRegistry,
-      @Nonnull TimelineService timelineService,
-      @Nonnull GroupService groupService) {
+      @Nonnull TimelineService timelineService) {
     this.documentService = documentService;
     this.entityTypes = entityTypes;
     this.documentType = documentType;
@@ -56,7 +53,6 @@ public class DocumentResolvers {
     this.graphClient = graphClient;
     this.entityRegistry = entityRegistry;
     this.timelineService = timelineService;
-    this.groupService = groupService;
   }
 
   public void configureResolvers(final RuntimeWiring.Builder builder) {
@@ -72,7 +68,7 @@ public class DocumentResolvers {
                 .dataFetcher(
                     "searchDocuments",
                     new com.linkedin.datahub.graphql.resolvers.knowledge.SearchDocumentsResolver(
-                        documentService, entityClient, groupService)));
+                        documentService, entityClient)));
 
     // Mutation resolvers
     builder.type(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/RelatedDocumentsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/RelatedDocumentsResolver.java
@@ -2,7 +2,6 @@ package com.linkedin.datahub.graphql.resolvers.knowledge;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
 
-import com.datahub.authentication.group.GroupService;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
@@ -54,7 +53,6 @@ public class RelatedDocumentsResolver
 
   private final DocumentService _documentService;
   private final EntityClient _entityClient;
-  private final GroupService _groupService;
 
   @Override
   public CompletableFuture<RelatedDocumentsResult> get(final DataFetchingEnvironment environment)
@@ -82,7 +80,8 @@ public class RelatedDocumentsResolver
             // Get current user and their groups for ownership filtering
             final Urn currentUserUrn = Urn.createFromString(context.getActorUrn());
             final List<Urn> userGroupUrns =
-                _groupService.getGroupsForUser(context.getOperationContext(), currentUserUrn);
+                new ArrayList<>(
+                    context.getOperationContext().getSessionActorContext().getGroupMembership());
             final List<String> userAndGroupUrns = new ArrayList<>();
             userAndGroupUrns.add(currentUserUrn.toString());
             userGroupUrns.forEach(groupUrn -> userAndGroupUrns.add(groupUrn.toString()));

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/SearchDocumentsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/SearchDocumentsResolver.java
@@ -2,7 +2,6 @@ package com.linkedin.datahub.graphql.resolvers.knowledge;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
 
-import com.datahub.authentication.group.GroupService;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
@@ -51,7 +50,6 @@ public class SearchDocumentsResolver
 
   private final DocumentService _documentService;
   private final EntityClient _entityClient;
-  private final GroupService _groupService;
 
   @Override
   public CompletableFuture<SearchDocumentsResult> get(final DataFetchingEnvironment environment)
@@ -71,7 +69,8 @@ public class SearchDocumentsResolver
             // Get current user and their groups for ownership filtering
             final Urn currentUserUrn = Urn.createFromString(context.getActorUrn());
             final List<Urn> userGroupUrns =
-                _groupService.getGroupsForUser(context.getOperationContext(), currentUserUrn);
+                new ArrayList<>(
+                    context.getOperationContext().getSessionActorContext().getGroupMembership());
             final List<String> userAndGroupUrns = new ArrayList<>();
             userAndGroupUrns.add(currentUserUrn.toString());
             userGroupUrns.forEach(groupUrn -> userAndGroupUrns.add(groupUrn.toString()));

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/GetGrantedPrivilegesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/GetGrantedPrivilegesResolver.java
@@ -55,7 +55,8 @@ public class GetGrantedPrivilegesResolver implements DataFetcher<CompletableFutu
           () -> {
             try {
               PolicyEngine.PolicyGrantedPrivileges evalResult =
-                  dataHubAuthorizer.getGrantedPrivileges(actor, resourceSpec);
+                  dataHubAuthorizer.getGrantedPrivileges(
+                      actor, resourceSpec, context.getOperationContext());
 
               List<PolicyEvaluationDetail> evaluationDetailList = null;
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/TestUtils.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/TestUtils.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.datahub.authentication.Actor;
@@ -11,6 +12,7 @@ import com.datahub.authorization.AuthorizationRequest;
 import com.datahub.authorization.AuthorizationResult;
 import com.datahub.plugins.auth.authorization.Authorizer;
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.entity.EntityService;
@@ -20,6 +22,7 @@ import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -38,7 +41,24 @@ public class TestUtils {
   }
 
   public static QueryContext getMockAllowContext(String actorUrn) {
-    return getMockAllowContext(actorUrn, null);
+    return getMockAllowContext(actorUrn, (AuthorizationRequest) null);
+  }
+
+  public static QueryContext getMockAllowContext(
+      @Nonnull String actorUrn, @Nonnull Collection<Urn> sessionGroupMembership) {
+    return withSessionGroupMembership(getMockAllowContext(actorUrn), sessionGroupMembership);
+  }
+
+  /** Stubs session group membership on an existing mock context. */
+  public static QueryContext withSessionGroupMembership(
+      @Nonnull QueryContext context, @Nonnull Collection<Urn> sessionGroupMembership) {
+    OperationContext operationContext = spy(context.getOperationContext());
+    io.datahubproject.metadata.context.ActorContext actorContext =
+        mock(io.datahubproject.metadata.context.ActorContext.class);
+    when(operationContext.getSessionActorContext()).thenReturn(actorContext);
+    when(actorContext.getGroupMembership()).thenReturn(sessionGroupMembership);
+    when(context.getOperationContext()).thenReturn(operationContext);
+    return context;
   }
 
   public static QueryContext getMockAllowContext(String actorUrn, AuthorizationRequest request) {

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/form/IsFormAssignedToMeResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/form/IsFormAssignedToMeResolverTest.java
@@ -1,10 +1,8 @@
 package com.linkedin.datahub.graphql.resolvers.form;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.testng.Assert.*;
 
-import com.datahub.authentication.group.GroupService;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
@@ -15,7 +13,6 @@ import com.linkedin.datahub.graphql.generated.FormActorAssignment;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -28,8 +25,6 @@ public class IsFormAssignedToMeResolverTest {
 
   @Test
   public void testGetSuccessUserMatch() throws Exception {
-    GroupService groupService = mockGroupService(TEST_USER_1, Collections.emptyList());
-
     CorpGroup assignedGroup = new CorpGroup();
     assignedGroup.setUrn(TEST_GROUP_1.toString());
 
@@ -45,121 +40,103 @@ public class IsFormAssignedToMeResolverTest {
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     Mockito.when(mockEnv.getSource()).thenReturn(actors);
 
-    IsFormAssignedToMeResolver resolver = new IsFormAssignedToMeResolver(groupService);
+    IsFormAssignedToMeResolver resolver = new IsFormAssignedToMeResolver();
     assertTrue(resolver.get(mockEnv).get());
-    Mockito.verifyNoMoreInteractions(groupService); // Should not perform group lookup.
   }
 
   @Test
   public void testGetSuccessGroupMatch() throws Exception {
-    GroupService groupService =
-        mockGroupService(TEST_USER_1, ImmutableList.of(TEST_GROUP_1)); // is in group
-
     CorpGroup assignedGroup = new CorpGroup();
     assignedGroup.setUrn(TEST_GROUP_1.toString());
 
     CorpUser assignedUser = new CorpUser();
-    assignedUser.setUrn(TEST_USER_2.toString()); // does not match
+    assignedUser.setUrn(TEST_USER_2.toString());
 
     FormActorAssignment actors = new FormActorAssignment();
     actors.setGroups(new ArrayList<>(ImmutableList.of(assignedGroup)));
     actors.setUsers(new ArrayList<>(ImmutableList.of(assignedUser)));
 
-    QueryContext mockContext = getMockAllowContext(TEST_USER_1.toString());
+    QueryContext mockContext =
+        getMockAllowContext(TEST_USER_1.toString(), ImmutableList.of(TEST_GROUP_1));
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     Mockito.when(mockEnv.getSource()).thenReturn(actors);
 
-    IsFormAssignedToMeResolver resolver = new IsFormAssignedToMeResolver(groupService);
+    IsFormAssignedToMeResolver resolver = new IsFormAssignedToMeResolver();
     assertTrue(resolver.get(mockEnv).get());
   }
 
   @Test
   public void testGetSuccessBothMatch() throws Exception {
-    GroupService groupService =
-        mockGroupService(TEST_USER_1, ImmutableList.of(TEST_GROUP_1)); // is in group
-
     CorpGroup assignedGroup = new CorpGroup();
     assignedGroup.setUrn(TEST_GROUP_1.toString());
 
     CorpUser assignedUser = new CorpUser();
-    assignedUser.setUrn(TEST_USER_1.toString()); // is matching user
+    assignedUser.setUrn(TEST_USER_1.toString());
 
     FormActorAssignment actors = new FormActorAssignment();
     actors.setGroups(new ArrayList<>(ImmutableList.of(assignedGroup)));
     actors.setUsers(new ArrayList<>(ImmutableList.of(assignedUser)));
 
-    QueryContext mockContext = getMockAllowContext(TEST_USER_1.toString());
+    QueryContext mockContext =
+        getMockAllowContext(TEST_USER_1.toString(), ImmutableList.of(TEST_GROUP_1));
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     Mockito.when(mockEnv.getSource()).thenReturn(actors);
 
-    IsFormAssignedToMeResolver resolver = new IsFormAssignedToMeResolver(groupService);
+    IsFormAssignedToMeResolver resolver = new IsFormAssignedToMeResolver();
     assertTrue(resolver.get(mockEnv).get());
-    Mockito.verifyNoMoreInteractions(groupService); // Should not perform group lookup.
   }
 
   @Test
   public void testGetSuccessNoMatchNullAssignment() throws Exception {
-    GroupService groupService =
-        mockGroupService(TEST_USER_1, ImmutableList.of(TEST_GROUP_1, TEST_GROUP_2));
-
     FormActorAssignment actors = new FormActorAssignment();
 
-    QueryContext mockContext = getMockAllowContext(TEST_USER_1.toString());
+    QueryContext mockContext =
+        getMockAllowContext(TEST_USER_1.toString(), ImmutableList.of(TEST_GROUP_1, TEST_GROUP_2));
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     Mockito.when(mockEnv.getSource()).thenReturn(actors);
 
-    IsFormAssignedToMeResolver resolver = new IsFormAssignedToMeResolver(groupService);
+    IsFormAssignedToMeResolver resolver = new IsFormAssignedToMeResolver();
     assertFalse(resolver.get(mockEnv).get());
   }
 
   @Test
   public void testGetSuccessNoMatchEmptyAssignment() throws Exception {
-    GroupService groupService =
-        mockGroupService(TEST_USER_1, ImmutableList.of(TEST_GROUP_1, TEST_GROUP_2));
-
     FormActorAssignment actors = new FormActorAssignment();
     actors.setUsers(Collections.emptyList());
     actors.setGroups(Collections.emptyList());
 
-    QueryContext mockContext = getMockAllowContext(TEST_USER_1.toString());
+    QueryContext mockContext =
+        getMockAllowContext(TEST_USER_1.toString(), ImmutableList.of(TEST_GROUP_1, TEST_GROUP_2));
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     Mockito.when(mockEnv.getSource()).thenReturn(actors);
 
-    IsFormAssignedToMeResolver resolver = new IsFormAssignedToMeResolver(groupService);
+    IsFormAssignedToMeResolver resolver = new IsFormAssignedToMeResolver();
     assertFalse(resolver.get(mockEnv).get());
   }
 
   @Test
   public void testGetSuccessNoMatchNoAssignmentMatch() throws Exception {
-    GroupService groupService = mockGroupService(TEST_USER_1, ImmutableList.of(TEST_GROUP_1));
-
     CorpGroup assignedGroup = new CorpGroup();
-    assignedGroup.setUrn(TEST_GROUP_2.toString()); // Does not match.
+    assignedGroup.setUrn(TEST_GROUP_2.toString());
 
     CorpUser assignedUser = new CorpUser();
-    assignedUser.setUrn(TEST_USER_2.toString()); // does not match
+    assignedUser.setUrn(TEST_USER_2.toString());
 
     FormActorAssignment actors = new FormActorAssignment();
     actors.setGroups(new ArrayList<>(ImmutableList.of(assignedGroup)));
     actors.setUsers(new ArrayList<>(ImmutableList.of(assignedUser)));
 
-    QueryContext mockContext = getMockAllowContext(TEST_USER_1.toString());
+    QueryContext mockContext =
+        getMockAllowContext(TEST_USER_1.toString(), ImmutableList.of(TEST_GROUP_1));
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     Mockito.when(mockEnv.getSource()).thenReturn(actors);
 
-    IsFormAssignedToMeResolver resolver = new IsFormAssignedToMeResolver(groupService);
+    IsFormAssignedToMeResolver resolver = new IsFormAssignedToMeResolver();
     assertFalse(resolver.get(mockEnv).get());
-  }
-
-  private GroupService mockGroupService(final Urn userUrn, final List<Urn> groupUrns)
-      throws Exception {
-    GroupService mockService = Mockito.mock(GroupService.class);
-    Mockito.when(mockService.getGroupsForUser(any(), Mockito.eq(userUrn))).thenReturn(groupUrns);
-    return mockService;
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/form/VerifyFormResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/form/VerifyFormResolverTest.java
@@ -5,13 +5,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
-import com.datahub.authentication.group.GroupService;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.VerifyFormInput;
 import com.linkedin.metadata.service.FormService;
 import graphql.schema.DataFetchingEnvironment;
-import java.util.ArrayList;
 import java.util.concurrent.CompletionException;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
@@ -28,8 +26,7 @@ public class VerifyFormResolverTest {
   @Test
   public void testGetSuccess() throws Exception {
     FormService mockFormService = initMockFormService(true, true);
-    GroupService mockGroupService = initMockGroupService();
-    VerifyFormResolver resolver = new VerifyFormResolver(mockFormService, mockGroupService);
+    VerifyFormResolver resolver = new VerifyFormResolver(mockFormService);
 
     // Execute resolver
     QueryContext mockContext = getMockAllowContext();
@@ -52,8 +49,7 @@ public class VerifyFormResolverTest {
   @Test
   public void testGetUnauthorized() throws Exception {
     FormService mockFormService = initMockFormService(false, true);
-    GroupService mockGroupService = initMockGroupService();
-    VerifyFormResolver resolver = new VerifyFormResolver(mockFormService, mockGroupService);
+    VerifyFormResolver resolver = new VerifyFormResolver(mockFormService);
 
     // Execute resolver
     QueryContext mockContext = getMockAllowContext();
@@ -70,8 +66,7 @@ public class VerifyFormResolverTest {
   @Test
   public void testThrowErrorOnVerification() throws Exception {
     FormService mockFormService = initMockFormService(true, false);
-    GroupService mockGroupService = initMockGroupService();
-    VerifyFormResolver resolver = new VerifyFormResolver(mockFormService, mockGroupService);
+    VerifyFormResolver resolver = new VerifyFormResolver(mockFormService);
 
     // Execute resolver
     QueryContext mockContext = getMockAllowContext();
@@ -100,13 +95,6 @@ public class VerifyFormResolverTest {
       Mockito.when(service.verifyFormForEntity(any(), Mockito.any(), Mockito.any()))
           .thenThrow(new RuntimeException());
     }
-
-    return service;
-  }
-
-  private GroupService initMockGroupService() throws Exception {
-    GroupService service = Mockito.mock(GroupService.class);
-    Mockito.when(service.getGroupsForUser(any(), Mockito.any())).thenReturn(new ArrayList<>());
 
     return service;
   }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentResolversTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentResolversTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertNotNull;
 
-import com.datahub.authentication.group.GroupService;
 import com.linkedin.datahub.graphql.types.dataplatform.DataPlatformType;
 import com.linkedin.datahub.graphql.types.dataplatforminstance.DataPlatformInstanceType;
 import com.linkedin.datahub.graphql.types.knowledge.DocumentType;
@@ -34,7 +33,6 @@ public class DocumentResolversTest {
   private GraphClient mockGraphClient;
   private EntityRegistry mockEntityRegistry;
   private com.linkedin.metadata.timeline.TimelineService mockTimelineService;
-  private GroupService mockGroupService;
   private DocumentResolvers resolvers;
 
   @BeforeMethod
@@ -48,7 +46,6 @@ public class DocumentResolversTest {
     mockGraphClient = mock(GraphClient.class);
     mockEntityRegistry = mock(EntityRegistry.class);
     mockTimelineService = mock(com.linkedin.metadata.timeline.TimelineService.class);
-    mockGroupService = mock(GroupService.class);
 
     resolvers =
         new DocumentResolvers(
@@ -61,8 +58,7 @@ public class DocumentResolversTest {
             mockEntityService,
             mockGraphClient,
             mockEntityRegistry,
-            mockTimelineService,
-            mockGroupService);
+            mockTimelineService);
   }
 
   @Test

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/RelatedDocumentsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/RelatedDocumentsResolverTest.java
@@ -6,12 +6,10 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 
-import com.datahub.authentication.group.GroupService;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.Owner;
 import com.linkedin.common.OwnerArray;
 import com.linkedin.common.Ownership;
-import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.Entity;
@@ -53,7 +51,6 @@ public class RelatedDocumentsResolverTest {
 
   private DocumentService mockService;
   private EntityClient mockEntityClient;
-  private GroupService mockGroupService;
   private RelatedDocumentsResolver resolver;
   private DataFetchingEnvironment mockEnv;
   private RelatedDocumentsInput input;
@@ -63,7 +60,6 @@ public class RelatedDocumentsResolverTest {
   public void setupTest() throws Exception {
     mockService = mock(DocumentService.class);
     mockEntityClient = mock(EntityClient.class);
-    mockGroupService = mock(GroupService.class);
     mockEnv = mock(DataFetchingEnvironment.class);
 
     // Setup mock parent entity
@@ -105,11 +101,8 @@ public class RelatedDocumentsResolverTest {
     when(mockEntityClient.batchGetV2(any(OperationContext.class), any(String.class), any(), any()))
         .thenReturn(entityResponseMap);
 
-    // Mock GroupService to return empty groups by default
-    when(mockGroupService.getGroupsForUser(any(OperationContext.class), any(Urn.class)))
-        .thenReturn(Collections.emptyList());
-
-    resolver = new RelatedDocumentsResolver(mockService, mockEntityClient, mockGroupService);
+    // Session group membership is stubbed via TestUtils.withSessionGroupMembership when needed
+    resolver = new RelatedDocumentsResolver(mockService, mockEntityClient);
   }
 
   private EntityResponse createPublishedDocumentResponse(String documentUrn, String ownerUrn) {
@@ -389,14 +382,10 @@ public class RelatedDocumentsResolverTest {
 
   @Test
   public void testContextDocumentsWithGroupOwnership() throws Exception {
-    QueryContext mockContext = getMockAllowContext();
-    when(mockContext.getActorUrn()).thenReturn(TEST_USER_URN);
+    QueryContext mockContext =
+        getMockAllowContext(TEST_USER_URN, ImmutableList.of(UrnUtils.getUrn(TEST_GROUP_URN)));
     when(mockEnv.getContext()).thenReturn(mockContext);
     when(mockEnv.getArgument(eq("input"))).thenReturn(input);
-
-    // Mock user belongs to a group
-    when(mockGroupService.getGroupsForUser(any(OperationContext.class), any(Urn.class)))
-        .thenReturn(ImmutableList.of(UrnUtils.getUrn(TEST_GROUP_URN)));
 
     // Create unpublished document owned by user's group
     Map<com.linkedin.common.urn.Urn, EntityResponse> entityResponseMap = new HashMap<>();

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/SearchDocumentsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/SearchDocumentsResolverTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 
-import com.datahub.authentication.group.GroupService;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.Owner;
 import com.linkedin.common.OwnerArray;
@@ -33,7 +32,6 @@ import com.linkedin.metadata.search.SearchResultMetadata;
 import com.linkedin.metadata.service.DocumentService;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
@@ -50,7 +48,6 @@ public class SearchDocumentsResolverTest {
 
   private DocumentService mockService;
   private EntityClient mockEntityClient;
-  private GroupService mockGroupService;
   private SearchDocumentsResolver resolver;
   private DataFetchingEnvironment mockEnv;
   private SearchDocumentsInput input;
@@ -59,7 +56,6 @@ public class SearchDocumentsResolverTest {
   public void setupTest() throws Exception {
     mockService = mock(DocumentService.class);
     mockEntityClient = mock(EntityClient.class);
-    mockGroupService = mock(GroupService.class);
     mockEnv = mock(DataFetchingEnvironment.class);
 
     // Setup default input
@@ -96,11 +92,8 @@ public class SearchDocumentsResolverTest {
     when(mockEntityClient.batchGetV2(any(OperationContext.class), any(String.class), any(), any()))
         .thenReturn(entityResponseMap);
 
-    // Mock GroupService to return empty groups by default
-    when(mockGroupService.getGroupsForUser(any(OperationContext.class), any(Urn.class)))
-        .thenReturn(Collections.emptyList());
-
-    resolver = new SearchDocumentsResolver(mockService, mockEntityClient, mockGroupService);
+    // Session group membership is stubbed via TestUtils.withSessionGroupMembership when needed
+    resolver = new SearchDocumentsResolver(mockService, mockEntityClient);
   }
 
   private EntityResponse createPublishedDocumentResponse(String documentUrn, String ownerUrn) {
@@ -501,22 +494,17 @@ public class SearchDocumentsResolverTest {
 
   @Test
   public void testUnpublishedDocumentShownToGroupMember() throws Exception {
-    QueryContext mockContext = getMockAllowContext(OTHER_USER_URN);
+    QueryContext mockContext =
+        getMockAllowContext(OTHER_USER_URN, ImmutableList.of(UrnUtils.getUrn(TEST_GROUP_URN)));
     when(mockEnv.getContext()).thenReturn(mockContext);
     when(mockEnv.getArgument(eq("input"))).thenReturn(input);
 
-    // Document is UNPUBLISHED and owned by a GROUP that the current user belongs to
     Map<Urn, EntityResponse> entityResponseMap = new HashMap<>();
     EntityResponse entityResponse =
         createUnpublishedDocumentResponse(TEST_DOCUMENT_URN, TEST_GROUP_URN);
     entityResponseMap.put(UrnUtils.getUrn(TEST_DOCUMENT_URN), entityResponse);
     when(mockEntityClient.batchGetV2(any(OperationContext.class), any(String.class), any(), any()))
         .thenReturn(entityResponseMap);
-
-    // Mock that the current user is part of TEST_GROUP
-    when(mockGroupService.getGroupsForUser(
-            any(OperationContext.class), eq(UrnUtils.getUrn(OTHER_USER_URN))))
-        .thenReturn(ImmutableList.of(UrnUtils.getUrn(TEST_GROUP_URN)));
 
     SearchDocumentsResult result = resolver.get(mockEnv).get();
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/policy/GetGrantedPrivilegesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/policy/GetGrantedPrivilegesResolverTest.java
@@ -22,6 +22,7 @@ import com.linkedin.datahub.graphql.generated.Privileges;
 import com.linkedin.datahub.graphql.generated.ResourceSpec;
 import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
 import graphql.schema.DataFetchingEnvironment;
+import io.datahubproject.metadata.context.OperationContext;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -39,6 +40,7 @@ public class GetGrantedPrivilegesResolverTest {
   private QueryContext context;
   private AuthorizerChain authorizerChain;
   private DataHubAuthorizer dataHubAuthorizer;
+  private OperationContext operationContext;
   private MockedStatic<ResolverUtils> resolverUtils;
   private MockedStatic<PolicyAuthUtils> policyAuthUtils;
   private MockedStatic<GraphQLConcurrencyUtils> concurrencyUtils;
@@ -52,12 +54,14 @@ public class GetGrantedPrivilegesResolverTest {
     context = mock(QueryContext.class);
     authorizerChain = mock(AuthorizerChain.class);
     dataHubAuthorizer = mock(DataHubAuthorizer.class);
+    operationContext = mock(OperationContext.class);
     resolverUtils = mockStatic(ResolverUtils.class);
     policyAuthUtils = mockStatic(PolicyAuthUtils.class);
     concurrencyUtils = mockStatic(GraphQLConcurrencyUtils.class);
 
     when(environment.getContext()).thenReturn(context);
     when(context.getAuthorizer()).thenReturn(authorizerChain);
+    when(context.getOperationContext()).thenReturn(operationContext);
     when(authorizerChain.getDefaultAuthorizer()).thenReturn(dataHubAuthorizer);
   }
 
@@ -88,7 +92,8 @@ public class GetGrantedPrivilegesResolverTest {
         mock(PolicyEngine.PolicyGrantedPrivileges.class);
     when(mockResult.getPrivileges()).thenReturn(privileges);
     when(mockResult.getReasonOfDeny()).thenReturn(denyReasons);
-    when(dataHubAuthorizer.getGrantedPrivileges(any(), any())).thenReturn(mockResult);
+    when(dataHubAuthorizer.getGrantedPrivileges(any(), any(), eq(operationContext)))
+        .thenReturn(mockResult);
 
     Privileges expectedPrivileges =
         Privileges.builder().setPrivileges(privileges).setEvaluationDetails(null).build();
@@ -131,7 +136,8 @@ public class GetGrantedPrivilegesResolverTest {
         mock(PolicyEngine.PolicyGrantedPrivileges.class);
     when(mockResult.getPrivileges()).thenReturn(privileges);
     when(mockResult.getReasonOfDeny()).thenReturn(denyReasons);
-    when(dataHubAuthorizer.getGrantedPrivileges(any(), any())).thenReturn(mockResult);
+    when(dataHubAuthorizer.getGrantedPrivileges(any(), any(), eq(operationContext)))
+        .thenReturn(mockResult);
 
     Privileges expectedPrivileges =
         Privileges.builder().setPrivileges(privileges).setEvaluationDetails(null).build();
@@ -169,7 +175,8 @@ public class GetGrantedPrivilegesResolverTest {
         mock(PolicyEngine.PolicyGrantedPrivileges.class);
     when(mockResult.getPrivileges()).thenReturn(privileges);
     when(mockResult.getReasonOfDeny()).thenReturn(denyReasons);
-    when(dataHubAuthorizer.getGrantedPrivileges(any(), any())).thenReturn(mockResult);
+    when(dataHubAuthorizer.getGrantedPrivileges(any(), any(), eq(operationContext)))
+        .thenReturn(mockResult);
 
     List<PolicyEvaluationDetail> evaluationDetails = new ArrayList<>();
     evaluationDetails.add(new PolicyEvaluationDetail("policy1", "Access denied by policy1"));

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/role/IsAssignedToMeResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/role/IsAssignedToMeResolverTest.java
@@ -4,7 +4,6 @@ import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
-import com.datahub.authentication.group.GroupService;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
@@ -51,9 +50,7 @@ public class IsAssignedToMeResolverTest {
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     Mockito.when(mockEnv.getSource()).thenReturn(role);
 
-    GroupService groupService =
-        createTestGroupService(TEST_CORP_USER_URN_1, Collections.emptyList());
-    IsAssignedToMeResolver resolver = new IsAssignedToMeResolver(groupService);
+    IsAssignedToMeResolver resolver = new IsAssignedToMeResolver();
     assertTrue(resolver.get(mockEnv).get());
   }
 
@@ -82,111 +79,69 @@ public class IsAssignedToMeResolverTest {
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     Mockito.when(mockEnv.getSource()).thenReturn(role);
 
-    GroupService groupService =
-        createTestGroupService(TEST_CORP_USER_URN_1, Collections.emptyList());
-    IsAssignedToMeResolver resolver = new IsAssignedToMeResolver(groupService);
+    IsAssignedToMeResolver resolver = new IsAssignedToMeResolver();
     assertFalse(resolver.get(mockEnv).get());
   }
 
   @Test
   public void testReturnsTrueIfCurrentUserIsAssignedToRoleViaGroup() throws Exception {
 
-    // Create a group that will be assigned to the role
     CorpGroup corpGroup1 = new CorpGroup();
     corpGroup1.setUrn(TEST_CORP_GROUP_URN_1.toString());
 
-    // Create RoleGroup that links the group to the role
     RoleGroup roleGroup1 = new RoleGroup();
     roleGroup1.setGroup(corpGroup1);
 
     ArrayList<RoleGroup> roleGroups = new ArrayList<>();
     roleGroups.add(roleGroup1);
 
-    // Create Actor with groups but no direct user assignments
     Actor actor = new Actor();
-    actor.setUsers(Collections.emptyList()); // No direct user assignments
-    actor.setGroups(roleGroups); // Group is assigned to role
+    actor.setUsers(Collections.emptyList());
+    actor.setGroups(roleGroups);
 
     Role role = new Role();
     role.setUrn("urn:li:role:fake-role");
     role.setActors(actor);
 
-    QueryContext mockContext = getMockAllowContext(TEST_CORP_USER_URN_1.toString());
+    List<Urn> userGroups = Collections.singletonList(TEST_CORP_GROUP_URN_1);
+    QueryContext mockContext = getMockAllowContext(TEST_CORP_USER_URN_1.toString(), userGroups);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     Mockito.when(mockEnv.getSource()).thenReturn(role);
 
-    // Mock that the user is a member of the group that's assigned to the role
-    List<Urn> userGroups = Collections.singletonList(TEST_CORP_GROUP_URN_1);
-    GroupService groupService = createTestGroupService(TEST_CORP_USER_URN_1, userGroups);
+    IsAssignedToMeResolver resolver = new IsAssignedToMeResolver();
 
-    IsAssignedToMeResolver resolver = new IsAssignedToMeResolver(groupService);
-
-    // This should return true because:
-    // 1. The user is not directly assigned to the role
-    // 2. But the user is a member of a group that IS assigned to the role
     assertTrue(resolver.get(mockEnv).get());
   }
 
   @Test
   public void testReturnsFalseIfCurrentUserIsNotInGroupAssignedToRole() throws Exception {
 
-    // Create a group that will be assigned to the role
     CorpGroup corpGroup1 = new CorpGroup();
     corpGroup1.setUrn(TEST_CORP_GROUP_URN_1.toString());
 
-    // Create RoleGroup that links the group to the role
     RoleGroup roleGroup1 = new RoleGroup();
     roleGroup1.setGroup(corpGroup1);
 
     ArrayList<RoleGroup> roleGroups = new ArrayList<>();
     roleGroups.add(roleGroup1);
 
-    // Create Actor with groups but no direct user assignments
     Actor actor = new Actor();
-    actor.setUsers(Collections.emptyList()); // No direct user assignments
-    actor.setGroups(roleGroups); // Group is assigned to role
+    actor.setUsers(Collections.emptyList());
+    actor.setGroups(roleGroups);
 
     Role role = new Role();
     role.setUrn("urn:li:role:fake-role");
     role.setActors(actor);
 
-    QueryContext mockContext = getMockAllowContext(TEST_CORP_USER_URN_1.toString());
+    List<Urn> userGroups = Collections.singletonList(TEST_CORP_GROUP_URN_2);
+    QueryContext mockContext = getMockAllowContext(TEST_CORP_USER_URN_1.toString(), userGroups);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     Mockito.when(mockEnv.getSource()).thenReturn(role);
 
-    // Mock that the user is NOT a member of the group that's assigned to the role
-    // Instead, they're in a different group
-    List<Urn> userGroups = Collections.singletonList(TEST_CORP_GROUP_URN_2);
-    GroupService groupService = createTestGroupService(TEST_CORP_USER_URN_1, userGroups);
+    IsAssignedToMeResolver resolver = new IsAssignedToMeResolver();
 
-    IsAssignedToMeResolver resolver = new IsAssignedToMeResolver(groupService);
-
-    // This should return false because:
-    // 1. The user is not directly assigned to the role
-    // 2. The user is in a group, but that group is NOT assigned to the role
     assertFalse(resolver.get(mockEnv).get());
-  }
-
-  private GroupService createTestGroupService(final Urn userUrn, final List<Urn> groupUrns) {
-    // Create minimal mocks for the required dependencies
-    com.linkedin.entity.client.EntityClient mockEntityClient =
-        Mockito.mock(com.linkedin.entity.client.EntityClient.class);
-    com.linkedin.metadata.entity.EntityService mockEntityService =
-        Mockito.mock(com.linkedin.metadata.entity.EntityService.class);
-    com.linkedin.metadata.graph.GraphClient mockGraphClient =
-        Mockito.mock(com.linkedin.metadata.graph.GraphClient.class);
-
-    return new GroupService(mockEntityClient, mockEntityService, mockGraphClient) {
-      @Override
-      public List<Urn> getGroupsForUser(
-          io.datahubproject.metadata.context.OperationContext opContext, Urn user) {
-        if (user.equals(userUrn)) {
-          return groupUrns;
-        }
-        return Collections.emptyList();
-      }
-    };
   }
 }

--- a/li-utils/src/main/java/com/datahub/authorization/AuthorizationRequest.java
+++ b/li-utils/src/main/java/com/datahub/authorization/AuthorizationRequest.java
@@ -1,10 +1,12 @@
 package com.datahub.authorization;
 
+import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nullable;
 import lombok.Value;
 
@@ -32,17 +34,74 @@ public class AuthorizationRequest {
    */
   @Nullable Map<String, List<RecordTemplate>> actorPoliciesByPrivilege;
 
+  /**
+   * Session-scoped group membership for the actor, or {@code null} when not supplied (direct
+   * authorizer invocations, test mocks).
+   */
+  @Nullable Collection<Urn> actorGroupMembership;
+
+  /** Session-scoped direct role membership for the actor, or {@code null} when not supplied. */
+  @Nullable Set<Urn> actorDirectRoles;
+
+  /**
+   * Request-scoped session actor identity, or {@code null} when not supplied. When present, group
+   * role inheritance is resolved at most once per request via {@link SessionActorIdentity}.
+   */
+  @Nullable SessionActorIdentity sessionActorIdentity;
+
+  public AuthorizationRequest(
+      String actorUrn,
+      String privilege,
+      Optional<EntitySpec> resourceSpec,
+      Collection<EntitySpec> subResources,
+      @Nullable Map<String, List<RecordTemplate>> actorPoliciesByPrivilege,
+      @Nullable Collection<Urn> actorGroupMembership,
+      @Nullable Set<Urn> actorDirectRoles,
+      @Nullable SessionActorIdentity sessionActorIdentity) {
+    this.actorUrn = actorUrn;
+    this.privilege = privilege;
+    this.resourceSpec = resourceSpec;
+    this.subResources = subResources;
+    this.actorPoliciesByPrivilege = actorPoliciesByPrivilege;
+    this.actorGroupMembership = actorGroupMembership;
+    this.actorDirectRoles = actorDirectRoles;
+    this.sessionActorIdentity = sessionActorIdentity;
+  }
+
+  public AuthorizationRequest(
+      String actorUrn,
+      String privilege,
+      Optional<EntitySpec> resourceSpec,
+      Collection<EntitySpec> subResources,
+      @Nullable Map<String, List<RecordTemplate>> actorPoliciesByPrivilege,
+      @Nullable Collection<Urn> actorGroupMembership,
+      @Nullable Set<Urn> actorDirectRoles) {
+    this(
+        actorUrn,
+        privilege,
+        resourceSpec,
+        subResources,
+        actorPoliciesByPrivilege,
+        actorGroupMembership,
+        actorDirectRoles,
+        null);
+  }
+
   public AuthorizationRequest(
       String actorUrn,
       String privilege,
       Optional<EntitySpec> resourceSpec,
       Collection<EntitySpec> subResources,
       @Nullable Map<String, List<RecordTemplate>> actorPoliciesByPrivilege) {
-    this.actorUrn = actorUrn;
-    this.privilege = privilege;
-    this.resourceSpec = resourceSpec;
-    this.subResources = subResources;
-    this.actorPoliciesByPrivilege = actorPoliciesByPrivilege;
+    this(
+        actorUrn,
+        privilege,
+        resourceSpec,
+        subResources,
+        actorPoliciesByPrivilege,
+        null,
+        null,
+        null);
   }
 
   public AuthorizationRequest(

--- a/li-utils/src/main/java/com/datahub/authorization/SessionActorIdentity.java
+++ b/li-utils/src/main/java/com/datahub/authorization/SessionActorIdentity.java
@@ -1,0 +1,70 @@
+package com.datahub.authorization;
+
+import com.linkedin.common.urn.Urn;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import lombok.Getter;
+
+/**
+ * Request-scoped snapshot of a corp user's group membership and role membership. Group URNs include
+ * both corp (SSO) and native groups, deduplicated. Roles inherited via groups are resolved lazily.
+ */
+@Getter
+public final class SessionActorIdentity {
+
+  private final Urn actorUrn;
+  private final List<Urn> groups;
+  private final Set<Urn> directRoles;
+  private volatile Set<Urn> allRoles;
+
+  public SessionActorIdentity(
+      @Nonnull final Urn actorUrn,
+      @Nonnull final List<Urn> groups,
+      @Nonnull final Set<Urn> directRoles) {
+    this.actorUrn = actorUrn;
+    this.groups = List.copyOf(groups);
+    this.directRoles = Collections.unmodifiableSet(new HashSet<>(directRoles));
+  }
+
+  public static SessionActorIdentity empty(@Nonnull final Urn actorUrn) {
+    return new SessionActorIdentity(actorUrn, List.of(), Set.of());
+  }
+
+  /**
+   * Returns direct roles plus roles inherited from group membership. The group role lookup runs at
+   * most once per identity instance.
+   */
+  @Nonnull
+  public Set<Urn> resolveAllRoles(
+      @Nonnull final Function<Collection<Urn>, Set<Urn>> rolesViaGroupsFetcher) {
+    if (allRoles != null) {
+      return allRoles;
+    }
+    synchronized (this) {
+      if (allRoles == null) {
+        final Set<Urn> roles = new HashSet<>(directRoles);
+        if (!groups.isEmpty()) {
+          roles.addAll(rolesViaGroupsFetcher.apply(groups));
+        }
+        allRoles = Collections.unmodifiableSet(roles);
+      }
+      return allRoles;
+    }
+  }
+
+  /** Builds a deduplicated group list from corp and native membership aspects. */
+  @Nonnull
+  public static List<Urn> mergeGroupMembership(
+      @Nonnull final Collection<Urn> corpGroups, @Nonnull final Collection<Urn> nativeGroups) {
+    final Set<Urn> merged = new HashSet<>();
+    merged.addAll(corpGroups);
+    merged.addAll(nativeGroups);
+    return new ArrayList<>(merged);
+  }
+}

--- a/li-utils/src/test/java/com/datahub/authorization/AuthorizationRequestTest.java
+++ b/li-utils/src/test/java/com/datahub/authorization/AuthorizationRequestTest.java
@@ -3,11 +3,13 @@ package com.datahub.authorization;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
+import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.RecordTemplate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.testng.annotations.Test;
 
 public class AuthorizationRequestTest {
@@ -31,6 +33,45 @@ public class AuthorizationRequestTest {
     assertEquals(request.getResourceSpec(), Optional.of(resource));
     assertEquals(request.getSubResources(), List.of(resource));
     assertEquals(request.getActorPoliciesByPrivilege(), actorPolicies);
+  }
+
+  @Test
+  public void sevenArgConstructorSetsSessionActorFields() {
+    EntitySpec resource = new EntitySpec("dataset", "urn:li:dataset:test");
+    SessionActorIdentity identity =
+        SessionActorIdentity.empty(UrnUtils.getUrn("urn:li:corpuser:testuser"));
+
+    AuthorizationRequest request =
+        new AuthorizationRequest(
+            "urn:li:corpuser:testuser",
+            "VIEW",
+            Optional.of(resource),
+            List.of(resource),
+            null,
+            List.of(UrnUtils.getUrn("urn:li:corpGroup:test")),
+            Set.of(UrnUtils.getUrn("urn:li:dataHubRole:Admin")),
+            identity);
+
+    assertEquals(
+        request.getActorGroupMembership(), List.of(UrnUtils.getUrn("urn:li:corpGroup:test")));
+    assertEquals(
+        request.getActorDirectRoles(), Set.of(UrnUtils.getUrn("urn:li:dataHubRole:Admin")));
+    assertEquals(request.getSessionActorIdentity(), identity);
+  }
+
+  @Test
+  public void sixArgConstructorLeavesSessionActorIdentityNull() {
+    AuthorizationRequest request =
+        new AuthorizationRequest(
+            "urn:li:corpuser:testuser",
+            "VIEW",
+            Optional.empty(),
+            Collections.emptyList(),
+            null,
+            Collections.emptyList(),
+            Set.of());
+
+    assertNull(request.getSessionActorIdentity());
   }
 
   @Test

--- a/li-utils/src/test/java/com/datahub/authorization/SessionActorIdentityTest.java
+++ b/li-utils/src/test/java/com/datahub/authorization/SessionActorIdentityTest.java
@@ -1,0 +1,106 @@
+package com.datahub.authorization;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.testng.annotations.Test;
+
+public class SessionActorIdentityTest {
+
+  private static final Urn ACTOR_URN = UrnUtils.getUrn("urn:li:corpuser:testuser");
+  private static final Urn GROUP_URN = UrnUtils.getUrn("urn:li:corpGroup:test");
+  private static final Urn DIRECT_ROLE = UrnUtils.getUrn("urn:li:dataHubRole:Editor");
+  private static final Urn INHERITED_ROLE = UrnUtils.getUrn("urn:li:dataHubRole:Admin");
+
+  @Test
+  public void empty_createsIdentityWithNoGroupsOrRoles() {
+    SessionActorIdentity identity = SessionActorIdentity.empty(ACTOR_URN);
+
+    assertEquals(identity.getActorUrn(), ACTOR_URN);
+    assertTrue(identity.getGroups().isEmpty());
+    assertTrue(identity.getDirectRoles().isEmpty());
+  }
+
+  @Test
+  public void constructor_copiesGroupAndRoleCollections() {
+    List<Urn> mutableGroups = new ArrayList<>(List.of(GROUP_URN));
+    Set<Urn> mutableRoles = Set.of(DIRECT_ROLE);
+
+    SessionActorIdentity identity =
+        new SessionActorIdentity(ACTOR_URN, mutableGroups, mutableRoles);
+    mutableGroups.add(UrnUtils.getUrn("urn:li:corpGroup:other"));
+
+    assertEquals(identity.getGroups(), List.of(GROUP_URN));
+    assertEquals(identity.getDirectRoles(), Set.of(DIRECT_ROLE));
+  }
+
+  @Test
+  public void resolveAllRoles_returnsDirectRolesWhenNoGroups() {
+    SessionActorIdentity identity =
+        new SessionActorIdentity(ACTOR_URN, List.of(), Set.of(DIRECT_ROLE));
+    AtomicInteger fetchCount = new AtomicInteger();
+
+    Set<Urn> roles =
+        identity.resolveAllRoles(
+            groups -> {
+              fetchCount.incrementAndGet();
+              return Set.of(INHERITED_ROLE);
+            });
+
+    assertEquals(roles, Set.of(DIRECT_ROLE));
+    assertEquals(fetchCount.get(), 0);
+  }
+
+  @Test
+  public void resolveAllRoles_includesInheritedRolesFromGroups() {
+    SessionActorIdentity identity =
+        new SessionActorIdentity(ACTOR_URN, List.of(GROUP_URN), Set.of(DIRECT_ROLE));
+
+    Set<Urn> roles = identity.resolveAllRoles(groups -> Set.of(INHERITED_ROLE));
+
+    assertEquals(roles, Set.of(DIRECT_ROLE, INHERITED_ROLE));
+  }
+
+  @Test
+  public void resolveAllRoles_invokesFetcherOnceWhenCalledMultipleTimes() {
+    SessionActorIdentity identity =
+        new SessionActorIdentity(ACTOR_URN, List.of(GROUP_URN), Set.of(DIRECT_ROLE));
+    AtomicInteger fetchCount = new AtomicInteger();
+
+    Set<Urn> first =
+        identity.resolveAllRoles(
+            groups -> {
+              fetchCount.incrementAndGet();
+              return Set.of(INHERITED_ROLE);
+            });
+    Set<Urn> second =
+        identity.resolveAllRoles(
+            groups -> {
+              fetchCount.incrementAndGet();
+              return Set.of(INHERITED_ROLE);
+            });
+
+    assertEquals(first, second);
+    assertEquals(fetchCount.get(), 1);
+  }
+
+  @Test
+  public void mergeGroupMembership_deduplicatesCorpAndNativeGroups() {
+    Urn sharedGroup = UrnUtils.getUrn("urn:li:corpGroup:shared");
+    Urn corpOnly = UrnUtils.getUrn("urn:li:corpGroup:corp");
+    Urn nativeOnly = UrnUtils.getUrn("urn:li:corpGroup:native");
+
+    List<Urn> merged =
+        SessionActorIdentity.mergeGroupMembership(
+            List.of(sharedGroup, corpOnly), List.of(sharedGroup, nativeOnly));
+
+    assertEquals(merged.size(), 3);
+    assertTrue(merged.containsAll(List.of(sharedGroup, corpOnly, nativeOnly)));
+  }
+}

--- a/metadata-auth/auth-api/src/main/java/com/datahub/plugins/auth/authorization/Authorizer.java
+++ b/metadata-auth/auth-api/src/main/java/com/datahub/plugins/auth/authorization/Authorizer.java
@@ -5,6 +5,7 @@ import com.datahub.authorization.AuthorizationResult;
 import com.datahub.authorization.AuthorizedActors;
 import com.datahub.authorization.AuthorizerContext;
 import com.datahub.authorization.EntitySpec;
+import com.datahub.authorization.SessionActorIdentity;
 import com.datahub.plugins.Plugin;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.Constants;
@@ -15,6 +16,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * An Authorizer is responsible for determining whether an actor should be granted a specific
@@ -75,6 +77,29 @@ public interface Authorizer extends Plugin {
    */
   default Set<DataHubPolicyInfo> getActorPolicies(@Nonnull Urn actorUrn) {
     return Collections.emptySet();
+  }
+
+  /**
+   * Given the actor's urn retrieve the policies, using preloaded group membership when provided to
+   * avoid redundant storage reads.
+   */
+  default Set<DataHubPolicyInfo> getActorPolicies(
+      @Nonnull Urn actorUrn, @Nullable Collection<Urn> preloadedGroups) {
+    return getActorPolicies(actorUrn, preloadedGroups, null);
+  }
+
+  default Set<DataHubPolicyInfo> getActorPolicies(
+      @Nonnull Urn actorUrn,
+      @Nullable Collection<Urn> preloadedGroups,
+      @Nullable Set<Urn> preloadedDirectRoles) {
+    return getActorPolicies(actorUrn);
+  }
+
+  /**
+   * Resolves corp + native group membership and direct roles for a corp user in one storage read.
+   */
+  default Optional<SessionActorIdentity> resolveSessionActorIdentity(@Nonnull Urn actorUrn) {
+    return Optional.empty();
   }
 
   /** Given the actor's urn retrieve the actor's groups */

--- a/metadata-auth/auth-api/src/test/java/com/datahub/plugins/auth/authorization/AuthorizerTest.java
+++ b/metadata-auth/auth-api/src/test/java/com/datahub/plugins/auth/authorization/AuthorizerTest.java
@@ -1,0 +1,17 @@
+package com.datahub.plugins.auth.authorization;
+
+import static org.testng.Assert.assertFalse;
+
+import com.linkedin.common.urn.UrnUtils;
+import org.testng.annotations.Test;
+
+public class AuthorizerTest {
+
+  @Test
+  public void defaultResolveSessionActorIdentityReturnsEmpty() {
+    assertFalse(
+        Authorizer.EMPTY
+            .resolveSessionActorIdentity(UrnUtils.getUrn("urn:li:corpuser:test"))
+            .isPresent());
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESAccessControlUtilTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESAccessControlUtilTest.java
@@ -14,6 +14,7 @@ import static org.testng.Assert.assertEquals;
 import com.datahub.authentication.Actor;
 import com.datahub.authentication.ActorType;
 import com.datahub.authentication.Authentication;
+import com.datahub.authentication.group.GroupService;
 import com.datahub.authorization.AuthorizerContext;
 import com.datahub.authorization.DataHubAuthorizer;
 import com.datahub.authorization.DefaultEntitySpecResolver;
@@ -34,6 +35,8 @@ import com.linkedin.entity.EnvelopedAspectMap;
 import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.identity.GroupMembership;
 import com.linkedin.metadata.authorization.PoliciesConfig;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.graph.GraphClient;
 import com.linkedin.metadata.search.MatchedFieldArray;
 import com.linkedin.metadata.search.SearchEntity;
 import com.linkedin.metadata.search.SearchEntityArray;
@@ -616,14 +619,23 @@ public class ESAccessControlUtilTest {
       super(
           ENABLED_CONTEXT,
           mockUserGroupEntityClient(userGroups, resourceOwnerTypes),
+          new GroupService(
+              mockUserGroupEntityClient(userGroups, resourceOwnerTypes),
+              mock(EntityService.class),
+              mock(GraphClient.class)),
           0,
           0,
           AuthorizationMode.DEFAULT,
           0);
 
+      SystemEntityClient specEntityClient =
+          mockUserGroupEntityClient(userGroups, resourceOwnerTypes);
       DefaultEntitySpecResolver specResolver =
           new DefaultEntitySpecResolver(
-              opContext, mockUserGroupEntityClient(userGroups, resourceOwnerTypes));
+              opContext,
+              specEntityClient,
+              new GroupService(
+                  specEntityClient, mock(EntityService.class), mock(GraphClient.class)));
 
       AuthorizerContext ctx = mock(AuthorizerContext.class);
       when(ctx.getEntitySpecResolver()).thenReturn(specResolver);

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/ActorContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/ActorContext.java
@@ -47,6 +47,7 @@ public class ActorContext implements ContextInterface {
       Authentication authentication,
       Set<DataHubPolicyInfo> dataHubPolicySet,
       Collection<Urn> groupMembership,
+      Set<Urn> directRoleMembership,
       boolean enforceExistenceEnabled) {
     return ActorContext.builder()
         .systemAuth(false)
@@ -54,8 +55,23 @@ public class ActorContext implements ContextInterface {
         .policyInfoSet(dataHubPolicySet)
         .actorPoliciesByPrivilege(indexPoliciesByPrivilege(dataHubPolicySet))
         .groupMembership(groupMembership)
+        .directRoleMembership(directRoleMembership)
         .enforceExistenceEnabled(enforceExistenceEnabled)
         .build();
+  }
+
+  /**
+   * True when the session authentication is the same actor as the system authentication. Used when
+   * constructing a session {@link ActorContext}; distinct from {@link
+   * OperationContext#isSystemAuth()} which also requires allow-system-authentication config.
+   *
+   * @param systemAuthentication system authentication when available, otherwise {@code null}
+   */
+  public static boolean isSystemSession(
+      @Nonnull final Authentication sessionAuthentication,
+      @Nullable final Authentication systemAuthentication) {
+    return systemAuthentication != null
+        && systemAuthentication.getActor().equals(sessionAuthentication.getActor());
   }
 
   private final Authentication authentication;
@@ -73,6 +89,9 @@ public class ActorContext implements ContextInterface {
 
   @EqualsAndHashCode.Exclude @Builder.Default
   private final Collection<Urn> groupMembership = Collections.emptyList();
+
+  @EqualsAndHashCode.Exclude @Builder.Default
+  private final Set<Urn> directRoleMembership = Collections.emptySet();
 
   @EqualsAndHashCode.Exclude private final boolean systemAuth;
 

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/ActorGroupMembershipService.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/ActorGroupMembershipService.java
@@ -1,0 +1,22 @@
+package io.datahubproject.metadata.context;
+
+import com.datahub.authorization.SessionActorIdentity;
+import com.linkedin.common.urn.Urn;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+/** Canonical read API for corp user group membership and role inheritance. */
+public interface ActorGroupMembershipService {
+
+  @Nonnull
+  SessionActorIdentity fetchUserIdentity(@Nonnull OperationContext opContext, @Nonnull Urn userUrn);
+
+  @Nonnull
+  List<Urn> getGroupsForUser(@Nonnull OperationContext opContext, @Nonnull Urn userUrn);
+
+  @Nonnull
+  Set<Urn> fetchRolesViaGroups(
+      @Nonnull OperationContext opContext, @Nonnull Collection<Urn> groupUrns);
+}

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/AuthorizationContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/AuthorizationContext.java
@@ -1,15 +1,22 @@
 package io.datahubproject.metadata.context;
 
+import com.datahub.authentication.Authentication;
 import com.datahub.authorization.AuthorizationRequest;
 import com.datahub.authorization.AuthorizationResult;
 import com.datahub.authorization.EntitySpec;
 import com.datahub.authorization.ResolvedEntitySpec;
+import com.datahub.authorization.SessionActorIdentity;
 import com.datahub.plugins.auth.authorization.Authorizer;
 import com.datahub.plugins.auth.authorization.ResourceSpecCachingAuthorizer;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.policy.DataHubPolicyInfo;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.Builder;
@@ -38,6 +45,105 @@ public class AuthorizationContext implements ContextInterface {
       new ConcurrentHashMap<>();
 
   /**
+   * Request-scoped cache of session actor identity (groups + direct roles). Populated once per
+   * session actor per request.
+   */
+  @Builder.Default
+  private final ConcurrentHashMap<Urn, SessionActorIdentity> sessionActorIdentityByUrn =
+      new ConcurrentHashMap<>();
+
+  /**
+   * Returns cached session actor identity, resolving via {@code fetcher} on first access for this
+   * request.
+   */
+  @Nonnull
+  public SessionActorIdentity getOrResolveSessionActorIdentity(
+      @Nonnull final Urn sessionActorUrn, @Nonnull final Supplier<SessionActorIdentity> fetcher) {
+    return sessionActorIdentityByUrn.computeIfAbsent(sessionActorUrn, urn -> fetcher.get());
+  }
+
+  @Nullable
+  public SessionActorIdentity getSessionActorIdentity(@Nonnull final Urn sessionActorUrn) {
+    return sessionActorIdentityByUrn.get(sessionActorUrn);
+  }
+
+  /**
+   * Builds a fully populated session {@link ActorContext} (identity, policies, membership) using
+   * the session {@link OperationContext} for authorizer storage reads.
+   */
+  @Nonnull
+  public ActorContext buildSessionActor(
+      @Nonnull final OperationContext opContext,
+      @Nonnull final Authentication sessionAuthentication,
+      @Nullable final Authentication systemAuthentication,
+      boolean enforceExistenceEnabled) {
+    final Urn actorUrn = UrnUtils.getUrn(sessionAuthentication.getActor().toUrnStr());
+    final SessionActorIdentity sessionActorIdentity =
+        getOrResolveSessionActorIdentity(
+            actorUrn,
+            () ->
+                resolveSessionActorIdentity(opContext, actorUrn)
+                    .orElse(SessionActorIdentity.empty(actorUrn)));
+    final Set<DataHubPolicyInfo> policyInfoSet =
+        resolveActorPolicies(opContext, actorUrn, sessionActorIdentity);
+    return ActorContext.builder()
+        .authentication(sessionAuthentication)
+        .systemAuth(ActorContext.isSystemSession(sessionAuthentication, systemAuthentication))
+        .policyInfoSet(policyInfoSet)
+        .actorPoliciesByPrivilege(ActorContext.indexPoliciesByPrivilege(policyInfoSet))
+        .groupMembership(sessionActorIdentity.getGroups())
+        .directRoleMembership(sessionActorIdentity.getDirectRoles())
+        .enforceExistenceEnabled(enforceExistenceEnabled)
+        .build();
+  }
+
+  /**
+   * Session actor's roles (direct + inherited via groups). Group role inheritance is resolved at
+   * most once per request via the cached {@link SessionActorIdentity}.
+   */
+  @Nonnull
+  public Set<Urn> resolveSessionActorRoles(
+      @Nonnull final OperationContext opContext, @Nonnull final ActorContext sessionActor) {
+    final SessionActorIdentity identity = getSessionActorIdentity(sessionActor.getActorUrn());
+    if (identity != null) {
+      return identity.resolveAllRoles(
+          groups ->
+              Optional.ofNullable(opContext.getServicesRegistryContext())
+                  .map(ctx -> ctx.fetchRolesViaGroups(opContext, groups))
+                  .orElse(Collections.emptySet()));
+    }
+    return Set.copyOf(sessionActor.getDirectRoleMembership());
+  }
+
+  @Nonnull
+  Optional<SessionActorIdentity> resolveSessionActorIdentity(
+      @Nonnull final OperationContext opContext, @Nonnull final Urn actorUrn) {
+    if (authorizer instanceof OperationContextAuthorizer) {
+      return ((OperationContextAuthorizer) authorizer)
+          .resolveSessionActorIdentity(actorUrn, opContext);
+    }
+    return authorizer.resolveSessionActorIdentity(actorUrn);
+  }
+
+  @Nonnull
+  Set<DataHubPolicyInfo> resolveActorPolicies(
+      @Nonnull final OperationContext opContext,
+      @Nonnull final Urn actorUrn,
+      @Nonnull final SessionActorIdentity sessionActorIdentity) {
+    if (authorizer instanceof OperationContextAuthorizer) {
+      return ((OperationContextAuthorizer) authorizer)
+          .getActorPolicies(
+              actorUrn,
+              sessionActorIdentity,
+              sessionActorIdentity.getGroups(),
+              sessionActorIdentity.getDirectRoles(),
+              opContext);
+    }
+    return authorizer.getActorPolicies(
+        actorUrn, sessionActorIdentity.getGroups(), sessionActorIdentity.getDirectRoles());
+  }
+
+  /**
    * Run authorization through the actor's session cache
    *
    * @param actorContext the actor context
@@ -46,46 +152,55 @@ public class AuthorizationContext implements ContextInterface {
    * @return authorization result
    */
   public AuthorizationResult authorize(
+      @Nonnull OperationContext opContext,
       @Nonnull ActorContext actorContext,
       @Nonnull final String privilege,
       @Nullable final EntitySpec resourceSpec) {
     final AuthorizationRequest request =
-        new AuthorizationRequest(
-            actorContext.getActorUrn().toString(),
-            privilege,
-            Optional.ofNullable(resourceSpec),
-            Collections.emptyList(),
-            actorContext.getActorPoliciesByPrivilege());
+        buildAuthorizationRequest(actorContext, privilege, resourceSpec, Collections.emptyList());
     // Graphql CompletableFutures causes a recursive exception, we avoid computeIfAbsent and do work
     // outside a blocking function
     AuthorizationResult result = sessionAuthorizationCache.get(request);
     if (result == null) {
-      result = runAuthorize(request);
+      result = runAuthorize(opContext, request);
       sessionAuthorizationCache.putIfAbsent(request, result);
     }
     return result;
   }
 
   public AuthorizationResult authorize(
+      @Nonnull OperationContext opContext,
       @Nonnull ActorContext actorContext,
       @Nonnull final String privilege,
       @Nullable final EntitySpec resourceSpec,
       @Nonnull final Collection<EntitySpec> subResources) {
     final AuthorizationRequest request =
-        new AuthorizationRequest(
-            actorContext.getActorUrn().toString(),
-            privilege,
-            Optional.ofNullable(resourceSpec),
-            subResources,
-            actorContext.getActorPoliciesByPrivilege());
+        buildAuthorizationRequest(actorContext, privilege, resourceSpec, subResources);
     // Graphql CompletableFutures causes a recursive exception, we avoid computeIfAbsent and do work
     // outside a blocking function
     AuthorizationResult result = sessionAuthorizationCache.get(request);
     if (result == null) {
-      result = runAuthorize(request);
+      result = runAuthorize(opContext, request);
       sessionAuthorizationCache.putIfAbsent(request, result);
     }
     return result;
+  }
+
+  @Nonnull
+  private AuthorizationRequest buildAuthorizationRequest(
+      @Nonnull final ActorContext actorContext,
+      @Nonnull final String privilege,
+      @Nullable final EntitySpec resourceSpec,
+      @Nonnull final Collection<EntitySpec> subResources) {
+    return new AuthorizationRequest(
+        actorContext.getActorUrn().toString(),
+        privilege,
+        Optional.ofNullable(resourceSpec),
+        subResources,
+        actorContext.getActorPoliciesByPrivilege(),
+        actorContext.getGroupMembership(),
+        actorContext.getDirectRoleMembership(),
+        getSessionActorIdentity(actorContext.getActorUrn()));
   }
 
   /**
@@ -94,7 +209,16 @@ public class AuthorizationContext implements ContextInterface {
    * double) falls back to the standard {@link Authorizer#authorize(AuthorizationRequest)} path,
    * which is behaviourally identical aside from the per-request spec cache.
    */
-  private AuthorizationResult runAuthorize(@Nonnull final AuthorizationRequest request) {
+  private AuthorizationResult runAuthorize(
+      @Nonnull final OperationContext opContext, @Nonnull final AuthorizationRequest request) {
+    if (authorizer instanceof OperationContextAuthorizer) {
+      final AuthorizationResult result =
+          ((OperationContextAuthorizer) authorizer)
+              .authorize(request, sessionResourceSpecCache, opContext);
+      if (result != null) {
+        return result;
+      }
+    }
     if (authorizer instanceof ResourceSpecCachingAuthorizer) {
       final AuthorizationResult result =
           ((ResourceSpecCachingAuthorizer) authorizer).authorize(request, sessionResourceSpecCache);

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContext.java
@@ -20,7 +20,6 @@ import com.linkedin.metadata.query.SearchFlags;
 import com.linkedin.metadata.utils.AuditStampUtils;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.mxe.SystemMetadata;
-import com.linkedin.policy.DataHubPolicyInfo;
 import io.datahubproject.metadata.exception.ActorAccessException;
 import io.datahubproject.metadata.exception.OperationContextException;
 import io.datahubproject.metadata.exception.TraceException;
@@ -421,7 +420,7 @@ public class OperationContext implements AuthorizationSession, OperationFingerpr
   @Override
   public AuthorizationResult authorize(
       @Nonnull String privilege, @Nullable EntitySpec resourceSpec) {
-    return authorizationContext.authorize(getSessionActorContext(), privilege, resourceSpec);
+    return authorizationContext.authorize(this, getSessionActorContext(), privilege, resourceSpec);
   }
 
   public AuthorizationResult authorize(
@@ -429,7 +428,7 @@ public class OperationContext implements AuthorizationSession, OperationFingerpr
       @Nullable EntitySpec resourceSpec,
       @Nonnull Collection<EntitySpec> subResources) {
     return authorizationContext.authorize(
-        getSessionActorContext(), privilege, resourceSpec, subResources);
+        this, getSessionActorContext(), privilege, resourceSpec, subResources);
   }
 
   @Nullable
@@ -688,24 +687,26 @@ public class OperationContext implements AuthorizationSession, OperationFingerpr
         @Nonnull Authentication sessionAuthentication,
         boolean skipCache,
         boolean enforceExistenceEnabled) {
-      final Urn actorUrn = UrnUtils.getUrn(sessionAuthentication.getActor().toUrnStr());
-      final Set<DataHubPolicyInfo> policyInfoSet =
-          this.authorizationContext.getAuthorizer().getActorPolicies(actorUrn);
-      final ActorContext sessionActor =
+      final Authentication systemAuthentication = systemAuthenticationOrNull();
+      final ActorContext provisionalActor =
           ActorContext.builder()
               .authentication(sessionAuthentication)
-              .systemAuth(
-                  this.systemActorContext != null
-                      && this.systemActorContext
-                          .getAuthentication()
-                          .getActor()
-                          .equals(sessionAuthentication.getActor()))
-              .policyInfoSet(policyInfoSet)
-              .actorPoliciesByPrivilege(ActorContext.indexPoliciesByPrivilege(policyInfoSet))
-              .groupMembership(this.authorizationContext.getAuthorizer().getActorGroups(actorUrn))
+              .systemAuth(ActorContext.isSystemSession(sessionAuthentication, systemAuthentication))
               .enforceExistenceEnabled(enforceExistenceEnabled)
               .build();
+      final OperationContext provisionalContext = build(provisionalActor, skipCache);
+      final ActorContext sessionActor =
+          this.authorizationContext.buildSessionActor(
+              provisionalContext,
+              sessionAuthentication,
+              systemAuthentication,
+              enforceExistenceEnabled);
       return build(sessionActor, skipCache);
+    }
+
+    @Nullable
+    private Authentication systemAuthenticationOrNull() {
+      return this.systemActorContext != null ? this.systemActorContext.getAuthentication() : null;
     }
 
     @Nonnull

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContextAuthorizer.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContextAuthorizer.java
@@ -1,0 +1,41 @@
+package io.datahubproject.metadata.context;
+
+import com.datahub.authorization.AuthorizationRequest;
+import com.datahub.authorization.AuthorizationResult;
+import com.datahub.authorization.EntitySpec;
+import com.datahub.authorization.ResolvedEntitySpec;
+import com.datahub.authorization.SessionActorIdentity;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.policy.DataHubPolicyInfo;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Extension of {@link com.datahub.plugins.auth.authorization.Authorizer} for implementations that
+ * require the session {@link OperationContext} when authorizing a user request. Storage reads
+ * during user authorization must use the session context, not the system context.
+ */
+public interface OperationContextAuthorizer {
+
+  @Nonnull
+  AuthorizationResult authorize(
+      @Nonnull AuthorizationRequest request,
+      @Nullable Map<EntitySpec, ResolvedEntitySpec> resourceSpecCache,
+      @Nonnull OperationContext opContext);
+
+  @Nonnull
+  Optional<SessionActorIdentity> resolveSessionActorIdentity(
+      @Nonnull Urn actorUrn, @Nonnull OperationContext opContext);
+
+  @Nonnull
+  Set<DataHubPolicyInfo> getActorPolicies(
+      @Nonnull Urn actorUrn,
+      @Nullable SessionActorIdentity sessionActorIdentity,
+      @Nullable Collection<Urn> preloadedGroups,
+      @Nullable Set<Urn> preloadedDirectRoles,
+      @Nonnull OperationContext opContext);
+}

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/ServicesRegistryContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/ServicesRegistryContext.java
@@ -1,8 +1,15 @@
 package io.datahubproject.metadata.context;
 
+import com.datahub.authorization.SessionActorIdentity;
+import com.linkedin.common.urn.Urn;
 import io.datahubproject.metadata.services.RestrictedService;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,6 +18,34 @@ import lombok.Getter;
 public class ServicesRegistryContext implements ContextInterface {
 
   @Nonnull private final RestrictedService restrictedService;
+
+  @Nullable private final ActorGroupMembershipService actorGroupMembershipService;
+
+  @Nonnull
+  public SessionActorIdentity fetchUserIdentity(
+      @Nonnull OperationContext opContext, @Nonnull Urn userUrn) {
+    if (actorGroupMembershipService == null) {
+      return SessionActorIdentity.empty(userUrn);
+    }
+    return actorGroupMembershipService.fetchUserIdentity(opContext, userUrn);
+  }
+
+  @Nonnull
+  public List<Urn> getGroupsForUser(@Nonnull OperationContext opContext, @Nonnull Urn userUrn) {
+    if (actorGroupMembershipService == null) {
+      return Collections.emptyList();
+    }
+    return actorGroupMembershipService.getGroupsForUser(opContext, userUrn);
+  }
+
+  @Nonnull
+  public Set<Urn> fetchRolesViaGroups(
+      @Nonnull OperationContext opContext, @Nonnull Collection<Urn> groupUrns) {
+    if (actorGroupMembershipService == null) {
+      return Collections.emptySet();
+    }
+    return actorGroupMembershipService.fetchRolesViaGroups(opContext, groupUrns);
+  }
 
   @Override
   public Optional<Integer> getCacheKeyComponent() {

--- a/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/ActorContextTest.java
+++ b/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/ActorContextTest.java
@@ -104,43 +104,54 @@ public class ActorContextTest {
     Authentication userAuth = new Authentication(new Actor(ActorType.USER, "USER"), "");
 
     assertEquals(
-        ActorContext.asSessionRestricted(userAuth, Set.of(), Set.of(), true).getCacheKeyComponent(),
-        ActorContext.asSessionRestricted(userAuth, Set.of(), Set.of(), true).getCacheKeyComponent(),
+        ActorContext.asSessionRestricted(userAuth, Set.of(), Set.of(), Set.of(), true)
+            .getCacheKeyComponent(),
+        ActorContext.asSessionRestricted(userAuth, Set.of(), Set.of(), Set.of(), true)
+            .getCacheKeyComponent(),
         "Expected equality across instances");
 
     assertEquals(
-        ActorContext.asSessionRestricted(userAuth, Set.of(), Set.of(), true).getCacheKeyComponent(),
+        ActorContext.asSessionRestricted(userAuth, Set.of(), Set.of(), Set.of(), true)
+            .getCacheKeyComponent(),
         ActorContext.asSessionRestricted(
-                userAuth, Set.of(), Set.of(UrnUtils.getUrn("urn:li:corpGroup:group1")), true)
+                userAuth,
+                Set.of(),
+                Set.of(UrnUtils.getUrn("urn:li:corpGroup:group1")),
+                Set.of(),
+                true)
             .getCacheKeyComponent(),
         "Expected no impact to cache context from group membership");
 
     assertEquals(
-        ActorContext.asSessionRestricted(userAuth, Set.of(POLICY_ABC, POLICY_D), Set.of(), true)
+        ActorContext.asSessionRestricted(
+                userAuth, Set.of(POLICY_ABC, POLICY_D), Set.of(), Set.of(), true)
             .getCacheKeyComponent(),
-        ActorContext.asSessionRestricted(userAuth, Set.of(POLICY_ABC, POLICY_D), Set.of(), true)
+        ActorContext.asSessionRestricted(
+                userAuth, Set.of(POLICY_ABC, POLICY_D), Set.of(), Set.of(), true)
             .getCacheKeyComponent(),
         "Expected equality when non-ownership policies are identical");
 
     assertNotEquals(
         ActorContext.asSessionRestricted(
-                userAuth, Set.of(POLICY_ABC_RESOURCE, POLICY_D), Set.of(), true)
+                userAuth, Set.of(POLICY_ABC_RESOURCE, POLICY_D), Set.of(), Set.of(), true)
             .getCacheKeyComponent(),
-        ActorContext.asSessionRestricted(userAuth, Set.of(POLICY_ABC, POLICY_D), Set.of(), true)
+        ActorContext.asSessionRestricted(
+                userAuth, Set.of(POLICY_ABC, POLICY_D), Set.of(), Set.of(), true)
             .getCacheKeyComponent(),
         "Expected differences with non-identical resource policy");
 
     assertNotEquals(
-        ActorContext.asSessionRestricted(userAuth, Set.of(POLICY_D_OWNER), Set.of(), true)
+        ActorContext.asSessionRestricted(userAuth, Set.of(POLICY_D_OWNER), Set.of(), Set.of(), true)
             .getCacheKeyComponent(),
-        ActorContext.asSessionRestricted(userAuth, Set.of(POLICY_D), Set.of(), true)
+        ActorContext.asSessionRestricted(userAuth, Set.of(POLICY_D), Set.of(), Set.of(), true)
             .getCacheKeyComponent(),
         "Expected differences with ownership policy");
 
     assertNotEquals(
-        ActorContext.asSessionRestricted(userAuth, Set.of(POLICY_D_OWNER_TYPE), Set.of(), true)
+        ActorContext.asSessionRestricted(
+                userAuth, Set.of(POLICY_D_OWNER_TYPE), Set.of(), Set.of(), true)
             .getCacheKeyComponent(),
-        ActorContext.asSessionRestricted(userAuth, Set.of(POLICY_D), Set.of(), true)
+        ActorContext.asSessionRestricted(userAuth, Set.of(POLICY_D), Set.of(), Set.of(), true)
             .getCacheKeyComponent(),
         "Expected differences with ownership type policy");
   }
@@ -173,10 +184,22 @@ public class ActorContextTest {
   }
 
   @Test
+  public void isSystemSessionMatchesSystemAuthentication() {
+    Authentication systemAuth =
+        new Authentication(new Actor(ActorType.USER, "__datahub_system"), "");
+    Authentication userAuth = new Authentication(new Actor(ActorType.USER, "user"), "");
+
+    assertTrue(ActorContext.isSystemSession(systemAuth, systemAuth));
+    assertFalse(ActorContext.isSystemSession(userAuth, systemAuth));
+    assertFalse(ActorContext.isSystemSession(userAuth, null));
+  }
+
+  @Test
   public void isActiveSkipsLookupForSystemActor() {
     Authentication systemAuth =
         new Authentication(new Actor(ActorType.USER, "__datahub_system"), "");
-    ActorContext ctx = ActorContext.asSessionRestricted(systemAuth, Set.of(), List.of(), true);
+    ActorContext ctx =
+        ActorContext.asSessionRestricted(systemAuth, Set.of(), List.of(), Set.of(), true);
     AspectRetriever retriever = mock(AspectRetriever.class);
     assertTrue(ctx.isActive(mock(OperationContext.class), retriever));
     verifyNoInteractions(retriever);
@@ -186,7 +209,8 @@ public class ActorContextTest {
   public void isActiveFalseWhenEnforcingExistenceAndCorpUserKeyMissing() {
     Urn userUrn = UrnUtils.getUrn("urn:li:corpuser:nobody");
     Authentication userAuth = new Authentication(new Actor(ActorType.USER, "nobody"), "");
-    ActorContext ctx = ActorContext.asSessionRestricted(userAuth, Set.of(), List.of(), true);
+    ActorContext ctx =
+        ActorContext.asSessionRestricted(userAuth, Set.of(), List.of(), Set.of(), true);
     AspectRetriever retriever = mock(AspectRetriever.class);
     when(retriever.getLatestAspectObjects(any(OperationFingerprint.class), any(), any()))
         .thenReturn(
@@ -198,7 +222,8 @@ public class ActorContextTest {
   public void isActiveTrueWhenNotEnforcingExistenceAndCorpUserKeyMissing() {
     Urn userUrn = UrnUtils.getUrn("urn:li:corpuser:nobody");
     Authentication userAuth = new Authentication(new Actor(ActorType.USER, "nobody"), "");
-    ActorContext ctx = ActorContext.asSessionRestricted(userAuth, Set.of(), List.of(), false);
+    ActorContext ctx =
+        ActorContext.asSessionRestricted(userAuth, Set.of(), List.of(), Set.of(), false);
     AspectRetriever retriever = mock(AspectRetriever.class);
     when(retriever.getLatestAspectObjects(any(OperationFingerprint.class), any(), any()))
         .thenReturn(Map.of(userUrn, Map.of()));
@@ -209,7 +234,8 @@ public class ActorContextTest {
   public void isActiveTrueWithCorpUserKeyAndNoFlags() {
     Urn userUrn = UrnUtils.getUrn("urn:li:corpuser:activeone");
     Authentication userAuth = new Authentication(new Actor(ActorType.USER, "activeone"), "");
-    ActorContext ctx = ActorContext.asSessionRestricted(userAuth, Set.of(), List.of(), true);
+    ActorContext ctx =
+        ActorContext.asSessionRestricted(userAuth, Set.of(), List.of(), Set.of(), true);
     CorpUserKey key = new CorpUserKey().setUsername("activeone");
     AspectRetriever retriever = mock(AspectRetriever.class);
     when(retriever.getLatestAspectObjects(any(OperationFingerprint.class), any(), any()))
@@ -228,7 +254,8 @@ public class ActorContextTest {
   public void isActiveFalseWhenCorpUserSuspended() {
     Urn userUrn = UrnUtils.getUrn("urn:li:corpuser:suspended");
     Authentication userAuth = new Authentication(new Actor(ActorType.USER, "suspended"), "");
-    ActorContext ctx = ActorContext.asSessionRestricted(userAuth, Set.of(), List.of(), true);
+    ActorContext ctx =
+        ActorContext.asSessionRestricted(userAuth, Set.of(), List.of(), Set.of(), true);
     CorpUserKey key = new CorpUserKey().setUsername("suspended");
     CorpUserStatus suspended = new CorpUserStatus().setStatus(CORP_USER_STATUS_SUSPENDED);
     AspectRetriever retriever = mock(AspectRetriever.class);

--- a/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/AuthorizationContextTest.java
+++ b/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/AuthorizationContextTest.java
@@ -1,11 +1,16 @@
 package io.datahubproject.metadata.context;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import com.datahub.authentication.Actor;
 import com.datahub.authentication.ActorType;
@@ -13,18 +18,24 @@ import com.datahub.authentication.Authentication;
 import com.datahub.authorization.AuthorizationRequest;
 import com.datahub.authorization.AuthorizationResult;
 import com.datahub.authorization.EntitySpec;
+import com.datahub.authorization.SessionActorIdentity;
 import com.datahub.plugins.auth.authorization.Authorizer;
 import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.policy.DataHubActorFilter;
 import com.linkedin.policy.DataHubPolicyInfo;
+import io.datahubproject.metadata.services.RestrictedService;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.Test;
 
@@ -55,8 +66,9 @@ public class AuthorizationContextTest {
     AuthorizationContext authorizationContext =
         AuthorizationContext.builder().authorizer(authorizer).build();
     EntitySpec resource = new EntitySpec("dataset", "urn:li:dataset:test");
+    OperationContext opContext = TestOperationContexts.systemContextNoValidate();
 
-    authorizationContext.authorize(actorContext, "VIEW", resource);
+    authorizationContext.authorize(opContext, actorContext, "VIEW", resource);
 
     AuthorizationRequest request = captor.getValue();
     assertEquals(request.getActorPoliciesByPrivilege(), actorPoliciesByPrivilege);
@@ -82,13 +94,283 @@ public class AuthorizationContextTest {
         AuthorizationContext.builder().authorizer(authorizer).build();
     EntitySpec resource = new EntitySpec("dataset", "urn:li:dataset:test");
     EntitySpec subResource = new EntitySpec("tag", "urn:li:tag:test");
+    OperationContext opContext = TestOperationContexts.systemContextNoValidate();
 
-    authorizationContext.authorize(actorContext, "EDIT", resource, List.of(subResource));
+    authorizationContext.authorize(opContext, actorContext, "EDIT", resource, List.of(subResource));
 
     AuthorizationRequest request = captor.getValue();
     assertEquals(request.getActorPoliciesByPrivilege(), actorPoliciesByPrivilege);
     assertEquals(request.getSubResources(), List.of(subResource));
     verify(authorizer, times(1)).authorize(any());
+  }
+
+  @Test
+  public void authorizeUsesOperationContextAuthorizerWhenThreeArgReturnsResult() {
+    Authorizer authorizer =
+        mock(Authorizer.class, withSettings().extraInterfaces(OperationContextAuthorizer.class));
+    OperationContextAuthorizer operationContextAuthorizer = (OperationContextAuthorizer) authorizer;
+    when(operationContextAuthorizer.authorize(any(), any(), any()))
+        .thenAnswer(
+            invocation ->
+                new AuthorizationResult(
+                    invocation.getArgument(0), AuthorizationResult.Type.ALLOW, null));
+
+    Map<String, List<RecordTemplate>> actorPoliciesByPrivilege =
+        ActorContext.indexPoliciesByPrivilege(Set.of(POLICY));
+    ActorContext actorContext = sessionActor(actorPoliciesByPrivilege);
+    AuthorizationContext authorizationContext =
+        AuthorizationContext.builder().authorizer(authorizer).build();
+    OperationContext opContext = TestOperationContexts.systemContextNoValidate();
+
+    AuthorizationResult result =
+        authorizationContext.authorize(
+            opContext, actorContext, "VIEW", new EntitySpec("dataset", "urn:li:dataset:test"));
+
+    assertEquals(result.getType(), AuthorizationResult.Type.ALLOW);
+    verify(operationContextAuthorizer, times(1)).authorize(any(), any(), any());
+    verify(authorizer, never()).authorize(any(AuthorizationRequest.class));
+  }
+
+  private static final Urn ACTOR_URN = UrnUtils.getUrn("urn:li:corpuser:testuser");
+  private static final Urn GROUP_URN = UrnUtils.getUrn("urn:li:corpGroup:test");
+  private static final Urn DIRECT_ROLE = UrnUtils.getUrn("urn:li:dataHubRole:Editor");
+  private static final Urn INHERITED_ROLE = UrnUtils.getUrn("urn:li:dataHubRole:Admin");
+
+  @Test
+  public void getOrResolveSessionActorIdentity_cachesResult() {
+    AuthorizationContext authorizationContext =
+        AuthorizationContext.builder().authorizer(Authorizer.EMPTY).build();
+    AtomicInteger fetchCount = new AtomicInteger();
+    SessionActorIdentity identity =
+        new SessionActorIdentity(ACTOR_URN, List.of(GROUP_URN), Set.of(DIRECT_ROLE));
+
+    SessionActorIdentity first =
+        authorizationContext.getOrResolveSessionActorIdentity(
+            ACTOR_URN, () -> identityForFetch(fetchCount, identity));
+    SessionActorIdentity second =
+        authorizationContext.getOrResolveSessionActorIdentity(
+            ACTOR_URN, () -> identityForFetch(fetchCount, identity));
+
+    assertEquals(first, identity);
+    assertEquals(second, identity);
+    assertEquals(fetchCount.get(), 1);
+  }
+
+  @Test
+  public void getSessionActorIdentity_returnsNullWhenNotCached() {
+    AuthorizationContext authorizationContext =
+        AuthorizationContext.builder().authorizer(Authorizer.EMPTY).build();
+
+    assertNull(authorizationContext.getSessionActorIdentity(ACTOR_URN));
+  }
+
+  @Test
+  public void buildSessionActor_resolvesIdentityAndPoliciesViaOperationContextAuthorizer() {
+    Authorizer authorizer =
+        mock(Authorizer.class, withSettings().extraInterfaces(OperationContextAuthorizer.class));
+    OperationContextAuthorizer operationContextAuthorizer = (OperationContextAuthorizer) authorizer;
+    SessionActorIdentity identity =
+        new SessionActorIdentity(ACTOR_URN, List.of(GROUP_URN), Set.of(DIRECT_ROLE));
+    OperationContext opContext = TestOperationContexts.systemContextNoValidate();
+    when(operationContextAuthorizer.resolveSessionActorIdentity(ACTOR_URN, opContext))
+        .thenReturn(Optional.of(identity));
+    when(operationContextAuthorizer.getActorPolicies(
+            eq(ACTOR_URN),
+            eq(identity),
+            eq(identity.getGroups()),
+            eq(identity.getDirectRoles()),
+            eq(opContext)))
+        .thenReturn(Set.of(POLICY));
+
+    AuthorizationContext authorizationContext =
+        AuthorizationContext.builder().authorizer(authorizer).build();
+    Authentication authentication = new Authentication(new Actor(ActorType.USER, "testuser"), "");
+
+    ActorContext actorContext =
+        authorizationContext.buildSessionActor(opContext, authentication, null, false);
+
+    assertEquals(actorContext.getGroupMembership(), List.of(GROUP_URN));
+    assertEquals(actorContext.getDirectRoleMembership(), Set.of(DIRECT_ROLE));
+    assertEquals(actorContext.getPolicyInfoSet(), Set.of(POLICY));
+    assertEquals(authorizationContext.getSessionActorIdentity(ACTOR_URN), identity);
+  }
+
+  @Test
+  public void buildSessionActor_usesEmptyIdentityWhenAuthorizerReturnsEmpty() {
+    Authorizer authorizer = mock(Authorizer.class);
+    OperationContext opContext = TestOperationContexts.systemContextNoValidate();
+    when(authorizer.resolveSessionActorIdentity(ACTOR_URN)).thenReturn(Optional.empty());
+    when(authorizer.getActorPolicies(ACTOR_URN, List.of(), Set.of())).thenReturn(Set.of());
+
+    AuthorizationContext authorizationContext =
+        AuthorizationContext.builder().authorizer(authorizer).build();
+    Authentication authentication = new Authentication(new Actor(ActorType.USER, "testuser"), "");
+
+    ActorContext actorContext =
+        authorizationContext.buildSessionActor(opContext, authentication, null, false);
+
+    assertTrue(actorContext.getGroupMembership().isEmpty());
+    assertTrue(actorContext.getDirectRoleMembership().isEmpty());
+    verify(authorizer).resolveSessionActorIdentity(ACTOR_URN);
+  }
+
+  @Test
+  public void resolveSessionActorIdentity_usesPlainAuthorizerWhenNotOperationContextAuthorizer() {
+    Authorizer authorizer = mock(Authorizer.class);
+    SessionActorIdentity identity = SessionActorIdentity.empty(ACTOR_URN);
+    OperationContext opContext = TestOperationContexts.systemContextNoValidate();
+    when(authorizer.resolveSessionActorIdentity(ACTOR_URN)).thenReturn(Optional.of(identity));
+
+    AuthorizationContext authorizationContext =
+        AuthorizationContext.builder().authorizer(authorizer).build();
+
+    assertEquals(
+        authorizationContext.resolveSessionActorIdentity(opContext, ACTOR_URN),
+        Optional.of(identity));
+    verify(authorizer).resolveSessionActorIdentity(ACTOR_URN);
+  }
+
+  @Test
+  public void resolveActorPolicies_usesPlainAuthorizerWhenNotOperationContextAuthorizer() {
+    Authorizer authorizer = mock(Authorizer.class);
+    SessionActorIdentity identity =
+        new SessionActorIdentity(ACTOR_URN, List.of(GROUP_URN), Set.of(DIRECT_ROLE));
+    OperationContext opContext = TestOperationContexts.systemContextNoValidate();
+    when(authorizer.getActorPolicies(ACTOR_URN, identity.getGroups(), identity.getDirectRoles()))
+        .thenReturn(Set.of(POLICY));
+
+    AuthorizationContext authorizationContext =
+        AuthorizationContext.builder().authorizer(authorizer).build();
+
+    assertEquals(
+        authorizationContext.resolveActorPolicies(opContext, ACTOR_URN, identity), Set.of(POLICY));
+  }
+
+  @Test
+  public void resolveSessionActorRoles_resolvesInheritedRolesFromServicesRegistry() {
+    ActorGroupMembershipService membershipService = mock(ActorGroupMembershipService.class);
+    SessionActorIdentity identity =
+        new SessionActorIdentity(ACTOR_URN, List.of(GROUP_URN), Set.of(DIRECT_ROLE));
+    OperationContext opContext =
+        TestOperationContexts.systemContext(
+            null,
+            null,
+            () ->
+                ServicesRegistryContext.builder()
+                    .restrictedService(mock(RestrictedService.class))
+                    .actorGroupMembershipService(membershipService)
+                    .build(),
+            null,
+            null,
+            null,
+            null,
+            () -> ValidationContext.builder().alternateValidation(true).build());
+    when(membershipService.fetchRolesViaGroups(opContext, List.of(GROUP_URN)))
+        .thenReturn(Set.of(INHERITED_ROLE));
+
+    AuthorizationContext authorizationContext =
+        AuthorizationContext.builder().authorizer(Authorizer.EMPTY).build();
+    authorizationContext.getOrResolveSessionActorIdentity(ACTOR_URN, () -> identity);
+    ActorContext actorContext =
+        ActorContext.builder()
+            .authentication(new Authentication(new Actor(ActorType.USER, "testuser"), ""))
+            .groupMembership(identity.getGroups())
+            .directRoleMembership(identity.getDirectRoles())
+            .build();
+
+    assertEquals(
+        authorizationContext.resolveSessionActorRoles(opContext, actorContext),
+        Set.of(DIRECT_ROLE, INHERITED_ROLE));
+    verify(membershipService).fetchRolesViaGroups(opContext, List.of(GROUP_URN));
+  }
+
+  @Test
+  public void resolveSessionActorRoles_fallsBackToDirectRolesWhenIdentityNotCached() {
+    AuthorizationContext authorizationContext =
+        AuthorizationContext.builder().authorizer(Authorizer.EMPTY).build();
+    ActorContext actorContext =
+        ActorContext.builder()
+            .authentication(new Authentication(new Actor(ActorType.USER, "testuser"), ""))
+            .directRoleMembership(Set.of(DIRECT_ROLE))
+            .build();
+
+    assertEquals(
+        authorizationContext.resolveSessionActorRoles(
+            TestOperationContexts.systemContextNoValidate(), actorContext),
+        Set.of(DIRECT_ROLE));
+  }
+
+  @Test
+  public void authorizeIncludesSessionActorIdentityWhenCached() {
+    Authorizer authorizer = mock(Authorizer.class);
+    ArgumentCaptor<AuthorizationRequest> captor =
+        ArgumentCaptor.forClass(AuthorizationRequest.class);
+    when(authorizer.authorize(captor.capture()))
+        .thenAnswer(
+            invocation ->
+                new AuthorizationResult(
+                    invocation.getArgument(0), AuthorizationResult.Type.DENY, null));
+
+    SessionActorIdentity identity =
+        new SessionActorIdentity(ACTOR_URN, List.of(GROUP_URN), Set.of(DIRECT_ROLE));
+    AuthorizationContext authorizationContext =
+        AuthorizationContext.builder().authorizer(authorizer).build();
+    authorizationContext.getOrResolveSessionActorIdentity(ACTOR_URN, () -> identity);
+
+    Map<String, List<RecordTemplate>> actorPoliciesByPrivilege =
+        ActorContext.indexPoliciesByPrivilege(Set.of(POLICY));
+    ActorContext actorContext =
+        ActorContext.builder()
+            .authentication(new Authentication(new Actor(ActorType.USER, "testuser"), ""))
+            .policyInfoSet(Set.of(POLICY))
+            .actorPoliciesByPrivilege(actorPoliciesByPrivilege)
+            .groupMembership(identity.getGroups())
+            .directRoleMembership(identity.getDirectRoles())
+            .build();
+
+    authorizationContext.authorize(
+        TestOperationContexts.systemContextNoValidate(),
+        actorContext,
+        "VIEW",
+        new EntitySpec("dataset", "urn:li:dataset:test"));
+
+    assertEquals(captor.getValue().getSessionActorIdentity(), identity);
+    assertEquals(captor.getValue().getActorGroupMembership(), List.of(GROUP_URN));
+    assertEquals(captor.getValue().getActorDirectRoles(), Set.of(DIRECT_ROLE));
+  }
+
+  @Test
+  public void authorizeFallsBackToOneArgWhenOperationContextAuthorizerReturnsNull() {
+    Authorizer authorizer =
+        mock(Authorizer.class, withSettings().extraInterfaces(OperationContextAuthorizer.class));
+    OperationContextAuthorizer operationContextAuthorizer = (OperationContextAuthorizer) authorizer;
+    when(operationContextAuthorizer.authorize(any(), any(), any())).thenReturn(null);
+    when(authorizer.authorize(any()))
+        .thenAnswer(
+            invocation ->
+                new AuthorizationResult(
+                    invocation.getArgument(0), AuthorizationResult.Type.ALLOW, null));
+
+    Map<String, List<RecordTemplate>> actorPoliciesByPrivilege =
+        ActorContext.indexPoliciesByPrivilege(Set.of(POLICY));
+    ActorContext actorContext = sessionActor(actorPoliciesByPrivilege);
+    AuthorizationContext authorizationContext =
+        AuthorizationContext.builder().authorizer(authorizer).build();
+    OperationContext opContext = TestOperationContexts.systemContextNoValidate();
+
+    AuthorizationResult result =
+        authorizationContext.authorize(
+            opContext, actorContext, "VIEW", new EntitySpec("dataset", "urn:li:dataset:test"));
+
+    assertEquals(result.getType(), AuthorizationResult.Type.ALLOW);
+    verify(operationContextAuthorizer, times(1)).authorize(any(), any(), any());
+    verify(authorizer, times(1)).authorize(any(AuthorizationRequest.class));
+  }
+
+  private static SessionActorIdentity identityForFetch(
+      AtomicInteger fetchCount, SessionActorIdentity identity) {
+    fetchCount.incrementAndGet();
+    return identity;
   }
 
   private static ActorContext sessionActor(

--- a/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/OperationContextTest.java
+++ b/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/OperationContextTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -16,6 +17,7 @@ import static org.testng.Assert.assertTrue;
 import com.datahub.authentication.Actor;
 import com.datahub.authentication.ActorType;
 import com.datahub.authentication.Authentication;
+import com.datahub.authorization.SessionActorIdentity;
 import com.datahub.plugins.auth.authorization.Authorizer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.common.urn.Urn;
@@ -24,11 +26,14 @@ import com.linkedin.metadata.aspect.AspectRetriever;
 import com.linkedin.metadata.aspect.CachingAspectRetriever;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.mxe.SystemMetadata;
+import io.datahubproject.metadata.exception.ActorAccessException;
+import io.datahubproject.metadata.services.RestrictedService;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.testng.annotations.BeforeMethod;
@@ -276,8 +281,12 @@ public class OperationContextTest {
 
     // Setup Actor URN and mock Authorizer responses
     Urn actorUrn = UrnUtils.getUrn(actor.toUrnStr());
-    when(mockAuthorizer.getActorPolicies(eq(actorUrn))).thenReturn(Collections.emptySet());
-    when(mockAuthorizer.getActorGroups(eq(actorUrn))).thenReturn(Collections.emptySet());
+    SessionActorIdentity identity = SessionActorIdentity.empty(actorUrn);
+    when(mockAuthorizer.resolveSessionActorIdentity(eq(actorUrn)))
+        .thenReturn(Optional.of(identity));
+    when(mockAuthorizer.getActorPolicies(
+            eq(actorUrn), eq(identity.getGroups()), eq(identity.getDirectRoles())))
+        .thenReturn(Collections.emptySet());
 
     // Mock ActorContext isActive
     ActorContext mockActorContext = mock(ActorContext.class);
@@ -302,6 +311,91 @@ public class OperationContextTest {
     // Assert
     assertEquals(actualAspectNames, expectedAspectNames);
     verify(mockEntityRegistryContext).getEntityAspectNames(entityType);
+  }
+
+  @Test
+  public void testSessionBuildResolvesActorIdentityOnce() {
+    Authentication userAuth = new Authentication(new Actor(ActorType.USER, "USER"), "");
+    Urn actorUrn = UrnUtils.getUrn(userAuth.getActor().toUrnStr());
+    Urn groupUrn = UrnUtils.getUrn("urn:li:corpGroup:test");
+    SessionActorIdentity identity = new SessionActorIdentity(actorUrn, List.of(groupUrn), Set.of());
+
+    Authorizer mockAuthorizer = mock(Authorizer.class);
+    when(mockAuthorizer.resolveSessionActorIdentity(actorUrn)).thenReturn(Optional.of(identity));
+    when(mockAuthorizer.getActorPolicies(
+            eq(actorUrn), eq(identity.getGroups()), eq(identity.getDirectRoles())))
+        .thenReturn(Collections.emptySet());
+
+    OperationContext systemOpContext =
+        OperationContext.asSystem(
+            OperationContextConfig.builder().build(),
+            new Authentication(new Actor(ActorType.USER, "SYSTEM"), ""),
+            mock(EntityRegistry.class),
+            mock(ServicesRegistryContext.class),
+            null,
+            TestOperationContexts.emptyActiveUsersRetrieverContext(null),
+            mock(ValidationContext.class),
+            null,
+            false);
+
+    systemOpContext.asSession(RequestContext.TEST, mockAuthorizer, userAuth);
+
+    verify(mockAuthorizer).resolveSessionActorIdentity(actorUrn);
+    verify(mockAuthorizer)
+        .getActorPolicies(actorUrn, identity.getGroups(), identity.getDirectRoles());
+    verifyNoMoreInteractions(mockAuthorizer);
+  }
+
+  @Test
+  public void testSkipCacheStillCachesIdentityForLazyRoleResolution() {
+    Authentication userAuth = new Authentication(new Actor(ActorType.USER, "USER"), "");
+    Urn actorUrn = UrnUtils.getUrn(userAuth.getActor().toUrnStr());
+    Urn groupUrn = UrnUtils.getUrn("urn:li:corpGroup:test");
+    Urn inheritedRole = UrnUtils.getUrn("urn:li:dataHubRole:Admin");
+    SessionActorIdentity identity = new SessionActorIdentity(actorUrn, List.of(groupUrn), Set.of());
+
+    Authorizer mockAuthorizer = mock(Authorizer.class);
+    when(mockAuthorizer.resolveSessionActorIdentity(actorUrn)).thenReturn(Optional.of(identity));
+    when(mockAuthorizer.getActorPolicies(
+            eq(actorUrn), eq(identity.getGroups()), eq(identity.getDirectRoles())))
+        .thenReturn(Collections.emptySet());
+
+    ActorGroupMembershipService membershipService = mock(ActorGroupMembershipService.class);
+    when(membershipService.fetchRolesViaGroups(any(OperationContext.class), eq(List.of(groupUrn))))
+        .thenReturn(Set.of(inheritedRole));
+
+    OperationContext systemOpContext =
+        OperationContext.asSystem(
+            OperationContextConfig.builder().build(),
+            new Authentication(new Actor(ActorType.USER, "SYSTEM"), ""),
+            mock(EntityRegistry.class),
+            ServicesRegistryContext.builder()
+                .restrictedService(mock(RestrictedService.class))
+                .actorGroupMembershipService(membershipService)
+                .build(),
+            null,
+            TestOperationContexts.emptyActiveUsersRetrieverContext(null),
+            mock(ValidationContext.class),
+            null,
+            false);
+
+    OperationContext sessionContext;
+    try {
+      sessionContext =
+          OperationContext.asSession(
+              systemOpContext, RequestContext.TEST, mockAuthorizer, userAuth, true, true);
+    } catch (ActorAccessException e) {
+      throw new RuntimeException(e);
+    }
+
+    assertEquals(sessionContext.getSessionActorContext().getGroupMembership(), List.of(groupUrn));
+    assertEquals(
+        sessionContext
+            .getAuthorizationContext()
+            .resolveSessionActorRoles(sessionContext, sessionContext.getSessionActorContext()),
+        Set.of(inheritedRole));
+    verify(membershipService, times(1))
+        .fetchRolesViaGroups(any(OperationContext.class), eq(List.of(groupUrn)));
   }
 
   @Test

--- a/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/ServicesRegistryContextTest.java
+++ b/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/ServicesRegistryContextTest.java
@@ -1,0 +1,109 @@
+package io.datahubproject.metadata.context;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.datahub.authorization.SessionActorIdentity;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import io.datahubproject.metadata.services.RestrictedService;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.testng.annotations.Test;
+
+public class ServicesRegistryContextTest {
+
+  private static final Urn USER_URN = UrnUtils.getUrn("urn:li:corpuser:testuser");
+  private static final Urn GROUP_URN = UrnUtils.getUrn("urn:li:corpGroup:test");
+  private static final Urn ROLE_URN = UrnUtils.getUrn("urn:li:dataHubRole:Admin");
+
+  @Test
+  public void fetchUserIdentity_returnsEmptyWhenMembershipServiceMissing() {
+    ServicesRegistryContext context =
+        ServicesRegistryContext.builder().restrictedService(mock(RestrictedService.class)).build();
+    OperationContext opContext = TestOperationContexts.systemContextNoValidate();
+
+    SessionActorIdentity identity = context.fetchUserIdentity(opContext, USER_URN);
+
+    assertEquals(identity.getActorUrn(), USER_URN);
+    assertTrue(identity.getGroups().isEmpty());
+    assertTrue(identity.getDirectRoles().isEmpty());
+  }
+
+  @Test
+  public void fetchUserIdentity_delegatesToMembershipService() {
+    ActorGroupMembershipService membershipService = mock(ActorGroupMembershipService.class);
+    SessionActorIdentity identity =
+        new SessionActorIdentity(USER_URN, List.of(GROUP_URN), Set.of());
+    OperationContext opContext = TestOperationContexts.systemContextNoValidate();
+    when(membershipService.fetchUserIdentity(opContext, USER_URN)).thenReturn(identity);
+
+    ServicesRegistryContext context =
+        ServicesRegistryContext.builder()
+            .restrictedService(mock(RestrictedService.class))
+            .actorGroupMembershipService(membershipService)
+            .build();
+
+    assertEquals(context.fetchUserIdentity(opContext, USER_URN), identity);
+    verify(membershipService).fetchUserIdentity(opContext, USER_URN);
+  }
+
+  @Test
+  public void getGroupsForUser_returnsEmptyWhenMembershipServiceMissing() {
+    ServicesRegistryContext context =
+        ServicesRegistryContext.builder().restrictedService(mock(RestrictedService.class)).build();
+
+    assertEquals(
+        context.getGroupsForUser(TestOperationContexts.systemContextNoValidate(), USER_URN),
+        Collections.emptyList());
+  }
+
+  @Test
+  public void getGroupsForUser_delegatesToMembershipService() {
+    ActorGroupMembershipService membershipService = mock(ActorGroupMembershipService.class);
+    OperationContext opContext = TestOperationContexts.systemContextNoValidate();
+    when(membershipService.getGroupsForUser(opContext, USER_URN)).thenReturn(List.of(GROUP_URN));
+
+    ServicesRegistryContext context =
+        ServicesRegistryContext.builder()
+            .restrictedService(mock(RestrictedService.class))
+            .actorGroupMembershipService(membershipService)
+            .build();
+
+    assertEquals(context.getGroupsForUser(opContext, USER_URN), List.of(GROUP_URN));
+  }
+
+  @Test
+  public void fetchRolesViaGroups_returnsEmptyWhenMembershipServiceMissing() {
+    ServicesRegistryContext context =
+        ServicesRegistryContext.builder().restrictedService(mock(RestrictedService.class)).build();
+
+    assertEquals(
+        context.fetchRolesViaGroups(
+            TestOperationContexts.systemContextNoValidate(), List.of(GROUP_URN)),
+        Collections.emptySet());
+  }
+
+  @Test
+  public void fetchRolesViaGroups_delegatesToMembershipService() {
+    ActorGroupMembershipService membershipService = mock(ActorGroupMembershipService.class);
+    OperationContext opContext = TestOperationContexts.systemContextNoValidate();
+    when(membershipService.fetchRolesViaGroups(opContext, List.of(GROUP_URN)))
+        .thenReturn(Set.of(ROLE_URN));
+
+    ServicesRegistryContext context =
+        ServicesRegistryContext.builder()
+            .restrictedService(mock(RestrictedService.class))
+            .actorGroupMembershipService(membershipService)
+            .build();
+
+    assertEquals(context.fetchRolesViaGroups(opContext, List.of(GROUP_URN)), Set.of(ROLE_URN));
+    verify(membershipService).fetchRolesViaGroups(eq(opContext), eq(List.of(GROUP_URN)));
+  }
+}

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/group/GroupService.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/group/GroupService.java
@@ -2,6 +2,7 @@ package com.datahub.authentication.group;
 
 import static com.linkedin.metadata.Constants.*;
 
+import com.datahub.authorization.SessionActorIdentity;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.CorpGroupUrnArray;
@@ -14,11 +15,12 @@ import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.entity.EntityResponse;
-import com.linkedin.entity.client.EntityClient;
+import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.identity.CorpGroupInfo;
 import com.linkedin.identity.GroupMembership;
 import com.linkedin.identity.NativeGroupMembership;
+import com.linkedin.identity.RoleMembership;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.graph.GraphClient;
@@ -28,9 +30,11 @@ import com.linkedin.metadata.utils.EntityKeyUtils;
 import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
+import io.datahubproject.metadata.context.ActorGroupMembershipService;
 import io.datahubproject.metadata.context.OperationContext;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -39,23 +43,138 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
 
-public class GroupService {
-  private final EntityClient _entityClient;
+@Slf4j
+public class GroupService implements ActorGroupMembershipService {
+
+  private static final ImmutableSet<String> USER_MEMBERSHIP_ASPECTS =
+      ImmutableSet.of(
+          GROUP_MEMBERSHIP_ASPECT_NAME,
+          NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME,
+          ROLE_MEMBERSHIP_ASPECT_NAME);
+
+  private final SystemEntityClient _entityClient;
   private final EntityService<?> _entityService;
   private final GraphClient _graphClient;
 
   public GroupService(
-      @Nonnull EntityClient entityClient,
+      @Nonnull SystemEntityClient entityClient,
       @Nonnull EntityService<?> entityService,
       @Nonnull GraphClient graphClient) {
     Objects.requireNonNull(entityClient, "entityClient must not be null!");
     Objects.requireNonNull(entityService, "entityService must not be null!");
-    Objects.requireNonNull(graphClient, "secretService must not be null!");
+    Objects.requireNonNull(graphClient, "graphClient must not be null!");
 
     _entityClient = entityClient;
     _entityService = entityService;
     _graphClient = graphClient;
+  }
+
+  @Override
+  @Nonnull
+  public SessionActorIdentity fetchUserIdentity(
+      @Nonnull final OperationContext opContext, @Nonnull final Urn userUrn) {
+    Objects.requireNonNull(userUrn, "userUrn must not be null");
+    try {
+      final EntityResponse entityResponse =
+          _entityClient
+              .batchGetV2(
+                  opContext, CORP_USER_ENTITY_NAME, Set.of(userUrn), USER_MEMBERSHIP_ASPECTS)
+              .get(userUrn);
+
+      if (entityResponse == null || !entityResponse.hasAspects()) {
+        return SessionActorIdentity.empty(userUrn);
+      }
+
+      final List<Urn> corpGroups = new ArrayList<>();
+      if (entityResponse.getAspects().containsKey(GROUP_MEMBERSHIP_ASPECT_NAME)) {
+        final GroupMembership groupMembership =
+            new GroupMembership(
+                entityResponse.getAspects().get(GROUP_MEMBERSHIP_ASPECT_NAME).getValue().data());
+        if (groupMembership.hasGroups()) {
+          corpGroups.addAll(groupMembership.getGroups());
+        }
+      }
+
+      final List<Urn> nativeGroups = new ArrayList<>();
+      if (entityResponse.getAspects().containsKey(NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME)) {
+        final NativeGroupMembership nativeGroupMembership =
+            new NativeGroupMembership(
+                entityResponse
+                    .getAspects()
+                    .get(NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME)
+                    .getValue()
+                    .data());
+        if (nativeGroupMembership.hasNativeGroups()) {
+          nativeGroups.addAll(nativeGroupMembership.getNativeGroups());
+        }
+      }
+
+      final Set<Urn> directRoles = new HashSet<>();
+      if (entityResponse.getAspects().containsKey(ROLE_MEMBERSHIP_ASPECT_NAME)) {
+        final RoleMembership roleMembership =
+            new RoleMembership(
+                entityResponse.getAspects().get(ROLE_MEMBERSHIP_ASPECT_NAME).getValue().data());
+        if (roleMembership.hasRoles()) {
+          directRoles.addAll(roleMembership.getRoles());
+        }
+      }
+
+      return new SessionActorIdentity(
+          userUrn,
+          SessionActorIdentity.mergeGroupMembership(corpGroups, nativeGroups),
+          directRoles);
+    } catch (Exception e) {
+      log.error("Failed to fetch group membership for urn {}", userUrn, e);
+      return SessionActorIdentity.empty(userUrn);
+    }
+  }
+
+  @Override
+  @Nonnull
+  public List<Urn> getGroupsForUser(
+      @Nonnull OperationContext opContext, @Nonnull final Urn userUrn) {
+    if (userUrn.equals(opContext.getSessionActorContext().getActorUrn())) {
+      return new ArrayList<>(opContext.getSessionActorContext().getGroupMembership());
+    }
+    return new ArrayList<>(fetchUserIdentity(opContext, userUrn).getGroups());
+  }
+
+  @Override
+  @Nonnull
+  public Set<Urn> fetchRolesViaGroups(
+      @Nonnull final OperationContext opContext, @Nonnull final Collection<Urn> groups) {
+    if (groups.isEmpty()) {
+      return Collections.emptySet();
+    }
+    final HashSet<Urn> groupUrns = new HashSet<>(groups);
+    try {
+      final Map<Urn, EntityResponse> responseMap =
+          _entityClient.batchGetV2(
+              opContext,
+              CORP_GROUP_ENTITY_NAME,
+              groupUrns,
+              ImmutableSet.of(ROLE_MEMBERSHIP_ASPECT_NAME));
+
+      return responseMap.keySet().stream()
+          .filter(Objects::nonNull)
+          .filter(key -> responseMap.get(key) != null)
+          .filter(key -> responseMap.get(key).hasAspects())
+          .map(key -> responseMap.get(key).getAspects())
+          .filter(aspectMap -> aspectMap.containsKey(ROLE_MEMBERSHIP_ASPECT_NAME))
+          .map(
+              aspectMap ->
+                  new RoleMembership(aspectMap.get(ROLE_MEMBERSHIP_ASPECT_NAME).getValue().data()))
+          .filter(RoleMembership::hasRoles)
+          .map(RoleMembership::getRoles)
+          .flatMap(List::stream)
+          .collect(Collectors.toSet());
+    } catch (Exception e) {
+      log.error("Failed to fetch {} for urns {}", ROLE_MEMBERSHIP_ASPECT_NAME, groupUrns, e);
+      return Collections.emptySet();
+    }
   }
 
   public boolean groupExists(@Nonnull OperationContext opContext, @Nonnull Urn groupUrn) {
@@ -81,9 +200,8 @@ public class GroupService {
     }
 
     try {
-      // First, fetch user's group membership aspect.
       NativeGroupMembership nativeGroupMembership =
-          getExistingNativeGroupMembership(opContext, userUrn);
+          loadNativeGroupMembershipForUpdate(opContext, userUrn);
       // Handle the duplicate case.
       nativeGroupMembership.getNativeGroups().remove(groupUrn);
       nativeGroupMembership.getNativeGroups().add(groupUrn);
@@ -132,24 +250,8 @@ public class GroupService {
 
     final Set<Urn> userUrns = new HashSet<>(userUrnList);
     for (Urn userUrn : userUrns) {
-      final Map<Urn, EntityResponse> entityResponseMap =
-          _entityClient.batchGetV2(
-              opContext,
-              CORP_USER_ENTITY_NAME,
-              userUrns,
-              Collections.singleton(NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME));
-      EntityResponse entityResponse = entityResponseMap.get(userUrn);
-      if (entityResponse == null) {
-        continue;
-      }
-
       final NativeGroupMembership nativeGroupMembership =
-          new NativeGroupMembership(
-              entityResponse
-                  .getAspects()
-                  .get(NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME)
-                  .getValue()
-                  .data());
+          loadNativeGroupMembershipForUpdate(opContext, userUrn);
       if (nativeGroupMembership.getNativeGroups().remove(groupUrn)) {
         // Finally, create the MetadataChangeProposal.
         final MetadataChangeProposal proposal = new MetadataChangeProposal();
@@ -178,17 +280,6 @@ public class GroupService {
     userUrnList.forEach(userUrn -> addUserToNativeGroup(opContext, userUrn, groupUrn));
   }
 
-  public List<Urn> getGroupsForUser(@Nonnull OperationContext opContext, @Nonnull final Urn userUrn)
-      throws Exception {
-    final NativeGroupMembership nativeGroupMembership =
-        getExistingNativeGroupMembership(opContext, userUrn);
-    final GroupMembership groupMembership = getExistingGroupMembership(opContext, userUrn);
-    final List<Urn> allGroups = new ArrayList<>();
-    allGroups.addAll(nativeGroupMembership.getNativeGroups());
-    allGroups.addAll(groupMembership.getGroups());
-    return allGroups;
-  }
-
   NativeGroupMembership getExistingNativeGroupMembership(
       @Nonnull OperationContext opContext, @Nonnull final Urn userUrn) throws Exception {
     final EntityResponse entityResponse =
@@ -200,22 +291,7 @@ public class GroupService {
                 Collections.singleton(NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME))
             .get(userUrn);
 
-    final NativeGroupMembership nativeGroupMembership;
-    if (entityResponse == null
-        || !entityResponse.getAspects().containsKey(NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME)) {
-      // If the user doesn't have the NativeGroupMembership aspect, create one.
-      nativeGroupMembership = new NativeGroupMembership();
-      nativeGroupMembership.setNativeGroups(new UrnArray());
-    } else {
-      nativeGroupMembership =
-          new NativeGroupMembership(
-              entityResponse
-                  .getAspects()
-                  .get(NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME)
-                  .getValue()
-                  .data());
-    }
-    return nativeGroupMembership;
+    return toNativeGroupMembership(entityResponse);
   }
 
   GroupMembership getExistingGroupMembership(
@@ -230,18 +306,7 @@ public class GroupService {
                 Collections.singleton(GROUP_MEMBERSHIP_ASPECT_NAME))
             .get(userUrn);
 
-    final GroupMembership groupMembership;
-    if (entityResponse == null
-        || !entityResponse.getAspects().containsKey(GROUP_MEMBERSHIP_ASPECT_NAME)) {
-      // If the user doesn't have the GroupMembership aspect, create one.
-      groupMembership = new GroupMembership();
-      groupMembership.setGroups(new UrnArray());
-    } else {
-      groupMembership =
-          new GroupMembership(
-              entityResponse.getAspects().get(GROUP_MEMBERSHIP_ASPECT_NAME).getValue().data());
-    }
-    return groupMembership;
+    return toGroupMembership(entityResponse);
   }
 
   String createGroupInfo(
@@ -320,20 +385,7 @@ public class GroupService {
 
     final Set<Urn> userUrns = new HashSet<>(userUrnList);
     for (Urn userUrn : userUrns) {
-      final Map<Urn, EntityResponse> entityResponseMap =
-          _entityClient.batchGetV2(
-              opContext,
-              CORP_USER_ENTITY_NAME,
-              userUrns,
-              Collections.singleton(GROUP_MEMBERSHIP_ASPECT_NAME));
-      EntityResponse entityResponse = entityResponseMap.get(userUrn);
-      if (entityResponse == null) {
-        continue;
-      }
-
-      final GroupMembership groupMembership =
-          new GroupMembership(
-              entityResponse.getAspects().get(GROUP_MEMBERSHIP_ASPECT_NAME).getValue().data());
+      final GroupMembership groupMembership = loadGroupMembershipForUpdate(opContext, userUrn);
       if (groupMembership.getGroups().remove(groupUrn)) {
         // Finally, create the MetadataChangeProposal.
         final MetadataChangeProposal proposal = new MetadataChangeProposal();
@@ -345,5 +397,57 @@ public class GroupService {
         _entityClient.ingestProposal(opContext, proposal);
       }
     }
+  }
+
+  private NativeGroupMembership loadNativeGroupMembershipForUpdate(
+      @Nonnull OperationContext opContext, @Nonnull Urn userUrn) throws Exception {
+    final EntityResponse entityResponse =
+        batchGetUserAspectsNoCache(
+                opContext,
+                Collections.singleton(userUrn),
+                Set.of(NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME))
+            .get(userUrn);
+    return toNativeGroupMembership(entityResponse);
+  }
+
+  private GroupMembership loadGroupMembershipForUpdate(
+      @Nonnull OperationContext opContext, @Nonnull Urn userUrn)
+      throws RemoteInvocationException, URISyntaxException {
+    final EntityResponse entityResponse =
+        batchGetUserAspectsNoCache(
+                opContext, Collections.singleton(userUrn), Set.of(GROUP_MEMBERSHIP_ASPECT_NAME))
+            .get(userUrn);
+    return toGroupMembership(entityResponse);
+  }
+
+  private NativeGroupMembership toNativeGroupMembership(@Nullable EntityResponse entityResponse) {
+    if (entityResponse == null
+        || !entityResponse.getAspects().containsKey(NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME)) {
+      final NativeGroupMembership nativeGroupMembership = new NativeGroupMembership();
+      nativeGroupMembership.setNativeGroups(new UrnArray());
+      return nativeGroupMembership;
+    }
+    return new NativeGroupMembership(
+        entityResponse.getAspects().get(NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME).getValue().data());
+  }
+
+  private GroupMembership toGroupMembership(@Nullable EntityResponse entityResponse) {
+    if (entityResponse == null
+        || !entityResponse.getAspects().containsKey(GROUP_MEMBERSHIP_ASPECT_NAME)) {
+      final GroupMembership groupMembership = new GroupMembership();
+      groupMembership.setGroups(new UrnArray());
+      return groupMembership;
+    }
+    return new GroupMembership(
+        entityResponse.getAspects().get(GROUP_MEMBERSHIP_ASPECT_NAME).getValue().data());
+  }
+
+  /** Bypasses {@link SystemEntityClient}'s aspect cache for read-modify-write mutations only. */
+  private Map<Urn, EntityResponse> batchGetUserAspectsNoCache(
+      @Nonnull OperationContext opContext,
+      @Nonnull Set<Urn> userUrns,
+      @Nonnull Set<String> aspectNames)
+      throws RemoteInvocationException, URISyntaxException {
+    return _entityClient.batchGetV2NoCache(opContext, CORP_USER_ENTITY_NAME, userUrns, aspectNames);
   }
 }

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/AuthorizerChain.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/AuthorizerChain.java
@@ -4,6 +4,8 @@ import com.datahub.plugins.auth.authorization.Authorizer;
 import com.datahub.plugins.auth.authorization.ResourceSpecCachingAuthorizer;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.policy.DataHubPolicyInfo;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.OperationContextAuthorizer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -27,7 +29,8 @@ import lombok.extern.slf4j.Slf4j;
  * #authorize(AuthorizationRequest)}.
  */
 @Slf4j
-public class AuthorizerChain implements Authorizer, ResourceSpecCachingAuthorizer {
+public class AuthorizerChain
+    implements Authorizer, ResourceSpecCachingAuthorizer, OperationContextAuthorizer {
 
   private final List<Authorizer> authorizers;
 
@@ -85,7 +88,67 @@ public class AuthorizerChain implements Authorizer, ResourceSpecCachingAuthorize
         if (AuthorizationResult.Type.ALLOW.equals(result.type)) {
           // Authorization was successful - Short circuit
           log.debug("Authorization is successful");
+          return result;
+        } else {
+          log.debug(
+              "Received DENY result from Authorizer with class name {}. message: {}",
+              authorizer.getClass().getCanonicalName(),
+              result.getMessage());
+        }
+      } catch (Exception e) {
+        log.error(
+            "Caught exception while attempting to authorize request using Authorizer {}. Skipping authorizer.",
+            authorizer.getClass().getCanonicalName(),
+            e);
+      } finally {
+        Thread.currentThread().setContextClassLoader(contextClassLoader);
+      }
+    }
+    // Return failed Authorization result.
+    return new AuthorizationResult(request, AuthorizationResult.Type.DENY, null);
+  }
 
+  @Override
+  @Nonnull
+  public AuthorizationResult authorize(
+      @Nonnull final AuthorizationRequest request,
+      @Nullable final Map<EntitySpec, ResolvedEntitySpec> resourceSpecCache,
+      @Nonnull final OperationContext opContext) {
+    Objects.requireNonNull(request);
+    Objects.requireNonNull(opContext);
+    // Save contextClassLoader
+    ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+
+    for (final Authorizer authorizer : this.authorizers) {
+      try {
+        log.debug(
+            "Executing Authorizer with class name {}", authorizer.getClass().getCanonicalName());
+        log.debug("Authorization Request: {}", request.toString());
+        // The library came with plugin can use the contextClassLoader to load the classes. For
+        // example apache-ranger library does this.
+        // Here we need to set our IsolatedClassLoader as contextClassLoader to resolve such class
+        // loading request from plugin's home directory,
+        // otherwise plugin's internal library wouldn't be able to find their dependent classes
+        Thread.currentThread().setContextClassLoader(authorizer.getClass().getClassLoader());
+        // Forward the request-scoped resolved-spec cache and session OperationContext to delegates
+        // that support them; others resolve per call as before.
+        AuthorizationResult result;
+        if (authorizer instanceof OperationContextAuthorizer) {
+          result =
+              ((OperationContextAuthorizer) authorizer)
+                  .authorize(request, resourceSpecCache, opContext);
+        } else if (authorizer instanceof ResourceSpecCachingAuthorizer) {
+          result =
+              ((ResourceSpecCachingAuthorizer) authorizer).authorize(request, resourceSpecCache);
+        } else {
+          result = authorizer.authorize(request);
+        }
+        // reset
+        Thread.currentThread().setContextClassLoader(contextClassLoader);
+
+        if (AuthorizationResult.Type.ALLOW.equals(result.type)) {
+          // Authorization was successful - Short circuit
+          log.debug("Authorization is successful");
           return result;
         } else {
           log.debug(
@@ -180,9 +243,89 @@ public class AuthorizerChain implements Authorizer, ResourceSpecCachingAuthorize
   }
 
   @Override
+  public Set<DataHubPolicyInfo> getActorPolicies(
+      @Nonnull Urn actorUrn, @Nullable Collection<Urn> preloadedGroups) {
+    return authorizers.stream()
+        .flatMap(authorizer -> authorizer.getActorPolicies(actorUrn, preloadedGroups).stream())
+        .collect(Collectors.toSet());
+  }
+
+  @Override
+  public Set<DataHubPolicyInfo> getActorPolicies(
+      @Nonnull Urn actorUrn,
+      @Nullable Collection<Urn> preloadedGroups,
+      @Nullable Set<Urn> preloadedDirectRoles) {
+    return authorizers.stream()
+        .flatMap(
+            authorizer ->
+                authorizer
+                    .getActorPolicies(actorUrn, preloadedGroups, preloadedDirectRoles)
+                    .stream())
+        .collect(Collectors.toSet());
+  }
+
+  @Override
+  public Optional<SessionActorIdentity> resolveSessionActorIdentity(@Nonnull Urn actorUrn) {
+    return authorizers.stream()
+        .map(authorizer -> authorizer.resolveSessionActorIdentity(actorUrn))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .findFirst();
+  }
+
+  @Override
+  public Optional<SessionActorIdentity> resolveSessionActorIdentity(
+      @Nonnull Urn actorUrn, @Nonnull OperationContext opContext) {
+    return authorizers.stream()
+        .filter(authorizer -> authorizer instanceof OperationContextAuthorizer)
+        .map(
+            authorizer ->
+                ((OperationContextAuthorizer) authorizer)
+                    .resolveSessionActorIdentity(actorUrn, opContext))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .findFirst();
+  }
+
+  @Override
+  public Set<DataHubPolicyInfo> getActorPolicies(
+      @Nonnull Urn actorUrn,
+      @Nullable SessionActorIdentity sessionActorIdentity,
+      @Nullable Collection<Urn> preloadedGroups,
+      @Nullable Set<Urn> preloadedDirectRoles,
+      @Nonnull OperationContext opContext) {
+    return authorizers.stream()
+        .filter(authorizer -> authorizer instanceof OperationContextAuthorizer)
+        .flatMap(
+            authorizer ->
+                ((OperationContextAuthorizer) authorizer)
+                        .getActorPolicies(
+                            actorUrn,
+                            sessionActorIdentity,
+                            preloadedGroups,
+                            preloadedDirectRoles,
+                            opContext)
+                        .stream())
+        .collect(Collectors.toSet());
+  }
+
+  @Override
   public Collection<Urn> getActorGroups(@Nonnull Urn actorUrn) {
     return authorizers.stream()
         .flatMap(authorizer -> authorizer.getActorGroups(actorUrn).stream())
+        .collect(Collectors.toList());
+  }
+
+  public Collection<Urn> getActorGroups(
+      @Nonnull Urn actorUrn, @Nonnull OperationContext opContext) {
+    return authorizers.stream()
+        .flatMap(
+            authorizer -> {
+              if (authorizer instanceof DataHubAuthorizer dataHubAuthorizer) {
+                return dataHubAuthorizer.getActorGroups(actorUrn, opContext).stream();
+              }
+              return authorizer.getActorGroups(actorUrn).stream();
+            })
         .collect(Collectors.toList());
   }
 

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/ContextualEntitySpecResolver.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/ContextualEntitySpecResolver.java
@@ -1,0 +1,16 @@
+package com.datahub.authorization;
+
+import io.datahubproject.metadata.context.OperationContext;
+import javax.annotation.Nonnull;
+
+/**
+ * Extension of {@link EntitySpecResolver} that resolves actor-scoped fields (e.g. group membership)
+ * using the session {@link OperationContext}. Resource metadata reads during policy evaluation may
+ * still use the system context via {@link #resolve(EntitySpec)}.
+ */
+public interface ContextualEntitySpecResolver extends EntitySpecResolver {
+
+  /** Resolve a {@link EntitySpec} using the provided operation context for field resolvers. */
+  @Nonnull
+  ResolvedEntitySpec resolve(@Nonnull EntitySpec entitySpec, @Nonnull OperationContext opContext);
+}

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/DataHubAuthorizer.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/DataHubAuthorizer.java
@@ -1,6 +1,7 @@
 package com.datahub.authorization;
 
 import com.datahub.authentication.Authentication;
+import com.datahub.authentication.group.GroupService;
 import com.datahub.plugins.auth.authorization.Authorizer;
 import com.datahub.plugins.auth.authorization.ResourceSpecCachingAuthorizer;
 import com.google.common.annotations.VisibleForTesting;
@@ -10,7 +11,9 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.policy.DataHubPolicyInfo;
+import io.datahubproject.metadata.context.ActorContext;
 import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.OperationContextAuthorizer;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -44,7 +47,8 @@ import lombok.extern.slf4j.Slf4j;
  */
 // TODO: Decouple this from all Rest.li objects if possible.
 @Slf4j
-public class DataHubAuthorizer implements Authorizer, ResourceSpecCachingAuthorizer {
+public class DataHubAuthorizer
+    implements Authorizer, ResourceSpecCachingAuthorizer, OperationContextAuthorizer {
 
   public enum AuthorizationMode {
     /** Default mode simply means that authorization is enforced, with a DENY result returned */
@@ -67,6 +71,7 @@ public class DataHubAuthorizer implements Authorizer, ResourceSpecCachingAuthori
       Executors.newScheduledThreadPool(1);
   private final PolicyRefreshRunnable policyRefreshRunnable;
   private final PolicyEngine policyEngine;
+  private final GroupService groupService;
   private EntitySpecResolver entitySpecResolver;
   private AuthorizationMode mode;
   @Getter private final OperationContext systemOpContext;
@@ -76,13 +81,15 @@ public class DataHubAuthorizer implements Authorizer, ResourceSpecCachingAuthori
   public DataHubAuthorizer(
       @Nonnull final OperationContext systemOpContext,
       final EntityClient entityClient,
+      @Nonnull final GroupService groupService,
       final int delayIntervalSeconds,
       final int refreshIntervalSeconds,
       final AuthorizationMode mode,
       final int policyFetchSize) {
     this.systemOpContext = systemOpContext;
     this.mode = Objects.requireNonNull(mode);
-    policyEngine = new PolicyEngine(Objects.requireNonNull(entityClient));
+    this.groupService = Objects.requireNonNull(groupService);
+    policyEngine = new PolicyEngine(entityClient, groupService);
     if (refreshIntervalSeconds > 0) {
       policyRefreshRunnable =
           new PolicyRefreshRunnable(
@@ -112,6 +119,14 @@ public class DataHubAuthorizer implements Authorizer, ResourceSpecCachingAuthori
   public AuthorizationResult authorize(
       @Nonnull final AuthorizationRequest request,
       @Nullable final Map<EntitySpec, ResolvedEntitySpec> resourceSpecCache) {
+    return authorize(request, resourceSpecCache, systemOpContext);
+  }
+
+  @Override
+  public AuthorizationResult authorize(
+      @Nonnull final AuthorizationRequest request,
+      @Nullable final Map<EntitySpec, ResolvedEntitySpec> resourceSpecCache,
+      @Nonnull final OperationContext opContext) {
 
     // 0. Short circuit: If the action is being performed by the system (root), always allow it.
     if (isSystemRequest(request, systemOpContext.getAuthentication())) {
@@ -145,9 +160,32 @@ public class DataHubAuthorizer implements Authorizer, ResourceSpecCachingAuthori
       }
     }
 
+    Optional<Urn> actorUrn = getUrnFromRequestActor(request.getActorUrn());
+    if (actorUrn.isEmpty()) {
+      return new AuthorizationResult(request, AuthorizationResult.Type.DENY, null);
+    }
+
+    final ResolvedEntitySpec resolvedActorSpec =
+        resolveActorEntitySpec(
+            new EntitySpec(actorUrn.get().getEntityType(), request.getActorUrn()), opContext);
+
+    final PolicyEngine.PolicyEvaluationContext sharedEvaluationContext =
+        policyEngine.createSeededEvaluationContext(
+            request.getSessionActorIdentity(),
+            request.getActorGroupMembership(),
+            request.getActorDirectRoles(),
+            opContext);
+
     // 2. Evaluate each policy.
     for (DataHubPolicyInfo policy : policiesToEvaluate) {
-      if (isRequestGranted(policy, request, resolvedResourceSpec, resolvedSubResources)) {
+      if (isRequestGranted(
+          policy,
+          request,
+          resolvedActorSpec,
+          resolvedResourceSpec,
+          resolvedSubResources,
+          sharedEvaluationContext,
+          opContext)) {
         // Short circuit if policy has granted privileges to this actor.
         return new AuthorizationResult(
             request,
@@ -173,6 +211,13 @@ public class DataHubAuthorizer implements Authorizer, ResourceSpecCachingAuthori
 
   public PolicyEngine.PolicyGrantedPrivileges getGrantedPrivileges(
       final String actor, final Optional<EntitySpec> resourceSpec) {
+    return getGrantedPrivileges(actor, resourceSpec, systemOpContext);
+  }
+
+  public PolicyEngine.PolicyGrantedPrivileges getGrantedPrivileges(
+      final String actor,
+      final Optional<EntitySpec> resourceSpec,
+      @Nonnull final OperationContext opContext) {
 
     Urn actorUrn = UrnUtils.getUrn(actor);
 
@@ -182,21 +227,57 @@ public class DataHubAuthorizer implements Authorizer, ResourceSpecCachingAuthori
     policiesToEvaluate.addAll(PoliciesConfig.getDefaultPolicies(actorUrn));
 
     final ResolvedEntitySpec resolvedActorSpec =
-        entitySpecResolver.resolve(new EntitySpec(actorUrn.getEntityType(), actor));
+        resolveActorEntitySpec(new EntitySpec(actorUrn.getEntityType(), actor), opContext);
 
     Optional<ResolvedEntitySpec> resolvedResourceSpec =
         resourceSpec.map(entitySpecResolver::resolve);
 
+    final PolicyEngine.PolicyEvaluationContext evaluationContext =
+        buildActorEvaluationContext(opContext, actorUrn, null, null, null);
+
     return policyEngine.getGrantedPrivileges(
-        systemOpContext,
+        opContext,
         policiesToEvaluate,
         resolvedActorSpec,
         resolvedResourceSpec,
-        Collections.emptyList());
+        Collections.emptyList(),
+        evaluationContext);
   }
 
   @Override
   public Set<DataHubPolicyInfo> getActorPolicies(@Nonnull Urn actorUrn) {
+    return getActorPolicies(actorUrn, null);
+  }
+
+  @Override
+  public Set<DataHubPolicyInfo> getActorPolicies(
+      @Nonnull Urn actorUrn, @Nullable Collection<Urn> preloadedGroups) {
+    return getActorPolicies(actorUrn, preloadedGroups, null);
+  }
+
+  @Override
+  public Set<DataHubPolicyInfo> getActorPolicies(
+      @Nonnull Urn actorUrn,
+      @Nullable Collection<Urn> preloadedGroups,
+      @Nullable Set<Urn> preloadedDirectRoles) {
+    return getActorPolicies(actorUrn, preloadedGroups, preloadedDirectRoles, systemOpContext);
+  }
+
+  public Set<DataHubPolicyInfo> getActorPolicies(
+      @Nonnull Urn actorUrn,
+      @Nullable Collection<Urn> preloadedGroups,
+      @Nullable Set<Urn> preloadedDirectRoles,
+      @Nonnull OperationContext opContext) {
+    return getActorPolicies(actorUrn, null, preloadedGroups, preloadedDirectRoles, opContext);
+  }
+
+  @Override
+  public Set<DataHubPolicyInfo> getActorPolicies(
+      @Nonnull Urn actorUrn,
+      @Nullable SessionActorIdentity sessionActorIdentity,
+      @Nullable Collection<Urn> preloadedGroups,
+      @Nullable Set<Urn> preloadedDirectRoles,
+      @Nonnull OperationContext opContext) {
     // 1. Fetch all policies
     final List<DataHubPolicyInfo> policiesToEvaluate =
         new LinkedList<>(getOrDefault(ALL, new ArrayList<>()));
@@ -204,7 +285,12 @@ public class DataHubAuthorizer implements Authorizer, ResourceSpecCachingAuthori
 
     // 2. Actor identity
     final ResolvedEntitySpec resolvedActorSpec =
-        entitySpecResolver.resolve(new EntitySpec(actorUrn.getEntityType(), actorUrn.toString()));
+        resolveActorEntitySpec(
+            new EntitySpec(actorUrn.getEntityType(), actorUrn.toString()), opContext);
+
+    final PolicyEngine.PolicyEvaluationContext sharedContext =
+        buildActorEvaluationContext(
+            opContext, actorUrn, sessionActorIdentity, preloadedGroups, preloadedDirectRoles);
 
     return policiesToEvaluate.stream()
         .filter(policy -> PoliciesConfig.ACTIVE_POLICY_STATE.equals(policy.getState()))
@@ -212,23 +298,33 @@ public class DataHubAuthorizer implements Authorizer, ResourceSpecCachingAuthori
             policy ->
                 (policy.getActors() != null && policy.getActors().isResourceOwners())
                     || policyEngine.isActorMatch(
-                        systemOpContext,
+                        opContext,
                         resolvedActorSpec,
                         policy.getActors(),
                         Optional.empty(),
-                        new PolicyEngine.PolicyEvaluationContext()))
+                        sharedContext))
         .collect(Collectors.toSet());
   }
 
   @Override
-  public Collection<Urn> getActorGroups(@Nonnull Urn actorUrn) {
-    // 1. Actor identity
-    final ResolvedEntitySpec resolvedActorSpec =
-        entitySpecResolver.resolve(new EntitySpec(actorUrn.getEntityType(), actorUrn.toString()));
+  public Optional<SessionActorIdentity> resolveSessionActorIdentity(@Nonnull Urn actorUrn) {
+    return resolveSessionActorIdentity(actorUrn, systemOpContext);
+  }
 
-    return resolvedActorSpec.getGroupMembership().stream()
-        .map(UrnUtils::getUrn)
-        .collect(Collectors.toList());
+  @Override
+  public Optional<SessionActorIdentity> resolveSessionActorIdentity(
+      @Nonnull Urn actorUrn, @Nonnull OperationContext opContext) {
+    return Optional.of(groupService.fetchUserIdentity(opContext, actorUrn));
+  }
+
+  @Override
+  public Collection<Urn> getActorGroups(@Nonnull Urn actorUrn) {
+    return getActorGroups(actorUrn, systemOpContext);
+  }
+
+  public Collection<Urn> getActorGroups(
+      @Nonnull Urn actorUrn, @Nonnull OperationContext opContext) {
+    return groupService.getGroupsForUser(opContext, actorUrn);
   }
 
   @Override
@@ -314,30 +410,25 @@ public class DataHubAuthorizer implements Authorizer, ResourceSpecCachingAuthori
   private boolean isRequestGranted(
       final DataHubPolicyInfo policy,
       final AuthorizationRequest request,
+      final ResolvedEntitySpec resolvedActorSpec,
       final Optional<ResolvedEntitySpec> resourceSpec,
-      final List<ResolvedEntitySpec> subResources) {
+      final List<ResolvedEntitySpec> subResources,
+      final PolicyEngine.PolicyEvaluationContext sharedEvaluationContext,
+      @Nonnull final OperationContext opContext) {
     if (AuthorizationMode.ALLOW_ALL.equals(mode())) {
       return true;
     }
 
-    Optional<Urn> actorUrn = getUrnFromRequestActor(request.getActorUrn());
-    if (actorUrn.isEmpty()) {
-      return false;
-    }
-
     try {
-      final ResolvedEntitySpec resolvedActorSpec =
-          entitySpecResolver.resolve(
-              new EntitySpec(actorUrn.get().getEntityType(), request.getActorUrn()));
-
       final PolicyEngine.PolicyEvaluationResult result =
           policyEngine.evaluatePolicy(
-              systemOpContext,
+              opContext,
               policy,
               resolvedActorSpec,
               request.getPrivilege(),
               resourceSpec,
-              subResources);
+              subResources,
+              sharedEvaluationContext);
       return result.isGranted();
     } catch (RuntimeException e) {
       log.error("Error evaluating policy {} for request {}", policy.getDisplayName(), request);
@@ -355,6 +446,53 @@ public class DataHubAuthorizer implements Authorizer, ResourceSpecCachingAuthori
               actor));
       return Optional.empty();
     }
+  }
+
+  /**
+   * Resolves actor-scoped entity fields (group membership, roles) using the session context.
+   * Resource specs continue to use the system context via {@link EntitySpecResolver#resolve}.
+   */
+  @Nonnull
+  private ResolvedEntitySpec resolveActorEntitySpec(
+      @Nonnull final EntitySpec entitySpec, @Nonnull final OperationContext opContext) {
+    if (entitySpecResolver instanceof ContextualEntitySpecResolver contextualResolver) {
+      return contextualResolver.resolve(entitySpec, opContext);
+    }
+    return entitySpecResolver.resolve(entitySpec);
+  }
+
+  /**
+   * Builds a policy evaluation context seeded with the actor's identity. Uses request-scoped
+   * session data when the actor is the session user; otherwise resolves identity via the session
+   * context.
+   */
+  @Nonnull
+  private PolicyEngine.PolicyEvaluationContext buildActorEvaluationContext(
+      @Nonnull final OperationContext opContext,
+      @Nonnull final Urn actorUrn,
+      @Nullable final SessionActorIdentity sessionActorIdentity,
+      @Nullable final Collection<Urn> preloadedGroups,
+      @Nullable final Set<Urn> preloadedDirectRoles) {
+    if (sessionActorIdentity != null || preloadedGroups != null || preloadedDirectRoles != null) {
+      return policyEngine.createSeededEvaluationContext(
+          sessionActorIdentity, preloadedGroups, preloadedDirectRoles, opContext);
+    }
+
+    final ActorContext sessionActor = opContext.getSessionActorContext();
+    if (actorUrn.equals(sessionActor.getActorUrn())) {
+      return policyEngine.createSeededEvaluationContext(
+          opContext.getAuthorizationContext().getSessionActorIdentity(actorUrn),
+          sessionActor.getGroupMembership(),
+          sessionActor.getDirectRoleMembership(),
+          opContext);
+    }
+
+    return resolveSessionActorIdentity(actorUrn, opContext)
+        .map(
+            identity ->
+                policyEngine.createSeededEvaluationContext(
+                    identity, identity.getGroups(), identity.getDirectRoles(), opContext))
+        .orElse(new PolicyEngine.PolicyEvaluationContext());
   }
 
   private List<DataHubPolicyInfo> getOrDefault(String key, List<DataHubPolicyInfo> defaultValue) {

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/DefaultEntitySpecResolver.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/DefaultEntitySpecResolver.java
@@ -1,5 +1,6 @@
 package com.datahub.authorization;
 
+import com.datahub.authentication.group.GroupService;
 import com.datahub.authorization.fieldresolverprovider.*;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.entity.client.SystemEntityClient;
@@ -10,12 +11,14 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
-public class DefaultEntitySpecResolver implements EntitySpecResolver {
+public class DefaultEntitySpecResolver implements ContextualEntitySpecResolver {
   private final List<EntityFieldResolverProvider> _entityFieldResolverProviders;
   private final OperationContext systemOperationContext;
 
   public DefaultEntitySpecResolver(
-      @Nonnull OperationContext systemOperationContext, SystemEntityClient entityClient) {
+      @Nonnull OperationContext systemOperationContext,
+      SystemEntityClient entityClient,
+      GroupService groupService) {
     _entityFieldResolverProviders =
         ImmutableList.of(
             new EntityTypeFieldResolverProvider(),
@@ -23,7 +26,7 @@ public class DefaultEntitySpecResolver implements EntitySpecResolver {
             new DomainFieldResolverProvider(entityClient),
             new OwnerFieldResolverProvider(entityClient),
             new DataPlatformInstanceFieldResolverProvider(entityClient),
-            new GroupMembershipFieldResolverProvider(entityClient),
+            new GroupMembershipFieldResolverProvider(groupService),
             new TagFieldResolverProvider(entityClient),
             new ContainerFieldResolverProvider(entityClient),
             new GlossaryFieldResolverProvider(entityClient));
@@ -32,8 +35,14 @@ public class DefaultEntitySpecResolver implements EntitySpecResolver {
 
   @Override
   public ResolvedEntitySpec resolve(EntitySpec entitySpec) {
-    return new ResolvedEntitySpec(
-        entitySpec, getFieldResolvers(systemOperationContext, entitySpec));
+    return resolve(entitySpec, systemOperationContext);
+  }
+
+  @Override
+  @Nonnull
+  public ResolvedEntitySpec resolve(
+      @Nonnull EntitySpec entitySpec, @Nonnull OperationContext opContext) {
+    return new ResolvedEntitySpec(entitySpec, getFieldResolvers(opContext, entitySpec));
   }
 
   private Map<EntityFieldType, FieldResolver> getFieldResolvers(

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/PolicyEngine.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/PolicyEngine.java
@@ -2,20 +2,15 @@ package com.datahub.authorization;
 
 import static com.linkedin.metadata.Constants.*;
 
-import com.google.common.collect.ImmutableSet;
+import com.datahub.authentication.group.GroupService;
 import com.linkedin.common.Owner;
 import com.linkedin.common.Ownership;
-import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspect;
-import com.linkedin.entity.EnvelopedAspectMap;
 import com.linkedin.entity.client.EntityClient;
-import com.linkedin.identity.GroupMembership;
-import com.linkedin.identity.NativeGroupMembership;
-import com.linkedin.identity.RoleMembership;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.policy.DataHubActorFilter;
@@ -26,7 +21,9 @@ import com.linkedin.policy.PolicyMatchCriterion;
 import com.linkedin.policy.PolicyMatchCriterionArray;
 import com.linkedin.policy.PolicyMatchFilter;
 import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.ServicesRegistryContext;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -40,16 +37,21 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.map.HashedMap;
 
 @Slf4j
-@RequiredArgsConstructor
 public class PolicyEngine {
 
   private final EntityClient _entityClient;
+  private final GroupService _groupService;
+
+  public PolicyEngine(
+      @Nonnull final EntityClient entityClient, @Nonnull final GroupService groupService) {
+    this._entityClient = Objects.requireNonNull(entityClient);
+    this._groupService = Objects.requireNonNull(groupService);
+  }
 
   public PolicyEvaluationResult evaluatePolicy(
       @Nonnull OperationContext opContext,
@@ -59,7 +61,24 @@ public class PolicyEngine {
       final Optional<ResolvedEntitySpec> resource,
       final List<ResolvedEntitySpec> subResources) {
 
-    final PolicyEvaluationContext context = new PolicyEvaluationContext();
+    return evaluatePolicy(
+        opContext,
+        policy,
+        resolvedActorSpec,
+        privilege,
+        resource,
+        subResources,
+        new PolicyEvaluationContext());
+  }
+
+  public PolicyEvaluationResult evaluatePolicy(
+      @Nonnull OperationContext opContext,
+      final DataHubPolicyInfo policy,
+      final ResolvedEntitySpec resolvedActorSpec,
+      final String privilege,
+      final Optional<ResolvedEntitySpec> resource,
+      final List<ResolvedEntitySpec> subResources,
+      @Nonnull final PolicyEvaluationContext context) {
     log.debug("Evaluating policy {}", policy.getDisplayName());
 
     // If the privilege is not in scope, deny the request.
@@ -84,6 +103,38 @@ public class PolicyEngine {
     }
 
     return new PolicyEvaluationResult(policy.getDisplayName(), true, "Policy allowed");
+  }
+
+  /** Builds a policy evaluation context pre-seeded with session actor groups and direct roles. */
+  @Nonnull
+  public PolicyEvaluationContext createSeededEvaluationContext(
+      @Nullable final SessionActorIdentity sessionActorIdentity,
+      @Nullable final Collection<Urn> actorGroupMembership,
+      @Nullable final Set<Urn> actorDirectRoles,
+      @Nonnull final OperationContext opContext) {
+    final PolicyEvaluationContext context = new PolicyEvaluationContext();
+    if (actorGroupMembership != null) {
+      context.setGroups(
+          actorGroupMembership.stream().map(Urn::toString).collect(Collectors.toSet()));
+    }
+    if (actorDirectRoles != null) {
+      context.setDirectRoles(actorDirectRoles);
+    }
+    if (sessionActorIdentity != null) {
+      context.setSessionActorIdentity(sessionActorIdentity);
+      if (opContext != null) {
+        context.setOpContext(opContext);
+      }
+    }
+    return context;
+  }
+
+  /** Builds a policy evaluation context pre-seeded with session actor groups and direct roles. */
+  @Nonnull
+  public PolicyEvaluationContext createSeededEvaluationContext(
+      @Nullable final Collection<Urn> actorGroupMembership,
+      @Nullable final Set<Urn> actorDirectRoles) {
+    return createSeededEvaluationContext(null, actorGroupMembership, actorDirectRoles, null);
   }
 
   public PolicyActors getMatchingActors(
@@ -196,9 +247,24 @@ public class PolicyEngine {
       final ResolvedEntitySpec resolvedActorSpec,
       final Optional<ResolvedEntitySpec> resource,
       final List<ResolvedEntitySpec> subResources) {
+    return getGrantedPrivileges(
+        opContext,
+        policies,
+        resolvedActorSpec,
+        resource,
+        subResources,
+        new PolicyEvaluationContext());
+  }
+
+  public PolicyGrantedPrivileges getGrantedPrivileges(
+      @Nonnull OperationContext opContext,
+      final List<DataHubPolicyInfo> policies,
+      final ResolvedEntitySpec resolvedActorSpec,
+      final Optional<ResolvedEntitySpec> resource,
+      final List<ResolvedEntitySpec> subResources,
+      @Nonnull final PolicyEvaluationContext context) {
     Set<String> privileges = new HashSet<>();
     Map<String, String> reasonsOfDeny = new HashedMap<>();
-    PolicyEvaluationContext context = new PolicyEvaluationContext();
     for (DataHubPolicyInfo policy : policies) {
       PolicyEvaluationResult result =
           isPolicyApplicable(opContext, policy, resolvedActorSpec, resource, context, subResources);
@@ -492,57 +558,37 @@ public class PolicyEngine {
       return context.roles;
     }
 
+    if (context.sessionActorIdentity != null && context.opContext != null) {
+      final Set<Urn> roles =
+          context.sessionActorIdentity.resolveAllRoles(
+              groups -> fetchRolesViaGroups(context.opContext, groups));
+      context.setRoles(roles);
+      return roles;
+    }
+
+    if (context.directRoles != null && context.groups != null) {
+      final Set<Urn> roles = new HashSet<>(context.directRoles);
+      if (!context.groups.isEmpty()) {
+        roles.addAll(
+            fetchRolesViaGroups(
+                opContext,
+                context.groups.stream().map(UrnUtils::getUrn).collect(Collectors.toList())));
+      }
+      context.setRoles(roles);
+      return roles;
+    }
+
     String actor = resolvedActorSpec.getSpec().getEntity();
 
     Set<Urn> roles = new HashSet<>();
-    final EnvelopedAspectMap aspectMap;
     try {
       Urn actorUrn = Urn.createFromString(actor);
-      final EntityResponse corpUser =
-          _entityClient
-              .batchGetV2(
-                  opContext,
-                  CORP_USER_ENTITY_NAME,
-                  Collections.singleton(actorUrn),
-                  ImmutableSet.of(
-                      ROLE_MEMBERSHIP_ASPECT_NAME,
-                      GROUP_MEMBERSHIP_ASPECT_NAME,
-                      NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME))
-              .get(actorUrn);
-      if (corpUser == null || !corpUser.hasAspects()) {
-        return roles;
-      }
-      aspectMap = corpUser.getAspects();
+      final SessionActorIdentity identity = _groupService.fetchUserIdentity(opContext, actorUrn);
+      roles.addAll(identity.resolveAllRoles(groups -> fetchRolesViaGroups(opContext, groups)));
     } catch (Exception e) {
       log.error(
           String.format("Failed to fetch %s for urn %s", ROLE_MEMBERSHIP_ASPECT_NAME, actor), e);
       return roles;
-    }
-
-    if (aspectMap.containsKey(ROLE_MEMBERSHIP_ASPECT_NAME)) {
-      RoleMembership roleMembership =
-          new RoleMembership(aspectMap.get(ROLE_MEMBERSHIP_ASPECT_NAME).getValue().data());
-      if (roleMembership.hasRoles()) {
-        roles.addAll(roleMembership.getRoles());
-      }
-    }
-
-    List<Urn> groups = new ArrayList<>();
-    if (aspectMap.containsKey(GROUP_MEMBERSHIP_ASPECT_NAME)) {
-      GroupMembership groupMembership =
-          new GroupMembership(aspectMap.get(GROUP_MEMBERSHIP_ASPECT_NAME).getValue().data());
-      groups.addAll(groupMembership.getGroups());
-    }
-    if (aspectMap.containsKey(NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME)) {
-      NativeGroupMembership nativeGroupMembership =
-          new NativeGroupMembership(
-              aspectMap.get(NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME).getValue().data());
-      groups.addAll(nativeGroupMembership.getNativeGroups());
-    }
-    if (!groups.isEmpty()) {
-      GroupMembership memberships = new GroupMembership();
-      memberships.setGroups(new UrnArray(groups));
-      roles.addAll(getRolesFromGroups(opContext, memberships));
     }
 
     if (!roles.isEmpty()) {
@@ -552,37 +598,14 @@ public class PolicyEngine {
     return roles;
   }
 
-  private Set<Urn> getRolesFromGroups(
-      @Nonnull OperationContext opContext, final GroupMembership groupMembership) {
-
-    HashSet<Urn> groups = new HashSet<>(groupMembership.getGroups());
-    try {
-      Map<Urn, EntityResponse> responseMap =
-          _entityClient.batchGetV2(
-              opContext,
-              CORP_GROUP_ENTITY_NAME,
-              groups,
-              ImmutableSet.of(ROLE_MEMBERSHIP_ASPECT_NAME));
-
-      return responseMap.keySet().stream()
-          .filter(Objects::nonNull)
-          .filter(key -> responseMap.get(key) != null)
-          .filter(key -> responseMap.get(key).hasAspects())
-          .map(key -> responseMap.get(key).getAspects())
-          .filter(aspectMap -> aspectMap.containsKey(ROLE_MEMBERSHIP_ASPECT_NAME))
-          .map(
-              aspectMap ->
-                  new RoleMembership(aspectMap.get(ROLE_MEMBERSHIP_ASPECT_NAME).getValue().data()))
-          .filter(RoleMembership::hasRoles)
-          .map(RoleMembership::getRoles)
-          .flatMap(List::stream)
-          .collect(Collectors.toSet());
-
-    } catch (Exception e) {
-      log.error(
-          String.format("Failed to fetch %s for urns %s", ROLE_MEMBERSHIP_ASPECT_NAME, groups), e);
-      return new HashSet<>();
+  @Nonnull
+  private Set<Urn> fetchRolesViaGroups(
+      @Nonnull final OperationContext opContext, @Nonnull final Collection<Urn> groups) {
+    final ServicesRegistryContext servicesRegistry = opContext.getServicesRegistryContext();
+    if (servicesRegistry != null && servicesRegistry.getActorGroupMembershipService() != null) {
+      return servicesRegistry.fetchRolesViaGroups(opContext, groups);
     }
+    return _groupService.fetchRolesViaGroups(opContext, groups);
   }
 
   private Set<String> resolveGroups(
@@ -598,16 +621,31 @@ public class PolicyEngine {
   }
 
   /** Class used to store state across a single Policy evaluation. */
-  static class PolicyEvaluationContext {
+  public static class PolicyEvaluationContext {
     private Set<String> groups;
+    private Set<Urn> directRoles;
     private Set<Urn> roles;
+    private SessionActorIdentity sessionActorIdentity;
+    private OperationContext opContext;
 
     public void setGroups(Set<String> groups) {
       this.groups = groups;
     }
 
+    public void setDirectRoles(Set<Urn> directRoles) {
+      this.directRoles = directRoles;
+    }
+
     public void setRoles(Set<Urn> roles) {
       this.roles = roles;
+    }
+
+    public void setSessionActorIdentity(SessionActorIdentity sessionActorIdentity) {
+      this.sessionActorIdentity = sessionActorIdentity;
+    }
+
+    public void setOpContext(OperationContext opContext) {
+      this.opContext = opContext;
     }
   }
 

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/fieldresolverprovider/GroupMembershipFieldResolverProvider.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/fieldresolverprovider/GroupMembershipFieldResolverProvider.java
@@ -1,22 +1,12 @@
 package com.datahub.authorization.fieldresolverprovider;
 
-import static com.linkedin.metadata.Constants.GROUP_MEMBERSHIP_ASPECT_NAME;
-import static com.linkedin.metadata.Constants.NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME;
-
+import com.datahub.authentication.group.GroupService;
 import com.datahub.authorization.EntityFieldType;
 import com.datahub.authorization.EntitySpec;
 import com.datahub.authorization.FieldResolver;
-import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
-import com.linkedin.entity.EntityResponse;
-import com.linkedin.entity.EnvelopedAspect;
-import com.linkedin.entity.client.SystemEntityClient;
-import com.linkedin.identity.GroupMembership;
-import com.linkedin.identity.NativeGroupMembership;
-import com.linkedin.metadata.Constants;
 import io.datahubproject.metadata.context.OperationContext;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,12 +14,12 @@ import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-/** Provides field resolver for owners given entitySpec */
+/** Provides field resolver for group membership given entitySpec */
 @Slf4j
 @RequiredArgsConstructor
 public class GroupMembershipFieldResolverProvider implements EntityFieldResolverProvider {
 
-  private final SystemEntityClient _entityClient;
+  private final GroupService _groupService;
 
   @Override
   public List<EntityFieldType> getFieldTypes() {
@@ -45,49 +35,22 @@ public class GroupMembershipFieldResolverProvider implements EntityFieldResolver
 
   private FieldResolver.FieldValue getGroupMembership(
       @Nonnull OperationContext opContext, EntitySpec entitySpec) {
-
-    EnvelopedAspect groupMembershipAspect;
-    EnvelopedAspect nativeGroupMembershipAspect;
-    List<Urn> groups = new ArrayList<>();
     try {
       if (entitySpec.getEntity().isEmpty()) {
         return FieldResolver.emptyFieldValue();
       }
 
       Urn entityUrn = UrnUtils.getUrn(entitySpec.getEntity());
-
-      EntityResponse response =
-          _entityClient.getV2(
-              opContext,
-              entityUrn.getEntityType(),
-              entityUrn,
-              ImmutableSet.of(GROUP_MEMBERSHIP_ASPECT_NAME, NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME));
-      if (response == null
-          || !(response.getAspects().containsKey(Constants.GROUP_MEMBERSHIP_ASPECT_NAME)
-              || response
-                  .getAspects()
-                  .containsKey(Constants.NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME))) {
+      List<Urn> groups = _groupService.getGroupsForUser(opContext, entityUrn);
+      if (groups.isEmpty()) {
         return FieldResolver.emptyFieldValue();
       }
-      if (response.getAspects().containsKey(Constants.GROUP_MEMBERSHIP_ASPECT_NAME)) {
-        groupMembershipAspect = response.getAspects().get(Constants.GROUP_MEMBERSHIP_ASPECT_NAME);
-        GroupMembership groupMembership =
-            new GroupMembership(groupMembershipAspect.getValue().data());
-        groups.addAll(groupMembership.getGroups());
-      }
-      if (response.getAspects().containsKey(Constants.NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME)) {
-        nativeGroupMembershipAspect =
-            response.getAspects().get(Constants.NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME);
-        NativeGroupMembership nativeGroupMembership =
-            new NativeGroupMembership(nativeGroupMembershipAspect.getValue().data());
-        groups.addAll(nativeGroupMembership.getNativeGroups());
-      }
+      return FieldResolver.FieldValue.builder()
+          .values(groups.stream().map(Urn::toString).collect(Collectors.toSet()))
+          .build();
     } catch (Exception e) {
       log.error("Error while retrieving group membership aspect for entitySpec {}", entitySpec, e);
       return FieldResolver.emptyFieldValue();
     }
-    return FieldResolver.FieldValue.builder()
-        .values(groups.stream().map(Urn::toString).collect(Collectors.toSet()))
-        .build();
   }
 }

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authentication/group/GroupServiceTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authentication/group/GroupServiceTest.java
@@ -21,9 +21,10 @@ import com.linkedin.entity.Aspect;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspect;
 import com.linkedin.entity.EnvelopedAspectMap;
-import com.linkedin.entity.client.EntityClient;
+import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.identity.GroupMembership;
 import com.linkedin.identity.NativeGroupMembership;
+import com.linkedin.identity.RoleMembership;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.graph.GraphClient;
 import com.linkedin.metadata.key.CorpGroupKey;
@@ -34,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -57,7 +59,7 @@ public class GroupServiceTest {
   private static Map<Urn, EntityResponse> _entityResponseMap;
   private static EntityRelationships _entityRelationships;
 
-  private EntityClient _entityClient;
+  private SystemEntityClient _entityClient;
   private EntityService<?> _entityService;
   private GraphClient _graphClient;
   private GroupService _groupService;
@@ -103,7 +105,7 @@ public class GroupServiceTest {
                             .setEntity(USER_URN)
                             .setType(IS_MEMBER_OF_GROUP_RELATIONSHIP_NAME))));
 
-    _entityClient = mock(EntityClient.class);
+    _entityClient = mock(SystemEntityClient.class);
     _entityService = mock(EntityService.class);
     _graphClient = mock(GraphClient.class);
 
@@ -159,12 +161,82 @@ public class GroupServiceTest {
   public void testAddUserToNativeGroupPasses() throws Exception {
     when(_entityService.exists(any(OperationContext.class), eq(USER_URN), eq(true)))
         .thenReturn(true);
-    when(_entityClient.batchGetV2(
+    when(_entityClient.batchGetV2NoCache(
             any(OperationContext.class), eq(CORP_USER_ENTITY_NAME), any(), any()))
         .thenReturn(_entityResponseMap);
 
     _groupService.addUserToNativeGroup(opContext, USER_URN, _groupUrn);
     verify(_entityClient).ingestProposal(any(OperationContext.class), any());
+    verify(_entityClient).batchGetV2NoCache(any(), eq(CORP_USER_ENTITY_NAME), any(), any());
+  }
+
+  @Test
+  public void testAddUserToNativeGroupWhenAspectMissing() throws Exception {
+    when(_entityService.exists(any(OperationContext.class), eq(USER_URN), eq(true)))
+        .thenReturn(true);
+    when(_entityClient.batchGetV2NoCache(
+            any(OperationContext.class), eq(CORP_USER_ENTITY_NAME), any(), any()))
+        .thenReturn(Map.of());
+
+    _groupService.addUserToNativeGroup(opContext, USER_URN, _groupUrn);
+
+    verify(_entityClient).ingestProposal(any(OperationContext.class), any());
+    verify(_entityClient).batchGetV2NoCache(any(), eq(CORP_USER_ENTITY_NAME), any(), any());
+    verify(_entityClient, never()).batchGetV2(any(), eq(CORP_USER_ENTITY_NAME), any(), any());
+  }
+
+  @Test
+  public void testGetExistingNativeGroupMembershipUsesCachedRead() throws Exception {
+    when(_entityClient.batchGetV2(
+            any(OperationContext.class), eq(CORP_USER_ENTITY_NAME), any(), any()))
+        .thenReturn(_entityResponseMap);
+
+    NativeGroupMembership membership =
+        _groupService.getExistingNativeGroupMembership(opContext, USER_URN);
+
+    assertEquals(1, membership.getNativeGroups().size());
+    assertEquals(
+        Urn.createFromString(NATIVE_GROUP_URN_STRING), membership.getNativeGroups().get(0));
+    verify(_entityClient).batchGetV2(any(), eq(CORP_USER_ENTITY_NAME), any(), any());
+    verify(_entityClient, never()).batchGetV2NoCache(any(), any(), any(), any());
+  }
+
+  @Test
+  public void testGetExistingGroupMembershipUsesCachedRead() throws Exception {
+    when(_entityClient.batchGetV2(
+            any(OperationContext.class), eq(CORP_USER_ENTITY_NAME), any(), any()))
+        .thenReturn(_entityResponseMap);
+
+    GroupMembership membership = _groupService.getExistingGroupMembership(opContext, USER_URN);
+
+    assertEquals(1, membership.getGroups().size());
+    assertEquals(Urn.createFromString(EXTERNAL_GROUP_URN_STRING), membership.getGroups().get(0));
+    verify(_entityClient).batchGetV2(any(), eq(CORP_USER_ENTITY_NAME), any(), any());
+    verify(_entityClient, never()).batchGetV2NoCache(any(), any(), any(), any());
+  }
+
+  @Test
+  public void testRemoveExistingNativeGroupMembersNoOpWhenAspectMissing() throws Exception {
+    when(_entityClient.batchGetV2NoCache(
+            any(OperationContext.class), eq(CORP_USER_ENTITY_NAME), any(), any()))
+        .thenReturn(Map.of());
+
+    _groupService.removeExistingNativeGroupMembers(
+        opContext, Urn.createFromString(NATIVE_GROUP_URN_STRING), USER_URN_LIST);
+
+    verify(_entityClient, never()).ingestProposal(any(OperationContext.class), any());
+  }
+
+  @Test
+  public void testRemoveExistingGroupMembersNoOpWhenAspectMissing() throws Exception {
+    when(_entityClient.batchGetV2NoCache(
+            any(OperationContext.class), eq(CORP_USER_ENTITY_NAME), any(), any()))
+        .thenReturn(Map.of());
+
+    _groupService.removeExistingGroupMembers(
+        opContext, Urn.createFromString(EXTERNAL_GROUP_URN_STRING), USER_URN_LIST);
+
+    verify(_entityClient, never()).ingestProposal(any(OperationContext.class), any());
   }
 
   @Test
@@ -204,7 +276,7 @@ public class GroupServiceTest {
   @Test
   public void testRemoveExistingNativeGroupMembersGroupNotInNativeGroupMembership()
       throws Exception {
-    when(_entityClient.batchGetV2(
+    when(_entityClient.batchGetV2NoCache(
             any(OperationContext.class), eq(CORP_USER_ENTITY_NAME), any(), any()))
         .thenReturn(_entityResponseMap);
 
@@ -217,7 +289,7 @@ public class GroupServiceTest {
 
   @Test
   public void testRemoveExistingNativeGroupMembersPasses() throws Exception {
-    when(_entityClient.batchGetV2(
+    when(_entityClient.batchGetV2NoCache(
             any(OperationContext.class), eq(CORP_USER_ENTITY_NAME), any(), any()))
         .thenReturn(_entityResponseMap);
 
@@ -244,7 +316,7 @@ public class GroupServiceTest {
             anyInt(),
             any()))
         .thenReturn(_entityRelationships);
-    when(_entityClient.batchGetV2(any(), eq(CORP_USER_ENTITY_NAME), any(), any()))
+    when(_entityClient.batchGetV2NoCache(any(), eq(CORP_USER_ENTITY_NAME), any(), any()))
         .thenReturn(_entityResponseMap);
     when(_entityService.exists(any(), eq(USER_URN), eq(true))).thenReturn(true);
 
@@ -320,7 +392,7 @@ public class GroupServiceTest {
 
   @Test
   public void testRemoveExistingGroupMembersGroupNotInGroupMembership() throws Exception {
-    when(_entityClient.batchGetV2(any(), eq(CORP_USER_ENTITY_NAME), any(), any()))
+    when(_entityClient.batchGetV2NoCache(any(), eq(CORP_USER_ENTITY_NAME), any(), any()))
         .thenReturn(_entityResponseMap);
 
     _groupService.removeExistingGroupMembers(
@@ -330,12 +402,111 @@ public class GroupServiceTest {
 
   @Test
   public void testRemoveExistingGroupMembersPasses() throws Exception {
-    when(_entityClient.batchGetV2(
+    when(_entityClient.batchGetV2NoCache(
             any(OperationContext.class), eq(CORP_USER_ENTITY_NAME), any(), any()))
         .thenReturn(_entityResponseMap);
 
     _groupService.removeExistingGroupMembers(
         opContext, Urn.createFromString(EXTERNAL_GROUP_URN_STRING), USER_URN_LIST);
     verify(_entityClient).ingestProposal(any(OperationContext.class), any());
+  }
+
+  @Test
+  public void testGetGroupsForUserUsesSessionCacheForSessionActor() throws Exception {
+    Urn externalGroup = Urn.createFromString(EXTERNAL_GROUP_URN_STRING);
+    Urn nativeGroup = Urn.createFromString(NATIVE_GROUP_URN_STRING);
+    OperationContext sessionOpContext = mock(OperationContext.class);
+    io.datahubproject.metadata.context.ActorContext actorContext =
+        mock(io.datahubproject.metadata.context.ActorContext.class);
+    when(sessionOpContext.getSessionActorContext()).thenReturn(actorContext);
+    when(actorContext.getActorUrn()).thenReturn(USER_URN);
+    when(actorContext.getGroupMembership())
+        .thenReturn(ImmutableList.of(externalGroup, nativeGroup));
+
+    List<Urn> groups = _groupService.getGroupsForUser(sessionOpContext, USER_URN);
+
+    assertEquals(groups, ImmutableList.of(externalGroup, nativeGroup));
+    verifyNoInteractions(_entityClient);
+  }
+
+  @Test
+  public void testGetGroupsForUserFetchesForNonSessionActor() throws Exception {
+    Urn otherUser = new CorpuserUrn("other@email.com");
+    when(_entityClient.batchGetV2(
+            any(OperationContext.class), eq(CORP_USER_ENTITY_NAME), eq(Set.of(otherUser)), any()))
+        .thenReturn(ImmutableMap.of(otherUser, _entityResponseMap.get(USER_URN)));
+
+    List<Urn> groups = _groupService.getGroupsForUser(opContext, otherUser);
+
+    assertEquals(
+        groups,
+        ImmutableList.of(
+            Urn.createFromString(EXTERNAL_GROUP_URN_STRING),
+            Urn.createFromString(NATIVE_GROUP_URN_STRING)));
+    verify(_entityClient)
+        .batchGetV2(
+            any(OperationContext.class), eq(CORP_USER_ENTITY_NAME), eq(Set.of(otherUser)), any());
+  }
+
+  @Test
+  public void testFetchUserIdentityMergesAndDedupesGroups() throws Exception {
+    NativeGroupMembership nativeGroupMembership = new NativeGroupMembership();
+    nativeGroupMembership.setNativeGroups(
+        new UrnArray(
+            Urn.createFromString(NATIVE_GROUP_URN_STRING),
+            Urn.createFromString(EXTERNAL_GROUP_URN_STRING)));
+    GroupMembership groupMembership = new GroupMembership();
+    groupMembership.setGroups(new UrnArray(Urn.createFromString(EXTERNAL_GROUP_URN_STRING)));
+    RoleMembership roleMembership = new RoleMembership();
+    roleMembership.setRoles(new UrnArray(Urn.createFromString("urn:li:dataHubRole:Admin")));
+
+    EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    aspectMap.put(
+        GROUP_MEMBERSHIP_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(groupMembership.data())));
+    aspectMap.put(
+        NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(nativeGroupMembership.data())));
+    aspectMap.put(
+        ROLE_MEMBERSHIP_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(roleMembership.data())));
+
+    when(_entityClient.batchGetV2(
+            any(OperationContext.class),
+            eq(CORP_USER_ENTITY_NAME),
+            eq(Set.of(USER_URN)),
+            eq(
+                ImmutableSet.of(
+                    GROUP_MEMBERSHIP_ASPECT_NAME,
+                    NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME,
+                    ROLE_MEMBERSHIP_ASPECT_NAME))))
+        .thenReturn(Map.of(USER_URN, new EntityResponse().setAspects(aspectMap)));
+
+    var identity = _groupService.fetchUserIdentity(opContext, USER_URN);
+
+    assertEquals(identity.getGroups().size(), 2);
+    assertTrue(identity.getGroups().contains(Urn.createFromString(EXTERNAL_GROUP_URN_STRING)));
+    assertTrue(identity.getGroups().contains(Urn.createFromString(NATIVE_GROUP_URN_STRING)));
+    assertEquals(
+        identity.getDirectRoles(), Set.of(Urn.createFromString("urn:li:dataHubRole:Admin")));
+  }
+
+  @Test
+  public void testFetchUserIdentityEmptyWhenUserMissing() throws Exception {
+    when(_entityClient.batchGetV2(
+            any(OperationContext.class),
+            eq(CORP_USER_ENTITY_NAME),
+            eq(Set.of(USER_URN)),
+            eq(
+                ImmutableSet.of(
+                    GROUP_MEMBERSHIP_ASPECT_NAME,
+                    NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME,
+                    ROLE_MEMBERSHIP_ASPECT_NAME))))
+        .thenReturn(Map.of());
+
+    var identity = _groupService.fetchUserIdentity(opContext, USER_URN);
+
+    assertTrue(identity.getGroups().isEmpty());
+    assertTrue(identity.getDirectRoles().isEmpty());
   }
 }

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authorization/AuthorizerChainTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authorization/AuthorizerChainTest.java
@@ -1,0 +1,215 @@
+package com.datahub.authorization;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.datahub.plugins.auth.authorization.Authorizer;
+import com.datahub.plugins.auth.authorization.ResourceSpecCachingAuthorizer;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.policy.DataHubPolicyInfo;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.OperationContextAuthorizer;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class AuthorizerChainTest {
+
+  private static final AuthorizationRequest REQUEST =
+      new AuthorizationRequest(
+          "urn:li:corpuser:testuser", "VIEW", Optional.empty(), Collections.emptyList());
+
+  private DataHubAuthorizer defaultAuthorizer;
+  private OperationContext opContext;
+
+  @BeforeMethod
+  public void setUp() {
+    defaultAuthorizer = mock(DataHubAuthorizer.class);
+    opContext = TestOperationContexts.systemContextNoValidate();
+  }
+
+  @Test
+  public void authorizeWithOperationContext_delegatesToOperationContextAuthorizerOnAllow() {
+    Authorizer delegate =
+        mock(Authorizer.class, withSettings().extraInterfaces(OperationContextAuthorizer.class));
+    OperationContextAuthorizer operationContextAuthorizer = (OperationContextAuthorizer) delegate;
+    when(operationContextAuthorizer.authorize(any(), any(), eq(opContext)))
+        .thenReturn(new AuthorizationResult(REQUEST, AuthorizationResult.Type.ALLOW, null));
+
+    AuthorizerChain chain = new AuthorizerChain(List.of(delegate), defaultAuthorizer);
+
+    AuthorizationResult result = chain.authorize(REQUEST, null, opContext);
+
+    assertEquals(result.getType(), AuthorizationResult.Type.ALLOW);
+    verify(operationContextAuthorizer, times(1)).authorize(any(), any(), eq(opContext));
+    verify(delegate, never()).authorize(any(AuthorizationRequest.class));
+  }
+
+  @Test
+  public void authorizeWithOperationContext_delegatesToResourceSpecCachingAuthorizer() {
+    Authorizer delegate =
+        mock(Authorizer.class, withSettings().extraInterfaces(ResourceSpecCachingAuthorizer.class));
+    ResourceSpecCachingAuthorizer cachingAuthorizer = (ResourceSpecCachingAuthorizer) delegate;
+    Map<EntitySpec, ResolvedEntitySpec> cache = Map.of();
+    when(cachingAuthorizer.authorize(any(), eq(cache)))
+        .thenReturn(new AuthorizationResult(REQUEST, AuthorizationResult.Type.ALLOW, null));
+
+    AuthorizerChain chain = new AuthorizerChain(List.of(delegate), defaultAuthorizer);
+
+    AuthorizationResult result = chain.authorize(REQUEST, cache, opContext);
+
+    assertEquals(result.getType(), AuthorizationResult.Type.ALLOW);
+    verify(cachingAuthorizer, times(1)).authorize(any(), eq(cache));
+    verify(delegate, never()).authorize(any(AuthorizationRequest.class));
+  }
+
+  @Test
+  public void authorizeWithOperationContext_delegatesToPlainAuthorizer() {
+    Authorizer delegate = mock(Authorizer.class);
+    when(delegate.authorize(any()))
+        .thenReturn(new AuthorizationResult(REQUEST, AuthorizationResult.Type.ALLOW, null));
+
+    AuthorizerChain chain = new AuthorizerChain(List.of(delegate), defaultAuthorizer);
+
+    AuthorizationResult result = chain.authorize(REQUEST, null, opContext);
+
+    assertEquals(result.getType(), AuthorizationResult.Type.ALLOW);
+    verify(delegate, times(1)).authorize(any(AuthorizationRequest.class));
+  }
+
+  @Test
+  public void authorizeWithOperationContext_returnsDenyWhenAllDelegatesDeny() {
+    Authorizer delegate =
+        mock(Authorizer.class, withSettings().extraInterfaces(OperationContextAuthorizer.class));
+    OperationContextAuthorizer operationContextAuthorizer = (OperationContextAuthorizer) delegate;
+    when(operationContextAuthorizer.authorize(any(), any(), eq(opContext)))
+        .thenReturn(new AuthorizationResult(REQUEST, AuthorizationResult.Type.DENY, "denied"));
+
+    AuthorizerChain chain = new AuthorizerChain(List.of(delegate), defaultAuthorizer);
+
+    AuthorizationResult result = chain.authorize(REQUEST, null, opContext);
+
+    assertEquals(result.getType(), AuthorizationResult.Type.DENY);
+  }
+
+  @Test
+  public void authorizeWithOperationContext_skipsAuthorizerOnException() {
+    Authorizer failingDelegate =
+        mock(Authorizer.class, withSettings().extraInterfaces(OperationContextAuthorizer.class));
+    OperationContextAuthorizer failingOperationContextAuthorizer =
+        (OperationContextAuthorizer) failingDelegate;
+    when(failingOperationContextAuthorizer.authorize(any(), any(), eq(opContext)))
+        .thenThrow(new RuntimeException("boom"));
+
+    Authorizer succeedingDelegate =
+        mock(Authorizer.class, withSettings().extraInterfaces(OperationContextAuthorizer.class));
+    OperationContextAuthorizer succeedingOperationContextAuthorizer =
+        (OperationContextAuthorizer) succeedingDelegate;
+    when(succeedingOperationContextAuthorizer.authorize(any(), any(), eq(opContext)))
+        .thenReturn(new AuthorizationResult(REQUEST, AuthorizationResult.Type.ALLOW, null));
+
+    AuthorizerChain chain =
+        new AuthorizerChain(List.of(failingDelegate, succeedingDelegate), defaultAuthorizer);
+
+    AuthorizationResult result = chain.authorize(REQUEST, null, opContext);
+
+    assertEquals(result.getType(), AuthorizationResult.Type.ALLOW);
+    verify(succeedingOperationContextAuthorizer, times(1)).authorize(any(), any(), eq(opContext));
+  }
+
+  @Test
+  public void
+      resolveSessionActorIdentityWithOperationContext_delegatesToOperationContextAuthorizer() {
+    Authorizer delegate =
+        mock(Authorizer.class, withSettings().extraInterfaces(OperationContextAuthorizer.class));
+    OperationContextAuthorizer operationContextAuthorizer = (OperationContextAuthorizer) delegate;
+    SessionActorIdentity identity =
+        SessionActorIdentity.empty(UrnUtils.getUrn("urn:li:corpuser:testuser"));
+    when(operationContextAuthorizer.resolveSessionActorIdentity(
+            eq(identity.getActorUrn()), eq(opContext)))
+        .thenReturn(Optional.of(identity));
+
+    AuthorizerChain chain = new AuthorizerChain(List.of(delegate), defaultAuthorizer);
+
+    Optional<SessionActorIdentity> result =
+        chain.resolveSessionActorIdentity(identity.getActorUrn(), opContext);
+
+    assertTrue(result.isPresent());
+    assertEquals(result.get(), identity);
+  }
+
+  @Test
+  public void resolveSessionActorIdentityWithOperationContext_ignoresPlainAuthorizers() {
+    Authorizer delegate = mock(Authorizer.class);
+    when(delegate.resolveSessionActorIdentity(any()))
+        .thenReturn(Optional.of(SessionActorIdentity.empty(UrnUtils.getUrn("urn:li:corpuser:x"))));
+
+    AuthorizerChain chain = new AuthorizerChain(List.of(delegate), defaultAuthorizer);
+
+    Optional<SessionActorIdentity> result =
+        chain.resolveSessionActorIdentity(UrnUtils.getUrn("urn:li:corpuser:testuser"), opContext);
+
+    assertFalse(result.isPresent());
+    verify(delegate, never()).resolveSessionActorIdentity(any());
+  }
+
+  @Test
+  public void getActorPoliciesWithOperationContext_delegatesToOperationContextAuthorizer() {
+    Authorizer delegate =
+        mock(Authorizer.class, withSettings().extraInterfaces(OperationContextAuthorizer.class));
+    OperationContextAuthorizer operationContextAuthorizer = (OperationContextAuthorizer) delegate;
+    SessionActorIdentity identity =
+        SessionActorIdentity.empty(UrnUtils.getUrn("urn:li:corpuser:testuser"));
+    Set<DataHubPolicyInfo> policies = Set.of(new DataHubPolicyInfo());
+    when(operationContextAuthorizer.getActorPolicies(
+            eq(identity.getActorUrn()), eq(identity), isNull(), isNull(), eq(opContext)))
+        .thenReturn(policies);
+
+    AuthorizerChain chain = new AuthorizerChain(List.of(delegate), defaultAuthorizer);
+
+    Set<DataHubPolicyInfo> result =
+        chain.getActorPolicies(identity.getActorUrn(), identity, null, null, opContext);
+
+    assertEquals(result, policies);
+  }
+
+  @Test
+  public void getActorGroupsWithOperationContext_delegatesToDataHubAuthorizer() {
+    DataHubAuthorizer delegate = mock(DataHubAuthorizer.class);
+    List<com.linkedin.common.urn.Urn> groups = List.of(UrnUtils.getUrn("urn:li:corpGroup:test"));
+    when(delegate.getActorGroups(any(), eq(opContext))).thenReturn(groups);
+
+    AuthorizerChain chain = new AuthorizerChain(List.of(delegate), defaultAuthorizer);
+
+    assertEquals(
+        chain.getActorGroups(UrnUtils.getUrn("urn:li:corpuser:testuser"), opContext), groups);
+  }
+
+  @Test
+  public void getActorGroupsWithOperationContext_fallsBackToPlainGetActorGroups() {
+    Authorizer delegate = mock(Authorizer.class);
+    List<com.linkedin.common.urn.Urn> groups = List.of(UrnUtils.getUrn("urn:li:corpGroup:test"));
+    when(delegate.getActorGroups(any())).thenReturn(groups);
+
+    AuthorizerChain chain = new AuthorizerChain(List.of(delegate), defaultAuthorizer);
+
+    assertEquals(
+        chain.getActorGroups(UrnUtils.getUrn("urn:li:corpuser:testuser"), opContext), groups);
+    verify(delegate, times(1)).getActorGroups(any());
+  }
+}

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
@@ -16,6 +16,7 @@ import static org.testng.Assert.assertTrue;
 import com.datahub.authentication.Actor;
 import com.datahub.authentication.ActorType;
 import com.datahub.authentication.Authentication;
+import com.datahub.authentication.group.GroupService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.AuditStamp;
@@ -38,6 +39,8 @@ import com.linkedin.entity.EnvelopedAspectMap;
 import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.identity.GroupMembership;
 import com.linkedin.identity.RoleMembership;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.graph.GraphClient;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.ScrollResult;
@@ -84,12 +87,15 @@ public class DataHubAuthorizerTest {
       UrnUtils.getUrn("urn:li:dataset:testDomainContainer");
 
   private SystemEntityClient _entityClient;
+  private GroupService _groupService;
   private DataHubAuthorizer _dataHubAuthorizer;
   private OperationContext systemOpContext;
 
   @BeforeMethod
   public void setupTest() throws Exception {
     _entityClient = mock(SystemEntityClient.class);
+    _groupService =
+        new GroupService(_entityClient, mock(EntityService.class), mock(GraphClient.class));
 
     // Init mocks.
     final Urn activePolicyUrn = Urn.createFromString("urn:li:dataHubPolicy:0");
@@ -540,6 +546,7 @@ public class DataHubAuthorizerTest {
         new DataHubAuthorizer(
             systemOpContext,
             _entityClient,
+            _groupService,
             10,
             10,
             DataHubAuthorizer.AuthorizationMode.DEFAULT,
@@ -1137,6 +1144,223 @@ public class DataHubAuthorizerTest {
     assertEquals(_dataHubAuthorizer.authorize(request).getType(), AuthorizationResult.Type.ALLOW);
   }
 
+  @Test
+  public void testAuthorizationGrantedBasedOnSeededGroupMembershipSkipsUserFetch()
+      throws Exception {
+    final EntitySpec resourceSpec = new EntitySpec("dataset", "urn:li:dataset:custom");
+
+    final Urn userUrnWithoutPermissions = UrnUtils.getUrn("urn:li:corpuser:userWithoutRole");
+    final Urn groupWithAdminPermission = UrnUtils.getUrn("urn:li:corpGroup:groupWithRole");
+    final UrnArray groups = new UrnArray(List.of(groupWithAdminPermission));
+    final GroupMembership groupMembership = new GroupMembership();
+    groupMembership.setGroups(groups);
+
+    when(_entityClient.batchGetV2(
+            any(OperationContext.class),
+            any(),
+            eq(Collections.singleton(userUrnWithoutPermissions)),
+            eq(
+                ImmutableSet.of(
+                    ROLE_MEMBERSHIP_ASPECT_NAME,
+                    GROUP_MEMBERSHIP_ASPECT_NAME,
+                    NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME))))
+        .thenReturn(
+            createEntityBatchResponse(
+                userUrnWithoutPermissions, GROUP_MEMBERSHIP_ASPECT_NAME, groupMembership));
+
+    when(_entityClient.batchGetV2(
+            any(OperationContext.class),
+            any(),
+            eq(Collections.singleton(groupWithAdminPermission)),
+            eq(Collections.singleton(ROLE_MEMBERSHIP_ASPECT_NAME))))
+        .thenReturn(
+            createRoleMembershipBatchResponse(
+                groupWithAdminPermission, UrnUtils.getUrn("urn:li:dataHubRole:Admin")));
+
+    clearInvocations(_entityClient);
+
+    AuthorizationRequest request =
+        new AuthorizationRequest(
+            userUrnWithoutPermissions.toString(),
+            "EDIT_USER_PROFILE",
+            Optional.of(resourceSpec),
+            Collections.emptyList(),
+            null,
+            List.of(groupWithAdminPermission),
+            Collections.emptySet());
+
+    assertEquals(_dataHubAuthorizer.authorize(request).getType(), AuthorizationResult.Type.ALLOW);
+
+    verify(_entityClient, never())
+        .batchGetV2(
+            any(OperationContext.class),
+            any(),
+            eq(Collections.singleton(userUrnWithoutPermissions)),
+            any());
+    verify(_entityClient, times(1))
+        .batchGetV2(
+            any(OperationContext.class),
+            any(),
+            eq(Collections.singleton(groupWithAdminPermission)),
+            eq(Collections.singleton(ROLE_MEMBERSHIP_ASPECT_NAME)));
+  }
+
+  @Test
+  public void testMultipleAuthorizeCallsReuseSessionActorRoleResolution() throws Exception {
+    final EntitySpec resourceSpec = new EntitySpec("dataset", "urn:li:dataset:custom");
+    final EntitySpec otherResourceSpec = new EntitySpec("dataset", "urn:li:dataset:other");
+
+    final Urn userUrnWithoutPermissions = UrnUtils.getUrn("urn:li:corpuser:userWithoutRole");
+    final Urn groupWithAdminPermission = UrnUtils.getUrn("urn:li:corpGroup:groupWithRole");
+    final SessionActorIdentity sessionIdentity =
+        new SessionActorIdentity(
+            userUrnWithoutPermissions, List.of(groupWithAdminPermission), Set.of());
+
+    when(_entityClient.batchGetV2(
+            any(OperationContext.class),
+            any(),
+            eq(Collections.singleton(groupWithAdminPermission)),
+            eq(Collections.singleton(ROLE_MEMBERSHIP_ASPECT_NAME))))
+        .thenReturn(
+            createRoleMembershipBatchResponse(
+                groupWithAdminPermission, UrnUtils.getUrn("urn:li:dataHubRole:Admin")));
+
+    clearInvocations(_entityClient);
+
+    AuthorizationRequest requestOne =
+        new AuthorizationRequest(
+            userUrnWithoutPermissions.toString(),
+            "EDIT_USER_PROFILE",
+            Optional.of(resourceSpec),
+            Collections.emptyList(),
+            null,
+            List.of(groupWithAdminPermission),
+            Collections.emptySet(),
+            sessionIdentity);
+    AuthorizationRequest requestTwo =
+        new AuthorizationRequest(
+            userUrnWithoutPermissions.toString(),
+            "EDIT_USER_PROFILE",
+            Optional.of(otherResourceSpec),
+            Collections.emptyList(),
+            null,
+            List.of(groupWithAdminPermission),
+            Collections.emptySet(),
+            sessionIdentity);
+
+    assertEquals(
+        _dataHubAuthorizer.authorize(requestOne, null, systemOpContext).getType(),
+        AuthorizationResult.Type.ALLOW);
+    assertEquals(
+        _dataHubAuthorizer.authorize(requestTwo, null, systemOpContext).getType(),
+        AuthorizationResult.Type.ALLOW);
+
+    verify(_entityClient, times(1))
+        .batchGetV2(
+            any(OperationContext.class),
+            any(),
+            eq(Collections.singleton(groupWithAdminPermission)),
+            eq(Collections.singleton(ROLE_MEMBERSHIP_ASPECT_NAME)));
+  }
+
+  @Test
+  public void testGetActorPoliciesWithSeededGroupsSkipsUserFetch() throws Exception {
+    final Urn userUrnWithoutPermissions = UrnUtils.getUrn("urn:li:corpuser:userWithoutRole");
+    final Urn groupWithAdminPermission = UrnUtils.getUrn("urn:li:corpGroup:groupWithRole");
+
+    when(_entityClient.batchGetV2(
+            any(OperationContext.class),
+            any(),
+            eq(Collections.singleton(groupWithAdminPermission)),
+            eq(Collections.singleton(ROLE_MEMBERSHIP_ASPECT_NAME))))
+        .thenReturn(
+            createRoleMembershipBatchResponse(
+                groupWithAdminPermission, UrnUtils.getUrn("urn:li:dataHubRole:Admin")));
+
+    clearInvocations(_entityClient);
+
+    Set<DataHubPolicyInfo> policies =
+        _dataHubAuthorizer.getActorPolicies(
+            userUrnWithoutPermissions, List.of(groupWithAdminPermission), Collections.emptySet());
+
+    assertTrue(
+        policies.stream().anyMatch(policy -> policy.getPrivileges().contains("EDIT_USER_PROFILE")));
+
+    verify(_entityClient, never())
+        .batchGetV2(
+            any(OperationContext.class),
+            any(),
+            eq(Collections.singleton(userUrnWithoutPermissions)),
+            any());
+    verify(_entityClient, times(1))
+        .batchGetV2(
+            any(OperationContext.class),
+            any(),
+            eq(Collections.singleton(groupWithAdminPermission)),
+            eq(Collections.singleton(ROLE_MEMBERSHIP_ASPECT_NAME)));
+  }
+
+  @Test
+  public void testGetGrantedPrivilegesSeedsSessionActorGroups() throws Exception {
+    final Urn userUrnWithoutPermissions = UrnUtils.getUrn("urn:li:corpuser:userWithoutRole");
+    final Urn groupWithAdminPermission = UrnUtils.getUrn("urn:li:corpGroup:groupWithRole");
+
+    when(_entityClient.batchGetV2(
+            any(OperationContext.class),
+            any(),
+            eq(Collections.singleton(groupWithAdminPermission)),
+            eq(Collections.singleton(ROLE_MEMBERSHIP_ASPECT_NAME))))
+        .thenReturn(
+            createRoleMembershipBatchResponse(
+                groupWithAdminPermission, UrnUtils.getUrn("urn:li:dataHubRole:Admin")));
+
+    OperationContext sessionOpContext = mock(OperationContext.class);
+    ActorContext actorContext = mock(ActorContext.class);
+    when(sessionOpContext.getSessionActorContext()).thenReturn(actorContext);
+    when(actorContext.getActorUrn()).thenReturn(userUrnWithoutPermissions);
+    when(actorContext.getGroupMembership()).thenReturn(List.of(groupWithAdminPermission));
+    when(actorContext.getDirectRoleMembership()).thenReturn(Collections.emptySet());
+    io.datahubproject.metadata.context.AuthorizationContext authorizationContext =
+        mock(io.datahubproject.metadata.context.AuthorizationContext.class);
+    when(sessionOpContext.getAuthorizationContext()).thenReturn(authorizationContext);
+    when(authorizationContext.getSessionActorIdentity(userUrnWithoutPermissions)).thenReturn(null);
+
+    clearInvocations(_entityClient);
+
+    EntitySpec resourceSpec = new EntitySpec("dataset", "urn:li:dataset:test");
+    PolicyEngine.PolicyGrantedPrivileges result =
+        _dataHubAuthorizer.getGrantedPrivileges(
+            userUrnWithoutPermissions.toString(), Optional.of(resourceSpec), sessionOpContext);
+
+    assertTrue(result.getPrivileges().contains("EDIT_USER_PROFILE"));
+
+    verify(_entityClient, never())
+        .batchGetV2(
+            any(OperationContext.class),
+            any(),
+            eq(Collections.singleton(userUrnWithoutPermissions)),
+            any());
+  }
+
+  @Test
+  public void testGetActorGroupsUsesSessionContextCache() {
+    final Urn userUrn = UrnUtils.getUrn("urn:li:corpuser:test");
+    final Urn groupUrn = UrnUtils.getUrn("urn:li:corpGroup:testGroup");
+
+    OperationContext sessionOpContext = mock(OperationContext.class);
+    ActorContext actorContext = mock(ActorContext.class);
+    when(sessionOpContext.getSessionActorContext()).thenReturn(actorContext);
+    when(actorContext.getActorUrn()).thenReturn(userUrn);
+    when(actorContext.getGroupMembership()).thenReturn(List.of(groupUrn));
+
+    clearInvocations(_entityClient);
+
+    Collection<Urn> groups = _dataHubAuthorizer.getActorGroups(userUrn, sessionOpContext);
+
+    assertEquals(groups, List.of(groupUrn));
+    verifyNoInteractions(_entityClient);
+  }
+
   private DataHubPolicyInfo createDataHubPolicyInfo(
       boolean active, List<String> privileges, @Nullable final Urn domain) throws Exception {
 
@@ -1304,6 +1528,7 @@ public class DataHubAuthorizerTest {
   private AuthorizerContext createAuthorizerContext(
       final OperationContext systemOpContext, final SystemEntityClient entityClient) {
     return new AuthorizerContext(
-        Collections.emptyMap(), new DefaultEntitySpecResolver(systemOpContext, entityClient));
+        Collections.emptyMap(),
+        new DefaultEntitySpecResolver(systemOpContext, entityClient, _groupService));
   }
 }

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authorization/PolicyEngineTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authorization/PolicyEngineTest.java
@@ -5,6 +5,7 @@ import static com.linkedin.metadata.authorization.PoliciesConfig.*;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 
+import com.datahub.authentication.group.GroupService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -20,9 +21,11 @@ import com.linkedin.entity.Aspect;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspect;
 import com.linkedin.entity.EnvelopedAspectMap;
-import com.linkedin.entity.client.EntityClient;
+import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.identity.RoleMembership;
 import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.graph.GraphClient;
 import com.linkedin.policy.*;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
@@ -45,7 +48,8 @@ public class PolicyEngineTest {
   private static final String OTHER_OWNERSHIP_TYPE_URN =
       "urn:li:ownershipType:__system__data_steward";
 
-  private EntityClient _entityClient;
+  private SystemEntityClient _entityClient;
+  private GroupService _groupService;
   private OperationContext systemOperationContext;
   private PolicyEngine _policyEngine;
 
@@ -57,9 +61,12 @@ public class PolicyEngineTest {
 
   @BeforeMethod
   public void setupTest() throws Exception {
-    _entityClient = Mockito.mock(EntityClient.class);
+    _entityClient = Mockito.mock(SystemEntityClient.class);
+    _groupService =
+        new GroupService(
+            _entityClient, Mockito.mock(EntityService.class), Mockito.mock(GraphClient.class));
     systemOperationContext = TestOperationContexts.systemContextNoSearchAuthorization();
-    _policyEngine = new PolicyEngine(_entityClient);
+    _policyEngine = new PolicyEngine(_entityClient, _groupService);
 
     authorizedUserUrn = Urn.createFromString(AUTHORIZED_PRINCIPAL);
     resolvedAuthorizedUserSpec =
@@ -394,7 +401,131 @@ public class PolicyEngineTest {
   }
 
   @Test
-  // Write a test to verify that the policy engine is able to evaluate a policy with a role match
+  public void testEvaluatePolicyWithSeededGroupMembershipSkipsUserFetch() throws Exception {
+    final DataHubPolicyInfo groupPolicy = createGroupMatchPolicy();
+    final ResolvedEntitySpec actorWithoutGroupMembership =
+        buildEntityResolvers(CORP_USER_ENTITY_NAME, AUTHORIZED_PRINCIPAL);
+    final ResolvedEntitySpec resourceSpec = buildEntityResolvers("dataset", RESOURCE_URN);
+
+    final PolicyEngine.PolicyEvaluationContext seededContext =
+        _policyEngine.createSeededEvaluationContext(
+            List.of(Urn.createFromString(AUTHORIZED_GROUP)), Collections.emptySet());
+
+    PolicyEngine.PolicyEvaluationResult result =
+        _policyEngine.evaluatePolicy(
+            systemOperationContext,
+            groupPolicy,
+            actorWithoutGroupMembership,
+            "EDIT_ENTITY_TAGS",
+            Optional.of(resourceSpec),
+            Collections.emptyList(),
+            seededContext);
+
+    assertTrue(result.isGranted());
+    verify(_entityClient, times(0)).batchGetV2(any(), any(), any(), any());
+  }
+
+  @Test
+  public void testEvaluatePolicyWithSeededRolesSkipsUserFetch() throws Exception {
+    final DataHubPolicyInfo rolePolicy = createRoleMatchPolicy();
+    final ResolvedEntitySpec actorWithoutMembership =
+        buildEntityResolvers(CORP_USER_ENTITY_NAME, AUTHORIZED_PRINCIPAL);
+    final ResolvedEntitySpec resourceSpec = buildEntityResolvers("dataset", RESOURCE_URN);
+
+    final Urn adminRole = Urn.createFromString("urn:li:dataHubRole:admin");
+    final Urn groupUrn = Urn.createFromString(AUTHORIZED_GROUP);
+    when(_entityClient.batchGetV2(
+            eq(systemOperationContext),
+            eq(CORP_GROUP_ENTITY_NAME),
+            eq(Collections.singleton(groupUrn)),
+            eq(Collections.singleton(ROLE_MEMBERSHIP_ASPECT_NAME))))
+        .thenReturn(createGroupRoleBatchResponse(groupUrn, adminRole));
+
+    final PolicyEngine.PolicyEvaluationContext seededContext =
+        _policyEngine.createSeededEvaluationContext(List.of(groupUrn), Collections.emptySet());
+
+    PolicyEngine.PolicyEvaluationResult result =
+        _policyEngine.evaluatePolicy(
+            systemOperationContext,
+            rolePolicy,
+            actorWithoutMembership,
+            "EDIT_ENTITY_TAGS",
+            Optional.of(resourceSpec),
+            Collections.emptyList(),
+            seededContext);
+
+    assertTrue(result.isGranted());
+    verify(_entityClient, never())
+        .batchGetV2(
+            eq(systemOperationContext),
+            eq(CORP_USER_ENTITY_NAME),
+            eq(Collections.singleton(authorizedUserUrn)),
+            any());
+    verify(_entityClient, times(1))
+        .batchGetV2(
+            eq(systemOperationContext),
+            eq(CORP_GROUP_ENTITY_NAME),
+            eq(Collections.singleton(groupUrn)),
+            eq(Collections.singleton(ROLE_MEMBERSHIP_ASPECT_NAME)));
+  }
+
+  @Test
+  public void testSharedSeededContextFetchesGroupRolesOnceAcrossPolicies() throws Exception {
+    final DataHubPolicyInfo rolePolicy = createRoleMatchPolicy();
+    final ResolvedEntitySpec actorWithoutMembership =
+        buildEntityResolvers(CORP_USER_ENTITY_NAME, AUTHORIZED_PRINCIPAL);
+    final ResolvedEntitySpec resourceSpec = buildEntityResolvers("dataset", RESOURCE_URN);
+
+    final Urn adminRole = Urn.createFromString("urn:li:dataHubRole:admin");
+    final Urn groupUrn = Urn.createFromString(AUTHORIZED_GROUP);
+    when(_entityClient.batchGetV2(
+            eq(systemOperationContext),
+            eq(CORP_GROUP_ENTITY_NAME),
+            eq(Collections.singleton(groupUrn)),
+            eq(Collections.singleton(ROLE_MEMBERSHIP_ASPECT_NAME))))
+        .thenReturn(createGroupRoleBatchResponse(groupUrn, adminRole));
+
+    final PolicyEngine.PolicyEvaluationContext sharedContext =
+        _policyEngine.createSeededEvaluationContext(List.of(groupUrn), Collections.emptySet());
+
+    assertTrue(
+        _policyEngine
+            .evaluatePolicy(
+                systemOperationContext,
+                rolePolicy,
+                actorWithoutMembership,
+                "EDIT_ENTITY_TAGS",
+                Optional.of(resourceSpec),
+                Collections.emptyList(),
+                sharedContext)
+            .isGranted());
+    assertFalse(
+        _policyEngine
+            .evaluatePolicy(
+                systemOperationContext,
+                rolePolicy,
+                actorWithoutMembership,
+                "EDIT_ENTITY_DOMAINS",
+                Optional.of(resourceSpec),
+                Collections.emptyList(),
+                sharedContext)
+            .isGranted());
+
+    verify(_entityClient, times(1))
+        .batchGetV2(
+            eq(systemOperationContext),
+            eq(CORP_GROUP_ENTITY_NAME),
+            eq(Collections.singleton(groupUrn)),
+            eq(Collections.singleton(ROLE_MEMBERSHIP_ASPECT_NAME)));
+    verify(_entityClient, never())
+        .batchGetV2(
+            eq(systemOperationContext),
+            eq(CORP_USER_ENTITY_NAME),
+            eq(Collections.singleton(authorizedUserUrn)),
+            any());
+  }
+
+  @Test
   public void testEvaluatePolicyActorFilterRoleMatch() throws Exception {
 
     final DataHubPolicyInfo dataHubPolicyInfo = new DataHubPolicyInfo();
@@ -2443,6 +2574,70 @@ public class PolicyEngineTest {
             mixedOwnerships);
 
     assertFalse(result.isGranted());
+  }
+
+  private DataHubPolicyInfo createGroupMatchPolicy() throws Exception {
+    final DataHubPolicyInfo dataHubPolicyInfo = new DataHubPolicyInfo();
+    dataHubPolicyInfo.setType(METADATA_POLICY_TYPE);
+    dataHubPolicyInfo.setState(ACTIVE_POLICY_STATE);
+    dataHubPolicyInfo.setPrivileges(new StringArray("EDIT_ENTITY_TAGS"));
+    dataHubPolicyInfo.setDisplayName("Seeded group policy");
+    dataHubPolicyInfo.setDescription("Seeded group policy");
+    dataHubPolicyInfo.setEditable(true);
+
+    final DataHubActorFilter actorFilter = new DataHubActorFilter();
+    final UrnArray groupsUrnArray = new UrnArray();
+    groupsUrnArray.add(Urn.createFromString(AUTHORIZED_GROUP));
+    actorFilter.setGroups(groupsUrnArray);
+    actorFilter.setResourceOwners(false);
+    actorFilter.setAllUsers(false);
+    actorFilter.setAllGroups(false);
+    dataHubPolicyInfo.setActors(actorFilter);
+
+    final DataHubResourceFilter resourceFilter = new DataHubResourceFilter();
+    resourceFilter.setAllResources(true);
+    resourceFilter.setType("dataset");
+    dataHubPolicyInfo.setResources(resourceFilter);
+    return dataHubPolicyInfo;
+  }
+
+  private DataHubPolicyInfo createRoleMatchPolicy() throws Exception {
+    final DataHubPolicyInfo dataHubPolicyInfo = new DataHubPolicyInfo();
+    dataHubPolicyInfo.setType(METADATA_POLICY_TYPE);
+    dataHubPolicyInfo.setState(ACTIVE_POLICY_STATE);
+    dataHubPolicyInfo.setPrivileges(new StringArray("EDIT_ENTITY_TAGS"));
+    dataHubPolicyInfo.setDisplayName("Seeded role policy");
+    dataHubPolicyInfo.setDescription("Seeded role policy");
+    dataHubPolicyInfo.setEditable(true);
+
+    final DataHubActorFilter actorFilter = new DataHubActorFilter();
+    final UrnArray rolesUrnArray = new UrnArray();
+    rolesUrnArray.add(Urn.createFromString("urn:li:dataHubRole:admin"));
+    actorFilter.setRoles(rolesUrnArray);
+    actorFilter.setResourceOwners(false);
+    actorFilter.setAllUsers(false);
+    actorFilter.setAllGroups(false);
+    dataHubPolicyInfo.setActors(actorFilter);
+
+    final DataHubResourceFilter resourceFilter = new DataHubResourceFilter();
+    resourceFilter.setAllResources(true);
+    resourceFilter.setType("dataset");
+    dataHubPolicyInfo.setResources(resourceFilter);
+    return dataHubPolicyInfo;
+  }
+
+  private Map<Urn, EntityResponse> createGroupRoleBatchResponse(
+      final Urn groupUrn, final Urn roleUrn) throws URISyntaxException {
+    final RoleMembership roleMembership = new RoleMembership();
+    roleMembership.setRoles(new UrnArray(roleUrn));
+    final EntityResponse entityResponse = new EntityResponse();
+    entityResponse.setUrn(groupUrn);
+    final EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    aspectMap.put(
+        ROLE_MEMBERSHIP_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(roleMembership.data())));
+    entityResponse.setAspects(aspectMap);
+    return Collections.singletonMap(groupUrn, entityResponse);
   }
 
   private Ownership createOwnershipAspect(final Boolean addUserOwner, final Boolean addGroupOwner)

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authorization/fieldresolverprovider/GroupMembershipFieldResolverProviderTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authorization/fieldresolverprovider/GroupMembershipFieldResolverProviderTest.java
@@ -1,29 +1,22 @@
 package com.datahub.authorization.fieldresolverprovider;
 
-import static com.linkedin.metadata.Constants.*;
+import static com.linkedin.metadata.Constants.DATASET_ENTITY_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import com.datahub.authentication.group.GroupService;
 import com.datahub.authorization.EntityFieldType;
 import com.datahub.authorization.EntitySpec;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
-import com.linkedin.entity.Aspect;
-import com.linkedin.entity.EntityResponse;
-import com.linkedin.entity.EnvelopedAspect;
-import com.linkedin.entity.EnvelopedAspectMap;
-import com.linkedin.entity.client.SystemEntityClient;
-import com.linkedin.identity.GroupMembership;
-import com.linkedin.identity.NativeGroupMembership;
-import com.linkedin.r2.RemoteInvocationException;
+import com.linkedin.common.urn.UrnUtils;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
-import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -39,7 +32,7 @@ public class GroupMembershipFieldResolverProviderTest
       "urn:li:dataset:(urn:li:dataPlatform:testPlatform,testDataset,PROD)";
   private static final EntitySpec RESOURCE_SPEC = new EntitySpec(DATASET_ENTITY_NAME, RESOURCE_URN);
 
-  @Mock private SystemEntityClient entityClientMock;
+  @Mock private GroupService groupServiceMock;
 
   private OperationContext systemOperationContext;
 
@@ -54,7 +47,7 @@ public class GroupMembershipFieldResolverProviderTest
 
   @Override
   protected GroupMembershipFieldResolverProvider buildFieldResolverProvider() {
-    return new GroupMembershipFieldResolverProvider(entityClientMock);
+    return new GroupMembershipFieldResolverProvider(groupServiceMock);
   }
 
   @Test
@@ -65,169 +58,76 @@ public class GroupMembershipFieldResolverProviderTest
   }
 
   @Test
-  public void shouldReturnEmptyFieldValueWhenResponseIsNull()
-      throws RemoteInvocationException, URISyntaxException {
-    when(entityClientMock.getV2(
-            eq(systemOperationContext),
-            eq(DATASET_ENTITY_NAME),
-            any(Urn.class),
-            eq(ImmutableSet.of(GROUP_MEMBERSHIP_ASPECT_NAME, NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME))))
-        .thenReturn(null);
+  public void shouldReturnEmptyFieldValueWhenResponseIsNull() {
+    when(groupServiceMock.getGroupsForUser(eq(systemOperationContext), any(Urn.class)))
+        .thenReturn(Collections.emptyList());
 
     var result =
         groupMembershipFieldResolverProvider.getFieldResolver(
             systemOperationContext, RESOURCE_SPEC);
 
     assertTrue(result.getFieldValuesFuture().join().getValues().isEmpty());
-    verify(entityClientMock, times(1))
-        .getV2(
-            eq(systemOperationContext),
-            eq(DATASET_ENTITY_NAME),
-            any(Urn.class),
-            eq(ImmutableSet.of(GROUP_MEMBERSHIP_ASPECT_NAME, NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME)));
+    verify(groupServiceMock, times(1)).getGroupsForUser(eq(systemOperationContext), any(Urn.class));
   }
 
   @Test
-  public void shouldReturnEmptyFieldValueWhenResourceDoesNotBelongToAnyGroup()
-      throws RemoteInvocationException, URISyntaxException {
-    var entityResponseMock = mock(EntityResponse.class);
-    when(entityResponseMock.getAspects()).thenReturn(new EnvelopedAspectMap());
-    when(entityClientMock.getV2(
-            eq(systemOperationContext),
-            eq(DATASET_ENTITY_NAME),
-            any(Urn.class),
-            eq(ImmutableSet.of(GROUP_MEMBERSHIP_ASPECT_NAME, NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME))))
-        .thenReturn(entityResponseMock);
+  public void shouldReturnEmptyFieldValueWhenResourceDoesNotBelongToAnyGroup() {
+    when(groupServiceMock.getGroupsForUser(eq(systemOperationContext), any(Urn.class)))
+        .thenReturn(Collections.emptyList());
 
     var result =
         groupMembershipFieldResolverProvider.getFieldResolver(
             systemOperationContext, RESOURCE_SPEC);
 
     assertTrue(result.getFieldValuesFuture().join().getValues().isEmpty());
-    verify(entityClientMock, times(1))
-        .getV2(
-            eq(systemOperationContext),
-            eq(DATASET_ENTITY_NAME),
-            any(Urn.class),
-            eq(ImmutableSet.of(GROUP_MEMBERSHIP_ASPECT_NAME, NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME)));
+    verify(groupServiceMock, times(1)).getGroupsForUser(eq(systemOperationContext), any(Urn.class));
   }
 
   @Test
-  public void shouldReturnEmptyFieldValueWhenThereIsAnException()
-      throws RemoteInvocationException, URISyntaxException {
-    when(entityClientMock.getV2(
-            eq(systemOperationContext),
-            eq(DATASET_ENTITY_NAME),
-            any(Urn.class),
-            eq(ImmutableSet.of(GROUP_MEMBERSHIP_ASPECT_NAME, NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME))))
-        .thenThrow(new RemoteInvocationException());
+  public void shouldReturnEmptyFieldValueWhenThereIsAnException() {
+    when(groupServiceMock.getGroupsForUser(eq(systemOperationContext), any(Urn.class)))
+        .thenThrow(new RuntimeException("fetch failed"));
 
     var result =
         groupMembershipFieldResolverProvider.getFieldResolver(
             systemOperationContext, RESOURCE_SPEC);
 
     assertTrue(result.getFieldValuesFuture().join().getValues().isEmpty());
-    verify(entityClientMock, times(1))
-        .getV2(
-            eq(systemOperationContext),
-            eq(DATASET_ENTITY_NAME),
-            any(Urn.class),
-            eq(ImmutableSet.of(GROUP_MEMBERSHIP_ASPECT_NAME, NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME)));
+    verify(groupServiceMock, times(1)).getGroupsForUser(eq(systemOperationContext), any(Urn.class));
   }
 
   @Test
-  public void shouldReturnFieldValueWithOnlyGroupsOfTheResource()
-      throws RemoteInvocationException, URISyntaxException {
-
-    var groupMembership =
-        new GroupMembership()
-            .setGroups(new UrnArray(ImmutableList.of(Urn.createFromString(CORPGROUP_URN))));
-    var entityResponseMock = mock(EntityResponse.class);
-    var envelopedAspectMap = new EnvelopedAspectMap();
-    envelopedAspectMap.put(
-        GROUP_MEMBERSHIP_ASPECT_NAME,
-        new EnvelopedAspect().setValue(new Aspect(groupMembership.data())));
-    when(entityResponseMock.getAspects()).thenReturn(envelopedAspectMap);
-    when(entityClientMock.getV2(
-            eq(systemOperationContext),
-            eq(DATASET_ENTITY_NAME),
-            any(Urn.class),
-            eq(ImmutableSet.of(GROUP_MEMBERSHIP_ASPECT_NAME, NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME))))
-        .thenReturn(entityResponseMock);
+  public void shouldReturnFieldValueWithOnlyGroupsOfTheResource() {
+    when(groupServiceMock.getGroupsForUser(eq(systemOperationContext), any(Urn.class)))
+        .thenReturn(List.of(UrnUtils.getUrn(CORPGROUP_URN)));
 
     var result =
         groupMembershipFieldResolverProvider.getFieldResolver(
             systemOperationContext, RESOURCE_SPEC);
 
     assertEquals(Set.of(CORPGROUP_URN), result.getFieldValuesFuture().join().getValues());
-    verify(entityClientMock, times(1))
-        .getV2(
-            eq(systemOperationContext),
-            eq(DATASET_ENTITY_NAME),
-            any(Urn.class),
-            eq(ImmutableSet.of(GROUP_MEMBERSHIP_ASPECT_NAME, NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME)));
+    verify(groupServiceMock, times(1)).getGroupsForUser(eq(systemOperationContext), any(Urn.class));
   }
 
   @Test
-  public void shouldReturnFieldValueWithOnlyNativeGroupsOfTheResource()
-      throws RemoteInvocationException, URISyntaxException {
-
-    var nativeGroupMembership =
-        new NativeGroupMembership()
-            .setNativeGroups(
-                new UrnArray(ImmutableList.of(Urn.createFromString(NATIVE_CORPGROUP_URN))));
-    var entityResponseMock = mock(EntityResponse.class);
-    var envelopedAspectMap = new EnvelopedAspectMap();
-    envelopedAspectMap.put(
-        NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME,
-        new EnvelopedAspect().setValue(new Aspect(nativeGroupMembership.data())));
-    when(entityResponseMock.getAspects()).thenReturn(envelopedAspectMap);
-    when(entityClientMock.getV2(
-            eq(systemOperationContext),
-            eq(DATASET_ENTITY_NAME),
-            any(Urn.class),
-            eq(ImmutableSet.of(GROUP_MEMBERSHIP_ASPECT_NAME, NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME))))
-        .thenReturn(entityResponseMock);
+  public void shouldReturnFieldValueWithOnlyNativeGroupsOfTheResource() {
+    when(groupServiceMock.getGroupsForUser(eq(systemOperationContext), any(Urn.class)))
+        .thenReturn(List.of(UrnUtils.getUrn(NATIVE_CORPGROUP_URN)));
 
     var result =
         groupMembershipFieldResolverProvider.getFieldResolver(
             systemOperationContext, RESOURCE_SPEC);
 
     assertEquals(Set.of(NATIVE_CORPGROUP_URN), result.getFieldValuesFuture().join().getValues());
-    verify(entityClientMock, times(1))
-        .getV2(
-            eq(systemOperationContext),
-            eq(DATASET_ENTITY_NAME),
-            any(Urn.class),
-            eq(ImmutableSet.of(GROUP_MEMBERSHIP_ASPECT_NAME, NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME)));
+    verify(groupServiceMock, times(1)).getGroupsForUser(eq(systemOperationContext), any(Urn.class));
   }
 
   @Test
-  public void shouldReturnFieldValueWithGroupsAndNativeGroupsOfTheResource()
-      throws RemoteInvocationException, URISyntaxException {
-
-    var groupMembership =
-        new GroupMembership()
-            .setGroups(new UrnArray(ImmutableList.of(Urn.createFromString(CORPGROUP_URN))));
-    var nativeGroupMembership =
-        new NativeGroupMembership()
-            .setNativeGroups(
-                new UrnArray(ImmutableList.of(Urn.createFromString(NATIVE_CORPGROUP_URN))));
-    var entityResponseMock = mock(EntityResponse.class);
-    var envelopedAspectMap = new EnvelopedAspectMap();
-    envelopedAspectMap.put(
-        GROUP_MEMBERSHIP_ASPECT_NAME,
-        new EnvelopedAspect().setValue(new Aspect(groupMembership.data())));
-    envelopedAspectMap.put(
-        NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME,
-        new EnvelopedAspect().setValue(new Aspect(nativeGroupMembership.data())));
-    when(entityResponseMock.getAspects()).thenReturn(envelopedAspectMap);
-    when(entityClientMock.getV2(
-            eq(systemOperationContext),
-            eq(DATASET_ENTITY_NAME),
-            any(Urn.class),
-            eq(ImmutableSet.of(GROUP_MEMBERSHIP_ASPECT_NAME, NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME))))
-        .thenReturn(entityResponseMock);
+  public void shouldReturnFieldValueWithGroupsAndNativeGroupsOfTheResource() {
+    when(groupServiceMock.getGroupsForUser(eq(systemOperationContext), any(Urn.class)))
+        .thenReturn(
+            ImmutableList.of(
+                UrnUtils.getUrn(CORPGROUP_URN), UrnUtils.getUrn(NATIVE_CORPGROUP_URN)));
 
     var result =
         groupMembershipFieldResolverProvider.getFieldResolver(
@@ -236,11 +136,6 @@ public class GroupMembershipFieldResolverProviderTest
     assertEquals(
         Set.of(CORPGROUP_URN, NATIVE_CORPGROUP_URN),
         result.getFieldValuesFuture().join().getValues());
-    verify(entityClientMock, times(1))
-        .getV2(
-            eq(systemOperationContext),
-            eq(DATASET_ENTITY_NAME),
-            any(Urn.class),
-            eq(ImmutableSet.of(GROUP_MEMBERSHIP_ASPECT_NAME, NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME)));
+    verify(groupServiceMock, times(1)).getGroupsForUser(eq(systemOperationContext), any(Urn.class));
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/AuthorizerChainFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/AuthorizerChainFactory.java
@@ -1,5 +1,6 @@
 package com.linkedin.gms.factory.auth;
 
+import com.datahub.authentication.group.GroupService;
 import com.datahub.authorization.AuthorizerChain;
 import com.datahub.authorization.AuthorizerContext;
 import com.datahub.authorization.DataHubAuthorizer;
@@ -48,9 +49,11 @@ public class AuthorizerChainFactory {
   @Scope("singleton")
   @Nonnull
   protected AuthorizerChain getInstance(
-      final DataHubAuthorizer dataHubAuthorizer, final SystemEntityClient systemEntityClient) {
+      final DataHubAuthorizer dataHubAuthorizer,
+      final SystemEntityClient systemEntityClient,
+      @Qualifier("groupService") final GroupService groupService) {
     final EntitySpecResolver resolver =
-        initResolver(dataHubAuthorizer.getSystemOpContext(), systemEntityClient);
+        initResolver(dataHubAuthorizer.getSystemOpContext(), systemEntityClient, groupService);
 
     // Extract + initialize customer authorizers from application configs.
     final List<Authorizer> authorizers = new ArrayList<>(initCustomAuthorizers(resolver));
@@ -66,8 +69,10 @@ public class AuthorizerChainFactory {
   }
 
   private EntitySpecResolver initResolver(
-      @Nonnull OperationContext systemOpContext, SystemEntityClient systemEntityClient) {
-    return new DefaultEntitySpecResolver(systemOpContext, systemEntityClient);
+      @Nonnull OperationContext systemOpContext,
+      SystemEntityClient systemEntityClient,
+      GroupService groupService) {
+    return new DefaultEntitySpecResolver(systemOpContext, systemEntityClient, groupService);
   }
 
   private List<Authorizer> initCustomAuthorizers(EntitySpecResolver resolver) {

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/DataHubAuthorizerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/DataHubAuthorizerFactory.java
@@ -1,5 +1,6 @@
 package com.linkedin.gms.factory.auth;
 
+import com.datahub.authentication.group.GroupService;
 import com.datahub.authorization.DataHubAuthorizer;
 import com.linkedin.entity.client.SystemEntityClient;
 import io.datahubproject.metadata.context.OperationContext;
@@ -27,7 +28,8 @@ public class DataHubAuthorizerFactory {
   @Nonnull
   protected DataHubAuthorizer dataHubAuthorizer(
       @Qualifier("systemOperationContext") final OperationContext systemOpContext,
-      final SystemEntityClient systemEntityClient) {
+      final SystemEntityClient systemEntityClient,
+      @Qualifier("groupService") final GroupService groupService) {
 
     final DataHubAuthorizer.AuthorizationMode mode =
         policiesEnabled
@@ -37,6 +39,7 @@ public class DataHubAuthorizerFactory {
     return new DataHubAuthorizer(
         systemOpContext,
         systemEntityClient,
+        groupService,
         10,
         policyCacheRefreshIntervalSeconds,
         mode,

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/GroupServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/GroupServiceFactory.java
@@ -1,31 +1,26 @@
 package com.linkedin.gms.factory.auth;
 
 import com.datahub.authentication.group.GroupService;
-import com.linkedin.entity.client.EntityClient;
+import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.graph.GraphClient;
 import javax.annotation.Nonnull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Scope;
 
 @Configuration
 public class GroupServiceFactory {
-  @Autowired
-  @Qualifier("entityService")
-  private EntityService<?> _entityService;
-
-  @Autowired
-  @Qualifier("graphClient")
-  private GraphClient _graphClient;
 
   @Bean(name = "groupService")
   @Scope("singleton")
   @Nonnull
-  protected GroupService getInstance(@Qualifier("entityClient") final EntityClient entityClient)
-      throws Exception {
-    return new GroupService(entityClient, _entityService, _graphClient);
+  protected GroupService getInstance(
+      @Qualifier("systemEntityClient") final SystemEntityClient systemEntityClient,
+      @Lazy @Qualifier("entityService") final EntityService<?> entityService,
+      @Lazy @Qualifier("graphClient") final GraphClient graphClient) {
+    return new GroupService(systemEntityClient, entityService, graphClient);
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/context/SystemOperationContextFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/context/SystemOperationContextFactory.java
@@ -1,6 +1,7 @@
 package com.linkedin.gms.factory.context;
 
 import com.datahub.authentication.Authentication;
+import com.datahub.authentication.group.GroupService;
 import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.gms.factory.search.BaseElasticSearchComponentsFactory;
@@ -57,6 +58,8 @@ public class SystemOperationContextFactory {
       @Qualifier("systemEntityClient") @Nonnull final SystemEntityClient systemEntityClient,
       @Qualifier("mappingsBuilder") @Nonnull final MappingsBuilder mappingsBuilder,
       @Nonnull final SystemTelemetryContext systemTelemetryContext,
+      @Autowired(required = false) @Qualifier("groupService") @Nullable
+          final GroupService groupService,
       @Autowired(required = false) @Nullable PrimaryStorageResolver primaryStorageResolver) {
 
     EntityServiceAspectRetriever entityServiceAspectRetriever =
@@ -87,7 +90,10 @@ public class SystemOperationContextFactory {
             operationContextConfig,
             systemAuthentication,
             entityServiceAspectRetriever.getEntityRegistry(),
-            ServicesRegistryContext.builder().restrictedService(restrictedService).build(),
+            ServicesRegistryContext.builder()
+                .restrictedService(restrictedService)
+                .actorGroupMembershipService(groupService)
+                .build(),
             searchContext,
             RetrieverContext.builder()
                 .aspectRetriever(entityServiceAspectRetriever)
@@ -133,6 +139,8 @@ public class SystemOperationContextFactory {
       @Nonnull final ConfigurationProvider configurationProvider,
       @Nonnull final SystemTelemetryContext systemTelemetryContext,
       @Qualifier("mappingsBuilder") @Nonnull final MappingsBuilder mappingsBuilder,
+      @Autowired(required = false) @Qualifier("groupService") @Nullable
+          final GroupService groupService,
       @Autowired(required = false) @Nullable PrimaryStorageResolver primaryStorageResolver) {
 
     EntityClientAspectRetriever entityClientAspectRetriever =
@@ -157,7 +165,10 @@ public class SystemOperationContextFactory {
             operationContextConfig,
             systemAuthentication,
             entityRegistry,
-            ServicesRegistryContext.builder().restrictedService(restrictedService).build(),
+            ServicesRegistryContext.builder()
+                .restrictedService(restrictedService)
+                .actorGroupMembershipService(groupService)
+                .build(),
             searchContext,
             RetrieverContext.builder()
                 .cachingAspectRetriever(entityClientAspectRetriever)

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/elastic/ElasticsearchRawControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/elastic/ElasticsearchRawControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.testng.Assert.assertNotNull;
@@ -27,6 +28,7 @@ import com.linkedin.metadata.systemmetadata.SystemMetadataService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.openapi.config.GlobalControllerExceptionHandler;
+import io.datahubproject.openapi.test.AuthorizerChainTestSupport;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -79,9 +81,8 @@ public class ElasticsearchRawControllerTest extends AbstractTestNGSpringContextT
     when(authentication.getActor()).thenReturn(new Actor(ActorType.USER, "datahub"));
     AuthenticationContext.setAuthentication(authentication);
 
-    // Setup AuthorizerChain to allow access
-    when(authorizerChain.authorize(any()))
-        .thenReturn(new AuthorizationResult(null, AuthorizationResult.Type.ALLOW, ""));
+    // Default: 1-arg stub only (OperationContextAuthorizer null fallback).
+    AuthorizerChainTestSupport.stubAllowViaOneArgOnly(authorizerChain);
   }
 
   @Test
@@ -91,6 +92,9 @@ public class ElasticsearchRawControllerTest extends AbstractTestNGSpringContextT
 
   @Test
   public void testGetEntityRaw() throws Exception {
+    reset(authorizerChain);
+    AuthorizerChainTestSupport.stubAllowViaOperationContextAuthorizer(authorizerChain);
+
     // Mock raw entity response
     Map<Urn, Map<String, Object>> rawEntityMap = new HashMap<>();
 

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/k8/KubernetesControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/k8/KubernetesControllerTest.java
@@ -10,7 +10,6 @@ import com.datahub.authentication.Actor;
 import com.datahub.authentication.ActorType;
 import com.datahub.authentication.Authentication;
 import com.datahub.authentication.AuthenticationContext;
-import com.datahub.authorization.AuthorizationResult;
 import com.datahub.authorization.AuthorizerChain;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.datahubproject.metadata.context.ObjectMapperContext;
@@ -22,6 +21,7 @@ import io.datahubproject.openapi.operations.k8.models.ConfigMapUpdateRequest;
 import io.datahubproject.openapi.operations.k8.models.CronJobTriggerRequest;
 import io.datahubproject.openapi.operations.k8.models.DeploymentEnvUpdateRequest;
 import io.datahubproject.openapi.operations.k8.models.DeploymentScaleRequest;
+import io.datahubproject.openapi.test.AuthorizerChainTestSupport;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.EnvVar;
@@ -91,9 +91,8 @@ public class KubernetesControllerTest extends AbstractTestNGSpringContextTests {
     when(authentication.getActor()).thenReturn(new Actor(ActorType.USER, "datahub"));
     AuthenticationContext.setAuthentication(authentication);
 
-    // Setup authorization
-    when(authorizerChain.authorize(any()))
-        .thenReturn(new AuthorizationResult(null, AuthorizationResult.Type.ALLOW, ""));
+    // Setup authorization — 1-arg stub only; exercises OperationContextAuthorizer null fallback.
+    AuthorizerChainTestSupport.stubAllowViaOneArgOnly(authorizerChain);
 
     // Setup K8s client config
     Config config = mock(Config.class);
@@ -122,6 +121,32 @@ public class KubernetesControllerTest extends AbstractTestNGSpringContextTests {
 
   @Test
   public void testListDeployments() throws Exception {
+    Deployment deployment = createTestDeployment("test-deployment");
+
+    MixedOperation deploymentsOp = mock(MixedOperation.class);
+    NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);
+    DeploymentList deploymentList = new DeploymentList();
+    deploymentList.setItems(List.of(deployment));
+
+    when(kubernetesClient.apps()).thenReturn(mock(AppsAPIGroupDSL.class));
+    when(kubernetesClient.apps().deployments()).thenReturn(deploymentsOp);
+    when(deploymentsOp.inNamespace(NAMESPACE)).thenReturn(nsOp);
+    when(nsOp.list()).thenReturn(deploymentList);
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(BASE_PATH + "/deployments")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.total").value(1))
+        .andExpect(jsonPath("$.elements[0].metadata.name").value("test-deployment"));
+  }
+
+  @Test
+  public void testListDeploymentsWithOperationContextAuthorizer() throws Exception {
+    reset(authorizerChain);
+    AuthorizerChainTestSupport.stubAllowViaOperationContextAuthorizer(authorizerChain);
+
     Deployment deployment = createTestDeployment("test-deployment");
 
     MixedOperation deploymentsOp = mock(MixedOperation.class);
@@ -2225,8 +2250,7 @@ public class KubernetesControllerTest extends AbstractTestNGSpringContextTests {
       AuthorizerChain authorizerChain = mock(AuthorizerChain.class);
       Authentication authentication = mock(Authentication.class);
       when(authentication.getActor()).thenReturn(new Actor(ActorType.USER, "datahub"));
-      when(authorizerChain.authorize(any()))
-          .thenReturn(new AuthorizationResult(null, AuthorizationResult.Type.ALLOW, ""));
+      AuthorizerChainTestSupport.stubAllowViaOneArgOnly(authorizerChain);
       AuthenticationContext.setAuthentication(authentication);
       return authorizerChain;
     }

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/test/AuthorizerChainTestSupport.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/test/AuthorizerChainTestSupport.java
@@ -1,0 +1,44 @@
+package io.datahubproject.openapi.test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.datahub.authorization.AuthorizationRequest;
+import com.datahub.authorization.AuthorizationResult;
+import com.datahub.authorization.AuthorizerChain;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.Map;
+
+/** Shared stubs for mocked {@link AuthorizerChain} beans in openapi-servlet integration tests. */
+public final class AuthorizerChainTestSupport {
+
+  private static final AuthorizationResult ALLOW =
+      new AuthorizationResult(null, AuthorizationResult.Type.ALLOW, "");
+
+  private AuthorizerChainTestSupport() {}
+
+  /**
+   * Stubs only the 1-arg {@link AuthorizerChain#authorize(AuthorizationRequest)} path. Exercises
+   * {@link io.datahubproject.metadata.context.AuthorizationContext}'s fallback when a mock {@link
+   * io.datahubproject.metadata.context.OperationContextAuthorizer} returns null.
+   */
+  public static void stubAllowViaOneArgOnly(AuthorizerChain authorizerChain) {
+    when(authorizerChain.authorize(any(AuthorizationRequest.class))).thenReturn(ALLOW);
+  }
+
+  /**
+   * Stubs the session {@link io.datahubproject.metadata.context.OperationContextAuthorizer} 3-arg
+   * path used by {@link io.datahubproject.metadata.context.AuthorizationContext}.
+   */
+  public static void stubAllowViaOperationContextAuthorizer(AuthorizerChain authorizerChain) {
+    when(authorizerChain.authorize(
+            any(AuthorizationRequest.class), any(Map.class), any(OperationContext.class)))
+        .thenReturn(ALLOW);
+  }
+
+  /** Stubs both authorization entry points. */
+  public static void stubAllowAllPaths(AuthorizerChain authorizerChain) {
+    stubAllowViaOneArgOnly(authorizerChain);
+    stubAllowViaOperationContextAuthorizer(authorizerChain);
+  }
+}

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/controller/EntityControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/controller/EntityControllerTest.java
@@ -21,7 +21,6 @@ import com.datahub.authentication.Actor;
 import com.datahub.authentication.ActorType;
 import com.datahub.authentication.Authentication;
 import com.datahub.authentication.AuthenticationContext;
-import com.datahub.authorization.AuthorizationResult;
 import com.datahub.authorization.AuthorizerChain;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -85,6 +84,7 @@ import io.datahubproject.openapi.config.GlobalControllerExceptionHandler;
 import io.datahubproject.openapi.config.SpringWebConfig;
 import io.datahubproject.openapi.config.TracingInterceptor;
 import io.datahubproject.openapi.exception.InvalidUrnException;
+import io.datahubproject.openapi.test.AuthorizerChainTestSupport;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -127,6 +127,7 @@ import org.testng.annotations.Test;
 public class EntityControllerTest extends AbstractTestNGSpringContextTests {
   @Autowired private EntityController entityController;
   @Autowired private MockMvc mockMvc;
+  @Autowired private AuthorizerChain authorizerChain;
   @Autowired private EntityRegistry entityRegistry;
   @Autowired private OperationContext opContext;
   @MockitoBean private ConfigurationProvider configurationProvider;
@@ -268,6 +269,9 @@ public class EntityControllerTest extends AbstractTestNGSpringContextTests {
 
   @Test
   public void testDeleteEntity() throws Exception {
+    reset(authorizerChain);
+    AuthorizerChainTestSupport.stubAllowViaOperationContextAuthorizer(authorizerChain);
+
     Urn TEST_URN = UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:testPlatform,4,PROD)");
 
     // test delete entity
@@ -487,8 +491,7 @@ public class EntityControllerTest extends AbstractTestNGSpringContextTests {
 
       Authentication authentication = mock(Authentication.class);
       when(authentication.getActor()).thenReturn(new Actor(ActorType.USER, "datahub"));
-      when(authorizerChain.authorize(any()))
-          .thenReturn(new AuthorizationResult(null, AuthorizationResult.Type.ALLOW, ""));
+      AuthorizerChainTestSupport.stubAllowViaOneArgOnly(authorizerChain);
       AuthenticationContext.setAuthentication(authentication);
 
       return authorizerChain;


### PR DESCRIPTION
## Summary

- Resolve corp user group membership and direct roles once per request via `SessionActorIdentity`, cached on `AuthorizationContext` and copied into `ActorContext` at session build.
- Seed policy evaluation and `authorize()` with session membership/identity so group-role inheritance is computed at most once per request (shared `SessionActorIdentity.resolveAllRoles()`), avoiding repeated storage reads across multiple privilege checks.
- Route user authorization storage reads through the session `OperationContext` via `OperationContextAuthorizer`, instead of the system context.
- Consolidate all membership reads behind a single `GroupService` bean (backed by `systemEntityClient`): fold `ActorGroupMembershipFetcher` into `GroupService`, wire it through `DataHubAuthorizer`, `PolicyEngine`, `ServicesRegistryContext`, and `GroupMembershipFieldResolverProvider`, and remove the standalone fetcher/wrapper classes.
- Migrate GraphQL resolvers to read groups from `ActorContext` (no storage fetch on the hot path).

## Architecture

```
Session build / authorize / policy / field resolver → GroupService (singleton)
GraphQL reads → ActorContext cache
Group admin writes → GroupService mutation methods
```

`ActorGroupMembershipService` in `metadata-operation-context` is the registry-facing interface; `GroupService` is the sole implementation.

## Test plan

- [x] `./gradlew :li-utils:test`
- [x] `./gradlew :metadata-operation-context:test` (119 passing)
- [x] `./gradlew :metadata-service:auth-impl:test` (349 passing)
- [x] `./gradlew :datahub-graphql-core:test`
- [x] `./gradlew :metadata-io:test --tests com.linkedin.metadata.search.utils.ESAccessControlUtilTest`
- [x] `spotlessApply` on touched modules