### PR TITLE
fix(entity): avoid NPE when delete hits empty version range

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -3018,8 +3018,18 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                   List<SystemAspect> aspectsToDelete = new ArrayList<>();
                   Pair<Long, Long> versionRange =
                       aspectDao.getVersionRange(opContext, urn, aspectName);
-                  long minVersion = Math.max(0, versionRange.getFirst());
-                  long maxVersion = Math.max(0, versionRange.getSecond());
+                  if (versionRange.getFirst() == null
+                      || versionRange.getSecond() == null
+                      || versionRange.getFirst() < 0
+                      || versionRange.getSecond() < 0) {
+                    log.debug(
+                        "Delete skipped due to empty version range. urn {} aspect {}",
+                        urn,
+                        aspectName);
+                    return TransactionResult.rollback();
+                  }
+                  long minVersion = versionRange.getFirst();
+                  long maxVersion = versionRange.getSecond();
 
                   EntityAspect.EntitySystemAspect survivingAspect = null;
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
@@ -1008,7 +1008,14 @@ public class EbeanAspectDao implements AspectDao, AspectMigrationsDao {
       return Pair.of(-1L, -1L);
     }
 
-    return Pair.of(result.getLong("min_version"), result.getLong("max_version"));
+    Long minVersion = result.getLong("min_version");
+    Long maxVersion = result.getLong("max_version");
+    if (minVersion == null || maxVersion == null) {
+      // MySQL returns a row with NULL MIN/MAX when no versions exist for urn+aspect.
+      return Pair.of(-1L, -1L);
+    }
+
+    return Pair.of(minVersion, maxVersion);
   }
 
   @Override

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceImplTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceImplTest.java
@@ -5,6 +5,7 @@ import static com.linkedin.metadata.entity.EntityServiceTest.TEST_AUDIT_STAMP;
 import static com.linkedin.metadata.telemetry.OpenTelemetryKeyConstants.EVENT_TYPE_ATTR;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -1058,6 +1059,66 @@ public class EntityServiceImplTest {
     // Verify metric was incremented
     verify(metricUtils, times(1))
         .increment(eq(EntityServiceImpl.class), eq("delete_nonexisting"), eq(1d));
+  }
+
+  @Test
+  public void testDeleteAspectWithoutMCL_EmptyVersionRangeRollsBack() throws URISyntaxException {
+    AspectDao mockAspectDao = mock(AspectDao.class);
+    EntityServiceImpl entityService =
+        new EntityServiceImpl(
+            mockAspectDao,
+            mock(EventProducer.class),
+            false,
+            false,
+            mock(PreProcessHooks.class),
+            0,
+            true,
+            null);
+
+    Urn testUrn = UrnUtils.getUrn("urn:li:corpuser:emptyVersionRange");
+    String aspectName = STATUS_ASPECT_NAME;
+    SystemMetadata systemMetadata = SystemMetadataUtils.createDefaultSystemMetadata();
+
+    EbeanAspectV2 statusRow =
+        new EbeanAspectV2(
+            testUrn.toString(),
+            aspectName,
+            0L,
+            RecordUtils.toJsonString(new Status().setRemoved(false)),
+            new Timestamp(System.currentTimeMillis()),
+            TEST_AUDIT_STAMP.getActor().toString(),
+            null,
+            RecordUtils.toJsonString(systemMetadata));
+    SystemAspect latestStatus =
+        EbeanSystemAspect.builder().forUpdate(statusRow, testEntityRegistry);
+
+    when(mockAspectDao.getLatestAspect(
+            any(OperationContext.class), eq(testUrn.toString()), eq(aspectName), eq(false)))
+        .thenReturn(latestStatus);
+    when(mockAspectDao.getVersionRange(
+            any(OperationContext.class), eq(testUrn.toString()), eq(aspectName)))
+        .thenReturn(Pair.of(-1L, -1L));
+
+    doAnswer(
+            invocation -> {
+              Function<TransactionContext, TransactionResult<RollbackResult>> function =
+                  invocation.getArgument(1);
+              return function.apply(TransactionContext.empty(3)).getResults();
+            })
+        .when(mockAspectDao)
+        .runInTransactionWithRetry(any(), any(), anyInt());
+
+    RollbackResult result =
+        entityService.deleteAspectWithoutMCL(
+            opContext, testUrn.toString(), aspectName, Collections.emptyMap(), false);
+
+    assertNull(result);
+    verify(mockAspectDao)
+        .getVersionRange(any(OperationContext.class), eq(testUrn.toString()), eq(aspectName));
+    verify(mockAspectDao, never())
+        .deleteUrn(any(OperationContext.class), any(), eq(testUrn.toString()));
+    verify(mockAspectDao, never())
+        .getAspect(any(OperationContext.class), eq(testUrn.toString()), eq(aspectName), anyLong());
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EbeanAspectDaoTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EbeanAspectDaoTest.java
@@ -548,4 +548,14 @@ public class EbeanAspectDaoTest {
             opContext, "urn:li:corpuser:postMigration", "status", ASPECT_LATEST_VERSION);
     assertTrue(aspect != null, "Writes work after migration");
   }
+
+  @Test
+  public void getVersionRangeReturnsSentinelWhenAspectMissing() {
+    com.linkedin.util.Pair<Long, Long> range =
+        testDao.getVersionRange(
+            opContext, "urn:li:container:missing-aspect-range-test", "containerKey");
+
+    assertEquals(range.getFirst(), Long.valueOf(-1L));
+    assertEquals(range.getSecond(), Long.valueOf(-1L));
+  }
 }


### PR DESCRIPTION
MySQL MIN/MAX aggregation returns NULL when no aspect versions exist, which caused deleteAspectWithoutMCL to NPE on Pair.getFirst(). Map NULL to (-1, -1) in EbeanAspectDao and rollback the delete transaction when the version range is empty (common under concurrent hard deletes).

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
