### PR TITLE
feat(ingest): expose includeHiddenLifecycleStages/includeDraft in get_urns_by_filter

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -924,6 +924,8 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
         extraFilters: Optional[List[RawSearchFilterRule]] = None,
         extra_or_filters: Optional[RawSearchFilter] = None,
         skip_cache: bool = False,
+        include_hidden_lifecycle_stages: bool = False,
+        include_draft: bool = False,
     ) -> Iterable[str]:
         """Fetch all urns that match all of the given filters.
 
@@ -943,6 +945,8 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
         :param status: Filter on the deletion status of the entity. The default is only return non-soft-deleted entities.
         :param extraFilters: Additional filters to apply. If specified, the results will match all of the filters.
         :param skip_cache: Whether to bypass caching. Defaults to False.
+        :param include_hidden_lifecycle_stages: Whether to include entities hidden by lifecycle stage.
+        :param include_draft: Whether to include entities in DRAFT lifecycle state.
 
         :return: An iterable of urns that match the filters.
         """
@@ -972,6 +976,8 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
                 $batchSize: Int!,
                 $scrollId: String,
                 $skipCache: Boolean!,
+                $includeHiddenLifecycleStages: Boolean!,
+                $includeDraft: Boolean!,
                 $includeSoftDeleted: Boolean) {
 
                 scrollAcrossEntities(input: {
@@ -984,6 +990,8 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
                         skipHighlighting: true
                         skipAggregates: true
                         skipCache: $skipCache
+                        includeHiddenLifecycleStages: $includeHiddenLifecycleStages
+                        includeDraft: $includeDraft
                         includeSoftDeleted: $includeSoftDeleted
                     }
                 }) {
@@ -991,6 +999,10 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
                     searchResults {
                         entity {
                             urn
+                        }
+                        extraProperties {
+                            name
+                            value
                         }
                     }
                 }
@@ -1004,6 +1016,8 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
             "orFilters": orFilters,
             "batchSize": batch_size,
             "skipCache": skip_cache,
+            "includeHiddenLifecycleStages": include_hidden_lifecycle_stages,
+            "includeDraft": include_draft,
             "includeSoftDeleted": (
                 None
                 if status is None

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -16,6 +16,7 @@ from typing import (
     Literal,
     Optional,
     Sequence,
+    Set,
     Tuple,
     Type,
     Union,
@@ -179,6 +180,37 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
         )
         self.server_id: str = _MISSING_SERVER_ID
         self._query_projector: Optional["QueryProjector"] = None
+        self._graphql_input_fields_cache: Dict[str, Set[str]] = {}
+
+    def _graphql_input_type_has_field(self, input_type: str, field_name: str) -> bool:
+        if input_type not in self._graphql_input_fields_cache:
+            response = self.execute_graphql(
+                textwrap.dedent(
+                    """
+                    query inputTypeFields($name: String!) {
+                      __type(name: $name) {
+                        inputFields {
+                          name
+                        }
+                      }
+                    }
+                    """
+                ),
+                variables={"name": input_type},
+            )
+            input_fields = (response.get("__type") or {}).get("inputFields") or []
+            self._graphql_input_fields_cache[input_type] = {
+                field["name"] for field in input_fields if field.get("name")
+            }
+
+        return field_name in self._graphql_input_fields_cache[input_type]
+
+    def _ensure_search_flag_supported(self, field_name: str) -> None:
+        if not self._graphql_input_type_has_field("SearchFlags", field_name):
+            raise ValueError(
+                f"SearchFlags.{field_name} is not supported by this DataHub server. "
+                "Upgrade GMS or disable the corresponding option."
+            )
 
     def test_connection(self) -> None:
         super().test_connection()
@@ -967,6 +999,27 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
             extra_or_filters=extra_or_filters,
         )
 
+        optional_variable_defs = ""
+        optional_search_flag_fields = ""
+        optional_variables: Dict[str, bool] = {}
+        if include_hidden_lifecycle_stages:
+            self._ensure_search_flag_supported("includeHiddenLifecycleStages")
+            optional_variable_defs += (
+                "\n                $includeHiddenLifecycleStages: Boolean!,"
+            )
+            optional_search_flag_fields += (
+                "\n                        includeHiddenLifecycleStages: "
+                "$includeHiddenLifecycleStages"
+            )
+            optional_variables["includeHiddenLifecycleStages"] = True
+        if include_draft:
+            self._ensure_search_flag_supported("includeDraft")
+            optional_variable_defs += "\n                $includeDraft: Boolean!,"
+            optional_search_flag_fields += (
+                "\n                        includeDraft: $includeDraft"
+            )
+            optional_variables["includeDraft"] = True
+
         graphql_query = textwrap.dedent(
             """
             query scrollUrnsWithFilters(
@@ -976,8 +1029,9 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
                 $batchSize: Int!,
                 $scrollId: String,
                 $skipCache: Boolean!,
-                $includeHiddenLifecycleStages: Boolean!,
-                $includeDraft: Boolean!,
+            """
+            + optional_variable_defs
+            + """
                 $includeSoftDeleted: Boolean) {
 
                 scrollAcrossEntities(input: {
@@ -990,8 +1044,9 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
                         skipHighlighting: true
                         skipAggregates: true
                         skipCache: $skipCache
-                        includeHiddenLifecycleStages: $includeHiddenLifecycleStages
-                        includeDraft: $includeDraft
+            """
+            + optional_search_flag_fields
+            + """
                         includeSoftDeleted: $includeSoftDeleted
                     }
                 }) {
@@ -1016,14 +1071,13 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
             "orFilters": orFilters,
             "batchSize": batch_size,
             "skipCache": skip_cache,
-            "includeHiddenLifecycleStages": include_hidden_lifecycle_stages,
-            "includeDraft": include_draft,
             "includeSoftDeleted": (
                 None
                 if status is None
                 else status != RemovedStatusFilter.NOT_SOFT_DELETED
             ),
         }
+        variables.update(optional_variables)
 
         for entity in self._scroll_across_entities(graphql_query, variables):
             yield entity["urn"]

--- a/metadata-ingestion/tests/unit/sdk/test_client.py
+++ b/metadata-ingestion/tests/unit/sdk/test_client.py
@@ -1,4 +1,7 @@
+from typing import Any
 from unittest.mock import Mock, patch
+
+import pytest
 
 from datahub.ingestion.graph.client import (
     DatahubClientConfig,
@@ -47,3 +50,74 @@ def test_graphql_entity_types() -> None:
 
     for entity_type, graphql_type in known_mappings.items():
         assert entity_type_to_graphql(entity_type) == graphql_type
+
+
+def _scroll_response(
+    urn: str = "urn:li:dataset:(urn:li:dataPlatform:hive,test,PROD)",
+) -> dict[str, Any]:
+    return {
+        "scrollAcrossEntities": {
+            "nextScrollId": None,
+            "searchResults": [{"entity": {"urn": urn}}],
+        }
+    }
+
+
+def test_get_urns_by_filter_omits_optional_lifecycle_flags_by_default() -> None:
+    graph = DataHubGraph(DatahubClientConfig(server="http://fake-domain.local"))
+
+    with patch.object(
+        graph, "execute_graphql", return_value=_scroll_response()
+    ) as mock_execute_graphql:
+        urns = list(graph.get_urns_by_filter(entity_types=["dataset"]))
+
+    assert urns == ["urn:li:dataset:(urn:li:dataPlatform:hive,test,PROD)"]
+    assert mock_execute_graphql.call_count == 1
+    query = mock_execute_graphql.call_args.args[0]
+    variables = mock_execute_graphql.call_args.kwargs["variables"]
+    assert "includeDraft" not in query
+    assert "includeHiddenLifecycleStages" not in query
+    assert "includeDraft" not in variables
+    assert "includeHiddenLifecycleStages" not in variables
+
+
+def test_get_urns_by_filter_includes_draft_when_server_supports_flag() -> None:
+    graph = DataHubGraph(DatahubClientConfig(server="http://fake-domain.local"))
+
+    with patch.object(
+        graph,
+        "execute_graphql",
+        side_effect=[
+            {"__type": {"inputFields": [{"name": "includeDraft"}]}},
+            _scroll_response(),
+        ],
+    ) as mock_execute_graphql:
+        urns = list(
+            graph.get_urns_by_filter(entity_types=["dataset"], include_draft=True)
+        )
+
+    assert urns == ["urn:li:dataset:(urn:li:dataPlatform:hive,test,PROD)"]
+    assert mock_execute_graphql.call_count == 2
+    query = mock_execute_graphql.call_args.args[0]
+    variables = mock_execute_graphql.call_args.kwargs["variables"]
+    assert "includeDraft: $includeDraft" in query
+    assert variables["includeDraft"] is True
+
+
+def test_get_urns_by_filter_rejects_draft_when_server_does_not_support_flag() -> None:
+    graph = DataHubGraph(DatahubClientConfig(server="http://fake-domain.local"))
+
+    with patch.object(
+        graph,
+        "execute_graphql",
+        return_value={"__type": {"inputFields": [{"name": "includeSoftDeleted"}]}},
+    ) as mock_execute_graphql:
+        with pytest.raises(ValueError, match="SearchFlags.includeDraft"):
+            list(
+                graph.get_urns_by_filter(
+                    entity_types=["dataset"],
+                    include_draft=True,
+                )
+            )
+
+    assert mock_execute_graphql.call_count == 1


### PR DESCRIPTION
OSS GMS already supports the `includeHiddenLifecycleStages` and `includeDraft` SearchFlags (`SearchFlags.pdl`, `SearchFlagsInputMapper`, `ESUtils`, `lifecycle.graphql`), but the Python `get_urns_by_filter` helper does not surface them.

Add both as optional params (default `False`, backward-compatible) so callers can query entities hidden by lifecycle stage or in DRAFT state.