### PR TITLE
fix(ebean): default datasource autoCommit to true

### DIFF
--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -426,7 +426,7 @@ ebean:
   maxAgeMinutes: ${EBEAN_MAX_AGE_MINUTES:120}
   leakTimeMinutes: ${EBEAN_LEAK_TIME_MINUTES:15}
   waitTimeoutMillis: ${EBEAN_WAIT_TIMEOUT_MILLIS:1000}
-  autoCommit: ${EBEAN_DATASOURCE_AUTOCOMMIT:false}
+  autoCommit: ${EBEAN_DATASOURCE_AUTOCOMMIT:true}
   autoCreateDdl: ${EBEAN_AUTOCREATE:false}
   postgresUseIamAuth: ${EBEAN_POSTGRES_USE_AWS_IAM_AUTH:false}
   useIamAuth: ${EBEAN_USE_IAM_AUTH:false} # Generic IAM auth for cross-cloud compatibility

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/LocalEbeanConfigFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/LocalEbeanConfigFactory.java
@@ -45,7 +45,7 @@ public class LocalEbeanConfigFactory {
   @Value("${ebean.waitTimeoutMillis:1000}")
   private Integer ebeanWaitTimeoutMillis;
 
-  @Value("${ebean.autoCommit:false}")
+  @Value("${ebean.autoCommit:true}")
   private Boolean ebeanAutoCommit;
 
   @Value("${ebean.autoCreateDdl:false}")


### PR DESCRIPTION
## Summary
- Changes the default value of `ebean.autoCommit` from `false` to `true` in both `application.yaml` and `LocalEbeanConfigFactory.java`
- Ebean's connection pool performs better with autoCommit enabled — avoids wrapping every read in an unnecessary transaction
- Operators can still override via `EBEAN_DATASOURCE_AUTOCOMMIT=false`