### PR TITLE
docs(ingest): document SDK emit modes (sync vs async) for the Python emitter

### DIFF
--- a/metadata-ingestion/as-a-library.md
+++ b/metadata-ingestion/as-a-library.md
@@ -63,6 +63,43 @@ Other examples:
 
 - [lineage_emitter_mcpw_rest.py](./examples/library/lineage_emitter_mcpw_rest.py) - emits simple bigquery table-to-table (dataset-to-dataset) lineage via REST as MetadataChangeProposalWrapper.
 
+### Emit Modes
+
+`emit()` and `emit_mcp()` accept an optional `emit_mode: EmitMode` argument that controls how long the call waits and what consistency it guarantees. The emitter default is `SYNC_PRIMARY`. You can override it per call, or set `default_emit_mode` once on the emitter.
+
+| `EmitMode`                 | Call returns after…                          | Use when                                                                  |
+| -------------------------- | -------------------------------------------- | ------------------------------------------------------------------------- |
+| `SYNC_WAIT`                | SQL **and** Elasticsearch are updated        | The write must be immediately searchable; strongest consistency, slowest. |
+| `SYNC_PRIMARY` _(default)_ | SQL is updated (Elasticsearch indexed async) | Low-volume writes that need read-after-write on direct entity gets.       |
+| `ASYNC`                    | The change is queued (returns immediately)   | High-throughput or bulk ingestion where eventual consistency is fine.     |
+| `ASYNC_WAIT`               | The queued change is confirmed persisted     | You want async batching/parallelism but still need persistence confirmed. |
+
+#### Choosing a mode
+
+- **Low volume, and you read back or need failures raised at the call site** → keep `SYNC_PRIMARY` (or `SYNC_WAIT` if the write must be searchable immediately).
+- **High-volume or bulk ingestion** → set `ASYNC` explicitly.
+
+The default `SYNC_PRIMARY` is **not** suited to high-throughput or bulk ingestion: a synchronous primary-storage commit per write puts heavy load on GMS and its backing SQL store at volume. Custom scripts and direct SDK usage that emit at scale should opt into `ASYNC`.
+
+#### Async behavior to be aware of
+
+With `ASYNC`, the change is processed after the call returns. Two consequences:
+
+- **`emit()` does not raise on a rejected or invalid write.** The call succeeds once the change is queued; validation or persistence failures surface later in the Failed-MCP topic and consumer logs, not at the call site.
+- **No read-after-write guarantee.** Any flow that writes and then immediately reads the same entity must tolerate eventual consistency.
+
+#### Example
+
+```python
+from datahub.emitter.rest_emitter import DatahubRestEmitter, EmitMode
+
+# Set the default for every emit on this emitter (recommended for bulk ingestion)
+emitter = DatahubRestEmitter(gms_server="http://localhost:8080", default_emit_mode=EmitMode.ASYNC)
+
+# Or override per call
+emitter.emit(metadata_event, emit_mode=EmitMode.ASYNC)
+```
+
 ### Emitter Code
 
 If you're interested in looking at the REST emitter code, it is available [here](./src/datahub/emitter/rest_emitter.py)


### PR DESCRIPTION
## Summary

Adds an **Emit Modes** section to the Python Emitter guide (`metadata-ingestion/as-a-library.md`), documenting the SDK's `EmitMode` options so custom-ingestion / direct-SDK users pick the right mode for their workload.

Follow-up to #18014 (which flipped the push-based plugins — Airflow, Dagster, Prefect, Great Expectations — to `ASYNC`). The SDK / `RestEmitter` default stays `SYNC_PRIMARY`, so for direct SDK users the docs are the only safety net. Custom ingestions have been unintentionally running `sync` at high volume, severely impacting GMS/MySQL performance.

The new section covers:

- What each `EmitMode` does and when to use it (`SYNC_WAIT`, `SYNC_PRIMARY`, `ASYNC`, `ASYNC_WAIT`).
- The SDK default (`SYNC_PRIMARY`) stated explicitly, with a callout that it is **not** suited to high-throughput / bulk ingestion.
- An explicit recommendation: **high-volume / bulk ingestion should set `ASYNC`**.
- The async behavioral caveats so users aren't surprised:
  - the emit call does not raise on a rejected/invalid write — failures surface later in the Failed-MCP topic / consumer logs;
  - no read-after-write guarantee.
- A short "choosing a mode" decision guide.

Docs-only change; no code or behavior changes.
