### PR TITLE
docs(managed-datahub): release notes for v2.0.1

### DIFF
--- a/docs/managed-datahub/release-notes/v_2_0_0.md
+++ b/docs/managed-datahub/release-notes/v_2_0_0.md
@@ -6,6 +6,66 @@ description: "DataHub Cloud v2.0.0 release notes — major release with Search V
 
 ## Release Changelog
 
+### v2.0.1
+
+This release rolls up hotfixes on top of v2.0.0.
+
+#### Release Availability Date
+
+02-July-2026
+
+**Recommended Versions**
+
+- **CLI/SDK**: 1.6.0.4
+- **Remote Executor**: v2.0.1-cloud, v1.1.3-cloud, v1.0.3-cloud
+- **Helm**: 1.6.173
+  - **API Gateway**: 0.7.3
+
+#### Product
+
+- **Change History sidebar and documentation diffs** — a clock-icon button on the entity profile version picker opens a timeline drawer showing documentation, tag, ownership, schema, and version-milestone changes for the current or all versions of an entity. Documentation changes render as collapsible diffs.
+- **Timeline API for versioned entities** — the timeline API can now return the change history of a versioned entity (currently Glossary Term) scoped to a single version or unified across the entire version set.
+
+#### AI / Ask DataHub
+
+- **SQL-context MCP tools share a single rollout flag.** `find_sql_context` and `draft_sql_for_tables` are now gated behind one `ENABLE_SQL_CONTEXT_TOOLS` flag (default off) so they roll out together; `generate_sql_sketch` keeps its own separate flag.
+
+#### Platform
+
+- **Actor-scoped policy authorization.** Session-scoped actor identity now flows through authorization checks, and resource resolution for a request is cached and resolved once per authorization request instead of repeatedly.
+- **Faster semantic-search bridge-document backfill.** The backfill now writes a single full-document index update per bridge URN instead of per-aspect writes, batched with bounded parallelism — large-scale dataset semantic-search backfills now complete instead of stalling at production scale.
+
+#### Breaking Changes
+
+- **Linking a physical dataset to a logical parent now requires Edit Entity on both datasets** (datahub-project/datahub#17904). Previously enforcement only checked the child dataset. Creating or changing a `logicalParent` link now also requires **Edit Entity** on the proposed parent dataset; clearing a logical parent still only requires **Edit Entity** on the child. **Action:** grant **Edit Entity** on logical-parent datasets to principals who create or change these links, or update policies so those operations continue to succeed.
+
+#### Security / Dependencies
+
+- **Netty**: bumped to 4.2.15.Final to address CVE-2026-47691.
+- **Jackson databind**: bumped to 2.21.4 to address CVE-2026-54512 / CVE-2026-54513.
+- **Apache Shiro**: bumped to 2.2.1 to address CVE-2026-49268.
+- **PyJWT**: bumped to 2.13.0 to address GHSA-xgmm-8j9v-c9wx.
+- **redshift-connector**: bumped to >=2.1.14 to address CVE-2026-8838.
+- Routine dependency refresh: spring-kafka, jline, cryptography, pyOpenSSL.
+
+#### Bug Fixes
+
+- Fixed a prompt-caching regression from v2.0.0 where Ask DataHub's system prompt included a sub-hour timestamp, invalidating the model provider's cache on every turn.
+- Fixed mTLS certificates not reliably reloading on rotation.
+- Fixed the Settings → Roles page crashing when a role's policy list contained a non-policy entity.
+- Restored workflow form submission on deployments still running v1 Action Workflows.
+- Fixed the "(0)" count incorrectly showing on the More filters dropdown when no filters are selected.
+- Fixed policies using a `NOT_EQUALS` condition returning an error when view-based authorization is enabled.
+- Fixed nested column stats not appearing for BigQuery datasets with lowercased field paths.
+- Fixed incorrect links in translated (i18n) UI text.
+- Allowed `EDIT_ENTITY_TAGS` to be used for tag writes via the REST API.
+- Restored the homepage's MCP page templates to their pre-v2.0.0 layout after a regression.
+- Restored DELTA-bounds anchoring for smart-assertion evaluation and fixed executor timeseries queries sending invalid time-range filters.
+
+#### Environment Variables
+
+- `ENABLE_SQL_CONTEXT_TOOLS` (default `false`): replaces the separate `FIND_SQL_CONTEXT_TOOL` / `DRAFT_SQL_FOR_TABLES_TOOL` gates — enables `find_sql_context` and `draft_sql_for_tables` together. `generate_sql_sketch` keeps its own `GENERATE_SQL_SKETCH_TOOL` gate, unaffected.
+
 ### v2.0.0
 
 #### Release Availability Date


### PR DESCRIPTION
DataHub Cloud v2.0.1 release notes.

See the added block under `docs/managed-datahub/release-notes/v_2_0_0.md`.

## Test plan
- [ ] `markdown_format / markdown_format_check (pull_request)` passes
- [ ] Release Availability Date and Recommended Versions filled in before marking ready