### PR TITLE
fix(ui): case-insensitive field profile matching for lowercased BigQuery paths

### DIFF
--- a/datahub-web-react/src/app/entityV2/dataset/profile/schema/utils/__tests__/utils.test.ts
+++ b/datahub-web-react/src/app/entityV2/dataset/profile/schema/utils/__tests__/utils.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { downgradeV2FieldPath, pathMatchesInsensitiveToV2 } from '@app/entityV2/dataset/profile/schema/utils/utils';
+
+describe('downgradeV2FieldPath', () => {
+    it('strips V2 bracket annotations', () => {
+        expect(downgradeV2FieldPath('[version=2.0].[type=struct].address')).toBe('address');
+        expect(downgradeV2FieldPath('[version=2.0].[type=struct].address.[type=struct].street')).toBe('address.street');
+    });
+
+    it('returns V1 paths unchanged', () => {
+        expect(downgradeV2FieldPath('order_id')).toBe('order_id');
+        expect(downgradeV2FieldPath('address.street')).toBe('address.street');
+    });
+
+    it('handles null/undefined', () => {
+        expect(downgradeV2FieldPath(null)).toBeNull();
+        expect(downgradeV2FieldPath(undefined)).toBeUndefined();
+    });
+});
+
+describe('pathMatchesInsensitiveToV2', () => {
+    it('matches identical paths', () => {
+        expect(pathMatchesInsensitiveToV2('order_id', 'order_id')).toBe(true);
+    });
+
+    it('matches V1 path against V2 path (same case)', () => {
+        expect(pathMatchesInsensitiveToV2('address', '[version=2.0].[type=struct].address')).toBe(true);
+        expect(
+            pathMatchesInsensitiveToV2(
+                'address.street',
+                '[version=2.0].[type=struct].address.[type=struct].street',
+            ),
+        ).toBe(true);
+    });
+
+    it('matches camelCase V1 profiler path against lowercased V2 schema path (ING-2174)', () => {
+        // BigQuery convert_column_urns_to_lowercase=true produces lowercased schema paths,
+        // while the profiler emits the original camelCase.
+        const profilerPath = 'payload.additionalInfo.rawCounterpartyId';
+        const schemaPath =
+            '[version=2.0].[type=struct].payload.[type=struct].additionalinfo.[type=string].rawcounterpartyid';
+        expect(pathMatchesInsensitiveToV2(profilerPath, schemaPath)).toBe(true);
+    });
+
+    it('does not match genuinely different fields', () => {
+        expect(pathMatchesInsensitiveToV2('order_id', 'address')).toBe(false);
+        expect(
+            pathMatchesInsensitiveToV2(
+                'address.street',
+                '[version=2.0].[type=struct].address.[type=struct].city',
+            ),
+        ).toBe(false);
+    });
+
+    it('returns false when either path is null or undefined', () => {
+        expect(pathMatchesInsensitiveToV2(null, 'address')).toBe(false);
+        expect(pathMatchesInsensitiveToV2('address', undefined)).toBe(false);
+        expect(pathMatchesInsensitiveToV2(null, null)).toBe(false);
+    });
+});

--- a/datahub-web-react/src/app/entityV2/dataset/profile/schema/utils/__tests__/utils.test.ts
+++ b/datahub-web-react/src/app/entityV2/dataset/profile/schema/utils/__tests__/utils.test.ts
@@ -27,10 +27,7 @@ describe('pathMatchesInsensitiveToV2', () => {
     it('matches V1 path against V2 path (same case)', () => {
         expect(pathMatchesInsensitiveToV2('address', '[version=2.0].[type=struct].address')).toBe(true);
         expect(
-            pathMatchesInsensitiveToV2(
-                'address.street',
-                '[version=2.0].[type=struct].address.[type=struct].street',
-            ),
+            pathMatchesInsensitiveToV2('address.street', '[version=2.0].[type=struct].address.[type=struct].street'),
         ).toBe(true);
     });
 
@@ -46,10 +43,7 @@ describe('pathMatchesInsensitiveToV2', () => {
     it('does not match genuinely different fields', () => {
         expect(pathMatchesInsensitiveToV2('order_id', 'address')).toBe(false);
         expect(
-            pathMatchesInsensitiveToV2(
-                'address.street',
-                '[version=2.0].[type=struct].address.[type=struct].city',
-            ),
+            pathMatchesInsensitiveToV2('address.street', '[version=2.0].[type=struct].address.[type=struct].city'),
         ).toBe(false);
     });
 

--- a/datahub-web-react/src/app/entityV2/dataset/profile/schema/utils/utils.ts
+++ b/datahub-web-react/src/app/entityV2/dataset/profile/schema/utils/utils.ts
@@ -38,7 +38,11 @@ export function pathMatchesNewPath(fieldPathA?: string | null, fieldPathB?: stri
 }
 
 export function pathMatchesInsensitiveToV2(fieldPathA?: string | null, fieldPathB?: string | null) {
-    return fieldPathA === fieldPathB || downgradeV2FieldPath(fieldPathA) === downgradeV2FieldPath(fieldPathB);
+    if (!fieldPathA || !fieldPathB) return false;
+    if (fieldPathA === fieldPathB) return true;
+    const a = downgradeV2FieldPath(fieldPathA);
+    const b = downgradeV2FieldPath(fieldPathB);
+    return !!a && !!b && a.toLowerCase() === b.toLowerCase();
 }
 
 // should use pathMatchesExact when rendering editable info so the user edits the correct field

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/SchemaFieldDrawer.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/SchemaFieldDrawer.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 
 import { useBaseEntity } from '@app/entity/shared/EntityContext';
 import { ExtendedSchemaFields } from '@app/entityV2/dataset/profile/schema/utils/types';
+import { pathMatchesInsensitiveToV2 } from '@app/entityV2/dataset/profile/schema/utils/utils';
 import { AboutFieldTab } from '@app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/AboutFieldTab';
 import DrawerFooter from '@app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/DrawerFooter';
 import FieldHeader from '@app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/FieldHeader';
@@ -21,7 +22,7 @@ import StatsTabWrapper from '@app/entityV2/shared/tabs/Dataset/Schema/components
 import { SchemaTimelineSection } from '@app/entityV2/shared/tabs/Dataset/Timeline/SchemaTimelineSection';
 import { generateSchemaFieldUrn } from '@app/entityV2/shared/tabs/Lineage/utils';
 import { PropertiesTab } from '@app/entityV2/shared/tabs/Properties/PropertiesTab';
-import { TabRenderType } from '@src/app/entityV2/shared/types';
+import { TabRenderType } from '@app/entityV2/shared/types';
 
 import { GetDatasetQuery, useGetDataProfilesLazyQuery } from '@graphql/dataset.generated';
 import { useGetEntitiesNotesQuery } from '@graphql/relationships.generated';
@@ -84,7 +85,7 @@ interface Props {
     expandedDrawerFieldPath: string | null;
     setExpandedDrawerFieldPath: (fieldPath: string | null) => void;
     openTimelineDrawer?: boolean;
-    setOpenTimelineDrawer?: any;
+    setOpenTimelineDrawer?: (open: boolean) => void;
     selectPreviousField?: () => void;
     selectNextField?: () => void;
     usageStats?: UsageQueryResult | null;
@@ -123,8 +124,8 @@ export default function SchemaFieldDrawer({
 
     const latestProfile = latestFullTableProfile || latestPartitionProfile;
 
-    const fieldProfile = latestProfile?.fieldProfiles?.find(
-        (profile) => profile.fieldPath === expandedField?.fieldPath,
+    const fieldProfile = latestProfile?.fieldProfiles?.find((profile) =>
+        pathMatchesInsensitiveToV2(profile.fieldPath, expandedField?.fieldPath),
     );
 
     const urn = (baseEntity && baseEntity.dataset && baseEntity.dataset?.urn) || '';
@@ -169,10 +170,6 @@ export default function SchemaFieldDrawer({
     const profiles = profilesData?.dataset?.datasetProfiles || [];
     const [selectedTabKey, setSelectedTabKey] = useState(defaultSelectedTabKey);
 
-    /**
-     * Fetches updated data profiles when the lookback window is changed in the Historical Chart view.
-     * @param lookbackWindow The new time window for data fetching.
-     */
     const fetchDataWithLookbackWindow = useCallback(
         (lookbackWindow: TimeWindow) => {
             if (urn) {

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/SchemaFieldDrawer.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/SchemaFieldDrawer.tsx
@@ -297,7 +297,7 @@ export default function SchemaFieldDrawer({
             {!!openTimelineDrawer && (
                 <StyledDrawer
                     open={!!openTimelineDrawer}
-                    onClose={() => setOpenTimelineDrawer(false)}
+                    onClose={() => setOpenTimelineDrawer?.(false)}
                     getContainer={() => document.getElementById('entity-profile-sidebar') as HTMLElement}
                     contentWrapperStyle={{ width: '33%' }}
                     mask={false}

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/utils/useUsageStatsRenderer.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/utils/useUsageStatsRenderer.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
+import { pathMatchesInsensitiveToV2 } from '@app/entityV2/dataset/profile/schema/utils/utils';
 import { FieldPopularity } from '@app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/FieldPopularity';
 import { useBaseEntity } from '@src/app/entity/shared/EntityContext';
 
@@ -42,7 +43,9 @@ export default function useUsageStatsRenderer(
     const usageStatsRenderer = (fieldPath: string) => {
         const isFieldSelected = expandedDrawerFieldPath === fieldPath;
 
-        const fieldProfile = latestProfile?.fieldProfiles?.find((profile) => profile.fieldPath === fieldPath);
+        const fieldProfile = latestProfile?.fieldProfiles?.find((profile) =>
+            pathMatchesInsensitiveToV2(profile.fieldPath, fieldPath),
+        );
 
         return (
             <IconsContainer>

--- a/datahub-web-react/src/app/entityV2/shared/utils.ts
+++ b/datahub-web-react/src/app/entityV2/shared/utils.ts
@@ -2,6 +2,7 @@ import { Maybe } from 'graphql/jsutils/Maybe';
 import i18next from 'i18next';
 
 import { GenericEntityProperties } from '@app/entity/shared/types';
+import { pathMatchesInsensitiveToV2 } from '@app/entityV2/dataset/profile/schema/utils/utils';
 import { OUTPUT_PORTS_FIELD } from '@app/search/utils/constants';
 import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
 import { TimeWindowSize } from '@app/shared/time/timeUtils';
@@ -240,7 +241,7 @@ export const extractChartValuesFromFieldProfiles = (profiles: Array<any>, fieldP
         .filter((profile) => profile.fieldProfiles)
         .map((profile) => {
             const fieldProfiles = profile.fieldProfiles
-                ?.filter((field) => field.fieldPath === fieldPath)
+                ?.filter((field) => pathMatchesInsensitiveToV2(field.fieldPath, fieldPath))
                 .filter((field) => field[statName] !== null && field[statName] !== undefined);
 
             if (fieldProfiles?.length === 1) {

--- a/e2e-test/ui/playwright/tests/nested-column-stats/fixtures/data.json
+++ b/e2e-test/ui/playwright/tests/nested-column-stats/fixtures/data.json
@@ -1,0 +1,115 @@
+[
+  {
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,playwright_test.nested_schema.orders,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "Test dataset with nested BigQuery fields for ING-2174 regression test",
+              "customProperties": {}
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.common.BrowsePaths": {
+              "paths": ["/prod/bigquery/playwright_test/nested_schema/orders"]
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+              "schemaName": "playwright_test.nested_schema.orders",
+              "platform": "urn:li:dataPlatform:bigquery",
+              "version": 0,
+              "created": {
+                "time": 1700000000000,
+                "actor": "urn:li:corpuser:datahub"
+              },
+              "lastModified": {
+                "time": 1700000000000,
+                "actor": "urn:li:corpuser:datahub"
+              },
+              "hash": "",
+              "platformSchema": {
+                "com.linkedin.pegasus2avro.schema.OtherSchema": {
+                  "rawSchema": "schema"
+                }
+              },
+              "fields": [
+                {
+                  "fieldPath": "order_id",
+                  "nullable": false,
+                  "description": "Unique order identifier",
+                  "type": {
+                    "type": {
+                      "com.linkedin.pegasus2avro.schema.NumberType": {}
+                    }
+                  },
+                  "nativeDataType": "INT64",
+                  "recursive": false
+                },
+                {
+                  "fieldPath": "[version=2.0].[type=struct].address",
+                  "nullable": false,
+                  "description": "Shipping address struct",
+                  "type": {
+                    "type": {
+                      "com.linkedin.pegasus2avro.schema.RecordType": {}
+                    }
+                  },
+                  "nativeDataType": "STRUCT",
+                  "recursive": false
+                },
+                {
+                  "fieldPath": "[version=2.0].[type=struct].address.[type=struct].street",
+                  "nullable": true,
+                  "description": "Street line of the address",
+                  "type": {
+                    "type": {
+                      "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                  },
+                  "nativeDataType": "STRING",
+                  "recursive": false
+                },
+                {
+                  "fieldPath": "[version=2.0].[type=struct].address.[type=struct].city",
+                  "nullable": true,
+                  "description": "City of the address",
+                  "type": {
+                    "type": {
+                      "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                  },
+                  "nativeDataType": "STRING",
+                  "recursive": false
+                },
+                {
+                  "fieldPath": "[version=2.0].[type=string].rawcounterpartyid",
+                  "nullable": true,
+                  "description": "Schema path lowercased by convert_column_urns_to_lowercase; profiler emits camelCase rawCounterpartyId",
+                  "type": {
+                    "type": {
+                      "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                  },
+                  "nativeDataType": "STRING",
+                  "recursive": false
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,playwright_test.nested_schema.orders,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProfile",
+    "aspect": {
+      "contentType": "application/json",
+      "value": "{\"timestampMillis\": 1700000000000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 100, \"columnCount\": 5, \"fieldProfiles\": [{\"fieldPath\": \"order_id\", \"uniqueCount\": 100, \"uniqueProportion\": 1.0, \"nullCount\": 0, \"nullProportion\": 0.0, \"sampleValues\": [\"1\", \"2\", \"3\"]}, {\"fieldPath\": \"address\", \"uniqueCount\": 80, \"uniqueProportion\": 0.8, \"nullCount\": 5, \"nullProportion\": 0.05, \"sampleValues\": [\"123 Main St Seattle\", \"456 Oak Ave Portland\"]}, {\"fieldPath\": \"address.street\", \"uniqueCount\": 90, \"uniqueProportion\": 0.9, \"nullCount\": 5, \"nullProportion\": 0.05, \"sampleValues\": [\"123 Main St\", \"456 Oak Ave\", \"789 Pine Rd\"]}, {\"fieldPath\": \"address.city\", \"uniqueCount\": 20, \"uniqueProportion\": 0.2, \"nullCount\": 5, \"nullProportion\": 0.05, \"sampleValues\": [\"Seattle\", \"Portland\", \"San Francisco\"]}, {\"fieldPath\": \"rawCounterpartyId\", \"uniqueCount\": 85, \"uniqueProportion\": 0.85, \"nullCount\": 10, \"nullProportion\": 0.1, \"sampleValues\": [\"RAW-001\", \"RAW-002\", \"RAW-003\"]}]}"
+    }
+  }
+]

--- a/e2e-test/ui/playwright/tests/nested-column-stats/nested-column-stats.spec.ts
+++ b/e2e-test/ui/playwright/tests/nested-column-stats/nested-column-stats.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression test for ING-2174: BigQuery nested field sample data missing in Columns tab.
+ *
+ * Root cause: SchemaFieldDrawer.tsx used an exact string match to resolve fieldProfile
+ * from latestProfile.fieldProfiles. BigQuery schema fields use V2 paths
+ * (e.g. [version=2.0].[type=struct].address) while the profiler emits V1 paths
+ * (e.g. address). For nested fields the exact match always failed, so fieldProfile
+ * was undefined and the Statistics tab showed "No column statistics found".
+ *
+ * Fix: use pathMatchesInsensitiveToV2 which normalises both sides before comparing,
+ * also folding case so that lowercased schema paths (produced by BigQuery ingestion
+ * with convert_column_urns_to_lowercase=true) match camelCase profiler paths.
+ *
+ * Fixture: tests/nested-column-stats/fixtures/data.json
+ *   - SchemaMetadata with V2 field paths (as BigQuery ingestion emits)
+ *   - DatasetProfile with V1 field paths (as ge_data_profiler emits)
+ *     The "address" struct field has profile path "address" (V1) but schema path
+ *     "[version=2.0].[type=struct].address" (V2).
+ *   - Additionally, "rawcounterpartyid" (top-level) demonstrates the case-fold fix:
+ *     schema path is fully lowercased while the profiler path retains the original
+ *     camelCase ("rawCounterpartyId").
+ */
+
+import { test, expect } from '../../fixtures/base-test';
+
+test.use({ featureName: 'nested-column-stats' });
+
+const DATASET_URN = 'urn:li:dataset:(urn:li:dataPlatform:bigquery,playwright_test.nested_schema.orders,PROD)';
+
+const TOP_LEVEL_FIELD = 'order_id';
+
+test.describe('ING-2174: nested BigQuery field stats in Columns tab', () => {
+  test('nested struct field shows sample values in Statistics tab (not "No column statistics found")', async ({
+    page,
+  }) => {
+    await page.goto(`/dataset/${encodeURIComponent(DATASET_URN)}/Schema`);
+    await page.waitForLoadState('networkidle');
+
+    // Wait for schema table to render
+    // eslint-disable-next-line playwright/no-raw-locators -- id-prefix attribute selector has no semantic equivalent
+    await expect(page.locator('[id^="column-"]').first()).toBeVisible({ timeout: 30000 });
+
+    // Click the 'address' struct row. Its data-testid contains a V2 path with brackets,
+    // so use XPath for reliable exact attribute matching.
+    // eslint-disable-next-line playwright/no-raw-locators -- XPath required to match data-testid containing reserved characters ([], =, .)
+    const addressRow = page.locator('xpath=//tr[@data-testid="column-[version=2.0].[type=struct].address"]');
+    await expect(addressRow).toBeVisible({ timeout: 10000 });
+    await addressRow.click();
+
+    // Open the Statistics tab in the schema field drawer
+    await page.locator('[data-testid="Statistics-field-drawer-tab-header"]').click();
+
+    // Pre-fix: "No column statistics found" appears — V2 fieldPath can't match V1 profile path
+    // Post-fix: sample values from the profile are shown
+    await expect(page.getByText('No column statistics found')).not.toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('123 Main St Seattle')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('lowercased schema path (ING-2174 case-fold) shows sample values in About tab from Columns tab', async ({
+    page,
+  }) => {
+    // The schema path is lowercased by convert_column_urns_to_lowercase=true while the profiler
+    // retains the original camelCase. The field is top-level so no struct expansion is needed.
+    await page.goto(`/dataset/${encodeURIComponent(DATASET_URN)}/Schema`);
+    await page.waitForLoadState('networkidle');
+
+    // eslint-disable-next-line playwright/no-raw-locators -- id-prefix attribute selector has no semantic equivalent
+    await expect(page.locator('[id^="column-"]').first()).toBeVisible({ timeout: 30000 });
+
+    // Click the lowercased top-level field — opens the drawer on the About tab (default).
+    // eslint-disable-next-line playwright/no-raw-locators -- XPath required to match data-testid containing reserved characters ([], =, .)
+    const rawCounterpartyRow = page.locator(
+      'xpath=//tr[@data-testid="column-[version=2.0].[type=string].rawcounterpartyid"]',
+    );
+    await expect(rawCounterpartyRow).toBeVisible({ timeout: 10000 });
+    await rawCounterpartyRow.click();
+
+    // About tab is the default — no tab click needed.
+    // Pre-fix: pathMatchesInsensitiveToV2 was case-sensitive, so fieldProfile was undefined
+    //          and the About section showed "No column statistics found".
+    // Post-fix: case-folded match resolves fieldProfile correctly and sample values render.
+    await expect(page.getByText('No column statistics found')).not.toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('RAW-001')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('top-level field still shows stats correctly (regression guard)', async ({ page }) => {
+    await page.goto(`/dataset/${encodeURIComponent(DATASET_URN)}/Schema`);
+    await page.waitForLoadState('networkidle');
+
+    // eslint-disable-next-line playwright/no-raw-locators -- id-prefix attribute selector has no semantic equivalent
+    await expect(page.locator('[id^="column-"]').first()).toBeVisible({ timeout: 30000 });
+
+    await page.locator(`[data-testid="column-${TOP_LEVEL_FIELD}"]`).click();
+    await page.locator('[data-testid="Statistics-field-drawer-tab-header"]').click();
+
+    await expect(page.getByText('No column statistics found')).not.toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Sample Values')).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/e2e-test/ui/playwright/tests/nested-column-stats/nested-column-stats.spec.ts
+++ b/e2e-test/ui/playwright/tests/nested-column-stats/nested-column-stats.spec.ts
@@ -40,10 +40,11 @@ test.describe('ING-2174: nested BigQuery field stats in Columns tab', () => {
     // eslint-disable-next-line playwright/no-raw-locators -- id-prefix attribute selector has no semantic equivalent
     await expect(page.locator('[id^="column-"]').first()).toBeVisible({ timeout: 30000 });
 
-    // Click the 'address' struct row. Its data-testid contains a V2 path with brackets,
-    // so use XPath for reliable exact attribute matching.
-    // eslint-disable-next-line playwright/no-raw-locators -- XPath required to match data-testid containing reserved characters ([], =, .)
-    const addressRow = page.locator('xpath=//tr[@data-testid="column-[version=2.0].[type=struct].address"]');
+    // Click the 'address' struct row. Its id contains a V2 path with brackets;
+    // use XPath on the id attribute for reliable exact matching (CSS id selector
+    // cannot handle the brackets and dots in V2 field paths).
+    // eslint-disable-next-line playwright/no-raw-locators -- XPath required to match id containing reserved characters ([], =, .)
+    const addressRow = page.locator('xpath=//tr[@id="column-[version=2.0].[type=struct].address"]');
     await expect(addressRow).toBeVisible({ timeout: 10000 });
     await addressRow.click();
 
@@ -68,9 +69,9 @@ test.describe('ING-2174: nested BigQuery field stats in Columns tab', () => {
     await expect(page.locator('[id^="column-"]').first()).toBeVisible({ timeout: 30000 });
 
     // Click the lowercased top-level field — opens the drawer on the About tab (default).
-    // eslint-disable-next-line playwright/no-raw-locators -- XPath required to match data-testid containing reserved characters ([], =, .)
+    // eslint-disable-next-line playwright/no-raw-locators -- XPath required to match id containing reserved characters ([], =, .)
     const rawCounterpartyRow = page.locator(
-      'xpath=//tr[@data-testid="column-[version=2.0].[type=string].rawcounterpartyid"]',
+      'xpath=//tr[@id="column-[version=2.0].[type=string].rawcounterpartyid"]',
     );
     await expect(rawCounterpartyRow).toBeVisible({ timeout: 10000 });
     await rawCounterpartyRow.click();
@@ -90,7 +91,7 @@ test.describe('ING-2174: nested BigQuery field stats in Columns tab', () => {
     // eslint-disable-next-line playwright/no-raw-locators -- id-prefix attribute selector has no semantic equivalent
     await expect(page.locator('[id^="column-"]').first()).toBeVisible({ timeout: 30000 });
 
-    await page.getByTestId(`column-${TOP_LEVEL_FIELD}`).click();
+    await page.getByTestId(`schema-field-${TOP_LEVEL_FIELD}`).click();
     await page.getByTestId('Statistics-field-drawer-tab-header').click();
 
     await expect(page.getByText('No column statistics found')).not.toBeVisible({ timeout: 10000 });

--- a/e2e-test/ui/playwright/tests/nested-column-stats/nested-column-stats.spec.ts
+++ b/e2e-test/ui/playwright/tests/nested-column-stats/nested-column-stats.spec.ts
@@ -70,9 +70,7 @@ test.describe('ING-2174: nested BigQuery field stats in Columns tab', () => {
 
     // Click the lowercased top-level field — opens the drawer on the About tab (default).
     // eslint-disable-next-line playwright/no-raw-locators -- XPath required to match id containing reserved characters ([], =, .)
-    const rawCounterpartyRow = page.locator(
-      'xpath=//tr[@id="column-[version=2.0].[type=string].rawcounterpartyid"]',
-    );
+    const rawCounterpartyRow = page.locator('xpath=//tr[@id="column-[version=2.0].[type=string].rawcounterpartyid"]');
     await expect(rawCounterpartyRow).toBeVisible({ timeout: 10000 });
     await rawCounterpartyRow.click();
 

--- a/e2e-test/ui/playwright/tests/nested-column-stats/nested-column-stats.spec.ts
+++ b/e2e-test/ui/playwright/tests/nested-column-stats/nested-column-stats.spec.ts
@@ -48,7 +48,7 @@ test.describe('ING-2174: nested BigQuery field stats in Columns tab', () => {
     await addressRow.click();
 
     // Open the Statistics tab in the schema field drawer
-    await page.locator('[data-testid="Statistics-field-drawer-tab-header"]').click();
+    await page.getByTestId('Statistics-field-drawer-tab-header').click();
 
     // Pre-fix: "No column statistics found" appears — V2 fieldPath can't match V1 profile path
     // Post-fix: sample values from the profile are shown
@@ -90,8 +90,8 @@ test.describe('ING-2174: nested BigQuery field stats in Columns tab', () => {
     // eslint-disable-next-line playwright/no-raw-locators -- id-prefix attribute selector has no semantic equivalent
     await expect(page.locator('[id^="column-"]').first()).toBeVisible({ timeout: 30000 });
 
-    await page.locator(`[data-testid="column-${TOP_LEVEL_FIELD}"]`).click();
-    await page.locator('[data-testid="Statistics-field-drawer-tab-header"]').click();
+    await page.getByTestId(`column-${TOP_LEVEL_FIELD}`).click();
+    await page.getByTestId('Statistics-field-drawer-tab-header').click();
 
     await expect(page.getByText('No column statistics found')).not.toBeVisible({ timeout: 10000 });
     await expect(page.getByText('Sample Values')).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
With convert_column_urns_to_lowercase=true, BigQuery ingestion emits lowercased schema field paths (e.g. rawcounterpartyid) while the profiler retains the original camelCase (e.g. rawCounterpartyId). The Columns tab was broken because pathMatchesInsensitiveToV2 stripped V2 bracket annotations but did not fold case, so schema-to-profile reconciliation failed and the drawer showed "No column statistics found".

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
