### PR TITLE
fix(ingest/redshift): handle connection read-timeouts gracefully

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/exception.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/exception.py
@@ -20,6 +20,13 @@ def handle_redshift_exceptions(
     except redshift_connector.Error as e:
         report_redshift_failure(report, e)
         return None
+    except OSError as e:
+        # redshift_connector surfaces a dropped/timed-out socket as a bare OSError
+        # (e.g. "cannot read from timed out object") rather than a
+        # redshift_connector.Error. Treat it as a graceful failure so a transient
+        # connection drop doesn't crash the whole pipeline with an uncaught error.
+        report_redshift_connection_failure(report, e)
+        return None
 
 
 def handle_redshift_exceptions_yield(
@@ -32,6 +39,8 @@ def handle_redshift_exceptions_yield(
         yield from func(*args, **kwargs)
     except redshift_connector.Error as e:
         report_redshift_failure(report, e)
+    except OSError as e:
+        report_redshift_connection_failure(report, e)
 
 
 def report_redshift_failure(
@@ -63,3 +72,19 @@ def report_redshift_failure(
             message="Failed to extract some metadata from Redshift.",
             exc=e,
         )
+
+
+def report_redshift_connection_failure(report: RedshiftReport, e: OSError) -> None:
+    report.failure(
+        title="Lost connection to Redshift",
+        message=(
+            "The Redshift connection dropped or timed out while reading a query result "
+            "(often a slow system-table or query-history scan). Some metadata may be "
+            "missing. Retrying the ingestion usually clears a transient drop. If it "
+            "recurs, increase the client read timeout via the `timeout` key in "
+            "`extra_client_options` (value in seconds, e.g. "
+            "`extra_client_options: {timeout: 1200}`) and/or enable TCP keep-alive with "
+            "`extra_client_options: {tcp_keepalive: true}` to avoid idle-connection reaps."
+        ),
+        exc=e,
+    )

--- a/metadata-ingestion/tests/unit/redshift/test_redshift_exception.py
+++ b/metadata-ingestion/tests/unit/redshift/test_redshift_exception.py
@@ -1,0 +1,50 @@
+import socket
+
+import redshift_connector
+
+from datahub.ingestion.source.redshift.exception import (
+    handle_redshift_exceptions,
+    handle_redshift_exceptions_yield,
+)
+from datahub.ingestion.source.redshift.report import RedshiftReport
+
+
+def test_handle_redshift_exceptions_yield_catches_connection_timeout():
+    # redshift_connector surfaces a socket read-timeout as a bare OSError
+    # ("cannot read from timed out object"), NOT as a redshift_connector.Error.
+    # A transient connection drop must be reported and end the stream gracefully
+    # rather than crashing the whole ingestion pipeline with an uncaught error.
+    report = RedshiftReport()
+
+    def boom():
+        raise OSError("cannot read from timed out object")
+        yield  # pragma: no cover - makes this a generator
+
+    # Must not propagate.
+    list(handle_redshift_exceptions_yield(report, boom))
+
+    assert len(report.failures) == 1
+
+
+def test_handle_redshift_exceptions_catches_connection_timeout():
+    report = RedshiftReport()
+
+    def boom():
+        raise socket.timeout("timed out")
+
+    # Must not propagate; returns None like the redshift_connector.Error path.
+    assert handle_redshift_exceptions(report, boom) is None
+    assert len(report.failures) == 1
+
+
+def test_handle_redshift_exceptions_yield_still_catches_connector_error():
+    # Regression guard: the existing redshift_connector.Error path keeps working.
+    report = RedshiftReport()
+
+    def boom():
+        raise redshift_connector.Error("svv_table_info permission denied")
+        yield  # pragma: no cover - makes this a generator
+
+    list(handle_redshift_exceptions_yield(report, boom))
+
+    assert len(report.failures) == 1


### PR DESCRIPTION
## Summary

`redshift_connector` surfaces a dropped or timed-out socket as a bare **`OSError`** (`"cannot read from timed out object"`), **not** as a `redshift_connector.Error`. The Redshift source's `handle_redshift_exceptions` / `handle_redshift_exceptions_yield` only caught `redshift_connector.Error`, so a transient connection drop during a slow system-table / query-history scan escaped as an **uncaught exception and crashed the whole ingestion run** — even when earlier stages (e.g. lineage) had already succeeded.

Observed in a golden-update run where the usage operational-stats query (`stl_insert`/`stl_delete` ⋈ `stl_query` ⋈ `svv_table_info` ⋈ `svl_user_info`) hit the socket timeout:

```
OSError: cannot read from timed out object
ERROR ... Ingestion pipeline threw an uncaught exception: cannot read from timed out object
```

## What this changes

- Catch `OSError` in both `handle_redshift_exceptions` and `handle_redshift_exceptions_yield` and route it to a new `report_redshift_connection_failure`.
- Report it as a **structured failure with remediation guidance** instead of crashing: retry usually clears a transient drop; if it recurs, raise the client read timeout (`extra_client_options: {timeout: <seconds>}`) and/or enable `extra_client_options: {tcp_keepalive: true}` to avoid idle-connection reaps.

This protects every extraction path (metadata, lineage, usage), so a one-off Redshift connection drop degrades gracefully rather than sinking an otherwise-successful run.

## Testing

New `tests/unit/redshift/test_redshift_exception.py` (TDD — written first, watched fail):
- read-timeout `OSError` is caught (not propagated) and reported, for both the yielding and non-yielding handlers;
- regression guard that the existing `redshift_connector.Error` path still reports.

`./gradlew :metadata-ingestion:lintFix` clean; the 3 unit tests pass.

## Checklist
- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing/#commit-message-format))
- [x] Tests added/updated
- [ ] Docs updated (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)