### PR TITLE
fix(docs): remove redundant Overview nav entries in sidebars.js

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -489,11 +489,6 @@ module.exports = {
           },
           items: [
             {
-              label: "Overview",
-              type: "doc",
-              id: "docs/features/feature-guides/logical-models/overview",
-            },
-            {
               label: "Centralized Management",
               type: "doc",
               id: "docs/features/feature-guides/logical-models/centralized-management",

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -226,11 +226,6 @@ module.exports = {
           link: { type: "doc", id: "docs/managed-datahub/observe/assertions" },
           items: [
             {
-              label: "Overview",
-              type: "doc",
-              id: "docs/managed-datahub/observe/assertions",
-            },
-            {
               label: "Column Assertions",
               type: "doc",
               id: "docs/managed-datahub/observe/column-assertions",


### PR DESCRIPTION
## Summary

Two sidebar categories in `docs-website/sidebars.js` — "Assertions (Data Quality)" and "Logical Models" — each had a `link:` on the category header plus a redundant `Overview` child pointing to the same doc. This removes the duplicate `Overview` children; the category headers still link to those pages, so no URLs change and no redirects are needed.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)