### PR TITLE
fix(nightly): Fix various issues with nightly build workflow

### DIFF
--- a/.github/workflows/docker-unified-nightly.yml
+++ b/.github/workflows/docker-unified-nightly.yml
@@ -3,8 +3,8 @@ name: Nightly Docker Test
 # and if tests pass, tags them as nightly and daily for publishing
 on:
   workflow_dispatch:
-  # schedule:
-  # - cron: "0 8 * * *" # Run at midnight Pacific time (8 AM UTC) every day
+  schedule:
+    - cron: "0 8 * * *" # Run at midnight Pacific time (8 AM UTC) every day
 
 concurrency:
   group: ${{ github.workflow }}
@@ -116,7 +116,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          run_id=$(gh run list  --workflow="docker-unified.yml" --branch master --event push --status success --limit 1 --json=databaseId  | jq '.[].databaseId')
+          run_id=$(gh run list --workflow="docker-unified.yml" --branch master --event push --status success --limit 1 --json=databaseId | jq '.[].databaseId')
           mkdir -p "${{ github.workspace }}/build"
           artifact_id=$(gh api --paginate "repos/datahub-project/datahub/actions/runs/$run_id/artifacts" --jq '[.artifacts[] | select(.name | startswith("build-metadata-sha-"))] | last | .id')
           gh api "repos/datahub-project/datahub/actions/artifacts/${artifact_id}/zip" >"${{ github.workspace }}/build/build-metadata.zip"
@@ -365,7 +365,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          run_id=$(gh run list  --workflow="docker-unified.yml" --branch master --event push --status success --limit 1 --json=databaseId  | jq '.[].databaseId')
+          run_id=$(gh run list --workflow="docker-unified.yml" --branch master --event push --status success --limit 1 --json=databaseId | jq '.[].databaseId')
           mkdir -p "${{ github.workspace }}/build"
           artifact_id=$(gh api --paginate "repos/datahub-project/datahub/actions/runs/$run_id/artifacts" --jq '[.artifacts[] | select(.name | startswith("build-metadata-sha-"))] | last | .id')
           gh api "repos/datahub-project/datahub/actions/artifacts/${artifact_id}/zip" >"${{ github.workspace }}/build/build-metadata.zip"
@@ -582,7 +582,7 @@ jobs:
     name: Tag and push head images as nightly
     runs-on: ${{ needs.setup.outputs.test_runner_type_small }}
     needs: [setup, smoke_test]
-    if: ${{ needs.setup.outputs.publish == 'true' && always() && !failure() && !cancelled() }}
+    if: ${{ github.ref_name == github.event.repository.default_branch && needs.setup.outputs.publish == 'true' && always() && !failure() && !cancelled() }}
     steps:
       - name: Check out the repo
         uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
@@ -630,7 +630,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          run_id=$(gh run list  --workflow="docker-unified.yml" --branch master --event push --status success --limit 1 --json=databaseId  | jq '.[].databaseId')
+          run_id=$(gh run list --workflow="docker-unified.yml" --branch master --event push --status success --limit 1 --json=databaseId | jq '.[].databaseId')
           mkdir -p "${{ github.workspace }}/build"
           artifact_id=$(gh api --paginate "repos/datahub-project/datahub/actions/runs/$run_id/artifacts" --jq '[.artifacts[] | select(.name | startswith("build-metadata-sha-"))] | last | .id')
           gh api "repos/datahub-project/datahub/actions/artifacts/${artifact_id}/zip" >"${{ github.workspace }}/build/build-metadata.zip"

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/EntityAssertionsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/EntityAssertionsResolver.java
@@ -90,6 +90,7 @@ public class EntityAssertionsResolver
                     .map(entities::get) // null for hard-deleted urns
                     .filter(Objects::nonNull)
                     .map(r -> AssertionMapper.map(context, r))
+                    .filter(assertion -> assertion.getInfo() != null)
                     .filter(assertion -> includeSoftDeleted || !isSoftDeleted(assertion))
                     .collect(Collectors.toList());
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/EntityAssertionsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/EntityAssertionsResolverTest.java
@@ -355,6 +355,63 @@ public class EntityAssertionsResolverTest {
         .exists(Mockito.any(), Mockito.any(Urn.class), Mockito.any());
   }
 
+  /**
+   * Hard-deleted assertions can leave a stale {@code Asserts} graph edge while {@code batchGetV2}
+   * returns only key/timeseries aspects (no {@code assertionInfo}). Those entries must not appear
+   * in {@code dataset.assertions}.
+   */
+  @Test
+  public void testHardDeletedAssertionWithoutInfoFilteredOut() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    GraphClient graphClient = Mockito.mock(GraphClient.class);
+
+    Urn datasetUrn = Urn.createFromString("urn:li:dataset:(test,test,test)");
+    Urn liveAssertionUrn = Urn.createFromString("urn:li:assertion:live");
+    Urn hardDeletedAssertionUrn = Urn.createFromString("urn:li:assertion:hard-deleted");
+
+    Mockito.when(
+            graphClient.getRelatedEntities(
+                Mockito.eq(datasetUrn.toString()),
+                Mockito.eq(ImmutableSet.of("Asserts")),
+                Mockito.eq(RelationshipDirection.INCOMING),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any()))
+        .thenReturn(
+            new EntityRelationships()
+                .setStart(0)
+                .setCount(2)
+                .setTotal(2)
+                .setRelationships(
+                    new EntityRelationshipArray(
+                        ImmutableList.of(
+                            new EntityRelationship().setEntity(liveAssertionUrn).setType("Asserts"),
+                            new EntityRelationship()
+                                .setEntity(hardDeletedAssertionUrn)
+                                .setType("Asserts")))));
+
+    Mockito.when(
+            mockClient.batchGetV2(
+                any(),
+                Mockito.eq(Constants.ASSERTION_ENTITY_NAME),
+                Mockito.eq(ImmutableSet.of(liveAssertionUrn, hardDeletedAssertionUrn)),
+                Mockito.eq(null)))
+        .thenReturn(
+            ImmutableMap.of(
+                liveAssertionUrn,
+                assertionResponse(liveAssertionUrn, datasetUrn, "live-guid", false),
+                hardDeletedAssertionUrn,
+                hardDeletedAssertionResponse(hardDeletedAssertionUrn, "hard-deleted-guid")));
+
+    EntityAssertionsResolver resolver = new EntityAssertionsResolver(mockClient, graphClient);
+
+    EntityAssertionsResult result =
+        resolver.get(mockEnv(datasetUrn, false /* includeSoftDeleted */)).get();
+
+    assertEquals(result.getAssertions().size(), 1);
+    assertEquals(result.getAssertions().get(0).getUrn(), liveAssertionUrn.toString());
+  }
+
   // ---------- Helpers ----------
 
   private static DataFetchingEnvironment mockEnv(Urn datasetUrn, boolean includeSoftDeleted) {
@@ -397,6 +454,20 @@ public class EntityAssertionsResolverTest {
         Constants.STATUS_ASPECT_NAME,
         new com.linkedin.entity.EnvelopedAspect()
             .setValue(new Aspect(new com.linkedin.common.Status().setRemoved(removed).data())));
+    return new EntityResponse()
+        .setEntityName(Constants.ASSERTION_ENTITY_NAME)
+        .setUrn(assertionUrn)
+        .setAspects(new EnvelopedAspectMap(aspects));
+  }
+
+  private static EntityResponse hardDeletedAssertionResponse(Urn assertionUrn, String guid)
+      throws Exception {
+    Map<String, com.linkedin.entity.EnvelopedAspect> aspects = new HashMap<>();
+    aspects.put(
+        Constants.ASSERTION_KEY_ASPECT_NAME,
+        new com.linkedin.entity.EnvelopedAspect()
+            .setValue(new Aspect(new AssertionKey().setAssertionId(guid).data())));
+    // Intentionally no assertionInfo aspect — simulates hard delete with stale graph edge.
     return new EntityResponse()
         .setEntityName(Constants.ASSERTION_ENTITY_NAME)
         .setUrn(assertionUrn)

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/CreateCdcUserStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/CreateCdcUserStep.java
@@ -75,25 +75,42 @@ public class CreateCdcUserStep implements UpgradeStep {
 
     try {
       try (Connection connection = server.dataSource().getConnection()) {
-        String createCdcUserSql = dbOps.createCdcUserSql(args.getCdcUser(), args.getCdcPassword());
-        try (PreparedStatement stmt = connection.prepareStatement(createCdcUserSql)) {
-          stmt.executeUpdate();
-        }
+        boolean previousAutoCommit = connection.getAutoCommit();
+        try {
+          connection.setAutoCommit(false);
 
-        java.util.List<String> grantCdcPrivilegesStmts =
-            dbOps.grantCdcPrivilegesSql(
-                args.getCdcUser(), args.getDatabaseName(), args.getPostgresMetadataSchema());
-        for (String grantSql : grantCdcPrivilegesStmts) {
-          try (PreparedStatement grantStmt = connection.prepareStatement(grantSql)) {
-            grantStmt.executeUpdate();
+          String createCdcUserSql =
+              dbOps.createCdcUserSql(args.getCdcUser(), args.getCdcPassword());
+          try (PreparedStatement stmt = connection.prepareStatement(createCdcUserSql)) {
+            stmt.executeUpdate();
+          }
+
+          java.util.List<String> grantCdcPrivilegesStmts =
+              dbOps.grantCdcPrivilegesSql(
+                  args.getCdcUser(), args.getDatabaseName(), args.getPostgresMetadataSchema());
+          for (String grantSql : grantCdcPrivilegesStmts) {
+            try (PreparedStatement grantStmt = connection.prepareStatement(grantSql)) {
+              grantStmt.executeUpdate();
+            }
+          }
+
+          connection.commit();
+          result.setCdcUserCreated(true);
+          log.info("CDC user '{}' created successfully", args.getCdcUser());
+        } catch (SQLException e) {
+          try {
+            connection.rollback();
+          } catch (SQLException rollbackEx) {
+            log.warn("Failed to rollback CDC user creation transaction", rollbackEx);
+          }
+          throw e;
+        } finally {
+          try {
+            connection.setAutoCommit(previousAutoCommit);
+          } catch (SQLException e) {
+            log.warn("Failed to restore autoCommit", e);
           }
         }
-
-        // Commit the transaction to persist the user creation and grants
-        connection.commit();
-
-        result.setCdcUserCreated(true);
-        log.info("CDC user '{}' created successfully", args.getCdcUser());
       }
     } catch (Exception e) {
       throw new RuntimeException("Failed to create CDC user: " + e.getMessage(), e);

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/CreateCdcUserStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/CreateCdcUserStepTest.java
@@ -18,6 +18,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.function.Function;
 import javax.sql.DataSource;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
@@ -489,6 +490,7 @@ public class CreateCdcUserStepTest {
 
   @Test
   public void testCreateCdcUserSuccess() throws SQLException {
+    when(mockConnection.getAutoCommit()).thenReturn(false);
 
     SqlSetupArgs testArgs =
         new SqlSetupArgs(
@@ -518,8 +520,44 @@ public class CreateCdcUserStepTest {
     verify(mockDatabase).dataSource();
     verify(mockConnection, times(6)).prepareStatement(anyString());
     verify(mockPreparedStatement, times(6)).executeUpdate();
-    // Verify commit is called to persist the transaction
-    verify(mockConnection).commit();
+    InOrder order = inOrder(mockConnection);
+    order.verify(mockConnection).getAutoCommit();
+    order.verify(mockConnection).setAutoCommit(false);
+    order.verify(mockConnection).commit();
+    order.verify(mockConnection).setAutoCommit(false);
+  }
+
+  @Test
+  public void testCreateCdcUserSuccessWithAutoCommitTrue() throws SQLException {
+    when(mockConnection.getAutoCommit()).thenReturn(true);
+
+    SqlSetupArgs testArgs =
+        new SqlSetupArgs(
+            true,
+            true,
+            false,
+            false,
+            DatabaseType.MYSQL,
+            true,
+            "datahub_cdc",
+            "datahub_cdc",
+            null,
+            null,
+            "localhost",
+            3306,
+            "testdb",
+            null,
+            false,
+            null);
+    SqlSetupResult result = createCdcUserStep.createCdcUser(testArgs);
+
+    assertNotNull(result);
+    assertEquals(result.isCdcUserCreated(), true);
+    InOrder order = inOrder(mockConnection);
+    order.verify(mockConnection).getAutoCommit();
+    order.verify(mockConnection).setAutoCommit(false);
+    order.verify(mockConnection).commit();
+    order.verify(mockConnection).setAutoCommit(true);
   }
 
   @Test

--- a/smoke-test/tests/assertions/custom_assertions_test.py
+++ b/smoke-test/tests/assertions/custom_assertions_test.py
@@ -8,9 +8,82 @@ from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.metadata.schema_classes import StatusClass
 from tests.consistency_utils import wait_for_writes_to_sync
-from tests.utils import delete_urn
+from tests.utils import delete_urn, with_test_retry
 
 TEST_DATASET_URN = make_dataset_urn(platform="postgres", name="foo_custom")
+
+DATASET_ASSERTIONS_QUERY = """
+    query dataset($datasetUrn: String!) {
+        dataset(urn: $datasetUrn) {
+            assertions(start: 0, count: 1000) {
+                start
+                count
+                total
+                assertions {
+                    urn
+                    # Fetch the last run of each associated assertion.
+                    runEvents(status: COMPLETE, limit: 3) {
+                        total
+                        failed
+                        succeeded
+                        runEvents {
+                            timestampMillis
+                            status
+                            result {
+                                type
+                                externalUrl
+                                nativeResults {
+                                    key
+                                    value
+                                }
+                            }
+                        }
+                    }
+                    info {
+                        type
+                        description
+                        externalUrl
+                        lastUpdated {
+                            time
+                            actor
+                        }
+                        customAssertion {
+                            type
+                            entityUrn
+                            field {
+                                path
+                            }
+                            logic
+                        }
+                        source {
+                            type
+                            created {
+                                time
+                                actor
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
+
+def _get_dataset_assertions(graph_client: DataHubGraph, dataset_urn: str) -> list:
+    dataset_assertions = graph_client.execute_graphql(
+        query=DATASET_ASSERTIONS_QUERY,
+        variables={"datasetUrn": dataset_urn},
+    )
+    return dataset_assertions["dataset"]["assertions"]["assertions"]
+
+
+@with_test_retry(max_attempts=15)
+def _assert_dataset_has_no_assertions(
+    graph_client: DataHubGraph, dataset_urn: str
+) -> None:
+    assertions = _get_dataset_assertions(graph_client, dataset_urn)
+    assert not assertions
 
 
 @pytest.fixture(scope="module")
@@ -81,69 +154,7 @@ def test_create_update_delete_dataset_custom_assertion(
 
     wait_for_writes_to_sync()
 
-    graphql_query_retrive_assertion = """
-        query dataset($datasetUrn: String!) {
-            dataset(urn: $datasetUrn) {
-                assertions(start: 0, count: 1000) {
-                    start
-                    count
-                    total
-                    assertions {
-                        urn
-                        # Fetch the last run of each associated assertion. 
-                        runEvents(status: COMPLETE, limit: 3) {
-                            total
-                            failed
-                            succeeded
-                            runEvents {
-                                timestampMillis
-                                status
-                                result {
-                                    type
-                                    externalUrl
-                                    nativeResults {
-                                        key
-                                        value
-                                    }
-                                }
-                            }
-                        }
-                        info {
-                            type
-                            description
-                            externalUrl
-                            lastUpdated {
-                                time
-                                actor
-                            }
-                            customAssertion {
-                                type
-                                entityUrn
-                                field {
-                                    path
-                                }
-                                logic
-                            }
-                            source {
-                                type
-                                created {
-                                    time
-                                    actor
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    """
-
-    dataset_assertions = graph_client.execute_graphql(
-        query=graphql_query_retrive_assertion,
-        variables={"datasetUrn": TEST_DATASET_URN},
-    )
-
-    assertions = dataset_assertions["dataset"]["assertions"]["assertions"]
+    assertions = _get_dataset_assertions(graph_client, TEST_DATASET_URN)
     assert assertions
     assert assertions[0]["urn"] == assertion_urn
     assert assertions[0]["info"]
@@ -163,10 +174,5 @@ def test_create_update_delete_dataset_custom_assertion(
     assert assertions[0]["runEvents"]["runEvents"][0]["result"]["externalUrl"]
 
     graph_client.delete_entity(assertion_urn, True)
-
-    dataset_assertions = graph_client.execute_graphql(
-        query=graphql_query_retrive_assertion,
-        variables={"datasetUrn": TEST_DATASET_URN},
-    )
-    assertions = dataset_assertions["dataset"]["assertions"]["assertions"]
-    assert not assertions
+    wait_for_writes_to_sync()
+    _assert_dataset_has_no_assertions(graph_client, TEST_DATASET_URN)


### PR DESCRIPTION
## Summary
- Fix `CreateCdcUserStep` failing nightly `quickstart-consumers-cdc` Docker tests with `Can't call commit when autocommit=true` by wrapping CDC user creation in an explicit transaction (disable autocommit, commit/rollback, restore prior setting).
- Add a regression test covering the production Ebean autocommit=true case.
- Re-enable the daily Nightly Docker Test schedule (disabled in #17866) and restrict nightly image publishing to the repository default branch.

## Test plan
- [x] `./gradlew :datahub-upgrade:test --tests "com.linkedin.datahub.upgrade.sqlsetup.CreateCdcUserStepTest"`
- [ ] Nightly Docker Test passes for `quickstart-consumers-cdc` and `quickstart-postgres-cdc` after merge


Made with [Cursor](https://cursor.com)