### PR TITLE
fix(search): correct structured-property filtering & display by value type

### DIFF
--- a/datahub-web-react/src/app/searchV2/filters/__tests__/useSearchFilterDropdown.test.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/__tests__/useSearchFilterDropdown.test.tsx
@@ -1,0 +1,60 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import useSearchFilterDropdown from '@app/searchV2/filters/useSearchFilterDropdown';
+import { STRUCTURED_PROPERTIES_FILTER_NAME } from '@app/searchV2/utils/constants';
+import { STRING_TYPE_URN } from '@src/app/shared/constants';
+
+import { FacetMetadata, FilterOperator } from '@types';
+
+// The hook pulls its search context and the aggregation lazy-query from other hooks; stub both so we
+// can exercise updateFilters in isolation. updateFilters does not run the aggregation query, so the
+// lazy-query mock only needs to satisfy the [trigger, state] tuple shape.
+vi.mock('@app/searchV2/useGetSearchQueryInputs', () => ({
+    default: () => ({ entityFilters: [], query: '*', orFilters: [], viewUrn: undefined }),
+}));
+
+vi.mock('@src/graphql/search.generated', () => ({
+    useAggregateAcrossEntitiesLazyQuery: () => [vi.fn(), { data: undefined, loading: false }],
+}));
+
+const businessNameField = `${STRUCTURED_PROPERTIES_FILTER_NAME}.datasetBusinessName`;
+
+// A free-form text structured property: STRING valueType with no constrained allowedValues.
+function freeFormTextSpFacet(): FacetMetadata {
+    return {
+        field: businessNameField,
+        displayName: 'Dataset Business Name',
+        aggregations: [],
+        entity: {
+            definition: { valueType: { urn: STRING_TYPE_URN } },
+        },
+    } as unknown as FacetMetadata;
+}
+
+describe('useSearchFilterDropdown - updateFilters', () => {
+    // Regression guard for the bug where the dropdown showed "contains" but the query sent EQUAL:
+    // updateFilters must forward the field's facet to getNewFilters so a free-form text structured
+    // property resolves to a CONTAINS condition rather than falling back to the backend default (EQUAL).
+    it('applies a CONTAINS condition for free-form text structured properties', () => {
+        const onChangeFilters = vi.fn();
+        const { result } = renderHook(() =>
+            useSearchFilterDropdown({
+                filter: freeFormTextSpFacet(),
+                activeFilters: [],
+                onChangeFilters,
+            }),
+        );
+
+        act(() => {
+            result.current.updateFilters([{ value: 'posted' }]);
+        });
+
+        expect(onChangeFilters).toHaveBeenCalledWith([
+            expect.objectContaining({
+                field: businessNameField,
+                values: ['posted'],
+                condition: FilterOperator.Contain,
+            }),
+        ]);
+    });
+});

--- a/datahub-web-react/src/app/searchV2/filters/__tests__/utils.test.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/__tests__/utils.test.tsx
@@ -21,12 +21,18 @@ import {
     isAnyOptionSelected,
     isFilterOptionSelected,
 } from '@app/searchV2/filters/utils';
-import { ENTITY_SUB_TYPE_FILTER_NAME } from '@app/searchV2/utils/constants';
+import { ENTITY_SUB_TYPE_FILTER_NAME, STRUCTURED_PROPERTIES_FILTER_NAME } from '@app/searchV2/utils/constants';
 import { dataPlatform, dataPlatformInstance, dataset1, glossaryTerm1, user1 } from '@src/Mocks';
-import { DATE_TYPE_URN } from '@src/app/shared/constants';
+import {
+    DATE_TYPE_URN,
+    NUMBER_TYPE_URN,
+    RICH_TEXT_TYPE_URN,
+    STRING_TYPE_URN,
+    URN_TYPE_URN,
+} from '@src/app/shared/constants';
 import { getTestEntityRegistry } from '@utils/test-utils/TestPageContainer';
 
-import { AggregationMetadata, EntityType } from '@types';
+import { AggregationMetadata, EntityType, FilterOperator } from '@types';
 
 describe('filter utils - getNewFilters', () => {
     it('should get the correct list of filters when adding filters where the filter field did not already exist', () => {
@@ -534,8 +540,15 @@ describe('filter utils - getStructuredPropFilterDisplayName', () => {
         ).toBe('10/01/2024');
     });
 
-    it('should return a properly formatted number if it is a number type', () => {
-        expect(getStructuredPropFilterDisplayName('structuredProperties.retentionTime', '90.0')).toBe('90');
+    it('should return a properly formatted number when entity has NUMBER valueType', () => {
+        const entity = { definition: { valueType: { urn: NUMBER_TYPE_URN } } } as any;
+        expect(getStructuredPropFilterDisplayName('structuredProperties.retentionTime', '90.0', entity)).toBe('90');
+    });
+
+    it('should return the raw string when no entity is provided (avoids parseFloat corrupting UUIDs)', () => {
+        // Without entity type info we cannot safely call parseFloat — a value like "02d22a5f-..."
+        // would be silently truncated to "2". Fall through to raw rendering instead.
+        expect(getStructuredPropFilterDisplayName('structuredProperties.retentionTime', '90.0')).toBe('90.0');
     });
 
     it('should strip rich text formatting to be displayed', () => {
@@ -565,5 +578,114 @@ describe('filter utils - getFilterDisplayName', () => {
         const option = { value: 'testValue' };
         const field: FilterField = { type: FieldType.ENUM, field: 'test', displayName: 'test' };
         expect(getFilterDisplayName(option, field)).toBe(undefined);
+    });
+});
+
+describe('filter utils - getStructuredPropFilterDisplayName NUMBER type', () => {
+    it('should format a number value correctly when entity has NUMBER valueType', () => {
+        const entity = { definition: { valueType: { urn: NUMBER_TYPE_URN } } } as any;
+        expect(getStructuredPropFilterDisplayName('structuredProperties.count', '42.0', entity)).toBe('42');
+        expect(getStructuredPropFilterDisplayName('structuredProperties.count', '1000.0', entity)).toBe('1000');
+    });
+
+    it('should NOT corrupt a UUID-shaped value when no entity/type info is provided', () => {
+        // parseFloat('550e8400-e29b-41d4-a716-446655440000') === Infinity before the fix
+        const result = getStructuredPropFilterDisplayName(
+            'structuredProperties.uuidProp',
+            '550e8400-e29b-41d4-a716-446655440000',
+        );
+        expect(result).toBe('550e8400-e29b-41d4-a716-446655440000');
+    });
+
+    it('should NOT corrupt a UUID-shaped value even when entity has STRING valueType', () => {
+        const entity = { definition: { valueType: { urn: STRING_TYPE_URN } } } as any;
+        const result = getStructuredPropFilterDisplayName(
+            'structuredProperties.uuidProp',
+            '550e8400-e29b-41d4-a716-446655440000',
+            entity,
+        );
+        expect(result).toBe('550e8400-e29b-41d4-a716-446655440000');
+    });
+
+    it('should return undefined for URN values regardless of entity type', () => {
+        const entity = { definition: { valueType: { urn: URN_TYPE_URN } } } as any;
+        expect(
+            getStructuredPropFilterDisplayName('structuredProperties.steward', 'urn:li:corpuser:admin', entity),
+        ).toBe(undefined);
+    });
+});
+
+describe('filter utils - getNewFilters with availableFilters (TEXT condition)', () => {
+    const makeStringPropFilter = (hasAllowedValues: boolean) => ({
+        field: `${STRUCTURED_PROPERTIES_FILTER_NAME}.uuidProp`,
+        aggregations: [],
+        entity: {
+            __typename: 'StructuredPropertyEntity',
+            definition: {
+                valueType: { urn: STRING_TYPE_URN },
+                allowedValues: hasAllowedValues ? [{ value: { __typename: 'StringValue', stringValue: 'a' } }] : [],
+            },
+        } as any,
+    });
+
+    it('should set condition=CONTAIN for a free-form STRING structured property', () => {
+        const availableFilters = [makeStringPropFilter(false)];
+        const result = getNewFilters(
+            `${STRUCTURED_PROPERTIES_FILTER_NAME}.uuidProp`,
+            [],
+            ['550e8400-e29b-41d4-a716-446655440000'],
+            availableFilters,
+        );
+        expect(result[0].condition).toBe(FilterOperator.Contain);
+    });
+
+    it('should NOT set condition=CONTAIN for a STRING structured property with allowedValues (ENUM)', () => {
+        const availableFilters = [makeStringPropFilter(true)];
+        const result = getNewFilters(
+            `${STRUCTURED_PROPERTIES_FILTER_NAME}.uuidProp`,
+            [],
+            ['someValue'],
+            availableFilters,
+        );
+        expect(result[0].condition).toBeUndefined();
+    });
+
+    it('should set condition=CONTAIN for a free-form RICH_TEXT structured property', () => {
+        const richTextFilter = {
+            field: `${STRUCTURED_PROPERTIES_FILTER_NAME}.notes`,
+            aggregations: [],
+            entity: {
+                __typename: 'StructuredPropertyEntity',
+                definition: {
+                    valueType: { urn: RICH_TEXT_TYPE_URN },
+                    allowedValues: [],
+                },
+            } as any,
+        };
+        const result = getNewFilters(
+            `${STRUCTURED_PROPERTIES_FILTER_NAME}.notes`,
+            [],
+            ['hello world'],
+            [richTextFilter],
+        );
+        expect(result[0].condition).toBe(FilterOperator.Contain);
+    });
+
+    it('should NOT set condition for a NUMBER structured property', () => {
+        const numberFilter = {
+            field: `${STRUCTURED_PROPERTIES_FILTER_NAME}.count`,
+            aggregations: [],
+            entity: {
+                __typename: 'StructuredPropertyEntity',
+                definition: { valueType: { urn: NUMBER_TYPE_URN }, allowedValues: [] },
+            } as any,
+        };
+        const result = getNewFilters(`${STRUCTURED_PROPERTIES_FILTER_NAME}.count`, [], ['42'], [numberFilter]);
+        expect(result[0].condition).toBeUndefined();
+    });
+
+    it('should default to no condition when availableFilters is omitted', () => {
+        const result = getNewFilters('platform', [], ['snowflake']);
+        expect(result[0].condition).toBeUndefined();
     });
 });

--- a/datahub-web-react/src/app/searchV2/filters/useSearchFilterDropdown.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/useSearchFilterDropdown.tsx
@@ -90,6 +90,10 @@ export default function useSearchFilterDropdown({
                 filter.field,
                 activeFilters,
                 newFilters.map((f) => f.value),
+                // Pass this field's facet so getNewFilters can read the structured-property valueType
+                // and pick the right default condition (free-form TEXT -> CONTAINS). Without it the
+                // condition falls back to the backend default (EQUAL) even though the UI shows "contains".
+                [filter],
             ),
         );
     }

--- a/datahub-web-react/src/app/searchV2/filters/utils.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/utils.tsx
@@ -49,7 +49,13 @@ import {
 import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
 import getTypeIcon from '@app/sharedV2/icons/getTypeIcon';
 import { removeMarkdown } from '@src/app/entity/shared/components/styled/StripMarkdownText';
-import { DATE_TYPE_URN, URN_TYPE_URN } from '@src/app/shared/constants';
+import {
+    DATE_TYPE_URN,
+    NUMBER_TYPE_URN,
+    RICH_TEXT_TYPE_URN,
+    STRING_TYPE_URN,
+    URN_TYPE_URN,
+} from '@src/app/shared/constants';
 import { useEntityRegistryV2 } from '@src/app/useEntityRegistry';
 import { EntityRegistry } from '@src/entityRegistryContext';
 import dayjs from '@utils/dayjs';
@@ -72,10 +78,26 @@ import {
 } from '@types';
 
 // either adds or removes selectedFilterValues to/from activeFilters for a given filterField
+/**
+ * Picks the backend condition to use when a brand-new filter is created for a field. Mirrors the
+ * field type's natural default: date fields use GreaterThan, free-form TEXT fields use CONTAINS, and
+ * everything else falls back to the backend default (EQUAL). Without this, the "More" menu created
+ * every filter with no condition, so a free-form text property (e.g. a UUID) applied as an exact
+ * EQUAL match and partial values never matched.
+ */
+function getNewFilterCondition(filterField: string, availableFilters: FacetMetadata[]): FilterOperator | undefined {
+    if (filterField === LAST_MODIFIED_FILTER_NAME) {
+        return FilterOperator.GreaterThan;
+    }
+    const field = getKnownFilterField(filterField) || getDynamicFilterField(filterField, availableFilters);
+    return field.type === FieldType.TEXT ? FilterOperator.Contain : undefined;
+}
+
 export function getNewFilters(
     filterField: string,
     activeFilters: FacetFilterInput[],
     selectedFilterValues: string[],
+    availableFilters: FacetMetadata[] = [],
 ): FacetFilterInput[] {
     if (activeFilters.find((activeFilter) => activeFilter.field === filterField)) {
         return activeFilters
@@ -89,7 +111,7 @@ export function getNewFilters(
             field: filterField,
             values: selectedFilterValues,
             // TODO: Define on filter field instead
-            condition: filterField === LAST_MODIFIED_FILTER_NAME ? FilterOperator.GreaterThan : undefined,
+            condition: getNewFilterCondition(filterField, availableFilters),
         },
     ].filter((f) => !(f.values?.length === 0));
 }
@@ -485,6 +507,7 @@ function getDynamicFilterField(field: string, availableFilters: FacetMetadata[])
     if (field.startsWith(STRUCTURED_PROPERTIES_FILTER_NAME) && entity) {
         const structuredPropEntity = entity as StructuredPropertyEntity;
         const valueTypeUrn = structuredPropEntity.definition?.valueType?.urn;
+        const hasAllowedValues = !!structuredPropEntity.definition?.allowedValues?.length;
         if (valueTypeUrn === URN_TYPE_URN) {
             type = FieldType.ENTITY;
             // Prefer the explicit typeQualifier allowedTypes; fall back to inference from aggregations.
@@ -492,6 +515,14 @@ function getDynamicFilterField(field: string, availableFilters: FacetMetadata[])
             if (qualifierTypes?.length) {
                 entityTypes = qualifierTypes.map((t) => t.type).filter(Boolean) as EntityType[];
             }
+        } else if ((valueTypeUrn === STRING_TYPE_URN || valueTypeUrn === RICH_TEXT_TYPE_URN) && !hasAllowedValues) {
+            // Free-form text properties (no constrained allowedValues) are not enumerable — e.g. one
+            // holding arbitrary UUIDs. Render them as a type-a-value TEXT filter (which applies a
+            // CONTAINS query), like the description / field-path text filters, instead of an
+            // aggregation bucket picker that can only surface the top-N distinct values and breaks on
+            // high-cardinality values. Properties WITH allowedValues stay ENUM so users can pick from
+            // the constrained set.
+            type = FieldType.TEXT;
         }
     }
 
@@ -555,8 +586,11 @@ export function getStructuredPropFilterDisplayName(field: string, value: string,
         return dayjs(parseInt(value, 10)).tz('GMT').format('MM/DD/YYYY').toString();
     }
 
-    // check for structured prop number values
-    if (!Number.isNaN(parseFloat(value))) {
+    // check for structured prop number values. Detect by the property's declared value type rather
+    // than sniffing the string with parseFloat — parseFloat parses a leading numeric chunk and
+    // ignores the rest, so values like "550e8400-..." (a UUID) became "Infinity" and "02d22a5f-..."
+    // became "2". When the value type is unknown, fall through to render the raw value verbatim.
+    if (entity && (entity as StructuredPropertyEntity).definition?.valueType?.urn === NUMBER_TYPE_URN) {
         return parseFloat(value).toString();
     }
 
@@ -573,13 +607,17 @@ export function getStructuredPropFilterDisplayName(field: string, value: string,
 function convertToFilterPredicate(filter: FacetFilterInput, availableFilters: FacetMetadata[]): FilterPredicate {
     // First, check whether this is a well-supported filter field.
     const field = getKnownFilterField(filter.field) || getDynamicFilterField(filter.field, availableFilters);
+    // When no explicit condition is set (e.g. an available-but-unapplied filter in the "More" menu),
+    // fall back to the field type's natural default: free-form TEXT fields filter by CONTAINS,
+    // everything else by EQUALS. Mirrors getDefaultFieldOperatorType, inlined to avoid a circular
+    // import between this module and value/utils.
     const operator =
         (filter.condition &&
             convertBackendToFrontendOperatorType({
                 operator: filter.condition,
                 negated: filter.negated || false,
             })) ||
-        FilterOperatorType.EQUALS;
+        (field.type === FieldType.TEXT ? FilterOperatorType.CONTAINS : FilterOperatorType.EQUALS);
 
     const values = getFilterValues(filter, availableFilters);
     const defaultOptions = getDefaultFilterOptions(filter, availableFilters);
@@ -721,6 +759,8 @@ export function getFilterDisplayName(option: FilterValueOption, field: FilterFie
     }
 
     return field.field.startsWith(STRUCTURED_PROPERTIES_FILTER_NAME)
-        ? getStructuredPropFilterDisplayName(field.field, option.value)
+        ? // pass the field's structured-property entity so the formatter can detect the value type
+          // (NUMBER/DATE) — without it, numeric buckets render as the raw double (e.g. "42000.0").
+          getStructuredPropFilterDisplayName(field.field, option.value, field.entity)
         : undefined;
 }

--- a/datahub-web-react/src/app/searchV2/filters/value/EntityValueMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/EntityValueMenu.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDebounce } from 'react-use';
 
 import OptionsDropdownMenu from '@app/searchV2/filters/OptionsDropdownMenu';
 import { mapFilterOption } from '@app/searchV2/filters/mapFilterOption';
@@ -11,6 +12,8 @@ import {
     useLoadSearchOptions,
 } from '@app/searchV2/filters/value/utils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
+
+const DEBOUNCE_MS = 300;
 
 interface Props {
     field: EntityFilterField;
@@ -41,8 +44,18 @@ export default function EntityValueMenu({
     // Ideally we would not have staged values, and filters would update automatically.
     const [searchQuery, setSearchQuery] = useState<string | undefined>(undefined);
 
+    // Debounce the value that drives the server-side autocomplete query so we don't fire a
+    // GetAutoCompleteMultipleResults request on every keystroke. The raw searchQuery still
+    // drives the input and local (client-side) option filtering for instant feedback.
+    const [debouncedSearchQuery, setDebouncedSearchQuery] = useState<string | undefined>(undefined);
+    useDebounce(() => setDebouncedSearchQuery(searchQuery), DEBOUNCE_MS, [searchQuery]);
+
     // Here we optionally load the search options, which are the options that are displayed when the user searches.
-    const { options: searchOptions, loading: searchLoading } = useLoadSearchOptions(field, searchQuery, !isSearchable);
+    const { options: searchOptions, loading: searchLoading } = useLoadSearchOptions(
+        field,
+        debouncedSearchQuery,
+        !isSearchable,
+    );
 
     const localSearchOptions = useFilterOptionsBySearchQuery(defaultOptions, searchQuery);
 

--- a/datahub-web-react/src/app/searchV2/filters/value/EnumValueMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/EnumValueMenu.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useDebounce } from 'react-use';
 
 import OptionsDropdownMenu from '@app/searchV2/filters/OptionsDropdownMenu';
 import { mapFilterOption } from '@app/searchV2/filters/mapFilterOption';
@@ -12,6 +13,8 @@ import {
 } from '@app/searchV2/filters/value/utils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 import { EntityType } from '@src/types.generated';
+
+const DEBOUNCE_MS = 300;
 
 interface Props {
     field: FilterField;
@@ -42,6 +45,12 @@ export default function EnumValueMenu({
     // Ideally we would not have staged values, and filters would update automatically.
     const [searchQuery, setSearchQuery] = useState<string | undefined>(undefined);
 
+    // Debounce the value that drives the server-side aggregation query so we don't fire
+    // an aggregateAcrossEntities request on every keystroke. The raw searchQuery still
+    // drives the input and local (client-side) option filtering for instant feedback.
+    const [debouncedSearchQuery, setDebouncedSearchQuery] = useState<string | undefined>(undefined);
+    useDebounce(() => setDebouncedSearchQuery(searchQuery), DEBOUNCE_MS, [searchQuery]);
+
     // Here we optionally load the aggregation options, which are the options that are displayed by default.
     const { options: aggOptions, loading: aggLoading } = useLoadAggregationOptions({
         field,
@@ -55,10 +64,10 @@ export default function EnumValueMenu({
     // Do an aggregations query with the given search query as a filter to find any values not in the first set of results
     const { options: searchAggOptions, loading: searchAggsLoading } = useLoadAggregationOptions({
         field,
-        visible: !!searchQuery, // only run this query if there's a search query
+        visible: !!debouncedSearchQuery, // only run this query if there's a (debounced) search query
         includeCounts: includeCount,
         aggregationsEntityTypes,
-        extraOrFilters: [{ and: [{ field: field.field, values: [searchQuery || ''] }] }],
+        extraOrFilters: [{ and: [{ field: field.field, values: [debouncedSearchQuery || ''] }] }],
         removeOptionsWithNoCount: true,
     });
 

--- a/datahub-web-react/src/app/searchV2/filters/value/TextValueMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/TextValueMenu.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { FilterField, FilterValue } from '@app/searchV2/filters/types';
+import { useFilterDisplayName } from '@app/searchV2/filters/utils';
 import TextValueInput from '@app/searchV2/filters/value/TextValueInput';
 
 const Container = styled.div`
@@ -31,7 +32,9 @@ interface Props {
 export default function TextValueMenu({ field, values, onChangeValues, onApply }: Props) {
     const { t } = useTranslation('search');
     const { t: tc } = useTranslation('common.actions');
-    const { displayName } = field;
+    // Resolve the human-readable label (e.g. "UUID Filter Test") rather than the raw field name
+    // (structuredProperties.uuidFilterTest), consistent with the enum/entity menus.
+    const displayName = useFilterDisplayName(field);
     const value = values.length > 0 ? values[0].displayName || values[0].value : '';
 
     return (

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilder.java
@@ -242,6 +242,35 @@ public class V2MappingsBuilder implements MappingsBuilder {
         .build();
   }
 
+  /**
+   * Mapping for URN-typed structured-property values. Identical to {@link #getMappingsForUrn()} but
+   * also exposes a ".keyword" subfield. Structured-property values are filtered and aggregated by
+   * exact match, which targets "&lt;field&gt;.keyword" (see {@link
+   * com.linkedin.metadata.search.utils.ESUtils#toKeywordField} and {@link
+   * com.linkedin.metadata.models.StructuredPropertyUtils#toStructuredPropertyFacetName}). The
+   * shared URN mapping only provides ".delimited"/".ngram", so without ".keyword" URN-typed
+   * structured property filters and facets silently return nothing. Regular URN filter fields
+   * (owners, domains, ...) likewise expose a keyword subfield for exact match.
+   */
+  private Map<String, Object> getMappingsForStructuredPropertyUrn() {
+    Map<String, Object> subFields = new HashMap<>();
+    subFields.put(
+        DELIMITED,
+        ImmutableMap.of(
+            TYPE, ESUtils.TEXT_FIELD_TYPE,
+            ANALYZER, URN_ANALYZER,
+            SEARCH_ANALYZER, URN_SEARCH_ANALYZER,
+            SEARCH_QUOTE_ANALYZER, CUSTOM_QUOTE_ANALYZER));
+    subFields.put(
+        NGRAM,
+        getPartialNgramConfigWithOverrides(ImmutableMap.of(ANALYZER, PARTIAL_URN_COMPONENT)));
+    subFields.put(KEYWORD, KEYWORD_TYPE_MAP);
+    return ImmutableMap.<String, Object>builder()
+        .put(TYPE, ESUtils.KEYWORD_FIELD_TYPE)
+        .put(FIELDS, subFields)
+        .build();
+  }
+
   private static Map<String, Object> getMappingsForRunId() {
     return ImmutableMap.<String, Object>builder().put(TYPE, ESUtils.KEYWORD_FIELD_TYPE).build();
   }
@@ -270,7 +299,7 @@ public class V2MappingsBuilder implements MappingsBuilder {
                   mappingForField.put(TYPE, ESUtils.DATE_FIELD_TYPE);
                   break;
                 case URN:
-                  mappingForField = getMappingsForUrn();
+                  mappingForField = getMappingsForStructuredPropertyUrn();
                   break;
                 case NUMBER:
                   mappingForField.put(TYPE, ESUtils.DOUBLE_FIELD_TYPE);

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilderTest.java
@@ -735,6 +735,90 @@ public class V2MappingsBuilderTest {
     }
   }
 
+  @Test
+  public void testUrnStructuredPropertyHasKeywordSubfield() throws URISyntaxException {
+    // URN-typed structured properties must have a .keyword subfield so that
+    // toStructuredPropertyFacetName() (which appends ".keyword") resolves correctly in
+    // aggregations.
+    // Without .keyword the facet returns no results and the filter never appears in the UI.
+    StructuredPropertyDefinition urnProp =
+        new StructuredPropertyDefinition()
+            .setVersion(null, SetMode.REMOVE_IF_NULL)
+            .setQualifiedName("steward")
+            .setDisplayName("Steward")
+            .setEntityTypes(new UrnArray(Urn.createFromString(ENTITY_TYPE_URN_PREFIX + "dataset")))
+            .setValueType(Urn.createFromString("urn:li:dataType:datahub.urn"));
+
+    Urn spUrn = UrnUtils.getUrn("urn:li:structuredProperty:steward");
+    EntityRegistry entityRegistry = operationContext.getEntityRegistry();
+    EntitySpec datasetSpec = entityRegistry.getEntitySpec("dataset");
+
+    Map<String, Object> mappings =
+        mappingsBuilder.getIndexMappings(
+            entityRegistry, datasetSpec, List.of(Pair.of(spUrn, urnProp)));
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> spProps = (Map<String, Object>) properties.get("structuredProperties");
+    assertNotNull(spProps, "Dataset mapping must have structuredProperties for a URN prop");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> spFields = (Map<String, Object>) spProps.get("properties");
+
+    assertTrue(spFields.containsKey("steward"), "Should contain the steward field");
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> stewardMapping = (Map<String, Object>) spFields.get("steward");
+    assertEquals(stewardMapping.get("type"), "keyword", "Top-level type should be keyword");
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> subFields = (Map<String, Object>) stewardMapping.get("fields");
+    assertNotNull(subFields, "URN structured property must have subfields");
+    assertTrue(
+        subFields.containsKey("keyword"),
+        "URN structured property must have .keyword subfield for aggregation facets");
+    assertTrue(
+        subFields.containsKey("delimited"),
+        "URN structured property must have .delimited subfield for URN component search");
+  }
+
+  @Test
+  public void testStringStructuredPropertyHasKeywordSubfield() throws URISyntaxException {
+    // Baseline: STRING-typed structured properties already had .keyword — ensure we did not
+    // regress.
+    StructuredPropertyDefinition stringProp =
+        new StructuredPropertyDefinition()
+            .setVersion(null, SetMode.REMOVE_IF_NULL)
+            .setQualifiedName("category")
+            .setDisplayName("Category")
+            .setEntityTypes(new UrnArray(Urn.createFromString(ENTITY_TYPE_URN_PREFIX + "dataset")))
+            .setValueType(Urn.createFromString("urn:li:dataType:datahub.string"));
+
+    Urn spUrn = UrnUtils.getUrn("urn:li:structuredProperty:category");
+    EntityRegistry entityRegistry = operationContext.getEntityRegistry();
+    EntitySpec datasetSpec = entityRegistry.getEntitySpec("dataset");
+
+    Map<String, Object> mappings =
+        mappingsBuilder.getIndexMappings(
+            entityRegistry, datasetSpec, List.of(Pair.of(spUrn, stringProp)));
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> spProps = (Map<String, Object>) properties.get("structuredProperties");
+    assertNotNull(spProps, "Dataset mapping must have structuredProperties for a STRING prop");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> spFields = (Map<String, Object>) spProps.get("properties");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> catMapping = (Map<String, Object>) spFields.get("category");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> subFields = (Map<String, Object>) catMapping.get("fields");
+    assertNotNull(subFields, "STRING structured property must have subfields");
+    assertTrue(
+        subFields.containsKey("keyword"),
+        "STRING structured property must still have .keyword subfield");
+  }
+
   private EntityRegistry getTestEntityRegistry() {
     return new ConfigEntityRegistry(
         TestSearchFieldConfig.class


### PR DESCRIPTION
## Summary

Improves structured property filter reliability across five areas:

- **URN-type structured properties now show up as filter options in the search sidebar.** These properties were missing a `.keyword` subfield in their OpenSearch mapping, but `toStructuredPropertyFacetName()` appends `.keyword` for aggregation queries. Without it, the aggregation returned zero buckets and the filter widget never appeared. Added `getMappingsForStructuredPropertyUrn()` to include the subfield.

- **Free-form text filters now return results for partial values.** STRING/RICH_TEXT structured properties without `allowedValues` were getting `condition: undefined` (backend defaults to EQUAL), so typing a partial value in the filter input returned nothing. Added `getNewFilterCondition()` to set `FilterOperator.Contain` for text fields, and routed free-form STRING/RICH_TEXT props to `FieldType.TEXT` in `getDynamicFilterField`.

- **Numeric type detection no longer misidentifies UUID values as numbers.** `getStructuredPropFilterDisplayName` used `parseFloat()` to detect numbers, which parses UUID strings (e.g. `"550e8400-..."`) as `Infinity`. Now checks `valueType.urn` against `NUMBER_TYPE_URN` instead.

- **`TextValueMenu` now shows the property's display name instead of its raw field key.** The filter input title was showing `structuredProperties.myProp` rather than the human-readable name. Now uses `useFilterDisplayName`, consistent with the enum and entity filter menus.

- **NUMBER-typed filter buckets now render the formatted value instead of the raw ES double.** `useLoadAggregationOptions` passed `field.entity` to `getStructuredPropFilterDisplayName`, but `field.entity` doesn't reliably carry the structured property's definition (`valueType`) in every dropdown code path. Without it, number buckets rendered as `"42000.0"` in the dropdown, inconsistent with the formatted value the selected-filter chip showed for the same value. Now prefers the aggregation facet's own entity, which does carry the definition, falling back to `field.entity`.

## Testing

- Unit tests added for numeric type detection, UUID safety, and CONTAINS condition routing (`utils.test.tsx`)
- Java unit tests added for URN and STRING structured property keyword subfield mapping (`V2MappingsBuilderTest.java`)

## Checklist

- [x] URN-type structured property filter option appears in the search sidebar
- [x] STRING property with a UUID value displays the UUID correctly
- [x] Free-form STRING property: typing a partial value returns matching results
- [x] NUMBER property filter dropdown shows the formatted value, matching the selected-filter chip
- [x] CI green
