### PR TITLE
fix(ingest/powerbi): recover BigQuery ODBC lineage for views and native queries

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
@@ -56,6 +56,7 @@ from datahub.sql_parsing.sqlglot_lineage import (
     DownstreamColumnRef,
     SqlParsingResult,
 )
+from datahub.sql_parsing.sqlglot_utils import get_dialect
 
 logger = logging.getLogger(__name__)
 
@@ -367,12 +368,16 @@ class AbstractLineage(ABC):
         return None
 
     @staticmethod
-    def is_sql_query(query: Optional[str]) -> bool:
+    def is_sql_query(query: Optional[str], platform: Optional[str] = None) -> bool:
         if not query:
             return False
         query = native_sql_parser.remove_special_characters(query)
+        # Parse with the source platform's dialect so platform-specific syntax
+        # (e.g. BigQuery backtick-quoted, hyphenated project ids) isn't misread
+        # as non-SQL and wrongly routed to the navigation path.
+        dialect = get_dialect(platform) if platform else None
         try:
-            expression = sqlglot.parse_one(query)
+            expression = sqlglot.parse_one(query, dialect=dialect)
             return isinstance(expression, exp.Select)
         except (ParseError, Exception):
             logger.debug(f"Failed to parse query as SQL: {query}")
@@ -1589,7 +1594,7 @@ class OdbcLineage(AbstractLineage):
         elif not server_name:
             server_name = "unknown"
 
-        if self.is_sql_query(query):
+        if self.is_sql_query(query, platform_pair.datahub_data_platform_name):
             return self.query_lineage(query, platform_pair, server_name, dsn)
         else:
             return self.expression_lineage(
@@ -1825,7 +1830,9 @@ class OdbcLineage(AbstractLineage):
             if temp_accessor.items.get("Kind") == "Schema":
                 schema_name = temp_accessor.items["Name"]
 
-            if temp_accessor.items.get("Kind") == "Table":
+            # ODBC navigation labels a view leaf with Kind="View" rather than
+            # "Table"; both are valid dataset leaves (see create_reference_table).
+            if temp_accessor.items.get("Kind") in ("Table", "View"):
                 table_name = temp_accessor.items["Name"]
 
             if temp_accessor.next is not None:

--- a/metadata-ingestion/tests/unit/powerbi/test_pattern_handler.py
+++ b/metadata-ingestion/tests/unit/powerbi/test_pattern_handler.py
@@ -30,9 +30,11 @@ from datahub.ingestion.source.powerbi.dataplatform_instance_resolver import (
 from datahub.ingestion.source.powerbi.m_query.data_classes import (
     DataAccessFunctionDetail,
     DataPlatformTable,
+    IdentifierAccessor,
     Lineage,
 )
 from datahub.ingestion.source.powerbi.m_query.pattern_handler import (
+    OdbcLineage,
     OracleLineage,
     _remap_column_lineage_to_pbi_fields,
 )
@@ -682,3 +684,77 @@ def test_remap_column_lineage_multi_table_shared_column_name():
             "setid",
         ),
     ]
+
+
+# ---------------------------------------------------------------------------
+# OdbcLineage — view leaves and dialect-aware SQL detection
+# ---------------------------------------------------------------------------
+
+
+def _build_odbc_lineage() -> OdbcLineage:
+    """OdbcLineage with a column-less table (so create_table_column_lineage is a
+    no-op) and a resolver that returns a plain PlatformDetail (no instance)."""
+    table = Table(columns=None, measures=[], expression="", name="t", full_name="ds.t")
+    resolver = MagicMock(spec=AbstractDataPlatformInstanceResolver)
+    resolver.get_platform_instance.return_value = PlatformDetail()
+    return OdbcLineage(
+        ctx=MagicMock(spec=PipelineContext),
+        table=table,
+        config=_build_config(),
+        reporter=PowerBiDashboardSourceReport(),
+        platform_instance_resolver=resolver,
+    )
+
+
+def _nav_accessor(*levels: tuple) -> IdentifierAccessor:
+    """Build a Database->Schema->Table IdentifierAccessor chain from
+    (Kind, Name) tuples, returning the head (first level)."""
+    head: Optional[IdentifierAccessor] = None
+    for kind, name in reversed(levels):
+        head = IdentifierAccessor(
+            identifier=name, items={"Kind": kind, "Name": name}, next=head
+        )
+    assert head is not None
+    return head
+
+
+def test_odbc_view_leaf_resolves_like_table():
+    """A view leaf is labelled Kind="View" (not "Table") in ODBC navigation.
+    It must still resolve to a dataset URN, otherwise BigQuery/Hive views are
+    silently dropped with "Can not determine qualified table name"."""
+    instance = _build_odbc_lineage()
+    detail = DataAccessFunctionDetail(
+        arg_list={},
+        data_access_function_name="Odbc.DataSource",
+        identifier_accessor=_nav_accessor(
+            ("Database", "myproject"),
+            ("Schema", "mydataset"),
+            ("View", "v_dim_country"),
+        ),
+        node_map={},
+    )
+    pair = DataPlatformPair(
+        powerbi_data_platform_name="GoogleBigQuery",
+        datahub_data_platform_name="bigquery",
+    )
+
+    result = instance.expression_lineage(detail, "bigquery", pair, server_name="dsn")
+
+    assert [u.urn for u in result.upstreams] == [
+        "urn:li:dataset:(urn:li:dataPlatform:bigquery,myproject.mydataset.v_dim_country,PROD)"
+    ]
+
+
+def test_is_sql_query_uses_platform_dialect():
+    """BigQuery native queries use backtick-quoted, hyphenated project ids that
+    fail under the default sqlglot dialect. is_sql_query must classify them as
+    SQL when given the platform, else they get routed to the navigation path and
+    dropped."""
+    query = (
+        "SELECT t.* FROM `ppp-pa-main-2e.bi_dim_tables.t_dim_time` t "
+        "WHERE fiscal_year IN (2025, 2026)"
+    )
+    # Default dialect cannot parse the hyphenated backtick identifier.
+    assert OdbcLineage.is_sql_query(query) is False
+    # With the BigQuery dialect it is recognised as SQL.
+    assert OdbcLineage.is_sql_query(query, "bigquery") is True


### PR DESCRIPTION
## Summary

The PowerBI ODBC handler silently dropped two classes of BigQuery upstream lineage edges (both surfaced as `Can not determine qualified table name for ODBC data source`):

- **View leaves were ignored.** In `OdbcLineage.expression_lineage`, the navigation walk only recognized `Kind == "Table"`. PowerBI labels a view leaf with `Kind == "View"`, so `table_name` was never set and the edge was dropped. This now treats `View` the same as `Table`, matching `create_reference_table`, which already accepts either (`table_detail.get("Table") or table_detail["View"]`).
- **`is_sql_query` ignored the platform dialect.** It parsed with the default sqlglot dialect, which throws on BigQuery backtick-quoted, hyphenated project ids (e.g. `` `my-proj.dataset.table` ``). Valid native queries were misclassified as non-SQL and wrongly routed to the navigation path (which has no accessor), so they were dropped. It now parses using the source platform's dialect via `get_dialect(platform)`.

Verified against a real PowerBI tenant (file sink): BigQuery upstream edges went from 94 → 102 (7 views + 1 native query recovered) and `Can not determine qualified table name` failures went from 8 → 0, with no regressions to Hive/Databricks edges. Recovered URNs are well-formed BigQuery `project.dataset.table`.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added (`test_odbc_view_leaf_resolves_like_table`, `test_is_sql_query_uses_platform_dialect`)
- [ ] Docs — n/a (bug fix, no user-facing config change)
- [ ] Breaking changes — none

Made with [Cursor](https://cursor.com)