### PR TITLE
fix(browse): show documents (e.g. Confluence) in the platform browse sidebar

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtils.java
@@ -130,7 +130,8 @@ public class SearchUtils {
           EntityType.MLFEATURE_TABLE,
           EntityType.DATA_FLOW,
           EntityType.DATA_JOB,
-          EntityType.NOTEBOOK);
+          EntityType.NOTEBOOK,
+          EntityType.DOCUMENT);
 
   /** A prioritized list of source filter types used to generate quick filters */
   public static final List<String> PRIORITIZED_SOURCE_ENTITY_TYPES =

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/browse/BrowseV2ResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/browse/BrowseV2ResolverTest.java
@@ -17,6 +17,7 @@ import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.FacetFilterInput;
 import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
 import com.linkedin.datahub.graphql.resolvers.chart.BrowseV2Resolver;
+import com.linkedin.datahub.graphql.types.entitytype.EntityTypeMapper;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.browse.BrowseResultGroupV2;
 import com.linkedin.metadata.browse.BrowseResultGroupV2Array;
@@ -293,6 +294,17 @@ public class BrowseV2ResolverTest {
     info.setDefinition(
         new DataHubViewDefinition().setEntityTypes(entityNames).setFilter(viewFilter));
     return info;
+  }
+
+  @Test
+  public void testGetEntityNamesDefaultsIncludeDocument() {
+    // With no explicit types, browseV2 falls back to BROWSE_ENTITY_TYPES. Documents
+    // must be in that default so the platform-browse sidebar can navigate
+    // document-only platforms (e.g. Confluence); otherwise their browse tree is empty.
+    List<String> defaultEntityNames = BrowseV2Resolver.getEntityNames(new BrowseV2Input());
+    Assert.assertTrue(
+        defaultEntityNames.contains(EntityTypeMapper.getName(EntityType.DOCUMENT)),
+        "Default browse entity types should include DOCUMENT");
   }
 
   private BrowseV2ResolverTest() {}

--- a/datahub-web-react/src/app/entityV2/document/DocumentEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/document/DocumentEntity.tsx
@@ -54,7 +54,7 @@ export class DocumentEntity implements Entity<Document> {
 
     isSearchEnabled = () => true;
 
-    isBrowseEnabled = () => false;
+    isBrowseEnabled = () => true;
 
     isLineageEnabled = () => false;
 

--- a/datahub-web-react/src/app/entityV2/document/__tests__/DocumentEntity.test.tsx
+++ b/datahub-web-react/src/app/entityV2/document/__tests__/DocumentEntity.test.tsx
@@ -1512,6 +1512,12 @@ describe('Document Profile Rendering', () => {
 
             expect(overrides.lastIngested).toBeUndefined();
         });
+
+        it('should enable browse so documents appear in the platform navigation sidebar', () => {
+            // Documents carry browsePathsV2, so they must be browse-enabled to
+            // surface (with their space/folder hierarchy) in the left-nav browse tree.
+            expect(new DocumentEntity().isBrowseEnabled()).toBe(true);
+        });
     });
 
     describe('Document Profile Sidebar Sections', () => {

--- a/datahub-web-react/src/app/searchV2/sidebar/__tests__/useSidebarPlatforms.test.tsx
+++ b/datahub-web-react/src/app/searchV2/sidebar/__tests__/useSidebarPlatforms.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import useAggregationsQuery from '@app/searchV2/sidebar/useAggregationsQuery';
+import useSidebarPlatforms from '@app/searchV2/sidebar/useSidebarPlatforms';
+import { PLATFORM_FILTER_NAME } from '@app/searchV2/utils/constants';
+
+vi.mock('@app/searchV2/sidebar/useAggregationsQuery');
+
+describe('useSidebarPlatforms', () => {
+    const mockUseAggregationsQuery = vi.mocked(useAggregationsQuery);
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns every platform matching the query, including long-tail platforms', () => {
+        // confluence (count 2) would previously be dropped because it falls below the
+        // top-N cap of the unfiltered base aggregation it used to be intersected with.
+        const platformAggregations = [
+            { value: 'urn:li:dataPlatform:snowflake', count: 35 },
+            { value: 'urn:li:dataPlatform:confluence', count: 2 },
+        ];
+        mockUseAggregationsQuery.mockReturnValue({
+            platformAggregations,
+            error: undefined,
+            retry: vi.fn(),
+        } as any);
+
+        const { result } = renderHook(() => useSidebarPlatforms({ skip: false }));
+
+        expect(result.current.platformAggregations).toEqual(platformAggregations);
+    });
+
+    it('only issues the filtered platform aggregation (no unfiltered base query)', () => {
+        mockUseAggregationsQuery.mockReturnValue({
+            platformAggregations: [],
+            error: undefined,
+            retry: vi.fn(),
+        } as any);
+
+        renderHook(() => useSidebarPlatforms({ skip: false }));
+
+        expect(mockUseAggregationsQuery).toHaveBeenCalledTimes(1);
+        expect(mockUseAggregationsQuery).toHaveBeenCalledWith({ skip: false, facets: [PLATFORM_FILTER_NAME] });
+        expect(mockUseAggregationsQuery).not.toHaveBeenCalledWith(expect.objectContaining({ excludeFilters: true }));
+    });
+});

--- a/datahub-web-react/src/app/searchV2/sidebar/useSidebarPlatforms.tsx
+++ b/datahub-web-react/src/app/searchV2/sidebar/useSidebarPlatforms.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 import useAggregationsQuery from '@app/searchV2/sidebar/useAggregationsQuery';
 import { PLATFORM_FILTER_NAME } from '@app/searchV2/utils/constants';
 
@@ -17,19 +15,12 @@ const useSidebarPlatforms = ({ skip }: Props) => {
         facets: [PLATFORM_FILTER_NAME],
     });
 
-    const { error: baseError, platformAggregations: baseAggs } = useAggregationsQuery({
-        skip,
-        facets: [PLATFORM_FILTER_NAME],
-        excludeFilters: true,
-    });
-
-    const result = useMemo(() => {
-        if (filteredError || baseError) return filteredAggs; // Fallback to filtered aggs on any error
-        if (!filteredAggs || !baseAggs) return null; // If we're loading one of the queries, wait to render
-        return filteredAggs.filter((agg) => baseAggs.some((base) => base.value === agg.value && !!base.count));
-    }, [baseAggs, baseError, filteredAggs, filteredError]);
-
-    return { error: filteredError, platformAggregations: result, retry: retryFilteredAggs } as const;
+    // Show every platform that has results for the current query. We intentionally
+    // do NOT intersect with an unfiltered ("base") aggregation: the base aggregation
+    // is a top-N terms query, so any platform ranked below that cap (e.g. a long-tail
+    // source like Confluence on a dataset-heavy instance) would be dropped from the
+    // sidebar even when it matches the active search.
+    return { error: filteredError, platformAggregations: filteredAggs, retry: retryFilteredAggs } as const;
 };
 
 export default useSidebarPlatforms;


### PR DESCRIPTION
## Summary

Document entities (Confluence, Notion, native DataHub docs) never showed up in the search **platform-browse sidebar**, and even when a document platform did appear, expanding it produced an empty tree. Three independent gaps caused this:

1. **`Document.isBrowseEnabled()` returned `false`** — documents were filtered out of the sidebar's entity aggregation. Documents carry `browsePathsV2`, so they can and should be browsable. → set it to `true`.

2. **`useSidebarPlatforms` intersected the query's platform aggregation with an unfiltered, top-N-capped "base" aggregation.** Any long-tail platform ranked below that cap (e.g. Confluence on a dataset-heavy instance) was dropped from the sidebar even when it matched the active search. → show all platforms that match the current query, without the base-aggregation gate.

3. **`browseV2` with no explicit `type` falls back to `BROWSE_ENTITY_TYPES`, which omitted `DOCUMENT`.** The platform-browse sidebar issues exactly this no-type call, so a document-only platform's browse tree always came back empty. → add `DOCUMENT` to the default browse entity types.

Together these let a Confluence/Notion platform appear in the sidebar and expand into its space/folder hierarchy.

## Test plan

- New unit tests:
  - `useSidebarPlatforms.test.tsx` — returns all query-matching platforms (incl. long-tail) and issues no unfiltered base aggregation.
  - `BrowseV2ResolverTest` — default browse entity types include `DOCUMENT`.
  - `DocumentEntity.test.tsx` — document browse capability is enabled.
- Verified end-to-end against a local instance: with the term-bucket cap forced low (to reproduce the truncation), the Confluence platform now appears and `browseV2` returns its space/folder groups.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline
- [x] Tests added/updated
- [x] Docs added/updated (n/a)
