### PR TITLE
fix(ingest/tableau): stable pagination, RATE_EXCEEDED retry, page size cap, null field tolerance

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
@@ -457,7 +457,12 @@ class TableauPageSizeConfig(ConfigModel):
 
     @property
     def effective_embedded_datasource_field_upstream_page_size(self) -> int:
-        return self.embedded_datasource_field_upstream_page_size or self.page_size * 10
+        # Tableau's fieldsConnection API has a hard limit of 1000 items per page.
+        # Requesting more results in silently truncated responses.
+        return min(
+            self.embedded_datasource_field_upstream_page_size or self.page_size * 10,
+            1000,
+        )
 
     published_datasource_page_size: Optional[int] = Field(
         default=None,
@@ -475,7 +480,12 @@ class TableauPageSizeConfig(ConfigModel):
 
     @property
     def effective_published_datasource_field_upstream_page_size(self) -> int:
-        return self.published_datasource_field_upstream_page_size or self.page_size * 10
+        # Tableau's fieldsConnection API has a hard limit of 1000 items per page.
+        # Requesting more results in silently truncated responses.
+        return min(
+            self.published_datasource_field_upstream_page_size or self.page_size * 10,
+            1000,
+        )
 
     virtual_connection_page_size: Optional[int] = Field(
         default=None,
@@ -1675,7 +1685,16 @@ class TableauSiteSource:
             if all(
                 # The format of the error messages is highly unpredictable, so we have to
                 # be extra defensive with our parsing.
-                error and (error.get(c.EXTENSIONS) or {}).get(c.SEVERITY) == c.WARNING
+                error
+                and (
+                    (error.get(c.EXTENSIONS) or {}).get(c.SEVERITY) == c.WARNING
+                    # Tableau's Metadata API sometimes returns NullValueInNonNullableField
+                    # when the node limit truncates the response before nested objects
+                    # (e.g. workbook.owner) can be fully resolved. The partial data is
+                    # still usable — treat as non-fatal.
+                    or (error.get(c.EXTENSIONS) or {}).get("classification")
+                    == "NullValueInNonNullableField"
+                )
                 for error in errors
             ):
                 # filter out PERMISSIONS_MODE_SWITCHED to report error in human-readable format
@@ -1736,6 +1755,9 @@ class TableauSiteSource:
                     # The Metadata API sometimes returns an 'unexpected error' message when querying
                     # embeddedDatasourcesConnection. Try retrying a couple of times.
                     or error.get("message") == "Unexpected error occurred"
+                    # RATE_EXCEEDED: Tableau Cloud throttling — the query cost
+                    # budget was exhausted. Retryable with backoff.
+                    or (error.get("extensions") or {}).get("code") == "RATE_EXCEEDED"
                     for error in errors
                 ):
                     # If it was only a timeout error, we can retry.

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
@@ -457,7 +457,12 @@ class TableauPageSizeConfig(ConfigModel):
 
     @property
     def effective_embedded_datasource_field_upstream_page_size(self) -> int:
-        return self.embedded_datasource_field_upstream_page_size or self.page_size * 10
+        # Tableau's fieldsConnection API has a hard limit of 1000 items per page.
+        # Requesting more results in silently truncated responses.
+        return min(
+            self.embedded_datasource_field_upstream_page_size or self.page_size * 10,
+            1000,
+        )
 
     published_datasource_page_size: Optional[int] = Field(
         default=None,
@@ -475,7 +480,12 @@ class TableauPageSizeConfig(ConfigModel):
 
     @property
     def effective_published_datasource_field_upstream_page_size(self) -> int:
-        return self.published_datasource_field_upstream_page_size or self.page_size * 10
+        # Tableau's fieldsConnection API has a hard limit of 1000 items per page.
+        # Requesting more results in silently truncated responses.
+        return min(
+            self.published_datasource_field_upstream_page_size or self.page_size * 10,
+            1000,
+        )
 
     virtual_connection_page_size: Optional[int] = Field(
         default=None,
@@ -1728,7 +1738,16 @@ class TableauSiteSource:
             if all(
                 # The format of the error messages is highly unpredictable, so we have to
                 # be extra defensive with our parsing.
-                error and (error.get(c.EXTENSIONS) or {}).get(c.SEVERITY) == c.WARNING
+                error
+                and (
+                    (error.get(c.EXTENSIONS) or {}).get(c.SEVERITY) == c.WARNING
+                    # Tableau's Metadata API sometimes returns NullValueInNonNullableField
+                    # when the node limit truncates the response before nested objects
+                    # (e.g. workbook.owner) can be fully resolved. The partial data is
+                    # still usable — treat as non-fatal.
+                    or (error.get(c.EXTENSIONS) or {}).get("classification")
+                    == "NullValueInNonNullableField"
+                )
                 for error in errors
             ):
                 # filter out PERMISSIONS_MODE_SWITCHED to report error in human-readable format
@@ -1789,6 +1808,9 @@ class TableauSiteSource:
                     # The Metadata API sometimes returns an 'unexpected error' message when querying
                     # embeddedDatasourcesConnection. Try retrying a couple of times.
                     or error.get("message") == "Unexpected error occurred"
+                    # RATE_EXCEEDED: Tableau Cloud throttling — the query cost
+                    # budget was exhausted. Retryable with backoff.
+                    or (error.get("extensions") or {}).get("code") == "RATE_EXCEEDED"
                     for error in errors
                 ):
                     # If it was only a timeout error, we can retry.

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau_common.py
@@ -1101,7 +1101,12 @@ def query_metadata_cursor_based_pagination(
           $first: Int,
           $after: String
         ) {{
-            {connection_name} (  first: $first, after: $after, filter:{{ {qry_filter} }})
+            {connection_name} (
+              first: $first,
+              after: $after,
+              orderBy: {{field: NAME, direction: ASC}},
+              filter:{{ {qry_filter} }}
+            )
             {{
                 nodes {main_query}
                 pageInfo {{

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau_common.py
@@ -1130,7 +1130,12 @@ def query_metadata_cursor_based_pagination(
           $first: Int,
           $after: String
         ) {{
-            {connection_name} (  first: $first, after: $after, filter:{{ {qry_filter} }})
+            {connection_name} (
+              first: $first,
+              after: $after,
+              orderBy: {{field: NAME, direction: ASC}},
+              filter:{{ {qry_filter} }}
+            )
             {{
                 nodes {main_query}
                 pageInfo {{


### PR DESCRIPTION
Fixes #19689

## Summary

Four small fixes for the Tableau connector that address issues encountered in production with large Tableau Cloud instances (thousands of datasources, frequent catalog changes).

### 1. Stable cursor pagination (`orderBy`)

Without ordering, the Metadata API cursor pagination is unstable — items can shift between pages when the catalog changes during ingestion, causing entities to be skipped or duplicated. This adds `orderBy: {field: NAME, direction: ASC}` to all paginated queries.

### 2. RATE_EXCEEDED is now retryable

Tableau Cloud throttles queries when the cost budget is exhausted, returning a `RATE_EXCEEDED` GraphQL error code. Previously this raised a fatal `RuntimeError` and crashed the pipeline. Now it's retried with exponential backoff, consistent with how timeout and unexpected errors are already handled.

### 3. NullValueInNonNullableField treated as non-fatal

When the 20k node limit truncates a response, nested objects (e.g. `workbook.owner`) are returned as `null`. Tableau classifies these errors as `NullValueInNonNullableField`. The existing code only treats errors with `severity: WARNING` as non-fatal — but this classification doesn't carry that severity. The partial data is still usable, so we now accept it instead of crashing.

### 4. Field upstream page size capped at 1000

`effective_embedded_datasource_field_upstream_page_size` and `effective_published_datasource_field_upstream_page_size` compute `page_size * 10`. With `page_size: 200` this yields 2000, but Tableau's `fieldsConnection` API silently truncates at 1000. Results were incomplete without any error. Now capped at 1000.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (specifically the [PR title format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Fixes production crashes and silent data loss on Tableau Cloud
- [ ] Tests added/updated
- [x] Docs: inline code comments explain the rationale

---

This is PR 1/5 in a series of Tableau connector improvements. Subsequent PRs (timeout guards, node limit recovery, performance optimizations, embedded LUID enrichment) build on this one.
