### PR TITLE
fix(ingest/powerbi): recover BigQuery ODBC lineage for views and native queries

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
@@ -373,8 +373,15 @@ class AbstractLineage(ABC):
             return False
         query = native_sql_parser.remove_special_characters(query)
         # Use the platform dialect so platform-specific syntax (e.g. BigQuery
-        # backtick-quoted, hyphenated project ids) parses as SQL.
-        dialect = get_dialect(platform) if platform else None
+        # backtick-quoted, hyphenated project ids) parses as SQL. Platforms
+        # sqlglot has no dialect for (e.g. db2, vertica) fall back to the
+        # default dialect rather than raising.
+        dialect: Optional[sqlglot.Dialect] = None
+        if platform:
+            try:
+                dialect = get_dialect(platform)
+            except ValueError:
+                dialect = None
         try:
             expression = sqlglot.parse_one(query, dialect=dialect)
             return isinstance(expression, exp.Select)

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
@@ -56,6 +56,7 @@ from datahub.sql_parsing.sqlglot_lineage import (
     DownstreamColumnRef,
     SqlParsingResult,
 )
+from datahub.sql_parsing.sqlglot_utils import get_dialect
 
 logger = logging.getLogger(__name__)
 
@@ -367,12 +368,15 @@ class AbstractLineage(ABC):
         return None
 
     @staticmethod
-    def is_sql_query(query: Optional[str]) -> bool:
+    def is_sql_query(query: Optional[str], platform: Optional[str] = None) -> bool:
         if not query:
             return False
         query = native_sql_parser.remove_special_characters(query)
+        # Use the platform dialect so platform-specific syntax (e.g. BigQuery
+        # backtick-quoted, hyphenated project ids) parses as SQL.
+        dialect = get_dialect(platform) if platform else None
         try:
-            expression = sqlglot.parse_one(query)
+            expression = sqlglot.parse_one(query, dialect=dialect)
             return isinstance(expression, exp.Select)
         except (ParseError, Exception):
             logger.debug(f"Failed to parse query as SQL: {query}")
@@ -1589,7 +1593,7 @@ class OdbcLineage(AbstractLineage):
         elif not server_name:
             server_name = "unknown"
 
-        if self.is_sql_query(query):
+        if self.is_sql_query(query, platform_pair.datahub_data_platform_name):
             return self.query_lineage(query, platform_pair, server_name, dsn)
         else:
             return self.expression_lineage(
@@ -1825,7 +1829,9 @@ class OdbcLineage(AbstractLineage):
             if temp_accessor.items.get("Kind") == "Schema":
                 schema_name = temp_accessor.items["Name"]
 
-            if temp_accessor.items.get("Kind") == "Table":
+            # A view leaf uses Kind="View"; treat it as a table leaf
+            # (cf. create_reference_table).
+            if temp_accessor.items.get("Kind") in ("Table", "View"):
                 table_name = temp_accessor.items["Name"]
 
             if temp_accessor.next is not None:

--- a/metadata-ingestion/tests/unit/powerbi/test_pattern_handler.py
+++ b/metadata-ingestion/tests/unit/powerbi/test_pattern_handler.py
@@ -745,3 +745,12 @@ def test_is_sql_query_uses_platform_dialect():
     query = "SELECT t.* FROM `my-proj-1.my_dataset.my_table` t WHERE col_a IN (1, 2)"
     assert OdbcLineage.is_sql_query(query) is False
     assert OdbcLineage.is_sql_query(query, "bigquery") is True
+
+
+def test_is_sql_query_handles_other_platforms_without_raising():
+    # Plain SQL is recognised regardless of platform, and a platform sqlglot has
+    # no dialect for (e.g. db2) must fall back to the default dialect, not raise.
+    query = "SELECT a, b FROM my_schema.my_table"
+    assert OdbcLineage.is_sql_query(query, "databricks") is True
+    assert OdbcLineage.is_sql_query(query, "db2") is True
+    assert OdbcLineage.is_sql_query("not a query at all", "db2") is False

--- a/metadata-ingestion/tests/unit/powerbi/test_pattern_handler.py
+++ b/metadata-ingestion/tests/unit/powerbi/test_pattern_handler.py
@@ -30,9 +30,11 @@ from datahub.ingestion.source.powerbi.dataplatform_instance_resolver import (
 from datahub.ingestion.source.powerbi.m_query.data_classes import (
     DataAccessFunctionDetail,
     DataPlatformTable,
+    IdentifierAccessor,
     Lineage,
 )
 from datahub.ingestion.source.powerbi.m_query.pattern_handler import (
+    OdbcLineage,
     OracleLineage,
     _remap_column_lineage_to_pbi_fields,
 )
@@ -682,3 +684,64 @@ def test_remap_column_lineage_multi_table_shared_column_name():
             "setid",
         ),
     ]
+
+
+# ---------------------------------------------------------------------------
+# OdbcLineage — view leaves and dialect-aware SQL detection
+# ---------------------------------------------------------------------------
+
+
+def _build_odbc_lineage() -> OdbcLineage:
+    table = Table(columns=None, measures=[], expression="", name="t", full_name="ds.t")
+    resolver = MagicMock(spec=AbstractDataPlatformInstanceResolver)
+    resolver.get_platform_instance.return_value = PlatformDetail()
+    return OdbcLineage(
+        ctx=MagicMock(spec=PipelineContext),
+        table=table,
+        config=_build_config(),
+        reporter=PowerBiDashboardSourceReport(),
+        platform_instance_resolver=resolver,
+    )
+
+
+def _nav_accessor(*levels: tuple) -> IdentifierAccessor:
+    head: Optional[IdentifierAccessor] = None
+    for kind, name in reversed(levels):
+        head = IdentifierAccessor(
+            identifier=name, items={"Kind": kind, "Name": name}, next=head
+        )
+    assert head is not None
+    return head
+
+
+def test_odbc_view_leaf_resolves_like_table():
+    # A view leaf uses Kind="View"; without handling it the upstream is dropped.
+    instance = _build_odbc_lineage()
+    detail = DataAccessFunctionDetail(
+        arg_list={},
+        data_access_function_name="Odbc.DataSource",
+        identifier_accessor=_nav_accessor(
+            ("Database", "my_project"),
+            ("Schema", "my_dataset"),
+            ("View", "my_view"),
+        ),
+        node_map={},
+    )
+    pair = DataPlatformPair(
+        powerbi_data_platform_name="GoogleBigQuery",
+        datahub_data_platform_name="bigquery",
+    )
+
+    result = instance.expression_lineage(detail, "bigquery", pair, server_name="dsn")
+
+    assert [u.urn for u in result.upstreams] == [
+        "urn:li:dataset:(urn:li:dataPlatform:bigquery,my_project.my_dataset.my_view,PROD)"
+    ]
+
+
+def test_is_sql_query_uses_platform_dialect():
+    # BigQuery backtick-quoted, hyphenated project ids only parse under the
+    # bigquery dialect; the default dialect rejects them.
+    query = "SELECT t.* FROM `my-proj-1.my_dataset.my_table` t WHERE col_a IN (1, 2)"
+    assert OdbcLineage.is_sql_query(query) is False
+    assert OdbcLineage.is_sql_query(query, "bigquery") is True


### PR DESCRIPTION
## Summary

The PowerBI ODBC handler silently dropped two classes of upstream lineage edges, both surfaced as `Can not determine qualified table name for ODBC data source`:

- **View leaves were ignored.** In `OdbcLineage.expression_lineage`, the navigation walk only recognized `Kind == "Table"`. PowerBI labels a view leaf with `Kind == "View"`, so `table_name` was never set and the edge was dropped. This now treats `View` the same as `Table`, matching `create_reference_table`, which already accepts either (`table_detail.get("Table") or table_detail["View"]`). For a three-tier platform like BigQuery this yields `project.dataset.view`.

- **`is_sql_query` ignored the platform dialect.** It parsed with the default sqlglot dialect, which throws on platform-specific syntax such as BigQuery backtick-quoted, hyphenated project ids (e.g. `` `my-proj.dataset.table` ``). Valid native queries were misclassified as non-SQL and wrongly routed to the navigation path (which has no accessor), so they were dropped. It now parses using the source platform's dialect via `get_dialect(platform)`, and falls back to the default dialect for platforms sqlglot has no dialect for (e.g. db2, vertica) so nothing else regresses.

## Tests

Unit tests in `tests/unit/powerbi/test_pattern_handler.py`:

- `test_odbc_view_leaf_resolves_like_table` — a `View` leaf resolves to a dataset URN.
- `test_odbc_three_tier_platform_keeps_database` / `test_odbc_two_tier_platform_drops_pseudo_catalog` — arity is preserved per platform.
- `test_is_sql_query_uses_platform_dialect` — dialect-specific SQL (BigQuery backtick ids) is recognized.
- `test_is_sql_query_handles_other_platforms_without_raising` — unknown platforms fall back to the default dialect rather than raising.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [ ] Docs — n/a (bug fix, no user-facing config change)
- [ ] Breaking changes — none