### PR TITLE
fix(ingest/tableau): pass ssl_verify through to requests verify

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
@@ -319,13 +319,7 @@ class TableauConnectionConfig(ConfigModel):
                 self.connect_uri,
                 use_server_version=True,
                 http_options={
-                    # As per https://community.tableau.com/s/question/0D54T00000F33bdSAB/tableauserverclient-signin-with-ssl-certificate
-                    "verify": bool(self.ssl_verify),
-                    **(
-                        {"cert": self.ssl_verify}
-                        if isinstance(self.ssl_verify, str)
-                        else {}
-                    ),
+                    "verify": self.ssl_verify,
                 },
             )
 

--- a/metadata-ingestion/tests/unit/tableau/test_tableau_source.py
+++ b/metadata-ingestion/tests/unit/tableau/test_tableau_source.py
@@ -178,6 +178,30 @@ def test_tableau_no_verify():
     assert "Unable to login" in report
 
 
+@pytest.mark.parametrize(
+    "ssl_verify",
+    [
+        True,
+        False,
+        "/etc/ssl/certs/custom-ca-bundle.pem",
+    ],
+)
+def test_tableau_ssl_verify_passed_to_http_options(ssl_verify):
+    config = TableauConfig.model_validate(
+        {
+            **default_config,
+            "ssl_verify": ssl_verify,
+        }
+    )
+
+    with mock.patch("datahub.ingestion.source.tableau.tableau.Server") as mock_server:
+        config.make_tableau_client(config.site)
+
+    http_options = mock_server.call_args.kwargs["http_options"]
+    assert http_options["verify"] == ssl_verify
+    assert "cert" not in http_options
+
+
 def test_tableau_unsupported_csql():
     context = PipelineContext(run_id="0", pipeline_name="test_tableau")
     config_dict = default_config.copy()


### PR DESCRIPTION
## Summary

- Fix Tableau connector SSL handling so `ssl_verify` is passed directly to `requests` as `verify` instead of being coerced to `bool` and misrouted to `cert`.
- When `ssl_verify` was a path (e.g. `/etc/ssl/certs/ca-certificates.crt`), the old code set `verify=True` and `cert=<path>`. The CA bundle was treated as a client certificate, causing SSL failures before sign-in (`[SSL] PEM lib` / `CERTIFICATE_VERIFY_FAILED`).
- Add a parametrized unit test asserting `http_options` uses `verify=<ssl_verify>` and never sets `cert`.

Fixes customer issues where Tableau ingestion failed against servers using internal/private CAs (ING-2485, ING-2741).