### PR TITLE
fix(policies): tolerate unknown policy type/state in list mapper

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/mappers/PolicyInfoPolicyMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/mappers/PolicyInfoPolicyMapper.java
@@ -21,11 +21,13 @@ import java.net.URISyntaxException;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Maps {@link com.linkedin.policy.DataHubPolicyInfo} to GraphQL {@link
  * com.linkedin.datahub.graphql.generated.Policy}.
  */
+@Slf4j
 public class PolicyInfoPolicyMapper implements ModelMapper<DataHubPolicyInfo, Policy> {
 
   public static final PolicyInfoPolicyMapper INSTANCE = new PolicyInfoPolicyMapper();
@@ -39,9 +41,12 @@ public class PolicyInfoPolicyMapper implements ModelMapper<DataHubPolicyInfo, Po
   public Policy apply(@Nullable QueryContext context, DataHubPolicyInfo info) {
     final Policy result = new Policy();
     result.setDescription(info.getDescription());
-    // Careful - we assume no other Policy types or states have been ingested using a backdoor.
-    result.setType(PolicyType.valueOf(info.getType()));
-    result.setState(PolicyState.valueOf(info.getState()));
+    // Type/state are free-form strings in the metadata model, so ingested or API-created policies
+    // can carry values outside these GraphQL enums. Fall back to a safe default rather than throw,
+    // so a single malformed policy does not fail the whole listPolicies request (which otherwise
+    // surfaces as "Failed to load policies!" on any page containing it).
+    result.setType(safeValueOf(PolicyType.class, info.getType(), PolicyType.METADATA));
+    result.setState(safeValueOf(PolicyState.class, info.getState(), PolicyState.INACTIVE));
     result.setName(info.getDisplayName()); // Rebrand to 'name'
     result.setPrivileges(info.getPrivileges());
     result.setActors(mapActors(info.getActors()));
@@ -50,6 +55,21 @@ public class PolicyInfoPolicyMapper implements ModelMapper<DataHubPolicyInfo, Po
       result.setResources(mapResources(context, info.getResources()));
     }
     return result;
+  }
+
+  @Nonnull
+  private static <T extends Enum<T>> T safeValueOf(
+      @Nonnull final Class<T> enumClass, @Nullable final String value, @Nonnull final T fallback) {
+    try {
+      return Enum.valueOf(enumClass, value);
+    } catch (IllegalArgumentException | NullPointerException e) {
+      log.warn(
+          "Unrecognized {} value '{}' on policy; defaulting to {}",
+          enumClass.getSimpleName(),
+          value,
+          fallback);
+      return fallback;
+    }
   }
 
   private ActorFilter mapActors(final DataHubActorFilter actorFilter) {

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/policy/mappers/PolicyInfoPolicyMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/policy/mappers/PolicyInfoPolicyMapperTest.java
@@ -1,0 +1,61 @@
+package com.linkedin.datahub.graphql.resolvers.policy.mappers;
+
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.data.template.StringArray;
+import com.linkedin.datahub.graphql.generated.Policy;
+import com.linkedin.datahub.graphql.generated.PolicyState;
+import com.linkedin.datahub.graphql.generated.PolicyType;
+import com.linkedin.policy.DataHubActorFilter;
+import com.linkedin.policy.DataHubPolicyInfo;
+import org.testng.annotations.Test;
+
+/**
+ * Guards against a single malformed policy taking down the entire {@code listPolicies} page.
+ *
+ * <p>{@link DataHubPolicyInfo#getType()} and {@link DataHubPolicyInfo#getState()} are free-form
+ * strings in the metadata model, so a policy created via ingestion / the API can carry a value that
+ * is not a member of the GraphQL {@link PolicyType} / {@link PolicyState} enums. An unguarded
+ * {@code Enum.valueOf} throws {@link IllegalArgumentException}, which fails the whole request and
+ * produces the UI's "Failed to load policies! An unexpected error occurred." on any page containing
+ * such a policy.
+ */
+public class PolicyInfoPolicyMapperTest {
+
+  private static DataHubPolicyInfo policyInfo(final String type, final String state) {
+    final DataHubPolicyInfo info = new DataHubPolicyInfo();
+    info.setDisplayName("My Policy");
+    info.setDescription("desc");
+    info.setType(type);
+    info.setState(state);
+    info.setPrivileges(new StringArray("EDIT_ENTITY_TAGS"));
+    info.setActors(new DataHubActorFilter().setAllUsers(true).setAllGroups(false));
+    info.setEditable(true);
+    return info;
+  }
+
+  @Test
+  public void testMapValidPolicy() {
+    final Policy result = PolicyInfoPolicyMapper.map(null, policyInfo("METADATA", "ACTIVE"));
+    assertEquals(result.getType(), PolicyType.METADATA);
+    assertEquals(result.getState(), PolicyState.ACTIVE);
+    assertEquals(result.getName(), "My Policy");
+  }
+
+  @Test
+  public void testUnknownStateFallsBackToInactive() {
+    // A state value not present in the GraphQL enum (e.g. ingested/backdoored data) must not throw.
+    final Policy result = PolicyInfoPolicyMapper.map(null, policyInfo("METADATA", "ENABLED"));
+    assertEquals(result.getState(), PolicyState.INACTIVE);
+    // The rest of the policy still maps so it stays visible/manageable in the UI.
+    assertEquals(result.getName(), "My Policy");
+    assertEquals(result.getType(), PolicyType.METADATA);
+  }
+
+  @Test
+  public void testUnknownTypeFallsBackToMetadata() {
+    final Policy result = PolicyInfoPolicyMapper.map(null, policyInfo("SUPERUSER", "ACTIVE"));
+    assertEquals(result.getType(), PolicyType.METADATA);
+    assertEquals(result.getState(), PolicyState.ACTIVE);
+  }
+}


### PR DESCRIPTION
## Summary

`PolicyInfoPolicyMapper` converts a policy's stored `type` and `state` to the GraphQL `PolicyType` / `PolicyState` enums with an unguarded `Enum.valueOf`:

```java
result.setType(PolicyType.valueOf(info.getType()));
result.setState(PolicyState.valueOf(info.getState()));
```

`DataHubPolicyInfo.type` and `.state` are free-form `string` fields in the metadata model, so a policy created via ingestion or the API can hold a value that is not a member of the GraphQL enum. In that case `valueOf` throws `IllegalArgumentException`, which is unhandled and fails the **entire** `listPolicies` request for any page that contains such a policy.

In the UI (Settings → Permissions → Policies) this appears as *"Failed to load policies! An unexpected error occurred."* — the first page of default/bootstrap policies loads fine, but later pages that contain the offending policy error out and render empty.

## Fix

Fall back to a safe default and log a warning instead of throwing, so one malformed policy no longer takes down the whole page (and the policy stays visible/manageable so an admin can correct or delete it):

- unknown `type` → `METADATA`
- unknown `state` → `INACTIVE`

This only affects the GraphQL read/mapping path; policy authorization enforcement reads `DataHubPolicyInfo` directly and is unaffected.

## Testing

New `PolicyInfoPolicyMapperTest` (written test-first): valid values map unchanged; an unknown `type`/`state` no longer throws and falls back to the default. 3 passing.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing#commit-message-format))
- [x] Links to related issues (if applicable) — n/a
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable) — n/a
- [ ] For any breaking changes, inform the DataHub team — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)