### PR TITLE
fix(frontend): post-merge fixes for #18010

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/FileNode/FileNode.tsx
+++ b/datahub-web-react/src/alchemy-components/components/FileNode/FileNode.tsx
@@ -1,13 +1,12 @@
 import { Button } from '@components';
 import { X } from '@phosphor-icons/react/dist/csr/X';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { getExtensionFromFileName } from '@components/components/Editor/extensions/fileDragDrop/fileUtils';
 import { FileIcon } from '@components/components/FileNode/FileIcon';
 import { FileNodeProps } from '@components/components/FileNode/types';
-import { Text } from '@components/components/Text';
 import { Tooltip } from '@components/components/Tooltip';
 import { getFontSize } from '@components/theme/utils';
 
@@ -44,13 +43,14 @@ const CloseButton = styled(Button)`
     padding: 0;
 `;
 
-const FileName = styled(Text)`
+const FileName = styled.span`
     color: ${({ theme }) => theme.colors.textBrand};
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     display: block;
     min-width: 0;
+    margin: 0;
 `;
 
 export function FileNode({
@@ -90,6 +90,13 @@ export function FileNode({
 
     const fontSize = useMemo(() => getFontSize(size), [size]);
 
+    const fileNameRef = useRef<HTMLSpanElement>(null);
+    const [isTruncated, setIsTruncated] = useState(false);
+    useEffect(() => {
+        const el = fileNameRef.current;
+        if (el) setIsTruncated(el.scrollWidth > el.clientWidth);
+    }, [fileName, loading, t]);
+
     if (!fileName) return null;
 
     if (loading) {
@@ -97,8 +104,8 @@ export function FileNode({
             <Container $border={border} className={className} $fontSize={fontSize}>
                 <FileDetails>
                     <Loading height={18} width={20} marginTop={0} />
-                    <Tooltip title={fileName}>
-                        <FileName type="span">{t('fileNode.uploading', { fileName })}</FileName>
+                    <Tooltip title={isTruncated ? fileName : undefined}>
+                        <FileName ref={fileNameRef}>{t('fileNode.uploading', { fileName })}</FileName>
                     </Tooltip>
                 </FileDetails>
             </Container>
@@ -109,8 +116,8 @@ export function FileNode({
         <Container $border={border} className={className} $fontSize={fontSize}>
             <FileDetails onClick={clickHandler}>
                 <FileIcon extension={extension} />
-                <Tooltip title={fileName}>
-                    <FileName type="span">{fileName}</FileName>
+                <Tooltip title={isTruncated ? fileName : undefined}>
+                    <FileName ref={fileNameRef}>{fileName}</FileName>
                 </Tooltip>
 
                 {hasRightContent && <SpaceFiller />}

--- a/datahub-web-react/src/app/entityV2/chart/shared/ChartStatsSummary.tsx
+++ b/datahub-web-react/src/app/entityV2/chart/shared/ChartStatsSummary.tsx
@@ -68,7 +68,7 @@ export const ChartStatsSummary = ({
             undefined,
         (!!effectiveViewCount && (
             <StatText>
-                <Icon icon={Eye} color="textTertiary" style={{ marginRight: 8 }} />
+                <Icon icon={Eye} color="textTertiary" size="md" style={{ marginRight: 8 }} />
                 {viewCountLast30Days
                     ? t('shared.viewsLast30DaysCount', {
                           count: effectiveViewCount,
@@ -91,7 +91,7 @@ export const ChartStatsSummary = ({
             undefined,
         (!!uniqueUserCountLast30Days && (
             <StatText>
-                <Icon icon={UsersThree} color="textTertiary" style={{ marginRight: 8 }} />
+                <Icon icon={UsersThree} color="textTertiary" size="md" style={{ marginRight: 8 }} />
                 {t('shared.usersCount', {
                     count: uniqueUserCountLast30Days,
                     formattedCount: formatNumber(uniqueUserCountLast30Days),
@@ -119,14 +119,14 @@ export const ChartStatsSummary = ({
                         <div>
                             {t('shared.changedOnDate', { date: toLocalDateTimeString(lastUpdatedMs) })}{' '}
                             <Tooltip title={t('chart.lastChangedTooltip')}>
-                                <Icon icon={Question} color="textTertiary" style={{ paddingLeft: 4 }} />
+                                <Icon icon={Question} color="textTertiary" size="md" style={{ paddingLeft: 4 }} />
                             </Tooltip>
                         </div>
                     </>
                 }
             >
                 <StatText>
-                    <Icon icon={Clock} color="textTertiary" style={{ marginRight: 8 }} />
+                    <Icon icon={Clock} color="textTertiary" size="md" style={{ marginRight: 8 }} />
                     {t('shared.changedRelativeTime', { time: toRelativeTimeString(lastUpdatedMs) })}
                 </StatText>
             </Popover>

--- a/datahub-web-react/src/app/entityV2/dashboard/shared/DashboardStatsSummary.tsx
+++ b/datahub-web-react/src/app/entityV2/dashboard/shared/DashboardStatsSummary.tsx
@@ -71,7 +71,7 @@ export const DashboardStatsSummary = ({
             undefined,
         (!!effectiveViewCount && (
             <StatText>
-                <Icon icon={Eye} color="textTertiary" style={{ marginRight: 8 }} />
+                <Icon icon={Eye} color="textTertiary" size="md" style={{ marginRight: 8 }} />
                 {viewCountLast30Days
                     ? t('shared.viewsLast30DaysCount', {
                           count: effectiveViewCount,
@@ -96,7 +96,7 @@ export const DashboardStatsSummary = ({
             undefined,
         (!!uniqueUserCountLast30Days && (
             <StatText>
-                <Icon icon={UsersThree} color="textTertiary" style={{ marginRight: 8 }} />
+                <Icon icon={UsersThree} color="textTertiary" size="md" style={{ marginRight: 8 }} />
                 {t('shared.usersCount', {
                     count: uniqueUserCountLast30Days,
                     formattedCount: formatNumber(uniqueUserCountLast30Days),
@@ -124,14 +124,14 @@ export const DashboardStatsSummary = ({
                         <div>
                             {t('shared.changedOnDate', { date: toLocalDateTimeString(lastUpdatedMs) })}{' '}
                             <Tooltip title={t('dashboard.lastChangedTooltip')}>
-                                <Icon icon={Question} color="textTertiary" style={{ paddingLeft: 4 }} />
+                                <Icon icon={Question} color="textTertiary" size="md" style={{ paddingLeft: 4 }} />
                             </Tooltip>
                         </div>
                     </>
                 }
             >
                 <StatText>
-                    <Icon icon={Clock} color="textTertiary" style={{ marginRight: 8 }} />
+                    <Icon icon={Clock} color="textTertiary" size="md" style={{ marginRight: 8 }} />
                     {t('shared.changedRelativeTime', { time: toRelativeTimeString(lastUpdatedMs) })}
                 </StatText>
             </Popover>

--- a/datahub-web-react/src/app/entityV2/mlFeatureTable/profile/features/MlFeatureDataTypeIcon.tsx
+++ b/datahub-web-react/src/app/entityV2/mlFeatureTable/profile/features/MlFeatureDataTypeIcon.tsx
@@ -14,6 +14,8 @@ import { VideoCamera } from '@phosphor-icons/react/dist/csr/VideoCamera';
 import React from 'react';
 import styled from 'styled-components';
 
+import { FontSizeOptions } from '@components/theme/config';
+
 import { capitalizeFirstLetter } from '@app/shared/textUtil';
 
 import { MlFeatureDataType } from '@types';
@@ -37,24 +39,27 @@ const TypeSubtitle = styled(Text)<{ hasicon?: string }>`
 type PhosphorIcon = React.ComponentType<any>;
 
 /* untranslated-text -- ML feature data-type enum display labels, mirror GraphQL MlFeatureDataType enum */
-const DATA_TYPE_ICON_MAP: Record<MlFeatureDataType, { icon: PhosphorIcon | null; size: number; text: string }> = {
-    [MlFeatureDataType.Byte]: { icon: Binary, size: 18, text: 'Byte' },
-    [MlFeatureDataType.Time]: { icon: Clock, size: 18, text: 'Time' },
-    [MlFeatureDataType.Set]: { icon: List, size: 18, text: 'Set' },
-    [MlFeatureDataType.Unknown]: { icon: Question, size: 16, text: 'Unknown' },
-    [MlFeatureDataType.Map]: { icon: List, size: 14, text: 'Map' },
-    [MlFeatureDataType.Useless]: { icon: Prohibit, size: 18, text: 'Useless' },
-    [MlFeatureDataType.Nominal]: { icon: Hash, size: 14, text: 'Nominal' },
-    [MlFeatureDataType.Ordinal]: { icon: ListNumbers, size: 18, text: 'Ordinal' },
-    [MlFeatureDataType.Binary]: { icon: Binary, size: 16, text: 'Binary' },
-    [MlFeatureDataType.Count]: { icon: Hash, size: 14, text: 'Count' },
-    [MlFeatureDataType.Interval]: { icon: Clock, size: 16, text: 'Interval' },
-    [MlFeatureDataType.Image]: { icon: Image, size: 16, text: 'Image' },
-    [MlFeatureDataType.Video]: { icon: VideoCamera, size: 16, text: 'Video' },
-    [MlFeatureDataType.Audio]: { icon: Microphone, size: 16, text: 'Audio' },
-    [MlFeatureDataType.Text]: { icon: TextT, size: 18, text: 'Text' },
-    [MlFeatureDataType.Sequence]: { icon: ListNumbers, size: 16, text: 'Sequence' },
-    [MlFeatureDataType.Continuous]: { icon: ChartLine, size: 16, text: 'Continuous' },
+const DATA_TYPE_ICON_MAP: Record<
+    MlFeatureDataType,
+    { icon: PhosphorIcon | null; size: FontSizeOptions; text: string }
+> = {
+    [MlFeatureDataType.Byte]: { icon: Binary, size: 'xl', text: 'Byte' },
+    [MlFeatureDataType.Time]: { icon: Clock, size: 'xl', text: 'Time' },
+    [MlFeatureDataType.Set]: { icon: List, size: 'xl', text: 'Set' },
+    [MlFeatureDataType.Unknown]: { icon: Question, size: 'lg', text: 'Unknown' },
+    [MlFeatureDataType.Map]: { icon: List, size: 'md', text: 'Map' },
+    [MlFeatureDataType.Useless]: { icon: Prohibit, size: 'xl', text: 'Useless' },
+    [MlFeatureDataType.Nominal]: { icon: Hash, size: 'md', text: 'Nominal' },
+    [MlFeatureDataType.Ordinal]: { icon: ListNumbers, size: 'xl', text: 'Ordinal' },
+    [MlFeatureDataType.Binary]: { icon: Binary, size: 'lg', text: 'Binary' },
+    [MlFeatureDataType.Count]: { icon: Hash, size: 'md', text: 'Count' },
+    [MlFeatureDataType.Interval]: { icon: Clock, size: 'lg', text: 'Interval' },
+    [MlFeatureDataType.Image]: { icon: Image, size: 'lg', text: 'Image' },
+    [MlFeatureDataType.Video]: { icon: VideoCamera, size: 'lg', text: 'Video' },
+    [MlFeatureDataType.Audio]: { icon: Microphone, size: 'lg', text: 'Audio' },
+    [MlFeatureDataType.Text]: { icon: TextT, size: 'xl', text: 'Text' },
+    [MlFeatureDataType.Sequence]: { icon: ListNumbers, size: 'lg', text: 'Sequence' },
+    [MlFeatureDataType.Continuous]: { icon: ChartLine, size: 'lg', text: 'Continuous' },
 };
 
 type Props = {
@@ -74,7 +79,7 @@ export default function MlFeatureDataTypeIcon({ dataType }: Props) {
     return (
         <NativeDataTypeTooltip>
             <TypeIconContainer>
-                {IconComponent && <Icon icon={IconComponent} style={{ fontSize: size }} />}
+                {IconComponent && <Icon icon={IconComponent} size={size} />}
                 <TypeSubtitle
                     type="span"
                     color="textSecondary"

--- a/datahub-web-react/src/app/ingestV2/source/builder/CreateScheduleStep.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/builder/CreateScheduleStep.tsx
@@ -150,12 +150,12 @@ export const CreateScheduleStep = ({ state, updateState, goTo, prev }: StepProps
                 <Form.Item
                     tooltip={t('schedule.enableTooltip')}
                     label={
-                        <Typography.Text strong>
+                        <Text type="span" weight="bold">
                             {t('schedule.runOnSchedule')}{' '}
                             <Text type="span" color="textSecondary">
                                 {t('schedule.recommended')}
                             </Text>
-                        </Typography.Text>
+                        </Text>
                     }
                 >
                     <Switch checked={scheduleEnabled} onChange={(v) => setScheduleEnabled(v)} />

--- a/datahub-web-react/src/conf/theme/colorThemes/color.ts
+++ b/datahub-web-react/src/conf/theme/colorThemes/color.ts
@@ -7,6 +7,7 @@ export default {
     gray400: '#F9FAFC',
     gray500: '#A3A7B9',
     gray600: '#8088A3',
+    gray650: '#6B7290',
     gray700: '#5F6685',
     gray800: '#374066',
     gray900: '#323A5D',

--- a/datahub-web-react/src/conf/theme/colorThemes/light.ts
+++ b/datahub-web-react/src/conf/theme/colorThemes/light.ts
@@ -21,7 +21,7 @@ const lightTheme: ColorTheme = {
     bgHover: colors.gray400,
     text: colors.gray800,
     textSecondary: colors.gray700,
-    textTertiary: colors.gray700,
+    textTertiary: colors.gray650,
     textBrand: colors.violet600,
     textBrandOnBgFill: colors.gray0,
     textOnFillBrand: colors.gray0,


### PR DESCRIPTION
- Map per-type ML feature icon sizes to alchemy size tokens; pass size="md" to Chart/Dashboard stat icons (Eye/UsersThree/Question/Clock). The outer style={{ fontSize }} on <Icon> is shadowed by the inner glyph and was rendering everything at 24px.
- FileNode: only show tooltip when the file name is truncated, matching antd's old ellipsis={{ tooltip }} behaviour. Convert FileName to styled.span so the truncation-detection ref reaches the DOM node.
- Add gray650 (#6B7290, ~4.7:1 on white, AA pass) and use it for light-mode textTertiary so secondary/tertiary text are visually distinct again.
- CreateScheduleStep: replace the remaining antd Typography.Text strong wrapping alchemy Text with Text type="span" weight="bold".

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
