### PR TITLE
fix(ui): Fix showing '(0)' next to More filter dropdown

### DIFF
--- a/datahub-web-react/src/i18n/locales/de/search.json
+++ b/datahub-web-react/src/i18n/locales/de/search.json
@@ -71,6 +71,7 @@
     "filters.incidents.hasActiveLabel": "Hat aktive Vorfälle",
     "filters.incidents.hasResolvedLabel": "Hat gelöste Vorfälle",
     "filters.incidents.title": "Vorfälle",
+    "filters.moreCount_zero": "Mehr",
     "filters.moreCount_one": "Mehr ({{count}})",
     "filters.moreCount_other": "Mehr ({{count}})",
     "filters.pluralizedTypeLabel": "{{type}}s",

--- a/datahub-web-react/src/i18n/locales/en/search.json
+++ b/datahub-web-react/src/i18n/locales/en/search.json
@@ -71,6 +71,7 @@
     "filters.incidents.hasActiveLabel": "Has Active Incidents",
     "filters.incidents.hasResolvedLabel": "Has Resolved Incidents",
     "filters.incidents.title": "Incidents",
+    "filters.moreCount_zero": "More",
     "filters.moreCount_one": "More ({{count}})",
     "filters.moreCount_other": "More ({{count}})",
     "filters.pluralizedTypeLabel": "{{type}}s",

--- a/datahub-web-react/src/i18n/locales/es/search.json
+++ b/datahub-web-react/src/i18n/locales/es/search.json
@@ -71,6 +71,7 @@
     "filters.incidents.hasActiveLabel": "Tiene incidencias activas",
     "filters.incidents.hasResolvedLabel": "Tiene incidencias resueltas",
     "filters.incidents.title": "Incidencias",
+    "filters.moreCount_zero": "Más",
     "filters.moreCount_one": "Más ({{count}})",
     "filters.moreCount_other": "Más ({{count}})",
     "filters.pluralizedTypeLabel": "{{type}}s",

--- a/datahub-web-react/src/i18n/locales/pt-BR/search.json
+++ b/datahub-web-react/src/i18n/locales/pt-BR/search.json
@@ -71,6 +71,7 @@
     "filters.incidents.hasActiveLabel": "Com Incidents Ativos",
     "filters.incidents.hasResolvedLabel": "Com Incidents Resolvidos",
     "filters.incidents.title": "Incidents",
+    "filters.moreCount_zero": "Mais",
     "filters.moreCount_one": "Mais ({{count}})",
     "filters.moreCount_other": "Mais ({{count}})",
     "filters.pluralizedTypeLabel": "{{type}}s",


### PR DESCRIPTION
Previously we had a bug where we were showing a count of 0 when there were no filters in the More filter dropdown due to changes with translations recently. This fixes that so we don't show a count when there are no filters selected in the dropdown, but we do show the count when there are like we did before.

<img width="592" height="250" alt="Screenshot 2026-06-23 at 10 39 51 AM" src="https://github.com/user-attachments/assets/5eb2381c-7954-4b09-8796-b8925cccfb0c" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
