### PR TITLE
feat(metrics): instrument common ForkJoinPool with Micrometer executor metrics

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/system_telemetry/CommonForkJoinPoolMetricsFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/system_telemetry/CommonForkJoinPoolMetricsFactory.java
@@ -1,0 +1,46 @@
+package com.linkedin.gms.factory.system_telemetry;
+
+import com.linkedin.metadata.utils.metrics.MicrometerMetricsRegistry;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.concurrent.ForkJoinPool;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Instruments the JVM-wide {@link ForkJoinPool#commonPool()} with Micrometer executor metrics under
+ * the meter name {@code fork-join-common}.
+ *
+ * <p>The common pool is shared process-wide: it backs parallel streams, every {@link
+ * java.util.concurrent.CompletableFuture} submitted without an explicit executor, and — when {@code
+ * graphQL.concurrency.separateThreadPool} is off — GraphQL resolver execution via {@code
+ * GraphQLConcurrencyUtils}. Because it is shared rather than owned by any one subsystem, it is
+ * named for what it is ({@code fork-join-common}) rather than for a single caller, and is
+ * registered unconditionally — independent of the GraphQL concurrency flag.
+ *
+ * <p>Micrometer's ForkJoinPool instrumentation emits {@code executor_queued}, {@code
+ * executor_steals_total}, {@code executor_active}, {@code executor_running}, {@code
+ * executor_parallelism_threads}, and {@code executor_pool_size_threads} (note: the queued gauge is
+ * {@code executor_queued}, not the {@code executor_queued_tasks} emitted for ThreadPoolExecutors).
+ * {@code executor_seconds} and {@code executor_idle_seconds} are registered as empty summaries but
+ * remain at zero — ForkJoinPoolMetrics has no task-timing instrumentation. {@code
+ * executor_scheduled_once_total} and {@code executor_scheduled_repetitively_total} are also zero
+ * because ForkJoinPool does not implement {@link java.util.concurrent.ScheduledExecutorService}.
+ */
+@Slf4j
+@Configuration
+public class CommonForkJoinPoolMetricsFactory {
+
+  /**
+   * @param meterRegistry registry where the executor meters land. Autowired by Spring.
+   */
+  @Autowired
+  public CommonForkJoinPoolMetricsFactory(final MeterRegistry meterRegistry) {
+    final boolean registered =
+        MicrometerMetricsRegistry.registerExecutorMetrics(
+            "fork-join-common", ForkJoinPool.commonPool(), meterRegistry);
+    if (registered) {
+      log.info("Registered executor metrics for the common ForkJoinPool as 'fork-join-common'");
+    }
+  }
+}

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/system_telemetry/CommonForkJoinPoolMetricsFactoryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/system_telemetry/CommonForkJoinPoolMetricsFactoryTest.java
@@ -1,0 +1,25 @@
+package com.linkedin.gms.factory.system_telemetry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.testng.annotations.Test;
+
+public class CommonForkJoinPoolMetricsFactoryTest {
+
+  private static final String POOL_NAME = "fork-join-common";
+
+  @Test
+  public void testCommonForkJoinPoolMetricsRegistered() {
+    MeterRegistry registry = new SimpleMeterRegistry();
+
+    new CommonForkJoinPoolMetricsFactory(registry);
+
+    // executor.queued is the ForkJoinPool analog of the ThreadPoolExecutor's executor.queued.tasks
+    assertThat(registry.find("executor.queued").tag("name", POOL_NAME).gauge()).isNotNull();
+    // executor.steals is unique to ForkJoinPool instrumentation, confirming the FJP branch ran
+    assertThat(registry.find("executor.steals").tag("name", POOL_NAME).functionCounter())
+        .isNotNull();
+  }
+}

--- a/metadata-utils/src/test/java/com/linkedin/metadata/utils/metrics/MicrometerMetricsRegistryTest.java
+++ b/metadata-utils/src/test/java/com/linkedin/metadata/utils/metrics/MicrometerMetricsRegistryTest.java
@@ -15,6 +15,7 @@ import java.lang.reflect.Field;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.mockito.Mock;
@@ -721,6 +722,42 @@ public class MicrometerMetricsRegistryTest {
                           && executorName.equals(meter.getId().getTag("name"))));
     } finally {
       threadPoolExecutor.shutdown();
+    }
+  }
+
+  @Test
+  public void testForkJoinPoolSpecificMetrics() {
+    // A ForkJoinPool (e.g. ForkJoinPool.commonPool(), used by GraphQL when no separate thread pool
+    // is configured) is an ExecutorService, so it must be instrumentable. Micrometer emits a
+    // different metric set for it than for ThreadPoolExecutor: executor.queued (not
+    // executor.queued.tasks), executor.steals/active/running/pool.size, and executor.parallelism.
+    String executorName = "forkJoinPool";
+    ForkJoinPool forkJoinPool = new ForkJoinPool(2);
+
+    try {
+      boolean result =
+          MicrometerMetricsRegistry.registerExecutorMetrics(
+              executorName, forkJoinPool, meterRegistry);
+
+      assertTrue(result);
+
+      // ForkJoinPool uses executor.queued (not executor.queued.tasks used by ThreadPoolExecutor)
+      assertTrue(
+          meterRegistry.getMeters().stream()
+              .anyMatch(
+                  meter ->
+                      meter.getId().getName().contains("executor.queued")
+                          && executorName.equals(meter.getId().getTag("name"))));
+
+      // executor.steals is unique to ForkJoinPool instrumentation
+      assertTrue(
+          meterRegistry.getMeters().stream()
+              .anyMatch(
+                  meter ->
+                      meter.getId().getName().contains("executor.steals")
+                          && executorName.equals(meter.getId().getTag("name"))));
+    } finally {
+      forkJoinPool.shutdown();
     }
   }
 


### PR DESCRIPTION
## Summary
- Registers `ForkJoinPool.commonPool()` with Micrometer under the meter name `fork-join-common` via a new `CommonForkJoinPoolMetricsFactory` Spring bean
- The common pool is shared process-wide — it backs parallel streams, `CompletableFuture` without an explicit executor, and GraphQL resolver execution when `graphQL.concurrency.separateThreadPool=false`
- Documents which metrics are useful (`executor_pool_size_threads`, `executor_queued`, `executor_steals_total`, `executor_active`, `executor_running`) and which are always zero for ForkJoinPool (`executor_seconds`, `executor_idle_seconds`, `executor_scheduled_*`)
## Motivation
Under high GraphQL load, the common pool can become a bottleneck. 
The key saturation signal is `executor_pool_size_threads - executor_parallelism_threads` (compensation threads created when workers block on I/O). This change makes that visible without any config changes.
## Test plan
- [ ] `CommonForkJoinPoolMetricsFactoryTest` — verifies `executor.queued` and `executor.steals` are registered on construction
- [ ] `MicrometerMetricsRegistryTest#testForkJoinPoolSpecificMetrics` - verifies `registerExecutorMetrics` works for `ForkJoinPool` (not just `ThreadPoolExecutor`)
- [ ] Manually verified against a running GMS instance: metrics appear at `/actuator/prometheus` under the `fork-join-common` tag; `pool_size_threads` and `steals_total` respond correctly under concurrent GraphQL load