### PR TITLE
fix(agent-context): pin acryl-datahub to 1.6.0.6 instead of self-pinning

### DIFF
--- a/datahub-agent-context/setup.py
+++ b/datahub-agent-context/setup.py
@@ -22,8 +22,16 @@ with open("./src/datahub_agent_context/_version.py") as fp:
     exec(fp.read(), package_metadata)
 
 _version: str = package_metadata["__version__"]
-_self_pin = (
-    f"=={_version}"
+
+# The CLI version is borrowed from the server version and is not reflective of
+# the Python code, so semantic versioning does not apply. Rather than self-pinning
+# acryl-datahub to this package's own (server-derived) version -- which can point
+# at a version that was never published as a stable wheel (e.g. 1.6.0.7, which
+# only had rc builds) -- pin published wheels to a known-good stable release and
+# bump it explicitly when we need newer functionality. During local/dev builds
+# the pin is omitted so the editable acryl-datahub from this monorepo resolves.
+_datahub_pin = (
+    "==1.6.0.6"
     if not (_version.endswith(("dev0", "dev1")) or "docker" in _version)
     else ""
 )
@@ -45,7 +53,7 @@ lint_requirements = {
 }
 
 base_requirements = {
-    f"acryl-datahub[datahub-rest]{_self_pin}",
+    f"acryl-datahub[datahub-rest]{_datahub_pin}",
     # Core dependencies for MCP tools
     "pydantic>=2.0.0,<3.0.0",
     "json-repair>=0.25.0,<1.0.0",

--- a/datahub-agent-context/setup.py
+++ b/datahub-agent-context/setup.py
@@ -23,15 +23,12 @@ with open("./src/datahub_agent_context/_version.py") as fp:
 
 _version: str = package_metadata["__version__"]
 
-# The CLI version is borrowed from the server version and is not reflective of
-# the Python code, so semantic versioning does not apply. Rather than self-pinning
-# acryl-datahub to this package's own (server-derived) version -- which can point
-# at a version that was never published as a stable wheel (e.g. 1.6.0.7, which
-# only had rc builds) -- pin published wheels to a known-good stable release and
-# bump it explicitly when we need newer functionality. During local/dev builds
-# the pin is omitted so the editable acryl-datahub from this monorepo resolves.
+# Pin acryl-datahub to a known-good stable release (see __acryl_datahub_pin__ in
+# _version.py) for published wheels instead of self-pinning to this package's own
+# server-derived version. During local/dev builds the pin is omitted so the
+# editable acryl-datahub from this monorepo resolves.
 _datahub_pin = (
-    "==1.6.0.6"
+    f"=={package_metadata['__acryl_datahub_pin__']}"
     if not (_version.endswith(("dev0", "dev1")) or "docker" in _version)
     else ""
 )

--- a/datahub-agent-context/src/datahub_agent_context/_version.py
+++ b/datahub-agent-context/src/datahub_agent_context/_version.py
@@ -14,3 +14,9 @@
 
 __package_name__ = "datahub-agent-context"
 __version__ = "0.1.0.dev0"
+# Stable acryl-datahub release this package is built and tested against. The CLI
+# version is borrowed from the server version and does not follow semantic
+# versioning, so we pin a known-good stable release rather than self-pinning to
+# this package's own (server-derived) version. Bump explicitly when newer CLI
+# functionality is required.
+__acryl_datahub_pin__ = "1.6.0.6"


### PR DESCRIPTION
## Summary

`datahub-agent-context` self-pinned `acryl-datahub` to its own (server-derived) CLI version for released wheels. Because the CLI version is borrowed from the server version and does **not** follow semantic versioning, it could resolve to a version that was never published as a stable wheel (e.g. `1.6.0.7`, which only had rc builds; latest stable is `1.6.0.6`). As a result, a bare `pip install datahub-agent-context` worked on some setups but hard-failed on others depending on pip version and environment.

This PR replaces the self-pin with an explicit pin to the known-good stable release `acryl-datahub==1.6.0.6` for published wheels, decoupling the two versions. We'll bump the pin explicitly when newer functionality is needed.

The existing dev/docker escape hatch is preserved — during local/dev builds (`dev0`/`dev1`/`docker` versions) no pin is applied, so the editable `acryl-datahub` from this monorepo still resolves.

Context: [Slack thread](https://datahub.slack.com/archives/C09E12NNTMH/p1782721420658599) — flagged ahead of the July 6 hackathon. Decision (with sign-off from @david-leifker) was to break the "shipped together with the CLI" assumption and pin a stable version explicitly.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated (n/a — packaging metadata only)
- [x] Docs added/updated (n/a)
- [x] Breaking changes documented (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
