### PR TITLE
refactor(theme): make commonStyles token-driven + enforce color lint

### DIFF
--- a/datahub-web-react/.eslintrc.js
+++ b/datahub-web-react/.eslintrc.js
@@ -153,9 +153,8 @@ const COLOR_RULE_EXCLUDED_FILES = [
     '**/*.test.tsx',
     '**/__tests__/**',
     '**/*.stories.tsx',
-    // Deferred to a design-led pass: chart series palette + static style objects.
+    // Deferred to a design-led pass: chart series palette.
     'src/app/dataviz/**',
-    'src/alchemy-components/components/commonStyles.ts',
 ];
 
 module.exports = {

--- a/datahub-web-react/src/alchemy-components/components/Select/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/components.ts
@@ -181,11 +181,12 @@ export const OptionLabel = styled.label<{
     ...getOptionLabelStyle(isSelected, isMultiSelect, isDisabled, applyHoverWidth, theme),
 }));
 
-export const SelectLabel = styled.label({
+export const SelectLabel = styled.label(({ theme }) => ({
     ...formLabelTextStyles,
+    color: theme.colors.text,
     marginBottom: spacing.xxsm,
     textAlign: 'left',
-});
+}));
 
 export const StyledIcon = styled(Icon)(({ theme }) => ({
     flexShrink: 0,

--- a/datahub-web-react/src/alchemy-components/components/commonStyles.ts
+++ b/datahub-web-react/src/alchemy-components/components/commonStyles.ts
@@ -1,23 +1,20 @@
-import { colors, typography } from '@components/theme';
+import { typography } from '@components/theme';
 
 export const INPUT_MAX_HEIGHT = '40px';
 
 export const formLabelTextStyles = {
     fontWeight: typography.fontWeights.normal,
     fontSize: typography.fontSizes.md,
-    color: colors.gray[600],
 };
 
 export const inputValueTextStyles = (size = 'md') => ({
     fontFamily: typography.fonts.body,
     fontWeight: typography.fontWeights.normal,
     fontSize: typography.fontSizes[size],
-    color: colors.gray[700],
 });
 
 export const inputPlaceholderTextStyles = {
     fontFamily: typography.fonts.body,
     fontWeight: typography.fontWeights.normal,
     fontSize: typography.fontSizes.md,
-    color: colors.gray[400],
 };


### PR DESCRIPTION
## Summary

Makes `alchemy-components/components/commonStyles.ts` token-driven and removes it from the color-lint exclusion list (`COLOR_RULE_EXCLUDED_FILES`), so the `no-hardcoded-colors` rule now enforces it like the rest of `src/**`.

The three shared text-style objects (`formLabelTextStyles`, `inputValueTextStyles`, `inputPlaceholderTextStyles`) each carried a hardcoded `color` from the raw alchemy palette (`colors.gray[600]/[700]/[400]`). Every consumer that renders text already overrides `color` with a semantic token immediately after spreading the object — so the exports become font-only and the one consumer that relied on a default now sets the token explicitly.

**Zero visual change.**

## Why

`commonStyles.ts` was one of two files deferred behind the color-lint exclusion list. This clears it so the file is covered by the rule. (The remaining deferral, `src/app/dataviz/**`, needs a design-led chart-palette mapping and stays excluded.)

## How

- `commonStyles.ts`: drop the `colors` import and the three hardcoded `color` keys — the exports are now font-only.
- `Select/components.ts`: `SelectLabel` was the only consumer rendering the default color (label text, formerly `colors.gray[600]`). Convert it from a static style object to a `theme` function and set `color: theme.colors.text`.
  - **Token-mapping note:** alchemy `colors.gray[600]` is `#374066`, which maps to `theme.colors.text` (theme `gray800`, `#374066`) — **not** `theme.colors.textTertiary` (theme `gray600`, `#8088A3`). The alchemy foundation palette and the semantic-token palette have *unrelated* `gray600` values; `theme.colors.text` preserves the exact shade.
- `.eslintrc.js`: remove `commonStyles.ts` from `COLOR_RULE_EXCLUDED_FILES`.

`Select`'s `Container` also spreads `inputValueTextStyles` without overriding `color`, but every text-rendering descendant (`SelectBase`, `OptionLabel`, `SelectValue`, `Placeholder`, `DescriptionContainer`, `StyledIcon`) sets its own color, so that default never reached a visible node — dropping it is a no-op.

## Test

- `yarn type-check` clean.
- `eslint` on both un-excluded files: 0 `no-hardcoded-colors` / `no-restricted-imports` violations.
- Select component tests pass (34/34 across its 4 test files).

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests — verified (type-check, lint, Select tests)
- [ ] Docs — n/a (internal refactor)
- [ ] Breaking changes — none (zero behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)