### PR TITLE
feat(datapack): register authz-perf-medium pack for policy benchmarking

### DIFF
--- a/docs/cli-commands/datapack.md
+++ b/docs/cli-commands/datapack.md
@@ -139,10 +139,13 @@ datahub datapack unload showcase-ecommerce --hard
 
 ## Built-in Data Packs
 
-| Pack                   | Description                                                                         | Entities | Platforms                                                       |
-| ---------------------- | ----------------------------------------------------------------------------------- | -------- | --------------------------------------------------------------- |
-| **bootstrap**          | Lightweight bootstrap data with basic datasets, dashboards, users, and tags         | ~50      | Kafka, Hive, HDFS                                               |
-| **showcase-ecommerce** | Rich e-commerce demo with lineage, governance, glossary, domains, and data products | ~1,050   | Snowflake, Looker, PowerBI, Tableau, dbt, Spark, PostgreSQL, S3 |
+| Pack                   | Description                                                                          | Entities | Platforms                                                          |
+| ---------------------- | ------------------------------------------------------------------------------------ | -------- | ------------------------------------------------------------------ |
+| **bootstrap**          | Lightweight bootstrap data with basic datasets, dashboards, users, and tags          | ~50      | Kafka, Hive, HDFS                                                  |
+| **showcase-ecommerce** | Rich e-commerce demo with lineage, governance, glossary, domains, and data products  | ~1,050   | Snowflake, Looker, PowerBI, Tableau, dbt, Spark, PostgreSQL, S3    |
+| **authz-perf-medium**  | Authz perf fixture: users, groups, domains, glossary, policies (standard boot roles) | ~1,900   | (authz structure only; deactivates editable boot policies on load) |
+
+For persona-level authz latency benchmarks, see [`perf-test/authz-perf/README.md`](../../perf-test/authz-perf/README.md). Pack MCP data is published via the registry (hosted in `datahub-project/static-assets`, same as `showcase-ecommerce`).
 
 ## Trust Model
 

--- a/metadata-ingestion/src/datahub/cli/datapack/resources/DATAPACK_AGENT_CONTEXT.md
+++ b/metadata-ingestion/src/datahub/cli/datapack/resources/DATAPACK_AGENT_CONTEXT.md
@@ -44,6 +44,15 @@ datahub datapack unload showcase-ecommerce
 | -------------------- | ---------------------------------------------------------------------------------- | ------- |
 | `bootstrap`          | Lightweight bootstrap data (datasets, dashboards, users, tags)                     | ~100 KB |
 | `showcase-ecommerce` | Rich e-commerce demo with 1049 entities across Snowflake, Looker, PowerBI, Tableau | ~2.7 MB |
+| `authz-perf-medium`  | Authz perf fixture: users, groups, domains, glossary, policies (~6378 MCPs)        | ~8 MB   |
+
+The `authz-perf-medium` pack UPSERT-deactivates editable boot policies on load so fixture policies take effect without default all-users grants. It uses standard DataHub roles (`Admin`, `Editor`, `Reader`) from boot — no custom role entities are ingested. Unload restores boot policy state via version rollback. Raw MCP data is published via the datapack registry (hosted in `datahub-project/static-assets`, same as `showcase-ecommerce`). Test oracles (`personas.json`, `benchmarks.json`) live in `perf-test/authz-perf/fixture/` and are not ingested; persona intent, policy descriptions, and login hints are already baked into the ingested entity/MCP JSON.
+
+**Load order:** Files are mostly independent. The only dependency is `corpGroup.json` before `corpuser.json`; `corpGroup.json` uses `wait_for_completion` so groups are persisted before user ingest starts. After editing fixture JSON locally, bump `index.json` version or use `--no-cache`.
+
+**Native login:** Pre-baked `corpUserCredentials` MCPs target quickstart/dev GMS with the default `secretService.encryptionKey` (`ENCRYPTION_KEY`, overridable via `SECRET_SERVICE_ENCRYPTION_KEY`). Password convention: **password equals username** (`corpUserKey` id, not the email address) — e.g. user `persona-admin` / password `persona-admin`. `corpUserInfo.customProperties` records `authzLoginUsername` and `authzFixturePasswordRule=password_equals_username`.
+
+**Perf harness:** [`perf-test/authz-perf/README.md`](../../../../../../perf-test/authz-perf/README.md) benchmarks all 17 personas via frontend GraphQL (`getMe`, `getDomain`, `getSearchResultsForMultiple`). Uses `perf-test/authz-perf/fixture/benchmarks.json` + `personas.json` as oracles; query text is generated at run time from GMS introspection.
 
 ## Agent Workflow
 

--- a/metadata-ingestion/src/datahub/cli/datapack/resources/registry.json
+++ b/metadata-ingestion/src/datahub/cli/datapack/resources/registry.json
@@ -22,6 +22,17 @@
       "reference_timestamp": 1769615173327,
       "min_server_version": "0.14.0",
       "pack_format_version": "1"
+    },
+    "authz-perf-medium": {
+      "name": "authz-perf-medium",
+      "description": "Medium-scale authz perf fixture: users, groups, domains, glossary, and policies for policy-evaluation benchmarking (uses standard Admin/Editor/Reader boot roles)",
+      "url": "https://raw.githubusercontent.com/datahub-project/static-assets/main/datapacks/authz-perf-medium/index.json",
+      "size_hint": "~8 MB",
+      "tags": ["perf", "authz", "testing"],
+      "trust": "verified",
+      "reference_timestamp": 1782247005037,
+      "min_server_version": "0.14.0",
+      "pack_format_version": "1"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Register `authz-perf-medium` in the bundled datapack registry, pointing at `static-assets/main/datapacks/authz-perf-medium/index.json` (same hosting pattern as `showcase-ecommerce`).
- Document the pack in `docs/cli-commands/datapack.md` and `DATAPACK_AGENT_CONTEXT.md`, including load behavior (boot policy deactivation), login conventions, and links to the authz perf harness.

## Stack

**Base PR:** #18025 (`feat/authz-perf-harness`) — merge that first, then this PR retargets to `master`.

## Dependencies

This PR is the registry/docs half of the datapack. It depends on a companion PR to `datahub-project/static-assets` publishing the MCP payload at `datapacks/authz-perf-medium/`. Until that lands, `datahub datapack load authz-perf-medium` will 404 on download.

## Test plan

- [ ] Verify `datahub datapack list` includes `authz-perf-medium` with correct URL and tags
- [ ] After static-assets PR merges: `datahub datapack load authz-perf-medium --dry-run`
- [ ] After static-assets PR merges: `datahub datapack load authz-perf-medium` on a fresh quickstart instance
- [ ] Confirm `datahub datapack unload authz-perf-medium` restores boot policy state