### PR TITLE
fix(roles): exclude non-policy entities from role policies list

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolver.java
@@ -450,7 +450,8 @@ public class EntityRelationshipsResultResolver
         context,
         entityRelationships,
         RelationshipDirection.valueOf(relationshipDirection.toString()),
-        includeSoftDelete);
+        includeSoftDelete,
+        null);
   }
 
   private EntityRelationshipsResult mapDomainChildRelationships(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolver.java
@@ -108,6 +108,8 @@ public class EntityRelationshipsResultResolver
     final RelationshipDirection resolvedDirection =
         RelationshipDirection.valueOf(relationshipDirection.toString());
     final boolean includeSoftDelete = input.getIncludeSoftDelete();
+    final Set<String> relatedEntityTypes =
+        input.getRelatedEntityTypes() == null ? null : new HashSet<>(input.getRelatedEntityTypes());
 
     if (isDomainDirectChildDomainsQuery(urn, relationshipTypes, resolvedDirection)) {
       return GraphQLConcurrencyUtils.supplyAsync(
@@ -174,7 +176,8 @@ public class EntityRelationshipsResultResolver
                 fetchEntityRelationships(
                     urn, relationshipTypes, resolvedDirection, start, count, context.getActorUrn()),
                 resolvedDirection,
-                includeSoftDelete),
+                includeSoftDelete,
+                relatedEntityTypes),
         this.getClass().getSimpleName(),
         "get");
   }
@@ -582,7 +585,8 @@ public class EntityRelationshipsResultResolver
       @Nullable final QueryContext context,
       final EntityRelationships entityRelationships,
       final RelationshipDirection relationshipDirection,
-      final boolean includeSoftDelete) {
+      final boolean includeSoftDelete,
+      @Nullable final Set<String> relatedEntityTypes) {
     final EntityRelationshipsResult result = new EntityRelationshipsResult();
 
     final Set<Urn> existentUrns;
@@ -601,6 +605,8 @@ public class EntityRelationshipsResultResolver
             .filter(
                 rel ->
                     (existentUrns == null || existentUrns.contains(rel.getEntity()))
+                        && (relatedEntityTypes == null
+                            || relatedEntityTypes.contains(rel.getEntity().getEntityType()))
                         && (context == null
                             || canView(context.getOperationContext(), rel.getEntity())))
             .collect(Collectors.toList());

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -1484,6 +1484,17 @@ input RelationshipsInput {
   Whether to include soft-deleted, related, entities
   """
   includeSoftDelete: Boolean = true
+
+  """
+  Optional filter restricting the related entities to the given entity-registry
+  entity names (e.g. "dataHubPolicy"). When omitted, related entities of all
+  types are returned. Use this when a relationship name is shared across
+  multiple source aspects and the caller only wants one entity type — for
+  example, IsAssociatedWithRole is emitted toward a role by both policy actor
+  filters and the global-settings maintenance-window audience, so a caller
+  fetching a role's policies passes ["dataHubPolicy"] to exclude the rest.
+  """
+  relatedEntityTypes: [String!]
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
@@ -147,6 +147,28 @@ public class EntityRelationshipsResultResolverTest {
   }
 
   @Test
+  public void testFilterByRelatedEntityTypesExcludesNonMatching()
+      throws ExecutionException, InterruptedException {
+    // The graph returns corpuser relationships; restricting to dataHubPolicy should drop them all.
+    // This mirrors the role "policies" query, where IsAssociatedWithRole edges from non-policy
+    // sources (e.g. global settings) must be excluded.
+    input.setRelatedEntityTypes(List.of("dataHubPolicy"));
+    EntityRelationshipsResult result = resolver.get(mockEnv).get();
+    assertTrue(result.getRelationships().isEmpty());
+    assertEquals(result.getCount().intValue(), 0);
+    assertEquals(result.getTotal().intValue(), 0);
+  }
+
+  @Test
+  public void testFilterByRelatedEntityTypesKeepsMatching()
+      throws ExecutionException, InterruptedException {
+    input.setRelatedEntityTypes(List.of("corpuser"));
+    EntityRelationshipsResult result = resolver.get(mockEnv).get();
+    assertEquals(result.getCount().intValue(), 2);
+    assertEquals(result.getRelationships().size(), 2);
+  }
+
+  @Test
   public void testResolverWithGraphClientOnlyUsesNullEntityService()
       throws ExecutionException, InterruptedException {
     EntityRelationshipsResultResolver resolverGraphOnly =

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
@@ -168,6 +168,106 @@ public class EntityRelationshipsResultResolverTest {
     assertEquals(result.getRelationships().size(), 2);
   }
 
+  /**
+   * Reproduces the Settings → Roles page crash. A role's {@code policies} are its incoming {@code
+   * IsAssociatedWithRole} edges, but that relationship name is shared: it is emitted toward a role
+   * by both policy actor filters ({@code DataHubPolicyInfo.actors}) and the global-settings
+   * maintenance-window audience ({@code GlobalSettingsInfo.maintenanceWindow.audience}), since both
+   * embed {@code DataHubActorFilter.roles}. So when an admin scopes a maintenance window to the
+   * Admin role, that role's edge set legitimately contains a {@code globalSettings} source mixed in
+   * with real {@code dataHubPolicy} sources. {@code UrnToEntityMapper} has no case for {@code
+   * globalSettings}, so under the {@code ... on DataHubPolicy} fragment it resolves to a null
+   * entity, and the frontend crashed dereferencing {@code .urn}. The {@code relatedEntityTypes:
+   * ["dataHubPolicy"]} filter must drop the {@code globalSettings} edge server-side while keeping
+   * the real policy.
+   */
+  @Test
+  public void testRolePoliciesExcludeMaintenanceWindowGlobalSettingsEdge()
+      throws ExecutionException, InterruptedException, URISyntaxException {
+    final Urn roleUrn = Urn.createFromString("urn:li:dataHubRole:Admin");
+    final Urn policyUrn = Urn.createFromString("urn:li:dataHubPolicy:test-policy");
+    final Urn globalSettingsUrn = Urn.createFromString("urn:li:globalSettings:0");
+
+    CorpGroup source = new CorpGroup();
+    source.setUrn(roleUrn.toString());
+    when(mockEnv.getSource()).thenReturn(source);
+
+    EntityRelationships roleEdges =
+        new EntityRelationships()
+            .setStart(0)
+            .setCount(2)
+            .setTotal(2)
+            .setRelationships(
+                new EntityRelationshipArray(
+                    new EntityRelationship().setEntity(policyUrn).setType("IsAssociatedWithRole"),
+                    new EntityRelationship()
+                        .setEntity(globalSettingsUrn)
+                        .setType("IsAssociatedWithRole")));
+    when(_graphClient.getRelatedEntities(eq(roleUrn.toString()), any(), any(), any(), any(), any()))
+        .thenReturn(roleEdges);
+
+    RelationshipsInput rolePoliciesInput = new RelationshipsInput();
+    rolePoliciesInput.setStart(0);
+    rolePoliciesInput.setCount(50);
+    rolePoliciesInput.setDirection(RelationshipDirection.INCOMING);
+    rolePoliciesInput.setTypes(List.of("IsAssociatedWithRole"));
+    rolePoliciesInput.setRelatedEntityTypes(List.of("dataHubPolicy"));
+    when(mockEnv.getArgument(eq("input"))).thenReturn(rolePoliciesInput);
+
+    EntityRelationshipsResult result = resolver.get(mockEnv).get();
+
+    assertEquals(result.getRelationships().size(), 1);
+    assertEquals(result.getRelationships().get(0).getEntity().getUrn(), policyUrn.toString());
+    assertEquals(result.getCount().intValue(), 1);
+    assertEquals(result.getTotal().intValue(), 1);
+  }
+
+  /**
+   * Without the {@code relatedEntityTypes} filter, the {@code globalSettings} maintenance-window
+   * edge survives into the result and resolves to a null entity (no {@code globalSettings} case in
+   * {@code UrnToEntityMapper}) — the exact precondition that crashed the Roles page. This guards
+   * against the filter being removed and the crash regressing.
+   */
+  @Test
+  public void testRolePoliciesWithoutFilterLeaksNullGlobalSettingsEntity()
+      throws ExecutionException, InterruptedException, URISyntaxException {
+    final Urn roleUrn = Urn.createFromString("urn:li:dataHubRole:Admin");
+    final Urn policyUrn = Urn.createFromString("urn:li:dataHubPolicy:test-policy");
+    final Urn globalSettingsUrn = Urn.createFromString("urn:li:globalSettings:0");
+
+    CorpGroup source = new CorpGroup();
+    source.setUrn(roleUrn.toString());
+    when(mockEnv.getSource()).thenReturn(source);
+
+    EntityRelationships roleEdges =
+        new EntityRelationships()
+            .setStart(0)
+            .setCount(2)
+            .setTotal(2)
+            .setRelationships(
+                new EntityRelationshipArray(
+                    new EntityRelationship().setEntity(policyUrn).setType("IsAssociatedWithRole"),
+                    new EntityRelationship()
+                        .setEntity(globalSettingsUrn)
+                        .setType("IsAssociatedWithRole")));
+    when(_graphClient.getRelatedEntities(eq(roleUrn.toString()), any(), any(), any(), any(), any()))
+        .thenReturn(roleEdges);
+
+    RelationshipsInput unfilteredInput = new RelationshipsInput();
+    unfilteredInput.setStart(0);
+    unfilteredInput.setCount(50);
+    unfilteredInput.setDirection(RelationshipDirection.INCOMING);
+    unfilteredInput.setTypes(List.of("IsAssociatedWithRole"));
+    when(mockEnv.getArgument(eq("input"))).thenReturn(unfilteredInput);
+
+    EntityRelationshipsResult result = resolver.get(mockEnv).get();
+
+    assertEquals(result.getRelationships().size(), 2);
+    assertTrue(
+        result.getRelationships().stream().anyMatch(rel -> rel.getEntity() == null),
+        "globalSettings edge should resolve to a null entity without the filter");
+  }
+
   @Test
   public void testResolverWithGraphClientOnlyUsesNullEntityService()
       throws ExecutionException, InterruptedException {

--- a/datahub-web-react/src/app/permissions/roles/ManageRoles.tsx
+++ b/datahub-web-react/src/app/permissions/roles/ManageRoles.tsx
@@ -14,12 +14,13 @@ import { clearUserListCache } from '@app/identity/user/cacheUtils';
 import { OnboardingTour } from '@app/onboarding/OnboardingTour';
 import { ROLES_INTRO_ID } from '@app/onboarding/config/RolesOnboardingConfig';
 import RoleDetailsModal from '@app/permissions/roles/RoleDetailsModal';
+import { getRolePolicies } from '@app/permissions/roles/roles.utils';
 import { ToastType, showToastMessage } from '@app/sharedV2/toastMessageUtils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { useBatchAssignRoleMutation } from '@graphql/mutations.generated';
 import { useListRolesQuery } from '@graphql/role.generated';
-import { CorpUser, DataHubPolicy, DataHubRole, EntityType } from '@types';
+import { CorpUser, DataHubRole, EntityType } from '@types';
 
 const TableScrollContainer = styled.div`
     flex: 1;
@@ -278,7 +279,7 @@ export const ManageRoles = () => {
         name: role?.name,
         users: role?.users?.relationships?.map((relationship) => relationship.entity as CorpUser),
         totalUsers: role?.users?.total || 0,
-        policies: role?.policies?.relationships?.map((relationship) => relationship.entity as DataHubPolicy),
+        policies: getRolePolicies(role),
     }));
 
     return (

--- a/datahub-web-react/src/app/permissions/roles/ManageRoles.tsx
+++ b/datahub-web-react/src/app/permissions/roles/ManageRoles.tsx
@@ -14,13 +14,13 @@ import { clearUserListCache } from '@app/identity/user/cacheUtils';
 import { OnboardingTour } from '@app/onboarding/OnboardingTour';
 import { ROLES_INTRO_ID } from '@app/onboarding/config/RolesOnboardingConfig';
 import RoleDetailsModal from '@app/permissions/roles/RoleDetailsModal';
-import { getRolePolicies } from '@app/permissions/roles/roles.utils';
+import { getRolePolicies, getRoleUsers } from '@app/permissions/roles/roles.utils';
 import { ToastType, showToastMessage } from '@app/sharedV2/toastMessageUtils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { useBatchAssignRoleMutation } from '@graphql/mutations.generated';
 import { useListRolesQuery } from '@graphql/role.generated';
-import { CorpUser, DataHubRole, EntityType } from '@types';
+import { DataHubRole, EntityType } from '@types';
 
 const TableScrollContainer = styled.div`
     flex: 1;
@@ -277,7 +277,7 @@ export const ManageRoles = () => {
         type: role?.type,
         description: role?.description,
         name: role?.name,
-        users: role?.users?.relationships?.map((relationship) => relationship.entity as CorpUser),
+        users: getRoleUsers(role),
         totalUsers: role?.users?.total || 0,
         policies: getRolePolicies(role),
     }));

--- a/datahub-web-react/src/app/permissions/roles/RoleDetailsModal.tsx
+++ b/datahub-web-react/src/app/permissions/roles/RoleDetailsModal.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 import { mapAvatarTypeToEntityType } from '@components/components/Avatar/utils';
 import { AvatarItemProps, AvatarType } from '@components/components/AvatarStack/types';
 
-import { getRolePolicies } from '@app/permissions/roles/roles.utils';
+import { getRolePolicies, getRoleUsers } from '@app/permissions/roles/roles.utils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { CorpUser, DataHubPolicy, DataHubRole, EntityType } from '@types';
@@ -40,9 +40,7 @@ export default function RoleDetailsModal({ role, open, onClose }: Props) {
     const { t } = useTranslation('settings.permissions');
     const entityRegistry = useEntityRegistry();
 
-    const castedRole = role as any;
-
-    const users: CorpUser[] = castedRole?.users?.relationships?.map((r) => r.entity as CorpUser) || [];
+    const users: CorpUser[] = getRoleUsers(role);
     const policies: DataHubPolicy[] = getRolePolicies(role);
 
     const allAvatars: AvatarItemProps[] = users.map((user) => {

--- a/datahub-web-react/src/app/permissions/roles/RoleDetailsModal.tsx
+++ b/datahub-web-react/src/app/permissions/roles/RoleDetailsModal.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import { mapAvatarTypeToEntityType } from '@components/components/Avatar/utils';
 import { AvatarItemProps, AvatarType } from '@components/components/AvatarStack/types';
 
+import { getRolePolicies } from '@app/permissions/roles/roles.utils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { CorpUser, DataHubPolicy, DataHubRole, EntityType } from '@types';
@@ -42,7 +43,7 @@ export default function RoleDetailsModal({ role, open, onClose }: Props) {
     const castedRole = role as any;
 
     const users: CorpUser[] = castedRole?.users?.relationships?.map((r) => r.entity as CorpUser) || [];
-    const policies: DataHubPolicy[] = castedRole?.policies?.relationships?.map((r) => r.entity as DataHubPolicy) || [];
+    const policies: DataHubPolicy[] = getRolePolicies(role);
 
     const allAvatars: AvatarItemProps[] = users.map((user) => {
         const isGroup = user?.urn?.startsWith('urn:li:corpGroup');

--- a/datahub-web-react/src/app/permissions/roles/__tests__/ManageRoles.test.tsx
+++ b/datahub-web-react/src/app/permissions/roles/__tests__/ManageRoles.test.tsx
@@ -1,0 +1,129 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ManageRoles } from '@app/permissions/roles/ManageRoles';
+import TestPageContainer from '@utils/test-utils/TestPageContainer';
+
+// useListRolesQuery is driven per-test; everything else keeps its real implementation.
+const mockUseListRolesQuery = vi.hoisted(() => vi.fn());
+
+vi.mock('@graphql/role.generated', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@graphql/role.generated')>();
+    return { ...actual, useListRolesQuery: (args: any) => mockUseListRolesQuery(args) };
+});
+
+vi.mock('@graphql/mutations.generated', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@graphql/mutations.generated')>();
+    return { ...actual, useBatchAssignRoleMutation: () => [vi.fn(), { client: {} }] };
+});
+
+// OnboardingTour pulls in unrelated onboarding context; stub it out for this render test.
+vi.mock('@app/onboarding/OnboardingTour', () => ({ OnboardingTour: () => null }));
+
+const PLATFORM_POLICY = {
+    urn: 'urn:li:dataHubPolicy:admin-platform-policy',
+    type: 'DATAHUB_POLICY',
+    name: 'Platform Policy',
+};
+const METADATA_POLICY = {
+    urn: 'urn:li:dataHubPolicy:admin-metadata-policy',
+    type: 'DATAHUB_POLICY',
+    name: 'Metadata Policy',
+};
+
+function adminRoleData(options: { policyRelationships?: any[]; userRelationships?: any[] }) {
+    const policyRelationships = options.policyRelationships ?? [];
+    const userRelationships = options.userRelationships ?? [];
+    return {
+        listRoles: {
+            start: 0,
+            count: 1,
+            total: 1,
+            roles: [
+                {
+                    urn: 'urn:li:dataHubRole:Admin',
+                    type: 'DATAHUB_ROLE',
+                    name: 'Admin',
+                    description: 'Admin role',
+                    users: {
+                        start: 0,
+                        count: userRelationships.length,
+                        total: userRelationships.length,
+                        relationships: userRelationships,
+                    },
+                    policies: {
+                        start: 0,
+                        count: policyRelationships.length,
+                        total: policyRelationships.length,
+                        relationships: policyRelationships,
+                    },
+                },
+            ],
+        },
+    };
+}
+
+function mockListRoles(data: any) {
+    mockUseListRolesQuery.mockReturnValue({ loading: false, error: undefined, data, refetch: vi.fn() });
+}
+
+function renderManageRoles() {
+    // MockedProvider supplies the Apollo client that TestPageContainer's context providers require;
+    // ManageRoles' own listRoles query is stubbed via the vi.mock above, so no GraphQL mocks are needed.
+    return render(
+        <MockedProvider mocks={[]} addTypename={false}>
+            <TestPageContainer>
+                <ManageRoles />
+            </TestPageContainer>
+        </MockedProvider>,
+    );
+}
+
+describe('ManageRoles', () => {
+    beforeEach(() => {
+        // The null-entity drop logs a defensive warning; silence it so it doesn't fail the run.
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        mockUseListRolesQuery.mockReset();
+    });
+
+    // Reproduces the Settings → Roles crash: a globalSettings maintenance-window edge resolves to a
+    // null entity under the `... on DataHubPolicy` fragment, sitting between two real policies.
+    // Rendering it previously threw `TypeError: can't access property "urn", U is null` on the React key.
+    it('renders without crashing when a policy relationship entity is null', () => {
+        mockListRoles(
+            adminRoleData({
+                policyRelationships: [{ entity: PLATFORM_POLICY }, { entity: null }, { entity: METADATA_POLICY }],
+            }),
+        );
+
+        renderManageRoles();
+
+        // Both real policies render; the null edge is skipped rather than rendered as a broken chip.
+        expect(screen.getByText('Platform Policy')).toBeInTheDocument();
+        expect(screen.getByText('Metadata Policy')).toBeInTheDocument();
+    });
+
+    it('renders without crashing when every policy relationship entity is null', () => {
+        mockListRoles(adminRoleData({ policyRelationships: [{ entity: null }, { entity: null }] }));
+
+        renderManageRoles();
+
+        expect(screen.getByText('Admin')).toBeInTheDocument();
+    });
+
+    // Defensive symmetry: a null member (users) edge must not crash the row either.
+    it('renders without crashing when a member relationship entity is null', () => {
+        mockListRoles(
+            adminRoleData({
+                policyRelationships: [{ entity: PLATFORM_POLICY }],
+                userRelationships: [{ entity: { urn: 'urn:li:corpuser:alice', type: 'CORP_USER' } }, { entity: null }],
+            }),
+        );
+
+        renderManageRoles();
+
+        expect(screen.getByText('Platform Policy')).toBeInTheDocument();
+    });
+});

--- a/datahub-web-react/src/app/permissions/roles/__tests__/roles.utils.test.ts
+++ b/datahub-web-react/src/app/permissions/roles/__tests__/roles.utils.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getRolePolicies } from '@app/permissions/roles/roles.utils';
+
+import { DataHubRole } from '@types';
+
+function roleWithPolicyEntities(entities: Array<{ urn: string; name: string } | null>): DataHubRole {
+    return {
+        policies: {
+            relationships: entities.map((entity) => ({ entity })),
+        },
+    } as unknown as DataHubRole;
+}
+
+describe('getRolePolicies', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+    });
+
+    it('returns the policy entities for a role', () => {
+        const role = roleWithPolicyEntities([
+            { urn: 'urn:li:dataHubPolicy:admin-platform-policy', name: 'Platform' },
+            { urn: 'urn:li:dataHubPolicy:admin-metadata-policy', name: 'Metadata' },
+        ]);
+
+        const policies = getRolePolicies(role);
+
+        expect(policies.map((p) => p.urn)).toEqual([
+            'urn:li:dataHubPolicy:admin-platform-policy',
+            'urn:li:dataHubPolicy:admin-metadata-policy',
+        ]);
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('drops null entities (non-policy edges) and warns', () => {
+        const role = roleWithPolicyEntities([
+            { urn: 'urn:li:dataHubPolicy:admin-platform-policy', name: 'Platform' },
+            null,
+            { urn: 'urn:li:dataHubPolicy:admin-metadata-policy', name: 'Metadata' },
+        ]);
+
+        const policies = getRolePolicies(role);
+
+        expect(policies.map((p) => p.urn)).toEqual([
+            'urn:li:dataHubPolicy:admin-platform-policy',
+            'urn:li:dataHubPolicy:admin-metadata-policy',
+        ]);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an empty array when the role has no policies relationship', () => {
+        expect(getRolePolicies({} as DataHubRole)).toEqual([]);
+        expect(getRolePolicies(undefined)).toEqual([]);
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+});

--- a/datahub-web-react/src/app/permissions/roles/__tests__/roles.utils.test.ts
+++ b/datahub-web-react/src/app/permissions/roles/__tests__/roles.utils.test.ts
@@ -1,12 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getRolePolicies } from '@app/permissions/roles/roles.utils';
+import { getRolePolicies, getRoleUsers } from '@app/permissions/roles/roles.utils';
 
 import { DataHubRole } from '@types';
 
 function roleWithPolicyEntities(entities: Array<{ urn: string; name: string } | null>): DataHubRole {
     return {
         policies: {
+            relationships: entities.map((entity) => ({ entity })),
+        },
+    } as unknown as DataHubRole;
+}
+
+function roleWithUserEntities(entities: Array<{ urn: string } | null>): DataHubRole {
+    return {
+        users: {
             relationships: entities.map((entity) => ({ entity })),
         },
     } as unknown as DataHubRole;
@@ -54,9 +62,48 @@ describe('getRolePolicies', () => {
         expect(warnSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('drops every edge when all policy entities are null', () => {
+        const role = roleWithPolicyEntities([null, null]);
+
+        expect(getRolePolicies(role)).toEqual([]);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('returns an empty array when the role has no policies relationship', () => {
         expect(getRolePolicies({} as DataHubRole)).toEqual([]);
         expect(getRolePolicies(undefined)).toEqual([]);
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe('getRoleUsers', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+    });
+
+    it('returns the member entities for a role', () => {
+        const role = roleWithUserEntities([{ urn: 'urn:li:corpuser:alice' }, { urn: 'urn:li:corpGroup:admins' }]);
+
+        expect(getRoleUsers(role).map((u) => u.urn)).toEqual(['urn:li:corpuser:alice', 'urn:li:corpGroup:admins']);
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('drops null member entities and warns', () => {
+        const role = roleWithUserEntities([{ urn: 'urn:li:corpuser:alice' }, null]);
+
+        expect(getRoleUsers(role).map((u) => u.urn)).toEqual(['urn:li:corpuser:alice']);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an empty array when the role has no users relationship', () => {
+        expect(getRoleUsers({} as DataHubRole)).toEqual([]);
+        expect(getRoleUsers(undefined)).toEqual([]);
         expect(warnSpy).not.toHaveBeenCalled();
     });
 });

--- a/datahub-web-react/src/app/permissions/roles/roles.utils.ts
+++ b/datahub-web-react/src/app/permissions/roles/roles.utils.ts
@@ -1,0 +1,34 @@
+import { DataHubPolicy, DataHubRole } from '@types';
+
+/**
+ * Extracts the DataHubPolicy entities associated with a role.
+ *
+ * A role's `policies` list comes from incoming `IsAssociatedWithRole` graph
+ * edges. That relationship name is shared — it is emitted toward a role by both
+ * policy actor filters and the global-settings maintenance-window audience — so
+ * the raw edge set can contain non-policy sources that resolve to `entity: null`
+ * under the `... on DataHubPolicy` fragment.
+ *
+ * The `listRoles` query constrains this server-side via
+ * `relatedEntityTypes: ["dataHubPolicy"]`, so nulls should no longer reach the
+ * client. This filter is a defensive backstop: rendering a null entity (reading
+ * `.urn` for a React key) crashes the Roles page, so we drop any nulls and warn.
+ * A fired warning now signals an unexpected non-policy edge that slipped past
+ * the backend filter.
+ */
+export function getRolePolicies(role: DataHubRole | null | undefined): DataHubPolicy[] {
+    const entities = (role as any)?.policies?.relationships?.map((relationship) => relationship?.entity) ?? [];
+    const policies = entities.filter((entity): entity is DataHubPolicy => entity != null);
+
+    const droppedCount = entities.length - policies.length;
+    if (droppedCount > 0) {
+        // eslint-disable-next-line no-console
+        console.warn(
+            `Role "${role?.urn}" returned ${droppedCount} policy relationship(s) that did not resolve to a ` +
+                `DataHubPolicy and were dropped. The backend should already exclude non-policy edges, so this ` +
+                `indicates an unexpected non-policy entity associated with the role.`,
+        );
+    }
+
+    return policies;
+}

--- a/datahub-web-react/src/app/permissions/roles/roles.utils.ts
+++ b/datahub-web-react/src/app/permissions/roles/roles.utils.ts
@@ -1,34 +1,59 @@
-import { DataHubPolicy, DataHubRole } from '@types';
+import { CorpUser, DataHubPolicy, DataHubRole } from '@types';
 
 /**
- * Extracts the DataHubPolicy entities associated with a role.
+ * Filters a role relationship list down to the edges whose entity actually
+ * resolved, warning once when any are dropped.
  *
- * A role's `policies` list comes from incoming `IsAssociatedWithRole` graph
- * edges. That relationship name is shared — it is emitted toward a role by both
- * policy actor filters and the global-settings maintenance-window audience — so
- * the raw edge set can contain non-policy sources that resolve to `entity: null`
- * under the `... on DataHubPolicy` fragment.
+ * A role's relationship lists (`policies`, `users`) are built from graph edges
+ * whose source/target type can be heterogeneous. For example, a role's
+ * `policies` come from incoming `IsAssociatedWithRole` edges, but that
+ * relationship name is shared — it is emitted toward a role by both policy actor
+ * filters and the global-settings maintenance-window audience — so a non-policy
+ * source resolves to `entity: null` under the `... on DataHubPolicy` fragment.
+ * Rendering such a null (reading `.urn` for a React key) crashes the Roles page.
  *
- * The `listRoles` query constrains this server-side via
+ * The `listRoles` query already constrains the policies edge server-side via
  * `relatedEntityTypes: ["dataHubPolicy"]`, so nulls should no longer reach the
- * client. This filter is a defensive backstop: rendering a null entity (reading
- * `.urn` for a React key) crashes the Roles page, so we drop any nulls and warn.
- * A fired warning now signals an unexpected non-policy edge that slipped past
- * the backend filter.
+ * client. This filter is a defensive backstop: a fired warning signals an
+ * unexpected unresolved edge that slipped past the backend.
  */
-export function getRolePolicies(role: DataHubRole | null | undefined): DataHubPolicy[] {
-    const entities = (role as any)?.policies?.relationships?.map((relationship) => relationship?.entity) ?? [];
-    const policies = entities.filter((entity): entity is DataHubPolicy => entity != null);
+function getResolvedRelationshipEntities<T>(
+    role: DataHubRole | null | undefined,
+    relationships: ReadonlyArray<{ entity?: T | null } | null> | null | undefined,
+    entityKind: string,
+): T[] {
+    const entities = (relationships ?? []).map((relationship) => relationship?.entity);
+    const resolved = entities.filter((entity): entity is T => entity != null);
 
-    const droppedCount = entities.length - policies.length;
+    const droppedCount = entities.length - resolved.length;
     if (droppedCount > 0) {
         // eslint-disable-next-line no-console
         console.warn(
-            `Role "${role?.urn}" returned ${droppedCount} policy relationship(s) that did not resolve to a ` +
-                `DataHubPolicy and were dropped. The backend should already exclude non-policy edges, so this ` +
-                `indicates an unexpected non-policy entity associated with the role.`,
+            `Role "${role?.urn}" returned ${droppedCount} relationship(s) that did not resolve to a ` +
+                `${entityKind} and were dropped. The backend should already exclude such edges, so this ` +
+                `indicates an unexpected entity associated with the role.`,
         );
     }
 
-    return policies;
+    return resolved;
+}
+
+/**
+ * Extracts the resolved DataHubPolicy entities associated with a role, dropping
+ * any unresolved (null) edges. See {@link getResolvedRelationshipEntities}.
+ */
+export function getRolePolicies(role: DataHubRole | null | undefined): DataHubPolicy[] {
+    return getResolvedRelationshipEntities<DataHubPolicy>(
+        role,
+        (role as any)?.policies?.relationships,
+        'DataHubPolicy',
+    );
+}
+
+/**
+ * Extracts the resolved member entities (users/groups) associated with a role,
+ * dropping any unresolved (null) edges. See {@link getResolvedRelationshipEntities}.
+ */
+export function getRoleUsers(role: DataHubRole | null | undefined): CorpUser[] {
+    return getResolvedRelationshipEntities<CorpUser>(role, (role as any)?.users?.relationships, 'CorpUser');
 }

--- a/datahub-web-react/src/graphql/role.graphql
+++ b/datahub-web-react/src/graphql/role.graphql
@@ -39,7 +39,13 @@ query listRoles($input: ListRolesInput!) {
                 }
             }
             policies: relationships(
-                input: { types: ["IsAssociatedWithRole"], direction: INCOMING, start: 0, count: 10 }
+                input: {
+                    types: ["IsAssociatedWithRole"]
+                    direction: INCOMING
+                    start: 0
+                    count: 10
+                    relatedEntityTypes: ["dataHubPolicy"]
+                }
             ) {
                 start
                 count


### PR DESCRIPTION
## Summary

The Settings → **Roles** page crashed with `TypeError: can't access property "urn", null` when rendering a role whose `policies` list contained a non-policy entity.

A role's `policies` are fetched as incoming `IsAssociatedWithRole` graph edges. That relationship **name is shared** — it is emitted toward a role by **two** different aspects, because both embed the same `DataHubActorFilter.roles` field:

| Source entity   | Path                                                                    |
| --------------- | ----------------------------------------------------------------------- |
| `dataHubPolicy` | `DataHubPolicyInfo.actors` → `DataHubActorFilter.roles`                 |
| `globalSettings`| `GlobalSettingsInfo.maintenanceWindow.audience` → `DataHubActorFilter.roles` |

So a role's incoming-`IsAssociatedWithRole` set can legitimately include a `globalSettings` edge (the maintenance-window banner audience). That source isn't a `DataHubPolicy`, so it resolves to `entity: null` under the `... on DataHubPolicy` fragment, and the frontend dereferenced `.urn` (used as a React key) without a guard. This is **not** data corruption — the relationship-name lookup simply returns a heterogeneous set of source types.

## Changes

**Backend (primary fix)**
- Add an **optional** `relatedEntityTypes: [String!]` to `RelationshipsInput`. Defaults to `null` (no-op), so every existing `relationships(...)` call site is unchanged.
- `EntityRelationshipsResultResolver` filters related entities by `urn.getEntityType()` when the filter is present, alongside the existing existence/authorization filter (so `total` stays consistent).
- The `listRoles` `policies` query opts in with `relatedEntityTypes: ["dataHubPolicy"]`, excluding the non-policy edges **server-side**.

**Frontend (defense-in-depth)**
- Shared `getResolvedRelationshipEntities` helper (`roles.utils.ts`) drops any null entity before rendering and warns once if one slips through. `getRolePolicies` and the new `getRoleUsers` both use it, so unresolved policy **and** member edges are guarded in `ManageRoles` and `RoleDetailsModal`.

## Testing

- `EntityRelationshipsResultResolverTest`: added filter tests plus realistic **mixed edge set** tests (a `globalSettings` maintenance-window edge among `dataHubPolicy` edges) that reproduce the crash precondition.
- `roles.utils.test.ts` + `ManageRoles.test.tsx`: render test proving the page survives a null policy entity between two real policies, plus null/empty/missing-relationship coverage.
- `spotlessApply` and frontend roles tests pass locally; `:datahub-graphql-core` compiles.

## Notes

Cherry-picked from acryldata/datahub-fork #10560. One adaptation for OSS master: `mapEntityRelationships` gained a `relatedEntityTypes` parameter, and master has an additional caller (`mapEntityRelationshipsFromList`, the domain/glossary/container direct-children path) that the fork lacks — it passes `null` to preserve its existing unfiltered behavior.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [ ] Docs — N/A (new schema field is documented inline; no user-facing doc change)
- [ ] Breaking changes — none (new input field is optional/backward-compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)