### PR TITLE
fix(system-update): disable RestoreColumnLineageIndices and RestoreDbtSiblingsIndices by default

### DIFF
--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -1227,7 +1227,7 @@ systemUpdate:
     delayMs: ${BOOTSTRAP_SYSTEM_UPDATE_DASHBOARD_INFO_DELAY_MS:30000}
     limit: ${BOOTSTRAP_SYSTEM_UPDATE_DASHBOARD_INFO_CLL_LIMIT:0}
   restoreColumnLineageIndices:
-    enabled: ${RESTORE_COLUMN_LINEAGE_INDICES_ENABLED:true}
+    enabled: ${RESTORE_COLUMN_LINEAGE_INDICES_ENABLED:false}
   restoreFormInfoIndices:
     enabled: ${RESTORE_FORM_INFO_INDICES_ENABLED:true}
   restoreGlossaryIndices:
@@ -1324,7 +1324,7 @@ systemUpdate:
   ingestEntityTypes:
     enabled: ${SYSTEM_UPDATE_INGEST_ENTITY_TYPES_ENABLED:true}
   restoreDbtSiblingsIndices:
-    enabled: ${SYSTEM_UPDATE_RESTORE_DBT_SIBLINGS_INDICES_ENABLED:true}
+    enabled: ${SYSTEM_UPDATE_RESTORE_DBT_SIBLINGS_INDICES_ENABLED:false}
   ingestDefaultGlobalSettings:
     enabled: ${SYSTEM_UPDATE_INGEST_DEFAULT_GLOBAL_SETTINGS_ENABLED:true}
   ingestPolicies:


### PR DESCRIPTION
## Summary

Disables `RestoreColumnLineageIndices` and `RestoreDbtSiblingsIndices` non-blocking system-update steps by default (was `true`, now `false`).

**Single file change:** `metadata-service/configuration/src/main/resources/application.yaml`
- `RESTORE_COLUMN_LINEAGE_INDICES_ENABLED` default: `true` → `false`
- `SYSTEM_UPDATE_RESTORE_DBT_SIBLINGS_INDICES_ENABLED` default: `true` → `false`

## Why `false` is the correct default

### 1. The normal ingestion pipeline already handles indexing

When ingestion writes `upstreamLineage` aspects, the existing MAE consumer pipeline handles everything:
- `UpdateIndicesHook` → `UpdateIndicesService` processes aspects through `UpdateIndicesV2Strategy`/`V3Strategy` for search index updates on every MCL event
- `UpdateGraphIndicesService` builds graph edges on every UPDATE/DELETE MCL
- `SiblingAssociationHook` automatically creates dbt sibling aspects during MAE consumption (`siblings.enabled=true` by default)

These restore steps are **backfill-only utilities** — they re-emit `RESTATE` MCLs for historical data written before the side-effect logic existed. They are not correctness requirements for any active deployment with running ingestion.

### 2. The jobs are dangerous on large DBs

Both steps have serious implementation issues that make them risky to run by default:
- **Hardcoded `BATCH_SIZE = 1000`** — not configurable via env var or config
- **Zero inter-batch throttling** — no `batchDelayMs`, no `Thread.sleep()`, unlike other restore steps that extend `AbstractMCLStep`
- **Synchronous `f.get()` blocking** — waits for all 1000 async MCL futures to complete before the next batch, causing sustained DB pressure
- **Delete-on-failure URN behavior** — on any exception, the completion-tracking URN is deleted (`entityService.deleteUrn(upgradeUrn)`), so the job restarts from scratch on next GMS boot instead of staying in a failed state

For customers with heavy `upstreamLineage` data (e.g. BigQuery CLL extraction, large dbt deployments), running these jobs performs a full-table scan on `metadata_aspect_v2` with no throttle knob — a direct DB CPU spike risk on every GMS restart until they complete.

### 3. Zero customers currently override these flags

Exhaustive search of customer deployment configurations found no customer has ever set `RESTORE_COLUMN_LINEAGE_INDICES_ENABLED` or `SYSTEM_UPDATE_RESTORE_DBT_SIBLINGS_INDICES_ENABLED` to any value. All deployments run whatever the default is. Flipping to `false` is safe with no opt-out needed.

### 4. One-time operations don't belong in the default hot path

Once these jobs successfully complete, the completion URN persists in the DB and they become a no-op forever. But until they complete, they run on **every GMS restart** — every rolling deploy, every pod OOM restart, every config change. That's the wrong default behavior for a heavy backfill job.

## How to opt in

Operators who need to run these backfills (e.g. upgrading from a very old version with corrupted/missing indices) can explicitly enable them:

```yaml
# application.yaml override or env vars
RESTORE_COLUMN_LINEAGE_INDICES_ENABLED=true
SYSTEM_UPDATE_RESTORE_DBT_SIBLINGS_INDICES_ENABLED=true
```

## Follow-up (not in this PR)

Both steps should be refactored to extend `AbstractMCLStep` (like `ReindexChartInfoStep` already does), which would give them:
- Configurable `batchDelayMs` throttling
- Resumable progress via `lastUrn`
- Proper failed-state tracking instead of delete-on-failure

That refactor would make these safe to run by default again in the future. This PR is the immediate safety fix.

## Test plan
- [ ] Verify GMS starts cleanly with these flags unset (defaults to `false`, steps skipped)
- [ ] Verify GMS starts cleanly with `RESTORE_COLUMN_LINEAGE_INDICES_ENABLED=true` — step runs as before
- [ ] Verify GMS starts cleanly with `SYSTEM_UPDATE_RESTORE_DBT_SIBLINGS_INDICES_ENABLED=true` — step runs as before
- [ ] Confirm no regression in CLL display or dbt sibling linking for active ingestion (normal pipeline unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)