### PR TITLE
docs(release-notes): add v1.1.3 release notes

### DIFF
--- a/docs/managed-datahub/release-notes/v_1_1_0.md
+++ b/docs/managed-datahub/release-notes/v_1_1_0.md
@@ -20,7 +20,7 @@ Hotfix release on top of **v1.1.2**. There are no breaking changes or deprecatio
 - **Remote Executor**: v1.1.3-cloud
 - **Helm**: 1.6.158
 
-### Bug Fixes
+#### Bug Fixes
 
 - **Action Workflows — review modal missing fields** — The "View Details" modal for Action Request reviews now shows all fields from the workflow definition (Dataset, Role, Use Case), not just "Requested by" and "Additional Notes".
 
@@ -30,7 +30,6 @@ Hotfix release on top of **v1.1.2**. There are no breaking changes or deprecatio
 
 - **kNN inner_hits chunk text for Cohere reranker** — kNN search now returns inner_hits chunk text, enabling the Cohere reranker to use chunk-level text for better relevance scoring.
 - **Semantic search bridge documents** — Dataset and entity bridge document support added for semantic search, including a bridge document backfill script, BridgeDocumentService, and SemanticSearchService enhancements.
-
 
 ### v1.1.2
 

--- a/docs/managed-datahub/release-notes/v_1_1_0.md
+++ b/docs/managed-datahub/release-notes/v_1_1_0.md
@@ -6,6 +6,32 @@ description: "DataHub Cloud v1.1.0 release notes covering OAuth2 dynamic client 
 
 ## Release Changelog
 
+### v1.1.3
+
+Hotfix release on top of **v1.1.2**. There are no breaking changes or deprecations.
+
+#### Release Availability Date
+
+17-June-2026
+
+**Recommended Versions**
+
+- **CLI / SDK**: v1.6.0
+- **Remote Executor**: v1.1.3-cloud
+- **Helm**: 1.6.158
+
+### Bug Fixes
+
+- **Action Workflows — review modal missing fields** — The "View Details" modal for Action Request reviews now shows all fields from the workflow definition (Dataset, Role, Use Case), not just "Requested by" and "Additional Notes".
+
+- **Ownership — ownerTypes materialization** — The `ownerTypes` aspect is now always materialized from the owners list, preventing stale or missing ownership type data.
+
+#### AI / Search
+
+- **kNN inner_hits chunk text for Cohere reranker** — kNN search now returns inner_hits chunk text, enabling the Cohere reranker to use chunk-level text for better relevance scoring.
+- **Semantic search bridge documents** — Dataset and entity bridge document support added for semantic search, including a bridge document backfill script, BridgeDocumentService, and SemanticSearchService enhancements.
+
+
 ### v1.1.2
 
 Hotfix release on top of **v1.1.1**. There are no breaking changes or deprecations.


### PR DESCRIPTION
## Summary

- Adds v1.1.3 release notes section to the v1.1.x release notes page
- Documents bug fixes (Action Workflows review modal, ownership ownerTypes materialization) and AI/Search improvements (kNN inner_hits for Cohere reranker, semantic search bridge documents)
- Marks availability date as 17-June-2026 with recommended versions (CLI v1.6.0, Remote Executor v1.1.3-cloud, Helm 1.6.158)

## Test plan

- [x] Verify the release notes render correctly in the docs site sidebar
- [x] Confirm v1.1.3 section appears above v1.1.2 in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)