### PR TITLE
fix(ingest/spark): restore Java 17 bytecode for the agent shadow jar (regressed by the Java 21 migration)

### DIFF
--- a/.github/workflows/spark-smoke-test.yml
+++ b/.github/workflows/spark-smoke-test.yml
@@ -29,6 +29,10 @@ concurrency:
 jobs:
   spark-smoke-test:
     runs-on: ubuntu-latest
+    # Fail fast instead of hanging toward the 6h default: the docker-based smoke test (quickstart +
+    # Spark image build + spark-submit) has stalled for >1h on flaky network fetches during image
+    # builds. A bounded timeout turns such stalls into a quick, actionable red.
+    timeout-minutes: 60
     steps:
       - uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
       - name: Set up JDK 21

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,16 @@ buildscript {
       : ext.jdkVersionDefault
   }
 
-  // Main bytecode version selector
+  // Main bytecode version selector.
+  // A per-module ext.javaClassVersionOverride takes precedence over the global default: it lets the
+  // modules bundled into the acryl-spark-lineage agent shadow jar pin Java 17 bytecode so the agent
+  // runs on managed Spark whose default JVM is Java 17 (Amazon EMR 7.x, Databricks Runtime 16-17),
+  // while the rest of the repo targets 21. (javaClassVersionDefault is always present via
+  // gradle.properties, so the override must be checked first.)
   ext.javaClassVersion = { p ->
+    if (p.hasProperty('javaClassVersionOverride')) {
+      return Integer.valueOf(String.valueOf(p.getProperty('javaClassVersionOverride')))
+    }
     return p.hasProperty('javaClassVersionDefault')
       ? Integer.valueOf((String) p.getProperty('javaClassVersionDefault'))
       : ext.javaClassVersionDefault

--- a/entity-registry/build.gradle
+++ b/entity-registry/build.gradle
@@ -6,6 +6,10 @@ plugins {
 
 apply from: "../gradle/coverage/java-coverage.gradle"
 
+// Pin Java 17 bytecode: bundled into the acryl-spark-lineage agent shadow jar, which must run on
+// managed Spark whose default JVM is Java 17 (Amazon EMR 7.x, Databricks Runtime 16-17).
+ext.javaClassVersionOverride = 17
+
 dependencies {
   implementation spec.product.pegasus.data
   compileOnly spec.product.pegasus.generator

--- a/entity-registry/src/main/java/com/linkedin/metadata/graph/cache/AncestorWalkResult.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/graph/cache/AncestorWalkResult.java
@@ -23,10 +23,10 @@ public sealed interface AncestorWalkResult {
 
   @Nonnull
   default List<String> ancestorsOrEmpty() {
-    return switch (this) {
-      case Hit hit -> hit.ancestors();
-      case Miss miss -> Collections.emptyList();
-    };
+    if (this instanceof Hit hit) {
+      return hit.ancestors();
+    }
+    return Collections.emptyList();
   }
 
   default boolean isHit() {

--- a/entity-registry/src/main/java/com/linkedin/metadata/graph/cache/GraphReadResult.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/graph/cache/GraphReadResult.java
@@ -33,11 +33,12 @@ public sealed interface GraphReadResult {
    */
   @Nonnull
   default Set<String> verticesOrEmpty() {
-    return switch (this) {
-      case Hit hit -> hit.vertices();
-      case EmptyHit emptyHit -> emptyHit.vertices();
-      case Miss miss -> Collections.emptySet();
-    };
+    if (this instanceof Hit hit) {
+      return hit.vertices();
+    } else if (this instanceof EmptyHit emptyHit) {
+      return emptyHit.vertices();
+    }
+    return Collections.emptySet();
   }
 
   default boolean isHit() {

--- a/entity-registry/src/main/java/com/linkedin/metadata/graph/cache/MembershipNeighborResult.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/graph/cache/MembershipNeighborResult.java
@@ -34,9 +34,9 @@ public sealed interface MembershipNeighborResult {
 
   @Nonnull
   default List<Neighbor> neighborsOrEmpty() {
-    return switch (this) {
-      case Hit hit -> hit.neighbors();
-      case Miss miss -> Collections.emptyList();
-    };
+    if (this instanceof Hit hit) {
+      return hit.neighbors();
+    }
+    return Collections.emptyList();
   }
 }

--- a/li-utils/build.gradle
+++ b/li-utils/build.gradle
@@ -8,6 +8,10 @@ apply from: "../gradle/coverage/java-coverage.gradle"
 // Apply shared Pegasus model index generation
 apply from: '../gradle/schema/pegasus-models-index.gradle'
 
+// Pin Java 17 bytecode: bundled into the acryl-spark-lineage agent shadow jar, which must run on
+// managed Spark whose default JVM is Java 17 (Amazon EMR 7.x, Databricks Runtime 16-17).
+ext.javaClassVersionOverride = 17
+
 dependencies {
     api spec.product.pegasus.data
     implementation(externalDependency.reflections) {

--- a/metadata-integration/java/acryl-spark-lineage/README.md
+++ b/metadata-integration/java/acryl-spark-lineage/README.md
@@ -399,12 +399,26 @@ log4j.logger.datahub.spark=DEBUG
 log4j.logger.datahub.client.rest=DEBUG
 ```
 
+## Runtime requirements
+
+The agent shadow jar is compiled to **Java 17 bytecode**, so it requires a Spark cluster running
+**Java 17 or newer**. This matches the current defaults of the major managed Spark platforms:
+
+- Amazon EMR 7.x (Java 17)
+- Databricks Runtime 16.4 LTS / 17.3 LTS and newer (Java 17; 18+ is Java 21)
+- Dataproc Serverless 2.x / 3.0 and Dataproc on GCE image 3.0
+- Microsoft Fabric runtime 2.0
+
+Java 8 and Java 11 runtimes are **not supported** (e.g. EMR 6.x, Databricks ≤ 15.4 LTS, AWS Glue
+≤ 4.0, Dataproc on GCE images 2.1–2.3, Microsoft Fabric 1.3). Run the agent on a Java 17+ runtime.
+
 ## How to build
 
-Use Java 8 to build the project. The project uses Gradle as the build tool. To build the project, run the following command:
+The build uses Gradle (the JDK 21 toolchain is provisioned automatically) and produces the Java
+17-bytecode shadow jar:
 
 ```shell
-./gradlew -PjavaClassVersionDefault=8 :metadata-integration:java:acryl-spark-lineage:shadowJar
+./gradlew :metadata-integration:java:acryl-spark-lineage:shadowJar
 ```
 
 ## Known limitations

--- a/metadata-integration/java/acryl-spark-lineage/build.gradle
+++ b/metadata-integration/java/acryl-spark-lineage/build.gradle
@@ -9,6 +9,11 @@ apply plugin: 'maven-publish'
 apply from: '../../../gradle/coverage/java-coverage.gradle'
 apply from: '../versioning.gradle'
 
+// Pin Java 17 bytecode: this agent shadow jar (and the modules it bundles) must run on managed
+// Spark whose default JVM is Java 17 (Amazon EMR 7.x, Databricks Runtime 16-17). The rest of the
+// repo targets Java 21; the bundled dependency chain is pinned to 17 via ext.javaClassVersionOverride.
+ext.javaClassVersionOverride = 17
+
 jar.enabled = false // Since we only want to build shadow jars, disabling the regular jar creation
 
 // Define supported Scala versions - always build for both

--- a/metadata-integration/java/acryl-spark-lineage/spark-smoke-test/docker/SparkBase.Dockerfile
+++ b/metadata-integration/java/acryl-spark-lineage/spark-smoke-test/docker/SparkBase.Dockerfile
@@ -7,13 +7,14 @@ ENV SHARED_WORKSPACE=${shared_workspace}
 
 # -- Layer: Apache Spark
 
-ARG spark_version=3.5.0
+ARG spark_version=3.5.8
 ARG hadoop_version=3
 
 # Common curl options for all downloads: fail on HTTP errors, follow redirects, and — critically —
 # bound every fetch with connect/overall timeouts and retries. Without these, a stalled download
-# (notably the Spark tarball from the throttled archive.apache.org host) hangs the build with no
-# output until the CI job's global timeout, instead of failing fast and retrying.
+# hangs the build with no output until the CI job's global timeout, instead of failing fast and
+# retrying. The Spark tarball is pulled from the fast CDN (dlcdn.apache.org) first, falling back to
+# archive.apache.org — dlcdn only keeps active patch releases, so keep spark_version current.
 ARG CURL_OPTS="--fail --location --show-error --connect-timeout 30 --retry 5 --retry-all-errors --retry-delay 10"
 
 RUN apt-get update -y && \
@@ -26,7 +27,8 @@ RUN apt-get update -y && \
 #    apt-cache search zulu && \
     apt-get install -y --no-install-recommends zulu21-jdk ant && \
     apt-get clean && \
-    curl -sS ${CURL_OPTS} --max-time 1800 https://archive.apache.org/dist/spark/spark-${spark_version}/spark-${spark_version}-bin-hadoop${hadoop_version}.tgz -o spark.tgz && \
+    { curl -sS ${CURL_OPTS} --max-time 1800 https://dlcdn.apache.org/spark/spark-${spark_version}/spark-${spark_version}-bin-hadoop${hadoop_version}.tgz -o spark.tgz || \
+      curl -sS ${CURL_OPTS} --max-time 1800 https://archive.apache.org/dist/spark/spark-${spark_version}/spark-${spark_version}-bin-hadoop${hadoop_version}.tgz -o spark.tgz ; } && \
     tar -xf spark.tgz && \
     mv spark-${spark_version}-bin-hadoop${hadoop_version} /usr/bin/ && \
     mkdir /usr/bin/spark-${spark_version}-bin-hadoop${hadoop_version}/logs && \

--- a/metadata-integration/java/acryl-spark-lineage/spark-smoke-test/docker/SparkBase.Dockerfile
+++ b/metadata-integration/java/acryl-spark-lineage/spark-smoke-test/docker/SparkBase.Dockerfile
@@ -10,17 +10,23 @@ ENV SHARED_WORKSPACE=${shared_workspace}
 ARG spark_version=3.5.0
 ARG hadoop_version=3
 
+# Common curl options for all downloads: fail on HTTP errors, follow redirects, and — critically —
+# bound every fetch with connect/overall timeouts and retries. Without these, a stalled download
+# (notably the Spark tarball from the throttled archive.apache.org host) hangs the build with no
+# output until the CI job's global timeout, instead of failing fast and retrying.
+ARG CURL_OPTS="--fail --location --show-error --connect-timeout 30 --retry 5 --retry-all-errors --retry-delay 10"
+
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends curl gnupg && \
-    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    curl -sS ${CURL_OPTS} --max-time 120 https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | tee /etc/apt/sources.list.d/zulu.list && \
-    curl https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb -o /tmp/zulu-repo_1.0.0-3_all.deb && \
+    curl -sS ${CURL_OPTS} --max-time 300 https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb -o /tmp/zulu-repo_1.0.0-3_all.deb && \
     apt-get install /tmp/zulu-repo_1.0.0-3_all.deb && \
     apt-get update && \
 #    apt-cache search zulu && \
     apt-get install -y --no-install-recommends zulu21-jdk ant && \
     apt-get clean && \
-    curl -sS https://archive.apache.org/dist/spark/spark-${spark_version}/spark-${spark_version}-bin-hadoop${hadoop_version}.tgz -o spark.tgz && \
+    curl -sS ${CURL_OPTS} --max-time 1800 https://archive.apache.org/dist/spark/spark-${spark_version}/spark-${spark_version}-bin-hadoop${hadoop_version}.tgz -o spark.tgz && \
     tar -xf spark.tgz && \
     mv spark-${spark_version}-bin-hadoop${hadoop_version} /usr/bin/ && \
     mkdir /usr/bin/spark-${spark_version}-bin-hadoop${hadoop_version}/logs && \

--- a/metadata-integration/java/datahub-client/build.gradle
+++ b/metadata-integration/java/datahub-client/build.gradle
@@ -11,6 +11,10 @@ apply from: "../../../gradle/coverage/java-coverage.gradle"
 apply from: "../versioning.gradle"
 import org.apache.tools.ant.filters.ReplaceTokens
 
+// Pin Java 17 bytecode: bundled into the acryl-spark-lineage agent shadow jar, which must run on
+// managed Spark whose default JVM is Java 17 (Amazon EMR 7.x, Databricks Runtime 16-17).
+ext.javaClassVersionOverride = 17
+
 
 jar {
   if (project.hasProperty('archiveAppendix')) {

--- a/metadata-integration/java/datahub-event/build.gradle
+++ b/metadata-integration/java/datahub-event/build.gradle
@@ -10,6 +10,10 @@ plugins {
 apply from: "../../../gradle/coverage/java-coverage.gradle"
 apply from: "../versioning.gradle"
 
+// Pin Java 17 bytecode: bundled into the acryl-spark-lineage agent shadow jar, which must run on
+// managed Spark whose default JVM is Java 17 (Amazon EMR 7.x, Databricks Runtime 16-17).
+ext.javaClassVersionOverride = 17
+
 dependencies {
   implementation project(':metadata-models')
   implementation project(path: ':metadata-models', configuration: "dataTemplate")

--- a/metadata-integration/java/datahub-schematron/lib/build.gradle
+++ b/metadata-integration/java/datahub-schematron/lib/build.gradle
@@ -8,6 +8,10 @@ apply plugin: 'io.codearte.nexus-staging'
 apply plugin: 'maven-publish'
 apply from: '../../versioning.gradle'
 
+// Pin Java 17 bytecode: bundled into the acryl-spark-lineage agent shadow jar, which must run on
+// managed Spark whose default JVM is Java 17 (Amazon EMR 7.x, Databricks Runtime 16-17).
+ext.javaClassVersionOverride = 17
+
 dependencies {
 
     implementation project(':entity-registry')

--- a/metadata-integration/java/openlineage-converter/build.gradle
+++ b/metadata-integration/java/openlineage-converter/build.gradle
@@ -5,6 +5,10 @@ apply plugin: 'maven-publish'
 apply from: '../../../gradle/coverage/java-coverage.gradle'
 apply from: '../versioning.gradle'
 
+// Pin Java 17 bytecode: bundled into the acryl-spark-lineage agent shadow jar, which must run on
+// managed Spark whose default JVM is Java 17 (Amazon EMR 7.x, Databricks Runtime 16-17).
+ext.javaClassVersionOverride = 17
+
 dependencies {
     implementation project(path: ':entity-registry')
     implementation project(path: ':metadata-integration:java:datahub-event')

--- a/metadata-models/build.gradle
+++ b/metadata-models/build.gradle
@@ -10,6 +10,10 @@ apply from: '../gradle/coverage/java-coverage.gradle'
 // Apply shared Pegasus model index generation
 apply from: '../gradle/schema/pegasus-models-index.gradle'
 
+// Pin Java 17 bytecode: bundled into the acryl-spark-lineage agent shadow jar, which must run on
+// managed Spark whose default JVM is Java 17 (Amazon EMR 7.x, Databricks Runtime 16-17).
+ext.javaClassVersionOverride = 17
+
 dependencies {
   constraints {
     implementation('org.apache.commons:commons-text:1.10.0') {


### PR DESCRIPTION
## Summary

The `acryl-spark-lineage` agent runs **inside customer Spark clusters**, whose default JVM today is **Java 17** on the dominant managed platforms — **Amazon EMR 7.x** (Corretto 17) and **Databricks Runtime 16–17.x LTS** (JDK 17). The repo-wide Java 17→21 toolchain migration made the agent's shadow jar **Java 21 bytecode**, so it now fails with `UnsupportedClassVersionError` on those runtimes. The previous `-PjavaClassVersionDefault=8` workaround is no longer usable (datahub-client dropped Java 8).

This keeps the agent — and every module bundled into its shadow jar — at **Java 17 bytecode**, while the rest of the repo (GMS/backend, which runs on your own Java 21) stays at 21. Java 17 bytecode loads fine on the Java 21 backend, so the shared modules are unaffected there.

## Changes

- **`build.gradle`**: `javaClassVersion()` now honors a per-module `ext.javaClassVersionOverride`, evaluated **before** the global default. (`javaClassVersionDefault` is always present via `gradle.properties`, so the override has to be checked first to take effect.)
- **Per-module pin** (`ext.javaClassVersionOverride = 17`) on exactly the modules the agent shadow jar bundles: `li-utils`, `metadata-models`, `entity-registry`, `datahub-event`, `datahub-schematron:lib`, `datahub-client`, `openlineage-converter`, `acryl-spark-lineage`.
- **`entity-registry`**: rewrite three Java 21 pattern-matching `switch` statements (`graph/cache/{AncestorWalkResult,GraphReadResult,MembershipNeighborResult}.java`) to Java 17 `instanceof` if-chains — the **only** Java 21 language features anywhere in the agent's bundled dependency chain. `sealed interface`/`record`/`instanceof` patterns are all Java 17-legal and are kept.

## Why per-module (not a global flag)

The published artifact must be Java 17 **by default**, not via a manual `-P` flag. Everything the shadow jar bundles must be ≤17 bytecode to load on a Java 17 JVM, so the pin covers the whole bundled chain; unrelated backend modules keep targeting Java 21.

## Testing

- Built `:acryl-spark-lineage:shadowJar_2_13` with **no `-P` flag** and confirmed the bundled classes are Java 17 bytecode (major version 61): the agent's own `DatahubSparkListener`, the pegasus module `metadata-models` (`ConfigEntitySpec`), and `entity-registry` (`GraphReadResult`).
- `:entity-registry:test` (537) and `:acryl-spark-lineage:test` (42) pass.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests pass for the touched modules; bytecode target verified
- [ ] No breaking changes — bytecode-target only; Java 17 classes run on the Java 21 backend

## Note

Complements #17947 (OpenLineage relocation for EMR/DataZone classpath coexistence): the relocation fixes the *collision*, this fixes the *bytecode runtime* — both are needed for the agent to actually run on EMR 7.x / Databricks 16–17.