### PR TITLE
feat(looker): capture explore join definitions as view logic

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
@@ -25,6 +25,7 @@ from looker_sdk.rtl.serialize import DeserializeError
 from looker_sdk.sdk.api40.models import (
     LookmlModelExplore,
     LookmlModelExploreField,
+    LookmlModelExploreJoins,
     User,
     WriteQuery,
 )
@@ -98,6 +99,7 @@ from datahub.metadata.schema_classes import (
     TagAssociationClass,
     TagPropertiesClass,
     TagSnapshotClass,
+    ViewPropertiesClass,
 )
 from datahub.metadata.urns import TagUrn
 from datahub.sdk.dataset import Dataset
@@ -918,6 +920,70 @@ class LookerUtil:
 
 
 @dataclass
+class LookerExploreJoin:
+    """The structured definition of a single join within a Looker explore.
+
+    Looker's explore joins carry the relationship semantics (which view is
+    joined, on what condition, with what cardinality) that are needed to
+    reconstruct the explore's semantic model. The ingestion historically only
+    derived join membership for lineage and discarded these fields.
+    """
+
+    # name of the join (the joined view, or the join alias when `from` is set)
+    name: str
+    # `from` param: the actual view when the join is aliased
+    from_view: Optional[str] = None
+    sql_on: Optional[str] = None
+    relationship: Optional[str] = None  # e.g. many_to_one, one_to_one
+    join_type: Optional[str] = None  # e.g. left_outer, inner
+    foreign_key: Optional[str] = None
+
+    @classmethod
+    def from_api_join(
+        cls, join: LookmlModelExploreJoins
+    ) -> Optional["LookerExploreJoin"]:
+        if join.name is None:
+            return None
+        return cls(
+            name=join.name,
+            from_view=join.from_,
+            sql_on=join.sql_on,
+            relationship=join.relationship,
+            join_type=join.type,
+            foreign_key=join.foreign_key,
+        )
+
+    @classmethod
+    def from_lkml_join(cls, join: Dict) -> Optional["LookerExploreJoin"]:
+        name = join.get("name")
+        if name is None:
+            return None
+        return cls(
+            name=name,
+            from_view=join.get("from"),
+            sql_on=join.get("sql_on"),
+            relationship=join.get("relationship"),
+            join_type=join.get("type"),
+            foreign_key=join.get("foreign_key"),
+        )
+
+    def to_lookml(self) -> str:
+        lines = [f"  join: {self.name} {{"]
+        if self.from_view is not None:
+            lines.append(f"    from: {self.from_view}")
+        if self.join_type is not None:
+            lines.append(f"    type: {self.join_type}")
+        if self.relationship is not None:
+            lines.append(f"    relationship: {self.relationship}")
+        if self.foreign_key is not None:
+            lines.append(f"    foreign_key: {self.foreign_key}")
+        if self.sql_on is not None:
+            lines.append(f"    sql_on: {self.sql_on} ;;")
+        lines.append("  }")
+        return "\n".join(lines)
+
+
+@dataclass
 class LookerExplore:
     name: str
     model_name: str
@@ -931,6 +997,10 @@ class LookerExplore:
         default_factory=dict
     )  # view_name is key and file_path is value. A single file may contains multiple views
     joins: Optional[List[str]] = None
+    # Structured join definitions (relationship semantics), used to reconstruct
+    # the explore's semantic model. Distinct from `joins`, which only holds the
+    # field names referenced in join conditions (retained for lineage).
+    join_definitions: Optional[List[LookerExploreJoin]] = None
     fields: Optional[List[ViewField]] = None  # the fields exposed in this explore
     source_file: Optional[str] = None
     tags: List[str] = dataclasses_field(default_factory=list)
@@ -959,6 +1029,7 @@ class LookerExplore:
     ) -> "LookerExplore":
         view_names: Set[str] = set()
         joins = None
+        join_definitions: List[LookerExploreJoin] = []
         assert "name" in dict, "Explore doesn't have a name field, this isn't allowed"
 
         # The view name that the explore refers to is resolved in the following order of priority:
@@ -977,6 +1048,9 @@ class LookerExplore:
                 if sql_on is not None:
                     fields = cls._get_fields_from_sql_equality(sql_on)
                     joins = fields
+                join_definition = LookerExploreJoin.from_lkml_join(join)
+                if join_definition is not None:
+                    join_definitions.append(join_definition)
 
         upstream_views: List[ProjectInclude] = []
         # create the list of extended explores
@@ -1030,6 +1104,7 @@ class LookerExplore:
             description=dict.get("description"),
             upstream_views=upstream_views,
             joins=joins,
+            join_definitions=join_definitions or None,
             # This method is getting called from lookml_source's get_internal_workunits method
             # & upstream_views_file_path is not in use in that code flow
             upstream_views_file_path={},
@@ -1063,6 +1138,7 @@ class LookerExplore:
                 if explore.name is not None:
                     views.add(explore.name)
 
+            join_definitions: List[LookerExploreJoin] = []
             if explore.joins is not None and explore.joins != []:
                 join_to_orig_name_map = {}
                 potential_views = []
@@ -1072,6 +1148,9 @@ class LookerExplore:
                         join_to_orig_name_map[e.name] = e.from_
                     elif e.name is not None:
                         potential_views.append(e.name)
+                    join_definition = LookerExploreJoin.from_api_join(e)
+                    if join_definition is not None:
+                        join_definitions.append(join_definition)
                 for e_join in [
                     e for e in explore.joins if e.dependent_fields is not None
                 ]:
@@ -1240,6 +1319,7 @@ class LookerExplore:
                 upstream_views_file_path=upstream_views_file_path,
                 source_file=explore.source_file,
                 tags=list(explore.tags) if explore.tags is not None else [],
+                join_definitions=join_definitions or None,
             )
             logger.debug(f"Created LookerExplore from API: {looker_explore}")
             return looker_explore
@@ -1307,6 +1387,25 @@ class LookerExplore:
     def _get_embed_url(self, base_url: str) -> str:
         base_url = remove_port_from_url(base_url)
         return f"{base_url}/embed/explore/{self.model_name}/{self.name}"
+
+    def _build_explore_view_logic(self) -> Optional[str]:
+        """Reconstruct the explore's LookML join graph as view logic.
+
+        The Looker API/LookML does not expose an explore's source file the way
+        it does for views, so the join relationships (sql_on, relationship,
+        type) are otherwise lost. Serializing them into a LookML `explore`
+        block lets downstream consumers reconstruct the semantic model
+        symmetrically with how views store their raw LookML in viewLogic.
+        """
+        if not self.join_definitions:
+            return None
+
+        lines = [f"explore: {self.name} {{"]
+        if self.label is not None:
+            lines.append(f'  label: "{self.label}"')
+        lines.extend(join.to_lookml() for join in self.join_definitions)
+        lines.append("}")
+        return "\n".join(lines)
 
     def _to_metadata_events(
         self,
@@ -1431,6 +1530,17 @@ class LookerExplore:
             "looker.explore.file": self.source_file,
         }
 
+        explore_view_logic = self._build_explore_view_logic()
+        view_definition = (
+            ViewPropertiesClass(
+                materialized=False,
+                viewLogic=explore_view_logic,
+                viewLanguage="lookml",
+            )
+            if explore_view_logic is not None
+            else None
+        )
+
         return Dataset(
             platform=config.platform_name,
             name=config.explore_naming_pattern.replace_variables(
@@ -1449,6 +1559,7 @@ class LookerExplore:
             external_url=self._get_url(base_url),
             upstreams=upstream_lineage,
             schema=schema_metadata,
+            view_definition=view_definition,
             parent_container=[
                 "Explore",
                 gen_model_key(config, self.model_name).as_urn(),

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field as dataclasses_field
 from enum import Enum
 from functools import lru_cache
 from typing import (
+    Any,
     Dict,
     Iterable,
     Iterator,
@@ -954,7 +955,7 @@ class LookerExploreJoin:
         )
 
     @classmethod
-    def from_lkml_join(cls, join: Dict) -> Optional["LookerExploreJoin"]:
+    def from_lkml_join(cls, join: Dict[str, Any]) -> Optional["LookerExploreJoin"]:
         name = join.get("name")
         if name is None:
             return None
@@ -1402,7 +1403,10 @@ class LookerExplore:
 
         lines = [f"explore: {self.name} {{"]
         if self.label is not None:
-            lines.append(f'  label: "{self.label}"')
+            # Labels are free-form and may contain double quotes; escape them so
+            # the reconstructed block remains parseable LookML.
+            escaped_label = self.label.replace('"', '\\"')
+            lines.append(f'  label: "{escaped_label}"')
         lines.extend(join.to_lookml() for join in self.join_definitions)
         lines.append("}")
         return "\n".join(lines)
@@ -1531,6 +1535,13 @@ class LookerExplore:
         }
 
         explore_view_logic = self._build_explore_view_logic()
+        # Explores without joins intentionally emit no viewProperties so that
+        # join-less explores remain unchanged. As a result, if an explore that
+        # previously had joins later loses all of them, the prior viewLogic is
+        # not actively cleared; this is acceptable since the value is a
+        # reconstruction aid rather than authoritative lineage.
+        # viewLanguage is hardcoded rather than importing
+        # lookml_source.VIEW_LANGUAGE_LOOKML to avoid a circular import.
         view_definition = (
             ViewPropertiesClass(
                 materialized=False,

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
@@ -21,6 +21,7 @@ from typing import (
     cast,
 )
 
+import lkml
 from looker_sdk.error import SDKError
 from looker_sdk.rtl.serialize import DeserializeError
 from looker_sdk.sdk.api40.models import (
@@ -968,20 +969,19 @@ class LookerExploreJoin:
             foreign_key=join.get("foreign_key"),
         )
 
-    def to_lookml(self) -> str:
-        lines = [f"  join: {self.name} {{"]
+    def to_lookml_dict(self) -> Dict[str, Any]:
+        join_dict: Dict[str, Any] = {"name": self.name}
         if self.from_view is not None:
-            lines.append(f"    from: {self.from_view}")
+            join_dict["from"] = self.from_view
         if self.join_type is not None:
-            lines.append(f"    type: {self.join_type}")
+            join_dict["type"] = self.join_type
         if self.relationship is not None:
-            lines.append(f"    relationship: {self.relationship}")
+            join_dict["relationship"] = self.relationship
         if self.foreign_key is not None:
-            lines.append(f"    foreign_key: {self.foreign_key}")
+            join_dict["foreign_key"] = self.foreign_key
         if self.sql_on is not None:
-            lines.append(f"    sql_on: {self.sql_on} ;;")
-        lines.append("  }")
-        return "\n".join(lines)
+            join_dict["sql_on"] = self.sql_on
+        return join_dict
 
 
 @dataclass
@@ -1401,15 +1401,13 @@ class LookerExplore:
         if not self.join_definitions:
             return None
 
-        lines = [f"explore: {self.name} {{"]
+        explore_dict: Dict[str, Any] = {"name": self.name}
         if self.label is not None:
-            # Labels are free-form and may contain double quotes; escape them so
-            # the reconstructed block remains parseable LookML.
-            escaped_label = self.label.replace('"', '\\"')
-            lines.append(f'  label: "{escaped_label}"')
-        lines.extend(join.to_lookml() for join in self.join_definitions)
-        lines.append("}")
-        return "\n".join(lines)
+            explore_dict["label"] = self.label
+        explore_dict["joins"] = [
+            join.to_lookml_dict() for join in self.join_definitions
+        ]
+        return str(lkml.dump({"explore": explore_dict})).strip()
 
     def _to_metadata_events(
         self,

--- a/metadata-ingestion/tests/integration/looker/golden_test_ingest_joins.json
+++ b/metadata-ingestion/tests/integration/looker/golden_test_ingest_joins.json
@@ -568,7 +568,7 @@
     "aspect": {
         "json": {
             "materialized": false,
-            "viewLogic": "explore: my_view {\n  label: \"My Explore View\"\n  join: my_joined_view {\n  }\n  join: my_view_has_no_fields {\n    relationship: one_to_one\n    sql_on: 1=1 ;;\n  }\n  join: my_joined_view_join_name {\n    from: my_joined_view_original_name\n  }\n}",
+            "viewLogic": "explore: my_view {\n  label: \"My Explore View\"\n\n  join: my_joined_view {}\n\n  join: my_view_has_no_fields {\n    relationship: one_to_one\n    sql_on: 1=1 ;;\n  }\n\n  join: my_joined_view_join_name {\n    from: my_joined_view_original_name\n  }\n}",
             "viewLanguage": "lookml"
         }
     },

--- a/metadata-ingestion/tests/integration/looker/golden_test_ingest_joins.json
+++ b/metadata-ingestion/tests/integration/looker/golden_test_ingest_joins.json
@@ -561,6 +561,24 @@
     }
 },
 {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,data.explore.my_view,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "json": {
+            "materialized": false,
+            "viewLogic": "explore: my_view {\n  label: \"My Explore View\"\n  join: my_joined_view {\n  }\n  join: my_view_has_no_fields {\n    relationship: one_to_one\n    sql_on: 1=1 ;;\n  }\n  join: my_joined_view_join_name {\n    from: my_joined_view_original_name\n  }\n}",
+            "viewLanguage": "lookml"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586872800000,
+        "runId": "looker-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
     "entityType": "platformResource",
     "entityUrn": "urn:li:platformResource:1cec84235c544a141e63dd2077da2562",
     "changeType": "UPSERT",

--- a/metadata-ingestion/tests/integration/looker/golden_test_ingest_unaliased_joins.json
+++ b/metadata-ingestion/tests/integration/looker/golden_test_ingest_unaliased_joins.json
@@ -300,6 +300,24 @@
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,data.explore.my_view,PROD)",
     "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "json": {
+            "materialized": false,
+            "viewLogic": "explore: my_view {\n  label: \"My Explore View\"\n  join: my_view_has_no_fields {\n    relationship: one_to_one\n    sql_on: 1=1 ;;\n  }\n  join: my_joined_view_join_name {\n    from: my_joined_view_original_name\n  }\n}",
+            "viewLanguage": "lookml"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586872800000,
+        "runId": "looker-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,data.explore.my_view,PROD)",
+    "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {

--- a/metadata-ingestion/tests/integration/looker/golden_test_ingest_unaliased_joins.json
+++ b/metadata-ingestion/tests/integration/looker/golden_test_ingest_unaliased_joins.json
@@ -304,7 +304,7 @@
     "aspect": {
         "json": {
             "materialized": false,
-            "viewLogic": "explore: my_view {\n  label: \"My Explore View\"\n  join: my_view_has_no_fields {\n    relationship: one_to_one\n    sql_on: 1=1 ;;\n  }\n  join: my_joined_view_join_name {\n    from: my_joined_view_original_name\n  }\n}",
+            "viewLogic": "explore: my_view {\n  label: \"My Explore View\"\n\n  join: my_view_has_no_fields {\n    relationship: one_to_one\n    sql_on: 1=1 ;;\n  }\n\n  join: my_joined_view_join_name {\n    from: my_joined_view_original_name\n  }\n}",
             "viewLanguage": "lookml"
         }
     },

--- a/metadata-ingestion/tests/unit/looker/test_looker_common.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_common.py
@@ -2,9 +2,17 @@ import logging
 from unittest.mock import MagicMock
 
 import pytest
-from looker_sdk.sdk.api40.models import LookmlModelExplore, LookmlModelExploreField
+from looker_sdk.sdk.api40.models import (
+    LookmlModelExplore,
+    LookmlModelExploreField,
+    LookmlModelExploreJoins,
+)
 
-from datahub.ingestion.source.looker.looker_common import ExploreUpstreamViewField
+from datahub.ingestion.source.looker.looker_common import (
+    ExploreUpstreamViewField,
+    LookerExplore,
+    LookerExploreJoin,
+)
 from datahub.ingestion.source.looker.looker_config import LookerCommonConfig
 
 
@@ -91,3 +99,63 @@ class TestExploreUpstreamViewFieldFormFieldName:
 
             assert result is None
             assert "Empty field name detected" in caplog.text
+
+
+class TestLookerExploreJoinReconstruction:
+    """Explore joins carry the relationship semantics needed to reconstruct the
+    semantic model. These tests cover capturing them and serializing them back
+    to LookML view logic."""
+
+    def test_from_api_join_captures_relationship_semantics(self):
+        join = LookerExploreJoin.from_api_join(
+            LookmlModelExploreJoins(
+                name="orders",
+                from_="orders_base",
+                sql_on="${orders.customer_id} = ${customers.id}",
+                relationship="many_to_one",
+                type="left_outer",
+                foreign_key="customer_id",
+            )
+        )
+        assert join is not None
+        assert join.name == "orders"
+        assert join.from_view == "orders_base"
+        assert join.sql_on == "${orders.customer_id} = ${customers.id}"
+        assert join.relationship == "many_to_one"
+        assert join.join_type == "left_outer"
+        assert join.foreign_key == "customer_id"
+
+    def test_from_lkml_join_reads_from_key(self):
+        join = LookerExploreJoin.from_lkml_join(
+            {"name": "orders", "from": "orders_base", "sql_on": "1=1"}
+        )
+        assert join is not None
+        assert join.from_view == "orders_base"
+        assert join.sql_on == "1=1"
+
+    def test_build_explore_view_logic_renders_joins(self):
+        explore = LookerExplore(
+            name="customer_orders",
+            model_name="ecommerce",
+            label="Customer Orders",
+            join_definitions=[
+                LookerExploreJoin(
+                    name="orders",
+                    sql_on="${orders.customer_id} = ${customers.id}",
+                    relationship="many_to_one",
+                    join_type="left_outer",
+                ),
+            ],
+        )
+        view_logic = explore._build_explore_view_logic()
+        assert view_logic is not None
+        assert "explore: customer_orders {" in view_logic
+        assert 'label: "Customer Orders"' in view_logic
+        assert "join: orders {" in view_logic
+        assert "type: left_outer" in view_logic
+        assert "relationship: many_to_one" in view_logic
+        assert "sql_on: ${orders.customer_id} = ${customers.id} ;;" in view_logic
+
+    def test_build_explore_view_logic_none_without_joins(self):
+        explore = LookerExplore(name="passthrough", model_name="ecommerce")
+        assert explore._build_explore_view_logic() is None

--- a/metadata-ingestion/tests/unit/looker/test_looker_common.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_common.py
@@ -159,3 +159,14 @@ class TestLookerExploreJoinReconstruction:
     def test_build_explore_view_logic_none_without_joins(self):
         explore = LookerExplore(name="passthrough", model_name="ecommerce")
         assert explore._build_explore_view_logic() is None
+
+    def test_build_explore_view_logic_escapes_label_quotes(self):
+        explore = LookerExplore(
+            name="customer_orders",
+            model_name="ecommerce",
+            label='My "Q3" Explore',
+            join_definitions=[LookerExploreJoin(name="orders")],
+        )
+        view_logic = explore._build_explore_view_logic()
+        assert view_logic is not None
+        assert r'label: "My \"Q3\" Explore"' in view_logic


### PR DESCRIPTION
## 📋 Summary

Capture Looker explore **join definitions** (relationship semantics) and emit them as the explore dataset's `viewProperties` (`viewLogic`), so the join graph is reconstructable from ingested metadata.

## 🎯 Motivation

Looker explore joins carry the relationship semantics — which view is joined, the `sql_on` condition, the cardinality (`relationship`), the join type, and the foreign key — that are needed to reconstruct an explore's semantic model.

Today, ingestion reads the Looker API's join objects only to derive **view membership** for lineage, then discards the join conditions. As a result, explore datasets are emitted with no record of *how* their views join: downstream consumers can see that views A and B are related, but not that they join `ON a.id = b.a_id` as `many_to_one`.

This change preserves that information so the join graph (the explore's semantic model) is reconstructable from ingested metadata, symmetric with how view datasets already store their raw LookML.

## 🔁 Old State vs New State

| | Old state (before) | New state (after) |
| --- | --- | --- |
| **Join conditions** (`sql_on`) | Read, used to derive view membership, then **discarded** | Captured and preserved |
| **Relationship / cardinality** (`many_to_one`, …) | Not captured | Captured |
| **Join type** (`left_outer`, `inner`, …) | Not captured | Captured |
| **Foreign key / `from` alias** | Not captured | Captured |
| **Explore dataset metadata** | Lineage edges to joined views only | Lineage edges **plus** a reconstructed LookML `explore { … }` block in `viewProperties.viewLogic` |
| **What a consumer can tell** | Views A and B are *related* | Views A and B join **`ON a.id = b.a_id` as `many_to_one`** |
| **Join-less explores** | No `viewProperties` | No `viewProperties` (**unchanged**) |

**Before** — explore dataset carried lineage edges but no record of *how* views join:

```text
upstreamLineage: [customers, orders]   # related, but join semantics lost
(no viewProperties aspect)
```

**After** — same lineage, plus the reconstructed join graph as view logic:

```lookml
explore: customer_orders {
  label: "Customer Orders"
  join: orders {
    type: left_outer
    relationship: many_to_one
    sql_on: ${orders.customer_id} = ${customers.id} ;;
  }
}
```

## 🔧 Changes Overview

**New Features:**
- New `LookerExploreJoin` structured representation holding `name`, `from_view`, `sql_on`, `relationship`, `join_type`, and `foreign_key`, with constructors for both the Looker API and LookML code paths and a serializer back to a LookML `join` block.
- Explore datasets that have joins now emit a reconstructed LookML `explore { ... join: ... }` block as `viewProperties.viewLogic` (`viewLanguage: lookml`).

**Modifications:**
- Both explore ingestion code paths (Looker API source and LookML source) now capture the structured joins in addition to the existing field-name extraction used for lineage. The existing lineage behavior is unchanged.
- Explores **without** joins are unaffected — no `viewProperties` aspect is emitted for them.

**Dependencies:** None.

## 🏗️ Architecture/Design Notes

- The new structured join capture is **additive and orthogonal** to the existing `joins` field (which only holds field names referenced in join conditions, retained for lineage). The two are kept distinct on purpose.
- The reconstructed LookML is stored in the standard `ViewProperties` aspect (`viewLogic`/`viewLanguage`), mirroring the existing convention for view datasets — no new aspect or model change is introduced.
- The Looker API does not expose an explore's source file the way it does for views, which is why the join relationships are serialized into view logic here rather than read from a file.

## 🧪 Testing

- **Unit tests** (`tests/unit/looker/test_looker_common.py`): cover capturing joins from both the API and LookML inputs, the LookML serialization, and the no-joins → `None` case.
- **Integration goldens**: `golden_test_ingest_joins.json` and `golden_test_ingest_unaliased_joins.json` updated with the additive `viewProperties` only.
- **Live ingestion smoke test**: ran end-to-end ingestion against a real Looker instance with a file sink; explore datasets correctly emitted reconstructed `viewProperties` with `join:` blocks and their `sql_on` / `relationship` / `type` rendered as expected.
- `ruff` + `mypy` clean on changed files (via Gradle lint).

## 📊 Impact Assessment

- **Affected Components:** Looker/LookML ingestion source (`metadata-ingestion`) only.
- **Breaking Changes:** None. The change is purely additive — a new aspect on explores that have joins; join-less explores are byte-for-byte unchanged.
- **Performance Impact:** Negligible — joins are already iterated for lineage; this reuses that pass.
- **Risk Level:** Low. No model/schema changes, no new dependencies, existing lineage behavior untouched.

## 🚀 Deployment Notes

None — no configuration, migrations, or feature flags required.

## 🔗 References

- Docs: [Looker entity reference](https://datahubproject.io/docs/generated/ingestion/sources/looker)

## ❓ Questions for Reviewers

- The reconstructed `explore` block omits params we don't currently capture (e.g. only `join`-level fields are serialized). If there's appetite for capturing additional explore-level params in `viewLogic`, happy to follow up in a separate PR.
