### PR TITLE
feat(ingest): default the Python REST emitter to ASYNC emit mode

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -44,6 +44,25 @@ Requirements:
 
 ### Breaking Changes
 
+- **(Python SDK / plugins / CLI)** The default emit mode for the Python REST emitter (`DataHubRestEmitter` and `DataHubGraph`) is now `ASYNC` instead of `SYNC_PRIMARY`. This changes the default for everything that emits metadata without explicitly setting an emit mode:
+
+  - Custom scripts using the Python SDK (`DataHubRestEmitter` / `DataHubGraph`) directly.
+  - The DataHub plugins for **Airflow**, **Dagster**, **Great Expectations**, and **Prefect**.
+  - `datahub` CLI write commands: `put`, `dataset` / `dataproduct` / `datacontract upsert`, `group`, `assertions`, and `migrate`.
+  - The high-level SDK clients (`entities.create` / `upsert` / `update`, lineage) and the API entity helpers (`corpuser`, `corpgroup`, `datajob`, `dataflow`, `dataproduct`, `forms`, structured properties, etc.).
+
+  Recipe-based ingestion through the `datahub-rest` sink is **not** changed — it has always defaulted to asynchronous emission (`mode: ASYNC_BATCH`).
+
+  With `ASYNC`, an `emit()` call returns as soon as DataHub accepts the request, rather than waiting for the change to be written to storage. This significantly reduces load on GMS and the database for high-volume emitters. Two behaviors change as a result:
+
+  - Failures are no longer raised at the call site. A rejected or invalid change is reported asynchronously (in the Failed MCP topic / consumer logs) instead of throwing an exception from `emit()`.
+  - Reads immediately following a write may not reflect the change yet, since it is applied a moment later.
+
+  **To keep the previous synchronous behavior:**
+
+  - In code (custom scripts, SDK clients, API helpers): pass `emit_mode=EmitMode.SYNC_PRIMARY` (or `SYNC_WAIT`) on the emit call.
+  - For the plugins and CLI (which do not expose a per-call option): set `DATAHUB_EMIT_MODE=SYNC_PRIMARY` in the environment of the process — e.g. your Airflow/Dagster workers, or the shell running the `datahub` CLI.
+
 - **(GMS / Logical Models)** Linking a physical dataset to a logical parent now requires **Edit Entity** on both the **child dataset** (whose `logicalParent` aspect is written) and the **proposed parent** dataset. Clearing a logical parent requires **Edit Entity** on the child only. The [logical models feature guide](../features/feature-guides/logical-models/overview.md) previously stated only the child was checked; enforcement now matches [metadata policies](../authorization/policies.md#logical-parent-logicalparent-aspect). **Action:** Grant **Edit Entity** on logical parent datasets to principals who create or change logical-parent links, or update policies so those operations succeed.
 
 - #17852: **(Ingestion framework)** Workunit processor helper functions have been removed and replaced with `WorkunitProcessor` classes. If you were directly calling these functions in custom code, you must update to use the processor class API. **Migration:** Import the processor class, create a `WorkunitProcessorContext`, instantiate the processor via `Processor.create(ctx)`, and call `.process(stream)`. Additionally, some processors have been renamed to follow a consistent naming convention:

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -276,7 +276,7 @@ class EmitMode(ConfigEnum):
 
 
 _DEFAULT_EMIT_MODE = pydantic.TypeAdapter(EmitMode).validate_python(
-    get_emit_mode() or EmitMode.SYNC_PRIMARY,
+    get_emit_mode() or EmitMode.ASYNC,
 )
 
 

--- a/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
+++ b/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
@@ -198,7 +198,7 @@ class TestDataHubRestEmitter:
             openapi_emitter.emit_mcp(item)
 
             mock_method.assert_called_once_with(
-                f"{MOCK_GMS_ENDPOINT}/openapi/v3/entity/dataset?async=false",
+                f"{MOCK_GMS_ENDPOINT}/openapi/v3/entity/dataset?async=true",
                 payload=[
                     {
                         "urn": "urn:li:dataset:(urn:li:dataPlatform:mysql,User.UserAccount,PROD)",
@@ -264,7 +264,7 @@ class TestDataHubRestEmitter:
             call_args = mock_emit.call_args
             assert (
                 call_args[0][0]
-                == f"{MOCK_GMS_ENDPOINT}/openapi/v3/entity/dataset?async=false"
+                == f"{MOCK_GMS_ENDPOINT}/openapi/v3/entity/dataset?async=true"
             )
             assert isinstance(call_args[1]["payload"], str)  # Should be JSON string
 
@@ -418,11 +418,11 @@ class TestDataHubRestEmitter:
             # Verify each URL got the right aspects
             for url, payload in calls.items():
                 if "datasetProfile" in payload[0]:
-                    assert url.endswith("dataset?async=false")
+                    assert url.endswith("dataset?async=true")
                     assert len(payload) == 2
                     assert all("datasetProfile" in item for item in payload)
                 else:
-                    assert url.endswith("dashboard?async=false")
+                    assert url.endswith("dashboard?async=true")
                     assert len(payload) == 2
                     assert all("status" in item for item in payload)
 
@@ -975,11 +975,11 @@ class TestDataHubRestEmitter:
 
             assert (
                 "post",
-                f"{MOCK_GMS_ENDPOINT}/openapi/v3/entity/dataset?async=false",
+                f"{MOCK_GMS_ENDPOINT}/openapi/v3/entity/dataset?async=true",
             ) in calls
             assert (
                 "patch",
-                f"{MOCK_GMS_ENDPOINT}/openapi/v3/entity/dataset?async=false",
+                f"{MOCK_GMS_ENDPOINT}/openapi/v3/entity/dataset?async=true",
             ) in calls
 
     def test_openapi_emitter_mixed_method_chunking(self, openapi_emitter):
@@ -1067,14 +1067,14 @@ class TestDataHubRestEmitter:
             for call in post_calls:
                 assert (
                     call[0][0]
-                    == f"{MOCK_GMS_ENDPOINT}/openapi/v3/entity/dataset?async=false"
+                    == f"{MOCK_GMS_ENDPOINT}/openapi/v3/entity/dataset?async=true"
                 )
 
             # Verify all patch calls are to the dataset endpoint
             for call in patch_calls:
                 assert (
                     call[0][0]
-                    == f"{MOCK_GMS_ENDPOINT}/openapi/v3/entity/dataset?async=false"
+                    == f"{MOCK_GMS_ENDPOINT}/openapi/v3/entity/dataset?async=true"
                 )
 
     def test_openapi_sync_full_emit_mode(self, openapi_emitter):

--- a/metadata-ingestion/tests/unit/test_rest_sink.py
+++ b/metadata-ingestion/tests/unit/test_rest_sink.py
@@ -260,7 +260,7 @@ basicAuditStamp = models.AuditStampClass(
             ),
             "/aspects?action=ingestProposal",
             {
-                "async": "false",
+                "async": "true",
                 "proposal": {
                     "entityType": "dataset",
                     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:foo,bar,PROD)",


### PR DESCRIPTION
## Summary

Changes the default emit mode of the Python REST emitter (`DataHubRestEmitter` / `DataHubGraph`) from `SYNC_PRIMARY` to `ASYNC`.

Any code that emits metadata **without** explicitly setting an emit mode now queues changes for asynchronous processing instead of blocking on a synchronous write. This significantly reduces load on GMS and the database for high-volume emitters.

## Motivation

Synchronous emission writes every MCP through GMS to MySQL inline and blocks until it commits. Under high volume (large custom-script backfills, busy Airflow deployments, etc.) this puts heavy, serialized pressure on GMS/MySQL. `ASYNC` hands the change off to Kafka and lets the consumers batch the writes, which is much easier on the backend — and is already how the `datahub-rest` ingestion sink has behaved by default for a long time. This brings the programmatic emitter in line with that.

## What changes

The new default applies to everything that emits without an explicit `emit_mode`:

AFFECTED SURFACE: TBD

The `datahub-rest` ingestion sink is **not** affected — it already defaults to `ASYNC_BATCH` and continues to control emission via its own `mode` option.

## Behavior change (breaking)

With `ASYNC`, an `emit()` call returns as soon as DataHub accepts the request rather than waiting for the write to be persisted. Two consequences:

- Failures are no longer raised at the call site — a rejected/invalid change is reported asynchronously (Failed MCP topic / consumer logs) instead of throwing from `emit()`. (Structural URN/entity/aspect-name and HTTP/auth errors are still returned synchronously.)
- A read immediately following a write may not reflect the change yet.

**To keep the previous synchronous behavior:**

- In code: pass `emit_mode=EmitMode.SYNC_PRIMARY` (or `SYNC_WAIT`) on the emit call.
- For the plugins/CLI: set `DATAHUB_EMIT_MODE=SYNC_PRIMARY` for the process.

Documented in `docs/how/updating-datahub.md`.