### PR TITLE
fix(frontend): respect basePath in user list links

### DIFF
--- a/datahub-web-react/src/app/identity/user/UserListV2.components.tsx
+++ b/datahub-web-react/src/app/identity/user/UserListV2.components.tsx
@@ -3,6 +3,7 @@ import { Key } from '@phosphor-icons/react/dist/csr/Key';
 import { Trash } from '@phosphor-icons/react/dist/csr/Trash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components/macro';
 
 import useDeleteEntity from '@app/entity/shared/EntityDropdown/useDeleteEntity';
@@ -154,8 +155,8 @@ export const UserNameCell = ({ user }: UserCellProps) => {
         <UserInfo>
             <Avatar name={displayName || user.username} size="lg" imageUrl={avatarUrl} />
             <UserDetails>
-                <a
-                    href={`/${entityRegistry.getPathName(EntityType.CorpUser)}/${user.urn}`}
+                <Link
+                    to={entityRegistry.getEntityUrl(EntityType.CorpUser, user.urn)}
                     target="_blank"
                     rel="noreferrer"
                     style={{ textDecoration: 'none' }}
@@ -163,7 +164,7 @@ export const UserNameCell = ({ user }: UserCellProps) => {
                     <Text weight="medium" size="md" color="gray">
                         {primaryText}
                     </Text>
-                </a>
+                </Link>
                 {secondaryText && (
                     <Text size="sm" color="gray">
                         {secondaryText}


### PR DESCRIPTION
## Why

There is a bug where the users URL is not rendered properly (basePath missing in the Manage Users & Groups settings view), while the groups URL is.

## What

`UserListV2` uses a `<a href>` instead of a `<Link>`, harmonized that.

## Test Summary — `UserListV2.components.tsx`

| Check | Result |
|-------|--------|
| ESLint (`--fix`) | ✅ Clean — no issues |
| Prettier | ✅ All matched files use Prettier code style |
| Type-check (`tsc --noEmit`) | ✅ No errors in the changed file |
| Unit tests (`src/app/identity/user`) | ✅ 82 / 83 passed |

The non-passing test in on `SimpleSelectRole.test.tsx`, it was pre-existing to this change (confirmed with a stash).

---

Do not hesitate if something is not quite right here, or if I made a mistake!