### PR TITLE
fix(ingest/datapack): stop internal file pipelines from self-registering as CLI sources

### DIFF
--- a/metadata-ingestion/src/datahub/cli/datapack/loader.py
+++ b/metadata-ingestion/src/datahub/cli/datapack/loader.py
@@ -676,7 +676,11 @@ def _run_pipeline_for_file(
     with _datapack_emit_mode(wait_for_completion) as emit_mode:
         if wait_for_completion:
             click.echo(f"  Using OpenAPI async_batch with emit mode {emit_mode}")
-        pipeline = Pipeline.create(pipeline_config)
+        # report_to=None disables the CLI ingestion-run reporter for these internal
+        # per-file pipelines. Without it, each "file" pipeline would register itself
+        # as a standalone "[CLI] file" ingestion source in the UI. The outer
+        # demo-data source / datapack-load command owns the run's provenance.
+        pipeline = Pipeline.create(pipeline_config, report_to=None)
         pipeline.run()
         pipeline.pretty_print_summary()
         pipeline.raise_from_status()

--- a/metadata-ingestion/tests/unit/cli/datapack/test_loader.py
+++ b/metadata-ingestion/tests/unit/cli/datapack/test_loader.py
@@ -107,6 +107,30 @@ class TestDatapackSinkConfig:
         mock_pipeline.raise_from_status.assert_called_once()
 
     @patch("datahub.ingestion.run.pipeline.Pipeline")
+    def test_run_pipeline_for_file_disables_cli_reporting(
+        self, mock_pipeline_cls: MagicMock, tmp_path: pathlib.Path
+    ) -> None:
+        # Internal per-file pipelines must not register themselves as standalone
+        # "[CLI] file" ingestion sources in the UI. report_to=None disables the
+        # DatahubIngestionRunSummaryProvider for these pipelines.
+        data_file = tmp_path / "data.json"
+        data_file.write_text("[]")
+        mock_pipeline_cls.create.return_value = MagicMock()
+
+        sink_config = {
+            "server": "http://localhost:8080",
+            "endpoint": "openapi",
+            "mode": "async_batch",
+        }
+        _run_pipeline_for_file(data_file, "run-1", sink_config)
+
+        # report_to must be passed *explicitly* as None. Its default is "datahub",
+        # so simply omitting it would leave CLI reporting enabled.
+        _, kwargs = mock_pipeline_cls.create.call_args
+        assert "report_to" in kwargs
+        assert kwargs["report_to"] is None
+
+    @patch("datahub.ingestion.run.pipeline.Pipeline")
     def test_run_pipeline_for_file_logs_emit_mode_when_waiting(
         self,
         mock_pipeline_cls: MagicMock,


### PR DESCRIPTION
## Summary

The `demo-data` source and `datahub datapack load` ingest each data file through an **internal** `Pipeline` (source type `file`, `datahub-rest` sink). These internal pipelines inherited the default `report_to="datahub"`, so each one ran the `DatahubIngestionRunSummaryProvider` and **registered itself as a standalone `[CLI] file` ingestion source** in the UI.

The result: after creating/running a `demo-data` ingestion source, an unexpected `[CLI] file` source appears in the ingestion sources list.

## What changed

Pass `report_to=None` when creating these internal per-file pipelines so they don't self-report. This matches the existing pattern already used for internal `file` pipelines in `ingest_cli.py` and `check_cli.py`. The outer `demo-data` source / `datapack load` command still owns the run's provenance and execution-request reporting.

## Testing

- Added a unit test asserting `report_to=None` is passed **explicitly** (its default is `"datahub"`, so omitting it leaves reporting enabled).
- Verified end-to-end on a local quickstart:
  - **Before:** running `demo-data` created a spurious `[CLI] file` source.
  - **After:** running `demo-data` creates only the legitimate outer source; no `[CLI] file` appears. Executor-managed runs (run_id = execution-request URN) create no extra sources.
- `ruff`, `mypy`, and the full `test_loader.py` suite (53 tests) pass.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing/#commit-message-format))
- [x] Tests added/updated
- [ ] Docs updated (n/a)