### PR TITLE
fix(datahub-documents): paginate through all documents when fetching for embedding backfill

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -760,22 +760,16 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
         }
         """
 
-        # Build search input with optional multi-platform filter
-        search_input: dict[str, Any] = {
-            "type": "DOCUMENT",
-            "query": "*",
-            "start": 0,
-            "count": 1000,  # Fetch in batches
-        }
+        page_size = 1000
 
-        # Only add platform filter if specific platforms are provided
-        # Empty list or wildcard ("*", "ALL") means no GraphQL filter (client-side filtering instead)
+        # Build optional platform filter
+        platform_filters = None
         if (
             self.config.platform_filter
             and "*" not in self.config.platform_filter
             and "ALL" not in self.config.platform_filter
         ):
-            search_input["filters"] = [
+            platform_filters = [
                 {
                     "field": "platform",
                     "values": [
@@ -785,47 +779,65 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                 }
             ]
 
-        variables = {"input": search_input}
-
         try:
-            response = self.graph.execute_graphql(query, variables)
-            search_data = response.get("search") or {}
-            search_results = search_data.get("searchResults") or []
-
             documents = []
-            for result in search_results:
-                entity = result.get("entity") or {}
-                urn = entity.get("urn")
+            start = 0
 
-                if not urn:
-                    continue
+            while True:
+                search_input: dict[str, Any] = {
+                    "type": "DOCUMENT",
+                    "query": "*",
+                    "start": start,
+                    "count": page_size,
+                }
+                if platform_filters:
+                    search_input["filters"] = platform_filters
 
-                # Filter by specific URNs if provided
-                if self.config.document_urns and urn not in self.config.document_urns:
-                    continue
+                response = self.graph.execute_graphql(query, {"input": search_input})
+                search_data = response.get("search") or {}
+                search_results = search_data.get("searchResults") or []
+                total = search_data.get("total") or 0
 
-                # Extract text content (GraphQL returns null for missing aspects)
-                info = entity.get("info") or {}
-                contents = info.get("contents") or {}
-                text = contents.get("text") or ""
+                for result in search_results:
+                    entity = result.get("entity") or {}
+                    urn = entity.get("urn")
 
-                # Filter by source type (NATIVE vs EXTERNAL) for batch mode
-                should_process = self._should_process_by_source_type(entity, info)
-                if not should_process:
-                    continue
+                    if not urn:
+                        continue
 
-                # Skip if no text or too short
-                if not text or (
-                    self.config.skip_empty_text
-                    and len(text) < self.config.min_text_length
-                ):
-                    logger.debug(
-                        f"Skipping document {urn} (empty or too short: {len(text)} chars)"
-                    )
-                    continue
+                    # Filter by specific URNs if provided
+                    if (
+                        self.config.document_urns
+                        and urn not in self.config.document_urns
+                    ):
+                        continue
 
-                documents.append({"urn": urn, "text": text})
-                self.report.report_document_fetched()
+                    # Extract text content (GraphQL returns null for missing aspects)
+                    info = entity.get("info") or {}
+                    contents = info.get("contents") or {}
+                    text = contents.get("text") or ""
+
+                    # Filter by source type (NATIVE vs EXTERNAL) for batch mode
+                    should_process = self._should_process_by_source_type(entity, info)
+                    if not should_process:
+                        continue
+
+                    # Skip if no text or too short
+                    if not text or (
+                        self.config.skip_empty_text
+                        and len(text) < self.config.min_text_length
+                    ):
+                        logger.debug(
+                            f"Skipping document {urn} (empty or too short: {len(text)} chars)"
+                        )
+                        continue
+
+                    documents.append({"urn": urn, "text": text})
+                    self.report.report_document_fetched()
+
+                start += len(search_results)
+                if not search_results or start >= total:
+                    break
 
             logger.info(
                 f"Fetched {len(documents)} documents with text content from platforms: {self.config.platform_filter}"

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -2481,3 +2481,142 @@ class TestDataHubGraphInitialization:
             # Verify source uses the context graph
             assert source.graph is mock_ctx_graph
             assert source.graph is not mock_graph_class.return_value
+
+
+class TestFetchDocumentsPagination:
+    """Test that _fetch_documents_graphql paginates through all pages."""
+
+    @pytest.fixture
+    def config(self):
+        return DataHubDocumentsSourceConfig(
+            platform_filter=["*"],
+            datahub={"server": "http://test-server:8080"},
+            embedding={
+                "provider": "bedrock",
+                "model": "cohere.embed-english-v3",
+                "aws_region": "us-west-2",
+                "allow_local_embedding_config": True,
+            },
+            min_text_length=10,
+            stateful_ingestion={"enabled": False},
+        )
+
+    @pytest.fixture
+    def ctx(self):
+        return PipelineContext(run_id="test-run", pipeline_name="test-pipeline")
+
+    @pytest.fixture
+    def mock_graph(self):
+        return patch(
+            "datahub.ingestion.source.datahub_documents.datahub_documents_source.DataHubGraph"
+        )
+
+    def _make_entity(self, i: int) -> dict:
+        return {
+            "entity": {
+                "urn": f"urn:li:document:doc-{i}",
+                "info": {
+                    "source": {"sourceType": "NATIVE"},
+                    "contents": {"text": f"Document {i} with sufficient text content."},
+                },
+            }
+        }
+
+    def _make_page(self, start: int, count: int, total: int) -> dict:
+        return {
+            "search": {
+                "total": total,
+                "searchResults": [
+                    self._make_entity(i) for i in range(start, start + count)
+                ],
+            }
+        }
+
+    def test_paginates_across_multiple_pages(self, ctx, config, mock_graph):
+        """Fetching >1000 documents issues multiple GraphQL calls and returns all results."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            responses = [
+                self._make_page(0, 1000, 1200),
+                self._make_page(1000, 200, 1200),
+            ]
+
+            with patch.object(
+                source.graph, "execute_graphql", side_effect=responses
+            ) as mock_execute:
+                documents = source._fetch_documents_graphql()
+
+            assert len(documents) == 1200
+            assert mock_execute.call_count == 2
+
+            first_call_input = mock_execute.call_args_list[0][0][1]["input"]
+            second_call_input = mock_execute.call_args_list[1][0][1]["input"]
+            assert first_call_input["start"] == 0
+            assert second_call_input["start"] == 1000
+
+    def test_stops_at_exact_page_boundary(self, ctx, config, mock_graph):
+        """Exactly page_size results with total=page_size issues only one call."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            response = self._make_page(0, 1000, 1000)
+
+            with patch.object(
+                source.graph, "execute_graphql", return_value=response
+            ) as mock_execute:
+                documents = source._fetch_documents_graphql()
+
+            assert len(documents) == 1000
+            assert mock_execute.call_count == 1
+
+    def test_empty_result_set(self, ctx, config, mock_graph):
+        """Zero documents returns empty list after one call."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            response = {"search": {"total": 0, "searchResults": []}}
+
+            with patch.object(
+                source.graph, "execute_graphql", return_value=response
+            ) as mock_execute:
+                documents = source._fetch_documents_graphql()
+
+            assert documents == []
+            assert mock_execute.call_count == 1
+
+    def test_missing_total_field_stops_after_first_page(self, ctx, config, mock_graph):
+        """If the API omits 'total', pagination stops after the first page without looping."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            response = {"search": {"searchResults": [self._make_entity(0)]}}
+
+            with patch.object(
+                source.graph, "execute_graphql", return_value=response
+            ) as mock_execute:
+                documents = source._fetch_documents_graphql()
+
+            assert len(documents) == 1
+            assert mock_execute.call_count == 1
+
+    def test_three_pages(self, ctx, config, mock_graph):
+        """Three-page fetch collects all documents and advances start correctly."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            responses = [
+                self._make_page(0, 1000, 2500),
+                self._make_page(1000, 1000, 2500),
+                self._make_page(2000, 500, 2500),
+            ]
+
+            with patch.object(
+                source.graph, "execute_graphql", side_effect=responses
+            ) as mock_execute:
+                documents = source._fetch_documents_graphql()
+
+            assert len(documents) == 2500
+            assert mock_execute.call_count == 3
+            starts = [c[0][1]["input"]["start"] for c in mock_execute.call_args_list]
+            assert starts == [0, 1000, 2000]


### PR DESCRIPTION
Document fetch for embedding backfill only returned the first page of results, so documents beyond the first batch were skipped. Paginate through all documents.

Adds unit tests for the pagination path.