### PR TITLE
feat(ingest): SchemaResolver casing/membership API (review slice of #18004)

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -953,10 +953,15 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
         status: RemovedStatusFilter = RemovedStatusFilter.NOT_SOFT_DELETED,
         batch_size: int = 100,
         extraFilters: Optional[List[RawSearchFilterRule]] = None,
-    ) -> Iterable[Tuple[str, "GraphQLSchemaMetadata"]]:
+        include_schemaless: bool = False,
+    ) -> Iterable[Tuple[str, Optional["GraphQLSchemaMetadata"]]]:
         """Fetch schema info for datasets that match all of the given filters.
 
-        :return: An iterable of (urn, schema info) tuple that match the filters.
+        :param include_schemaless: when True, also yield datasets that exist but have
+            no schema, as ``(urn, None)``. The default (False) preserves the original
+            behavior of yielding only schema-bearing datasets, so existing callers are
+            unaffected. Lets one scroll serve both schema and membership needs.
+        :return: An iterable of (urn, schema info or None) tuples that match the filters.
         """
         types = self._get_types(["dataset"])
 
@@ -1014,8 +1019,9 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
         }
 
         for entity in self._scroll_across_entities(graphql_query, variables):
-            if entity.get("schemaMetadata"):
-                yield entity["urn"], entity["schemaMetadata"]
+            schema_metadata = entity.get("schemaMetadata")
+            if include_schemaless or schema_metadata:
+                yield entity["urn"], schema_metadata
 
     def get_urns_by_filter(
         self,

--- a/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
@@ -24,6 +24,7 @@ from datahub.sql_parsing._models import _TableName as _TableName
 from datahub.sql_parsing.sql_parsing_common import PLATFORMS_WITH_CASE_SENSITIVE_TABLES
 from datahub.utilities.file_backed_collections import ConnectionWrapper, FileBackedDict
 from datahub.utilities.urns.field_paths import get_simple_field_path_from_v2_field_path
+from datahub.utilities.urns.urn_iter import lowercase_dataset_urn
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +90,18 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
             extra_columns={"is_missing": lambda v: v is None},
         )
 
+        # Membership / casing index for lineage URN casing reconciliation, kept
+        # separate from _schema_cache so it can track entities that exist *without* a
+        # schema without changing _schema_cache's None semantics (which SQL parsing
+        # relies on). Maps lowercase(urn) -> the real URNs sharing that form. Populated
+        # on demand via add_known_urn(); empty (and free) for resolvers that never use it.
+        # Disk-backed (like _schema_cache) so a large warehouse's catalog does not sit
+        # in memory; a distinct tablename keeps it separate on the shared connection.
+        self._casing_index: FileBackedDict[List[str]] = FileBackedDict(
+            shared_connection=shared_conn,
+            tablename="casing_index",
+        )
+
     @property
     def platform(self) -> str:
         return self._platform
@@ -145,6 +158,52 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
             return urn, schema_info
 
         return urn, None
+
+    def get_cached_schema_info(self, urn: str) -> Optional[SchemaInfo]:
+        """Return locally-cached schema info for `urn` (column -> type), or None.
+
+        Side-effect free, unlike resolve_urn(): only reads the cache populated by
+        bulk initialization. Used to correct column casing in fine-grained lineage.
+        """
+        return self._schema_cache.get(urn)
+
+    def add_known_urn(self, urn: str) -> None:
+        """Record that `urn` exists (schema-bearing or not), for casing reconciliation.
+
+        Feeds the membership/casing index used by the lineage URN casing processor.
+        Kept separate from the schema cache so a schemaless entity can be marked as
+        existing without affecting schema-cache (`None`) semantics.
+        """
+        try:
+            key = lowercase_dataset_urn(urn)
+        except Exception:
+            return
+        # Read-modify-write: the index is disk-backed, so re-assign to persist the
+        # change (and to mark the cache entry dirty). Most keys hold a single URN;
+        # the list only grows when genuinely distinct case-variants collide.
+        bucket = self._casing_index.get(key) or []
+        if urn not in bucket:
+            bucket.append(urn)
+            self._casing_index[key] = bucket
+
+    def find_by_casing(self, urn: str) -> List[str]:
+        """Return known URNs whose lowercase form matches `urn`'s.
+
+        Includes `urn` itself when it is a known exact match. Used to reconcile
+        upstream lineage references against the casing DataHub already stores.
+        """
+        try:
+            return list(self._casing_index.get(lowercase_dataset_urn(urn)) or [])
+        except Exception:
+            return []
+
+    def known_urn_count(self) -> int:
+        """Number of distinct lowercase keys in the casing index (≈ known URNs).
+
+        A cheap size signal for callers that want to log/threshold the catalog; not an
+        exact URN count when case-variants collide (rare).
+        """
+        return len(self._casing_index)
 
     def resolve_table(self, table: _TableName) -> Tuple[str, Optional[SchemaInfo]]:
         """Resolve a table to its URN and (best-effort) schema.
@@ -360,6 +419,7 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
 
     def close(self) -> None:
         self._schema_cache.close()
+        self._casing_index.close()
 
 
 class _SchemaResolverWithExtras(SchemaResolverInterface):

--- a/metadata-ingestion/src/datahub/sql_parsing/schema_resolver_provider.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/schema_resolver_provider.py
@@ -21,16 +21,23 @@ def provide_schema_resolver(
     platform_instance: Optional[str],
     env: str,
     batch_size: int = 100,
+    populate_membership: bool = False,
 ) -> SchemaResolver:
     """Return a bulk-initialized SchemaResolver, cached globally per (graph, platform, platform_instance, env).
 
     Using a module-level cache ensures deduplication across all callers in the same
     process, even when different SchemaResolverProvider instances are created.
+
+    :param populate_membership: also populate the resolver's casing/membership index
+        (including schemaless entities) from the same bulk scroll, so callers needing
+        existence/casing lookups don't have to run a second scroll. Default False keeps
+        the schema-only behavior for SQL-parsing callers.
     """
     return SchemaResolverProvider(graph=graph, batch_size=batch_size).get(
         platform=platform,
         platform_instance=platform_instance,
         env=env,
+        populate_membership=populate_membership,
     )
 
 
@@ -57,8 +64,15 @@ class SchemaResolverProvider:
         platform: str,
         platform_instance: Optional[str],
         env: str,
+        populate_membership: bool = False,
     ) -> SchemaResolver:
-        """Return a bulk-initialized SchemaResolver, cached per (platform, platform_instance, env)."""
+        """Return a bulk-initialized SchemaResolver, cached per (platform, platform_instance, env).
+
+        When ``populate_membership`` is True, the single bulk scroll also records every
+        existing URN (including schemaless ones) in the resolver's casing index — so a
+        caller that needs membership/casing lookups avoids a second scroll over the
+        same datasets.
+        """
         resolver = SchemaResolver(
             platform=platform,
             platform_instance=platform_instance,
@@ -68,16 +82,22 @@ class SchemaResolverProvider:
         )
         logger.info(f"Fetching schemas for platform {platform}, env {env}")
         count = 0
+        membership_count = 0
         with PerfTimer() as timer:
             for urn, schema_info in self._graph._bulk_fetch_schema_info_by_filter(
                 platform=platform,
                 platform_instance=platform_instance,
                 env=env,
                 batch_size=self._batch_size,
+                include_schemaless=populate_membership,
             ):
                 try:
-                    resolver.add_graphql_schema_metadata(urn, schema_info)
-                    count += 1
+                    if populate_membership:
+                        resolver.add_known_urn(urn)
+                        membership_count += 1
+                    if schema_info is not None:
+                        resolver.add_graphql_schema_metadata(urn, schema_info)
+                        count += 1
                 except Exception:
                     logger.warning(
                         f"Failed to add schema info for {urn}", exc_info=True
@@ -88,10 +108,14 @@ class SchemaResolverProvider:
                         f"Loaded {count} schema info in {timer.elapsed_seconds()} seconds"
                     )
             logger.info(
-                f"Finished loading {count} schema info in {timer.elapsed_seconds()} seconds"
+                f"Finished loading {count} schema info"
+                f"{f' and {membership_count} known URNs' if populate_membership else ''}"
+                f" in {timer.elapsed_seconds()} seconds"
             )
 
-        if count == 0:
+        # Only a schema-only fetch returning nothing is a problem worth flagging for SQL
+        # lineage; a membership fetch may legitimately find existing-but-schemaless URNs.
+        if count == 0 and not populate_membership:
             logger.warning(
                 f"Bulk schema fetch returned 0 results for platform={platform}, "
                 f"platform_instance={platform_instance}, env={env}. "

--- a/metadata-ingestion/tests/unit/sql_parsing/test_schema_resolver_provider.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_schema_resolver_provider.py
@@ -1,0 +1,59 @@
+from unittest.mock import MagicMock
+
+from datahub.sql_parsing.schema_resolver_provider import SchemaResolverProvider
+
+_WITH_SCHEMA = (
+    "urn:li:dataset:(urn:li:dataPlatform:snowflake,DB.SCHEMA.HAS_SCHEMA,PROD)"
+)
+_SCHEMALESS = "urn:li:dataset:(urn:li:dataPlatform:snowflake,DB.SCHEMA.NO_SCHEMA,PROD)"
+
+
+def _graph_yielding(captured: dict) -> MagicMock:
+    """A graph whose bulk fetch yields one schema-bearing and one schemaless entity.
+
+    The schemaless one is only yielded when include_schemaless is requested, mirroring
+    the real _bulk_fetch_schema_info_by_filter behavior.
+    """
+
+    def fake_bulk(
+        *, platform, platform_instance, env, batch_size, include_schemaless=False
+    ):
+        captured["include_schemaless"] = include_schemaless
+        yield (
+            _WITH_SCHEMA,
+            {"fields": [{"fieldPath": "amount", "nativeDataType": "int"}]},
+        )
+        if include_schemaless:
+            yield _SCHEMALESS, None
+
+    graph = MagicMock()
+    graph._bulk_fetch_schema_info_by_filter.side_effect = fake_bulk
+    return graph
+
+
+def test_provider_default_does_not_populate_membership() -> None:
+    captured: dict = {}
+    resolver = SchemaResolverProvider(graph=_graph_yielding(captured)).get(
+        platform="snowflake", platform_instance=None, env="PROD"
+    )
+    assert captured["include_schemaless"] is False  # schema-only scroll
+    assert resolver.get_cached_schema_info(_WITH_SCHEMA) is not None
+    assert resolver.find_by_casing(_WITH_SCHEMA) == []  # membership not populated
+
+
+def test_provider_populate_membership_includes_schemaless() -> None:
+    captured: dict = {}
+    resolver = SchemaResolverProvider(graph=_graph_yielding(captured)).get(
+        platform="snowflake",
+        platform_instance=None,
+        env="PROD",
+        populate_membership=True,
+    )
+    assert captured["include_schemaless"] is True  # single scroll covers everything
+    # Schemas are still populated...
+    assert resolver.get_cached_schema_info(_WITH_SCHEMA) is not None
+    assert resolver.get_cached_schema_info(_SCHEMALESS) is None  # exists, no schema
+    # ...and membership covers both schema-bearing and schemaless entities.
+    assert resolver.find_by_casing(_WITH_SCHEMA) == [_WITH_SCHEMA]
+    assert resolver.find_by_casing(_SCHEMALESS) == [_SCHEMALESS]
+    assert resolver.known_urn_count() == 2

--- a/metadata-ingestion/tests/unit/sql_parsing/test_schemaresolver.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_schemaresolver.py
@@ -531,3 +531,20 @@ class TestTableNameParts:
         assert table_with_parts == table_without_parts, "Equality ignores parts field"
         assert table_with_parts.parts == ("source", "schema", "table")
         assert table_without_parts.parts is None
+
+
+def test_casing_index_membership_and_lookup() -> None:
+    # The membership/casing index (used by lineage URN casing reconciliation) is
+    # separate from the schema cache and tracks existence regardless of schema.
+    r = SchemaResolver(platform="snowflake", env="PROD", graph=None)
+    upper = "urn:li:dataset:(urn:li:dataPlatform:snowflake,DB.SCHEMA.TABLE,PROD)"
+    lower = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)"
+    other = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.other,PROD)"
+
+    r.add_known_urn(upper)
+    assert upper in r.find_by_casing(upper)  # exact match present in its own bucket
+    assert r.find_by_casing(lower) == [upper]  # a different casing resolves to it
+    assert r.find_by_casing(other) == []  # unknown -> no candidates
+
+    r.add_known_urn(lower)  # both casings now exist
+    assert set(r.find_by_casing(upper)) == {upper, lower}  # ambiguous -> both returned


### PR DESCRIPTION
> **Draft / review aid — not for independent merge.** Isolated view of the **SchemaResolver-layer** changes from #18004 (lineage URN casing reconciliation), split out for focused review per discussion. Contains **only** the resolver-layer net diff — no work-unit processor, model, or connector changes.

## What's here

- **`SchemaResolver`** — a **disk-backed** casing/membership index (`FileBackedDict`) with `add_known_urn` / `find_by_casing` / `known_urn_count`, kept **separate from `_schema_cache`** so its `None` semantics (relied on by SQL parsing) are unchanged; plus `get_cached_schema_info`, a side-effect-free cache read used for column-casing correction.
- **`DataHubGraph._bulk_fetch_schema_info_by_filter`** — additive `include_schemaless` (default `False` = unchanged) so a single scroll can also yield existing-but-schemaless datasets as `(urn, None)`.
- **`SchemaResolverProvider`** — additive `populate_membership` (default `False`) so one bulk scroll fills both the schema cache and the casing index (no duplicate catalog scroll).

## Why it's safe

Everything is **additive and opt-in** — the new params default to today's behavior, so existing SQL-parsing consumers (bigquery, teradata, sql-parsing-aggregator, kafka-connect) are unaffected. The full `tests/unit/sql_parsing` suite passes; new tests cover the casing index (`test_schemaresolver.py`) and the `populate_membership` path (`test_schema_resolver_provider.py`).

## Deferred (not in this slice)

The sentinel-in-`_schema_cache` distinction (exists-no-schema vs not-found via the OpenAPI-v2 entity endpoint) and a configurable bulk-vs-lazy initialization remain follow-ups.

## Relationship to #18004

These changes already live in #18004; this branch is a **review aid** that shows just the resolver layer (and a head start should we split it into its own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
