### PR TITLE
fix(auth): allow EDIT_ENTITY_TAGS for tag writes via REST API

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LabelUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LabelUtils.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.mutate.util;
 
 import static com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils.*;
 
+import com.datahub.authorization.AuthUtil;
 import com.datahub.authorization.ConjunctivePrivilegeGroup;
 import com.datahub.authorization.DisjunctivePrivilegeGroup;
 import com.google.common.collect.ImmutableList;
@@ -236,23 +237,12 @@ public class LabelUtils {
 
   public static boolean isAuthorizedToUpdateTags(
       @Nonnull QueryContext context, Urn targetUrn, String subResource, Collection<Urn> tagUrns) {
-
-    Boolean isTargetingSchema = subResource != null && subResource.length() > 0;
-    // Decide whether the current principal should be allowed to update the Dataset.
-    // If you either have all entity privileges, or have the specific privileges required, you are
-    // authorized.
-    final DisjunctivePrivilegeGroup orPrivilegeGroups =
-        new DisjunctivePrivilegeGroup(
-            ImmutableList.of(
-                ALL_PRIVILEGES_GROUP,
-                new ConjunctivePrivilegeGroup(
-                    ImmutableList.of(
-                        isTargetingSchema
-                            ? PoliciesConfig.EDIT_DATASET_COL_TAGS_PRIVILEGE.getType()
-                            : PoliciesConfig.EDIT_ENTITY_TAGS_PRIVILEGE.getType()))));
-
-    return AuthorizationUtils.isAuthorizedForTags(
-        context, targetUrn.getEntityType(), targetUrn.toString(), orPrivilegeGroups, tagUrns);
+    boolean fieldLevel = subResource != null && !subResource.isEmpty();
+    return AuthUtil.isAuthorizedForTagModification(
+        context.getOperationContext(),
+        targetUrn,
+        tagUrns,
+        AuthUtil.tagModificationPrivilege(targetUrn, fieldLevel));
   }
 
   public static boolean isAuthorizedToUpdateTerms(

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LabelUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LabelUtilsTest.java
@@ -1,0 +1,43 @@
+package com.linkedin.datahub.graphql.resolvers.mutate.util;
+
+import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
+import static com.linkedin.datahub.graphql.TestUtils.getMockDenyContextWithOperationContext;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import java.util.Collections;
+import java.util.List;
+import org.testng.annotations.Test;
+
+public class LabelUtilsTest {
+
+  private static final Urn DATASET_URN =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:mysql,my-test,PROD)");
+  private static final Urn TAG_URN = UrnUtils.getUrn("urn:li:tag:test-tag");
+
+  @Test
+  public void testIsAuthorizedToUpdateGlobalTags() {
+    QueryContext context = getMockAllowContext();
+    assertTrue(LabelUtils.isAuthorizedToUpdateTags(context, DATASET_URN, null, List.of(TAG_URN)));
+    assertTrue(
+        LabelUtils.isAuthorizedToUpdateTags(context, DATASET_URN, null, Collections.emptyList()));
+  }
+
+  @Test
+  public void testIsAuthorizedToUpdateSchemaFieldTags() {
+    QueryContext context = getMockAllowContext();
+    assertTrue(
+        LabelUtils.isAuthorizedToUpdateTags(context, DATASET_URN, "field1", List.of(TAG_URN)));
+  }
+
+  @Test
+  public void testIsAuthorizedToUpdateTagsDenied() {
+    QueryContext context = getMockDenyContextWithOperationContext();
+    assertFalse(LabelUtils.isAuthorizedToUpdateTags(context, DATASET_URN, null, List.of(TAG_URN)));
+    assertFalse(
+        LabelUtils.isAuthorizedToUpdateTags(context, DATASET_URN, "field1", List.of(TAG_URN)));
+  }
+}

--- a/metadata-auth/auth-api/src/main/java/com/datahub/authorization/AuthUtil.java
+++ b/metadata-auth/auth-api/src/main/java/com/datahub/authorization/AuthUtil.java
@@ -305,6 +305,72 @@ public class AuthUtil {
                     subResourceSpecs));
   }
 
+  /** Authorizes a request when REST API authorization is enabled. */
+  public static boolean isAPIAuthorized(
+      @Nonnull final AuthorizationSession session,
+      @Nonnull final DisjunctivePrivilegeGroup privilegeGroup,
+      @Nullable final EntitySpec resourceSpec,
+      @Nonnull final Collection<EntitySpec> subResources) {
+    if (AuthUtil.isRestApiAuthorizationEnabled) {
+      return isAuthorized(session, privilegeGroup, resourceSpec, subResources);
+    }
+    return true;
+  }
+
+  /** Returns the tag-specific privilege required to modify tags on an entity. */
+  public static PoliciesConfig.Privilege tagModificationPrivilege(
+      @Nonnull final Urn entityUrn, final boolean fieldLevelTags) {
+    if (fieldLevelTags && DATASET_ENTITY_NAME.equals(entityUrn.getEntityType())) {
+      return PoliciesConfig.EDIT_DATASET_COL_TAGS_PRIVILEGE;
+    }
+    return PoliciesConfig.EDIT_ENTITY_TAGS_PRIVILEGE;
+  }
+
+  /** Either {@code EDIT_ENTITY} or the specific tag privilege is sufficient. */
+  public static DisjunctivePrivilegeGroup tagModificationPrivilegeGroup(
+      @Nonnull final PoliciesConfig.Privilege specificTagPrivilege) {
+    return new DisjunctivePrivilegeGroup(
+        List.of(
+            new ConjunctivePrivilegeGroup(List.of(PoliciesConfig.EDIT_ENTITY_PRIVILEGE.getType())),
+            new ConjunctivePrivilegeGroup(List.of(specificTagPrivilege.getType()))));
+  }
+
+  public static boolean isAuthorizedForTagModification(
+      @Nonnull final AuthorizationSession session,
+      @Nonnull final Urn entityUrn,
+      @Nonnull final Collection<Urn> tagUrns,
+      @Nonnull final PoliciesConfig.Privilege specificTagPrivilege) {
+    if (tagUrns.isEmpty()) {
+      return true;
+    }
+    return isAuthorized(
+        session,
+        tagModificationPrivilegeGroup(specificTagPrivilege),
+        new EntitySpec(entityUrn.getEntityType(), entityUrn.toString()),
+        tagSubResourceSpecs(tagUrns));
+  }
+
+  public static boolean isAPIAuthorizedForTagModification(
+      @Nonnull final AuthorizationSession session,
+      @Nonnull final Urn entityUrn,
+      @Nonnull final Collection<Urn> tagUrns,
+      @Nonnull final PoliciesConfig.Privilege specificTagPrivilege) {
+    if (tagUrns.isEmpty()) {
+      return true;
+    }
+    return isAPIAuthorized(
+        session,
+        tagModificationPrivilegeGroup(specificTagPrivilege),
+        new EntitySpec(entityUrn.getEntityType(), entityUrn.toString()),
+        tagSubResourceSpecs(tagUrns));
+  }
+
+  private static Set<EntitySpec> tagSubResourceSpecs(@Nonnull final Collection<Urn> tagUrns) {
+    return tagUrns.stream()
+        .map(urn -> new EntitySpec(urn.getEntityType(), urn.toString()))
+        .collect(Collectors.toSet());
+  }
+
   public static boolean isAPIAuthorizedEntityType(
       @Nonnull final AuthorizationSession session,
       @Nonnull final ApiOperation apiOperation,

--- a/metadata-auth/auth-api/src/test/java/com/datahub/authorization/AuthUtilTest.java
+++ b/metadata-auth/auth-api/src/test/java/com/datahub/authorization/AuthUtilTest.java
@@ -29,6 +29,8 @@ import com.linkedin.metadata.authorization.Conjunctive;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.util.Pair;
 import io.datahubproject.test.metadata.context.TestAuthSession;
+import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -482,6 +484,139 @@ public class AuthUtilTest {
             List.of(TEST_TAG),
             PoliciesConfig.EDIT_ENTITY_TAGS_PRIVILEGE),
         "Expected user without EDIT_ENTITY_TAGS to be denied");
+
+    assertTrue(
+        AuthUtil.isAPIAuthorizedForTagModification(
+            TestAuthSession.from(TEST_AUTH_B, mockAuthorizer),
+            TEST_ENTITY_1,
+            Collections.emptyList(),
+            PoliciesConfig.EDIT_ENTITY_TAGS_PRIVILEGE),
+        "Expected empty tag list to skip authorization");
+
+    Authorizer datasetColTagsAuthorizer =
+        mockAuthorizer(
+            Map.of(
+                TEST_AUTH_A.getActor().toUrnStr(),
+                Map.of("EDIT_DATASET_COL_TAGS", Set.of(TEST_ENTITY_1))));
+
+    assertTrue(
+        AuthUtil.isAPIAuthorizedForTagModification(
+            TestAuthSession.from(TEST_AUTH_A, datasetColTagsAuthorizer),
+            TEST_ENTITY_1,
+            List.of(TEST_TAG),
+            PoliciesConfig.EDIT_DATASET_COL_TAGS_PRIVILEGE),
+        "Expected EDIT_DATASET_COL_TAGS to authorize dataset column tag modifications");
+  }
+
+  @Test
+  public void testIsAuthorizedForTagModification() {
+    final Urn TEST_TAG = UrnUtils.getUrn("urn:li:tag:Legacy");
+
+    Authorizer editEntityAuthorizer =
+        mockAuthorizer(
+            Map.of(
+                TEST_AUTH_A.getActor().toUrnStr(), Map.of("EDIT_ENTITY", Set.of(TEST_ENTITY_1))));
+
+    assertTrue(
+        AuthUtil.isAuthorizedForTagModification(
+            TestAuthSession.from(TEST_AUTH_A, editEntityAuthorizer),
+            TEST_ENTITY_1,
+            List.of(TEST_TAG),
+            PoliciesConfig.EDIT_ENTITY_TAGS_PRIVILEGE),
+        "Expected EDIT_ENTITY to authorize tag modifications");
+
+    assertTrue(
+        AuthUtil.isAuthorizedForTagModification(
+            TestAuthSession.from(TEST_AUTH_B, editEntityAuthorizer),
+            TEST_ENTITY_1,
+            Collections.emptyList(),
+            PoliciesConfig.EDIT_ENTITY_TAGS_PRIVILEGE),
+        "Expected empty tag list to skip authorization");
+
+    Authorizer editEntityTagsAuthorizer =
+        mockAuthorizer(
+            Map.of(
+                TEST_AUTH_A.getActor().toUrnStr(),
+                Map.of("EDIT_ENTITY_TAGS", Set.of(TEST_ENTITY_1))));
+
+    assertTrue(
+        AuthUtil.isAuthorizedForTagModification(
+            TestAuthSession.from(TEST_AUTH_A, editEntityTagsAuthorizer),
+            TEST_ENTITY_1,
+            List.of(TEST_TAG),
+            PoliciesConfig.EDIT_ENTITY_TAGS_PRIVILEGE),
+        "Expected EDIT_ENTITY_TAGS to authorize tag modifications without EDIT_ENTITY");
+
+    assertFalse(
+        AuthUtil.isAuthorizedForTagModification(
+            TestAuthSession.from(TEST_AUTH_B, editEntityTagsAuthorizer),
+            TEST_ENTITY_1,
+            List.of(TEST_TAG),
+            PoliciesConfig.EDIT_ENTITY_TAGS_PRIVILEGE),
+        "Expected user without tag privileges to be denied");
+  }
+
+  @Test
+  public void testTagModificationPrivilege() {
+    Urn datasetUrn = UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:test,test,PROD)");
+    Urn dataFlowUrn = UrnUtils.getUrn("urn:li:dataFlow:(urn:li:dataPlatform:airflow,flow,PROD)");
+
+    assertEquals(
+        PoliciesConfig.EDIT_DATASET_COL_TAGS_PRIVILEGE,
+        AuthUtil.tagModificationPrivilege(datasetUrn, true));
+    assertEquals(
+        PoliciesConfig.EDIT_ENTITY_TAGS_PRIVILEGE,
+        AuthUtil.tagModificationPrivilege(datasetUrn, false));
+    assertEquals(
+        PoliciesConfig.EDIT_ENTITY_TAGS_PRIVILEGE,
+        AuthUtil.tagModificationPrivilege(dataFlowUrn, true));
+  }
+
+  @Test
+  public void testTagModificationPrivilegeGroup() {
+    assertEquals(
+        AuthUtil.tagModificationPrivilegeGroup(PoliciesConfig.EDIT_ENTITY_TAGS_PRIVILEGE),
+        new DisjunctivePrivilegeGroup(
+            List.of(
+                new ConjunctivePrivilegeGroup(List.of("EDIT_ENTITY")),
+                new ConjunctivePrivilegeGroup(List.of("EDIT_ENTITY_TAGS")))));
+
+    assertEquals(
+        AuthUtil.tagModificationPrivilegeGroup(PoliciesConfig.EDIT_DATASET_COL_TAGS_PRIVILEGE),
+        new DisjunctivePrivilegeGroup(
+            List.of(
+                new ConjunctivePrivilegeGroup(List.of("EDIT_ENTITY")),
+                new ConjunctivePrivilegeGroup(List.of("EDIT_DATASET_COL_TAGS")))));
+  }
+
+  @Test
+  public void testIsAPIAuthorizedSkipsWhenRestApiAuthorizationDisabled() throws Exception {
+    final Urn TEST_TAG = UrnUtils.getUrn("urn:li:tag:Legacy");
+    boolean previous = getRestApiAuthorizationEnabled();
+    setRestApiAuthorizationEnabled(false);
+    try {
+      assertTrue(
+          AuthUtil.isAPIAuthorizedForTagModification(
+              TestAuthSession.from(TEST_AUTH_B, mock(Authorizer.class)),
+              TEST_ENTITY_1,
+              List.of(TEST_TAG),
+              PoliciesConfig.EDIT_ENTITY_TAGS_PRIVILEGE),
+          "Expected REST API authorization disabled to bypass tag checks");
+    } finally {
+      setRestApiAuthorizationEnabled(previous);
+    }
+  }
+
+  private static boolean getRestApiAuthorizationEnabled() throws Exception {
+    Field field = AuthUtil.class.getDeclaredField("isRestApiAuthorizationEnabled");
+    field.setAccessible(true);
+    return field.getBoolean(null);
+  }
+
+  private static void setRestApiAuthorizationEnabled(boolean enabled) throws Exception {
+    Field field = AuthUtil.class.getDeclaredField("isRestApiAuthorizationEnabled");
+    field.setAccessible(true);
+    field.setBoolean(null, enabled);
   }
 
   private Authorizer mockAuthorizer(Map<String, Map<String, Set<Urn>>> allowActorPrivUrn) {

--- a/metadata-auth/auth-api/src/test/java/com/datahub/authorization/AuthUtilTest.java
+++ b/metadata-auth/auth-api/src/test/java/com/datahub/authorization/AuthUtilTest.java
@@ -457,6 +457,33 @@ public class AuthUtilTest {
         "Expected User B to be allowed access to subresources 2 & 3");
   }
 
+  @Test
+  public void testIsAPIAuthorizedForTagModification() {
+    final Urn TEST_TAG = UrnUtils.getUrn("urn:li:tag:Legacy");
+
+    Authorizer mockAuthorizer =
+        mockAuthorizer(
+            Map.of(
+                TEST_AUTH_A.getActor().toUrnStr(),
+                Map.of("EDIT_ENTITY_TAGS", Set.of(TEST_ENTITY_1))));
+
+    assertTrue(
+        AuthUtil.isAPIAuthorizedForTagModification(
+            TestAuthSession.from(TEST_AUTH_A, mockAuthorizer),
+            TEST_ENTITY_1,
+            List.of(TEST_TAG),
+            PoliciesConfig.EDIT_ENTITY_TAGS_PRIVILEGE),
+        "Expected EDIT_ENTITY_TAGS to authorize tag modifications without EDIT_ENTITY");
+
+    assertFalse(
+        AuthUtil.isAPIAuthorizedForTagModification(
+            TestAuthSession.from(TEST_AUTH_B, mockAuthorizer),
+            TEST_ENTITY_1,
+            List.of(TEST_TAG),
+            PoliciesConfig.EDIT_ENTITY_TAGS_PRIVILEGE),
+        "Expected user without EDIT_ENTITY_TAGS to be denied");
+  }
+
   private Authorizer mockAuthorizer(Map<String, Map<String, Set<Urn>>> allowActorPrivUrn) {
     Authorizer authorizer = mock(Authorizer.class);
     when(authorizer.authorize(any()))

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/TagPrivilegeConstraintsValidator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/TagPrivilegeConstraintsValidator.java
@@ -21,7 +21,7 @@ import com.linkedin.metadata.aspect.RetrieverContext;
 import com.linkedin.metadata.aspect.batch.BatchItem;
 import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
 import com.linkedin.metadata.aspect.plugins.validation.AspectValidationException;
-import com.linkedin.metadata.authorization.ApiOperation;
+import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.entity.ebean.batch.PatchItemImpl;
 import com.linkedin.metadata.entity.ebean.batch.ProposedItem;
 import com.linkedin.schema.EditableSchemaFieldInfo;
@@ -121,11 +121,8 @@ public class TagPrivilegeConstraintsValidator extends AbstractAspectAuthorizatio
     }
     if (newTags != null) {
       Set<Urn> tagDifference = extractTagDifference(newTags, currentTags);
-      if (!AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-          session,
-          ApiOperation.fromChangeType(item.getChangeType()),
-          List.of(item.getUrn()),
-          tagDifference)) {
+      if (!AuthUtil.isAPIAuthorizedForTagModification(
+          session, item.getUrn(), tagDifference, PoliciesConfig.EDIT_ENTITY_TAGS_PRIVILEGE)) {
         return List.of(
             AspectValidationException.forItem(
                 item, "Unauthorized to modify one or more tag Urns: " + tagDifference));
@@ -200,11 +197,11 @@ public class TagPrivilegeConstraintsValidator extends AbstractAspectAuthorizatio
                           existingTagsMap.get(schemaField.getFieldPath())))
               .flatMap(Set::stream)
               .collect(Collectors.toSet());
-      if (!AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
+      if (!AuthUtil.isAPIAuthorizedForTagModification(
           session,
-          ApiOperation.fromChangeType(item.getChangeType()),
-          List.of(item.getUrn()),
-          tagDifference)) {
+          item.getUrn(),
+          tagDifference,
+          AuthUtil.tagModificationPrivilege(item.getUrn(), true))) {
         return List.of(
             AspectValidationException.forItem(
                 item, "Unauthorized to modify one or more tag Urns: " + tagDifference));
@@ -260,11 +257,11 @@ public class TagPrivilegeConstraintsValidator extends AbstractAspectAuthorizatio
                           existingTagsMap.get(schemaField.getFieldPath())))
               .flatMap(Set::stream)
               .collect(Collectors.toSet());
-      if (!AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
+      if (!AuthUtil.isAPIAuthorizedForTagModification(
           session,
-          ApiOperation.fromChangeType(item.getChangeType()),
-          List.of(item.getUrn()),
-          tagDifference)) {
+          item.getUrn(),
+          tagDifference,
+          AuthUtil.tagModificationPrivilege(item.getUrn(), true))) {
         return List.of(
             AspectValidationException.forItem(
                 item, "Unauthorized to modify one or more tag Urns: " + tagDifference));

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/PrivilegeConstraintsValidatorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/PrivilegeConstraintsValidatorTest.java
@@ -1022,6 +1022,49 @@ public class PrivilegeConstraintsValidatorTest {
   }
 
   @Test
+  public void testEditDatasetColTagsPrivilegeAllowsAddingSchemaFieldTags() throws Exception {
+    closeAuthUtilMock();
+    boolean previousRestApiAuthorizationEnabled = getRestApiAuthorizationEnabled();
+    setRestApiAuthorizationEnabled(true);
+    try {
+      AuthorizationSession session =
+          TestAuthSession.from(
+              TAG_EDITOR_AUTH,
+              mockAuthorizer(
+                  Map.of(
+                      TAG_EDITOR_AUTH.getActor().toUrnStr(),
+                      Map.of("EDIT_DATASET_COL_TAGS", Set.of(TEST_DATASET_URN)))));
+
+      EditableSchemaMetadata editableSchemaMetadata =
+          createEditableSchemaMetadata("field1", TEST_TAG_URN);
+      BatchItem item =
+          TestMCP.ofOneUpsertItem(TEST_DATASET_URN, editableSchemaMetadata, TEST_REGISTRY).stream()
+              .findFirst()
+              .orElseThrow();
+
+      Mockito.doReturn(null)
+          .when(mockAspectRetriever)
+          .getLatestAspectObject(
+              any(OperationFingerprint.class),
+              Mockito.eq(TEST_DATASET_URN),
+              Mockito.eq(EDITABLE_SCHEMA_METADATA_ASPECT_NAME));
+
+      Stream<AspectValidationException> result =
+          validator.validateProposedAspectsWithAuth(
+              OperationFingerprint.EMPTY,
+              Collections.singletonList(item),
+              retrieverContext,
+              session);
+
+      Assert.assertTrue(
+          result.findAny().isEmpty(),
+          "Users granted only EDIT_DATASET_COL_TAGS should be able to add schema field tags");
+    } finally {
+      setRestApiAuthorizationEnabled(previousRestApiAuthorizationEnabled);
+    }
+  }
+
+  @Test
   public void testEditEntityTagsPrivilegeAllowsAddingGlobalTags() throws Exception {
     closeAuthUtilMock();
     boolean previousRestApiAuthorizationEnabled = getRestApiAuthorizationEnabled();

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/PrivilegeConstraintsValidatorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/PrivilegeConstraintsValidatorTest.java
@@ -7,10 +7,18 @@ import static com.linkedin.metadata.Constants.SCHEMA_METADATA_ASPECT_NAME;
 import static com.linkedin.metadata.Constants.SYSTEM_UPDATE_SOURCE;
 import static com.linkedin.metadata.Constants.UI_SOURCE;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.datahub.authentication.Actor;
+import com.datahub.authentication.ActorType;
+import com.datahub.authentication.Authentication;
 import com.datahub.authorization.AuthUtil;
+import com.datahub.authorization.AuthorizationRequest;
+import com.datahub.authorization.AuthorizationResult;
 import com.datahub.authorization.AuthorizationSession;
 import com.datahub.context.OperationFingerprint;
+import com.datahub.plugins.auth.authorization.Authorizer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.common.AuditStamp;
@@ -31,7 +39,6 @@ import com.linkedin.metadata.aspect.batch.BatchItem;
 import com.linkedin.metadata.aspect.patch.GenericJsonPatch;
 import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
 import com.linkedin.metadata.aspect.plugins.validation.AspectValidationException;
-import com.linkedin.metadata.authorization.ApiOperation;
 import com.linkedin.metadata.entity.SearchRetriever;
 import com.linkedin.metadata.entity.ebean.batch.ProposedItem;
 import com.linkedin.metadata.models.registry.EntityRegistry;
@@ -49,12 +56,15 @@ import com.linkedin.schema.StringType;
 import com.linkedin.test.metadata.aspect.TestEntityRegistry;
 import com.linkedin.test.metadata.aspect.batch.TestMCP;
 import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestAuthSession;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -68,8 +78,12 @@ public class PrivilegeConstraintsValidatorTest {
   private static final EntityRegistry TEST_REGISTRY = new TestEntityRegistry();
   private static final Urn TEST_DATASET_URN =
       UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:test,test,PROD)");
+  private static final Urn TEST_DATA_FLOW_URN =
+      UrnUtils.getUrn("urn:li:dataFlow:(urn:li:dataPlatform:airflow,my_flow,PROD)");
   private static final TagUrn TEST_TAG_URN = new TagUrn("TestTag");
   private static final TagUrn TEST_TAG_URN_2 = new TagUrn("TestTag2");
+  private static final Authentication TAG_EDITOR_AUTH =
+      new Authentication(new Actor(ActorType.USER, "tagEditor"), "");
 
   private PrivilegeConstraintsValidator validator;
   private SearchRetriever mockSearchRetriever;
@@ -173,11 +187,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.singleton(TEST_TAG_URN))))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(true);
 
     Stream<AspectValidationException> result =
@@ -208,11 +219,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.singleton(TEST_TAG_URN))))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(false);
 
     Stream<AspectValidationException> result =
@@ -252,11 +260,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.singleton(TEST_TAG_URN_2))))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(true);
 
     Stream<AspectValidationException> result =
@@ -291,11 +296,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.singleton(TEST_TAG_URN_2))))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(true);
 
     Stream<AspectValidationException> result =
@@ -330,11 +332,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.emptySet())))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(true);
 
     Stream<AspectValidationException> result =
@@ -364,11 +363,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.singleton(TEST_TAG_URN))))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(true);
 
     Stream<AspectValidationException> result =
@@ -398,11 +394,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.singleton(TEST_TAG_URN))))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(false);
 
     Stream<AspectValidationException> result =
@@ -443,11 +436,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.singleton(TEST_TAG_URN_2))))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(true);
 
     Stream<AspectValidationException> result =
@@ -483,11 +473,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.singleton(TEST_TAG_URN_2))))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(true);
 
     Stream<AspectValidationException> result =
@@ -524,11 +511,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.emptySet())))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(true);
 
     Stream<AspectValidationException> result =
@@ -559,11 +543,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.singleton(TEST_TAG_URN))))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(true);
 
     Stream<AspectValidationException> result =
@@ -594,11 +575,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.singleton(TEST_TAG_URN))))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(false);
 
     Stream<AspectValidationException> result =
@@ -640,11 +618,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.singleton(TEST_TAG_URN_2))))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(true);
 
     Stream<AspectValidationException> result =
@@ -681,11 +656,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.singleton(TEST_TAG_URN_2))))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(true);
 
     Stream<AspectValidationException> result =
@@ -722,11 +694,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.emptySet())))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(true);
 
     Stream<AspectValidationException> result =
@@ -823,11 +792,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.singleton(TEST_TAG_URN_2))))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(true);
 
     Stream<AspectValidationException> result =
@@ -885,11 +851,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.singleton(TEST_TAG_URN_2))))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(false);
 
     Stream<AspectValidationException> result =
@@ -950,7 +913,10 @@ public class PrivilegeConstraintsValidatorTest {
     item.setSystemMetadata(systemMetadata);
 
     authUtilMockedStatic
-        .when(() -> AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(any(), any(), any(), any()))
+        .when(
+            () ->
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    any(AuthorizationSession.class), any(Urn.class), any(), any()))
         .thenReturn(false);
 
     Stream<AspectValidationException> result =
@@ -1041,11 +1007,8 @@ public class PrivilegeConstraintsValidatorTest {
     authUtilMockedStatic
         .when(
             () ->
-                AuthUtil.isAPIAuthorizedEntityUrnsWithSubResources(
-                    Mockito.eq(mockAuthSession),
-                    Mockito.eq(ApiOperation.UPDATE),
-                    Mockito.eq(List.of(TEST_DATASET_URN)),
-                    Mockito.eq(Collections.singleton(TEST_TAG_URN))))
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    Mockito.eq(mockAuthSession), any(Urn.class), any(), any()))
         .thenReturn(true);
 
     Stream<AspectValidationException> result =
@@ -1056,6 +1019,103 @@ public class PrivilegeConstraintsValidatorTest {
             mockAuthSession);
 
     Assert.assertTrue(result.findAny().isEmpty());
+  }
+
+  @Test
+  public void testEditEntityTagsPrivilegeAllowsAddingGlobalTags() throws Exception {
+    closeAuthUtilMock();
+    boolean previousRestApiAuthorizationEnabled = getRestApiAuthorizationEnabled();
+    setRestApiAuthorizationEnabled(true);
+    try {
+      AuthorizationSession session =
+          TestAuthSession.from(
+              TAG_EDITOR_AUTH,
+              mockAuthorizer(
+                  Map.of(
+                      TAG_EDITOR_AUTH.getActor().toUrnStr(),
+                      Map.of("EDIT_ENTITY_TAGS", Set.of(TEST_DATA_FLOW_URN)))));
+
+      GlobalTags globalTags = createGlobalTags(TEST_TAG_URN);
+      BatchItem item =
+          TestMCP.ofOneUpsertItem(TEST_DATA_FLOW_URN, globalTags, TEST_REGISTRY).stream()
+              .findFirst()
+              .orElseThrow();
+
+      Mockito.doReturn(null)
+          .when(mockAspectRetriever)
+          .getLatestAspectObject(
+              any(OperationFingerprint.class),
+              Mockito.eq(TEST_DATA_FLOW_URN),
+              Mockito.eq(GLOBAL_TAGS_ASPECT_NAME));
+
+      Stream<AspectValidationException> result =
+          validator.validateProposedAspectsWithAuth(
+              OperationFingerprint.EMPTY,
+              Collections.singletonList(item),
+              retrieverContext,
+              session);
+
+      Assert.assertTrue(
+          result.findAny().isEmpty(),
+          "Users granted only EDIT_ENTITY_TAGS should be able to add tags to an asset");
+    } finally {
+      setRestApiAuthorizationEnabled(previousRestApiAuthorizationEnabled);
+    }
+  }
+
+  private void closeAuthUtilMock() {
+    if (authUtilMockedStatic != null) {
+      authUtilMockedStatic.close();
+      authUtilMockedStatic = null;
+    }
+  }
+
+  private static boolean getRestApiAuthorizationEnabled() throws Exception {
+    Field field = AuthUtil.class.getDeclaredField("isRestApiAuthorizationEnabled");
+    field.setAccessible(true);
+    return field.getBoolean(null);
+  }
+
+  private static void setRestApiAuthorizationEnabled(boolean enabled) throws Exception {
+    Field field = AuthUtil.class.getDeclaredField("isRestApiAuthorizationEnabled");
+    field.setAccessible(true);
+    field.setBoolean(null, enabled);
+  }
+
+  private Authorizer mockAuthorizer(Map<String, Map<String, Set<Urn>>> allowActorPrivUrn) {
+    Authorizer authorizer = mock(Authorizer.class);
+    when(authorizer.authorize(any()))
+        .thenAnswer(
+            args -> {
+              AuthorizationRequest req = args.getArgument(0);
+              String actorUrn = req.getActorUrn();
+              String priv = req.getPrivilege();
+
+              if (!allowActorPrivUrn.containsKey(actorUrn)) {
+                return new AuthorizationResult(
+                    req, AuthorizationResult.Type.DENY, String.format("Actor %s denied", actorUrn));
+              }
+
+              Map<String, Set<Urn>> privMap = allowActorPrivUrn.get(actorUrn);
+              if (!privMap.containsKey(priv)) {
+                return new AuthorizationResult(
+                    req, AuthorizationResult.Type.DENY, String.format("Privilege %s denied", priv));
+              }
+
+              if (req.getResourceSpec().isPresent()) {
+                Urn entityUrn = UrnUtils.getUrn(req.getResourceSpec().get().getEntity());
+                Set<Urn> resources = privMap.get(priv);
+                if (!resources.contains(entityUrn)) {
+                  return new AuthorizationResult(
+                      req,
+                      AuthorizationResult.Type.DENY,
+                      String.format("Entity %s denied", entityUrn));
+                }
+              }
+
+              return new AuthorizationResult(req, AuthorizationResult.Type.ALLOW, "Allowed");
+            });
+    return authorizer;
   }
 
   private GlobalTags createGlobalTags(TagUrn... tagUrns) {


### PR DESCRIPTION
## Summary
- Fix `TagPrivilegeConstraintsValidator` requiring broad `EDIT_ENTITY` for tag changes when REST API authorization is enabled, which blocked users with tag-only policies (e.g. `EDIT_ENTITY_TAGS` on a dataFlow).
- Consolidate tag authorization in `AuthUtil` (`tagModificationPrivilege`, `isAuthorizedForTagModification`, `isAPIAuthorizedForTagModification`) so GraphQL (`LabelUtils`) and aspect validation share the same logic.
- Add integration-style unit test covering `EDIT_ENTITY_TAGS`-only access.

## Test plan
- [x] `./gradlew spotlessApply`
- [x] `./gradlew :metadata-io:test --tests com.linkedin.metadata.aspect.validation.PrivilegeConstraintsValidatorTest` (28 passing)
- [x] `./gradlew :metadata-auth:auth-api:test --tests com.datahub.authorization.AuthUtilTest`


Made with [Cursor](https://cursor.com)