### PR TITLE
feat(ingestion/unity): remove legacy GE profiling method

### DIFF
--- a/metadata-ingestion/docs/sources/databricks/unity-catalog_pre.md
+++ b/metadata-ingestion/docs/sources/databricks/unity-catalog_pre.md
@@ -55,7 +55,6 @@ You can authenticate with Databricks using OAuth, Azure authentication, a Person
   - Otherwise (REST API path): `CAN_MANAGE` on the SQL warehouse: [guide](https://docs.databricks.com/security/auth-authz/access-control/sql-endpoint-acl.html).
 - To `include_table_constraints` (disabled by default), no additional permissions are required beyond the `SELECT` privilege already listed above. The connector uses the same `tables.get()` API endpoint.
 - To ingest `profiling` information with the default SQLAlchemy profiler (`method: sqlalchemy`), you need `SELECT` privilege on tables and views.
-- To ingest `profiling` information with `method: ge` (requires `pip install 'acryl-datahub[profiling-ge]'`), you need `SELECT` privileges on all profiled tables.
 - To ingest `profiling` information with `method: analyze` and `call_analyze: true` (enabled by default), your service principal must have ownership or `MODIFY` privilege on any tables you want to profile.
   - Alternatively, you can run [ANALYZE TABLE](https://docs.databricks.com/sql/language-manual/sql-ref-syntax-aux-analyze-table.html) yourself on any tables you want to profile, then set `call_analyze` to `false`.
     You will still need `SELECT` privilege on those tables to fetch the results.

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -65,8 +65,7 @@ class UnityCatalogProfilerConfig(ConfigModel):
     method: str = Field(
         description=(
             "Profiling method to use."
-            " Options supported are `ge`, `analyze`, and `sqlalchemy`."
-            " `ge` uses Great Expectations and runs SELECT SQL queries on profiled tables."
+            " Options supported are `analyze` and `sqlalchemy`."
             " `analyze` calls ANALYZE TABLE on profiled tables. Only works for delta tables."
             " `sqlalchemy` uses the custom SQLAlchemy-based profiler (no GE dependency)."
         ),
@@ -135,15 +134,6 @@ class UnityCatalogAnalyzeProfilerConfig(UnityCatalogProfilerConfig):
 
 
 # TODO: should this max_wait_secs had been implemented as a global profiler feature instead of keeping it specific to Unity Catalog?
-class UnityCatalogGEProfilerConfig(UnityCatalogProfilerConfig, GEProfilingConfig):
-    method: Literal["ge"] = "ge"
-
-    max_wait_secs: Optional[int] = Field(
-        default=None,
-        description="Maximum time to wait for a table to be profiled.",
-    )
-
-
 class UnityCatalogSQLAlchemyProfilerConfig(
     UnityCatalogProfilerConfig, GEProfilingConfig
 ):
@@ -424,7 +414,6 @@ class UnityCatalogSourceConfig(
 
     # TODO: Remove `type:ignore` by refactoring config
     profiling: Union[
-        UnityCatalogGEProfilerConfig,
         UnityCatalogAnalyzeProfilerConfig,
         UnityCatalogSQLAlchemyProfilerConfig,
     ] = Field(  # type: ignore
@@ -521,14 +510,11 @@ class UnityCatalogSourceConfig(
             self.profiling.operation_config
         )
 
-    def is_ge_profiling(self) -> bool:
-        return self.profiling.method == "ge"
-
     def is_sqlalchemy_profiling(self) -> bool:
         return self.profiling.method == "sqlalchemy"
 
     def uses_table_level_profiler(self) -> bool:
-        return self.is_ge_profiling() or self.is_sqlalchemy_profiling()
+        return self.is_sqlalchemy_profiling()
 
     stateful_ingestion: Optional[StatefulStaleMetadataRemovalConfig] = pydantic.Field(
         default=None, description="Unity Catalog Stateful Ingestion Config."

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/ge_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/ge_profiler.py
@@ -2,7 +2,7 @@ import concurrent.futures
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
-from typing import Iterable, List, Optional, Union
+from typing import Iterable, List, Optional
 
 from databricks.sdk.service.catalog import DataSourceFormat
 from sqlalchemy import create_engine
@@ -15,7 +15,6 @@ from datahub.ingestion.source.sql.sql_generic_profiler import (
     TableProfilerRequest,
 )
 from datahub.ingestion.source.unity.config import (
-    UnityCatalogGEProfilerConfig,
     UnityCatalogSourceConfig,
     UnityCatalogSQLAlchemyProfilerConfig,
 )
@@ -51,17 +50,13 @@ class UnityCatalogSQLGenericTable(BaseTable):
 
 
 class UnityCatalogGEProfiler(GenericProfiler):
-    profiling_config: Union[
-        UnityCatalogGEProfilerConfig, UnityCatalogSQLAlchemyProfilerConfig
-    ]
+    profiling_config: UnityCatalogSQLAlchemyProfilerConfig
     report: UnityCatalogReport
 
     def __init__(
         self,
         config: UnityCatalogSourceConfig,
-        profiling_config: Union[
-            UnityCatalogGEProfilerConfig, UnityCatalogSQLAlchemyProfilerConfig
-        ],
+        profiling_config: UnityCatalogSQLAlchemyProfilerConfig,
         report: UnityCatalogReport,
     ) -> None:
         config = config.model_copy(deep=True)

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
@@ -80,7 +80,6 @@ from datahub.ingestion.source.unity import proxy_types as unity_proxy_types
 from datahub.ingestion.source.unity.analyze_profiler import UnityCatalogAnalyzeProfiler
 from datahub.ingestion.source.unity.config import (
     UnityCatalogAnalyzeProfilerConfig,
-    UnityCatalogGEProfilerConfig,
     UnityCatalogSourceConfig,
     UnityCatalogSQLAlchemyProfilerConfig,
 )
@@ -564,15 +563,6 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                         "Using UnityCatalogGEProfiler with SQLAlchemyProfiler (method: sqlalchemy)"
                     )
                     # Use GenericProfiler which will use SQLAlchemyProfiler internally
-                    yield from UnityCatalogGEProfiler(
-                        config=self.config,
-                        profiling_config=self.config.profiling,
-                        report=self.report,
-                    ).get_workunits(list(self.tables.values()))
-                elif isinstance(self.config.profiling, UnityCatalogGEProfilerConfig):
-                    logger.info(
-                        "Using UnityCatalogGEProfiler with DatahubGEProfiler (method: ge)"
-                    )
                     yield from UnityCatalogGEProfiler(
                         config=self.config,
                         profiling_config=self.config.profiling,

--- a/metadata-ingestion/tests/unit/test_unity_catalog_config.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_config.py
@@ -5,7 +5,6 @@ import time_machine
 
 from datahub.ingestion.source.unity.config import (
     LineageDataSource,
-    UnityCatalogGEProfilerConfig,
     UnityCatalogSourceConfig,
     UnityCatalogSQLAlchemyProfilerConfig,
     UsageDataSource,
@@ -48,7 +47,7 @@ def test_profiling_requires_warehouses_id():
             "include_hive_metastore": False,
             "profiling": {
                 "enabled": True,
-                "method": "ge",
+                "method": "sqlalchemy",
                 "warehouse_id": "my_warehouse_id",
             },
         }
@@ -61,7 +60,7 @@ def test_profiling_requires_warehouses_id():
             "workspace_url": "https://workspace_url",
             "include_hive_metastore": False,
             "include_tags": False,
-            "profiling": {"enabled": False, "method": "ge"},
+            "profiling": {"enabled": False, "method": "sqlalchemy"},
         }
     )
     assert config.profiling.enabled is False
@@ -95,7 +94,7 @@ def test_global_warehouse_id_is_set_from_profiling():
             "token": "token",
             "workspace_url": "https://XXXXXXXXXXXXXXXXXXXXX",
             "profiling": {
-                "method": "ge",
+                "method": "sqlalchemy",
                 "enabled": True,
                 "warehouse_id": "my_warehouse_id",
             },
@@ -116,7 +115,7 @@ def test_set_different_warehouse_id_from_profiling():
                 "workspace_url": "https://XXXXXXXXXXXXXXXXXXXXX",
                 "warehouse_id": "my_global_warehouse_id",
                 "profiling": {
-                    "method": "ge",
+                    "method": "sqlalchemy",
                     "enabled": True,
                     "warehouse_id": "my_warehouse_id",
                 },
@@ -160,7 +159,7 @@ def test_set_profiling_warehouse_id_from_global():
             "workspace_url": "https://XXXXXXXXXXXXXXXXXXXXX",
             "warehouse_id": "my_global_warehouse_id",
             "profiling": {
-                "method": "ge",
+                "method": "sqlalchemy",
                 "enabled": True,
             },
         }
@@ -548,20 +547,6 @@ def test_profiling_prebuilt_instance_passes_through():
     assert config.profiling.method == "sqlalchemy"
 
 
-def test_profiling_explicit_ge_method_preserved():
-    # profiling: {method: ge, ...} → GE variant unchanged
-    config = UnityCatalogSourceConfig.model_validate(
-        {
-            "token": "token",
-            "workspace_url": "https://test.databricks.com",
-            "include_hive_metastore": False,
-            "profiling": {"method": "ge", "enabled": True, "warehouse_id": "wh"},
-        }
-    )
-    assert isinstance(config.profiling, UnityCatalogGEProfilerConfig)
-    assert config.profiling.method == "ge"
-
-
 def test_uses_table_level_profiler_helpers():
     base = {
         "token": "token",
@@ -574,15 +559,6 @@ def test_uses_table_level_profiler_helpers():
         {**base, "profiling": {"method": "sqlalchemy", "warehouse_id": "wh"}}
     )
     assert cfg.is_sqlalchemy_profiling() is True
-    assert cfg.is_ge_profiling() is False
-    assert cfg.uses_table_level_profiler() is True
-
-    # ge → True
-    cfg = UnityCatalogSourceConfig.model_validate(
-        {**base, "profiling": {"method": "ge", "warehouse_id": "wh"}}
-    )
-    assert cfg.is_sqlalchemy_profiling() is False
-    assert cfg.is_ge_profiling() is True
     assert cfg.uses_table_level_profiler() is True
 
     # analyze → False
@@ -590,7 +566,6 @@ def test_uses_table_level_profiler_helpers():
         {**base, "profiling": {"method": "analyze"}}
     )
     assert cfg.is_sqlalchemy_profiling() is False
-    assert cfg.is_ge_profiling() is False
     assert cfg.uses_table_level_profiler() is False
 
 


### PR DESCRIPTION
## Summary

Removes the legacy Great Expectations profiling method (`profiling.method: ge`) from the Unity Catalog source. It is superseded by the SQLAlchemy-based profiler (`method: sqlalchemy`, the default); `analyze` (ANALYZE TABLE) remains as the other option.

This is the first step toward bumping `databricks-sql-connector` (which is gated on dropping the databricks SQLAlchemy-dialect usages — see ING-2895). It removes the legacy GE path; the `sqlalchemy` method and `hive_metastore_proxy` still use the dialect, so this PR does not by itself unblock the connector bump.

## Changes

- Delete `UnityCatalogGEProfilerConfig` and drop it from the discriminated `profiling` union (now `analyze` | `sqlalchemy`).
- Remove the `method: ge` dispatch branch in `source.py`.
- Remove the now-unused `is_ge_profiling()` helper; `uses_table_level_profiler()` now checks only the sqlalchemy method.
- Narrow `UnityCatalogGEProfiler` typing to `UnityCatalogSQLAlchemyProfilerConfig` (the class is retained — it backs the `sqlalchemy` method).
- Update unit tests and the unity-catalog profiling permission docs.

## Migration

Recipes that set `profiling.method: ge` should switch to `sqlalchemy` (the default) or `analyze`.

## Testing

- `mypy src/datahub/ingestion/source/unity/` → Success (18 files)
- `pytest tests/unit/test_unity_catalog_config.py tests/unit/test_unity_catalog_proxy.py` → 94 passed, 1 skipped
- ruff check + format clean

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests updated
- [x] Docs updated (unity-catalog profiling permissions)