### PR TITLE
perf(auth): cache resource owners per authorize() call to remove ownership-fetch.

### DIFF
--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/PolicyEngine.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/PolicyEngine.java
@@ -25,6 +25,7 @@ import io.datahubproject.metadata.context.ServicesRegistryContext;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -482,34 +483,44 @@ public class PolicyEngine {
   private Set<String> getOwnersForType(
       @Nonnull OperationContext opContext,
       @Nonnull EntitySpec resourceSpec,
-      @Nonnull List<Urn> ownershipTypes) {
+      @Nonnull List<Urn> ownershipTypes,
+      @Nonnull PolicyEvaluationContext context) {
     if (resourceSpec.getEntity().isEmpty()) {
       return Set.of();
-    } else {
-      Urn entityUrn = UrnUtils.getUrn(resourceSpec.getEntity());
-      EnvelopedAspect ownershipAspect;
-      try {
-        EntityResponse response =
-            _entityClient.getV2(
-                opContext,
-                entityUrn.getEntityType(),
-                entityUrn,
-                Collections.singleton(Constants.OWNERSHIP_ASPECT_NAME));
-        if (response == null
-            || !response.getAspects().containsKey(Constants.OWNERSHIP_ASPECT_NAME)) {
-          return Collections.emptySet();
-        }
-        ownershipAspect = response.getAspects().get(Constants.OWNERSHIP_ASPECT_NAME);
-      } catch (Exception e) {
-        log.error("Error while retrieving ownership aspect for urn {}", entityUrn, e);
-        return Collections.emptySet();
+    }
+    // A resource's ownership is actor-independent. Fetch the full owner list once per resource per
+    // authorize() call (multiple ownership policies on the same resource reuse the cached fetch),
+    // then filter by ownership type in memory.
+    final List<Owner> owners =
+        context
+            .getResourceOwnersByUrn()
+            .computeIfAbsent(resourceSpec.getEntity(), urn -> fetchOwners(opContext, urn));
+
+    Stream<Owner> ownersStream = owners.stream();
+    if (ownershipTypes != null) {
+      ownersStream = ownersStream.filter(owner -> ownershipTypes.contains(owner.getTypeUrn()));
+    }
+    return ownersStream.map(owner -> owner.getOwner().toString()).collect(Collectors.toSet());
+  }
+
+  private List<Owner> fetchOwners(
+      @Nonnull OperationContext opContext, @Nonnull String resourceUrn) {
+    Urn entityUrn = UrnUtils.getUrn(resourceUrn);
+    try {
+      EntityResponse response =
+          _entityClient.getV2(
+              opContext,
+              entityUrn.getEntityType(),
+              entityUrn,
+              Collections.singleton(Constants.OWNERSHIP_ASPECT_NAME));
+      if (response == null || !response.getAspects().containsKey(Constants.OWNERSHIP_ASPECT_NAME)) {
+        return Collections.emptyList();
       }
-      Ownership ownership = new Ownership(ownershipAspect.getValue().data());
-      Stream<Owner> ownersStream = ownership.getOwners().stream();
-      if (ownershipTypes != null) {
-        ownersStream = ownersStream.filter(owner -> ownershipTypes.contains(owner.getTypeUrn()));
-      }
-      return ownersStream.map(owner -> owner.getOwner().toString()).collect(Collectors.toSet());
+      EnvelopedAspect ownershipAspect = response.getAspects().get(Constants.OWNERSHIP_ASPECT_NAME);
+      return new Ownership(ownershipAspect.getValue().data()).getOwners();
+    } catch (Exception e) {
+      log.error("Error while retrieving ownership aspect for urn {}", entityUrn, e);
+      return Collections.emptyList();
     }
   }
 
@@ -519,7 +530,8 @@ public class PolicyEngine {
       ResolvedEntitySpec resourceSpec,
       List<Urn> ownershipTypes,
       PolicyEvaluationContext context) {
-    Set<String> owners = this.getOwnersForType(opContext, resourceSpec.getSpec(), ownershipTypes);
+    Set<String> owners =
+        this.getOwnersForType(opContext, resourceSpec.getSpec(), ownershipTypes, context);
     if (isUserOwner(resolvedActorSpec, owners)) {
       return true;
     }
@@ -627,6 +639,13 @@ public class PolicyEngine {
     private Set<Urn> roles;
     private SessionActorIdentity sessionActorIdentity;
     private OperationContext opContext;
+    // Resource owners cache, keyed by resource URN. Scoped to a single authorize() call: dedupes
+    // the ownership fetch across all ownership policies evaluated for the same resource.
+    private final Map<String, List<Owner>> resourceOwnersByUrn = new HashMap<>();
+
+    Map<String, List<Owner>> getResourceOwnersByUrn() {
+      return resourceOwnersByUrn;
+    }
 
     public void setGroups(Set<String> groups) {
       this.groups = groups;

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authorization/PolicyEngineTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authorization/PolicyEngineTest.java
@@ -526,6 +526,82 @@ public class PolicyEngineTest {
   }
 
   @Test
+  public void testSharedContextFetchesResourceOwnersOnceAcrossPolicies() throws Exception {
+    // An ownership-based policy: the actor matches ONLY via resource ownership (no user/group/role
+    // match), so each evaluation reaches the ownership lookup.
+    final DataHubPolicyInfo ownerPolicy = new DataHubPolicyInfo();
+    ownerPolicy.setType(METADATA_POLICY_TYPE);
+    ownerPolicy.setState(ACTIVE_POLICY_STATE);
+    ownerPolicy.setPrivileges(new StringArray("EDIT_ENTITY_TAGS"));
+    ownerPolicy.setDisplayName("Owner policy");
+    ownerPolicy.setDescription("Owner policy");
+    ownerPolicy.setEditable(true);
+
+    final DataHubActorFilter actorFilter = new DataHubActorFilter();
+    actorFilter.setResourceOwners(true);
+    actorFilter.setAllUsers(false);
+    actorFilter.setAllGroups(false);
+    ownerPolicy.setActors(actorFilter);
+
+    final DataHubResourceFilter resourceFilter = new DataHubResourceFilter();
+    resourceFilter.setAllResources(true);
+    resourceFilter.setType("dataset");
+    ownerPolicy.setResources(resourceFilter);
+
+    final EntityResponse ownershipResponse = new EntityResponse();
+    final EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    aspectMap.put(
+        OWNERSHIP_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(createOwnershipAspect(true, false).data())));
+    ownershipResponse.setAspects(aspectMap);
+    when(_entityClient.getV2(
+            eq(systemOperationContext),
+            eq(resourceUrn.getEntityType()),
+            eq(resourceUrn),
+            eq(Collections.singleton(Constants.OWNERSHIP_ASPECT_NAME))))
+        .thenReturn(ownershipResponse);
+
+    final ResolvedEntitySpec resourceSpec = buildEntityResolvers("dataset", RESOURCE_URN);
+
+    // Shared per-request context: the resource-owner cache lives here.
+    final PolicyEngine.PolicyEvaluationContext sharedContext =
+        _policyEngine.createSeededEvaluationContext(
+            Collections.emptyList(), Collections.emptySet());
+
+    // Evaluate the ownership policy twice against the SAME resource, sharing one context.
+    assertTrue(
+        _policyEngine
+            .evaluatePolicy(
+                systemOperationContext,
+                ownerPolicy,
+                resolvedAuthorizedUserSpec,
+                "EDIT_ENTITY_TAGS",
+                Optional.of(resourceSpec),
+                Collections.emptyList(),
+                sharedContext)
+            .isGranted());
+    assertTrue(
+        _policyEngine
+            .evaluatePolicy(
+                systemOperationContext,
+                ownerPolicy,
+                resolvedAuthorizedUserSpec,
+                "EDIT_ENTITY_TAGS",
+                Optional.of(resourceSpec),
+                Collections.emptyList(),
+                sharedContext)
+            .isGranted());
+
+    // Ownership fetched exactly once across both evaluations, thanks to the per-context cache.
+    verify(_entityClient, times(1))
+        .getV2(
+            eq(systemOperationContext),
+            eq(resourceUrn.getEntityType()),
+            eq(resourceUrn),
+            eq(Collections.singleton(Constants.OWNERSHIP_ASPECT_NAME)));
+  }
+
+  @Test
   public void testEvaluatePolicyActorFilterRoleMatch() throws Exception {
 
     final DataHubPolicyInfo dataHubPolicyInfo = new DataHubPolicyInfo();


### PR DESCRIPTION
## Summary

`PolicyEngine.getOwnersForType()` fetched a resource's `ownership` aspect via
`entityClient.getV2(OWNERSHIP_ASPECT_NAME)` **once per ownership-based policy**, even when
multiple such policies were evaluated against the **same resource** in a single `authorize()`
call. On pages that authorize many assets under several ownership policies this produced a
large N+1 of uncached backend reads (e.g. 25 assets × 10 ownership policies ≈ 250 `getV2`
calls per page load).

This change caches the resolved owner list **per `authorize()` call**, keyed by resource URN,
so each resource's ownership is fetched at most once regardless of how many ownership policies
reference it. The full owner list is cached and ownership-type filtering is applied in memory
(the `getV2` already returns all owners), so different `ownershipTypes` reuse the same fetch.

## Changes

- `PolicyEvaluationContext` gains a `Map<String, List<Owner>> resourceOwnersByUrn` cache
  (request/authorize-call scoped — created once per `authorize()` and shared across the policies
  evaluated in that call).
- `getOwnersForType()` now reads through `computeIfAbsent(resourceUrn, ...)` and filters owners
  by type in memory. Extracted the actual fetch into a new `fetchOwners()` helper.
- Empty/missing ownership is negative-cached (empty list) so resources without owners are not
  re-fetched.

## Behavior

No functional change. Same owner-match semantics, same ownership-type filtering, same
ALLOW/DENY outcomes. Only the number of backend `getV2` calls is reduced.

## Scope

Improves resource-authorization paths (search / browse / list / entity views) where access is
ownership-driven. Does not affect platform-privilege checks (no resource → ownership path never
runs).