### PR TITLE
feat(ingestion): add ssl_verify option to Trino source

### DIFF
--- a/metadata-ingestion/docs/sources/trino/trino_recipe.yml
+++ b/metadata-ingestion/docs/sources/trino/trino_recipe.yml
@@ -15,7 +15,15 @@ source:
     # options:
     #   connect_args:
     #     http_scheme: https
-    
+    #
+    # Optional -- SSL certificate verification for HTTPS connections.
+    # Prefer a CA bundle / certificate file path for production environments that use
+    # a private CA or self-signed certificate. Setting ssl_verify: false disables SSL
+    # certificate verification and should only be used for testing or trusted internal
+    # environments.
+    # ssl_verify: /etc/datahub/certs/trino-server.crt
+    # ssl_verify: false
+
     # Optional -- A mapping of trino catalog to its connector details like connector database, env and platform instance.
     # This configuration is used to ingest lineage of datasets to connectors. Use catalog name as key.
     # catalog_to_connector_details:

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/trino.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/trino.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Iterable, List, Optional, Union
 import sqlalchemy
 import trino
 from packaging import version
+from pydantic import field_validator, model_validator
 from pydantic.fields import Field
 from sqlalchemy import exc, sql
 from sqlalchemy.engine import reflection
@@ -265,6 +266,40 @@ class TrinoConfig(BasicSQLAlchemyConfig):
         default=True,
         description="Experimental feature. Whether trino dataset should be primary entity of the set of siblings",
     )
+
+    ssl_verify: Optional[Union[bool, str]] = Field(
+        default=None,
+        description=(
+            "SSL certificate verification setting for Trino HTTPS connections. "
+            "Set to false to disable SSL verification, or set to a path to a CA "
+            "bundle / certificate file to verify Trino using a custom certificate. "
+            "When unset, the underlying Trino Python client's default behavior is used. "
+            "This value is passed to the Trino client as the `verify` connection argument."
+        ),
+    )
+
+    @field_validator("ssl_verify", mode="before")
+    @classmethod
+    def normalize_ssl_verify(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            normalized_value = value.strip().lower()
+            if normalized_value == "true":
+                return True
+            if normalized_value == "false":
+                return False
+        return value
+
+    @model_validator(mode="after")
+    def set_ssl_verify_connect_arg(self) -> "TrinoConfig":
+        if self.ssl_verify is not None:
+            connect_args = self.options.setdefault("connect_args", {})
+
+            if not isinstance(connect_args, dict):
+                raise ValueError("options.connect_args must be a dictionary")
+
+            connect_args["verify"] = self.ssl_verify
+
+        return self
 
     def get_identifier(self: BasicSQLAlchemyConfig, schema: str, table: str) -> str:
         return f"{self.database}.{schema}.{table}"

--- a/metadata-ingestion/tests/unit/test_trino.py
+++ b/metadata-ingestion/tests/unit/test_trino.py
@@ -1,5 +1,8 @@
 from unittest import mock
 
+import pytest
+from pydantic import ValidationError
+
 from datahub.emitter.mce_builder import make_schema_field_urn
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.source.sql.sql_common import PipelineContext, SQLAlchemySource
@@ -45,6 +48,132 @@ def get_test_trino_schema_metadata(
             for path in field_paths
         ],
     )
+
+
+def test_trino_ssl_verify_false_sets_connect_arg() -> None:
+    config = TrinoConfig.model_validate(
+        {
+            "host_port": "localhost:8443",
+            "database": "hive",
+            "username": "admin",
+            "password": "password",
+            "options": {"connect_args": {"http_scheme": "https"}},
+            "ssl_verify": False,
+        }
+    )
+
+    assert config.options["connect_args"]["http_scheme"] == "https"
+    assert config.options["connect_args"]["verify"] is False
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected_value"),
+    [
+        ("false", False),
+        ("true", True),
+        (" FALSE ", False),
+        (" True ", True),
+    ],
+)
+def test_trino_ssl_verify_string_booleans_set_bool_connect_arg(
+    raw_value: str, expected_value: bool
+) -> None:
+    config = TrinoConfig.model_validate(
+        {
+            "host_port": "localhost:8443",
+            "database": "hive",
+            "username": "admin",
+            "password": "password",
+            "options": {"connect_args": {"http_scheme": "https"}},
+            "ssl_verify": raw_value,
+        }
+    )
+
+    assert config.options["connect_args"]["http_scheme"] == "https"
+    assert config.options["connect_args"]["verify"] is expected_value
+
+
+def test_trino_ssl_verify_path_sets_connect_arg() -> None:
+    config = TrinoConfig.model_validate(
+        {
+            "host_port": "localhost:8443",
+            "database": "hive",
+            "username": "admin",
+            "password": "password",
+            "options": {"connect_args": {"http_scheme": "https"}},
+            "ssl_verify": "/etc/datahub/certs/trino-server.crt",
+        }
+    )
+
+    assert config.options["connect_args"]["http_scheme"] == "https"
+    assert (
+        config.options["connect_args"]["verify"]
+        == "/etc/datahub/certs/trino-server.crt"
+    )
+
+
+def test_trino_ssl_verify_unset_does_not_set_verify() -> None:
+    config = TrinoConfig.model_validate(
+        {
+            "host_port": "localhost:8080",
+            "database": "hive",
+            "username": "admin",
+            "password": "password",
+        }
+    )
+
+    assert "verify" not in config.options.get("connect_args", {})
+
+
+def test_trino_ssl_verify_preserves_existing_connect_args() -> None:
+    config = TrinoConfig.model_validate(
+        {
+            "host_port": "localhost:8443",
+            "database": "hive",
+            "username": "admin",
+            "password": "password",
+            "options": {
+                "connect_args": {
+                    "http_scheme": "https",
+                    "source": "datahub",
+                }
+            },
+            "ssl_verify": False,
+        }
+    )
+
+    assert config.options["connect_args"]["http_scheme"] == "https"
+    assert config.options["connect_args"]["source"] == "datahub"
+    assert config.options["connect_args"]["verify"] is False
+
+
+def test_trino_ssl_verify_takes_precedence_over_connect_args_verify() -> None:
+    config = TrinoConfig.model_validate(
+        {
+            "host_port": "localhost:8443",
+            "database": "hive",
+            "username": "admin",
+            "password": "password",
+            "options": {"connect_args": {"http_scheme": "https", "verify": True}},
+            "ssl_verify": False,
+        }
+    )
+
+    assert config.options["connect_args"]["verify"] is False
+
+
+def test_trino_ssl_verify_rejects_non_dict_connect_args() -> None:
+    with pytest.raises(ValidationError):
+        TrinoConfig.model_validate(
+            {
+                "host_port": "localhost:8443",
+                "database": "hive",
+                "username": "admin",
+                "password": "password",
+                "options": {"connect_args": "invalid"},
+                "ssl_verify": False,
+            }
+        )
 
 
 def test_trino_gen_lineage_workunit_includes_fine_grained_lineage_when_schema_provided():


### PR DESCRIPTION
Closes #18016

### Motivation

Trino ingestion over HTTPS with a self-signed certificate or a private CA currently requires container-wide `REQUESTS_CA_BUNDLE` / `SSL_CERT_FILE` settings. This is inconvenient for deployments that need to configure SSL verification per ingestion source.

This PR adds a source-level SSL verification option for the Trino source while keeping the default behavior unchanged.

- #18016

### Description

* Add `ssl_verify` to `TrinoConfig`.
* Map `ssl_verify` to Trino SQLAlchemy `connect_args.verify`.
* Support `true`, `false`, and certificate bundle path values.
* Preserve existing `options.connect_args` behavior.
* Update Trino recipe docs.
* Add unit coverage for boolean values, string boolean values, certificate bundle paths, default behavior, and existing `connect_args`.

### Testing

* Added/updated unit tests in `metadata-ingestion/tests/unit/test_trino.py`
* `./gradlew :metadata-ingestion:lintFix --no-daemon`
* `./gradlew :metadata-ingestion:lint --no-daemon`
* `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/test_trino.py --no-daemon`
