### PR TITLE
feat(): Safely support emission of hierarchical browse Path v2 for Notion + GitHub connectors

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/github_documents/github_documents_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/github_documents/github_documents_config.py
@@ -79,6 +79,22 @@ class GitHubDocumentsSourceConfig(
         default=True,
         description="Whether imported documents appear in global search and navigation.",
     )
+    include_repository_in_browse_path: bool = Field(
+        default=True,
+        description=(
+            "Include the repository name as a top-level entry in the browse path. "
+            "When a repository root document is created, that document already "
+            "provides the repository entry; this adds it for configurations that "
+            "skip the root document or nest under a configured parent document."
+        ),
+    )
+    include_organization_in_browse_path: bool = Field(
+        default=False,
+        description=(
+            "Include the GitHub organization/owner name as the top-most entry in "
+            "the browse path, above the repository name."
+        ),
+    )
 
     document_mapping: DocumentMappingConfig = Field(
         default_factory=DocumentMappingConfig,

--- a/metadata-ingestion/src/datahub/ingestion/source/github_documents/github_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/github_documents/github_documents_source.py
@@ -46,6 +46,9 @@ from datahub.ingestion.source.github_documents.github_documents_config import (
 from datahub.ingestion.source.github_documents.github_documents_report import (
     GitHubDocumentsSourceReport,
 )
+from datahub.ingestion.source.github_documents.github_hierarchy import (
+    GitHubHierarchyExtractor,
+)
 from datahub.ingestion.source.state.entity_removal_state import GenericCheckpointState
 from datahub.ingestion.source.state.stale_entity_removal_handler import (
     StaleEntityRemovalHandler,
@@ -114,6 +117,11 @@ class GitHubDocumentsSource(StatefulIngestionSourceBase, TestableSource):
             platform=self.platform,
         )
         self._source_id_to_urn: Dict[str, str] = {}
+        # Maps used to reconstruct hierarchical browse paths. Documents are
+        # emitted parent-before-child, so by the time a child is processed all
+        # of its ancestors are already present in these maps.
+        self._source_id_to_title: Dict[str, str] = {}
+        self._source_id_to_parent: Dict[str, Optional[str]] = {}
         self._repo_root_source_id: Optional[str] = (
             None
             if config.parent_document_urn or not config.create_repo_root_document
@@ -230,7 +238,9 @@ class GitHubDocumentsSource(StatefulIngestionSourceBase, TestableSource):
             parent_document=None,
             custom_properties=custom_properties,
         )
+        self._register_hierarchy(source_id, title, parent_source_id=None)
         self._source_id_to_urn[source_id] = str(doc.urn)
+        self._attach_browse_path(doc, source_id)
         self.report.folders_processed += 1
         yield from doc.as_workunits()
 
@@ -271,7 +281,9 @@ class GitHubDocumentsSource(StatefulIngestionSourceBase, TestableSource):
             parent_document=parent_urn,
             custom_properties=custom_properties,
         )
+        self._register_hierarchy(source_id, title, parent_source_id=parent_source_id)
         self._source_id_to_urn[source_id] = str(doc.urn)
+        self._attach_browse_path(doc, source_id)
         self.report.folders_processed += 1
         yield from doc.as_workunits()
 
@@ -332,7 +344,9 @@ class GitHubDocumentsSource(StatefulIngestionSourceBase, TestableSource):
             parent_document=parent_urn,
             custom_properties=custom_properties,
         )
+        self._register_hierarchy(source_id, title, parent_source_id=parent_source_id)
         self._source_id_to_urn[source_id] = str(doc.urn)
+        self._attach_browse_path(doc, source_id)
         self.report.files_processed += 1
         yield from doc.as_workunits()
 
@@ -360,6 +374,37 @@ class GitHubDocumentsSource(StatefulIngestionSourceBase, TestableSource):
 
     def _register_document_for_stale_removal(self, document_urn: str) -> None:
         self.stale_entity_removal_handler.add_entity_to_state("document", document_urn)
+
+    def _register_hierarchy(
+        self, source_id: str, title: str, parent_source_id: Optional[str]
+    ) -> None:
+        """Record a document's title and parent link for browse-path building."""
+        self._source_id_to_title[source_id] = title
+        self._source_id_to_parent[source_id] = parent_source_id
+
+    def _attach_browse_path(self, doc: Document, source_id: str) -> None:
+        """Attach a BrowsePathsV2 aspect describing the document's ancestry.
+
+        Browse paths are a navigation enhancement, not core document data, so any
+        failure here is logged and the document is emitted without one rather
+        than failing ingestion.
+        """
+        try:
+            browse_path = GitHubHierarchyExtractor.build_browse_path_v2(
+                source_id=source_id,
+                parent_links=self._source_id_to_parent,
+                titles=self._source_id_to_title,
+                urns=self._source_id_to_urn,
+                root_parent_urn=self.config.parent_document_urn,
+            )
+            if browse_path:
+                doc._set_aspect(browse_path)
+        except Exception as exc:
+            logger.warning(
+                "Failed to build browse path for %s; emitting document without it: %s",
+                source_id,
+                exc,
+            )
 
     def _resolve_parent_urn(self, parent_source_id: Optional[str]) -> Optional[str]:
         if parent_source_id:

--- a/metadata-ingestion/src/datahub/ingestion/source/github_documents/github_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/github_documents/github_documents_source.py
@@ -61,6 +61,7 @@ from datahub.ingestion.workunit_processors.auto_stale_entity_removal import (
     AutoStaleEntityRemovalProcessor,
 )
 from datahub.metadata.schema_classes import (
+    BrowsePathEntryClass,
     DataPlatformInstanceClass,
     DocumentInfoClass,
     DocumentStateClass,
@@ -382,6 +383,40 @@ class GitHubDocumentsSource(StatefulIngestionSourceBase, TestableSource):
         self._source_id_to_title[source_id] = title
         self._source_id_to_parent[source_id] = parent_source_id
 
+    def _browse_path_prefix_entries(self) -> List[BrowsePathEntryClass]:
+        """Build the leading browse-path entries shared by all documents.
+
+        Order (top-most first): configured parent document, organization, then
+        repository. The synthetic repository entry is only added when no
+        repo-root document exists; otherwise that document already provides a
+        (clickable) repository entry in each descendant's ancestor chain and
+        the repo-root document itself must not list itself as a parent.
+        """
+        entries: List[BrowsePathEntryClass] = []
+
+        if self.config.parent_document_urn:
+            entries.append(
+                BrowsePathEntryClass(
+                    id=self.config.parent_document_urn,
+                    urn=self.config.parent_document_urn,
+                )
+            )
+
+        owner_repo = self.config.repository
+        org_name, _, repo_name = owner_repo.partition("/")
+
+        if self.config.include_organization_in_browse_path and org_name:
+            entries.append(BrowsePathEntryClass(id=org_name))
+
+        if (
+            self.config.include_repository_in_browse_path
+            and repo_name
+            and self._repo_root_source_id is None
+        ):
+            entries.append(BrowsePathEntryClass(id=repo_name))
+
+        return entries
+
     def _attach_browse_path(self, doc: Document, source_id: str) -> None:
         """Attach a BrowsePathsV2 aspect describing the document's ancestry.
 
@@ -395,15 +430,20 @@ class GitHubDocumentsSource(StatefulIngestionSourceBase, TestableSource):
                 parent_links=self._source_id_to_parent,
                 titles=self._source_id_to_title,
                 urns=self._source_id_to_urn,
-                root_parent_urn=self.config.parent_document_urn,
+                prefix_entries=self._browse_path_prefix_entries(),
             )
             if browse_path:
                 doc._set_aspect(browse_path)
         except Exception as exc:
-            logger.warning(
-                "Failed to build browse path for %s; emitting document without it: %s",
-                source_id,
-                exc,
+            self.report.warning(
+                title="Browse path generation failed",
+                message=(
+                    "Failed to build the browse path for a document; it was "
+                    "emitted without one. Hierarchical navigation may be "
+                    "incomplete for the affected document."
+                ),
+                context=f"source_id={source_id}",
+                exc=exc,
             )
 
     def _resolve_parent_urn(self, parent_source_id: Optional[str]) -> Optional[str]:

--- a/metadata-ingestion/src/datahub/ingestion/source/github_documents/github_hierarchy.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/github_documents/github_hierarchy.py
@@ -54,39 +54,31 @@ class GitHubHierarchyExtractor:
         parent_links: Dict[str, Optional[str]],
         titles: Dict[str, str],
         urns: Dict[str, str],
-        root_parent_urn: Optional[str] = None,
+        prefix_entries: Optional[List[BrowsePathEntryClass]] = None,
     ) -> Optional[BrowsePathsV2Class]:
         """Build a BrowsePathsV2 aspect describing a document's ancestry.
 
         Creates a hierarchical browse path of the document's ancestors (the
-        document itself is not included). When ``root_parent_urn`` is provided
-        (an externally configured parent document), it is prepended as the
-        top-most entry.
+        document itself is not included). Any ``prefix_entries`` (e.g. a
+        configured parent document, organization, or repository name) are
+        prepended ahead of the reconstructed ancestor chain.
 
         Args:
             source_id: The document the browse path is for.
             parent_links: Map of source_id -> parent source_id.
             titles: Map of source_id -> display label.
             urns: Map of source_id -> document URN.
-            root_parent_urn: Optional configured parent document URN to root the
-                path under (used when documents are nested beneath an existing
-                document instead of a generated repo-root document).
+            prefix_entries: Optional leading entries to root the path under.
 
         Returns:
-            BrowsePathsV2Class with one entry per ancestor, or None when the
-            document has no ancestors (e.g. a repo-root document).
+            BrowsePathsV2Class with the prefix followed by one entry per
+            ancestor, or None when there are no entries at all (e.g. a repo-root
+            document with no prefix).
         """
         if not source_id:
             return None
 
-        path_entries: List[BrowsePathEntryClass] = []
-
-        # The configured external parent has no generated title; use its URN as
-        # the label, matching the SDK convention for URN-only browse entries.
-        if root_parent_urn:
-            path_entries.append(
-                BrowsePathEntryClass(id=root_parent_urn, urn=root_parent_urn)
-            )
+        path_entries: List[BrowsePathEntryClass] = list(prefix_entries or [])
 
         for ancestor_id in GitHubHierarchyExtractor.build_ancestor_chain(
             source_id, parent_links

--- a/metadata-ingestion/src/datahub/ingestion/source/github_documents/github_hierarchy.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/github_documents/github_hierarchy.py
@@ -1,0 +1,104 @@
+"""Hierarchy extraction logic for GitHub documents."""
+
+from typing import Dict, List, Optional, Set
+
+from datahub.metadata.schema_classes import BrowsePathEntryClass, BrowsePathsV2Class
+
+
+class GitHubHierarchyExtractor:
+    """Static utilities for deriving browse paths from GitHub document hierarchy.
+
+    GitHub documents form a tree that mirrors the repository folder structure:
+    an optional repo-root document, intermediate folder documents, and leaf file
+    documents. Each document records its immediate parent's ``source_id``; the
+    full ancestor chain is reconstructed by walking those parent links.
+
+    All folder/repo ancestors are themselves emitted as documents, so their URNs
+    are always resolvable (unlike Confluence/Notion, where ancestors can fall
+    outside the ingestion scope).
+    """
+
+    @staticmethod
+    def build_ancestor_chain(
+        source_id: str,
+        parent_links: Dict[str, Optional[str]],
+    ) -> List[str]:
+        """Reconstruct the ancestor chain for a document (root first, parent last).
+
+        Walks the ``source_id`` -> parent ``source_id`` links. The traversal is
+        cycle-safe: it stops if a node is revisited or a parent is absent.
+
+        Args:
+            source_id: The document whose ancestors to resolve.
+            parent_links: Map of source_id -> parent source_id (None at the root).
+
+        Returns:
+            Ordered list of ancestor source IDs from root down to the immediate
+            parent. Empty if the document has no in-repo parent.
+        """
+        chain: List[str] = []
+        visited: Set[str] = {source_id}
+        current = parent_links.get(source_id)
+
+        while current and current not in visited:
+            visited.add(current)
+            chain.append(current)
+            current = parent_links.get(current)
+
+        chain.reverse()
+        return chain
+
+    @staticmethod
+    def build_browse_path_v2(
+        source_id: str,
+        parent_links: Dict[str, Optional[str]],
+        titles: Dict[str, str],
+        urns: Dict[str, str],
+        root_parent_urn: Optional[str] = None,
+    ) -> Optional[BrowsePathsV2Class]:
+        """Build a BrowsePathsV2 aspect describing a document's ancestry.
+
+        Creates a hierarchical browse path of the document's ancestors (the
+        document itself is not included). When ``root_parent_urn`` is provided
+        (an externally configured parent document), it is prepended as the
+        top-most entry.
+
+        Args:
+            source_id: The document the browse path is for.
+            parent_links: Map of source_id -> parent source_id.
+            titles: Map of source_id -> display label.
+            urns: Map of source_id -> document URN.
+            root_parent_urn: Optional configured parent document URN to root the
+                path under (used when documents are nested beneath an existing
+                document instead of a generated repo-root document).
+
+        Returns:
+            BrowsePathsV2Class with one entry per ancestor, or None when the
+            document has no ancestors (e.g. a repo-root document).
+        """
+        if not source_id:
+            return None
+
+        path_entries: List[BrowsePathEntryClass] = []
+
+        # The configured external parent has no generated title; use its URN as
+        # the label, matching the SDK convention for URN-only browse entries.
+        if root_parent_urn:
+            path_entries.append(
+                BrowsePathEntryClass(id=root_parent_urn, urn=root_parent_urn)
+            )
+
+        for ancestor_id in GitHubHierarchyExtractor.build_ancestor_chain(
+            source_id, parent_links
+        ):
+            path_entries.append(
+                BrowsePathEntryClass(
+                    id=titles.get(ancestor_id, ancestor_id),
+                    urn=urns.get(ancestor_id),
+                )
+            )
+
+        if not path_entries:
+            return None
+
+        return BrowsePathsV2Class(path=path_entries)

--- a/metadata-ingestion/src/datahub/ingestion/source/notion/notion_hierarchy.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/notion/notion_hierarchy.py
@@ -1,0 +1,133 @@
+"""Hierarchy extraction logic for Notion pages."""
+
+from typing import Any, Callable, Dict, List, Optional, Set
+
+from datahub.metadata.schema_classes import BrowsePathEntryClass, BrowsePathsV2Class
+
+
+class NotionHierarchyExtractor:
+    """Static utilities for deriving parent-child hierarchy from Notion metadata.
+
+    Notion's per-page ``additional_metadata`` only records the *immediate* parent
+    (``{"type": "page_id"|"database_id"|"workspace", ...}``). Unlike Confluence,
+    Notion does not return a full ancestor array, so the complete chain is
+    reconstructed by walking parent links across the page metadata map.
+    """
+
+    @staticmethod
+    def extract_parent_id(
+        additional_metadata: Optional[Dict[str, Any]],
+    ) -> Optional[str]:
+        """Extract the immediate parent page/database ID for a single page.
+
+        Workspace parents are treated as the root (no parent page).
+
+        Args:
+            additional_metadata: A page's ``additional_metadata`` dict, which may
+                contain a ``parent`` entry.
+
+        Returns:
+            Parent page/database ID, or None if the page is at the workspace root.
+        """
+        if not additional_metadata or not isinstance(additional_metadata, dict):
+            return None
+
+        parent_info = additional_metadata.get("parent")
+        if not parent_info or not isinstance(parent_info, dict):
+            return None
+
+        parent_type = parent_info.get("type")
+        if parent_type == "page_id":
+            parent_id = parent_info.get("page_id")
+        elif parent_type == "database_id":
+            parent_id = parent_info.get("database_id")
+        else:
+            # workspace (or unknown) parents are the root - no parent page
+            return None
+
+        return str(parent_id) if parent_id else None
+
+    @staticmethod
+    def extract_ancestor_chain(
+        page_id: str,
+        parent_metadata: Dict[str, Any],
+    ) -> List[str]:
+        """Reconstruct the ancestor chain for a page (root first, immediate parent last).
+
+        Walks the parent links recorded in ``parent_metadata``. The traversal is
+        cycle-safe: it stops if a page is revisited or a parent is not present in
+        the metadata map.
+
+        Args:
+            page_id: ID of the page whose ancestors to resolve.
+            parent_metadata: Map of page_id -> ``additional_metadata`` for all
+                pages discovered during ingestion.
+
+        Returns:
+            Ordered list of ancestor page IDs from root down to the immediate
+            parent. Empty if the page is at the workspace root.
+        """
+        chain: List[str] = []
+        visited: Set[str] = {page_id}
+        current = page_id
+
+        while True:
+            parent_id = NotionHierarchyExtractor.extract_parent_id(
+                parent_metadata.get(current)
+            )
+            if not parent_id or parent_id in visited:
+                break
+            visited.add(parent_id)
+            chain.append(parent_id)
+            current = parent_id
+
+        chain.reverse()
+        return chain
+
+    @staticmethod
+    def build_browse_path_v2(
+        page_id: str,
+        parent_metadata: Dict[str, Any],
+        urn_builder: Callable[[str], str],
+        title_resolver: Callable[[str], str],
+        ingested_page_ids: Optional[Set[str]] = None,
+    ) -> Optional[BrowsePathsV2Class]:
+        """Build a BrowsePathsV2 aspect describing a Notion page's ancestry.
+
+        Creates a hierarchical browse path: Ancestor 1 / ... / Ancestor N (the
+        page itself is not included). A URN is attached to an ancestor entry only
+        when that ancestor is also being ingested, to avoid dangling references.
+
+        Args:
+            page_id: ID of the page the browse path is for.
+            parent_metadata: Map of page_id -> ``additional_metadata`` for all
+                pages discovered during ingestion.
+            urn_builder: Callable mapping an ancestor page ID to its document URN.
+            title_resolver: Callable mapping an ancestor page ID to a display label.
+            ingested_page_ids: Set of page IDs being ingested (for URN validation).
+
+        Returns:
+            BrowsePathsV2Class with one entry per ancestor, or None for root pages
+            (which have no ancestors).
+        """
+        if not page_id:
+            return None
+
+        chain = NotionHierarchyExtractor.extract_ancestor_chain(
+            page_id, parent_metadata
+        )
+        if not chain:
+            return None
+
+        path_entries: List[BrowsePathEntryClass] = []
+        for ancestor_id in chain:
+            # Only attach a URN if the ancestor is part of this ingestion run.
+            ancestor_urn = None
+            if ingested_page_ids and ancestor_id in ingested_page_ids:
+                ancestor_urn = urn_builder(ancestor_id)
+
+            path_entries.append(
+                BrowsePathEntryClass(id=title_resolver(ancestor_id), urn=ancestor_urn)
+            )
+
+        return BrowsePathsV2Class(path=path_entries)

--- a/metadata-ingestion/src/datahub/ingestion/source/notion/notion_hierarchy.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/notion/notion_hierarchy.py
@@ -51,6 +51,7 @@ class NotionHierarchyExtractor:
     def extract_ancestor_chain(
         page_id: str,
         parent_metadata: Dict[str, Any],
+        browse_path_root_ids: Optional[Set[str]] = None,
     ) -> List[str]:
         """Reconstruct the ancestor chain for a page (root first, immediate parent last).
 
@@ -58,15 +59,24 @@ class NotionHierarchyExtractor:
         cycle-safe: it stops if a page is revisited or a parent is not present in
         the metadata map.
 
+        When ``browse_path_root_ids`` is set (explicit ``page_ids`` / ``database_ids``
+        in the recipe), those IDs act as browse-path anchors: the chain for an
+        anchored page is empty, and descendants stop walking above their nearest
+        anchored ancestor.
+
         Args:
             page_id: ID of the page whose ancestors to resolve.
             parent_metadata: Map of page_id -> ``additional_metadata`` for all
                 pages discovered during ingestion.
+            browse_path_root_ids: Page/database IDs configured as ingestion roots.
 
         Returns:
             Ordered list of ancestor page IDs from root down to the immediate
             parent. Empty if the page is at the workspace root.
         """
+        if browse_path_root_ids and page_id in browse_path_root_ids:
+            return []
+
         chain: List[str] = []
         visited: Set[str] = {page_id}
         current = page_id
@@ -77,8 +87,12 @@ class NotionHierarchyExtractor:
             )
             if not parent_id or parent_id in visited:
                 break
-            visited.add(parent_id)
             chain.append(parent_id)
+            visited.add(parent_id)
+
+            if browse_path_root_ids and parent_id in browse_path_root_ids:
+                break
+
             current = parent_id
 
         chain.reverse()
@@ -91,12 +105,14 @@ class NotionHierarchyExtractor:
         urn_builder: Callable[[str], str],
         title_resolver: Callable[[str], str],
         ingested_page_ids: Optional[Set[str]] = None,
+        browse_path_root_ids: Optional[Set[str]] = None,
     ) -> Optional[BrowsePathsV2Class]:
         """Build a BrowsePathsV2 aspect describing a Notion page's ancestry.
 
         Creates a hierarchical browse path: Ancestor 1 / ... / Ancestor N (the
-        page itself is not included). A URN is attached to an ancestor entry only
-        when that ancestor is also being ingested, to avoid dangling references.
+        page itself is not included). Only ancestors that are part of the current
+        ingestion run are included, so browse paths never reference pages outside
+        the scoped set.
 
         Args:
             page_id: ID of the page the browse path is for.
@@ -105,6 +121,8 @@ class NotionHierarchyExtractor:
             urn_builder: Callable mapping an ancestor page ID to its document URN.
             title_resolver: Callable mapping an ancestor page ID to a display label.
             ingested_page_ids: Set of page IDs being ingested (for URN validation).
+            browse_path_root_ids: Explicitly configured ingestion roots; browse
+                paths do not walk above these IDs.
 
         Returns:
             BrowsePathsV2Class with one entry per ancestor, or None for root pages
@@ -114,18 +132,18 @@ class NotionHierarchyExtractor:
             return None
 
         chain = NotionHierarchyExtractor.extract_ancestor_chain(
-            page_id, parent_metadata
+            page_id, parent_metadata, browse_path_root_ids
         )
+        if ingested_page_ids is not None:
+            chain = [
+                ancestor_id for ancestor_id in chain if ancestor_id in ingested_page_ids
+            ]
         if not chain:
             return None
 
         path_entries: List[BrowsePathEntryClass] = []
         for ancestor_id in chain:
-            # Only attach a URN if the ancestor is part of this ingestion run.
-            ancestor_urn = None
-            if ingested_page_ids and ancestor_id in ingested_page_ids:
-                ancestor_urn = urn_builder(ancestor_id)
-
+            ancestor_urn = urn_builder(ancestor_id)
             path_entries.append(
                 BrowsePathEntryClass(id=title_resolver(ancestor_id), urn=ancestor_urn)
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/notion/notion_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/notion/notion_source.py
@@ -1749,9 +1749,15 @@ class NotionSource(StatefulIngestionSourceBase, TestableSource):
                         if title:
                             self.notion_page_titles[page_id] = title
                     except Exception as e:
-                        logger.warning(
-                            f"Failed to pre-compute title for Notion page {page_id}; "
-                            f"browse-path labels may fall back to the page ID: {e}"
+                        self.report.warning(
+                            title="Browse path label resolution failed",
+                            message=(
+                                "Failed to pre-compute a Notion page title for "
+                                "browse-path labels; ancestor entries may fall "
+                                "back to the raw page ID."
+                            ),
+                            context=f"page_id={page_id}",
+                            exc=e,
                         )
 
                 # Save for second pass
@@ -2127,9 +2133,15 @@ class NotionSource(StatefulIngestionSourceBase, TestableSource):
                 if browse_path_v2:
                     doc._set_aspect(browse_path_v2)
             except Exception as e:
-                logger.warning(
-                    f"Failed to build browse path for Notion page {page_id}; "
-                    f"emitting document without it: {e}"
+                self.report.warning(
+                    title="Browse path generation failed",
+                    message=(
+                        "Failed to build the browse path for a Notion page; it "
+                        "was emitted without one. Hierarchical navigation may be "
+                        "incomplete for the affected page."
+                    ),
+                    context=f"page_id={page_id}",
+                    exc=e,
                 )
 
         # Get document URN for chunking/embedding (convert to string)

--- a/metadata-ingestion/src/datahub/ingestion/source/notion/notion_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/notion/notion_source.py
@@ -349,6 +349,15 @@ class NotionSource(StatefulIngestionSourceBase, TestableSource):
         # page_id -> emitted document title, used to label browse-path ancestors
         self.notion_page_titles: Dict[str, str] = {}
 
+        # When the user scopes ingestion via page_ids/database_ids, browse paths
+        # are anchored at those roots instead of walking up to un-ingested parents.
+        if config.page_ids or config.database_ids:
+            self._browse_path_root_ids: Set[str] = set(config.page_ids) | set(
+                config.database_ids
+            )
+        else:
+            self._browse_path_root_ids = set()
+
         # Initialize stateful ingestion handler for stale entity removal
 
         # Initialize document state tracking for content-based change detection
@@ -2129,6 +2138,7 @@ class NotionSource(StatefulIngestionSourceBase, TestableSource):
                     urn_builder=self._build_notion_document_urn,
                     title_resolver=self._notion_title_for_page,
                     ingested_page_ids=ingested_page_ids,
+                    browse_path_root_ids=self._browse_path_root_ids or None,
                 )
                 if browse_path_v2:
                     doc._set_aspect(browse_path_v2)

--- a/metadata-ingestion/src/datahub/ingestion/source/notion/notion_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/notion/notion_source.py
@@ -24,6 +24,7 @@ from datahub.ingestion.api.source import (
 )
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.notion.notion_config import NotionSourceConfig
+from datahub.ingestion.source.notion.notion_hierarchy import NotionHierarchyExtractor
 from datahub.ingestion.source.notion.notion_report import NotionSourceReport
 from datahub.ingestion.source.state.stateful_ingestion_base import (
     StatefulIngestionSourceBase,
@@ -344,6 +345,9 @@ class NotionSource(StatefulIngestionSourceBase, TestableSource):
 
         # Notion parent metadata tracking
         self.notion_parent_metadata: Dict[str, Any] = {}
+
+        # page_id -> emitted document title, used to label browse-path ancestors
+        self.notion_page_titles: Dict[str, str] = {}
 
         # Initialize stateful ingestion handler for stale entity removal
 
@@ -1730,6 +1734,26 @@ class NotionSource(StatefulIngestionSourceBase, TestableSource):
                 if page_id:
                     ingested_page_ids.add(page_id)
 
+                    # Pre-compute the title so browse-path ancestor labels match
+                    # the titles emitted on the ancestor documents themselves.
+                    # This is best-effort: a failure only affects ancestor labels
+                    # (which fall back to the page ID), so never fail the page.
+                    try:
+                        self._inject_notion_url(metadata)
+                        page_elements = data.get("elements", [])
+                        title = self.document_builder.title_extractor.extract_title(
+                            page_elements if isinstance(page_elements, list) else [],
+                            metadata.get("filename", "unknown"),
+                            metadata,
+                        )
+                        if title:
+                            self.notion_page_titles[page_id] = title
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to pre-compute title for Notion page {page_id}; "
+                            f"browse-path labels may fall back to the page ID: {e}"
+                        )
+
                 # Save for second pass
                 files_to_process.append(data)
 
@@ -1978,15 +2002,41 @@ class NotionSource(StatefulIngestionSourceBase, TestableSource):
             return None
 
         # Generate parent URN using same ID pattern as documents
-        parent_doc_id = self.document_builder.id_generator.generate_id(
-            filename=f"{parent_id}.html",
-            directory="",
-            metadata={"source_record_locator": f"page_id={parent_id}"},
-        )
+        return self._build_notion_document_urn(parent_id)
 
-        # Construct URN
-        parent_urn = f"urn:li:document:{parent_doc_id}"
-        return parent_urn
+    def _build_notion_document_urn(self, page_id: str) -> str:
+        """Construct the DataHub document URN for a Notion page ID.
+
+        Uses the same id-generation logic as emitted documents so that
+        references (parent links, browse paths) resolve to real entities.
+        """
+        doc_id = self.document_builder.id_generator.generate_id(
+            filename=f"{page_id}.html",
+            directory="",
+            metadata={"source_record_locator": f"page_id={page_id}"},
+        )
+        return f"urn:li:document:{doc_id}"
+
+    def _inject_notion_url(self, metadata: Dict[str, Any]) -> Optional[str]:
+        """Resolve a page's Notion URL and inject it into ``data_source``.
+
+        The DocumentSource aspect and title extraction both read the URL from
+        ``metadata["data_source"]["url"]``. Returns the resolved URL (if any).
+        """
+        notion_url = self._extract_notion_url(metadata)
+        if notion_url:
+            if "data_source" not in metadata:
+                metadata["data_source"] = {}
+            metadata["data_source"]["url"] = notion_url
+        return notion_url
+
+    def _notion_title_for_page(self, page_id: str) -> str:
+        """Resolve a display label for a browse-path ancestor.
+
+        Prefers the title actually emitted for the page; falls back to the raw
+        page ID for ancestors outside the ingestion scope (which carry no URN).
+        """
+        return self.notion_page_titles.get(page_id) or page_id
 
     def _create_document_entity(
         self, data: dict, ingested_page_ids: Optional[Set[str]] = None
@@ -2028,13 +2078,8 @@ class NotionSource(StatefulIngestionSourceBase, TestableSource):
             self.config.processing.partition.strategy
         )
 
-        # Extract Notion URL from additional_metadata
-        notion_url = self._extract_notion_url(metadata)
-        if notion_url:
-            # Inject URL into data_source for DocumentSource aspect
-            if "data_source" not in metadata:
-                metadata["data_source"] = {}
-            metadata["data_source"]["url"] = notion_url
+        # Inject Notion URL into data_source for DocumentSource aspect
+        self._inject_notion_url(metadata)
 
         # Determine parent URN
         parent_urn = None
@@ -2064,6 +2109,28 @@ class NotionSource(StatefulIngestionSourceBase, TestableSource):
             platform="urn:li:dataPlatform:notion"
         )
         doc._set_aspect(platform_instance)
+
+        # Add BrowsePathsV2 for hierarchical navigation, mirroring Confluence.
+        # Notion exposes only the immediate parent per page, so the extractor
+        # reconstructs the full ancestor chain from the parent-metadata map.
+        # Browse paths are a navigation enhancement, not core document data, so
+        # any failure here must degrade gracefully rather than drop the document.
+        if self.config.hierarchy.enabled:
+            try:
+                browse_path_v2 = NotionHierarchyExtractor.build_browse_path_v2(
+                    page_id=page_id,
+                    parent_metadata=self.notion_parent_metadata,
+                    urn_builder=self._build_notion_document_urn,
+                    title_resolver=self._notion_title_for_page,
+                    ingested_page_ids=ingested_page_ids,
+                )
+                if browse_path_v2:
+                    doc._set_aspect(browse_path_v2)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to build browse path for Notion page {page_id}; "
+                    f"emitting document without it: {e}"
+                )
 
         # Get document URN for chunking/embedding (convert to string)
         document_urn = str(doc.urn)

--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/document_builder.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/document_builder.py
@@ -113,6 +113,44 @@ class TitleExtractor:
 
         return None
 
+    @staticmethod
+    def _looks_like_source_id(value: str) -> bool:
+        """Return True if a string is a bare 32-char hex ID (e.g. a Notion page ID).
+
+        Notion's connector hardcodes per-page filenames to ``{page_id}.html`` and
+        does not expose the page's title property, so the filename fallback would
+        otherwise surface a raw page ID as the document title. Detecting that shape
+        lets us skip it in favor of a human-readable fallback.
+        """
+        stripped = value.strip().replace("-", "")
+        if len(stripped) != 32:
+            return False
+        try:
+            int(stripped, 16)
+            return True
+        except ValueError:
+            return False
+
+    def _extract_title_from_content(
+        self, elements: List[Dict[str, Any]]
+    ) -> Optional[str]:
+        """Pull a title from content, preferring real headings over body text."""
+        # Prefer explicit Title/Header elements (real page headings).
+        for elem_type in ("Title", "Header"):
+            for elem in elements:
+                if elem.get("type") == elem_type:
+                    text = elem.get("text", "").strip()
+                    if text:
+                        return text
+
+        # Last resort: first non-empty text block, so we never emit a raw ID.
+        for elem in elements:
+            text = elem.get("text", "").strip()
+            if text:
+                return text
+
+        return None
+
     def extract_title(
         self,
         elements: List[Dict[str, Any]],
@@ -138,18 +176,17 @@ class TitleExtractor:
                 if title:
                     logger.debug(f"Extracted title from Notion URL: {title}")
 
-        # Then try content extraction
+        # Then try content extraction (headings first, then leading text)
         if not title and self.config.extract_from_content:
-            # Find first Title element
-            for elem in elements:
-                if elem.get("type") == "Title":
-                    title = elem.get("text", "").strip()
-                    if title:
-                        break
+            title = self._extract_title_from_content(elements)
 
-        # Finally fall back to filename
-        if not title and self.config.fallback_to_filename:
-            # Use filename without extension
+        # Fall back to filename, but never surface a raw source ID (e.g. a Notion
+        # page ID) as the title — that is worse than no title at all.
+        if (
+            not title
+            and self.config.fallback_to_filename
+            and not self._looks_like_source_id(os.path.splitext(filename)[0])
+        ):
             title = os.path.splitext(filename)[0]
 
         if not title:

--- a/metadata-ingestion/tests/unit/ingestion/source/github_documents/test_github_documents_source.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/github_documents/test_github_documents_source.py
@@ -23,6 +23,7 @@ from datahub.ingestion.source.github_documents.github_documents_source import (
     compute_file_content_hash,
 )
 from datahub.metadata.schema_classes import (
+    BrowsePathsV2Class,
     DataPlatformInstanceClass,
     DocumentInfoClass,
     DocumentSourceTypeClass,
@@ -54,6 +55,17 @@ def _document_infos_by_source_id(workunits: list) -> dict[str, DocumentInfoClass
             if source_id:
                 infos[source_id] = info
     return infos
+
+
+def _browse_paths_by_urn(workunits: list) -> dict[str, BrowsePathsV2Class]:
+    paths: dict[str, BrowsePathsV2Class] = {}
+    for wu in workunits:
+        if not isinstance(wu, MetadataWorkUnit):
+            continue
+        aspect = wu.get_aspect_of_type(BrowsePathsV2Class)
+        if aspect is not None:
+            paths[wu.get_urn()] = aspect
+    return paths
 
 
 def _mock_github_client(
@@ -443,6 +455,76 @@ def test_configured_parent_document_urn_used_for_top_level_files() -> None:
     configured_parent = infos[file_source_id].parentDocument
     assert configured_parent is not None
     assert configured_parent.document == parent_urn
+
+
+def test_browse_path_emitted_for_nested_file(source: GitHubDocumentsSource) -> None:
+    owner_repo = "acme/docs"
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/guides/setup.md", size=12)],
+    )
+
+    workunits = list(source.get_workunits())
+    urns = _entity_urns_by_source_id(workunits)
+    browse_paths = _browse_paths_by_urn(workunits)
+
+    repo_source_id = make_repo_source_id(owner_repo)
+    guides_dir_source_id = make_dir_source_id(owner_repo, "docs/guides")
+    file_source_id = make_file_source_id(owner_repo, "docs/guides/setup.md")
+
+    file_browse_path = browse_paths[urns[file_source_id]]
+    # Ancestors only (root -> immediate parent); the file itself is excluded.
+    assert [e.urn for e in file_browse_path.path] == [
+        urns[repo_source_id],
+        urns[guides_dir_source_id],
+    ]
+    assert [e.id for e in file_browse_path.path] == ["docs", "guides"]
+
+
+def test_browse_path_not_emitted_for_repo_root(source: GitHubDocumentsSource) -> None:
+    owner_repo = "acme/docs"
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/readme.md", size=12)],
+    )
+
+    workunits = list(source.get_workunits())
+    urns = _entity_urns_by_source_id(workunits)
+    browse_paths = _browse_paths_by_urn(workunits)
+
+    repo_source_id = make_repo_source_id(owner_repo)
+    # Repo-root document has no ancestors, so it carries no browse path.
+    assert urns[repo_source_id] not in browse_paths
+
+
+def test_browse_path_roots_under_configured_parent() -> None:
+    parent_urn = "urn:li:document:parent"
+    config = GitHubDocumentsSourceConfig(
+        github_token=SecretStr("ghp_test"),
+        repository="acme/docs",
+        path_prefix="docs",
+        parent_document_urn=parent_urn,
+    )
+    source = GitHubDocumentsSource(config, PipelineContext(run_id="test-run"))
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/guides/setup.md", size=12)],
+    )
+
+    workunits = list(source.get_workunits())
+    urns = _entity_urns_by_source_id(workunits)
+    browse_paths = _browse_paths_by_urn(workunits)
+
+    guides_dir_source_id = make_dir_source_id("acme/docs", "docs/guides")
+    file_source_id = make_file_source_id("acme/docs", "docs/guides/setup.md")
+
+    file_browse_path = browse_paths[urns[file_source_id]]
+    # Configured external parent roots the path, followed by in-repo ancestors.
+    assert file_browse_path.path[0].urn == parent_urn
+    assert [e.urn for e in file_browse_path.path] == [
+        parent_urn,
+        urns[guides_dir_source_id],
+    ]
 
 
 def test_file_document_includes_content_hash_and_blob_sha(

--- a/metadata-ingestion/tests/unit/ingestion/source/github_documents/test_github_documents_source.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/github_documents/test_github_documents_source.py
@@ -473,7 +473,8 @@ def test_browse_path_emitted_for_nested_file(source: GitHubDocumentsSource) -> N
     file_source_id = make_file_source_id(owner_repo, "docs/guides/setup.md")
 
     file_browse_path = browse_paths[urns[file_source_id]]
-    # Ancestors only (root -> immediate parent); the file itself is excluded.
+    # Default flow: the repo-root document provides the repo entry (clickable),
+    # followed by folder ancestors; the file itself is excluded.
     assert [e.urn for e in file_browse_path.path] == [
         urns[repo_source_id],
         urns[guides_dir_source_id],
@@ -493,8 +494,88 @@ def test_browse_path_not_emitted_for_repo_root(source: GitHubDocumentsSource) ->
     browse_paths = _browse_paths_by_urn(workunits)
 
     repo_source_id = make_repo_source_id(owner_repo)
-    # Repo-root document has no ancestors, so it carries no browse path.
+    # Repo-root document has no ancestors (org disabled), so no browse path.
     assert urns[repo_source_id] not in browse_paths
+
+
+def test_browse_path_includes_repo_name_without_root_document() -> None:
+    # When the repo-root document is skipped, a synthetic repo entry keeps the
+    # repository name in the browse path so users aren't confused.
+    config = GitHubDocumentsSourceConfig(
+        github_token=SecretStr("ghp_test"),
+        repository="acme/docs",
+        path_prefix="docs",
+        create_repo_root_document=False,
+    )
+    source = GitHubDocumentsSource(config, PipelineContext(run_id="test-run"))
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/guides/setup.md", size=12)],
+    )
+
+    workunits = list(source.get_workunits())
+    urns = _entity_urns_by_source_id(workunits)
+    browse_paths = _browse_paths_by_urn(workunits)
+
+    guides_dir_source_id = make_dir_source_id("acme/docs", "docs/guides")
+    file_source_id = make_file_source_id("acme/docs", "docs/guides/setup.md")
+
+    file_browse_path = browse_paths[urns[file_source_id]]
+    assert [e.id for e in file_browse_path.path] == ["docs", "guides"]
+    # Repo entry is synthetic (no document exists for it) -> no URN.
+    assert file_browse_path.path[0].urn is None
+    assert file_browse_path.path[1].urn == urns[guides_dir_source_id]
+
+
+def test_browse_path_includes_org_when_enabled() -> None:
+    config = GitHubDocumentsSourceConfig(
+        github_token=SecretStr("ghp_test"),
+        repository="acme/docs",
+        path_prefix="docs",
+        include_organization_in_browse_path=True,
+    )
+    source = GitHubDocumentsSource(config, PipelineContext(run_id="test-run"))
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/guides/setup.md", size=12)],
+    )
+
+    workunits = list(source.get_workunits())
+    urns = _entity_urns_by_source_id(workunits)
+    browse_paths = _browse_paths_by_urn(workunits)
+
+    repo_source_id = make_repo_source_id("acme/docs")
+    file_source_id = make_file_source_id("acme/docs", "docs/guides/setup.md")
+
+    file_browse_path = browse_paths[urns[file_source_id]]
+    # Org is the top-most entry; the repo-root document follows (clickable).
+    assert [e.id for e in file_browse_path.path] == ["acme", "docs", "guides"]
+    assert file_browse_path.path[0].urn is None  # org is synthetic
+    assert file_browse_path.path[1].urn == urns[repo_source_id]
+
+
+def test_browse_path_repo_can_be_disabled() -> None:
+    config = GitHubDocumentsSourceConfig(
+        github_token=SecretStr("ghp_test"),
+        repository="acme/docs",
+        path_prefix="docs",
+        create_repo_root_document=False,
+        include_repository_in_browse_path=False,
+    )
+    source = GitHubDocumentsSource(config, PipelineContext(run_id="test-run"))
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/guides/setup.md", size=12)],
+    )
+
+    workunits = list(source.get_workunits())
+    urns = _entity_urns_by_source_id(workunits)
+    browse_paths = _browse_paths_by_urn(workunits)
+
+    file_source_id = make_file_source_id("acme/docs", "docs/guides/setup.md")
+    file_browse_path = browse_paths[urns[file_source_id]]
+    # No repo-root doc and repo entry disabled -> only folder ancestors.
+    assert [e.id for e in file_browse_path.path] == ["guides"]
 
 
 def test_browse_path_roots_under_configured_parent() -> None:
@@ -519,12 +600,45 @@ def test_browse_path_roots_under_configured_parent() -> None:
     file_source_id = make_file_source_id("acme/docs", "docs/guides/setup.md")
 
     file_browse_path = browse_paths[urns[file_source_id]]
-    # Configured external parent roots the path, followed by in-repo ancestors.
+    # Configured external parent roots the path, then the synthetic repo name
+    # (no repo-root doc in this mode), then in-repo folder ancestors.
     assert file_browse_path.path[0].urn == parent_urn
+    assert [e.id for e in file_browse_path.path] == [
+        "urn:li:document:parent",
+        "docs",
+        "guides",
+    ]
     assert [e.urn for e in file_browse_path.path] == [
         parent_urn,
+        None,
         urns[guides_dir_source_id],
     ]
+
+
+def test_browse_path_failure_reports_warning_and_still_emits(
+    source: GitHubDocumentsSource,
+) -> None:
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/guides/setup.md", size=12)],
+    )
+
+    with patch(
+        "datahub.ingestion.source.github_documents.github_documents_source.GitHubHierarchyExtractor.build_browse_path_v2",
+        side_effect=RuntimeError("boom"),
+    ):
+        workunits = list(source.get_workunits())
+
+    # Document is still emitted despite the browse-path failure.
+    infos = _document_infos_by_source_id(workunits)
+    file_source_id = make_file_source_id("acme/docs", "docs/guides/setup.md")
+    assert file_source_id in infos
+
+    # Failure surfaces as a structured warning -> "succeeded with warnings".
+    assert any(
+        warning.title == "Browse path generation failed"
+        for warning in source.report.warnings
+    )
 
 
 def test_file_document_includes_content_hash_and_blob_sha(

--- a/metadata-ingestion/tests/unit/ingestion/source/github_documents/test_github_hierarchy.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/github_documents/test_github_hierarchy.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 from datahub.ingestion.source.github_documents.github_hierarchy import (
     GitHubHierarchyExtractor,
 )
-from datahub.metadata.schema_classes import BrowsePathsV2Class
+from datahub.metadata.schema_classes import BrowsePathEntryClass, BrowsePathsV2Class
 
 # repo -> docs -> guides -> setup.md
 PARENT_LINKS: Dict[str, Optional[str]] = {
@@ -89,40 +89,53 @@ def test_build_browse_path_v2_empty_source_id_returns_none() -> None:
     )
 
 
-def test_build_browse_path_v2_with_root_parent_urn() -> None:
-    # When nesting under an external configured parent, top-level docs have no
-    # in-repo ancestors, but the configured parent roots the path.
+def test_build_browse_path_v2_with_prefix_entries() -> None:
+    # Prefix entries (e.g. configured parent, org, repo) are prepended ahead of
+    # the reconstructed in-repo ancestor chain.
     links: Dict[str, Optional[str]] = {"guides": None, "setup": "guides"}
     titles = {"guides": "guides", "setup": "setup.md"}
     urns = {"guides": "urn:li:document:guides", "setup": "urn:li:document:setup"}
-    root = "urn:li:document:external-root"
+    prefix = [
+        BrowsePathEntryClass(
+            id="urn:li:document:external-root", urn="urn:li:document:external-root"
+        ),
+        BrowsePathEntryClass(id="acme"),
+    ]
 
     browse_path = GitHubHierarchyExtractor.build_browse_path_v2(
         source_id="setup",
         parent_links=links,
         titles=titles,
         urns=urns,
-        root_parent_urn=root,
+        prefix_entries=prefix,
     )
 
     assert browse_path is not None
-    assert [e.id for e in browse_path.path] == [root, "guides"]
-    assert [e.urn for e in browse_path.path] == [root, urns["guides"]]
+    assert [e.id for e in browse_path.path] == [
+        "urn:li:document:external-root",
+        "acme",
+        "guides",
+    ]
+    assert [e.urn for e in browse_path.path] == [
+        "urn:li:document:external-root",
+        None,
+        urns["guides"],
+    ]
 
 
-def test_build_browse_path_v2_root_parent_only_for_top_level() -> None:
-    # A top-level document under an external parent gets just that parent.
+def test_build_browse_path_v2_prefix_only_for_top_level() -> None:
+    # A top-level document with no in-repo ancestors still gets the prefix.
     links: Dict[str, Optional[str]] = {"setup": None}
-    root = "urn:li:document:external-root"
+    prefix = [BrowsePathEntryClass(id="my-repo")]
 
     browse_path = GitHubHierarchyExtractor.build_browse_path_v2(
         source_id="setup",
         parent_links=links,
         titles={"setup": "setup.md"},
         urns={"setup": "urn:li:document:setup"},
-        root_parent_urn=root,
+        prefix_entries=prefix,
     )
 
     assert browse_path is not None
-    assert [e.id for e in browse_path.path] == [root]
-    assert browse_path.path[0].urn == root
+    assert [e.id for e in browse_path.path] == ["my-repo"]
+    assert browse_path.path[0].urn is None

--- a/metadata-ingestion/tests/unit/ingestion/source/github_documents/test_github_hierarchy.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/github_documents/test_github_hierarchy.py
@@ -1,0 +1,128 @@
+"""Unit tests for GitHub documents hierarchy extraction."""
+
+from typing import Dict, Optional
+
+from datahub.ingestion.source.github_documents.github_hierarchy import (
+    GitHubHierarchyExtractor,
+)
+from datahub.metadata.schema_classes import BrowsePathsV2Class
+
+# repo -> docs -> guides -> setup.md
+PARENT_LINKS: Dict[str, Optional[str]] = {
+    "repo": None,
+    "docs": "repo",
+    "guides": "docs",
+    "setup": "guides",
+}
+TITLES = {
+    "repo": "docs",
+    "docs": "docs",
+    "guides": "guides",
+    "setup": "setup.md",
+}
+URNS = {
+    "repo": "urn:li:document:repo",
+    "docs": "urn:li:document:docs",
+    "guides": "urn:li:document:guides",
+    "setup": "urn:li:document:setup",
+}
+
+
+def test_build_ancestor_chain_multi_level() -> None:
+    chain = GitHubHierarchyExtractor.build_ancestor_chain("setup", PARENT_LINKS)
+    # Root first, immediate parent last; the document itself is excluded.
+    assert chain == ["repo", "docs", "guides"]
+
+
+def test_build_ancestor_chain_root_has_no_ancestors() -> None:
+    assert GitHubHierarchyExtractor.build_ancestor_chain("repo", PARENT_LINKS) == []
+
+
+def test_build_ancestor_chain_stops_on_missing_parent() -> None:
+    # "ghost" is referenced as a parent but absent from the link map.
+    links: Dict[str, Optional[str]] = {"orphan": "ghost"}
+    assert GitHubHierarchyExtractor.build_ancestor_chain("orphan", links) == ["ghost"]
+
+
+def test_build_ancestor_chain_is_cycle_safe() -> None:
+    links: Dict[str, Optional[str]] = {"a": "b", "b": "a"}
+    assert GitHubHierarchyExtractor.build_ancestor_chain("a", links) == ["b"]
+
+
+def test_build_browse_path_v2_with_ancestors() -> None:
+    browse_path = GitHubHierarchyExtractor.build_browse_path_v2(
+        source_id="setup",
+        parent_links=PARENT_LINKS,
+        titles=TITLES,
+        urns=URNS,
+    )
+
+    assert browse_path is not None
+    assert isinstance(browse_path, BrowsePathsV2Class)
+    assert [e.id for e in browse_path.path] == ["docs", "docs", "guides"]
+    assert [e.urn for e in browse_path.path] == [
+        URNS["repo"],
+        URNS["docs"],
+        URNS["guides"],
+    ]
+
+
+def test_build_browse_path_v2_repo_root_returns_none() -> None:
+    browse_path = GitHubHierarchyExtractor.build_browse_path_v2(
+        source_id="repo",
+        parent_links=PARENT_LINKS,
+        titles=TITLES,
+        urns=URNS,
+    )
+    assert browse_path is None
+
+
+def test_build_browse_path_v2_empty_source_id_returns_none() -> None:
+    assert (
+        GitHubHierarchyExtractor.build_browse_path_v2(
+            source_id="",
+            parent_links=PARENT_LINKS,
+            titles=TITLES,
+            urns=URNS,
+        )
+        is None
+    )
+
+
+def test_build_browse_path_v2_with_root_parent_urn() -> None:
+    # When nesting under an external configured parent, top-level docs have no
+    # in-repo ancestors, but the configured parent roots the path.
+    links: Dict[str, Optional[str]] = {"guides": None, "setup": "guides"}
+    titles = {"guides": "guides", "setup": "setup.md"}
+    urns = {"guides": "urn:li:document:guides", "setup": "urn:li:document:setup"}
+    root = "urn:li:document:external-root"
+
+    browse_path = GitHubHierarchyExtractor.build_browse_path_v2(
+        source_id="setup",
+        parent_links=links,
+        titles=titles,
+        urns=urns,
+        root_parent_urn=root,
+    )
+
+    assert browse_path is not None
+    assert [e.id for e in browse_path.path] == [root, "guides"]
+    assert [e.urn for e in browse_path.path] == [root, urns["guides"]]
+
+
+def test_build_browse_path_v2_root_parent_only_for_top_level() -> None:
+    # A top-level document under an external parent gets just that parent.
+    links: Dict[str, Optional[str]] = {"setup": None}
+    root = "urn:li:document:external-root"
+
+    browse_path = GitHubHierarchyExtractor.build_browse_path_v2(
+        source_id="setup",
+        parent_links=links,
+        titles={"setup": "setup.md"},
+        urns={"setup": "urn:li:document:setup"},
+        root_parent_urn=root,
+    )
+
+    assert browse_path is not None
+    assert [e.id for e in browse_path.path] == [root]
+    assert browse_path.path[0].urn == root

--- a/metadata-ingestion/tests/unit/ingestion/source/notion/test_notion_hierarchy.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/notion/test_notion_hierarchy.py
@@ -120,13 +120,13 @@ def test_build_browse_path_v2_with_ancestors() -> None:
     ]
 
 
-def test_build_browse_path_v2_ancestor_not_ingested_has_no_urn() -> None:
+def test_build_browse_path_v2_ancestor_not_ingested_is_omitted() -> None:
     parent_metadata = {
         "child": {"parent": {"type": "page_id", "page_id": "parent"}},
         "parent": {"parent": {"type": "page_id", "page_id": "root"}},
         "root": {"parent": {"type": "workspace", "workspace": True}},
     }
-    # Only the child is in scope; ancestors are referenced but not ingested.
+    # Only the child is in scope; ancestors outside the run are not in the path.
     browse_path = NotionHierarchyExtractor.build_browse_path_v2(
         page_id="child",
         parent_metadata=parent_metadata,
@@ -135,9 +135,7 @@ def test_build_browse_path_v2_ancestor_not_ingested_has_no_urn() -> None:
         ingested_page_ids={"child"},
     )
 
-    assert browse_path is not None
-    assert [e.id for e in browse_path.path] == ["Engineering", "API"]
-    assert all(e.urn is None for e in browse_path.path)
+    assert browse_path is None
 
 
 def test_build_browse_path_v2_empty_page_id_returns_none() -> None:
@@ -166,8 +164,8 @@ def test_build_browse_path_v2_no_metadata_map_returns_none() -> None:
     )
 
 
-def test_build_browse_path_v2_without_ingested_set_has_no_urns() -> None:
-    """When the ingested set is omitted, ancestors are labeled but carry no URN."""
+def test_build_browse_path_v2_without_ingested_set_includes_all_ancestors() -> None:
+    """When the ingested set is omitted, all resolved ancestors are included."""
     parent_metadata = {
         "child": {"parent": {"type": "page_id", "page_id": "root"}},
         "root": {"parent": {"type": "workspace", "workspace": True}},
@@ -181,4 +179,42 @@ def test_build_browse_path_v2_without_ingested_set_has_no_urns() -> None:
 
     assert browse_path is not None
     assert [e.id for e in browse_path.path] == ["Engineering"]
-    assert browse_path.path[0].urn is None
+    assert browse_path.path[0].urn == _urn("root")
+
+
+def test_build_browse_path_v2_explicit_root_has_no_ancestors() -> None:
+    """A page explicitly scoped via page_ids is a browse-path root."""
+    parent_metadata = {
+        "scoped-page": {"parent": {"type": "page_id", "page_id": "outside-parent"}},
+        "outside-parent": {"parent": {"type": "workspace", "workspace": True}},
+    }
+    browse_path = NotionHierarchyExtractor.build_browse_path_v2(
+        page_id="scoped-page",
+        parent_metadata=parent_metadata,
+        urn_builder=_urn,
+        title_resolver=_title,
+        ingested_page_ids={"scoped-page"},
+        browse_path_root_ids={"scoped-page"},
+    )
+
+    assert browse_path is None
+
+
+def test_build_browse_path_v2_explicit_root_anchors_descendants() -> None:
+    parent_metadata = {
+        "child": {"parent": {"type": "page_id", "page_id": "scoped-page"}},
+        "scoped-page": {"parent": {"type": "page_id", "page_id": "outside-parent"}},
+        "outside-parent": {"parent": {"type": "workspace", "workspace": True}},
+    }
+    browse_path = NotionHierarchyExtractor.build_browse_path_v2(
+        page_id="child",
+        parent_metadata=parent_metadata,
+        urn_builder=_urn,
+        title_resolver=_title,
+        ingested_page_ids={"scoped-page", "child"},
+        browse_path_root_ids={"scoped-page"},
+    )
+
+    assert browse_path is not None
+    assert [e.id for e in browse_path.path] == ["scoped-page"]
+    assert browse_path.path[0].urn == _urn("scoped-page")

--- a/metadata-ingestion/tests/unit/ingestion/source/notion/test_notion_hierarchy.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/notion/test_notion_hierarchy.py
@@ -1,0 +1,184 @@
+"""Unit tests for Notion hierarchy extraction."""
+
+from datahub.ingestion.source.notion.notion_hierarchy import NotionHierarchyExtractor
+from datahub.metadata.schema_classes import BrowsePathsV2Class
+
+
+def _urn(page_id: str) -> str:
+    return f"urn:li:document:notion-{page_id}"
+
+
+def _title(page_id: str) -> str:
+    titles = {
+        "root": "Engineering",
+        "mid": "Backend",
+        "parent": "API",
+    }
+    return titles.get(page_id, page_id)
+
+
+def test_extract_parent_id_page_parent() -> None:
+    metadata = {"parent": {"type": "page_id", "page_id": "parent-1"}}
+    assert NotionHierarchyExtractor.extract_parent_id(metadata) == "parent-1"
+
+
+def test_extract_parent_id_database_parent() -> None:
+    metadata = {"parent": {"type": "database_id", "database_id": "db-1"}}
+    assert NotionHierarchyExtractor.extract_parent_id(metadata) == "db-1"
+
+
+def test_extract_parent_id_workspace_is_root() -> None:
+    metadata = {"parent": {"type": "workspace", "workspace": True}}
+    assert NotionHierarchyExtractor.extract_parent_id(metadata) is None
+
+
+def test_extract_parent_id_missing_or_invalid() -> None:
+    assert NotionHierarchyExtractor.extract_parent_id(None) is None
+    assert NotionHierarchyExtractor.extract_parent_id({}) is None
+    assert NotionHierarchyExtractor.extract_parent_id({"parent": "nope"}) is None
+
+
+def test_extract_ancestor_chain_multi_level() -> None:
+    parent_metadata = {
+        "child": {"parent": {"type": "page_id", "page_id": "parent"}},
+        "parent": {"parent": {"type": "page_id", "page_id": "mid"}},
+        "mid": {"parent": {"type": "page_id", "page_id": "root"}},
+        "root": {"parent": {"type": "workspace", "workspace": True}},
+    }
+
+    chain = NotionHierarchyExtractor.extract_ancestor_chain("child", parent_metadata)
+    # Root first, immediate parent last; the page itself is excluded.
+    assert chain == ["root", "mid", "parent"]
+
+
+def test_extract_ancestor_chain_root_page() -> None:
+    parent_metadata = {
+        "root": {"parent": {"type": "workspace", "workspace": True}},
+    }
+    assert (
+        NotionHierarchyExtractor.extract_ancestor_chain("root", parent_metadata) == []
+    )
+
+
+def test_extract_ancestor_chain_stops_on_missing_parent() -> None:
+    # "mid" is referenced as a parent but absent from the map.
+    parent_metadata = {
+        "child": {"parent": {"type": "page_id", "page_id": "mid"}},
+    }
+    chain = NotionHierarchyExtractor.extract_ancestor_chain("child", parent_metadata)
+    assert chain == ["mid"]
+
+
+def test_extract_ancestor_chain_is_cycle_safe() -> None:
+    # Malformed data with a parent cycle should not loop forever.
+    parent_metadata = {
+        "a": {"parent": {"type": "page_id", "page_id": "b"}},
+        "b": {"parent": {"type": "page_id", "page_id": "a"}},
+    }
+    chain = NotionHierarchyExtractor.extract_ancestor_chain("a", parent_metadata)
+    assert chain == ["b"]
+
+
+def test_build_browse_path_v2_root_page_returns_none() -> None:
+    parent_metadata = {
+        "root": {"parent": {"type": "workspace", "workspace": True}},
+    }
+    browse_path = NotionHierarchyExtractor.build_browse_path_v2(
+        page_id="root",
+        parent_metadata=parent_metadata,
+        urn_builder=_urn,
+        title_resolver=_title,
+        ingested_page_ids={"root"},
+    )
+    assert browse_path is None
+
+
+def test_build_browse_path_v2_with_ancestors() -> None:
+    parent_metadata = {
+        "child": {"parent": {"type": "page_id", "page_id": "parent"}},
+        "parent": {"parent": {"type": "page_id", "page_id": "mid"}},
+        "mid": {"parent": {"type": "page_id", "page_id": "root"}},
+        "root": {"parent": {"type": "workspace", "workspace": True}},
+    }
+    ingested = {"child", "parent", "mid", "root"}
+
+    browse_path = NotionHierarchyExtractor.build_browse_path_v2(
+        page_id="child",
+        parent_metadata=parent_metadata,
+        urn_builder=_urn,
+        title_resolver=_title,
+        ingested_page_ids=ingested,
+    )
+
+    assert browse_path is not None
+    assert isinstance(browse_path, BrowsePathsV2Class)
+    assert [e.id for e in browse_path.path] == ["Engineering", "Backend", "API"]
+    assert [e.urn for e in browse_path.path] == [
+        _urn("root"),
+        _urn("mid"),
+        _urn("parent"),
+    ]
+
+
+def test_build_browse_path_v2_ancestor_not_ingested_has_no_urn() -> None:
+    parent_metadata = {
+        "child": {"parent": {"type": "page_id", "page_id": "parent"}},
+        "parent": {"parent": {"type": "page_id", "page_id": "root"}},
+        "root": {"parent": {"type": "workspace", "workspace": True}},
+    }
+    # Only the child is in scope; ancestors are referenced but not ingested.
+    browse_path = NotionHierarchyExtractor.build_browse_path_v2(
+        page_id="child",
+        parent_metadata=parent_metadata,
+        urn_builder=_urn,
+        title_resolver=_title,
+        ingested_page_ids={"child"},
+    )
+
+    assert browse_path is not None
+    assert [e.id for e in browse_path.path] == ["Engineering", "API"]
+    assert all(e.urn is None for e in browse_path.path)
+
+
+def test_build_browse_path_v2_empty_page_id_returns_none() -> None:
+    """Missing page id should yield no browse path rather than raising."""
+    assert (
+        NotionHierarchyExtractor.build_browse_path_v2(
+            page_id="",
+            parent_metadata={},
+            urn_builder=_urn,
+            title_resolver=_title,
+        )
+        is None
+    )
+
+
+def test_build_browse_path_v2_no_metadata_map_returns_none() -> None:
+    """A page absent from the metadata map has no ancestors -> no browse path."""
+    assert (
+        NotionHierarchyExtractor.build_browse_path_v2(
+            page_id="orphan",
+            parent_metadata={},
+            urn_builder=_urn,
+            title_resolver=_title,
+        )
+        is None
+    )
+
+
+def test_build_browse_path_v2_without_ingested_set_has_no_urns() -> None:
+    """When the ingested set is omitted, ancestors are labeled but carry no URN."""
+    parent_metadata = {
+        "child": {"parent": {"type": "page_id", "page_id": "root"}},
+        "root": {"parent": {"type": "workspace", "workspace": True}},
+    }
+    browse_path = NotionHierarchyExtractor.build_browse_path_v2(
+        page_id="child",
+        parent_metadata=parent_metadata,
+        urn_builder=_urn,
+        title_resolver=_title,
+    )
+
+    assert browse_path is not None
+    assert [e.id for e in browse_path.path] == ["Engineering"]
+    assert browse_path.path[0].urn is None

--- a/metadata-ingestion/tests/unit/ingestion/source/notion/test_notion_source.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/notion/test_notion_source.py
@@ -7,6 +7,7 @@ import pytest
 from pydantic import SecretStr
 
 from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.notion.notion_config import NotionSourceConfig
 from datahub.ingestion.source.notion.notion_report import NotionSourceReport
 from datahub.ingestion.source.notion.notion_source import NotionSource
@@ -422,6 +423,42 @@ def _make_notion_source() -> NotionSource:
         },
     )
     return NotionSource(config=config, ctx=PipelineContext(run_id="test"))
+
+
+def test_browse_path_failure_reports_warning_and_still_emits():
+    """A browse-path failure surfaces as a report warning but never drops the doc."""
+    from datahub.metadata.schema_classes import DocumentInfoClass
+
+    source = _make_notion_source()
+    source.notion_parent_metadata = {
+        "child": {"parent": {"type": "page_id", "page_id": "root"}},
+        "root": {"parent": {"type": "workspace", "workspace": True}},
+    }
+    source._should_process_document = MagicMock(return_value=True)  # type: ignore[method-assign]
+    source.chunking_source.process_elements_inline = MagicMock(return_value=[])  # type: ignore[method-assign]
+
+    data = {
+        "elements": [{"type": "Title", "text": "Child", "metadata": {}}],
+        "metadata": {"data_source": {"record_locator": {"page_id": "child"}}},
+    }
+
+    with patch(
+        "datahub.ingestion.source.notion.notion_source.NotionHierarchyExtractor.build_browse_path_v2",
+        side_effect=RuntimeError("boom"),
+    ):
+        workunits = list(source._create_document_entity(data, {"child", "root"}))
+
+    # Document still emitted despite the browse-path failure.
+    assert any(
+        isinstance(wu, MetadataWorkUnit)
+        and wu.get_aspect_of_type(DocumentInfoClass) is not None
+        for wu in workunits
+    )
+    # Failure surfaces as a structured warning -> "succeeded with warnings".
+    assert any(
+        warning.title == "Browse path generation failed"
+        for warning in source.report.warnings
+    )
 
 
 def test_build_notion_document_urn_matches_parent_urn():

--- a/metadata-ingestion/tests/unit/ingestion/source/notion/test_notion_source.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/notion/test_notion_source.py
@@ -410,6 +410,74 @@ def test_extract_notion_parent_urn_with_ingested_pages():
     assert parent_urn is None
 
 
+def _make_notion_source() -> NotionSource:
+    config = NotionSourceConfig(
+        api_key=SecretStr("secret_test_key"),
+        page_ids=["2bffc6a6-4277-8024-97c9-d0f26faa4480"],
+        embedding={
+            "provider": "bedrock",
+            "model": "cohere.embed-english-v3",
+            "aws_region": "us-west-2",
+            "allow_local_embedding_config": True,
+        },
+    )
+    return NotionSource(config=config, ctx=PipelineContext(run_id="test"))
+
+
+def test_build_notion_document_urn_matches_parent_urn():
+    """Browse-path URNs must match the URN derived for parent references."""
+    source = _make_notion_source()
+    source.notion_parent_metadata = {
+        "child-page-id": {"parent": {"type": "page_id", "page_id": "parent-page-id"}}
+    }
+    metadata = {"data_source": {"record_locator": {"page_id": "child-page-id"}}}
+
+    parent_urn = source._extract_notion_parent_urn(
+        [], metadata, {"child-page-id", "parent-page-id"}
+    )
+    assert parent_urn == source._build_notion_document_urn("parent-page-id")
+
+
+def test_notion_title_for_page_falls_back_to_page_id():
+    source = _make_notion_source()
+    source.notion_page_titles = {"known": "Known Title"}
+
+    assert source._notion_title_for_page("known") == "Known Title"
+    assert source._notion_title_for_page("unknown") == "unknown"
+
+
+def test_source_emits_hierarchical_browse_path():
+    """The source wiring should produce a BrowsePathsV2 with ancestor URNs/titles."""
+    from datahub.ingestion.source.notion.notion_hierarchy import (
+        NotionHierarchyExtractor,
+    )
+
+    source = _make_notion_source()
+    source.notion_parent_metadata = {
+        "child": {"parent": {"type": "page_id", "page_id": "parent"}},
+        "parent": {"parent": {"type": "page_id", "page_id": "root"}},
+        "root": {"parent": {"type": "workspace", "workspace": True}},
+    }
+    source.notion_page_titles = {
+        "parent": "Parent Page",
+        "root": "Root Page",
+    }
+    ingested = {"child", "parent", "root"}
+
+    browse_path = NotionHierarchyExtractor.build_browse_path_v2(
+        page_id="child",
+        parent_metadata=source.notion_parent_metadata,
+        urn_builder=source._build_notion_document_urn,
+        title_resolver=source._notion_title_for_page,
+        ingested_page_ids=ingested,
+    )
+
+    assert browse_path is not None
+    assert [e.id for e in browse_path.path] == ["Root Page", "Parent Page"]
+    assert browse_path.path[0].urn == source._build_notion_document_urn("root")
+    assert browse_path.path[1].urn == source._build_notion_document_urn("parent")
+
+
 def test_stateful_ingestion_config_disabled_by_default():
     """Test that stateful ingestion is disabled by default (no config set)."""
     config = NotionSourceConfig(

--- a/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_document_builder.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_document_builder.py
@@ -1,8 +1,19 @@
 """Tests for DocumentEntityBuilder import mode handling."""
 
-from datahub.ingestion.source.unstructured.config import DocumentMappingConfig
-from datahub.ingestion.source.unstructured.document_builder import DocumentEntityBuilder
+from datahub.ingestion.source.unstructured.config import (
+    DocumentMappingConfig,
+    TitleExtractionConfig,
+)
+from datahub.ingestion.source.unstructured.document_builder import (
+    DocumentEntityBuilder,
+    TitleExtractor,
+)
 from datahub.metadata.schema_classes import DocumentSourceTypeClass
+
+# A representative Notion page ID: the unstructured connector hardcodes the
+# per-page filename to "{page_id}.html", so this is what the filename fallback
+# would otherwise surface as the title.
+_NOTION_PAGE_ID = "2aafc6a6427780d1b553d4afb741bf22"
 
 
 def test_build_document_entity_native_source_type() -> None:
@@ -43,3 +54,65 @@ def test_build_document_entity_external_source_type() -> None:
     assert document_info.source is not None
     assert document_info.source.sourceType == DocumentSourceTypeClass.EXTERNAL
     assert document_info.source.externalUrl == "https://notion.so/page-123"
+
+
+def _title_extractor() -> TitleExtractor:
+    return TitleExtractor(TitleExtractionConfig())
+
+
+def test_extract_title_prefers_notion_url_slug() -> None:
+    title = _title_extractor().extract_title(
+        elements=[{"type": "NarrativeText", "text": "some body text"}],
+        filename=f"{_NOTION_PAGE_ID}.html",
+        metadata={
+            "data_source": {
+                "url": f"https://www.notion.so/Patching-upsert-in-SDK-v2-{_NOTION_PAGE_ID}"
+            }
+        },
+    )
+    assert title == "Patching upsert in SDK v2"
+
+
+def test_extract_title_falls_back_to_heading_when_url_has_no_slug() -> None:
+    # Bare-ID Notion URL carries no human-readable slug; a Header in the body
+    # should be used instead of the raw page ID filename.
+    title = _title_extractor().extract_title(
+        elements=[
+            {"type": "Header", "text": "Quarterly Planning"},
+            {"type": "NarrativeText", "text": "details"},
+        ],
+        filename=f"{_NOTION_PAGE_ID}.html",
+        metadata={"data_source": {"url": f"https://www.notion.so/{_NOTION_PAGE_ID}"}},
+    )
+    assert title == "Quarterly Planning"
+
+
+def test_extract_title_never_returns_raw_page_id() -> None:
+    # No URL slug and no heading/text content: the filename is a raw Notion page
+    # ID, which must not be surfaced as the title.
+    title = _title_extractor().extract_title(
+        elements=[],
+        filename=f"{_NOTION_PAGE_ID}.html",
+        metadata={"data_source": {"url": f"https://www.notion.so/{_NOTION_PAGE_ID}"}},
+    )
+    assert title == "Untitled Document"
+    assert _NOTION_PAGE_ID not in title
+
+
+def test_extract_title_uses_leading_text_over_page_id() -> None:
+    title = _title_extractor().extract_title(
+        elements=[{"type": "NarrativeText", "text": "Meeting notes from Monday"}],
+        filename=f"{_NOTION_PAGE_ID}.html",
+        metadata=None,
+    )
+    assert title == "Meeting notes from Monday"
+
+
+def test_extract_title_keeps_human_readable_filename() -> None:
+    # Non-ID filenames (e.g. GitHub-style paths) are still valid title fallbacks.
+    title = _title_extractor().extract_title(
+        elements=[],
+        filename="getting-started.md",
+        metadata=None,
+    )
+    assert title == "getting-started"


### PR DESCRIPTION
... As these were missing browse path emission. This ensures the search experience of DataHub is able to be navigated seamlessly! 

If failure happens, ensure we don't skip or break ingesting the document at large, simply log. 

Also, I fixed a title extraction issue that I saw in production. Sometimes, we resolve notion document titles to raw page ids. I'm attempting to fix this by taking the first header block on the page if title cannot be found. Here is the problem originally: 

<img width="411" height="408" alt="Screenshot 2026-06-26 at 9 11 33 AM" src="https://github.com/user-attachments/assets/ee5ea888-6070-457c-b520-2031967a8811" />


AFTER

<img width="347" height="620" alt="Screenshot 2026-06-26 at 9 53 44 AM" src="https://github.com/user-attachments/assets/0374071d-f2cf-4b14-8917-969c6fa5ea7b" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
