### PR TITLE
refactor(ui): align Import Documents modal with the alchemy design system

### DIFF
--- a/datahub-web-react/src/app/context/import/__tests__/useImportDocumentsModalButtons.test.ts
+++ b/datahub-web-react/src/app/context/import/__tests__/useImportDocumentsModalButtons.test.ts
@@ -22,7 +22,7 @@ describe('useImportDocumentsModalButtons', () => {
             }),
         );
 
-        expect(result.current).toEqual([{ text: 'Cancel', variant: 'outline', onClick: handlers.onClose }]);
+        expect(result.current).toEqual([{ text: 'Cancel', variant: 'text', color: 'gray', onClick: handlers.onClose }]);
     });
 
     it('returns back and import on configure step', () => {
@@ -36,7 +36,7 @@ describe('useImportDocumentsModalButtons', () => {
         );
 
         expect(result.current).toEqual([
-            { text: 'Back', variant: 'outline', onClick: handlers.onBack },
+            { text: 'Back', variant: 'text', color: 'primary', onClick: handlers.onBack },
             { text: 'Import', variant: 'filled', onClick: handlers.onImportFiles, disabled: false },
         ]);
     });

--- a/datahub-web-react/src/app/context/import/components/ImportDocumentsImportingStep.tsx
+++ b/datahub-web-react/src/app/context/import/components/ImportDocumentsImportingStep.tsx
@@ -1,17 +1,15 @@
-import { LoadingOutlined } from '@ant-design/icons';
-import { Spin } from 'antd';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { HelperText, ResultContainer } from '@app/context/import/components/importDocumentsModal.styles';
-import { Text } from '@src/alchemy-components';
+import { Loader, Text } from '@src/alchemy-components';
 
 export default function ImportDocumentsImportingStep() {
     const { t } = useTranslation('misc');
 
     return (
         <ResultContainer>
-            <Spin indicator={<LoadingOutlined style={{ fontSize: 36 }} spin />} />
+            <Loader size="md" />
             <Text weight="semiBold">{t('context.import.importingTitle')}</Text>
             <HelperText>{t('context.import.importingSubtitle')}</HelperText>
         </ResultContainer>

--- a/datahub-web-react/src/app/context/import/components/ImportDocumentsResultStep.tsx
+++ b/datahub-web-react/src/app/context/import/components/ImportDocumentsResultStep.tsx
@@ -1,13 +1,11 @@
+import { CheckCircle } from '@phosphor-icons/react/dist/csr/CheckCircle';
+import { WarningCircle } from '@phosphor-icons/react/dist/csr/WarningCircle';
+import { XCircle } from '@phosphor-icons/react/dist/csr/XCircle';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useTheme } from 'styled-components';
 
-import {
-    ErrorIcon,
-    HelperText,
-    ResultContainer,
-    SuccessIcon,
-    WarningIcon,
-} from '@app/context/import/components/importDocumentsModal.styles';
+import { HelperText, ResultContainer } from '@app/context/import/components/importDocumentsModal.styles';
 import { Text } from '@src/alchemy-components';
 
 type ImportDocumentsResultStepProps = {
@@ -17,6 +15,8 @@ type ImportDocumentsResultStepProps = {
     totalFailed: number;
 };
 
+const RESULT_ICON_SIZE = 36;
+
 export default function ImportDocumentsResultStep({
     importError,
     totalImported,
@@ -24,6 +24,7 @@ export default function ImportDocumentsResultStep({
     totalFailed,
 }: ImportDocumentsResultStepProps) {
     const { t } = useTranslation('misc');
+    const theme = useTheme();
 
     const summary = useMemo(() => {
         const parts: string[] = [];
@@ -42,7 +43,7 @@ export default function ImportDocumentsResultStep({
     if (importError) {
         return (
             <ResultContainer>
-                <ErrorIcon />
+                <XCircle size={RESULT_ICON_SIZE} color={theme.colors.iconError} weight="fill" />
                 <Text weight="semiBold" size="lg">
                     {t('context.import.failedTitle')}
                 </Text>
@@ -53,7 +54,11 @@ export default function ImportDocumentsResultStep({
 
     return (
         <ResultContainer>
-            {totalFailed === 0 ? <SuccessIcon /> : <WarningIcon />}
+            {totalFailed === 0 ? (
+                <CheckCircle size={RESULT_ICON_SIZE} color={theme.colors.iconSuccess} weight="fill" />
+            ) : (
+                <WarningCircle size={RESULT_ICON_SIZE} color={theme.colors.iconWarning} weight="fill" />
+            )}
             <Text weight="semiBold" size="lg">
                 {t('context.import.completeTitle')}
             </Text>

--- a/datahub-web-react/src/app/context/import/components/ImportDocumentsSourceGrid.tsx
+++ b/datahub-web-react/src/app/context/import/components/ImportDocumentsSourceGrid.tsx
@@ -1,20 +1,18 @@
 import { Upload } from '@phosphor-icons/react/dist/csr/Upload';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useTheme } from 'styled-components';
 
-import {
-    HelperText,
-    SourceCard,
-    SourceGrid,
-    SourceIcon,
-    SourceLogo,
-} from '@app/context/import/components/importDocumentsModal.styles';
+import { SourceGrid } from '@app/context/import/components/importDocumentsModal.styles';
 import { ImportSourceType } from '@app/context/import/import.types';
-import { Text } from '@src/alchemy-components';
+import { Card } from '@src/alchemy-components';
 
 import confluenceLogo from '@images/confluencelogo.svg';
 import githubLogo from '@images/githublogo.png';
 import notionLogo from '@images/notionlogo.png';
+
+const ICON_SIZE = 24;
+const LOGO_STYLE: React.CSSProperties = { width: ICON_SIZE, height: ICON_SIZE, objectFit: 'contain' };
 
 type ImportDocumentsSourceGridProps = {
     canImportFromScheduledSources: boolean;
@@ -26,34 +24,37 @@ export default function ImportDocumentsSourceGrid({
     onSelectSource,
 }: ImportDocumentsSourceGridProps) {
     const { t } = useTranslation('misc');
+    const theme = useTheme();
     const columnCount = canImportFromScheduledSources ? 2 : 1;
 
     return (
         <SourceGrid $columns={columnCount}>
-            <SourceCard type="button" onClick={() => onSelectSource(ImportSourceType.FILE_UPLOAD)}>
-                <SourceIcon>
-                    <Upload size={32} />
-                </SourceIcon>
-                <Text weight="semiBold">{t('context.import.uploadFilesTitle')}</Text>
-                <HelperText>{t('context.import.uploadFilesDescription')}</HelperText>
-            </SourceCard>
+            <Card
+                title={t('context.import.uploadFilesTitle')}
+                subTitle={t('context.import.uploadFilesDescription')}
+                icon={<Upload size={ICON_SIZE} color={theme.colors.iconBrand} />}
+                onClick={() => onSelectSource(ImportSourceType.FILE_UPLOAD)}
+            />
             {canImportFromScheduledSources && (
                 <>
-                    <SourceCard type="button" onClick={() => onSelectSource(ImportSourceType.GITHUB)}>
-                        <SourceLogo src={githubLogo} alt={t('context.import.githubAlt')} />
-                        <Text weight="semiBold">{t('context.import.githubTitle')}</Text>
-                        <HelperText>{t('context.import.githubDescription')}</HelperText>
-                    </SourceCard>
-                    <SourceCard type="button" onClick={() => onSelectSource(ImportSourceType.NOTION)}>
-                        <SourceLogo src={notionLogo} alt={t('context.import.notionAlt')} />
-                        <Text weight="semiBold">{t('context.import.notionTitle')}</Text>
-                        <HelperText>{t('context.import.notionDescription')}</HelperText>
-                    </SourceCard>
-                    <SourceCard type="button" onClick={() => onSelectSource(ImportSourceType.CONFLUENCE)}>
-                        <SourceLogo src={confluenceLogo} alt={t('context.import.confluenceAlt')} />
-                        <Text weight="semiBold">{t('context.import.confluenceTitle')}</Text>
-                        <HelperText>{t('context.import.confluenceDescription')}</HelperText>
-                    </SourceCard>
+                    <Card
+                        title={t('context.import.githubTitle')}
+                        subTitle={t('context.import.githubDescription')}
+                        icon={<img src={githubLogo} alt={t('context.import.githubAlt')} style={LOGO_STYLE} />}
+                        onClick={() => onSelectSource(ImportSourceType.GITHUB)}
+                    />
+                    <Card
+                        title={t('context.import.notionTitle')}
+                        subTitle={t('context.import.notionDescription')}
+                        icon={<img src={notionLogo} alt={t('context.import.notionAlt')} style={LOGO_STYLE} />}
+                        onClick={() => onSelectSource(ImportSourceType.NOTION)}
+                    />
+                    <Card
+                        title={t('context.import.confluenceTitle')}
+                        subTitle={t('context.import.confluenceDescription')}
+                        icon={<img src={confluenceLogo} alt={t('context.import.confluenceAlt')} style={LOGO_STYLE} />}
+                        onClick={() => onSelectSource(ImportSourceType.CONFLUENCE)}
+                    />
                 </>
             )}
         </SourceGrid>

--- a/datahub-web-react/src/app/context/import/components/importDocumentsModal.styles.ts
+++ b/datahub-web-react/src/app/context/import/components/importDocumentsModal.styles.ts
@@ -1,4 +1,3 @@
-import { CheckCircleOutlined, ExclamationCircleOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
 
 export const Content = styled.div`
@@ -14,54 +13,12 @@ export const SourceGrid = styled.div<{ $columns: number }>`
     gap: 12px;
 `;
 
-export const SourceCard = styled.button`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 12px;
-    padding: 24px 16px;
-    border: 2px solid ${({ theme }) => theme.colors.border};
-    border-radius: 8px;
-    background: transparent;
-    cursor: pointer;
-    transition: all 0.15s ease;
-
-    &:hover {
-        border-color: ${({ theme }) => theme.colors.borderBrand};
-    }
-`;
-
-export const SourceLogo = styled.img`
-    width: 32px;
-    height: 32px;
-    object-fit: contain;
-`;
-
-export const SourceIcon = styled.div`
-    color: ${({ theme }) => theme.colors.iconBrand};
-`;
-
 export const ResultContainer = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 16px;
     padding: 20px 0;
-`;
-
-export const SuccessIcon = styled(CheckCircleOutlined)`
-    font-size: 36px;
-    color: ${({ theme }) => theme.colors.iconSuccess};
-`;
-
-export const WarningIcon = styled(ExclamationCircleOutlined)`
-    font-size: 36px;
-    color: ${({ theme }) => theme.colors.iconWarning};
-`;
-
-export const ErrorIcon = styled(ExclamationCircleOutlined)`
-    font-size: 36px;
-    color: ${({ theme }) => theme.colors.iconError};
 `;
 
 export const HelperText = styled.span`

--- a/datahub-web-react/src/app/context/import/sources/FileUploadSource.tsx
+++ b/datahub-web-react/src/app/context/import/sources/FileUploadSource.tsx
@@ -30,10 +30,10 @@ const FileList = styled.div`
     overflow-y: auto;
 `;
 
-const WarningText = styled.span`
+const ErrorText = styled.span`
     display: block;
     margin-top: 8px;
-    color: ${({ theme }) => theme.colors.iconWarning};
+    color: ${({ theme }) => theme.colors.textError};
     font-size: 12px;
 `;
 
@@ -97,12 +97,12 @@ export default function FileUploadSource({ files, onFilesChange }: FileUploadSou
             />
 
             {rejectedNames.length > 0 && (
-                <WarningText>
+                <ErrorText>
                     {t('context.import.skippedUnsupported', {
                         count: rejectedNames.length,
                         names: rejectedNames.join(', '),
                     })}
-                </WarningText>
+                </ErrorText>
             )}
 
             {files.length > 0 && (

--- a/datahub-web-react/src/app/context/import/useImportDocumentsModalButtons.ts
+++ b/datahub-web-react/src/app/context/import/useImportDocumentsModalButtons.ts
@@ -25,11 +25,11 @@ export function useImportDocumentsModalButtons({
 
     return useMemo(() => {
         if (step === 'source') {
-            return [{ text: t('context.import.cancel'), variant: 'outline', onClick: onClose }];
+            return [{ text: t('context.import.cancel'), variant: 'text', color: 'gray', onClick: onClose }];
         }
         if (step === 'configure') {
             return [
-                { text: t('context.import.back'), variant: 'outline', onClick: onBack },
+                { text: t('context.import.back'), variant: 'text', color: 'primary', onClick: onBack },
                 {
                     text: t('context.import.import'),
                     variant: 'filled',


### PR DESCRIPTION
Before:
<img width="1840" height="1196" alt="Screenshot 2026-06-29 at 12 01 11 PM" src="https://github.com/user-attachments/assets/6360a0a2-b0ed-490d-becd-e057cc633cd6" />

After:
<img width="1840" height="1196" alt="Screenshot 2026-06-29 at 12 00 52 PM" src="https://github.com/user-attachments/assets/996f3e58-c01b-4024-9e11-e27f39772926" />

Source picker tiles → alchemy Card (no styled wrappers, default horizontal icon layout, icons sized to 24px) Result-step icons → Phosphor CheckCircle / WarningCircle / XCircle themed via useTheme() Importing-step spinner → alchemy Loader
Cancel button → variant: 'text', color: 'gray'
Back button → variant: 'text', color: 'violet'
"Skipped N unsupported file" copy → textError red (was misusing iconWarning) importDocumentsModal.styles.ts pruned to layout-only primitives; antd icon import removed

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
