### PR TITLE
fix(datahub-documents): switch batch fetch to scrollAcrossEntities to avoid ES 10k limit

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossEntitiesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossEntitiesResolver.java
@@ -3,9 +3,11 @@ package com.linkedin.datahub.graphql.resolvers.search;
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.getQueryContext;
 import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.*;
+import static com.linkedin.metadata.Constants.DOCUMENT_ENTITY_NAME;
 
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.ScrollAcrossEntitiesInput;
@@ -108,10 +110,16 @@ public class ScrollAcrossEntitiesResolver implements DataFetcher<CompletableFutu
                         baseFilter, maybeResolvedView.getDefinition().getFilter())
                     : baseFilter;
 
-            // Add default entity filters that should be applied to all queries
-            combinedFilter =
-                DefaultEntityFiltersUtil.addDefaultEntityFilters(
-                    combinedFilter, finalEntities, true);
+            boolean canBypassDocumentDefaults =
+                searchFlags != null
+                    && Boolean.TRUE.equals(searchFlags.isIncludeHiddenLifecycleStages())
+                    && finalEntities.contains(DOCUMENT_ENTITY_NAME)
+                    && AuthorizationUtils.canManageDocuments(context);
+            if (!canBypassDocumentDefaults) {
+              combinedFilter =
+                  DefaultEntityFiltersUtil.addDefaultEntityFilters(
+                      combinedFilter, finalEntities, true);
+            }
 
             // Execute scroll and remove default filter fields from aggregations
             com.linkedin.metadata.search.ScrollResult scrollResult =

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossEntitiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossEntitiesResolverTest.java
@@ -209,6 +209,99 @@ public class ScrollAcrossEntitiesResolverTest {
   }
 
   @Test
+  public void testWithoutIncludeHiddenLifecycleStagesKeepsDocumentDefaultFilters()
+      throws Exception {
+    ScrollResult mockResult = new ScrollResult();
+    mockResult.setPageSize(0);
+    mockResult.setNumEntities(0);
+    mockResult.setMetadata(new SearchResultMetadata());
+    mockResult.setEntities(new SearchEntityArray());
+
+    // Document manager, but includeHiddenLifecycleStages is not set: defaults must still apply.
+    SearchFlags searchFlags = new SearchFlags();
+    searchFlags.setIncludeHiddenLifecycleStages(false);
+
+    ScrollAcrossEntitiesInput input = new ScrollAcrossEntitiesInput();
+    input.setTypes(Collections.singletonList(EntityType.DOCUMENT));
+    input.setQuery("*");
+    input.setCount(10);
+    input.setSearchFlags(searchFlags);
+
+    QueryContext context = getMockAllowContext();
+    Mockito.when(_env.getArgument("input")).thenReturn(input);
+    Mockito.when(_env.getContext()).thenReturn(context);
+    Mockito.when(
+            _entityClient.scrollAcrossEntities(
+                any(), any(), eq("*"), any(), eq(null), eq("5m"), any(), eq(10)))
+        .thenReturn(mockResult);
+
+    ScrollResults result = _resolver.get(_env).get();
+
+    assertNotNull(result);
+
+    ArgumentCaptor<Filter> filterCaptor = ArgumentCaptor.forClass(Filter.class);
+    verify(_entityClient)
+        .scrollAcrossEntities(
+            any(),
+            eq(Collections.singletonList(Constants.DOCUMENT_ENTITY_NAME)),
+            eq("*"),
+            filterCaptor.capture(),
+            eq(null),
+            eq("5m"),
+            eq(Collections.emptyList()),
+            eq(10));
+    assertTrue(filterContainsField(filterCaptor.getValue(), "state"));
+    assertTrue(filterContainsField(filterCaptor.getValue(), "showInGlobalContext"));
+  }
+
+  @Test
+  public void testIncludeHiddenLifecycleStagesDoesNotBypassDefaultsForNonDocumentEntities()
+      throws Exception {
+    ScrollResult mockResult = new ScrollResult();
+    mockResult.setPageSize(0);
+    mockResult.setNumEntities(0);
+    mockResult.setMetadata(new SearchResultMetadata());
+    mockResult.setEntities(new SearchEntityArray());
+
+    // Document manager with the hidden-stages flag, but searching a non-document entity:
+    // the bypass is document-scoped, so no document default filters are injected.
+    SearchFlags searchFlags = new SearchFlags();
+    searchFlags.setIncludeHiddenLifecycleStages(true);
+
+    ScrollAcrossEntitiesInput input = new ScrollAcrossEntitiesInput();
+    input.setTypes(Collections.singletonList(EntityType.DATASET));
+    input.setQuery("*");
+    input.setCount(10);
+    input.setSearchFlags(searchFlags);
+
+    QueryContext context = getMockAllowContext();
+    Mockito.when(_env.getArgument("input")).thenReturn(input);
+    Mockito.when(_env.getContext()).thenReturn(context);
+    Mockito.when(
+            _entityClient.scrollAcrossEntities(
+                any(), any(), eq("*"), any(), eq(null), eq("5m"), any(), eq(10)))
+        .thenReturn(mockResult);
+
+    ScrollResults result = _resolver.get(_env).get();
+
+    assertNotNull(result);
+
+    ArgumentCaptor<Filter> filterCaptor = ArgumentCaptor.forClass(Filter.class);
+    verify(_entityClient)
+        .scrollAcrossEntities(
+            any(),
+            eq(Collections.singletonList(Constants.DATASET_ENTITY_NAME)),
+            eq("*"),
+            filterCaptor.capture(),
+            eq(null),
+            eq("5m"),
+            eq(Collections.emptyList()),
+            eq(10));
+    assertFalse(filterContainsField(filterCaptor.getValue(), "state"));
+    assertFalse(filterContainsField(filterCaptor.getValue(), "showInGlobalContext"));
+  }
+
+  @Test
   public void testGetExceptionThrowsRuntimeException() throws Exception {
     ScrollAcrossEntitiesInput input = new ScrollAcrossEntitiesInput();
     input.setTypes(Collections.singletonList(EntityType.DATASET));

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossEntitiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossEntitiesResolverTest.java
@@ -10,8 +10,10 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.ScrollAcrossEntitiesInput;
 import com.linkedin.datahub.graphql.generated.ScrollResults;
+import com.linkedin.datahub.graphql.generated.SearchFlags;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.ScrollResult;
 import com.linkedin.metadata.search.SearchEntityArray;
 import com.linkedin.metadata.search.SearchResultMetadata;
@@ -20,6 +22,7 @@ import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.Collections;
 import java.util.concurrent.CompletionException;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -117,6 +120,95 @@ public class ScrollAcrossEntitiesResolverTest {
   }
 
   @Test
+  public void testIncludeHiddenLifecycleStagesSkipsDocumentDefaultFiltersForDocumentManagers()
+      throws Exception {
+    ScrollResult mockResult = new ScrollResult();
+    mockResult.setPageSize(0);
+    mockResult.setNumEntities(0);
+    mockResult.setMetadata(new SearchResultMetadata());
+    mockResult.setEntities(new SearchEntityArray());
+
+    SearchFlags searchFlags = new SearchFlags();
+    searchFlags.setIncludeHiddenLifecycleStages(true);
+
+    ScrollAcrossEntitiesInput input = new ScrollAcrossEntitiesInput();
+    input.setTypes(Collections.singletonList(EntityType.DOCUMENT));
+    input.setQuery("*");
+    input.setCount(10);
+    input.setSearchFlags(searchFlags);
+
+    QueryContext context = getMockAllowContext();
+    Mockito.when(_env.getArgument("input")).thenReturn(input);
+    Mockito.when(_env.getContext()).thenReturn(context);
+    Mockito.when(
+            _entityClient.scrollAcrossEntities(
+                any(), any(), eq("*"), any(), eq(null), eq("5m"), any(), eq(10)))
+        .thenReturn(mockResult);
+
+    ScrollResults result = _resolver.get(_env).get();
+
+    assertNotNull(result);
+
+    ArgumentCaptor<Filter> filterCaptor = ArgumentCaptor.forClass(Filter.class);
+    verify(_entityClient)
+        .scrollAcrossEntities(
+            any(),
+            eq(Collections.singletonList(Constants.DOCUMENT_ENTITY_NAME)),
+            eq("*"),
+            filterCaptor.capture(),
+            eq(null),
+            eq("5m"),
+            eq(Collections.emptyList()),
+            eq(10));
+    assertNull(filterCaptor.getValue());
+  }
+
+  @Test
+  public void testIncludeHiddenLifecycleStagesKeepsDocumentDefaultFiltersWithoutManageDocuments()
+      throws Exception {
+    ScrollResult mockResult = new ScrollResult();
+    mockResult.setPageSize(0);
+    mockResult.setNumEntities(0);
+    mockResult.setMetadata(new SearchResultMetadata());
+    mockResult.setEntities(new SearchEntityArray());
+
+    SearchFlags searchFlags = new SearchFlags();
+    searchFlags.setIncludeHiddenLifecycleStages(true);
+
+    ScrollAcrossEntitiesInput input = new ScrollAcrossEntitiesInput();
+    input.setTypes(Collections.singletonList(EntityType.DOCUMENT));
+    input.setQuery("*");
+    input.setCount(10);
+    input.setSearchFlags(searchFlags);
+
+    QueryContext context = getMockDenyContext();
+    Mockito.when(_env.getArgument("input")).thenReturn(input);
+    Mockito.when(_env.getContext()).thenReturn(context);
+    Mockito.when(
+            _entityClient.scrollAcrossEntities(
+                any(), any(), eq("*"), any(), eq(null), eq("5m"), any(), eq(10)))
+        .thenReturn(mockResult);
+
+    ScrollResults result = _resolver.get(_env).get();
+
+    assertNotNull(result);
+
+    ArgumentCaptor<Filter> filterCaptor = ArgumentCaptor.forClass(Filter.class);
+    verify(_entityClient)
+        .scrollAcrossEntities(
+            any(),
+            eq(Collections.singletonList(Constants.DOCUMENT_ENTITY_NAME)),
+            eq("*"),
+            filterCaptor.capture(),
+            eq(null),
+            eq("5m"),
+            eq(Collections.emptyList()),
+            eq(10));
+    assertTrue(filterContainsField(filterCaptor.getValue(), "state"));
+    assertTrue(filterContainsField(filterCaptor.getValue(), "showInGlobalContext"));
+  }
+
+  @Test
   public void testGetExceptionThrowsRuntimeException() throws Exception {
     ScrollAcrossEntitiesInput input = new ScrollAcrossEntitiesInput();
     input.setTypes(Collections.singletonList(EntityType.DATASET));
@@ -138,5 +230,14 @@ public class ScrollAcrossEntitiesResolverTest {
       assertTrue(e.getCause() instanceof RuntimeException);
       assertTrue(e.getCause().getMessage().contains("Failed to execute search"));
     }
+  }
+
+  private static boolean filterContainsField(Filter filter, String field) {
+    if (filter == null || !filter.hasOr()) {
+      return false;
+    }
+    return filter.getOr().stream()
+        .flatMap(conjunction -> conjunction.getAnd().stream())
+        .anyMatch(criterion -> field.equals(criterion.getField()));
   }
 }

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -725,12 +725,26 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
 
     def _fetch_documents_graphql(self) -> list[dict[str, Any]]:
         """Fetch Document entities from DataHub using GraphQL."""
+        # scrollAcrossEntities uses cursor-based pagination and is not subject to
+        # Elasticsearch's max_result_window limit (default 10,000), unlike offset-based search.
         query = """
-        query listDocuments($input: SearchInput!) {
-          search(input: $input) {
-            start
-            count
-            total
+        query scrollDocuments(
+            $scrollId: String,
+            $batchSize: Int!,
+            $orFilters: [AndFilterInput!]
+        ) {
+          scrollAcrossEntities(input: {
+            types: [DOCUMENT],
+            query: "*",
+            count: $batchSize,
+            scrollId: $scrollId,
+            orFilters: $orFilters,
+            searchFlags: {
+              skipHighlighting: true,
+              skipAggregates: true
+            }
+          }) {
+            nextScrollId
             searchResults {
               entity {
                 urn
@@ -763,40 +777,46 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
         page_size = 1000
 
         # Build optional platform filter
-        platform_filters = None
+        or_filters = None
         if (
             self.config.platform_filter
             and "*" not in self.config.platform_filter
             and "ALL" not in self.config.platform_filter
         ):
-            platform_filters = [
+            or_filters = [
                 {
-                    "field": "platform",
-                    "values": [
-                        f"urn:li:dataPlatform:{platform}"
-                        for platform in self.config.platform_filter
-                    ],
+                    "and": [
+                        {
+                            "field": "platform",
+                            "values": [
+                                f"urn:li:dataPlatform:{platform}"
+                                for platform in self.config.platform_filter
+                            ],
+                        }
+                    ]
                 }
             ]
 
         try:
             documents = []
-            start = 0
+            scroll_id: Optional[str] = None
+            first_iter = True
 
-            while True:
-                search_input: dict[str, Any] = {
-                    "type": "DOCUMENT",
-                    "query": "*",
-                    "start": start,
-                    "count": page_size,
+            while first_iter or scroll_id:
+                first_iter = False
+                variables: dict[str, Any] = {
+                    "batchSize": page_size,
+                    "scrollId": scroll_id,
+                    "orFilters": or_filters,
                 }
-                if platform_filters:
-                    search_input["filters"] = platform_filters
+                response = self.graph.execute_graphql(query, variables)
+                scroll_data = response.get("scrollAcrossEntities") or {}
+                scroll_id = scroll_data.get("nextScrollId")
+                search_results = scroll_data.get("searchResults") or []
 
-                response = self.graph.execute_graphql(query, {"input": search_input})
-                search_data = response.get("search") or {}
-                search_results = search_data.get("searchResults") or []
-                total = search_data.get("total") or 0
+                logger.debug(
+                    f"Fetched page of {len(search_results)} documents (scrollId={scroll_id})"
+                )
 
                 for result in search_results:
                     entity = result.get("entity") or {}
@@ -834,10 +854,6 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
 
                     documents.append({"urn": urn, "text": text})
                     self.report.report_document_fetched()
-
-                start += len(search_results)
-                if not search_results or start >= total:
-                    break
 
             logger.info(
                 f"Fetched {len(documents)} documents with text content from platforms: {self.config.platform_filter}"

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -742,6 +742,7 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             searchFlags: {
               skipHighlighting: true,
               skipAggregates: true
+              includeHiddenLifecycleStages: true
             }
           }) {
             nextScrollId

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -2577,12 +2577,27 @@ class TestFetchDocumentsPagination:
             assert len(documents) == 1000
             assert mock_execute.call_count == 1
 
+    def test_requests_hidden_lifecycle_stages(self, ctx, config, mock_graph):
+        """Document backfills request hidden-lifecycle stages so hidden documents are included."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            response = self._make_scroll_page(0, 0, next_scroll_id=None)
+
+            with patch.object(
+                source.graph, "execute_graphql", return_value=response
+            ) as mock_execute:
+                source._fetch_documents_graphql()
+
+            query = mock_execute.call_args[0][0]
+            assert "includeHiddenLifecycleStages: true" in query
+
     def test_empty_result_set(self, ctx, config, mock_graph):
         """Zero documents returns empty list after one call."""
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
 
-            response = {
+            response: dict[str, Any] = {
                 "scrollAcrossEntities": {
                     "nextScrollId": None,
                     "searchResults": [],

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -1724,7 +1724,8 @@ class TestConfigFingerprintInHash:
 
             # Mock GraphQL to return both NATIVE and EXTERNAL documents
             mock_response = {
-                "search": {
+                "scrollAcrossEntities": {
+                    "nextScrollId": None,
                     "searchResults": [
                         {
                             "entity": {
@@ -1748,7 +1749,7 @@ class TestConfigFingerprintInHash:
                                 },
                             }
                         },
-                    ]
+                    ],
                 }
             }
 
@@ -1781,7 +1782,8 @@ class TestConfigFingerprintInHash:
 
             # Mock GraphQL to return documents from different platforms
             mock_response = {
-                "search": {
+                "scrollAcrossEntities": {
+                    "nextScrollId": None,
                     "searchResults": [
                         {
                             "entity": {
@@ -1813,7 +1815,7 @@ class TestConfigFingerprintInHash:
                                 },
                             }
                         },
-                    ]
+                    ],
                 }
             }
 
@@ -1869,7 +1871,8 @@ class TestPartialEntityHandling:
             source = DataHubDocumentsSource(ctx, config)
 
             mock_response = {
-                "search": {
+                "scrollAcrossEntities": {
+                    "nextScrollId": None,
                     "searchResults": [
                         {
                             "entity": {
@@ -1888,7 +1891,7 @@ class TestPartialEntityHandling:
                                 },
                             }
                         },
-                    ]
+                    ],
                 }
             }
 
@@ -1908,7 +1911,8 @@ class TestPartialEntityHandling:
             source = DataHubDocumentsSource(ctx, config)
 
             mock_response = {
-                "search": {
+                "scrollAcrossEntities": {
+                    "nextScrollId": None,
                     "searchResults": [
                         {
                             "entity": {
@@ -1919,7 +1923,7 @@ class TestPartialEntityHandling:
                                 },
                             }
                         },
-                    ]
+                    ],
                 }
             }
 
@@ -1937,7 +1941,7 @@ class TestPartialEntityHandling:
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
 
-            mock_response: dict[str, Any] = {"search": None}
+            mock_response: dict[str, Any] = {"scrollAcrossEntities": None}
 
             with patch.object(
                 source.graph, "execute_graphql", return_value=mock_response
@@ -2013,7 +2017,8 @@ class TestPartialEntityHandling:
             source = DataHubDocumentsSource(ctx, config)
 
             mock_response = {
-                "search": {
+                "scrollAcrossEntities": {
+                    "nextScrollId": None,
                     "searchResults": [
                         {
                             "entity": {
@@ -2050,7 +2055,7 @@ class TestPartialEntityHandling:
                                 },
                             }
                         },
-                    ]
+                    ],
                 }
             }
 
@@ -2484,7 +2489,7 @@ class TestDataHubGraphInitialization:
 
 
 class TestFetchDocumentsPagination:
-    """Test that _fetch_documents_graphql paginates through all pages."""
+    """Test that _fetch_documents_graphql paginates through all pages via scrollAcrossEntities."""
 
     @pytest.fixture
     def config(self):
@@ -2522,10 +2527,12 @@ class TestFetchDocumentsPagination:
             }
         }
 
-    def _make_page(self, start: int, count: int, total: int) -> dict:
+    def _make_scroll_page(
+        self, start: int, count: int, next_scroll_id: Any = None
+    ) -> dict:
         return {
-            "search": {
-                "total": total,
+            "scrollAcrossEntities": {
+                "nextScrollId": next_scroll_id,
                 "searchResults": [
                     self._make_entity(i) for i in range(start, start + count)
                 ],
@@ -2538,8 +2545,8 @@ class TestFetchDocumentsPagination:
             source = DataHubDocumentsSource(ctx, config)
 
             responses = [
-                self._make_page(0, 1000, 1200),
-                self._make_page(1000, 200, 1200),
+                self._make_scroll_page(0, 1000, next_scroll_id="cursor-1"),
+                self._make_scroll_page(1000, 200, next_scroll_id=None),
             ]
 
             with patch.object(
@@ -2550,17 +2557,17 @@ class TestFetchDocumentsPagination:
             assert len(documents) == 1200
             assert mock_execute.call_count == 2
 
-            first_call_input = mock_execute.call_args_list[0][0][1]["input"]
-            second_call_input = mock_execute.call_args_list[1][0][1]["input"]
-            assert first_call_input["start"] == 0
-            assert second_call_input["start"] == 1000
+            first_scroll_id = mock_execute.call_args_list[0][0][1]["scrollId"]
+            second_scroll_id = mock_execute.call_args_list[1][0][1]["scrollId"]
+            assert first_scroll_id is None
+            assert second_scroll_id == "cursor-1"
 
-    def test_stops_at_exact_page_boundary(self, ctx, config, mock_graph):
-        """Exactly page_size results with total=page_size issues only one call."""
+    def test_stops_when_no_next_scroll_id(self, ctx, config, mock_graph):
+        """A single page with no nextScrollId issues only one call."""
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
 
-            response = self._make_page(0, 1000, 1000)
+            response = self._make_scroll_page(0, 1000, next_scroll_id=None)
 
             with patch.object(
                 source.graph, "execute_graphql", return_value=response
@@ -2575,7 +2582,12 @@ class TestFetchDocumentsPagination:
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
 
-            response = {"search": {"total": 0, "searchResults": []}}
+            response = {
+                "scrollAcrossEntities": {
+                    "nextScrollId": None,
+                    "searchResults": [],
+                }
+            }
 
             with patch.object(
                 source.graph, "execute_graphql", return_value=response
@@ -2585,30 +2597,15 @@ class TestFetchDocumentsPagination:
             assert documents == []
             assert mock_execute.call_count == 1
 
-    def test_missing_total_field_stops_after_first_page(self, ctx, config, mock_graph):
-        """If the API omits 'total', pagination stops after the first page without looping."""
-        with mock_graph:
-            source = DataHubDocumentsSource(ctx, config)
-
-            response = {"search": {"searchResults": [self._make_entity(0)]}}
-
-            with patch.object(
-                source.graph, "execute_graphql", return_value=response
-            ) as mock_execute:
-                documents = source._fetch_documents_graphql()
-
-            assert len(documents) == 1
-            assert mock_execute.call_count == 1
-
     def test_three_pages(self, ctx, config, mock_graph):
-        """Three-page fetch collects all documents and advances start correctly."""
+        """Three-page fetch collects all documents and threads scroll cursors correctly."""
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
 
             responses = [
-                self._make_page(0, 1000, 2500),
-                self._make_page(1000, 1000, 2500),
-                self._make_page(2000, 500, 2500),
+                self._make_scroll_page(0, 1000, next_scroll_id="cursor-1"),
+                self._make_scroll_page(1000, 1000, next_scroll_id="cursor-2"),
+                self._make_scroll_page(2000, 500, next_scroll_id=None),
             ]
 
             with patch.object(
@@ -2618,5 +2615,53 @@ class TestFetchDocumentsPagination:
 
             assert len(documents) == 2500
             assert mock_execute.call_count == 3
-            starts = [c[0][1]["input"]["start"] for c in mock_execute.call_args_list]
-            assert starts == [0, 1000, 2000]
+            scroll_ids = [c[0][1]["scrollId"] for c in mock_execute.call_args_list]
+            assert scroll_ids == [None, "cursor-1", "cursor-2"]
+
+    def test_raw_page_size_used_as_start_advance(self, ctx, config, mock_graph):
+        """Pagination advances by raw page size even when some results are filtered client-side.
+
+        This test locks in that start is advanced by the number of results returned from the
+        server, not the number that pass client-side filters. Using filtered count would cause
+        pages to be requested at wrong offsets or loop incorrectly.
+        """
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            # Page 1: 1000 results, 800 pass client filters (200 have empty text).
+            # Page 2: remaining results with no next scroll id.
+            page1_results = [self._make_entity(i) for i in range(800)]
+            # Add 200 entities with empty text that will be filtered out
+            for i in range(800, 1000):
+                page1_results.append(
+                    {
+                        "entity": {
+                            "urn": f"urn:li:document:doc-{i}",
+                            "info": {
+                                "source": {"sourceType": "NATIVE"},
+                                "contents": {"text": ""},
+                            },
+                        }
+                    }
+                )
+
+            responses = [
+                {
+                    "scrollAcrossEntities": {
+                        "nextScrollId": "cursor-1",
+                        "searchResults": page1_results,
+                    }
+                },
+                self._make_scroll_page(1000, 300, next_scroll_id=None),
+            ]
+
+            with patch.object(
+                source.graph, "execute_graphql", side_effect=responses
+            ) as mock_execute:
+                documents = source._fetch_documents_graphql()
+
+            # 800 from page 1 (200 filtered) + 300 from page 2
+            assert len(documents) == 1100
+            assert mock_execute.call_count == 2
+            # Second call must use the cursor from page 1, not a derived offset
+            assert mock_execute.call_args_list[1][0][1]["scrollId"] == "cursor-1"


### PR DESCRIPTION
The batch document fetch used a search that caps at Elasticsearch's 10k result window, silently missing documents in large deployments. Switch to `scrollAcrossEntities` to iterate all results.

Builds on #17975 (the pagination fix), now merged — this PR is rebased onto master and stands alone.

Updates unit tests.