### PR TITLE
fix(ingest/unity): drain query history before parsing to avoid operation-handle eviction

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -575,6 +575,17 @@ class UnityCatalogSourceConfig(
             )
         return workspace_url
 
+    @field_validator("local_temp_path", mode="after")
+    @classmethod
+    def local_temp_path_must_be_dir(
+        cls, v: Optional[pathlib.Path]
+    ) -> Optional[pathlib.Path]:
+        # Fail fast with a clear message instead of a confusing extraction error when
+        # the audit-log cache directory doesn't exist (matches Snowflake/BigQuery).
+        if v is not None and not v.is_dir():
+            raise ValueError(f"local_temp_path must be an existing directory, got: {v}")
+        return v
+
     @field_validator("include_metastore", mode="after")
     @classmethod
     def include_metastore_warning(cls, v: bool) -> bool:

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pathlib
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Union
 
@@ -419,6 +420,19 @@ class UnityCatalogSourceConfig(
             "parses every query). Takes precedence over "
             "push_down_database_pattern_access_history and "
             "skip_sqlglot_when_system_table_lineage_missing, which are ignored when set."
+        ),
+    )
+
+    local_temp_path: HiddenFromDocs[Optional[pathlib.Path]] = pydantic.Field(
+        default=None,
+        description=(
+            "Advanced/dev only. Local directory in which to persist the drained "
+            "query-history audit log (SQLite). When set, the audit log is kept across "
+            "runs so the next run over the same time window reloads it and skips "
+            "re-fetching (including after a crash). The file name is keyed by the usage "
+            "source and time window so it never serves a stale window; files for other "
+            "windows are not pruned automatically. When unset, an ephemeral, "
+            "self-cleaning buffer is used and no caching occurs."
         ),
     )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/report.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Optional, Tuple
 from datahub.ingestion.api.report import EntityFilterReport
 from datahub.ingestion.source.sql.sql_report import SQLSourceReport
 from datahub.utilities.lossy_collections import LossyDict, LossyList
+from datahub.utilities.perf_timer import PerfTimer
 
 if TYPE_CHECKING:
     from datahub.ingestion.source.unity.platform_resource_repository import (
@@ -46,6 +47,14 @@ class UnityCatalogReport(SQLSourceReport):
     )
     num_lineage_row_field_read_errors: int = 0
     num_usage_query_fetch_failures: int = 0
+
+    # Usage step timers. fetch = draining query history off the warehouse cursor
+    # (released as soon as the generator is consumed); parsing = sqlglot/preparsed
+    # processing of the buffered queries. Splitting them makes the drain-before-parse
+    # behavior measurable and surfaces eviction-risk (fetch time creeping toward
+    # parse time) — mirroring BigQuery's query_log_fetch_timer / sql_parsing_sec.
+    usage_query_fetch_timer: PerfTimer = field(default_factory=PerfTimer)
+    usage_parsing_timer: PerfTimer = field(default_factory=PerfTimer)
 
     profile_table_timeouts: LossyList[str] = field(default_factory=LossyList)
     profile_table_empty: LossyList[str] = field(default_factory=LossyList)

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
@@ -412,6 +412,48 @@ class UnityCatalogUsageExtractor:
                 context=context,
             )
 
+    def _report_no_queries(self) -> None:
+        # Called when query history yielded zero usable queries (and no fetch
+        # failure occurred). Distinguishes "rows were present but unparseable"
+        # from "no rows at all", and tailors the permission hint to the path.
+        if self.report.num_queries_missing_info > 0:
+            self.report.report_warning(
+                title="Query history rows could not be parsed",
+                message=(
+                    "Statements from system.query.history could not be "
+                    "parsed and were skipped, so no usage was extracted."
+                ),
+                context=f"count={self.report.num_queries_missing_info}",
+            )
+            return
+
+        if self._use_system_tables_join():
+            hint = (
+                "verify SELECT privilege on system.query and system.access "
+                "and that the time window covers recent activity"
+            )
+            if (
+                self.config.push_down_database_pattern_access_history
+                and self.config.catalog_pattern is not None
+            ):
+                hint += (
+                    "; if catalog pushdown is enabled, also verify "
+                    "catalog_pattern allow/deny rules are not over-restrictive"
+                )
+        else:
+            hint = (
+                "verify CAN_MANAGE privilege on the SQL warehouse "
+                "and that the time window covers recent activity"
+            )
+        self.report.report_warning(
+            title="No queries found for usage",
+            message=(
+                "No queries were found in the configured time range "
+                "for usage extraction."
+            ),
+            context=hint,
+        )
+
     def get_usage_workunits(
         self, table_refs: Set[TableReference]
     ) -> Iterable[MetadataWorkUnit]:
@@ -452,11 +494,12 @@ class UnityCatalogUsageExtractor:
             try:
                 aggregator = self._build_aggregator(is_allowed_table=is_allowed_table)
                 buffered_queries = FileBackedList[Query]()
-                for query in self._fetch_queries():
-                    # Drain only — the cursor/connection is released once the
-                    # generator is fully consumed here.
-                    self.report.num_queries += 1
-                    buffered_queries.append(query)
+                with self.report.usage_query_fetch_timer:
+                    for query in self._fetch_queries():
+                        # Drain only — the cursor/connection is released once the
+                        # generator is fully consumed here.
+                        self.report.num_queries += 1
+                        buffered_queries.append(query)
             except (MemoryError, SystemExit, KeyboardInterrupt):
                 raise
             except Exception as e:
@@ -480,75 +523,44 @@ class UnityCatalogUsageExtractor:
                 )
                 return
             if self.report.num_queries == 0:
-                if not fetch_failed:
-                    if self.report.num_queries_missing_info > 0:
-                        self.report.report_warning(
-                            title="Query history rows could not be parsed",
-                            message=(
-                                "Statements from system.query.history could not be "
-                                "parsed and were skipped, so no usage was extracted."
-                            ),
-                            context=(f"count={self.report.num_queries_missing_info}"),
-                        )
-                    else:
-                        if self._use_system_tables_join():
-                            hint = (
-                                "verify SELECT privilege on system.query and system.access "
-                                "and that the time window covers recent activity"
-                            )
-                            if (
-                                self.config.push_down_database_pattern_access_history
-                                and self.config.catalog_pattern is not None
-                            ):
-                                hint += (
-                                    "; if catalog pushdown is enabled, also verify "
-                                    "catalog_pattern allow/deny rules are not over-restrictive"
-                                )
-                        else:
-                            hint = (
-                                "verify CAN_MANAGE privilege on the SQL warehouse "
-                                "and that the time window covers recent activity"
-                            )
-                        self.report.report_warning(
-                            title="No queries found for usage",
-                            message=(
-                                "No queries were found in the configured time range "
-                                "for usage extraction."
-                            ),
-                            context=hint,
-                        )
-                # Skip resetting per-table usage when we couldn't read any queries at
-                # all (empty history or missing permission).  Emitting zero-usage aspects
-                # in that case would wrongly wipe existing usage stats in DataHub.
-                return
+                # No usable queries, but the fetch itself succeeded — a fetch
+                # failure would have returned at the fetch_failed check above.
+                # Emit a diagnostic warning, then fall through so
+                # auto_empty_dataset_usage_statistics stamps zero-usage for the
+                # idle window, matching Snowflake/BigQuery/Redshift (which call
+                # auto_empty whenever the read succeeded). datasetUsageStatistics
+                # is a timeseries aspect and the empty aspect is UPSERTed (a
+                # current-bucket zero datapoint); it does not delete prior history.
+                self._report_no_queries()
 
             assert buffered_queries is not None
-            for query in buffered_queries:
-                try:
-                    self._add_query_to_aggregator(
-                        aggregator, query, default_db=default_db
-                    )
-                except (
-                    MemoryError,
-                    SystemExit,
-                    KeyboardInterrupt,
-                ):  # never swallow system-level errors as a "dropped query"
-                    raise
-                except Exception as per_query_exc:
-                    self.report.num_queries_dropped += 1
-                    logger.warning(
-                        "Skipping query due to error during usage processing "
-                        "(query_id=%s): %r",
-                        query.query_id,
-                        per_query_exc,
-                        exc_info=True,
-                    )
-                    self.report.report_warning(
-                        title="Skipped query during usage extraction",
-                        message="A query from query history could not be processed and was skipped, so its usage is not counted.",
-                        context=f"query_id={query.query_id}",
-                        exc=per_query_exc,
-                    )
+            with self.report.usage_parsing_timer:
+                for query in buffered_queries:
+                    try:
+                        self._add_query_to_aggregator(
+                            aggregator, query, default_db=default_db
+                        )
+                    except (
+                        MemoryError,
+                        SystemExit,
+                        KeyboardInterrupt,
+                    ):  # never swallow system-level errors as a "dropped query"
+                        raise
+                    except Exception as per_query_exc:
+                        self.report.num_queries_dropped += 1
+                        logger.warning(
+                            "Skipping query due to error during usage processing "
+                            "(query_id=%s): %r",
+                            query.query_id,
+                            per_query_exc,
+                            exc_info=True,
+                        )
+                        self.report.report_warning(
+                            title="Skipped query during usage extraction",
+                            message="A query from query history could not be processed and was skipped, so its usage is not counted.",
+                            context=f"query_id={query.query_id}",
+                            exc=per_query_exc,
+                        )
             self._log_usage_routing_summary()
             self._report_usage_lineage_warnings()
 

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
@@ -422,9 +422,8 @@ class UnityCatalogUsageExtractor:
             )
 
     def _report_no_queries(self) -> None:
-        # Called when query history yielded zero usable queries (and no fetch
-        # failure occurred). Distinguishes "rows were present but unparseable"
-        # from "no rows at all", and tailors the permission hint to the path.
+        # Zero usable queries: distinguish unparseable rows from an empty read,
+        # with a path-specific permission hint.
         if self.report.num_queries_missing_info > 0:
             self.report.report_warning(
                 title="Query history rows could not be parsed",
@@ -492,20 +491,12 @@ class UnityCatalogUsageExtractor:
 
         aggregator: Optional[SqlParsingAggregator] = None
         shared_connection: Optional[ConnectionWrapper] = None
-        # Drain all rows from _fetch_queries() into a disk-backed buffer before
-        # parsing. Holding the Databricks warehouse cursor open across slow per-query
-        # sqlglot parsing (~20-30 min for large histories) causes the server-side
-        # operation handle to be evicted with a non-retryable RESOURCE_DOES_NOT_EXIST.
-        # Draining is near-instant; the cursor/connection is released as soon as the
-        # generator is fully consumed. Parsing then runs against the buffer.
-        # Ref: https://github.com/databricks/databricks-sql-python/pull/785
-        #
-        # When local_temp_path is set the buffer is a named, window-keyed SQLite file
-        # that persists across runs: the next run over the same window reloads it and
-        # skips the fetch (use_cached_audit_log) — including after a crash. The
-        # window-keyed name keeps it from ever serving a stale window (a different
-        # window or usage source resolves to a different file). Without local_temp_path
-        # the buffer is an ephemeral, self-cleaning FileBackedList and no caching occurs.
+        # Drain query history to a disk-backed buffer before parsing: holding the
+        # warehouse cursor open across the slow sqlglot parse risks the server-side
+        # operation handle being evicted (non-retryable RESOURCE_DOES_NOT_EXIST after
+        # ~20-30 min). See https://github.com/databricks/databricks-sql-python/pull/785.
+        # With local_temp_path set, the buffer is a window-keyed SQLite file reused
+        # across runs (use_cached_audit_log); otherwise it is ephemeral and self-cleaning.
         audit_log_file: Optional[pathlib.Path] = None
         if isinstance(self.config.local_temp_path, pathlib.Path):
             audit_log_file = self.config.local_temp_path / self._audit_log_filename()
@@ -558,14 +549,10 @@ class UnityCatalogUsageExtractor:
                 )
                 return
             if self.report.num_queries == 0:
-                # No usable queries, but the fetch itself succeeded — a fetch
-                # failure would have returned at the fetch_failed check above.
-                # Emit a diagnostic warning, then fall through so
-                # auto_empty_dataset_usage_statistics stamps zero-usage for the
-                # idle window, matching Snowflake/BigQuery/Redshift (which call
-                # auto_empty whenever the read succeeded). datasetUsageStatistics
-                # is a timeseries aspect and the empty aspect is UPSERTed (a
-                # current-bucket zero datapoint); it does not delete prior history.
+                # Successful but empty read (a fetch failure returns above): warn, then
+                # fall through to auto_empty so the idle window records a zero datapoint,
+                # matching Snowflake/BigQuery/Redshift. (Timeseries UPSERT — adds a
+                # current-bucket zero, does not delete history.)
                 self._report_no_queries()
 
             assert buffered_queries is not None

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
@@ -1,4 +1,5 @@
 import logging
+import pathlib
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Callable, Iterable, List, Optional, Set
@@ -25,7 +26,7 @@ from datahub.sql_parsing.sql_parsing_aggregator import (
 )
 from datahub.sql_parsing.sql_parsing_common import QueryType
 from datahub.sql_parsing.sqlglot_utils import get_query_fingerprint
-from datahub.utilities.file_backed_collections import FileBackedList
+from datahub.utilities.file_backed_collections import ConnectionWrapper, FileBackedList
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +76,14 @@ class UnityCatalogUsageExtractor:
             format_queries=False,
             is_allowed_table=is_allowed_table,
         )
+
+    def _audit_log_filename(self) -> str:
+        # Key the cache file by usage source and time window so a file left behind by a
+        # crashed run is only reused for an identical window, never a stale one.
+        mode = "systables" if self._use_system_tables_join() else "api"
+        start = int(self.config.start_time.timestamp())
+        end = int(self.config.end_time.timestamp())
+        return f"unity_usage_audit_log_{mode}_{start}_{end}.sqlite"
 
     def _fetch_queries(self) -> Iterable[Query]:
         include_ops = self.config.include_operational_stats
@@ -482,6 +491,7 @@ class UnityCatalogUsageExtractor:
         fetch_failures_before = self.report.num_usage_query_fetch_failures
 
         aggregator: Optional[SqlParsingAggregator] = None
+        shared_connection: Optional[ConnectionWrapper] = None
         # Drain all rows from _fetch_queries() into a disk-backed buffer before
         # parsing. Holding the Databricks warehouse cursor open across slow per-query
         # sqlglot parsing (~20-30 min for large histories) causes the server-side
@@ -489,17 +499,42 @@ class UnityCatalogUsageExtractor:
         # Draining is near-instant; the cursor/connection is released as soon as the
         # generator is fully consumed. Parsing then runs against the buffer.
         # Ref: https://github.com/databricks/databricks-sql-python/pull/785
+        #
+        # When local_temp_path is set the buffer is a named, window-keyed SQLite file
+        # that persists across runs: the next run over the same window reloads it and
+        # skips the fetch (use_cached_audit_log) — including after a crash. The
+        # window-keyed name keeps it from ever serving a stale window (a different
+        # window or usage source resolves to a different file). Without local_temp_path
+        # the buffer is an ephemeral, self-cleaning FileBackedList and no caching occurs.
+        audit_log_file: Optional[pathlib.Path] = None
+        if isinstance(self.config.local_temp_path, pathlib.Path):
+            audit_log_file = self.config.local_temp_path / self._audit_log_filename()
+        use_cached_audit_log = audit_log_file is not None and audit_log_file.exists()
+
         buffered_queries: Optional[FileBackedList[Query]] = None
         try:
             try:
                 aggregator = self._build_aggregator(is_allowed_table=is_allowed_table)
-                buffered_queries = FileBackedList[Query]()
-                with self.report.usage_query_fetch_timer:
-                    for query in self._fetch_queries():
-                        # Drain only — the cursor/connection is released once the
-                        # generator is fully consumed here.
-                        self.report.num_queries += 1
-                        buffered_queries.append(query)
+                if use_cached_audit_log:
+                    assert audit_log_file is not None
+                    logger.info(
+                        "Using cached query-history audit log at %s", audit_log_file
+                    )
+                    shared_connection = ConnectionWrapper(audit_log_file)
+                    buffered_queries = FileBackedList(shared_connection)
+                else:
+                    if audit_log_file is not None:
+                        audit_log_file.unlink(missing_ok=True)
+                        shared_connection = ConnectionWrapper(audit_log_file)
+                        buffered_queries = FileBackedList(shared_connection)
+                    else:
+                        buffered_queries = FileBackedList[Query]()
+                    with self.report.usage_query_fetch_timer:
+                        for query in self._fetch_queries():
+                            # Drain only — the cursor/connection is released once the
+                            # generator is fully consumed here.
+                            buffered_queries.append(query)
+                self.report.num_queries = len(buffered_queries)
             except (MemoryError, SystemExit, KeyboardInterrupt):
                 raise
             except Exception as e:
@@ -572,6 +607,12 @@ class UnityCatalogUsageExtractor:
         finally:
             if buffered_queries is not None:
                 buffered_queries.close()
+            if shared_connection is not None:
+                # Closing flushes the SQLite file but does NOT delete it (it is a named
+                # file, not the auto-cleaned temp-dir case). The window-keyed file is
+                # intentionally left behind so the next run over the same window reloads
+                # it (use_cached_audit_log) — including after a crash.
+                shared_connection.close()
             if aggregator is not None:
                 try:
                     aggregator.close()

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
@@ -25,6 +25,7 @@ from datahub.sql_parsing.sql_parsing_aggregator import (
 )
 from datahub.sql_parsing.sql_parsing_common import QueryType
 from datahub.sql_parsing.sqlglot_utils import get_query_fingerprint
+from datahub.utilities.file_backed_collections import FileBackedList
 
 logger = logging.getLogger(__name__)
 
@@ -439,38 +440,23 @@ class UnityCatalogUsageExtractor:
         fetch_failures_before = self.report.num_usage_query_fetch_failures
 
         aggregator: Optional[SqlParsingAggregator] = None
+        # Drain all rows from _fetch_queries() into a disk-backed buffer before
+        # parsing. Holding the Databricks warehouse cursor open across slow per-query
+        # sqlglot parsing (~20-30 min for large histories) causes the server-side
+        # operation handle to be evicted with a non-retryable RESOURCE_DOES_NOT_EXIST.
+        # Draining is near-instant; the cursor/connection is released as soon as the
+        # generator is fully consumed. Parsing then runs against the buffer.
+        # Ref: https://github.com/databricks/databricks-sql-python/pull/785
+        buffered_queries: Optional[FileBackedList[Query]] = None
         try:
             try:
                 aggregator = self._build_aggregator(is_allowed_table=is_allowed_table)
+                buffered_queries = FileBackedList[Query]()
                 for query in self._fetch_queries():
+                    # Drain only — the cursor/connection is released once the
+                    # generator is fully consumed here.
                     self.report.num_queries += 1
-                    try:
-                        self._add_query_to_aggregator(
-                            aggregator, query, default_db=default_db
-                        )
-                    except (
-                        MemoryError,
-                        SystemExit,
-                        KeyboardInterrupt,
-                    ):  # never swallow system-level errors as a "dropped query"
-                        raise
-                    except Exception as per_query_exc:
-                        self.report.num_queries_dropped += 1
-                        logger.warning(
-                            "Skipping query due to error during usage processing "
-                            "(query_id=%s): %r",
-                            query.query_id,
-                            per_query_exc,
-                            exc_info=True,
-                        )
-                        self.report.report_warning(
-                            title="Skipped query during usage extraction",
-                            message="A query from query history could not be processed and was skipped, so its usage is not counted.",
-                            context=f"query_id={query.query_id}",
-                            exc=per_query_exc,
-                        )
-                self._log_usage_routing_summary()
-                self._report_usage_lineage_warnings()
+                    buffered_queries.append(query)
             except (MemoryError, SystemExit, KeyboardInterrupt):
                 raise
             except Exception as e:
@@ -536,12 +522,44 @@ class UnityCatalogUsageExtractor:
                 # in that case would wrongly wipe existing usage stats in DataHub.
                 return
 
+            assert buffered_queries is not None
+            for query in buffered_queries:
+                try:
+                    self._add_query_to_aggregator(
+                        aggregator, query, default_db=default_db
+                    )
+                except (
+                    MemoryError,
+                    SystemExit,
+                    KeyboardInterrupt,
+                ):  # never swallow system-level errors as a "dropped query"
+                    raise
+                except Exception as per_query_exc:
+                    self.report.num_queries_dropped += 1
+                    logger.warning(
+                        "Skipping query due to error during usage processing "
+                        "(query_id=%s): %r",
+                        query.query_id,
+                        per_query_exc,
+                        exc_info=True,
+                    )
+                    self.report.report_warning(
+                        title="Skipped query during usage extraction",
+                        message="A query from query history could not be processed and was skipped, so its usage is not counted.",
+                        context=f"query_id={query.query_id}",
+                        exc=per_query_exc,
+                    )
+            self._log_usage_routing_summary()
+            self._report_usage_lineage_warnings()
+
             yield from auto_empty_dataset_usage_statistics(
                 auto_workunit(aggregator.gen_metadata()),
                 dataset_urns={self.table_urn_builder(ref) for ref in table_refs},
                 config=self.config,
             )
         finally:
+            if buffered_queries is not None:
+                buffered_queries.close()
             if aggregator is not None:
                 try:
                     aggregator.close()

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
@@ -30,6 +30,11 @@ from datahub.utilities.file_backed_collections import ConnectionWrapper, FileBac
 
 logger = logging.getLogger(__name__)
 
+# Bump whenever the on-disk shape of a buffered Query (or its pickling) changes, so a
+# cache written by an older build resolves to a different filename — a clean miss that
+# re-fetches, rather than a deserialization error when reloading an incompatible Query.
+_AUDIT_LOG_FORMAT_VERSION = 1
+
 _STATEMENT_TYPE_TO_QUERY_TYPE = {
     QueryStatementType.SELECT: QueryType.SELECT,
     QueryStatementType.INSERT: QueryType.INSERT,
@@ -78,12 +83,16 @@ class UnityCatalogUsageExtractor:
         )
 
     def _audit_log_filename(self) -> str:
-        # Key the cache file by usage source and time window so a file left behind by a
-        # crashed run is only reused for an identical window, never a stale one.
+        # Key the cache file by format version, usage source, and time window so a file
+        # left behind by a crashed run is only reused for an identical window+format,
+        # never a stale window or an incompatible serialization.
         mode = "systables" if self._use_system_tables_join() else "api"
         start = int(self.config.start_time.timestamp())
         end = int(self.config.end_time.timestamp())
-        return f"unity_usage_audit_log_{mode}_{start}_{end}.sqlite"
+        return (
+            f"unity_usage_audit_log_v{_AUDIT_LOG_FORMAT_VERSION}"
+            f"_{mode}_{start}_{end}.sqlite"
+        )
 
     def _fetch_queries(self) -> Iterable[Query]:
         include_ops = self.config.include_operational_stats
@@ -462,6 +471,65 @@ class UnityCatalogUsageExtractor:
             context=hint,
         )
 
+    def _parse_buffered_queries(
+        self,
+        aggregator: SqlParsingAggregator,
+        buffered_queries: FileBackedList[Query],
+        default_db: Optional[str],
+    ) -> None:
+        # Iterate by index so a single unreadable row (e.g. a corrupt cached entry) can
+        # be skipped without aborting the rest — a generator closes on the first raise.
+        # buffered_queries[i] deserializes the row, which happens before the per-query
+        # try below, so reading it needs its own guard.
+        #
+        # Per-row failures use report.warning(log=False): the structured report groups
+        # them by title (bounded sample + count) WITHOUT emitting a log line per row, so
+        # a pathological run (e.g. every query unparseable) can't flood the logs. The
+        # full traceback stays available at DEBUG.
+        for i in range(len(buffered_queries)):
+            try:
+                query = buffered_queries[i]
+            except (MemoryError, SystemExit, KeyboardInterrupt):
+                raise
+            except Exception as read_exc:
+                self.report.num_queries_dropped += 1
+                logger.debug(
+                    "Skipping buffered query that could not be read back (index=%s)",
+                    i,
+                    exc_info=True,
+                )
+                self.report.warning(
+                    title="Skipped unreadable buffered query",
+                    message="A buffered query could not be read back from the audit-log "
+                    "buffer and was skipped, so its usage is not counted.",
+                    context=f"index={i}",
+                    exc=read_exc,
+                    log=False,
+                )
+                continue
+            try:
+                self._add_query_to_aggregator(aggregator, query, default_db=default_db)
+            except (
+                MemoryError,
+                SystemExit,
+                KeyboardInterrupt,
+            ):  # never swallow system-level errors as a "dropped query"
+                raise
+            except Exception as per_query_exc:
+                self.report.num_queries_dropped += 1
+                logger.debug(
+                    "Skipping query due to error during usage processing (query_id=%s)",
+                    query.query_id,
+                    exc_info=True,
+                )
+                self.report.warning(
+                    title="Skipped query during usage extraction",
+                    message="A query from query history could not be processed and was skipped, so its usage is not counted.",
+                    context=f"query_id={query.query_id}",
+                    exc=per_query_exc,
+                    log=False,
+                )
+
     def get_usage_workunits(
         self, table_refs: Set[TableReference]
     ) -> Iterable[MetadataWorkUnit]:
@@ -508,12 +576,35 @@ class UnityCatalogUsageExtractor:
                 aggregator = self._build_aggregator(is_allowed_table=is_allowed_table)
                 if use_cached_audit_log:
                     assert audit_log_file is not None
-                    logger.info(
-                        "Using cached query-history audit log at %s", audit_log_file
-                    )
-                    shared_connection = ConnectionWrapper(audit_log_file)
-                    buffered_queries = FileBackedList(shared_connection)
-                else:
+                    try:
+                        logger.info(
+                            "Using cached query-history audit log at %s", audit_log_file
+                        )
+                        shared_connection = ConnectionWrapper(audit_log_file)
+                        buffered_queries = FileBackedList(shared_connection)
+                    except (MemoryError, SystemExit, KeyboardInterrupt):
+                        raise
+                    except Exception as cache_exc:
+                        # The persisted cache could not be opened (corrupt, or written by
+                        # an incompatible build despite the version-keyed name). Discard
+                        # it and re-fetch rather than failing the run.
+                        if buffered_queries is not None:
+                            buffered_queries.close()
+                        if shared_connection is not None:
+                            shared_connection.close()
+                        buffered_queries = None
+                        shared_connection = None
+                        audit_log_file.unlink(missing_ok=True)
+                        use_cached_audit_log = False
+                        self.report.report_warning(
+                            title="Discarded unreadable cached audit log",
+                            message="The persisted query-history cache could not be read "
+                            "and was discarded; re-fetching query history.",
+                            context=str(audit_log_file),
+                            exc=cache_exc,
+                        )
+
+                if not use_cached_audit_log:
                     if audit_log_file is not None:
                         audit_log_file.unlink(missing_ok=True)
                         shared_connection = ConnectionWrapper(audit_log_file)
@@ -525,11 +616,16 @@ class UnityCatalogUsageExtractor:
                             # Drain only — the cursor/connection is released once the
                             # generator is fully consumed here.
                             buffered_queries.append(query)
+                assert buffered_queries is not None
                 self.report.num_queries = len(buffered_queries)
             except (MemoryError, SystemExit, KeyboardInterrupt):
                 raise
             except Exception as e:
                 logger.error("Error processing usage", exc_info=True)
+                # Drop a partially-written named file so it cannot be mistaken for a
+                # valid cache on the next run.
+                if audit_log_file is not None:
+                    audit_log_file.unlink(missing_ok=True)
                 self.report.report_failure(
                     title="Usage extraction failed",
                     message=f"Usage extraction failed: {e!r}",
@@ -557,32 +653,7 @@ class UnityCatalogUsageExtractor:
 
             assert buffered_queries is not None
             with self.report.usage_parsing_timer:
-                for query in buffered_queries:
-                    try:
-                        self._add_query_to_aggregator(
-                            aggregator, query, default_db=default_db
-                        )
-                    except (
-                        MemoryError,
-                        SystemExit,
-                        KeyboardInterrupt,
-                    ):  # never swallow system-level errors as a "dropped query"
-                        raise
-                    except Exception as per_query_exc:
-                        self.report.num_queries_dropped += 1
-                        logger.warning(
-                            "Skipping query due to error during usage processing "
-                            "(query_id=%s): %r",
-                            query.query_id,
-                            per_query_exc,
-                            exc_info=True,
-                        )
-                        self.report.report_warning(
-                            title="Skipped query during usage extraction",
-                            message="A query from query history could not be processed and was skipped, so its usage is not counted.",
-                            context=f"query_id={query.query_id}",
-                            exc=per_query_exc,
-                        )
+                self._parse_buffered_queries(aggregator, buffered_queries, default_db)
             self._log_usage_routing_summary()
             self._report_usage_lineage_warnings()
 
@@ -592,14 +663,24 @@ class UnityCatalogUsageExtractor:
                 config=self.config,
             )
         finally:
-            if buffered_queries is not None:
-                buffered_queries.close()
-            if shared_connection is not None:
-                # Closing flushes the SQLite file but does NOT delete it (it is a named
-                # file, not the auto-cleaned temp-dir case). The window-keyed file is
-                # intentionally left behind so the next run over the same window reloads
-                # it (use_cached_audit_log) — including after a crash.
-                shared_connection.close()
+            # Closing a shared connection also closes its dependent FileBackedList, so
+            # close exactly one to avoid a redundant double-close. Closing flushes the
+            # SQLite file but does NOT delete a named file — the window-keyed cache is
+            # intentionally left for the next run to reload (use_cached_audit_log).
+            buffer_closeable = shared_connection or buffered_queries
+            if buffer_closeable is not None:
+                try:
+                    buffer_closeable.close()
+                except (
+                    Exception
+                ) as close_exc:  # surface close failures in the report, not just logs
+                    logger.warning("Failed to close audit-log buffer", exc_info=True)
+                    self.report.report_warning(
+                        title="Failed to close usage buffer",
+                        message="The query-history buffer failed to close cleanly; its "
+                        "temporary resources may not have been released.",
+                        exc=close_exc,
+                    )
             if aggregator is not None:
                 try:
                     aggregator.close()

--- a/metadata-ingestion/tests/unit/test_unity_catalog_usage_join.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_usage_join.py
@@ -925,15 +925,17 @@ def test_auto_empty_usage_emitted_for_unqueried_tables(
     )
 
 
-def test_zero_queries_emits_no_usage_workunits(
+def test_zero_queries_emits_empty_usage_for_idle_window(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When the query history is empty (num_queries == 0), NO datasetUsageStatistics
-    workunit must be emitted, and the no-queries-found warning must fire.
+    """When the query history is genuinely empty (num_queries == 0 and no fetch
+    failure), the ingested tables must still receive a zero-usage aspect for the
+    window, and the no-queries-found warning must fire.
 
-    Emitting zero-usage aspects on a query-less run would wrongly wipe existing
-    usage stats in DataHub (e.g. when the warehouse has no recent activity or the
-    connector lacks SELECT privilege on query history tables).
+    A genuinely idle window should record a current-bucket zero datapoint (via
+    auto_empty_dataset_usage_statistics) rather than leaving stale usage stats —
+    fetch *failures* are handled separately and short-circuit before this point
+    (see test_fetch_failure_reports_failure_and_no_usage_workunits).
     """
 
     class FakeAgg:
@@ -951,11 +953,20 @@ def test_zero_queries_emits_no_usage_workunits(
 
     monkeypatch.setattr(usage_mod, "SqlParsingAggregator", FakeAgg)
 
+    start = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    end = datetime(2026, 6, 2, tzinfo=timezone.utc)
+
     config = MagicMock()
     config.include_queries = False
     config.include_query_usage_statistics = False
     config.include_operational_stats = False
     config.usage_uses_system_tables.return_value = True
+    # Real time-window values so auto_empty_dataset_usage_statistics can compute
+    # bucket timestamps via config.majority_buckets().
+    config.start_time = start
+    config.end_time = end
+    config.bucket_duration = BucketDuration.DAY
+    config.majority_buckets.return_value = [start]
 
     proxy = MagicMock()
     proxy.warehouse_id = "wh1"
@@ -966,19 +977,39 @@ def test_zero_queries_emits_no_usage_workunits(
     ex.report = UnityCatalogReport()
 
     ref = TableReference(metastore=None, catalog="main", schema="sales", table="orders")
+    expected_urn = ex.table_urn_builder(ref)
     workunits = list(ex.get_usage_workunits({ref}))
 
+    # The idle window must still stamp a zero-usage aspect for the ingested table.
     usage_wus = [
         wu
         for wu in workunits
-        if wu.get_aspect_of_type(DatasetUsageStatisticsClass) is not None
+        if wu.get_urn() == expected_urn
+        and wu.get_aspect_of_type(DatasetUsageStatisticsClass) is not None
     ]
-    assert not usage_wus, (
-        f"Expected NO datasetUsageStatistics workunits when num_queries == 0, "
-        f"but got {len(usage_wus)}: {[wu.id for wu in usage_wus]}"
+    assert usage_wus, (
+        f"Expected a zero-usage DatasetUsageStatistics workunit for {expected_urn!r} "
+        f"on an idle window, but none was emitted. Workunits: {[wu.id for wu in workunits]}"
     )
+    usage_aspect = usage_wus[0].get_aspect_of_type(DatasetUsageStatisticsClass)
+    assert usage_aspect is not None
+    assert usage_aspect.totalSqlQueries == 0
+    assert usage_aspect.uniqueUserCount == 0
 
-    # The "No queries found for usage" warning must be reported.
+    # Zeros must be scoped to the ingested table set, not over-stamped onto
+    # tables this recipe didn't ingest.
+    other_urn = ex.table_urn_builder(
+        TableReference(
+            metastore=None, catalog="main", schema="sales", table="not_ingested"
+        )
+    )
+    assert not any(
+        wu.get_urn() == other_urn
+        and wu.get_aspect_of_type(DatasetUsageStatisticsClass) is not None
+        for wu in workunits
+    ), "idle window must not stamp usage for non-ingested tables"
+
+    # The "No queries found for usage" warning must still be reported.
     warning_titles = [w.title for w in ex.report.warnings]
     assert any(t == "No queries found for usage" for t in warning_titles), (
         f"Expected 'No queries found for usage' warning, got: {warning_titles}"

--- a/metadata-ingestion/tests/unit/test_unity_catalog_usage_join.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_usage_join.py
@@ -3173,3 +3173,131 @@ def test_audit_log_cache_hit_skips_fetch(
     assert ex.report.num_queries == 1, "the one cached query must be read from the file"
     # A cached run leaves the file in place (only non-cached runs remove it).
     assert audit_file.exists()
+
+
+def test_audit_log_filename_keyed_by_version_window_and_mode(
+    tmp_path: pathlib.Path,
+) -> None:
+    """The cache filename encodes format version, usage source, and time window so a
+    leftover file is never reused for a different window/mode/version."""
+    config = _audit_log_config(tmp_path)
+    proxy = MagicMock()
+    proxy.warehouse_id = "wh1"
+    ex = _extractor(config, proxy)
+
+    name = ex._audit_log_filename()
+    assert name.startswith("unity_usage_audit_log_v"), name
+    assert "_systables_" in name, name
+    assert ex._audit_log_filename() == name, "stable for identical inputs"
+
+    # Different time window -> different filename.
+    config.end_time = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    assert ex._audit_log_filename() != name
+
+    # Different usage source (api vs systables) -> different filename.
+    config.usage_uses_system_tables.return_value = False
+    assert "_api_" in ex._audit_log_filename()
+
+
+def test_audit_log_different_window_does_not_reuse_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """A file left from window A must NOT be reused for window B (stale-window guard)."""
+    _no_op_aggregator(monkeypatch)
+    config = _audit_log_config(tmp_path)
+
+    fetch_calls: List[int] = []
+
+    def _fetch(*_a: object, **_k: object) -> Iterator[Query]:
+        fetch_calls.append(1)
+        return iter([_query("SELECT * FROM main.sales.orders", "q1")])
+
+    proxy = MagicMock()
+    proxy.warehouse_id = "wh1"
+    proxy.get_query_history_via_system_tables.side_effect = _fetch
+    ref = TableReference(metastore=None, catalog="main", schema="sales", table="orders")
+
+    # Window A: fetch + persist.
+    ex1 = _extractor(config, proxy)
+    ex1.report = UnityCatalogReport()
+    list(ex1.get_usage_workunits({ref}))
+    assert len(fetch_calls) == 1
+
+    # Window B (same local_temp_path): must re-fetch, not reuse window A's file.
+    config.start_time = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    config.end_time = datetime(2026, 7, 2, tzinfo=timezone.utc)
+    config.majority_buckets.return_value = [config.start_time]
+    ex2 = _extractor(config, proxy)
+    ex2.report = UnityCatalogReport()
+    list(ex2.get_usage_workunits({ref}))
+    assert len(fetch_calls) == 2, (
+        "a different window must re-fetch, not reuse the cache"
+    )
+    assert len(list(tmp_path.glob("unity_usage_audit_log_*.sqlite"))) == 2
+
+
+def test_no_caching_when_local_temp_path_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """With local_temp_path unset, the buffer is ephemeral — no named file persists."""
+    _no_op_aggregator(monkeypatch)
+    config = _audit_log_config(tmp_path)
+    config.local_temp_path = None  # disable caching
+
+    fetch_calls: List[int] = []
+
+    def _fetch(*_a: object, **_k: object) -> Iterator[Query]:
+        fetch_calls.append(1)
+        return iter([_query("SELECT * FROM main.sales.orders", "q1")])
+
+    proxy = MagicMock()
+    proxy.warehouse_id = "wh1"
+    proxy.get_query_history_via_system_tables.side_effect = _fetch
+    ref = TableReference(metastore=None, catalog="main", schema="sales", table="orders")
+
+    ex = _extractor(config, proxy)
+    ex.report = UnityCatalogReport()
+    list(ex.get_usage_workunits({ref}))
+
+    assert len(fetch_calls) == 1
+    assert list(tmp_path.glob("unity_usage_audit_log_*.sqlite")) == [], (
+        "no named cache file should be created when local_temp_path is unset"
+    )
+
+
+def test_corrupt_cached_audit_log_discarded_and_refetched(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """A corrupt/unreadable cached file must be discarded and re-fetched with a warning,
+    not crash the run or be served as valid."""
+    _no_op_aggregator(monkeypatch)
+    config = _audit_log_config(tmp_path)
+
+    fetch_calls: List[int] = []
+
+    def _fetch(*_a: object, **_k: object) -> Iterator[Query]:
+        fetch_calls.append(1)
+        return iter([_query("SELECT * FROM main.sales.orders", "q1")])
+
+    proxy = MagicMock()
+    proxy.warehouse_id = "wh1"
+    proxy.get_query_history_via_system_tables.side_effect = _fetch
+
+    ex = _extractor(config, proxy)
+    ex.report = UnityCatalogReport()
+
+    # Plant a non-SQLite file at the exact window-keyed path so use_cached is True but
+    # opening/reading it fails.
+    audit_file = tmp_path / ex._audit_log_filename()
+    audit_file.write_bytes(b"this is not a sqlite database")
+
+    ref = TableReference(metastore=None, catalog="main", schema="sales", table="orders")
+    list(ex.get_usage_workunits({ref}))
+
+    assert len(fetch_calls) == 1, "a corrupt cache must trigger a re-fetch"
+    warning_titles = [w.title for w in ex.report.warnings]
+    assert "Discarded unreadable cached audit log" in warning_titles, warning_titles
+    failure_titles = [getattr(f, "title", "") for f in ex.report.failures]
+    assert not any("Usage extraction failed" in t for t in failure_titles), (
+        "corrupt cache must not surface as a run failure; it should re-fetch"
+    )

--- a/metadata-ingestion/tests/unit/test_unity_catalog_usage_join.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_usage_join.py
@@ -1,3 +1,4 @@
+import pathlib
 from contextlib import closing
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
@@ -15,6 +16,7 @@ from datahub.ingestion.source.unity.report import UnityCatalogReport
 from datahub.ingestion.source.unity.usage import UnityCatalogUsageExtractor
 from datahub.metadata.schema_classes import DatasetUsageStatisticsClass
 from datahub.sql_parsing.schema_resolver import SchemaResolver
+from datahub.utilities.file_backed_collections import ConnectionWrapper, FileBackedList
 
 
 def _row(**kw):
@@ -3076,3 +3078,98 @@ def test_queries_drained_before_parsing(
     assert ex.report.num_queries == 3, (
         f"expected 3 queries counted, got {ex.report.num_queries}"
     )
+
+
+def _audit_log_config(tmp_path: pathlib.Path) -> MagicMock:
+    """A MagicMock config wired for the system-tables usage path with a real
+    local_temp_path (so the named/window-keyed audit-log cache is exercised)."""
+    start = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    end = datetime(2026, 6, 2, tzinfo=timezone.utc)
+    config = MagicMock()
+    config.include_queries = False
+    config.include_query_usage_statistics = False
+    config.include_operational_stats = False
+    config.usage_uses_system_tables.return_value = True
+    config.local_temp_path = tmp_path
+    config.start_time = start
+    config.end_time = end
+    config.bucket_duration = BucketDuration.DAY
+    config.majority_buckets.return_value = [start]
+    return config
+
+
+def test_audit_log_persists_and_second_run_reloads(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """With local_temp_path set, the audit log persists after a run, and a second run
+    over the same window reloads it and skips the fetch (the reload-from-file route)."""
+    _no_op_aggregator(monkeypatch)
+    config = _audit_log_config(tmp_path)
+
+    fetch_calls: List[int] = []
+
+    def _fetch(*_a: object, **_k: object) -> Iterator[Query]:
+        fetch_calls.append(1)
+        return iter([_query("SELECT * FROM main.sales.orders", "q1")])
+
+    proxy = MagicMock()
+    proxy.warehouse_id = "wh1"
+    proxy.get_query_history_via_system_tables.side_effect = _fetch
+    ref = TableReference(metastore=None, catalog="main", schema="sales", table="orders")
+
+    # First run: cache miss -> fetches, and leaves the audit log behind.
+    ex1 = _extractor(config, proxy)
+    ex1.report = UnityCatalogReport()
+    list(ex1.get_usage_workunits({ref}))
+    assert len(fetch_calls) == 1, "first run must fetch"
+    assert ex1.report.num_queries == 1
+    assert len(list(tmp_path.glob("unity_usage_audit_log_*.sqlite"))) == 1, (
+        "audit log must persist after a successful run so a re-run can reload it"
+    )
+
+    # Second run, same window: cache hit -> reloads from file, no new fetch.
+    ex2 = _extractor(config, proxy)
+    ex2.report = UnityCatalogReport()
+    list(ex2.get_usage_workunits({ref}))
+    assert len(fetch_calls) == 1, "second run must reload from file, not re-fetch"
+    assert ex2.report.num_queries == 1, "the cached query must be read back"
+
+
+def test_audit_log_cache_hit_skips_fetch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """When a window-keyed audit log already exists, the run reads it and skips the
+    fetch entirely; the cached file is left in place for re-use."""
+    _no_op_aggregator(monkeypatch)
+    config = _audit_log_config(tmp_path)
+
+    proxy = MagicMock()
+    proxy.warehouse_id = "wh1"
+
+    ex = _extractor(config, proxy)
+    ex.report = UnityCatalogReport()
+
+    # Pre-populate the exact window-keyed file the extractor will look for.
+    audit_file = tmp_path / ex._audit_log_filename()
+    conn = ConnectionWrapper(audit_file)
+    cached: FileBackedList[Query] = FileBackedList(conn)
+    cached.append(_query("SELECT * FROM main.sales.orders", "cached1"))
+    cached.close()
+    conn.close()
+    assert audit_file.exists()
+
+    fetch_calls: List[int] = []
+
+    def _fetch(*_a: object, **_k: object) -> Iterator[Query]:
+        fetch_calls.append(1)
+        return iter([])
+
+    proxy.get_query_history_via_system_tables.side_effect = _fetch
+
+    ref = TableReference(metastore=None, catalog="main", schema="sales", table="orders")
+    list(ex.get_usage_workunits({ref}))
+
+    assert not fetch_calls, "fetch must be skipped on a cache hit"
+    assert ex.report.num_queries == 1, "the one cached query must be read from the file"
+    # A cached run leaves the file in place (only non-cached runs remove it).
+    assert audit_file.exists()

--- a/metadata-ingestion/tests/unit/test_unity_catalog_usage_join.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_usage_join.py
@@ -2959,3 +2959,89 @@ def test_fetch_queries_omits_catalog_pattern_when_column_usage_stats_enabled(
         catalog_pattern=None,
         include_operational_stats=False,
     )
+
+
+def test_queries_drained_before_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fetch generator must be fully consumed before the first _add_query_to_aggregator
+    call (drain-before-parse invariant).
+
+    Holding the Databricks warehouse cursor open across slow per-query sqlglot parsing
+    causes the server-side operation handle to be evicted with a non-retryable
+    RESOURCE_DOES_NOT_EXIST error. The fix drains all rows into a FileBackedList first
+    (releasing the cursor/connection in seconds), then routes/parses from the buffer.
+    Ref: https://github.com/databricks/databricks-sql-python/pull/785
+
+    This test FAILS on the old interleaved code (first route call happens mid-fetch,
+    before the generator is exhausted, so fetch_exhausted would be False).
+    """
+    fetch_exhausted = [False]
+    fetch_exhausted_at_first_route: list = []
+
+    def _fake_fetch_queries() -> Iterator[Query]:
+        ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        for i in range(3):
+            yield Query(
+                query_id=f"q{i}",
+                query_text=f"SELECT {i}",
+                statement_type=None,
+                start_time=ts,
+                end_time=ts,
+                user_id=1,
+                user_name="u@x.io",
+                executed_as_user_id=None,
+                executed_as_user_name=None,
+            )
+        # Only set after the last item is yielded (generator fully consumed).
+        fetch_exhausted[0] = True
+
+    class FakeAgg:
+        def __init__(self, **kw: object) -> None:
+            self.observed: list = []
+
+        def add_observed_query(self, obs: object, **kw: object) -> None:
+            # Record the drain state at the moment of the very first routing call.
+            if not fetch_exhausted_at_first_route:
+                fetch_exhausted_at_first_route.append(fetch_exhausted[0])
+            self.observed.append(obs)
+
+        def add_preparsed_query(self, parsed: object, **kw: object) -> None:
+            if not fetch_exhausted_at_first_route:
+                fetch_exhausted_at_first_route.append(fetch_exhausted[0])
+
+        def gen_metadata(self):  # type: ignore[return]
+            return iter([])
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(usage_mod, "SqlParsingAggregator", FakeAgg)
+
+    config = MagicMock()
+    config.include_queries = False
+    config.include_query_usage_statistics = False
+    config.include_operational_stats = False
+    config.usage_uses_system_tables.return_value = True
+    proxy = MagicMock()
+    proxy.warehouse_id = "wh1"
+
+    ex = _extractor(config, proxy)
+    ex.report = UnityCatalogReport()
+    monkeypatch.setattr(ex, "_fetch_queries", _fake_fetch_queries)
+
+    list(ex.get_usage_workunits(set()))
+
+    # All three queries must have been routed.
+    assert len(fetch_exhausted_at_first_route) == 1, (
+        "expected exactly one first-route observation"
+    )
+    # Key assertion: fetch was fully exhausted BEFORE the first route call.
+    assert fetch_exhausted_at_first_route[0] is True, (
+        "fetch generator was not fully drained before the first _add_query_to_aggregator call; "
+        "the old interleaved code would cause this to be False"
+    )
+    # All three queries must still have been routed despite the drain-first change.
+    assert ex.report.num_queries == 3, (
+        f"expected 3 queries counted, got {ex.report.num_queries}"
+    )


### PR DESCRIPTION
## Summary

Hardening for the Unity Catalog **usage** path: drain query history into a disk-backed
`FileBackedList` **first**, then route/parse from the buffer — so usage no longer holds the
warehouse cursor open across the slow sqlglot parse.

> **#17961 has merged to master.** This PR now targets `master` and builds on its
> `_add_query_to_aggregator` routing.

## Why

`get_usage_workunits` previously iterated the live warehouse cursor while routing/parsing
each query (`_add_query_to_aggregator` inside the `for query in self._fetch_queries()`
loop). That holds the cursor open for the entire parse, which can take many minutes on a
large window. Databricks can drop a query's **server-side operation handle** mid-fetch (the
maintainers document eviction after ~20–30 min of fetch-inactivity in
[databricks-sql-python#785](https://github.com/databricks/databricks-sql-python/pull/785));
the next fetch then fails with a **non-retryable** `RESOURCE_DOES_NOT_EXIST` ("Command
&lt;id&gt; does not exist").

Fetching is cheap (≈0.1s for ~1k rows); the cost is the parse. Draining first releases the
cursor in seconds, and the buffer is disk-backed so memory stays bounded regardless of
history size. **This is the pattern the Snowflake and BigQuery query extractors already
use** — both fetch the audit log into a `FileBackedList` (`audit_log.sqlite`) before parsing.
This change brings Unity in line with them.

## Honest scope: hardening, not a proven fix

We observed a real `RESOURCE_DOES_NOT_EXIST` failure at ~22 min on a serverless SQL
warehouse, but **could not reproduce it deterministically** — controlled idle holds of
11 min and ~56 min both survived. So the trigger appears intermittent (likely a serverless
warehouse recycle/scale event rather than a simple idle timer). This PR therefore **removes
the connector's exposure** to the whole class of "held-open cursor dies mid-fetch" failures
(operation-handle eviction, idle timeout, mid-fetch recycle) rather than claiming to fix one
specific error. It is low-risk and aligns with existing connectors, so it's worth landing as
defensive hardening.

## What changed

- `usage.py` `get_usage_workunits`: split the single fetch+route loop into **drain** (append
  every `Query` to a `FileBackedList[Query]`, releasing the cursor once the fetch generator
  is fully consumed) → existing fetch-failure / no-queries checks → **parse** (route each
  buffered query through `_add_query_to_aggregator`). Routing-summary and lineage-warning
  reporting moved after the parse loop; `buffered_queries.close()` added to `finally`.
- Counters, routing decisions, and emitted aspects are unchanged — only *when* the cursor is
  released differs.

## Follow-ups from review

- **Idle windows now record zero-usage.** When a query-history read *succeeds* but yields no
  usable queries, `get_usage_workunits` no longer returns early — it emits a diagnostic
  warning and falls through to `auto_empty_dataset_usage_statistics`, stamping a
  current-bucket zero datapoint. This matches Snowflake/BigQuery/Redshift, which call
  `auto_empty` whenever the read succeeded and only short-circuit on a read/permission
  failure. Fetch *failures* still short-circuit with `report_failure` (no false zeros).
  `datasetUsageStatistics` is a timeseries aspect and the empty aspect is UPSERTed, so this
  records a zero datapoint for the window — it does not delete prior usage history.

- **Usage step timers.** Added `usage_query_fetch_timer` (drain) and `usage_parsing_timer`
  (parse) to the report, mirroring BigQuery's `query_log_fetch_timer` / `sql_parsing_sec`.
  This makes the drain-before-parse behavior measurable and surfaces eviction risk (fetch
  time creeping toward parse time).

- **Optional audit-log caching (`local_temp_path`).** Mirrors the Snowflake/BigQuery
  `use_cached_audit_log` optimization. When the hidden, dev/advanced `local_temp_path` is
  set, the drained query history is kept in a named, **window-keyed** SQLite file under
  that directory and reused across runs: the next run over the same window reloads it and
  skips re-fetching, **including after a crash**. The filename is keyed by usage source and
  time window, so a leftover file is never reused for a stale window (closing the
  `# TODO: check if the cached audit log is stale` that Snowflake/BigQuery carry). When
  unset, behavior is unchanged — an ephemeral, self-cleaning buffer with no caching.

## Benchmark &amp; correctness (master vs this branch)

Measured on a live Databricks workspace with identical dependencies — only the connector
source files were swapped, so the code path is the only variable. Usage-only
(lineage/notebooks off), with fixed time windows so both versions fetch the same queries.

**Correctness:** output is equivalent to master — identical aspect-type counts and **zero**
`datasetUsageStatistics` value differences across every emitted usage aspect.

**Memory:** equivalent (~360 MB at ~2.4k queries, ~420 MB at ~16k queries) — the drain
buffer is disk-backed (SQLite), so peak RSS stays bounded as history grows.

**Runtime — fetch vs parse, via the new timers:**

| Window | queries | fetch/drain | parse (sqlglot) |
| --- | --- | --- | --- |
| 7-day | ~2,400 | ~12 s | ~7 s |
| 90-day | ~16,100 | ~15 s | ~68 s |

Parse scales linearly with query volume; fetch/drain stays nearly flat (dominated by the
system-table query, not row count). This quantifies the drain rationale: the warehouse
cursor is held only for the **fetch/drain** window, then released, so the **O(query_count)**
parse runs cursor-free. On the pre-drain (interleaved) path the cursor stays open for fetch
**+** parse (~68 s and growing at 16k queries) — which is what walks into the ~20–30 min
operation-handle eviction window on large histories. (At small volumes the drain is a few
seconds of overhead; the payoff appears as parse time grows.)

## Testing

- New `test_queries_drained_before_parsing` — asserts the fetch generator is fully consumed
  before the first aggregator interaction (and all queries are still routed). Fails on the
  old interleaved code (first route happens mid-fetch).
- New `test_zero_queries_emits_empty_usage_for_idle_window` — a successful empty read stamps
  zero-usage for ingested tables and warns; `test_fetch_failure_*` still asserts **no** usage
  on a fetch failure, so the idle vs failure paths cannot collapse.
- Full unity suite: **152 passed, 1 skipped**; `ruff` + `mypy` clean.

## Checklist

- [x] PR conforms to the Contributing Guideline (Commit Message and PR Title formats)
- [x] Tests added/updated
- [x] Docs added/updated (N/A — internal behavior change)


