### PR TITLE
feat(ingestion): Predictable schema size trimming

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
@@ -203,7 +203,7 @@ class EnsureAspectSizeProcessor(WorkunitProcessor[EnsureAspectSizeProcessorRepor
         )
         return False
 
-    def _extract_field_path_length(self, field: SchemaFieldClass) -> int:
+    def _extract_field_path_depth(self, field: SchemaFieldClass) -> int:
         return len(
             [t for t in re.sub(r"\[[^]]*]", "", field.fieldPath).split(".") if t]
         )
@@ -236,7 +236,7 @@ class EnsureAspectSizeProcessor(WorkunitProcessor[EnsureAspectSizeProcessorRepor
 
         total_fields_size = self._schema_size_without_fields(schema)
         accepted_fields: List[SchemaFieldClass] = []
-        sorted_fields = sorted(schema.fields, key=self._extract_field_path_length)
+        sorted_fields = sorted(schema.fields, key=self._extract_field_path_depth)
         for schema_field in sorted_fields:
             field_size = len(json.dumps(pre_json_transform(schema_field.to_obj())))
             if total_fields_size + field_size >= self.schema_size_constraint:

--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 from dataclasses import dataclass, field
 from typing import Dict, Iterable, List, Optional
 
@@ -202,6 +203,11 @@ class EnsureAspectSizeProcessor(WorkunitProcessor[EnsureAspectSizeProcessorRepor
         )
         return False
 
+    def _extract_field_path_length(self, field: SchemaFieldClass) -> int:
+        return len(
+            [t for t in re.sub(r"\[[^]]*]", "", field.fieldPath).split(".") if t]
+        )
+
     def ensure_schema_metadata_size(
         self, dataset_urn: str, schema: SchemaMetadataClass
     ) -> None:
@@ -230,7 +236,8 @@ class EnsureAspectSizeProcessor(WorkunitProcessor[EnsureAspectSizeProcessorRepor
 
         total_fields_size = self._schema_size_without_fields(schema)
         accepted_fields: List[SchemaFieldClass] = []
-        for schema_field in schema.fields:
+        sorted_fields = sorted(schema.fields, key=self._extract_field_path_length)
+        for schema_field in sorted_fields:
             field_size = len(json.dumps(pre_json_transform(schema_field.to_obj())))
             if total_fields_size + field_size < self.schema_size_constraint:
                 accepted_fields.append(schema_field)

--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/ensure_aspect_size.py
@@ -239,9 +239,10 @@ class EnsureAspectSizeProcessor(WorkunitProcessor[EnsureAspectSizeProcessorRepor
         sorted_fields = sorted(schema.fields, key=self._extract_field_path_length)
         for schema_field in sorted_fields:
             field_size = len(json.dumps(pre_json_transform(schema_field.to_obj())))
-            if total_fields_size + field_size < self.schema_size_constraint:
-                accepted_fields.append(schema_field)
-                total_fields_size += field_size
+            if total_fields_size + field_size >= self.schema_size_constraint:
+                break
+            accepted_fields.append(schema_field)
+            total_fields_size += field_size
 
         dropped_field_count = len(schema.fields) - len(accepted_fields)
         if dropped_field_count:

--- a/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
+++ b/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
@@ -449,7 +449,6 @@ def test_schema_metadata_trims_fields_when_fields_are_too_large(processor):
         "urn:li:dataset:(s3, dummy_dataset, DEV)", schema
     )
     assert len(schema.fields) < 1004, "Schema has not been properly truncated"
-    assert schema.fields[-1].fieldPath == "dddd", "Small field was not added at the end"
     assert len(json.dumps(schema.to_obj())) < INGEST_MAX_PAYLOAD_BYTES, (
         "Aspect exceeded acceptable size"
     )

--- a/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
+++ b/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
@@ -1,5 +1,6 @@
 import json
 import time
+import unittest
 from typing import Callable, Dict
 from unittest.mock import MagicMock, patch
 
@@ -45,6 +46,7 @@ from datahub.metadata.schema_classes import (
     QueryStatementClass,
     QuerySubjectClass,
     QuerySubjectsClass,
+    RecordTypeClass,
     SchemaFieldClass,
     SchemaFieldDataTypeClass,
     SchemalessClass,
@@ -112,6 +114,58 @@ def too_big_schema_metadata() -> SchemaMetadataClass:
     )
     return SchemaMetadataClass(
         schemaName="abcdef",
+        version=1,
+        platform="s3",
+        hash="ABCDE1234567890",
+        platformSchema=OtherSchemaClass(rawSchema="aaa"),
+        fields=fields,
+    )
+
+
+def nested_schema_metadata() -> SchemaMetadataClass:
+    fields = [
+        # ---- level 4: array of structs with a leaf inside ----
+        SchemaFieldClass(
+            fieldPath="[version=2.0].[type=struct].[type=array].[type=struct].items.[type=struct].meta.[type=string].array_leaf",
+            nativeDataType="string",
+            type=SchemaFieldDataTypeClass(type=StringTypeClass()),
+        ),
+        # ---- level 2: a struct field and its child ----
+        SchemaFieldClass(
+            fieldPath="[version=2.0].[type=struct].[type=struct].level1_struct",
+            nativeDataType="struct",
+            type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
+        ),
+        SchemaFieldClass(
+            fieldPath="[version=2.0].[type=struct].[type=struct].level1_struct.[type=string].child_string",
+            nativeDataType="string",
+            type=SchemaFieldDataTypeClass(type=StringTypeClass()),
+        ),
+        # ---- level 1: flat top-level fields ----
+        SchemaFieldClass(
+            fieldPath="[version=2.0].[type=struct].[type=string].flat_string",
+            nativeDataType="string",
+            type=SchemaFieldDataTypeClass(type=StringTypeClass()),
+        ),
+        SchemaFieldClass(
+            fieldPath="[version=2.0].[type=struct].[type=int].flat_int",
+            nativeDataType="int",
+            type=SchemaFieldDataTypeClass(type=NumberTypeClass()),
+        ),
+        # ---- level 3: struct -> struct -> leaf ----
+        SchemaFieldClass(
+            fieldPath="[version=2.0].[type=struct].[type=struct].level1_struct.[type=struct].level2_struct",
+            nativeDataType="struct",
+            type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
+        ),
+        SchemaFieldClass(
+            fieldPath="[version=2.0].[type=struct].[type=struct].level1_struct.[type=struct].level2_struct.[type=int].deep_int",
+            nativeDataType="int",
+            type=SchemaFieldDataTypeClass(type=NumberTypeClass()),
+        ),
+    ]
+    return SchemaMetadataClass(
+        schemaName="nested_example",
         version=1,
         platform="s3",
         hash="ABCDE1234567890",
@@ -410,6 +464,33 @@ def test_schema_metadata_trims_fields_when_fields_are_too_large(processor):
     assert len(field_drop_warnings) == 1
     assert len(field_drop_warnings[0].context) == 1
     assert "fields from schema" in field_drop_warnings[0].context[0]
+
+
+@time_machine.travel("2023-01-02 00:00:00", tick=False)
+def test_schema_metadata_trims_deep_fields_first(processor):
+    processor.schema_size_constraint = 1000
+    schema = nested_schema_metadata()
+    processor.ensure_schema_metadata_size(
+        "urn:li:dataset:(s3, dummy_dataset, DEV)", schema
+    )
+    expected_fields = [
+        SchemaFieldClass(
+            fieldPath="[version=2.0].[type=struct].[type=struct].level1_struct",
+            nativeDataType="struct",
+            type=SchemaFieldDataTypeClass(type=RecordTypeClass()),
+        ),
+        SchemaFieldClass(
+            fieldPath="[version=2.0].[type=struct].[type=string].flat_string",
+            nativeDataType="string",
+            type=SchemaFieldDataTypeClass(type=StringTypeClass()),
+        ),
+        SchemaFieldClass(
+            fieldPath="[version=2.0].[type=struct].[type=int].flat_int",
+            nativeDataType="int",
+            type=SchemaFieldDataTypeClass(type=NumberTypeClass()),
+        ),
+    ]
+    unittest.TestCase().assertCountEqual(schema.fields, expected_fields)
 
 
 @time_machine.travel("2023-01-02 00:00:00", tick=False)


### PR DESCRIPTION
We want to truncate the aspect starting with the deepest fields first. This also ensures that we always have upper-level fields.