### PR TITLE
fix(smoke-test): restore CDC consumer auth env and enforce data product rename auth

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateNameResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateNameResolver.java
@@ -19,7 +19,6 @@ import com.linkedin.datahub.graphql.exception.DataHubGraphQLErrorCode;
 import com.linkedin.datahub.graphql.exception.DataHubGraphQLException;
 import com.linkedin.datahub.graphql.generated.UpdateNameInput;
 import com.linkedin.datahub.graphql.resolvers.businessattribute.BusinessAttributeAuthorizationUtils;
-import com.linkedin.datahub.graphql.resolvers.dataproduct.DataProductAuthorizationUtils;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.BusinessAttributeUtils;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.DomainUtils;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.GlossaryUtils;
@@ -37,6 +36,7 @@ import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.EntityUtils;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -304,14 +304,10 @@ public class UpdateNameResolver implements DataFetcher<CompletableFuture<Boolean
                   Constants.DOMAINS_ASPECT_NAME,
                   _entityService,
                   null);
-      if (!EntityAspectAuthorizationUtils.resolveUniqueDomainUrns(dataProductDomains).isEmpty()) {
-        if (!DataProductAuthorizationUtils.isAuthorizedToManageDataProductsOnAnyDomain(
-                context, dataProductDomains)
-            && !DataProductAuthorizationUtils.isAuthorizedToEditDataProduct(context, targetUrn)) {
-          throw new AuthorizationException(
-              "Unauthorized to perform this action. Please contact your DataHub administrator.");
-        }
-      } else if (!DataProductAuthorizationUtils.isAuthorizedToEditDataProduct(context, targetUrn)) {
+      Set<Urn> productDomainUrns =
+          EntityAspectAuthorizationUtils.resolveUniqueDomainUrns(dataProductDomains);
+      if (!EntityAspectAuthorizationUtils.isAuthorizedToRenameDataProduct(
+          context.getOperationContext(), targetUrn, productDomainUrns)) {
         throw new AuthorizationException(
             "Unauthorized to perform this action. Please contact your DataHub administrator.");
       }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/UpdateNameResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/UpdateNameResolverTest.java
@@ -8,6 +8,7 @@ import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 import com.datahub.authentication.Authentication;
+import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
@@ -15,7 +16,9 @@ import com.linkedin.datahub.graphql.generated.UpdateNameInput;
 import com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils;
 import com.linkedin.datahub.graphql.resolvers.mutate.UpdateNameResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.DomainUtils;
+import com.linkedin.dataproduct.DataProductProperties;
 import com.linkedin.domain.DomainProperties;
+import com.linkedin.domain.Domains;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.glossary.GlossaryNodeInfo;
 import com.linkedin.glossary.GlossaryTermInfo;
@@ -36,9 +39,12 @@ public class UpdateNameResolverTest {
   private static final String TERM_URN = "urn:li:glossaryTerm:11115397daf94708a8822b8106cfd451";
   private static final String NODE_URN = "urn:li:glossaryNode:22225397daf94708a8822b8106cfd451";
   private static final String DOMAIN_URN = "urn:li:domain:22225397daf94708a8822b8106cfd451";
+  private static final String DATA_PRODUCT_URN = "urn:li:dataProduct:test-product";
   private static final UpdateNameInput INPUT = new UpdateNameInput(NEW_NAME, TERM_URN);
   private static final UpdateNameInput INPUT_FOR_NODE = new UpdateNameInput(NEW_NAME, NODE_URN);
   private static final UpdateNameInput INPUT_FOR_DOMAIN = new UpdateNameInput(NEW_NAME, DOMAIN_URN);
+  private static final UpdateNameInput INPUT_FOR_DATA_PRODUCT =
+      new UpdateNameInput(NEW_NAME, DATA_PRODUCT_URN);
   private static final CorpuserUrn TEST_ACTOR_URN = new CorpuserUrn("test");
 
   private MetadataChangeProposal setupTests(
@@ -159,6 +165,93 @@ public class UpdateNameResolverTest {
 
     assertTrue(resolver.get(mockEnv).get());
     verifySingleIngestProposal(mockService, 1, proposal);
+  }
+
+  @Test
+  public void testGetSuccessForDataProduct() throws Exception {
+    EntityService<?> mockService = getMockEntityService();
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.when(
+            mockService.exists(
+                any(OperationContext.class), eq(Urn.createFromString(DATA_PRODUCT_URN)), eq(true)))
+        .thenReturn(true);
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT_FOR_DATA_PRODUCT);
+
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    Mockito.when(mockContext.getActorUrn()).thenReturn(TEST_ACTOR_URN.toString());
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    final String name = "test data product";
+    Mockito.when(
+            mockService.getAspect(
+                any(OperationContext.class),
+                eq(Urn.createFromString(DATA_PRODUCT_URN)),
+                eq(DATA_PRODUCT_PROPERTIES_ASPECT_NAME),
+                eq(0L)))
+        .thenReturn(new DataProductProperties().setName(name));
+    Domains domains = new Domains();
+    domains.setDomains(new UrnArray(Urn.createFromString(DOMAIN_URN)));
+    Mockito.when(
+            mockService.getAspect(
+                any(OperationContext.class),
+                eq(Urn.createFromString(DATA_PRODUCT_URN)),
+                eq(DOMAINS_ASPECT_NAME),
+                eq(0L)))
+        .thenReturn(domains);
+
+    DataProductProperties properties = new DataProductProperties();
+    properties.setName(NEW_NAME);
+    final MetadataChangeProposal proposal =
+        MutationUtils.buildMetadataChangeProposalWithUrn(
+            Urn.createFromString(DATA_PRODUCT_URN),
+            DATA_PRODUCT_PROPERTIES_ASPECT_NAME,
+            properties);
+
+    UpdateNameResolver resolver = new UpdateNameResolver(mockService, mockClient);
+
+    assertTrue(resolver.get(mockEnv).get());
+    verifySingleIngestProposal(mockService, 1, proposal);
+  }
+
+  @Test
+  public void testGetDeniedForDataProductWithoutPrivilege() throws Exception {
+    EntityService<?> mockService = getMockEntityService();
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.when(
+            mockService.exists(
+                any(OperationContext.class), eq(Urn.createFromString(DATA_PRODUCT_URN)), eq(true)))
+        .thenReturn(true);
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT_FOR_DATA_PRODUCT);
+
+    QueryContext mockContext = getMockDenyContextWithOperationContext();
+    Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    Mockito.when(mockContext.getActorUrn()).thenReturn(TEST_ACTOR_URN.toString());
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    Mockito.when(
+            mockService.getAspect(
+                any(OperationContext.class),
+                eq(Urn.createFromString(DATA_PRODUCT_URN)),
+                eq(DATA_PRODUCT_PROPERTIES_ASPECT_NAME),
+                eq(0L)))
+        .thenReturn(new DataProductProperties().setName("test data product"));
+    Domains domains = new Domains();
+    domains.setDomains(new UrnArray(Urn.createFromString(DOMAIN_URN)));
+    Mockito.when(
+            mockService.getAspect(
+                any(OperationContext.class),
+                eq(Urn.createFromString(DATA_PRODUCT_URN)),
+                eq(DOMAINS_ASPECT_NAME),
+                eq(0L)))
+        .thenReturn(domains);
+
+    UpdateNameResolver resolver = new UpdateNameResolver(mockService, mockClient);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    verifyNoIngestProposal(mockService);
   }
 
   @Test

--- a/docker/profiles/docker-compose.gms.yml
+++ b/docker/profiles/docker-compose.gms.yml
@@ -722,7 +722,7 @@ services:
   datahub-mae-consumer-quickstart-postgres-cdc:
     <<: *datahub-mae-consumer-service
     environment:
-      <<: [*primary-datastore-postgres-env, *graph-datastore-search-env, *search-datastore-env, *datahub-quickstart-telemetry-env, *kafka-env, *datahub-common-env]
+      <<: [*primary-datastore-postgres-env, *graph-datastore-search-env, *search-datastore-env, *datahub-quickstart-telemetry-env, *kafka-env, *datahub-common-env, *datahub-authentication-env]
       CDC_MCL_PROCESSING_ENABLED: true
       CDC_CONFIGURE_SOURCE: true
       DATAHUB_MESSAGING_TRANSPORT: ${DATAHUB_MESSAGING_TRANSPORT:-kafka}
@@ -796,7 +796,7 @@ services:
   datahub-mce-consumer-quickstart-postgres-consumers-cdc:
     <<: *datahub-mce-consumer-service
     environment:
-      <<: [*primary-datastore-postgres-env, *graph-datastore-search-env, *search-datastore-env, *datahub-quickstart-telemetry-env, *kafka-env, *datahub-common-env]
+      <<: [*primary-datastore-postgres-env, *graph-datastore-search-env, *search-datastore-env, *datahub-quickstart-telemetry-env, *kafka-env, *datahub-common-env, *datahub-authentication-env]
       CDC_MCL_PROCESSING_ENABLED: true
       CDC_CONFIGURE_SOURCE: true
       DATAHUB_MESSAGING_TRANSPORT: ${DATAHUB_MESSAGING_TRANSPORT:-kafka}

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/DataProductMembershipAuthorizationValidator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/DataProductMembershipAuthorizationValidator.java
@@ -53,6 +53,7 @@ public class DataProductMembershipAuthorizationValidator
     AspectRetriever aspectRetriever = retrieverContext.getAspectRetriever();
     List<BatchItem> membershipChanges = new ArrayList<>();
     Map<Urn, Set<Urn>> changedAssetsByProduct = new HashMap<>();
+    Set<Urn> nameChangeProducts = new HashSet<>();
 
     Set<Urn> dataProductUrns = items.stream().map(BatchItem::getUrn).collect(Collectors.toSet());
     Map<Urn, Map<String, Aspect>> currentPropertiesMap =
@@ -72,32 +73,60 @@ public class DataProductMembershipAuthorizationValidator
         membershipChanges.add(item);
         changedAssetsByProduct.put(item.getUrn(), changedAssets);
       }
+      if (hasNameChange(current, proposed)) {
+        nameChangeProducts.add(item.getUrn());
+      }
     }
 
-    if (membershipChanges.isEmpty()) {
+    if (membershipChanges.isEmpty() && nameChangeProducts.isEmpty()) {
       return List.of();
     }
 
     Map<Urn, Aspect> proposedProductDomainsAspects =
         extractProposedProductDomainsAspects(batchItems);
-    Set<Urn> unauthorized =
-        EntityAspectAuthorizationUtils.filterUnauthorizedToManageDataProductMembership(
-            operationContext,
-            session,
-            aspectRetriever,
-            changedAssetsByProduct,
-            proposedProductDomainsAspects);
-
     List<AspectValidationException> failures = new ArrayList<>();
-    for (BatchItem item : membershipChanges) {
-      if (unauthorized.contains(item.getUrn())) {
-        failures.add(
-            authFailure(
-                item,
-                "Unauthorized to modify dataProductProperties.assets on data product: "
-                    + item.getUrn()));
+
+    if (!membershipChanges.isEmpty()) {
+      Set<Urn> unauthorizedMembership =
+          EntityAspectAuthorizationUtils.filterUnauthorizedToManageDataProductMembership(
+              operationContext,
+              session,
+              aspectRetriever,
+              changedAssetsByProduct,
+              proposedProductDomainsAspects);
+
+      for (BatchItem item : membershipChanges) {
+        if (unauthorizedMembership.contains(item.getUrn())) {
+          failures.add(
+              authFailure(
+                  item,
+                  "Unauthorized to modify dataProductProperties.assets on data product: "
+                      + item.getUrn()));
+        }
       }
     }
+
+    if (!nameChangeProducts.isEmpty()) {
+      Set<Urn> unauthorizedRenames =
+          EntityAspectAuthorizationUtils.filterUnauthorizedToRenameDataProduct(
+              operationContext,
+              session,
+              aspectRetriever,
+              nameChangeProducts,
+              proposedProductDomainsAspects);
+
+      for (BatchItem item : items) {
+        if (nameChangeProducts.contains(item.getUrn())
+            && unauthorizedRenames.contains(item.getUrn())) {
+          failures.add(
+              authFailure(
+                  item,
+                  "Unauthorized to modify dataProductProperties.name on data product: "
+                      + item.getUrn()));
+        }
+      }
+    }
+
     return failures;
   }
 
@@ -139,6 +168,17 @@ public class DataProductMembershipAuthorizationValidator
       }
     }
     return urns;
+  }
+
+  private static boolean hasNameChange(
+      @Nullable DataProductProperties current, @Nullable DataProductProperties proposed) {
+    if (proposed == null || !proposed.hasName()) {
+      return false;
+    }
+    if (current == null || !current.hasName()) {
+      return true;
+    }
+    return !proposed.getName().equals(current.getName());
   }
 
   @Nullable

--- a/metadata-io/src/main/java/com/linkedin/metadata/authorization/EntityAspectAuthorizationUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/authorization/EntityAspectAuthorizationUtils.java
@@ -210,6 +210,69 @@ public final class EntityAspectAuthorizationUtils {
   }
 
   /**
+   * Returns true when the actor may rename a data product ({@code dataProductProperties.name} or
+   * {@code updateName}). Requires {@code MANAGE_DATA_PRODUCTS} on at least one product domain, or
+   * {@code EDIT_ENTITY} on the data product itself.
+   */
+  public static boolean isAuthorizedToRenameDataProduct(
+      @Nonnull AuthorizationSession session,
+      @Nonnull Urn dataProductUrn,
+      @Nonnull Set<Urn> productDomainUrns) {
+    if (!productDomainUrns.isEmpty()
+        && isAuthorizedToManageDataProductsOnAnyDomain(session, productDomainUrns)) {
+      return true;
+    }
+    return isAuthorizedToEditDataProductEntity(session, dataProductUrn);
+  }
+
+  /**
+   * Returns data product URNs whose {@code dataProductProperties.name} change is not authorized.
+   */
+  @Nonnull
+  public static Set<Urn> filterUnauthorizedToRenameDataProduct(
+      @Nonnull OperationFingerprint operationContext,
+      @Nonnull AuthorizationSession session,
+      @Nonnull AspectRetriever aspectRetriever,
+      @Nonnull Set<Urn> dataProductUrnsWithNameChange,
+      @Nonnull Map<Urn, Aspect> proposedProductDomainsAspects) {
+    if (dataProductUrnsWithNameChange.isEmpty()) {
+      return Set.of();
+    }
+
+    Map<Urn, Map<String, Aspect>> persistedProductDomainsAspects =
+        aspectRetriever.getLatestAspectObjects(
+            operationContext,
+            new HashSet<>(dataProductUrnsWithNameChange),
+            Set.of(DOMAINS_ASPECT_NAME));
+
+    Set<Urn> unauthorized = new HashSet<>();
+    for (Urn dataProductUrn : dataProductUrnsWithNameChange) {
+      Aspect productDomainsAspect = proposedProductDomainsAspects.get(dataProductUrn);
+      if (productDomainsAspect == null) {
+        productDomainsAspect =
+            persistedProductDomainsAspects
+                .getOrDefault(dataProductUrn, Map.of())
+                .get(DOMAINS_ASPECT_NAME);
+      }
+      Set<Urn> productDomainUrns = resolveUniqueDomainUrns(productDomainsAspect);
+      if (!isAuthorizedToRenameDataProduct(session, dataProductUrn, productDomainUrns)) {
+        unauthorized.add(dataProductUrn);
+      }
+    }
+    return unauthorized;
+  }
+
+  private static boolean isAuthorizedToEditDataProductEntity(
+      @Nonnull AuthorizationSession session, @Nonnull Urn dataProductUrn) {
+    EntitySpec productSpec =
+        new EntitySpec(dataProductUrn.getEntityType(), dataProductUrn.toString());
+    return com.datahub.authorization.AuthUtil.isAuthorized(
+        session,
+        new DisjunctivePrivilegeGroup(ImmutableList.of(ALL_ENTITY_PRIVILEGES)),
+        productSpec);
+  }
+
+  /**
    * Returns true when the actor may change {@code dataProductProperties.assets} via the
    * product-side path ({@code MANAGE_DATA_PRODUCTS} on any product domain) or the asset-side path
    * ({@code EDIT_ENTITY_DATA_PRODUCTS} on every changed asset).

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/DataProductMembershipAuthorizationValidatorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/DataProductMembershipAuthorizationValidatorTest.java
@@ -117,17 +117,52 @@ public class DataProductMembershipAuthorizationValidatorTest {
   }
 
   @Test
-  public void testSkipWhenAssetsUnchanged() {
+  public void testNameChangeTriggersAuthorizationCheck() {
     DataProductProperties current = propertiesWithAssets(MEMBER_DATASET_URN);
-    DataProductProperties proposed = new DataProductProperties(current.data());
+    current.setName("Original name");
+    DataProductProperties proposed = propertiesWithAssets(MEMBER_DATASET_URN);
     proposed.setName("Updated name only");
     mockCurrentProperties(current);
+
+    authUtilsMockedStatic
+        .when(
+            () ->
+                EntityAspectAuthorizationUtils.filterUnauthorizedToRenameDataProduct(
+                    any(), any(), any(), any(Set.class), any(Map.class)))
+        .thenReturn(Set.of());
+
+    TestMCP item = upsertItem(proposed);
+    validate(item);
+
+    authUtilsMockedStatic.verify(
+        () ->
+            EntityAspectAuthorizationUtils.filterUnauthorizedToRenameDataProduct(
+                any(),
+                eq(mockAuthSession),
+                eq(mockAspectRetriever),
+                eq(Set.of(DATA_PRODUCT_URN)),
+                any(Map.class)));
+  }
+
+  @Test
+  public void testDenyNameChangeWithoutPrivilege() {
+    DataProductProperties current = new DataProductProperties();
+    current.setName("Original name");
+    DataProductProperties proposed = new DataProductProperties();
+    proposed.setName("Updated name");
+    mockCurrentProperties(current);
+
+    authUtilsMockedStatic
+        .when(
+            () ->
+                EntityAspectAuthorizationUtils.filterUnauthorizedToRenameDataProduct(
+                    any(), any(), any(), any(Set.class), any(Map.class)))
+        .thenReturn(Set.of(DATA_PRODUCT_URN));
 
     TestMCP item = upsertItem(proposed);
     Stream<AspectValidationException> result = validate(item);
 
-    Assert.assertTrue(result.findAny().isEmpty());
-    authUtilsMockedStatic.verifyNoInteractions();
+    Assert.assertTrue(result.findAny().isPresent());
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/authorization/EntityAspectAuthorizationUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/authorization/EntityAspectAuthorizationUtilsTest.java
@@ -231,6 +231,118 @@ public class EntityAspectAuthorizationUtilsTest {
   }
 
   @Test
+  public void testFilterUnauthorizedToRenameDataProduct_returnsEmptyForEmptyInput() {
+    Set<Urn> unauthorized =
+        EntityAspectAuthorizationUtils.filterUnauthorizedToRenameDataProduct(
+            OperationFingerprint.EMPTY, mockAuthSession, mockAspectRetriever, Set.of(), Map.of());
+
+    Assert.assertTrue(unauthorized.isEmpty());
+  }
+
+  @Test
+  public void testFilterUnauthorizedToRenameDataProduct_usesProposedProductDomains() {
+    Domains productDomains = new Domains();
+    productDomains.setDomains(new UrnArray(DOMAIN_A));
+    Aspect proposedProductDomains = new Aspect(productDomains.data());
+
+    when(mockAspectRetriever.getLatestAspectObjects(
+            any(), eq(Set.of(DATA_PRODUCT_URN)), eq(Set.of(DOMAINS_ASPECT_NAME))))
+        .thenReturn(Map.of(DATA_PRODUCT_URN, Map.of()));
+
+    authUtilMockedStatic
+        .when(
+            () ->
+                AuthUtil.isAuthorized(
+                    eq(mockAuthSession),
+                    any(DisjunctivePrivilegeGroup.class),
+                    eq(new EntitySpec("domain", DOMAIN_A.toString()))))
+        .thenReturn(true);
+
+    Set<Urn> unauthorized =
+        EntityAspectAuthorizationUtils.filterUnauthorizedToRenameDataProduct(
+            OperationFingerprint.EMPTY,
+            mockAuthSession,
+            mockAspectRetriever,
+            Set.of(DATA_PRODUCT_URN),
+            Map.of(DATA_PRODUCT_URN, proposedProductDomains));
+
+    Assert.assertTrue(unauthorized.isEmpty());
+  }
+
+  @Test
+  public void testFilterUnauthorizedToRenameDataProduct_usesPersistedDomainsWhenNoProposed() {
+    Domains productDomains = new Domains();
+    productDomains.setDomains(new UrnArray(DOMAIN_A));
+    Aspect persistedDomains = new Aspect(productDomains.data());
+
+    when(mockAspectRetriever.getLatestAspectObjects(
+            any(), eq(Set.of(DATA_PRODUCT_URN)), eq(Set.of(DOMAINS_ASPECT_NAME))))
+        .thenReturn(Map.of(DATA_PRODUCT_URN, Map.of(DOMAINS_ASPECT_NAME, persistedDomains)));
+
+    authUtilMockedStatic
+        .when(
+            () ->
+                AuthUtil.isAuthorized(
+                    eq(mockAuthSession),
+                    any(DisjunctivePrivilegeGroup.class),
+                    eq(new EntitySpec("domain", DOMAIN_A.toString()))))
+        .thenReturn(true);
+
+    Set<Urn> unauthorized =
+        EntityAspectAuthorizationUtils.filterUnauthorizedToRenameDataProduct(
+            OperationFingerprint.EMPTY,
+            mockAuthSession,
+            mockAspectRetriever,
+            Set.of(DATA_PRODUCT_URN),
+            Map.of());
+
+    Assert.assertTrue(unauthorized.isEmpty());
+  }
+
+  @Test
+  public void testFilterUnauthorizedToRenameDataProduct_allowsEditOnProductWithoutDomains() {
+    when(mockAspectRetriever.getLatestAspectObjects(
+            any(), eq(Set.of(DATA_PRODUCT_URN)), eq(Set.of(DOMAINS_ASPECT_NAME))))
+        .thenReturn(Map.of(DATA_PRODUCT_URN, Map.of()));
+
+    authUtilMockedStatic
+        .when(
+            () ->
+                AuthUtil.isAuthorized(
+                    eq(mockAuthSession),
+                    any(DisjunctivePrivilegeGroup.class),
+                    eq(new EntitySpec("dataProduct", DATA_PRODUCT_URN.toString()))))
+        .thenReturn(true);
+
+    Set<Urn> unauthorized =
+        EntityAspectAuthorizationUtils.filterUnauthorizedToRenameDataProduct(
+            OperationFingerprint.EMPTY,
+            mockAuthSession,
+            mockAspectRetriever,
+            Set.of(DATA_PRODUCT_URN),
+            Map.of());
+
+    Assert.assertTrue(unauthorized.isEmpty());
+  }
+
+  @Test
+  public void testFilterUnauthorizedToRenameDataProduct_deniesWithoutPrivilege() {
+    when(mockAspectRetriever.getLatestAspectObjects(
+            any(), eq(Set.of(DATA_PRODUCT_URN)), eq(Set.of(DOMAINS_ASPECT_NAME))))
+        .thenReturn(Map.of(DATA_PRODUCT_URN, Map.of()));
+
+    Set<Urn> unauthorized =
+        EntityAspectAuthorizationUtils.filterUnauthorizedToRenameDataProduct(
+            OperationFingerprint.EMPTY,
+            mockAuthSession,
+            mockAspectRetriever,
+            Set.of(DATA_PRODUCT_URN),
+            Map.of());
+
+    Assert.assertEquals(unauthorized, Set.of(DATA_PRODUCT_URN));
+  }
+
+  @Test
   public void testIsAuthorizedToChangeDataProductMembership_allowsRemoveViaProductSide() {
     authUtilMockedStatic
         .when(

--- a/metadata-io/src/test/java/com/linkedin/metadata/authorization/EntityAspectAuthorizationUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/authorization/EntityAspectAuthorizationUtilsTest.java
@@ -192,6 +192,45 @@ public class EntityAspectAuthorizationUtilsTest {
   }
 
   @Test
+  public void testIsAuthorizedToRenameDataProduct_allowsManageOnDomain() {
+    authUtilMockedStatic
+        .when(
+            () ->
+                AuthUtil.isAuthorized(
+                    eq(mockAuthSession),
+                    any(DisjunctivePrivilegeGroup.class),
+                    eq(new EntitySpec("domain", DOMAIN_A.toString()))))
+        .thenReturn(true);
+
+    Assert.assertTrue(
+        EntityAspectAuthorizationUtils.isAuthorizedToRenameDataProduct(
+            mockAuthSession, DATA_PRODUCT_URN, Set.of(DOMAIN_A)));
+  }
+
+  @Test
+  public void testIsAuthorizedToRenameDataProduct_allowsEditOnProduct() {
+    authUtilMockedStatic
+        .when(
+            () ->
+                AuthUtil.isAuthorized(
+                    eq(mockAuthSession),
+                    any(DisjunctivePrivilegeGroup.class),
+                    eq(new EntitySpec("dataProduct", DATA_PRODUCT_URN.toString()))))
+        .thenReturn(true);
+
+    Assert.assertTrue(
+        EntityAspectAuthorizationUtils.isAuthorizedToRenameDataProduct(
+            mockAuthSession, DATA_PRODUCT_URN, Set.of()));
+  }
+
+  @Test
+  public void testIsAuthorizedToRenameDataProduct_deniesWithoutPrivilege() {
+    Assert.assertFalse(
+        EntityAspectAuthorizationUtils.isAuthorizedToRenameDataProduct(
+            mockAuthSession, DATA_PRODUCT_URN, Set.of(DOMAIN_A)));
+  }
+
+  @Test
   public void testIsAuthorizedToChangeDataProductMembership_allowsRemoveViaProductSide() {
     authUtilMockedStatic
         .when(


### PR DESCRIPTION
## Summary

- Restore `*datahub-authentication-env` on postgres-cdc MCE and MAE consumer services so token signing keys are passed through; fixes unhealthy MCE consumer containers in nightly Docker CDC quickstart jobs.
- Enforce authorization for `dataProductProperties.name` changes in `DataProductMembershipAuthorizationValidator` and align `updateName` GraphQL auth with shared `EntityAspectAuthorizationUtils` helpers, fixing failing `test_aspect_write_auth` denial cases.

## Test plan

- [x] `./gradlew :metadata-io:test --tests com.linkedin.metadata.aspect.validation.DataProductMembershipAuthorizationValidatorTest --tests com.linkedin.metadata.authorization.EntityAspectAuthorizationUtilsTest`
- [x] `./gradlew :datahub-graphql-core:compileJava spotlessApply`
- [ ] Nightly Docker Test / quickstart-postgres-cdc pytests (CI)
- [ ] Nightly Docker Test / quickstart-postgres pytests authorization suite (CI)


Made with [Cursor](https://cursor.com)