### PR TITLE
docs(managed-datahub): release notes for v1.1.4

### DIFF
--- a/docs/managed-datahub/release-notes/v_1_1_0.md
+++ b/docs/managed-datahub/release-notes/v_1_1_0.md
@@ -22,7 +22,10 @@ Hotfix release on top of **v1.1.3**.
 
 #### Platform
 
-- **Authorization — policy engine performance**: Authorization checks now resolve each resource once per request and evaluate actor-scoped policies directly, reducing redundant work on requests that touch many resources.
+- **Authorization — policy engine performance**
+  - Authorization checks now resolve each resource once per request and evaluate actor-scoped policies directly, reducing redundant work on requests that touch many resources.
+  - Request-scoped group/role membership fetched once at request start and shared across all checks; removes redundant fetcher classes and takes GraphQL resolvers off the storage hot path
+  - Per-request attribute memoization of asset attributes (e.g. domain hierarchy) resolved once per request instead of up to 9× across privilege checks
 
 - **Semantic search — enriched dataset bridge documents**: Dataset bridge documents now include structured properties, field-level tags and glossary terms, doc links, and domains, improving semantic-search relevance for dataset discovery.
 

--- a/docs/managed-datahub/release-notes/v_1_1_0.md
+++ b/docs/managed-datahub/release-notes/v_1_1_0.md
@@ -23,6 +23,7 @@ Hotfix release on top of **v1.1.3**.
 #### Platform
 
 - **Authorization — policy engine performance**
+
   - Authorization checks now resolve each resource once per request and evaluate actor-scoped policies directly, reducing redundant work on requests that touch many resources.
   - Request-scoped group/role membership fetched once at request start and shared across all checks; removes redundant fetcher classes and takes GraphQL resolvers off the storage hot path
   - Per-request attribute memoization of asset attributes (e.g. domain hierarchy) resolved once per request instead of up to 9× across privilege checks

--- a/docs/managed-datahub/release-notes/v_1_1_0.md
+++ b/docs/managed-datahub/release-notes/v_1_1_0.md
@@ -18,7 +18,7 @@ Hotfix release on top of **v1.1.3**.
 
 - **CLI / SDK**: v1.6.0
 - **Remote Executor**: v1.1.4-cloud
-- **Helm**: 1.6.158
+- **Helm**: 1.6.176
 
 #### Platform
 

--- a/docs/managed-datahub/release-notes/v_1_1_0.md
+++ b/docs/managed-datahub/release-notes/v_1_1_0.md
@@ -6,6 +6,48 @@ description: "DataHub Cloud v1.1.0 release notes covering OAuth2 dynamic client 
 
 ## Release Changelog
 
+### v1.1.4
+
+Hotfix release on top of **v1.1.3**.
+
+#### Release Availability Date
+
+25-June-2026
+
+**Recommended Versions**
+
+- **CLI / SDK**: v1.6.0
+- **Remote Executor**: v1.1.4-cloud
+- **Helm**: 1.6.158
+
+#### Platform
+
+- **Authorization — policy engine performance**: Authorization checks now resolve each resource once per request and evaluate actor-scoped policies directly, reducing redundant work on requests that touch many resources.
+
+- **Semantic search — enriched dataset bridge documents**: Dataset bridge documents now include structured properties, field-level tags and glossary terms, doc links, and domains, improving semantic-search relevance for dataset discovery.
+
+- **Semantic search — bridge document backfill**: The backfill is now significantly faster at production scale (direct full-doc writes, bounded-parallelism batching) and resilient to permanent failures — cursor advances past irrecoverable URNs rather than looping indefinitely.
+
+#### Ingestion / Executor
+
+- **Executor — reduced memory footprint on slim builds**: When `DATAHUB_USE_OBSERVE_MODELS=false`, the smart-assertion trainer no longer imports the observe-models package at module load, eliminating transitive PyTorch and Darts imports and reducing resident memory on slim or low-RAM executor builds.
+
+#### Breaking Changes
+
+- **Dataset semantic search is no longer enabled implicitly**: Enabling semantic search with the default `ELASTICSEARCH_SEMANTIC_SEARCH_ENTITIES=document` no longer also bridges datasets; `dataset` must be listed explicitly (`document,dataset`). **Action:** for instances relying on dataset semantic search, set `ELASTICSEARCH_SEMANTIC_SEARCH_ENTITIES=document,dataset` on GMS and the system-update job — otherwise datasets stop being semantically searchable after upgrade.
+
+- **Removed `REQUEST_MINIMAL_SLACK_PERMISSIONS` / `requestMinimalSlackPermissions` feature flag**: This deploy-wide knob hard-excluded the Slack `:history` scopes from the install manifest. Its job is now done by `DATAHUB_SLACK_SERVER_SIDE_HISTORY_ENABLED`, which marks the same scopes as **optional** in the Slack install screen — admins can deselect them per install rather than the choice being baked in at deploy time. If the env var was set on your instance, remove it and either (a) set `DATAHUB_SLACK_SERVER_SIDE_HISTORY_ENABLED=true` and have the workspace admin deselect the history scopes when refreshing the install, or (b) leave it off, in which case the Slack app will request the full scope set as before.
+
+- **Subscriptions without explicit notification settings now inherit notification defaults dynamically**: GraphQL callers that omit `notificationConfig` when creating a subscription through `syncSubscription`, or send `notificationConfig` without `notificationSettings`, will leave the subscription configured to use the actor's current notification defaults at delivery time instead of creating a subscription with no sinks. Existing subscriptions are unchanged when `notificationConfig` is omitted during a sync. Callers that intentionally want a no-sink subscription should send `notificationConfig.notificationSettings.sinkTypes: []` explicitly.
+
+- **Smart-assertion inference routing split into `DATAHUB_USE_INFERENCE_V2`**: Previously `DATAHUB_USE_OBSERVE_MODELS=true` both enabled the observe-models package and routed smart-assertion training to the V2 pipeline. These are now decoupled: `DATAHUB_USE_OBSERVE_MODELS` (default `false`) controls only whether observe-models may be loaded and used by the V1 trainer's preprocessor, and the new `DATAHUB_USE_INFERENCE_V2` (default `false`) selects the V2 trainer pipeline. V2 still requires observe-models. **Action required:** any executor currently running `DATAHUB_USE_OBSERVE_MODELS=true` to get V2 must also set `DATAHUB_USE_INFERENCE_V2=true`; otherwise on upgrade it falls back to the V1 trainer (with the observe-models preprocessor) instead of V2.
+
+- **MCP tools `register_feedback` and `note_sql_anchor_observation` removed**: These tools have been replaced by a single `note_metadata_observation` tool covering both metadata gaps and SQL-anchor quality observations. Agent prompts that reference the old tool names must be updated.
+
+#### Bug Fixes
+
+- **Executor — smart assertion timeseries queries**: Fixed timeseries range filters to use `Criterion.values` so GMS correctly applies timestamp bounds on smart assertion evaluation queries.
+
 ### v1.1.3
 
 Hotfix release on top of **v1.1.2**. There are no breaking changes or deprecations.


### PR DESCRIPTION
DataHub Cloud v1.1.4 release notes.

See the added block under `docs/managed-datahub/release-notes/v_1_1_0.md`.

## Test plan
- [ ] `markdown_format / markdown_format_check (pull_request)` passes
- [ ] Release Availability Date and Recommended Versions filled in before marking ready