### PR TITLE
docs(townhalls): update town hall content for July 2026

### DIFF
--- a/docs/townhalls.md
+++ b/docs/townhalls.md
@@ -4,11 +4,15 @@ Join us for community gatherings where we discuss roadmap updates, demo new feat
 
 ## 🗓️ Next Town Hall
 
-[Register for the June Town Hall](https://luma.com/1vz73xnf)
+[Register for the July Town Hall](https://luma.com/77lmmyb5)
 
 ---
 
 ## 📺 Recent Town Halls
+
+**June 2026: Inside the Context Platform feat. TiDB / PingCAP**
+
+- 📺 [Watch recording](https://www.youtube.com/watch?v=JboXwGIz54k)
 
 **May 2026: Context to Action with Grab, dltHub, and iFood**
 


### PR DESCRIPTION
## Summary

Routine monthly refresh of the Town Halls page:

- Point the **Next Town Hall** registration link at the July 2026 event (`https://luma.com/77lmmyb5`).
- Move June 2026 into the **Recent Town Halls** list with its YouTube recording.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Docs updated
- [ ] Tests added/updated (n/a - docs only)
- [ ] Breaking changes documented (n/a)
