### PR TITLE
docs(agents): forbid customer-identifiable data in committed code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -453,6 +453,21 @@ Example: `feat(parser): add ability to parse arrays`
 - [ ] Docs added/updated (if applicable)
 - [ ] Breaking changes documented in `docs/how/updating-datahub.md`
 
+### Confidentiality in Committed Code
+
+DataHub is a **public repository**. Never put customer-identifiable or
+environment-specific details into committed code, tests, docs, comments, commit
+messages, or PRs:
+
+- No real database / schema / table / view / column names, and no usernames,
+  customer names, host names, account IDs, or URLs from customer environments.
+- No Linear/Jira ticket IDs or links.
+- When reproducing a customer issue in a test, use generic placeholder names
+  (e.g. `my_db.my_schema.events`, `col_a`) that preserve the structural pattern
+  being tested, not the customer's actual identifiers.
+- Vendor/system built-ins (e.g. a platform's standard system tables) are fine,
+  but prefer generic names when in doubt.
+
 ## Starting / Operating DataHub
 
 Use `scripts/dev/datahub-dev.sh` for **ALL** environment operations.


### PR DESCRIPTION
## Summary

Adds a **Confidentiality in Committed Code** subsection to `AGENTS.md` (under Code Standards). DataHub is a public repository, so this codifies an explicit rule that agents and humans must not commit customer-identifiable or environment-specific details.

The rule forbids, in code/tests/docs/comments/commit messages/PRs:

- Real database / schema / table / view / column names, usernames, customer names, host names, account IDs, or URLs from customer environments
- Linear/Jira ticket IDs or links
- Real customer identifiers when reproducing an issue in a test — use generic placeholders (e.g. `my_db.my_schema.events`, `col_a`) that preserve the structural pattern instead

Vendor/system built-ins remain fine, with a preference for generic names when in doubt.

## Checklist

- [x] PR conforms to the Contributing Guideline (especially PR Title Format)
- [ ] Links to related issues (if applicable)
- [ ] Tests added/updated (not applicable — docs only)
- [x] Docs added/updated
- [ ] Breaking changes documented in `docs/how/updating-datahub.md` (not applicable)