### PR TITLE
fix(dataproduct): bypass entity client cache for domain auth reads

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/dataproduct/DataProductServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/dataproduct/DataProductServiceFactory.java
@@ -1,6 +1,6 @@
 package com.linkedin.gms.factory.dataproduct;
 
-import com.linkedin.entity.client.EntityClient;
+import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.metadata.graph.GraphClient;
 import com.linkedin.metadata.service.DataProductService;
 import javax.annotation.Nonnull;
@@ -21,7 +21,7 @@ public class DataProductServiceFactory {
   @Scope("singleton")
   @Nonnull
   protected DataProductService getInstance(
-      @Qualifier("entityClient") final EntityClient entityClient) throws Exception {
+      @Qualifier("systemEntityClient") final SystemEntityClient entityClient) throws Exception {
     return new DataProductService(entityClient, _graphClient);
   }
 }

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/DataProductService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/DataProductService.java
@@ -16,7 +16,7 @@ import com.linkedin.dataproduct.DataProductKey;
 import com.linkedin.dataproduct.DataProductProperties;
 import com.linkedin.domain.Domains;
 import com.linkedin.entity.EntityResponse;
-import com.linkedin.entity.client.EntityClient;
+import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.AspectUtils;
 import com.linkedin.metadata.graph.GraphClient;
@@ -26,6 +26,7 @@ import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -43,10 +44,11 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class DataProductService {
-  private final EntityClient _entityClient;
+  private final SystemEntityClient _entityClient;
   private final GraphClient _graphClient;
 
-  public DataProductService(@Nonnull EntityClient entityClient, @Nonnull GraphClient graphClient) {
+  public DataProductService(
+      @Nonnull SystemEntityClient entityClient, @Nonnull GraphClient graphClient) {
     _entityClient = entityClient;
     _graphClient = graphClient;
   }
@@ -189,17 +191,19 @@ public class DataProductService {
     Objects.requireNonNull(dataProductUrn, "dataProductUrn must not be null");
     Objects.requireNonNull(opContext.getSessionAuthentication(), "authentication must not be null");
     try {
-      final EntityResponse response =
-          _entityClient.getV2(
+      // Bypass entity client cache: setDomain may have cached a negative domains entry before
+      // ingest, and authorization reads must see the latest aspect (see SettingsService pattern).
+      final Map<Urn, EntityResponse> batchResponse =
+          _entityClient.batchGetV2NoCache(
               opContext,
               Constants.DATA_PRODUCT_ENTITY_NAME,
-              dataProductUrn,
+              ImmutableSet.of(dataProductUrn),
               ImmutableSet.of(Constants.DOMAINS_ASPECT_NAME));
+      final EntityResponse response = batchResponse.get(dataProductUrn);
       if (response != null && response.getAspects().containsKey(Constants.DOMAINS_ASPECT_NAME)) {
         return new Domains(
             response.getAspects().get(Constants.DOMAINS_ASPECT_NAME).getValue().data());
       }
-      // No aspect found
       return null;
     } catch (Exception e) {
       throw new RuntimeException(

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/service/DataProductServiceTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/service/DataProductServiceTest.java
@@ -9,17 +9,19 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.dataproduct.DataProductAssociation;
 import com.linkedin.dataproduct.DataProductAssociationArray;
 import com.linkedin.dataproduct.DataProductProperties;
+import com.linkedin.domain.Domains;
 import com.linkedin.entity.Aspect;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspect;
 import com.linkedin.entity.EnvelopedAspectMap;
-import com.linkedin.entity.client.EntityClient;
+import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.aspect.AspectRetriever;
 import com.linkedin.metadata.graph.GraphClient;
@@ -28,6 +30,7 @@ import com.linkedin.mxe.MetadataChangeProposal;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.List;
+import java.util.Map;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -52,7 +55,7 @@ public class DataProductServiceTest {
 
   @Test
   public void testBatchAddToDataProduct() throws Exception {
-    final EntityClient mockClient = mock(EntityClient.class);
+    final SystemEntityClient mockClient = mock(SystemEntityClient.class);
     final GraphClient mockGraphClient = mock(GraphClient.class);
     final DataProductService service = new DataProductService(mockClient, mockGraphClient);
 
@@ -109,7 +112,7 @@ public class DataProductServiceTest {
 
   @Test
   public void testBatchAddToDataProductDoesNotDuplicateExisting() throws Exception {
-    final EntityClient mockClient = mock(EntityClient.class);
+    final SystemEntityClient mockClient = mock(SystemEntityClient.class);
     final GraphClient mockGraphClient = mock(GraphClient.class);
     final DataProductService service = new DataProductService(mockClient, mockGraphClient);
 
@@ -174,7 +177,7 @@ public class DataProductServiceTest {
 
   @Test
   public void testBatchRemoveFromDataProduct() throws Exception {
-    final EntityClient mockClient = mock(EntityClient.class);
+    final SystemEntityClient mockClient = mock(SystemEntityClient.class);
     final GraphClient mockGraphClient = mock(GraphClient.class);
     final DataProductService service = new DataProductService(mockClient, mockGraphClient);
 
@@ -236,7 +239,7 @@ public class DataProductServiceTest {
 
   @Test
   public void testBatchRemoveFromDataProductRemovesMultiple() throws Exception {
-    final EntityClient mockClient = mock(EntityClient.class);
+    final SystemEntityClient mockClient = mock(SystemEntityClient.class);
     final GraphClient mockGraphClient = mock(GraphClient.class);
     final DataProductService service = new DataProductService(mockClient, mockGraphClient);
 
@@ -293,8 +296,64 @@ public class DataProductServiceTest {
   }
 
   @Test
+  public void testGetDataProductDomainsUsesNoCache() throws Exception {
+    final SystemEntityClient mockClient = mock(SystemEntityClient.class);
+    final GraphClient mockGraphClient = mock(GraphClient.class);
+    final DataProductService service = new DataProductService(mockClient, mockGraphClient);
+
+    final Urn domainUrn = UrnUtils.getUrn("urn:li:domain:marketing");
+    final Domains domains = new Domains().setDomains(new UrnArray(domainUrn));
+    final EntityResponse entityResponse = new EntityResponse();
+    entityResponse.setAspects(
+        new EnvelopedAspectMap(
+            ImmutableMap.of(
+                Constants.DOMAINS_ASPECT_NAME,
+                new EnvelopedAspect().setValue(new Aspect(domains.data())))));
+
+    when(mockClient.batchGetV2NoCache(
+            any(OperationContext.class),
+            eq(Constants.DATA_PRODUCT_ENTITY_NAME),
+            eq(ImmutableSet.of(TEST_DATA_PRODUCT_URN)),
+            eq(ImmutableSet.of(Constants.DOMAINS_ASPECT_NAME))))
+        .thenReturn(ImmutableMap.of(TEST_DATA_PRODUCT_URN, entityResponse));
+
+    final Domains result = service.getDataProductDomains(opContext, TEST_DATA_PRODUCT_URN);
+
+    assertNotNull(result);
+    assertEquals(result.getDomains().get(0), domainUrn);
+    verify(mockClient, times(1))
+        .batchGetV2NoCache(
+            any(OperationContext.class),
+            eq(Constants.DATA_PRODUCT_ENTITY_NAME),
+            eq(ImmutableSet.of(TEST_DATA_PRODUCT_URN)),
+            eq(ImmutableSet.of(Constants.DOMAINS_ASPECT_NAME)));
+    verify(mockClient, never())
+        .getV2(
+            any(OperationContext.class),
+            eq(Constants.DATA_PRODUCT_ENTITY_NAME),
+            eq(TEST_DATA_PRODUCT_URN),
+            eq(ImmutableSet.of(Constants.DOMAINS_ASPECT_NAME)));
+  }
+
+  @Test
+  public void testGetDataProductDomainsMissingAspect() throws Exception {
+    final SystemEntityClient mockClient = mock(SystemEntityClient.class);
+    final GraphClient mockGraphClient = mock(GraphClient.class);
+    final DataProductService service = new DataProductService(mockClient, mockGraphClient);
+
+    when(mockClient.batchGetV2NoCache(
+            any(OperationContext.class),
+            eq(Constants.DATA_PRODUCT_ENTITY_NAME),
+            eq(ImmutableSet.of(TEST_DATA_PRODUCT_URN)),
+            eq(ImmutableSet.of(Constants.DOMAINS_ASPECT_NAME))))
+        .thenReturn(Map.of());
+
+    assertNull(service.getDataProductDomains(opContext, TEST_DATA_PRODUCT_URN));
+  }
+
+  @Test
   public void testVerifyEntityExistsTrue() throws Exception {
-    final EntityClient mockClient = mock(EntityClient.class);
+    final SystemEntityClient mockClient = mock(SystemEntityClient.class);
     final GraphClient mockGraphClient = mock(GraphClient.class);
     final DataProductService service = new DataProductService(mockClient, mockGraphClient);
 
@@ -308,7 +367,7 @@ public class DataProductServiceTest {
 
   @Test
   public void testVerifyEntityExistsFalse() throws Exception {
-    final EntityClient mockClient = mock(EntityClient.class);
+    final SystemEntityClient mockClient = mock(SystemEntityClient.class);
     final GraphClient mockGraphClient = mock(GraphClient.class);
     final DataProductService service = new DataProductService(mockClient, mockGraphClient);
 


### PR DESCRIPTION
## Summary
- Route `DataProductService.getDataProductDomains` through `SystemEntityClient.batchGetV2NoCache` instead of cached `getV2`, matching the `SettingsService` pattern for auth-sensitive reads
- Wire `DataProductService` to `systemEntityClient` so the no-cache API is available
- Add unit tests verifying auth reads bypass the entity client cache

Fixes a fail-closed 403 on `batchSetDataProduct` when `setDomain` read-before-write cached a negative `domains` aspect entry (20s TTL) before ingest completed.

## Test plan
- [x] `./gradlew :metadata-service:services:test --tests com.linkedin.metadata.service.DataProductServiceTest`
- [ ] `smoke-test/tests/dataproduct/test_dataproduct.py::test_create_data_product`


Made with [Cursor](https://cursor.com)