### PR TITLE
feat(ingest/confluence): ingest folders as documents to preserve hierarchy

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_config.py
@@ -220,6 +220,17 @@ class ConfluenceSourceConfig(
         description="Optional parent document URN for top-level imported pages.",
     )
 
+    ingest_folders: bool = Field(
+        default=True,
+        description=(
+            "Ingest Confluence folders as document entities so that pages nested "
+            "under folders keep their place in the hierarchy. Confluence folders "
+            "are a separate content type that the page APIs never return, so when "
+            "this is disabled a page whose immediate parent is a folder is emitted "
+            "without a parent link and appears as a root document."
+        ),
+    )
+
     # Content processing
     processing: ProcessingConfig = Field(
         default_factory=ProcessingConfig,

--- a/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_hierarchy.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_hierarchy.py
@@ -1,8 +1,23 @@
 """Hierarchy extraction logic for Confluence pages."""
 
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set
 
 from datahub.metadata.schema_classes import BrowsePathEntryClass, BrowsePathsV2Class
+
+
+@dataclass
+class FolderNode:
+    """A Confluence folder discovered as an ancestor of an ingested page."""
+
+    id: str
+    title: str
+    # Immediate parent ancestor id (page or folder). None => directly under the space.
+    parent_id: Optional[str]
+    space_name: Optional[str]
+    space_key: Optional[str]
+    # Ancestors that precede this folder, used to build its browse path.
+    ancestor_prefix: List[Dict[str, Any]] = field(default_factory=list)
 
 
 class ConfluenceHierarchyExtractor:
@@ -244,3 +259,44 @@ class ConfluenceHierarchyExtractor:
             )
 
         return BrowsePathsV2Class(path=path_entries)
+
+    @staticmethod
+    def collect_folder_nodes(pages: List[Dict[str, Any]]) -> Dict[str, FolderNode]:
+        """Collect Confluence folders that appear as ancestors of ingested pages.
+
+        A page's ``ancestors`` array is ordered root-to-immediate-parent and may
+        contain folder entries (``type == "folder"``). An ancestor's parent is the
+        entry before it (or the space root for the first entry), which lets us
+        reconstruct the folder chain with no extra API calls. Empty folders (no
+        ingested descendant pages) are omitted since they add nothing to the tree.
+        """
+        folders: Dict[str, FolderNode] = {}
+        for page in pages:
+            ancestors = page.get("ancestors", [])
+            if not isinstance(ancestors, list):
+                continue
+            space_name = ConfluenceHierarchyExtractor.extract_space_name(page)
+            space_key = ConfluenceHierarchyExtractor.extract_space_key(page)
+            for index, ancestor in enumerate(ancestors):
+                if not isinstance(ancestor, dict):
+                    continue
+                if str(ancestor.get("type")) != "folder":
+                    continue
+                folder_id = str(ancestor.get("id") or "")
+                if not folder_id or folder_id in folders:
+                    continue
+                parent = ancestors[index - 1] if index > 0 else None
+                parent_id = (
+                    str(parent.get("id"))
+                    if isinstance(parent, dict) and parent.get("id")
+                    else None
+                )
+                folders[folder_id] = FolderNode(
+                    id=folder_id,
+                    title=str(ancestor.get("title") or f"Folder {folder_id}"),
+                    parent_id=parent_id,
+                    space_name=space_name,
+                    space_key=space_key,
+                    ancestor_prefix=ancestors[:index],
+                )
+        return folders

--- a/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_hierarchy.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_hierarchy.py
@@ -1,9 +1,12 @@
 """Hierarchy extraction logic for Confluence pages."""
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set
 
 from datahub.metadata.schema_classes import BrowsePathEntryClass, BrowsePathsV2Class
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -269,34 +272,51 @@ class ConfluenceHierarchyExtractor:
         entry before it (or the space root for the first entry), which lets us
         reconstruct the folder chain with no extra API calls. Empty folders (no
         ingested descendant pages) are omitted since they add nothing to the tree.
+
+        Folder discovery is a best-effort enrichment of the page hierarchy, so a
+        malformed page or ancestor entry is skipped rather than allowed to abort
+        discovery for the rest of the pages — it must never sink the ingestion job.
         """
         folders: Dict[str, FolderNode] = {}
+        if not isinstance(pages, list):
+            return folders
         for page in pages:
-            ancestors = page.get("ancestors", [])
-            if not isinstance(ancestors, list):
+            try:
+                if not isinstance(page, dict):
+                    continue
+                ancestors = page.get("ancestors", [])
+                if not isinstance(ancestors, list):
+                    continue
+                space_name = ConfluenceHierarchyExtractor.extract_space_name(page)
+                space_key = ConfluenceHierarchyExtractor.extract_space_key(page)
+                for index, ancestor in enumerate(ancestors):
+                    if not isinstance(ancestor, dict):
+                        continue
+                    if str(ancestor.get("type")) != "folder":
+                        continue
+                    folder_id = str(ancestor.get("id") or "")
+                    if not folder_id or folder_id in folders:
+                        continue
+                    parent = ancestors[index - 1] if index > 0 else None
+                    parent_id = (
+                        str(parent.get("id"))
+                        if isinstance(parent, dict) and parent.get("id")
+                        else None
+                    )
+                    folders[folder_id] = FolderNode(
+                        id=folder_id,
+                        title=str(ancestor.get("title") or f"Folder {folder_id}"),
+                        parent_id=parent_id,
+                        space_name=space_name,
+                        space_key=space_key,
+                        ancestor_prefix=ancestors[:index],
+                    )
+            except Exception as e:
+                # Never let a single malformed page abort folder discovery for the
+                # rest; folders are an enrichment, not a hard requirement.
+                logger.warning(
+                    f"Skipping folder discovery for page "
+                    f"{page.get('id') if isinstance(page, dict) else page!r}: {e}"
+                )
                 continue
-            space_name = ConfluenceHierarchyExtractor.extract_space_name(page)
-            space_key = ConfluenceHierarchyExtractor.extract_space_key(page)
-            for index, ancestor in enumerate(ancestors):
-                if not isinstance(ancestor, dict):
-                    continue
-                if str(ancestor.get("type")) != "folder":
-                    continue
-                folder_id = str(ancestor.get("id") or "")
-                if not folder_id or folder_id in folders:
-                    continue
-                parent = ancestors[index - 1] if index > 0 else None
-                parent_id = (
-                    str(parent.get("id"))
-                    if isinstance(parent, dict) and parent.get("id")
-                    else None
-                )
-                folders[folder_id] = FolderNode(
-                    id=folder_id,
-                    title=str(ancestor.get("title") or f"Folder {folder_id}"),
-                    parent_id=parent_id,
-                    space_name=space_name,
-                    space_key=space_key,
-                    ancestor_prefix=ancestors[:index],
-                )
         return folders

--- a/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_report.py
@@ -26,6 +26,9 @@ class ConfluenceSourceReport(StaleEntityRemovalSourceReport):
     pages_failed: int = 0
     failed_pages: List[Tuple[str, str]] = field(default_factory=list)
 
+    # Folder-level metrics
+    folders_ingested: int = 0
+
     # Content metrics
     total_text_extracted_bytes: int = 0
     total_chunks_generated: int = 0

--- a/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_report.py
@@ -28,6 +28,7 @@ class ConfluenceSourceReport(StaleEntityRemovalSourceReport):
 
     # Folder-level metrics
     folders_ingested: int = 0
+    folders_failed: int = 0
 
     # Content metrics
     total_text_extracted_bytes: int = 0
@@ -83,6 +84,16 @@ class ConfluenceSourceReport(StaleEntityRemovalSourceReport):
         self.pages_failed += 1
         self.failed_pages.append((space_key, page_id))
         self.report_failure(page_id, f"Failed to process page: {error}")
+
+    def report_folder_failed(self, folder_id: str, error: str) -> None:
+        """Record a folder discovery/emission failure.
+
+        Folders are a best-effort hierarchy reconstruction layered on top of the
+        pages we already ingest, so a folder problem is reported as a warning
+        rather than a hard failure — it must never sink the ingestion job.
+        """
+        self.folders_failed += 1
+        self.report_warning(folder_id, f"Failed to process folder: {error}")
 
     def report_text_extracted(self, num_bytes: int) -> None:
         """Record text extraction metrics."""

--- a/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_source.py
@@ -35,6 +35,7 @@ from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.confluence.confluence_config import ConfluenceSourceConfig
 from datahub.ingestion.source.confluence.confluence_hierarchy import (
     ConfluenceHierarchyExtractor,
+    FolderNode,
 )
 from datahub.ingestion.source.confluence.confluence_html import html_storage_to_markdown
 from datahub.ingestion.source.confluence.confluence_report import ConfluenceSourceReport
@@ -59,6 +60,10 @@ logger = logging.getLogger(__name__)
 # conversion, macro stripping, text normalization) to force re-ingestion of
 # all pages on the next run regardless of whether the raw Confluence body changed.
 EXTRACTION_ALGO_VERSION = "2"
+
+# Subtype applied to documents that represent Confluence folders, matching the
+# value DataHub uses for natively-created folders.
+FOLDER_SUBTYPE = "Folder"
 
 
 @platform_name("Confluence")
@@ -808,6 +813,99 @@ class ConfluenceSource(StatefulIngestionSourceBase, TestableSource):
             last_modified_time=last_modified_time,
         )
 
+    def _add_platform_instance(self, doc: Document) -> None:
+        """Attach the dataPlatformInstance aspect so the UI can render the
+        "View in Confluence" link. Uses the URL subdomain as the instance id.
+
+        TODO: promote this to an official Document SDK parameter instead of the
+        _set_aspect backdoor.
+        """
+        if not self.config.url:
+            return
+        from urllib.parse import urlparse
+
+        parsed_url = urlparse(self.config.url)
+        instance_id = (
+            parsed_url.netloc.split(".")[0] if parsed_url.netloc else self.config.url
+        )
+        doc._set_aspect(
+            DataPlatformInstanceClass(
+                platform=make_data_platform_urn(self.platform),
+                instance=make_dataplatform_instance_urn(self.platform, instance_id),
+            )
+        )
+
+    def _create_folder_entity(
+        self, folder: FolderNode, ingested_page_ids: Set[str]
+    ) -> Iterable[MetadataWorkUnit]:
+        """Emit a document entity for a Confluence folder so pages nested under it
+        keep their hierarchy. Folders have no content, so they carry the "Folder"
+        subtype and skip the chunking/embedding step that pages go through."""
+        instance_id = self._get_instance_id()
+        doc_id = f"confluence-{instance_id}-{folder.id}"
+
+        # Link to the folder's parent (a page or another folder) when it is also
+        # ingested; otherwise the folder is a root document under the space.
+        parent_urn = None
+        if folder.parent_id and folder.parent_id in ingested_page_ids:
+            parent_urn = ConfluenceHierarchyExtractor.build_parent_urn(
+                parent_id=folder.parent_id,
+                platform=self.platform,
+                instance_id=instance_id,
+            )
+
+        custom_properties = {
+            "space_key": folder.space_key or "",
+            "folder_id": folder.id,
+        }
+        if self.config.document_import_mode == DocumentImportMode.NATIVE:
+            doc = Document.create_document(
+                id=doc_id,
+                title=folder.title,
+                text="",
+                status=DocumentStateClass.PUBLISHED,
+                subtype=FOLDER_SUBTYPE,
+                custom_properties=custom_properties,
+                parent_document=parent_urn,
+            )
+        else:
+            base_url = self.config.url.rstrip("/").removesuffix("/wiki")
+            url = (
+                f"{base_url}/wiki/spaces/{folder.space_key}/folder/{folder.id}"
+                if folder.space_key
+                else f"{base_url}/wiki/folder/{folder.id}"
+            )
+            doc = Document.create_external_document(
+                id=doc_id,
+                title=folder.title,
+                platform=self.platform,
+                external_url=url,
+                external_id=folder.id,
+                text="",
+                status=DocumentStateClass.PUBLISHED,
+                subtype=FOLDER_SUBTYPE,
+                custom_properties=custom_properties,
+                parent_document=parent_urn,
+            )
+        self._add_platform_instance(doc)
+
+        # Reuse the page browse-path builder by passing the ancestors that
+        # precede this folder as a synthetic page metadata payload.
+        browse_path_v2 = ConfluenceHierarchyExtractor.build_browse_path_v2(
+            page_metadata={
+                "space": {"name": folder.space_name, "key": folder.space_key},
+                "ancestors": folder.ancestor_prefix,
+            },
+            platform=self.platform,
+            instance_id=instance_id,
+            ingested_page_ids=ingested_page_ids,
+        )
+        if browse_path_v2:
+            doc._set_aspect(browse_path_v2)
+
+        yield from doc.as_workunits()
+        self.report.folders_ingested += 1
+
     def _create_document_entity(
         self,
         page: Dict[str, Any],
@@ -943,26 +1041,7 @@ class ConfluenceSource(StatefulIngestionSourceBase, TestableSource):
             last_modified_time=last_modified_time,
         )
 
-        # Add dataPlatformInstance aspect for UI features (e.g., "View in Confluence" button)
-        # TODO: This should be added to the Document SDK as an official parameter
-        # instead of using the backdoor _set_aspect() method
-        if self.config.url:
-            # Extract instance identifier from URL (e.g., "datahub-integration-testing" from the domain)
-            from urllib.parse import urlparse
-
-            parsed_url = urlparse(self.config.url)
-            # Use the domain as the instance identifier
-            instance_id = (
-                parsed_url.netloc.split(".")[0]
-                if parsed_url.netloc
-                else self.config.url
-            )
-
-            platform_instance = DataPlatformInstanceClass(
-                platform=make_data_platform_urn(self.platform),
-                instance=make_dataplatform_instance_urn(self.platform, instance_id),
-            )
-            doc._set_aspect(platform_instance)
+        self._add_platform_instance(doc)
 
         # Add BrowsePathsV2 for hierarchical navigation
         browse_path_v2 = ConfluenceHierarchyExtractor.build_browse_path_v2(
@@ -1095,6 +1174,16 @@ class ConfluenceSource(StatefulIngestionSourceBase, TestableSource):
             f"Ingesting {len(ingested_page_ids)} pages: {sorted(list(ingested_page_ids))}"
         )
 
+        # Folders are a separate Confluence content type the page APIs never
+        # return, so a page nested under a folder loses its parent link unless we
+        # materialise the folder. Register folder URNs up front so child pages
+        # (and nested folders) resolve their parent against an entity we emit.
+        folder_nodes: Dict[str, FolderNode] = {}
+        if self.config.ingest_folders:
+            folder_nodes = ConfluenceHierarchyExtractor.collect_folder_nodes(all_pages)
+            ingested_page_ids |= set(folder_nodes.keys())
+            logger.info(f"Discovered {len(folder_nodes)} folder(s) in page ancestry")
+
         # Build set of parent page IDs (pages that have children)
         parent_page_ids: Set[str] = set()
         for page in all_pages:
@@ -1104,6 +1193,21 @@ class ConfluenceSource(StatefulIngestionSourceBase, TestableSource):
                 parent_id = str(ancestors[-1].get("id", ""))
                 if parent_id:
                     parent_page_ids.add(parent_id)
+
+        # Emit folder entities first so the parent documents exist before the
+        # child pages (and nested folders) that reference them.
+        for folder_node in folder_nodes.values():
+            try:
+                yield from self._create_folder_entity(folder_node, ingested_page_ids)
+            except Exception as e:
+                logger.error(
+                    f"Failed to create entity for folder {folder_node.id}: {e}"
+                )
+                self.report.report_page_failed(
+                    folder_node.id, folder_node.space_key or "unknown", str(e)
+                )
+                if not self.config.advanced.continue_on_failure:
+                    raise
 
         # Second pass: create document entities
         for page in all_pages:

--- a/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_source.py
@@ -1180,9 +1180,20 @@ class ConfluenceSource(StatefulIngestionSourceBase, TestableSource):
         # (and nested folders) resolve their parent against an entity we emit.
         folder_nodes: Dict[str, FolderNode] = {}
         if self.config.ingest_folders:
-            folder_nodes = ConfluenceHierarchyExtractor.collect_folder_nodes(all_pages)
-            ingested_page_ids |= set(folder_nodes.keys())
-            logger.info(f"Discovered {len(folder_nodes)} folder(s) in page ancestry")
+            try:
+                folder_nodes = ConfluenceHierarchyExtractor.collect_folder_nodes(
+                    all_pages
+                )
+                ingested_page_ids |= set(folder_nodes.keys())
+                logger.info(
+                    f"Discovered {len(folder_nodes)} folder(s) in page ancestry"
+                )
+            except Exception as e:
+                # Folder discovery is best-effort enrichment of the hierarchy;
+                # never let it abort the ingestion of the pages themselves.
+                logger.warning(f"Failed to discover folders from page ancestry: {e}")
+                self.report.report_folder_failed("<discovery>", str(e))
+                folder_nodes = {}
 
         # Build set of parent page IDs (pages that have children)
         parent_page_ids: Set[str] = set()
@@ -1200,14 +1211,14 @@ class ConfluenceSource(StatefulIngestionSourceBase, TestableSource):
             try:
                 yield from self._create_folder_entity(folder_node, ingested_page_ids)
             except Exception as e:
-                logger.error(
+                # Folders are best-effort hierarchy reconstruction; a folder that
+                # fails to materialise is logged as a warning but must never abort
+                # the ingestion of the actual pages, regardless of
+                # continue_on_failure.
+                logger.warning(
                     f"Failed to create entity for folder {folder_node.id}: {e}"
                 )
-                self.report.report_page_failed(
-                    folder_node.id, folder_node.space_key or "unknown", str(e)
-                )
-                if not self.config.advanced.continue_on_failure:
-                    raise
+                self.report.report_folder_failed(folder_node.id, str(e))
 
         # Second pass: create document entities
         for page in all_pages:

--- a/metadata-ingestion/tests/unit/ingestion/source/confluence/test_confluence_hierarchy.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/confluence/test_confluence_hierarchy.py
@@ -314,3 +314,89 @@ def test_build_browse_path_v2_fallback_to_space_key() -> None:
     # Should use space key as fallback
     assert browse_path.path[0].id == "TEAM"
     assert browse_path.path[0].urn is None
+
+
+def test_collect_folder_nodes_basic() -> None:
+    """A page nested under a folder yields a FolderNode whose parent is the
+    page above the folder in the ancestry."""
+    pages = [
+        {
+            "id": "67043329",
+            "title": "Doc inside a folder",
+            "space": {"key": "FB", "name": "Fiction Bank"},
+            "ancestors": [
+                {"id": "16351389", "title": "Fiction Bank", "type": "page"},
+                {"id": "67010561", "title": "Nick demo", "type": "folder"},
+            ],
+        }
+    ]
+
+    folders = ConfluenceHierarchyExtractor.collect_folder_nodes(pages)
+
+    assert set(folders.keys()) == {"67010561"}
+    node = folders["67010561"]
+    assert node.title == "Nick demo"
+    assert node.parent_id == "16351389"
+    assert node.space_key == "FB"
+    assert node.space_name == "Fiction Bank"
+    # ancestor_prefix is everything before the folder (used for its browse path)
+    assert [a["id"] for a in node.ancestor_prefix] == ["16351389"]
+
+
+def test_collect_folder_nodes_nested_folders() -> None:
+    """Folder-under-folder chains are reconstructed from a single page's
+    ancestry, each folder pointing at the entry immediately above it."""
+    pages = [
+        {
+            "id": "900",
+            "ancestors": [
+                {"id": "100", "title": "Home", "type": "page"},
+                {"id": "200", "title": "Outer", "type": "folder"},
+                {"id": "300", "title": "Inner", "type": "folder"},
+            ],
+        }
+    ]
+
+    folders = ConfluenceHierarchyExtractor.collect_folder_nodes(pages)
+
+    assert folders["200"].parent_id == "100"
+    assert folders["300"].parent_id == "200"
+
+
+def test_collect_folder_nodes_folder_directly_under_space() -> None:
+    """A folder that is the first ancestor has no parent (it is a root)."""
+    pages = [
+        {
+            "id": "900",
+            "ancestors": [
+                {"id": "200", "title": "Top Folder", "type": "folder"},
+            ],
+        }
+    ]
+
+    folders = ConfluenceHierarchyExtractor.collect_folder_nodes(pages)
+
+    assert folders["200"].parent_id is None
+
+
+def test_collect_folder_nodes_ignores_pages_and_dedupes() -> None:
+    """Page ancestors are ignored, and a folder shared by multiple pages is
+    only emitted once."""
+    pages = [
+        {
+            "id": "1",
+            "ancestors": [{"id": "200", "title": "Shared", "type": "folder"}],
+        },
+        {
+            "id": "2",
+            "ancestors": [{"id": "200", "title": "Shared", "type": "folder"}],
+        },
+        {
+            "id": "3",
+            "ancestors": [{"id": "50", "title": "Just a page", "type": "page"}],
+        },
+    ]
+
+    folders = ConfluenceHierarchyExtractor.collect_folder_nodes(pages)
+
+    assert set(folders.keys()) == {"200"}

--- a/metadata-ingestion/tests/unit/ingestion/source/confluence/test_confluence_hierarchy.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/confluence/test_confluence_hierarchy.py
@@ -400,3 +400,25 @@ def test_collect_folder_nodes_ignores_pages_and_dedupes() -> None:
     folders = ConfluenceHierarchyExtractor.collect_folder_nodes(pages)
 
     assert set(folders.keys()) == {"200"}
+
+
+def test_collect_folder_nodes_skips_malformed_pages() -> None:
+    """A malformed page must not abort folder discovery for the rest."""
+    pages = [
+        "not-a-dict",  # type: ignore[list-item]
+        {"id": "1", "ancestors": "not-a-list"},
+        {
+            "id": "2",
+            "ancestors": [{"id": "300", "title": "Good", "type": "folder"}],
+        },
+    ]
+
+    folders = ConfluenceHierarchyExtractor.collect_folder_nodes(pages)  # type: ignore[arg-type]
+
+    # The valid folder is still collected despite the malformed entries.
+    assert set(folders.keys()) == {"300"}
+
+
+def test_collect_folder_nodes_non_list_input() -> None:
+    """A non-list input is handled gracefully rather than raising."""
+    assert ConfluenceHierarchyExtractor.collect_folder_nodes(None) == {}  # type: ignore[arg-type]

--- a/metadata-ingestion/tests/unit/ingestion/source/confluence/test_confluence_report.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/confluence/test_confluence_report.py
@@ -1,0 +1,60 @@
+"""Unit tests for ConfluenceSourceReport metric tracking."""
+
+from datahub.ingestion.source.confluence.confluence_report import (
+    ConfluenceSourceReport,
+)
+
+
+def test_space_metrics_track_scanned_processed_and_failed() -> None:
+    report = ConfluenceSourceReport()
+
+    report.report_space_scanned("TEAM")
+    report.report_space_scanned("DOCS")
+    report.report_space_processed("TEAM")
+    report.report_space_failed("DOCS", "permission denied")
+
+    assert report.spaces_scanned == 2
+    assert report.spaces_processed == 1
+    assert report.spaces_failed == 1
+    # A failed space is recorded so operators can see which spaces to investigate.
+    assert report.failed_spaces == ["DOCS"]
+    assert any("permission denied" in str(warning) for warning in report.warnings)
+
+
+def test_page_skipped_and_failed_are_recorded() -> None:
+    report = ConfluenceSourceReport()
+
+    report.report_page_skipped("123", "Filtered by pages.deny")
+    report.report_page_failed("456", "DOCS", "boom")
+
+    assert report.pages_skipped == 1
+    assert report.pages_failed == 1
+    # Failed pages keep both the space and page id for triage.
+    assert report.failed_pages == [("DOCS", "456")]
+    assert any("boom" in str(failure) for failure in report.failures)
+
+
+def test_avg_page_processing_time_only_counts_timed_pages() -> None:
+    report = ConfluenceSourceReport()
+
+    # Pages reported without a processing time must not skew the average.
+    report.report_page_processed("1")
+    report.report_page_processed("2", processing_time=2.0)
+    report.report_page_processed("3", processing_time=4.0)
+
+    assert report.pages_processed == 3
+    assert report.avg_page_processing_time_seconds == 3.0
+
+
+def test_content_metrics_accumulate() -> None:
+    report = ConfluenceSourceReport()
+
+    report.report_text_extracted(100)
+    report.report_text_extracted(50)
+    report.report_chunks_generated(3)
+    report.report_chunks_generated(2)
+    report.report_embeddings_generated(4)
+
+    assert report.total_text_extracted_bytes == 150
+    assert report.total_chunks_generated == 5
+    assert report.total_embeddings_generated == 4

--- a/metadata-ingestion/tests/unit/ingestion/source/confluence/test_confluence_source.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/confluence/test_confluence_source.py
@@ -1118,3 +1118,190 @@ def test_content_hash_in_custom_properties(
         )
     ).hexdigest()
     assert different_hash != expected_hash
+
+
+def _build_source(
+    config: ConfluenceSourceConfig, ctx: PipelineContext
+) -> ConfluenceSource:
+    """Instantiate a ConfluenceSource with the network client patched out."""
+    with patch("datahub.ingestion.source.confluence.confluence_source.Confluence"):
+        return ConfluenceSource(config, ctx)
+
+
+def test_folder_entity_emits_folder_subtype_document(
+    cloud_config: ConfluenceSourceConfig, pipeline_context: PipelineContext
+) -> None:
+    """A folder ancestor is emitted as a Folder-subtyped document with no text."""
+    from datahub.emitter.mcp import MetadataChangeProposalWrapper
+    from datahub.ingestion.source.confluence.confluence_hierarchy import FolderNode
+    from datahub.ingestion.source.confluence.confluence_source import FOLDER_SUBTYPE
+    from datahub.metadata.schema_classes import (
+        DocumentInfoClass,
+        SubTypesClass,
+    )
+
+    source = _build_source(cloud_config, pipeline_context)
+    folder = FolderNode(
+        id="900",
+        title="Engineering",
+        parent_id=None,
+        space_name="Team Space",
+        space_key="TEAM",
+    )
+
+    workunits = list(source._create_folder_entity(folder, ingested_page_ids={"900"}))
+
+    assert source.report.folders_ingested == 1
+    assert workunits, "Folder should produce at least one workunit"
+
+    subtype = None
+    doc_info = None
+    for wu in workunits:
+        if isinstance(wu.metadata, MetadataChangeProposalWrapper):
+            if isinstance(wu.metadata.aspect, SubTypesClass):
+                subtype = wu.metadata.aspect
+            elif isinstance(wu.metadata.aspect, DocumentInfoClass):
+                doc_info = wu.metadata.aspect
+
+    assert subtype is not None and FOLDER_SUBTYPE in subtype.typeNames
+    assert doc_info is not None
+    assert doc_info.title == "Engineering"
+    # Folders carry no content but keep their Confluence id for traceability.
+    assert doc_info.customProperties.get("folder_id") == "900"
+    assert doc_info.customProperties.get("space_key") == "TEAM"
+
+
+def test_folder_entity_links_to_ingested_parent(
+    cloud_config: ConfluenceSourceConfig, pipeline_context: PipelineContext
+) -> None:
+    """When a folder's parent is also ingested, the folder links to it."""
+    from datahub.emitter.mcp import MetadataChangeProposalWrapper
+    from datahub.ingestion.source.confluence.confluence_hierarchy import FolderNode
+    from datahub.metadata.schema_classes import DocumentInfoClass
+
+    source = _build_source(cloud_config, pipeline_context)
+    instance_id = source._get_instance_id()
+    folder = FolderNode(
+        id="900",
+        title="Sub Folder",
+        parent_id="100",
+        space_name="Team Space",
+        space_key="TEAM",
+    )
+
+    workunits = list(
+        source._create_folder_entity(folder, ingested_page_ids={"100", "900"})
+    )
+
+    parent = None
+    for wu in workunits:
+        if isinstance(wu.metadata, MetadataChangeProposalWrapper) and isinstance(
+            wu.metadata.aspect, DocumentInfoClass
+        ):
+            parent = wu.metadata.aspect.parentDocument
+    assert parent is not None
+    assert parent.document == f"urn:li:document:confluence-{instance_id}-100"
+
+
+def test_folder_entity_omits_parent_when_not_ingested(
+    cloud_config: ConfluenceSourceConfig, pipeline_context: PipelineContext
+) -> None:
+    """A folder whose parent is outside the ingestion scope is a root document."""
+    from datahub.emitter.mcp import MetadataChangeProposalWrapper
+    from datahub.ingestion.source.confluence.confluence_hierarchy import FolderNode
+    from datahub.metadata.schema_classes import DocumentInfoClass
+
+    source = _build_source(cloud_config, pipeline_context)
+    folder = FolderNode(
+        id="900",
+        title="Orphan Folder",
+        parent_id="100",  # parent not in ingested_page_ids
+        space_name="Team Space",
+        space_key="TEAM",
+    )
+
+    workunits = list(source._create_folder_entity(folder, ingested_page_ids={"900"}))
+
+    for wu in workunits:
+        if isinstance(wu.metadata, MetadataChangeProposalWrapper) and isinstance(
+            wu.metadata.aspect, DocumentInfoClass
+        ):
+            assert wu.metadata.aspect.parentDocument is None
+
+
+def test_connection_reports_inaccessible_configured_space() -> None:
+    """Configured spaces that can't be reached surface as a failed capability."""
+    config_dict = {
+        "url": "https://test.atlassian.net/wiki",
+        "username": "test@example.com",
+        "api_token": "test-token-123",
+        "spaces": {"allow": ["SECRET"]},
+    }
+
+    with patch(
+        "datahub.ingestion.source.confluence.confluence_source.Confluence"
+    ) as mock_confluence:
+        mock_client = MagicMock()
+        mock_client.get_all_spaces.return_value = {"results": [{"key": "TEAM"}]}
+        mock_client.get_space.side_effect = Exception("403 Forbidden")
+        mock_confluence.return_value = mock_client
+
+        report = ConfluenceSource.test_connection(config_dict)
+
+    assert report.basic_connectivity is not None
+    assert report.basic_connectivity.capable is True
+    assert report.capability_report is not None
+    access = report.capability_report["Space/Page Access"]
+    assert access.capable is False
+    assert "SECRET" in (access.failure_reason or "")
+
+
+def test_connection_validates_accessible_configured_space() -> None:
+    """When configured spaces are reachable, access is reported as capable."""
+    config_dict = {
+        "url": "https://test.atlassian.net/wiki",
+        "username": "test@example.com",
+        "api_token": "test-token-123",
+        "spaces": {"allow": ["TEAM"]},
+    }
+
+    with patch(
+        "datahub.ingestion.source.confluence.confluence_source.Confluence"
+    ) as mock_confluence:
+        mock_client = MagicMock()
+        mock_client.get_all_spaces.return_value = {"results": [{"key": "TEAM"}]}
+        mock_client.get_space.return_value = {"key": "TEAM", "name": "Team Space"}
+        mock_client.get_all_pages_from_space.return_value = [{"id": "1"}, {"id": "2"}]
+        mock_confluence.return_value = mock_client
+
+        report = ConfluenceSource.test_connection(config_dict)
+
+    assert report.capability_report is not None
+    assert report.capability_report["Space/Page Access"].capable is True
+
+
+def test_connection_auto_discovery_reports_no_spaces() -> None:
+    """Auto-discovery surfaces a clear capability failure when no spaces exist."""
+    config_dict = {
+        "url": "https://test.atlassian.net/wiki",
+        "username": "test@example.com",
+        "api_token": "test-token-123",
+    }
+
+    with patch(
+        "datahub.ingestion.source.confluence.confluence_source.Confluence"
+    ) as mock_confluence:
+        mock_client = MagicMock()
+        # First call (basic connectivity) succeeds; the discovery call returns empty.
+        mock_client.get_all_spaces.side_effect = [
+            {"results": [{"key": "TEAM"}]},
+            {},
+        ]
+        mock_confluence.return_value = mock_client
+
+        report = ConfluenceSource.test_connection(config_dict)
+
+    assert report.basic_connectivity is not None
+    assert report.basic_connectivity.capable is True
+    assert report.capability_report is not None
+    assert report.capability_report["Auto-Discovery"].capable is False


### PR DESCRIPTION
## Summary

Confluence **folders** are a distinct content type that the page APIs (`get_all_pages_from_space`, `get_child_pages`, `get_page_by_id`) never return, so they were never ingested. A page nested under a folder therefore lost its parent link — the folder's URN wasn't among the ingested ids, so `parentDocument` was dropped — and the page showed up as an **orphan root** in the Documents tree even though its full path is known.

This PR materializes folders as `Document` entities so nested pages keep their place in the hierarchy.

## How

Folders already appear in each page's `ancestors` array (`type == "folder"`), so they can be reconstructed with **no extra API calls**:

- `ConfluenceHierarchyExtractor.collect_folder_nodes(...)` walks the `ancestors` of every ingested page and collects each folder, deriving its parent from the preceding ancestor (page or folder).
- Each folder is emitted as a `Document` with the `"Folder"` subtype (matching how DataHub represents natively-created folders), an empty body, a parent link to its nearest ingested ancestor, and a `browsePathsV2` aspect.
- Folder URNs are registered up front so child pages (and nested folders) resolve their parent against them.
- Gated by a new `ingest_folders` config option (default `true`). Folders carry no content, so they skip the chunking/embedding step pages go through.

Result — a page nested as `Overview → Nick demo (folder) → child page` now ingests with `child page.parentDocument = folder` and `folder.parentDocument = Overview`, instead of the child becoming a root.

## Test plan

- New unit tests in `test_confluence_hierarchy.py` covering folder collection (basic, nested folders, folder directly under space, page-ancestors ignored / de-duped). All 143 Confluence unit tests pass.
- `./gradlew :metadata-ingestion:lint` passes (ruff + mypy).
- Verified end-to-end with a live CLI ingest against a test Confluence: pages nested under a folder correctly parent to the folder, the folder parents to its containing page, and the folder is tagged `subType: Folder`.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing/#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests added/updated (if applicable)
- [x] Docs added/updated (if applicable)
