### PR TITLE
fix(ingest/gcs): patch GCS endpoint where it is used so s3 integration test stays mocked

### DIFF
--- a/metadata-ingestion/tests/integration/s3/test_s3.py
+++ b/metadata-ingestion/tests/integration/s3/test_s3.py
@@ -253,9 +253,9 @@ def test_data_lake_gcs_ingest(
 
     config_dict["run_id"] = source_file
 
-    with patch("datahub.ingestion.source.gcs.gcs_utils.GCS_ENDPOINT_URL", None):
+    with patch("datahub.ingestion.source.gcs.gcs_source.GCS_ENDPOINT_URL", None):
         pipeline = Pipeline.create(config_dict)
-    pipeline.run()
+        pipeline.run()
     pipeline.raise_from_status()
 
     # Verify the output.


### PR DESCRIPTION
## Summary

`test_data_lake_gcs_ingest` patched `datahub.ingestion.source.gcs.gcs_utils.GCS_ENDPOINT_URL`, but `gcs_source.py` does `from ...gcs_utils import GCS_ENDPOINT_URL`, so it holds its **own** name binding. Patching the `gcs_utils` attribute never changed the value the source actually reads — the client was built against the real `https://storage.googleapis.com`, escaped the `moto` mock, hit real GCS with dummy `test`/`test` credentials, and failed with `SignatureDoesNotMatch`.

This was masked on the introducing PR (#16802) because its selective CI only ran the slim `ci (s3, ...)` job, where `moto` happens to intercept the call. It surfaces in the full `testIntegrationBatch0`, where the request escapes to the network — so any PR touching core ingestion code hits it.

## Fix

- Patch the name as imported into `gcs_source` (`...gcs_source.GCS_ENDPOINT_URL`), so the endpoint resolves to `None` → the default S3 endpoint `moto` mocks in every environment.
- Widen the patch scope to cover `pipeline.run()`.

## Testing

`pytest tests/integration/s3/test_s3.py::test_data_lake_gcs_ingest` → 35 passed, no network calls.

## Checklist

- [x] Tests pass locally
- [x] No breaking changes