### PR TITLE
docs(agents): add frontend CI checklist and Playwright guidance

### DIFF
--- a/.cursor/rules/datahub-dev.mdc
+++ b/.cursor/rules/datahub-dev.mdc
@@ -88,6 +88,8 @@ Set `AGENT_MODE=1` to get machine-readable JSON test reports at `smoke-test/buil
 AGENT_MODE=1 scripts/dev/datahub-dev.sh test tests/test_system_info.py
 ```
 
+For the frontend and e2e pre-completion checklist (lint, Vitest, Playwright format check), see the *Frontend CI Checklist* section in [`AGENTS.md`](../../AGENTS.md).
+
 ---
 
 Canonical source: [`AGENTS.md`](../../AGENTS.md) — keep this file in sync with AGENTS.md

--- a/.cursor/rules/datahub-dev.mdc
+++ b/.cursor/rules/datahub-dev.mdc
@@ -88,7 +88,8 @@ Set `AGENT_MODE=1` to get machine-readable JSON test reports at `smoke-test/buil
 AGENT_MODE=1 scripts/dev/datahub-dev.sh test tests/test_system_info.py
 ```
 
-For the frontend and e2e pre-completion checklist (lint, Vitest, Playwright format check), see the *Frontend CI Checklist* section in [`AGENTS.md`](../../AGENTS.md).
+For the frontend pre-completion checklist (lint, Vitest), see the *Frontend CI Checklist*
+section in [`AGENTS.md`](../../AGENTS.md).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -730,21 +730,13 @@ Full reference: [`e2e-test/ui/playwright/README.md`](e2e-test/ui/playwright/READ
 feature per run. Do **not** set `featureName` for suites that create their own data
 via `apiMock` or direct API calls.
 
-### Formatting
-
-Run before pushing:
-
-```bash
-cd e2e-test/ui/playwright && yarn format:check
-```
-
 ## Frontend CI Checklist
 
-This checklist is for **commit- or PR-ready** work — i.e. when you're about to
-commit, push, or hand off frontend/e2e changes that are going into a PR. It is
-**not** required for every intermediate edit: work that is part of a larger task,
-a work-in-progress branch, or scratch experimentation that won't be committed yet
-can skip it. Run the relevant commands when the change is ready to ship:
+This checklist is for **commit- or PR-ready** frontend work — i.e. when you're about to
+commit, push, or hand off changes that are going into a PR. It is **not** required for
+every intermediate edit: work that is part of a larger task, a work-in-progress branch,
+or scratch experimentation that won't be committed yet can skip it. Run the relevant
+commands when the change is ready to ship:
 
 ```bash
 # Full lint (eslint + prettier src + type-check) for datahub-web-react
@@ -756,9 +748,6 @@ can skip it. Run the relevant commands when the change is ready to ship:
 # Vitest unit tests (requires icon stubs — run once per clone)
 node datahub-web-react/scripts/generate-lazy-icon-stubs.js
 cd datahub-web-react && yarn test src/path/to/file.test.ts --run
-
-# Playwright e2e formatting
-cd e2e-test/ui/playwright && yarn format:check
 ```
 
 `yarn type-check` in CI runs repo-wide and will surface pre-existing errors in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -719,6 +719,52 @@ datahub graphql --agent-context
 - https://docs.datahub.com/docs/developers - Official developer guide
 - https://demo.datahub.com/ - Live demo environment
 
+## Playwright UI E2E Tests
+
+Full reference: [`e2e-test/ui/playwright/README.md`](e2e-test/ui/playwright/README.md).
+
+### Seeding
+
+`test.use({ featureName: 'my-feature' })` at the `describe` level auto-loads
+`tests/my-feature/fixtures/data.json` via `seeding.fixture.ts` — once per worker per
+feature per run. Do **not** set `featureName` for suites that create their own data
+via `apiMock` or direct API calls.
+
+### Formatting
+
+Run before pushing:
+
+```bash
+cd e2e-test/ui/playwright && yarn format:check
+```
+
+## Frontend CI Checklist
+
+This checklist is for **commit- or PR-ready** work — i.e. when you're about to
+commit, push, or hand off frontend/e2e changes that are going into a PR. It is
+**not** required for every intermediate edit: work that is part of a larger task,
+a work-in-progress branch, or scratch experimentation that won't be committed yet
+can skip it. Run the relevant commands when the change is ready to ship:
+
+```bash
+# Full lint (eslint + prettier src + type-check) for datahub-web-react
+./gradlew :datahub-web-react:yarnLint
+
+# Targeted lint-fix on a single file
+./gradlew -x yarnInstall -x yarnGenerate yarnLintFix -Pfile=src/path/to/file.tsx
+
+# Vitest unit tests (requires icon stubs — run once per clone)
+node datahub-web-react/scripts/generate-lazy-icon-stubs.js
+cd datahub-web-react && yarn test src/path/to/file.test.ts --run
+
+# Playwright e2e formatting
+cd e2e-test/ui/playwright && yarn format:check
+```
+
+`yarn type-check` in CI runs repo-wide and will surface pre-existing errors in
+unrelated files. Focus on errors in files **you touched** — in particular, optional
+prop calls (`prop?.(arg)`) and import aliases.
+
 ## Python Virtual Environments
 
 Gradle tasks manage all venvs automatically. Never create, activate, or pip-install into them manually. When running smoke tests outside Gradle: `smoke-test/venv/bin/python -m pytest ...`

--- a/datahub-web-react/.prettierignore
+++ b/datahub-web-react/.prettierignore
@@ -1,5 +1,6 @@
 ../docs-website
 ../docs/generated
+**/.git/**
 **/.venv
 **/venv
 **/.tox


### PR DESCRIPTION
Document commit/PR-ready frontend verification steps and Playwright seeding conventions in AGENTS.md, with a cross-reference from the datahub-dev rule.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
