### PR TITLE
ci: increase Playwright shard count from 5 to 8

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -51,7 +51,7 @@ env:
   HAS_DEPOT_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'depot') }}
   IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
   DEPOT_TOKEN: "${{ secrets.DEPOT_TOKEN }}"
-  PLAYWRIGHT_SHARD_COUNT: "5"
+  PLAYWRIGHT_SHARD_COUNT: "8"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Increases `PLAYWRIGHT_SHARD_COUNT` from `5` to `8` in the CI workflow
- Reduces overall Playwright test suite wall-clock time as the migrated test suite has grown (~90% Cypress → Playwright migration complete)

## Test plan

- [ ] CI runs Playwright tests across 8 shards instead of 5
- [ ] No functional changes to test logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)