### PR TITLE
feat(ingest/gc): add query cleanup pass for stale SYSTEM queries

### DIFF
--- a/metadata-ingestion/docs/sources/datahubgc/datahub-gc_post.md
+++ b/metadata-ingestion/docs/sources/datahubgc/datahub-gc_post.md
@@ -133,8 +133,8 @@ source:
   type: datahub-gc
   config:
     query_cleanup:
-      enabled: false # Opt-in; destructive
-      retention_days: 90 # Age cutoff on lastModifiedAt
+      enabled: true # Enabled by default
+      retention_days: 180 # Age cutoff on lastModifiedAt (~6 months, conservative default)
       batch_size: 500
       limit_entities_delete: 25000
       runtime_limit_seconds: 7200

--- a/metadata-ingestion/docs/sources/datahubgc/datahub-gc_post.md
+++ b/metadata-ingestion/docs/sources/datahubgc/datahub-gc_post.md
@@ -122,8 +122,8 @@ Soft-deletes old `SYSTEM` queries so stale query entities don't accumulate as or
 
 - Selects `SYSTEM` queries whose `lastModifiedAt` is older than `retention_days` using a single server-side search filter (no per-query reference lookup)
 - Never touches `MANUAL` queries
-- Soft-deletes by default; `hard_delete_entities` can hard-delete directly (skips reference cleanup — prefer the two-pass default)
-- Soft deletes are emitted as status workunits and batched/written by the sink; hard deletes have no bulk or async endpoint and are parallelized across `max_workers` workers
+- Soft-deletes matched queries; the Soft-Deleted Entities Cleanup pass completes the hard delete on a later run
+- Soft deletes are emitted as status workunits and batched/written by the sink
 - Bounded by `limit_entities_delete` (approximate cap on queries deleted per run) and `runtime_limit_seconds`
 
 ##### Configuration
@@ -135,9 +135,7 @@ source:
     query_cleanup:
       enabled: false # Opt-in; destructive
       retention_days: 30 # Age cutoff on lastModifiedAt
-      hard_delete_entities: false
       batch_size: 500
-      max_workers: 10 # parallelism for hard delete only
       limit_entities_delete: 25000
       runtime_limit_seconds: 7200
 ```

--- a/metadata-ingestion/docs/sources/datahubgc/datahub-gc_post.md
+++ b/metadata-ingestion/docs/sources/datahubgc/datahub-gc_post.md
@@ -120,9 +120,9 @@ Soft-deletes old `SYSTEM` queries so stale query entities don't accumulate as or
 
 ##### Features
 
-- Selects `SYSTEM` queries whose `lastModifiedAt` is older than `retention_days` using a single server-side search filter (no per-query reference lookup)
+- Selects `SYSTEM` queries whose `lastModifiedAt` is older than `retention_days` using server-side search filters (no per-query reference lookup)
 - Never touches `MANUAL` queries
-- Soft-deletes matched queries; the Soft-Deleted Entities Cleanup pass completes the hard delete on a later run
+- Soft-deletes matched queries rather than hard-deleting them directly
 - Soft deletes are emitted as status workunits and batched/written by the sink
 - Bounded by `limit_entities_delete` (approximate cap on queries deleted per run) and `runtime_limit_seconds`
 

--- a/metadata-ingestion/docs/sources/datahubgc/datahub-gc_post.md
+++ b/metadata-ingestion/docs/sources/datahubgc/datahub-gc_post.md
@@ -114,6 +114,36 @@ source:
       max_read_errors: 10
 ```
 
+#### Query Cleanup
+
+Soft-deletes old `SYSTEM` queries so stale query entities don't accumulate as orphans in Elasticsearch and primary storage. This is the soft-delete first pass; the Soft-Deleted Entities Cleanup pass below completes the hard delete on a later run.
+
+##### Features
+
+- Selects `SYSTEM` queries whose `lastModifiedAt` is older than `retention_days` using a single server-side search filter (no per-query reference lookup)
+- Never touches `MANUAL` queries
+- Soft-deletes by default; `hard_delete_entities` can hard-delete directly (skips reference cleanup — prefer the two-pass default)
+- Concurrent deletion bounded by `limit_entities_delete` and `runtime_limit_seconds`
+
+##### Configuration
+
+```yaml
+source:
+  type: datahub-gc
+  config:
+    query_cleanup:
+      enabled: false # Opt-in; destructive
+      retention_days: 30 # Age cutoff on lastModifiedAt
+      hard_delete_entities: false
+      batch_size: 500
+      max_workers: 10
+      delay: 0.25
+      limit_entities_delete: 25000
+      runtime_limit_seconds: 7200
+```
+
+Set `retention_days` to at least your largest connector ingestion window: a live query's `lastModifiedAt` is refreshed on every re-observation, so only queries that have aged out of every ingestion window can cross the cutoff. This is a distinct clock from `soft_deleted_entities_cleanup.retention_days` (which measures time since soft-deletion).
+
 #### Soft-Deleted Entities Cleanup
 
 Manages the permanent removal of soft-deleted entities after a retention period.

--- a/metadata-ingestion/docs/sources/datahubgc/datahub-gc_post.md
+++ b/metadata-ingestion/docs/sources/datahubgc/datahub-gc_post.md
@@ -123,7 +123,8 @@ Soft-deletes old `SYSTEM` queries so stale query entities don't accumulate as or
 - Selects `SYSTEM` queries whose `lastModifiedAt` is older than `retention_days` using a single server-side search filter (no per-query reference lookup)
 - Never touches `MANUAL` queries
 - Soft-deletes by default; `hard_delete_entities` can hard-delete directly (skips reference cleanup — prefer the two-pass default)
-- Concurrent deletion bounded by `limit_entities_delete` and `runtime_limit_seconds`. `limit_entities_delete` is an approximate cap: because deletes run concurrently, a run may overshoot it by up to `max_workers` queries
+- Soft deletes are emitted as status workunits and batched/written by the sink; hard deletes have no bulk endpoint and are issued one at a time
+- Bounded by `limit_entities_delete` (approximate cap on queries deleted per run) and `runtime_limit_seconds`
 
 ##### Configuration
 
@@ -136,8 +137,6 @@ source:
       retention_days: 30 # Age cutoff on lastModifiedAt
       hard_delete_entities: false
       batch_size: 500
-      max_workers: 10
-      delay: 0.25
       limit_entities_delete: 25000
       runtime_limit_seconds: 7200
 ```

--- a/metadata-ingestion/docs/sources/datahubgc/datahub-gc_post.md
+++ b/metadata-ingestion/docs/sources/datahubgc/datahub-gc_post.md
@@ -134,7 +134,7 @@ source:
   config:
     query_cleanup:
       enabled: false # Opt-in; destructive
-      retention_days: 30 # Age cutoff on lastModifiedAt
+      retention_days: 90 # Age cutoff on lastModifiedAt
       batch_size: 500
       limit_entities_delete: 25000
       runtime_limit_seconds: 7200

--- a/metadata-ingestion/docs/sources/datahubgc/datahub-gc_post.md
+++ b/metadata-ingestion/docs/sources/datahubgc/datahub-gc_post.md
@@ -123,7 +123,7 @@ Soft-deletes old `SYSTEM` queries so stale query entities don't accumulate as or
 - Selects `SYSTEM` queries whose `lastModifiedAt` is older than `retention_days` using a single server-side search filter (no per-query reference lookup)
 - Never touches `MANUAL` queries
 - Soft-deletes by default; `hard_delete_entities` can hard-delete directly (skips reference cleanup — prefer the two-pass default)
-- Concurrent deletion bounded by `limit_entities_delete` and `runtime_limit_seconds`
+- Concurrent deletion bounded by `limit_entities_delete` and `runtime_limit_seconds`. `limit_entities_delete` is an approximate cap: because deletes run concurrently, a run may overshoot it by up to `max_workers` queries
 
 ##### Configuration
 

--- a/metadata-ingestion/docs/sources/datahubgc/datahub-gc_post.md
+++ b/metadata-ingestion/docs/sources/datahubgc/datahub-gc_post.md
@@ -123,7 +123,7 @@ Soft-deletes old `SYSTEM` queries so stale query entities don't accumulate as or
 - Selects `SYSTEM` queries whose `lastModifiedAt` is older than `retention_days` using a single server-side search filter (no per-query reference lookup)
 - Never touches `MANUAL` queries
 - Soft-deletes by default; `hard_delete_entities` can hard-delete directly (skips reference cleanup — prefer the two-pass default)
-- Soft deletes are emitted as status workunits and batched/written by the sink; hard deletes have no bulk endpoint and are issued one at a time
+- Soft deletes are emitted as status workunits and batched/written by the sink; hard deletes have no bulk or async endpoint and are parallelized across `max_workers` workers
 - Bounded by `limit_entities_delete` (approximate cap on queries deleted per run) and `runtime_limit_seconds`
 
 ##### Configuration
@@ -137,6 +137,7 @@ source:
       retention_days: 30 # Age cutoff on lastModifiedAt
       hard_delete_entities: false
       batch_size: 500
+      max_workers: 10 # parallelism for hard delete only
       limit_entities_delete: 25000
       runtime_limit_seconds: 7200
 ```

--- a/metadata-ingestion/docs/sources/datahubgc/datahub-gc_recipe.yml
+++ b/metadata-ingestion/docs/sources/datahubgc/datahub-gc_recipe.yml
@@ -11,5 +11,5 @@ source:
       hard_delete_entities: false
       keep_last_n: 5
     query_cleanup:
-      enabled: false
-      retention_days: 90
+      enabled: true
+      retention_days: 180

--- a/metadata-ingestion/docs/sources/datahubgc/datahub-gc_recipe.yml
+++ b/metadata-ingestion/docs/sources/datahubgc/datahub-gc_recipe.yml
@@ -13,4 +13,3 @@ source:
     query_cleanup:
       enabled: false
       retention_days: 30
-      hard_delete_entities: false

--- a/metadata-ingestion/docs/sources/datahubgc/datahub-gc_recipe.yml
+++ b/metadata-ingestion/docs/sources/datahubgc/datahub-gc_recipe.yml
@@ -12,4 +12,4 @@ source:
       keep_last_n: 5
     query_cleanup:
       enabled: false
-      retention_days: 30
+      retention_days: 90

--- a/metadata-ingestion/docs/sources/datahubgc/datahub-gc_recipe.yml
+++ b/metadata-ingestion/docs/sources/datahubgc/datahub-gc_recipe.yml
@@ -10,3 +10,7 @@ source:
       delete_empty_data_flows: true
       hard_delete_entities: false
       keep_last_n: 5
+    query_cleanup:
+      enabled: false
+      retention_days: 30
+      hard_delete_entities: false

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -1087,7 +1087,7 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
         :param include_hidden_lifecycle_stages: Whether to include entities hidden by lifecycle stage.
         :param include_draft: Whether to include entities in DRAFT lifecycle state.
         :param sort_by: Optional searchable field to sort on (e.g. "lastModifiedAt"). If None, uses the backend's default scroll order.
-        :param sort_order: Sort direction when sort_by is set. Defaults to ASCENDING.
+        :param sort_order: Sort direction when sort_by is set; ignored when sort_by is None. Defaults to ASCENDING.
 
         :return: An iterable of urns that match the filters.
         """

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -1063,6 +1063,8 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
         skip_cache: bool = False,
         include_hidden_lifecycle_stages: bool = False,
         include_draft: bool = False,
+        sort_by: Optional[str] = None,
+        sort_order: Literal["ASCENDING", "DESCENDING"] = "ASCENDING",
     ) -> Iterable[str]:
         """Fetch all urns that match all of the given filters.
 
@@ -1084,6 +1086,8 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
         :param skip_cache: Whether to bypass caching. Defaults to False.
         :param include_hidden_lifecycle_stages: Whether to include entities hidden by lifecycle stage.
         :param include_draft: Whether to include entities in DRAFT lifecycle state.
+        :param sort_by: Optional searchable field to sort on (e.g. "lastModifiedAt"). If None, uses the backend's default scroll order.
+        :param sort_order: Sort direction when sort_by is set. Defaults to ASCENDING.
 
         :return: An iterable of urns that match the filters.
         """
@@ -1134,6 +1138,7 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
                 $batchSize: Int!,
                 $scrollId: String,
                 $skipCache: Boolean!,
+                $sortInput: SearchSortInput,
             """
             + optional_variable_defs
             + """
@@ -1145,6 +1150,7 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
                     scrollId: $scrollId,
                     types: $types,
                     orFilters: $orFilters,
+                    sortInput: $sortInput,
                     searchFlags: {
                         skipHighlighting: true
                         skipAggregates: true
@@ -1176,6 +1182,11 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
             "orFilters": orFilters,
             "batchSize": batch_size,
             "skipCache": skip_cache,
+            "sortInput": (
+                {"sortCriteria": [{"field": sort_by, "sortOrder": sort_order}]}
+                if sort_by
+                else None
+            ),
             "includeSoftDeleted": (
                 None
                 if status is None

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/datahub_gc.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/datahub_gc.py
@@ -169,7 +169,7 @@ class DataHubGcSource(Source):
                 with self.report.new_stage("Query Cleanup"):
                     yield from self.query_cleanup.get_workunits()
             except Exception as e:
-                self.report.failure("While trying to cleanup queries ", exc=e)
+                self.report.failure("While trying to cleanup queries", exc=e)
         if self.config.soft_deleted_entities_cleanup.enabled:
             try:
                 with self.report.new_stage("Soft Deleted Entities Cleanup"):

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/datahub_gc.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/datahub_gc.py
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 class DataHubGcSourceConfig(ConfigModel):
     dry_run: bool = Field(
         default=False,
-        description="Whether to perform a dry run or not. This is only supported for dataprocess cleanup and soft deleted entities cleanup.",
+        description="Whether to perform a dry run or not. This is only supported for dataprocess cleanup, query cleanup, and soft deleted entities cleanup.",
     )
 
     cleanup_expired_tokens: bool = Field(

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/datahub_gc.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/datahub_gc.py
@@ -27,6 +27,11 @@ from datahub.ingestion.source.gc.execution_request_cleanup import (
     DatahubExecutionRequestCleanupConfig,
     DatahubExecutionRequestCleanupReport,
 )
+from datahub.ingestion.source.gc.query_cleanup import (
+    QueryCleanup,
+    QueryCleanupConfig,
+    QueryCleanupReport,
+)
 from datahub.ingestion.source.gc.soft_deleted_entity_cleanup import (
     SoftDeletedEntitiesCleanup,
     SoftDeletedEntitiesCleanupConfig,
@@ -81,12 +86,18 @@ class DataHubGcSourceConfig(ConfigModel):
         description="Configuration for execution request cleanup",
     )
 
+    query_cleanup: QueryCleanupConfig = Field(
+        default_factory=QueryCleanupConfig,
+        description="Configuration for query cleanup",
+    )
+
 
 @dataclass
 class DataHubGcSourceReport(
     DataProcessCleanupReport,
     SoftDeletedEntitiesReport,
     DatahubExecutionRequestCleanupReport,
+    QueryCleanupReport,
 ):
     expired_tokens_revoked: int = 0
 
@@ -125,6 +136,9 @@ class DataHubGcSource(Source):
             graph=self.graph,
             report=self.report,
         )
+        self.query_cleanup = QueryCleanup(
+            ctx, self.config.query_cleanup, self.report, self.config.dry_run
+        )
 
     @classmethod
     def create(cls, config_dict, ctx):
@@ -150,6 +164,12 @@ class DataHubGcSource(Source):
                     self.truncate_indices()
             except Exception as e:
                 self.report.failure("While trying to truncate indices ", exc=e)
+        if self.config.query_cleanup.enabled:
+            try:
+                with self.report.new_stage("Query Cleanup"):
+                    self.query_cleanup.cleanup_queries()
+            except Exception as e:
+                self.report.failure("While trying to cleanup queries ", exc=e)
         if self.config.soft_deleted_entities_cleanup.enabled:
             try:
                 with self.report.new_stage("Soft Deleted Entities Cleanup"):

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/datahub_gc.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/datahub_gc.py
@@ -167,7 +167,7 @@ class DataHubGcSource(Source):
         if self.config.query_cleanup.enabled:
             try:
                 with self.report.new_stage("Query Cleanup"):
-                    self.query_cleanup.cleanup_queries()
+                    yield from self.query_cleanup.get_workunits()
             except Exception as e:
                 self.report.failure("While trying to cleanup queries ", exc=e)
         if self.config.soft_deleted_entities_cleanup.enabled:

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
@@ -1,8 +1,15 @@
 import logging
 import time
+from concurrent.futures import (
+    ALL_COMPLETED,
+    FIRST_COMPLETED,
+    Future,
+    ThreadPoolExecutor,
+    wait,
+)
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Iterable, Optional
+from typing import Dict, Iterable, Optional
 
 from pydantic import Field
 
@@ -47,8 +54,8 @@ class QueryCleanupConfig(ConfigModel):
             "(False) soft-deletes here and lets soft_deleted_entities_cleanup hard-delete them "
             "on a later run, which additionally calls deleteReferences to clear inbound pointers. "
             "This shortcut skips that step, so `via` pointers on lineage aspects are left "
-            "pointing at the deleted query. Hard deletes are issued one at a time; soft deletes "
-            "are emitted as workunits and batched by the sink."
+            "pointing at the deleted query. Hard deletes are parallelized across "
+            "max_workers workers; soft deletes are emitted as workunits and batched by the sink."
         ),
     )
 
@@ -57,9 +64,21 @@ class QueryCleanupConfig(ConfigModel):
         description="The number of entities to fetch in a batch from search.",
     )
 
+    max_workers: int = Field(
+        10,
+        description=(
+            "Number of worker threads for parallel hard deletion. Only applies when "
+            "hard_delete_entities is set; soft deletes go through the sink."
+        ),
+    )
+
     limit_entities_delete: Optional[int] = Field(
         25000,
-        description="Approximate max number of queries to delete in a single run.",
+        description=(
+            "Approximate max number of queries to delete in a single run. For hard delete, "
+            "the cap is checked before each submission, so concurrent workers may overshoot "
+            "it by up to max_workers entities."
+        ),
     )
 
     runtime_limit_seconds: int = Field(
@@ -96,7 +115,7 @@ class QueryCleanup:
     `lastModifiedAt < cutoff`. Soft deletes are emitted as status workunits and left to the
     sink to batch and write (the same mechanism as stale-entity removal); the existing
     SoftDeletedEntitiesCleanup completes the hard-delete second pass. Hard deletes, when
-    enabled, have no bulk endpoint and are issued imperatively one at a time.
+    enabled, have no bulk or async endpoint, so they are parallelized across a worker pool.
     """
 
     def __init__(
@@ -162,11 +181,7 @@ class QueryCleanup:
             return True
         return False
 
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        if not self.config.enabled:
-            return
-        self.start_time = time.time()
-
+    def _iter_candidate_urns(self) -> Iterable[Urn]:
         for urn in self._get_urns():
             try:
                 query_urn = Urn.from_string(urn)
@@ -179,29 +194,75 @@ class QueryCleanup:
                 )
                 continue
             self.report.num_queries_found += 1
+            yield query_urn
 
+    def _preview_candidates(self) -> None:
+        for query_urn in self._iter_candidate_urns():
             if self._deletion_limit_reached() or self._times_up():
                 break
+            logger.info(
+                f"Dry run is on, otherwise it would have deleted {query_urn} "
+                f"(hard_delete={self.config.hard_delete_entities})"
+            )
+            # Record the candidate so a dry run still previews what would go.
+            self.report.sample_deleted_queries.append(query_urn.urn())
 
-            if self.dry_run:
-                logger.info(
-                    f"Dry run is on, otherwise it would have deleted {query_urn} "
-                    f"(hard_delete={self.config.hard_delete_entities})"
+    def _hard_delete_one(self, urn: Urn) -> None:
+        self.graph.delete_entity(urn=urn.urn(), hard=True)
+
+    def _collect_hard_deletes(
+        self, futures: Dict["Future[None]", Urn], return_when: str
+    ) -> Dict["Future[None]", Urn]:
+        done, not_done = wait(futures, return_when=return_when)
+        for future in done:
+            urn = futures[future]
+            exc = future.exception()
+            if exc is not None:
+                self.report.warning(
+                    title="Failed to hard delete query",
+                    message="Failed to hard delete query",
+                    context=urn.urn(),
+                    exc=exc,
                 )
-                # Record the candidate so a dry run still previews what would go.
-                self.report.sample_deleted_queries.append(query_urn.urn())
-                continue
-
-            if self.config.hard_delete_entities:
-                # There is no bulk hard-delete endpoint, so hard delete imperatively
-                # (one at a time) rather than through the workunit stream.
-                self.graph.delete_entity(urn=query_urn.urn(), hard=True)
-                self.report.report_query_hard_deleted(query_urn.urn())
             else:
-                # Soft delete is a plain status write, so hand it to the sink as a
-                # workunit and let it batch/async the write (like stale-entity removal).
-                self.report.report_query_soft_deleted(query_urn.urn())
-                yield MetadataChangeProposalWrapper(
-                    entityUrn=query_urn.urn(),
-                    aspect=StatusClass(removed=True),
-                ).as_workunit()
+                self.report.report_query_hard_deleted(urn.urn())
+        return {f: futures[f] for f in not_done}
+
+    def _hard_delete_queries(self) -> None:
+        # Hard delete has no bulk or async path, so parallelize the per-URN blocking
+        # calls across a worker pool. Completed futures are drained here on the calling
+        # thread, so report updates need no locking.
+        futures: Dict["Future[None]", Urn] = {}
+        with ThreadPoolExecutor(max_workers=self.config.max_workers) as executor:
+            for query_urn in self._iter_candidate_urns():
+                if self._deletion_limit_reached() or self._times_up():
+                    break
+                futures[executor.submit(self._hard_delete_one, query_urn)] = query_urn
+                # Bound in-flight work and let completed deletes advance the report so
+                # the deletion/runtime caps can trip mid-stream.
+                if len(futures) >= self.config.max_workers:
+                    futures = self._collect_hard_deletes(futures, FIRST_COMPLETED)
+            self._collect_hard_deletes(futures, ALL_COMPLETED)
+
+    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
+        if not self.config.enabled:
+            return
+        self.start_time = time.time()
+
+        if self.dry_run:
+            self._preview_candidates()
+            return
+        if self.config.hard_delete_entities:
+            self._hard_delete_queries()
+            return
+
+        # Soft delete is a plain status write, so hand each to the sink as a workunit
+        # and let it batch/async the write (like stale-entity removal).
+        for query_urn in self._iter_candidate_urns():
+            if self._deletion_limit_reached() or self._times_up():
+                break
+            self.report.report_query_soft_deleted(query_urn.urn())
+            yield MetadataChangeProposalWrapper(
+                entityUrn=query_urn.urn(),
+                aspect=StatusClass(removed=True),
+            ).as_workunit()

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
@@ -76,7 +76,10 @@ class QueryCleanupConfig(ConfigModel):
 
     limit_entities_delete: Optional[int] = Field(
         25000,
-        description="Max number of queries to delete in a single run.",
+        description=(
+            "Approximate max number of queries to delete in a single run. "
+            "Concurrent workers may overshoot this by up to max_workers entities."
+        ),
     )
 
     runtime_limit_seconds: int = Field(
@@ -88,14 +91,14 @@ class QueryCleanupConfig(ConfigModel):
 @dataclass
 class QueryCleanupReport(SourceReport):
     num_queries_found: int = 0
-    num_system_queries_found: int = 0
+    num_queries_invalid_urn: int = 0
     num_queries_soft_deleted: int = 0
     num_queries_hard_deleted: int = 0
     sample_deleted_queries: LossyList[str] = field(
         default_factory=lambda: LossyList(max_elements=get_report_info_sample_size())
     )
-    runtime_limit_reached: bool = False
-    deletion_limit_reached: bool = False
+    qc_runtime_limit_reached: bool = False
+    qc_deletion_limit_reached: bool = False
 
 
 class QueryCleanup:
@@ -208,20 +211,23 @@ class QueryCleanup:
             and time.time() - self.start_time > self.config.runtime_limit_seconds
         ):
             with self._report_lock:
-                self.report.runtime_limit_reached = True
+                self.report.qc_runtime_limit_reached = True
             return True
         return False
 
     def _deletion_limit_reached(self) -> bool:
+        # Approximate cap: the counter reads need no lock (int reads are atomic
+        # under the GIL), but the check-then-delete gap means concurrent workers
+        # can overshoot the limit by up to max_workers entities.
         num_deleted = (
             self.report.num_queries_soft_deleted + self.report.num_queries_hard_deleted
         )
         if (
             self.config.limit_entities_delete
-            and num_deleted > self.config.limit_entities_delete
+            and num_deleted >= self.config.limit_entities_delete
         ):
             with self._report_lock:
-                self.report.deletion_limit_reached = True
+                self.report.qc_deletion_limit_reached = True
             return True
         return False
 
@@ -235,10 +241,10 @@ class QueryCleanup:
             for urn in self._get_urns():
                 try:
                     self.report.num_queries_found += 1
-                    self.report.num_system_queries_found += 1
                     query_urn = Urn.from_string(urn)
                 except InvalidUrnError as e:
                     logger.error(f"Failed to parse urn {urn} with error {e}")
+                    self.report.num_queries_invalid_urn += 1
                     continue
 
                 self._print_report()

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
@@ -1,15 +1,8 @@
 import logging
 import time
-from concurrent.futures import (
-    ALL_COMPLETED,
-    FIRST_COMPLETED,
-    Future,
-    ThreadPoolExecutor,
-    wait,
-)
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Dict, Iterable, Optional
+from typing import Iterable, Optional
 
 from pydantic import Field
 
@@ -47,38 +40,14 @@ class QueryCleanupConfig(ConfigModel):
         ),
     )
 
-    hard_delete_entities: bool = Field(
-        False,
-        description=(
-            "Hard-delete matched queries directly instead of soft-deleting them. The default "
-            "(False) soft-deletes here and lets soft_deleted_entities_cleanup hard-delete them "
-            "on a later run, which additionally calls deleteReferences to clear inbound pointers. "
-            "This shortcut skips that step, so `via` pointers on lineage aspects are left "
-            "pointing at the deleted query. Hard deletes are parallelized across "
-            "max_workers workers; soft deletes are emitted as workunits and batched by the sink."
-        ),
-    )
-
     batch_size: int = Field(
         500,
         description="The number of entities to fetch in a batch from search.",
     )
 
-    max_workers: int = Field(
-        10,
-        description=(
-            "Number of worker threads for parallel hard deletion. Only applies when "
-            "hard_delete_entities is set; soft deletes go through the sink."
-        ),
-    )
-
     limit_entities_delete: Optional[int] = Field(
         25000,
-        description=(
-            "Approximate max number of queries to delete in a single run. For hard delete, "
-            "the cap is checked before each submission, so concurrent workers may overshoot "
-            "it by up to max_workers entities."
-        ),
+        description="Approximate max number of queries to soft-delete in a single run.",
     )
 
     runtime_limit_seconds: int = Field(
@@ -91,7 +60,6 @@ class QueryCleanupConfig(ConfigModel):
 class QueryCleanupReport(SourceReport):
     num_queries_found: int = 0
     num_queries_soft_deleted: int = 0
-    num_queries_hard_deleted: int = 0
     sample_deleted_queries: LossyList[str] = field(
         default_factory=lambda: LossyList(max_elements=get_report_info_sample_size())
     )
@@ -102,10 +70,6 @@ class QueryCleanupReport(SourceReport):
         self.num_queries_soft_deleted += 1
         self.sample_deleted_queries.append(urn)
 
-    def report_query_hard_deleted(self, urn: str) -> None:
-        self.num_queries_hard_deleted += 1
-        self.sample_deleted_queries.append(urn)
-
 
 class QueryCleanup:
     """
@@ -114,8 +78,7 @@ class QueryCleanup:
     Selection is a single server-side filter on `source == SYSTEM` and
     `lastModifiedAt < cutoff`. Soft deletes are emitted as status workunits and left to the
     sink to batch and write (the same mechanism as stale-entity removal); the existing
-    SoftDeletedEntitiesCleanup completes the hard-delete second pass. Hard deletes, when
-    enabled, have no bulk or async endpoint, so they are parallelized across a worker pool.
+    SoftDeletedEntitiesCleanup completes the hard-delete second pass.
     """
 
     def __init__(
@@ -170,12 +133,10 @@ class QueryCleanup:
         return False
 
     def _deletion_limit_reached(self) -> bool:
-        num_deleted = (
-            self.report.num_queries_soft_deleted + self.report.num_queries_hard_deleted
-        )
         if (
             self.config.limit_entities_delete
-            and num_deleted >= self.config.limit_entities_delete
+            and self.report.num_queries_soft_deleted
+            >= self.config.limit_entities_delete
         ):
             self.report.qc_deletion_limit_reached = True
             return True
@@ -200,56 +161,9 @@ class QueryCleanup:
         for query_urn in self._iter_candidate_urns():
             if self._deletion_limit_reached() or self._times_up():
                 break
-            logger.info(
-                f"Dry run is on, otherwise it would have deleted {query_urn} "
-                f"(hard_delete={self.config.hard_delete_entities})"
-            )
+            logger.info(f"Dry run is on, otherwise it would have deleted {query_urn}")
             # Record the candidate so a dry run still previews what would go.
             self.report.sample_deleted_queries.append(query_urn.urn())
-
-    def _hard_delete_one(self, urn: Urn) -> None:
-        self.graph.delete_entity(urn=urn.urn(), hard=True)
-
-    def _collect_hard_deletes(
-        self, futures: Dict["Future[None]", Urn], return_when: str
-    ) -> Dict["Future[None]", Urn]:
-        done, not_done = wait(futures, return_when=return_when)
-        for future in done:
-            urn = futures[future]
-            exc = future.exception()
-            if exc is not None:
-                self.report.warning(
-                    title="Failed to hard delete query",
-                    message="Failed to hard delete query",
-                    context=urn.urn(),
-                    exc=exc,
-                )
-            else:
-                self.report.report_query_hard_deleted(urn.urn())
-        return {f: futures[f] for f in not_done}
-
-    def _hard_delete_queries(self) -> None:
-        # Hard delete has no bulk or async path, so parallelize the per-URN blocking
-        # calls across a worker pool. Completed futures are drained here on the calling
-        # thread, so report updates need no locking.
-        futures: Dict["Future[None]", Urn] = {}
-        with ThreadPoolExecutor(max_workers=self.config.max_workers) as executor:
-            try:
-                for query_urn in self._iter_candidate_urns():
-                    if self._deletion_limit_reached() or self._times_up():
-                        break
-                    futures[executor.submit(self._hard_delete_one, query_urn)] = (
-                        query_urn
-                    )
-                    # Bound in-flight work and let completed deletes advance the report
-                    # so the deletion/runtime caps can trip mid-stream.
-                    if len(futures) >= self.config.max_workers:
-                        futures = self._collect_hard_deletes(futures, FIRST_COMPLETED)
-            finally:
-                # Drain in-flight futures even if enumeration raises mid-stream, so
-                # deletes that already completed are still recorded in the report.
-                if futures:
-                    self._collect_hard_deletes(futures, ALL_COMPLETED)
 
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:
         if not self.config.enabled:
@@ -258,9 +172,6 @@ class QueryCleanup:
 
         if self.dry_run:
             self._preview_candidates()
-            return
-        if self.config.hard_delete_entities:
-            self._hard_delete_queries()
             return
 
         # Soft delete is a plain status write, so hand each to the sink as a workunit

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
@@ -133,17 +133,15 @@ class QueryCleanup:
         )
 
     def _times_up(self) -> bool:
-        if (
-            self.config.runtime_limit_seconds
-            and time.time() - self.start_time > self.config.runtime_limit_seconds
-        ):
+        if time.time() - self.start_time > self.config.runtime_limit_seconds:
             self.report.qc_runtime_limit_reached = True
             return True
         return False
 
     def _deletion_limit_reached(self) -> bool:
+        # limit_entities_delete is None when the cap is disabled (see field description).
         if (
-            self.config.limit_entities_delete
+            self.config.limit_entities_delete is not None
             and self.report.num_queries_soft_deleted
             >= self.config.limit_entities_delete
         ):

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
@@ -113,6 +113,11 @@ class QueryCleanup:
             entity_types=["query"],
             status=RemovedStatusFilter.NOT_SOFT_DELETED,
             batch_size=self.config.batch_size,
+            # Oldest-first so a capped run (limit_entities_delete / runtime_limit_seconds)
+            # deletes the most-stale queries rather than an arbitrary scroll slice, and the
+            # dry-run preview reflects what a real run would delete.
+            sort_by="lastModifiedAt",
+            sort_order="ASCENDING",
             extraFilters=[
                 SearchFilterRule(
                     field="source",

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
@@ -24,15 +24,17 @@ logger = logging.getLogger(__name__)
 
 class QueryCleanupConfig(ConfigModel):
     enabled: bool = Field(
-        default=False,
+        default=True,
         description="Whether to do query cleanup or not.",
     )
 
     retention_days: int = Field(
-        90,
+        180,
         ge=1,
         description=(
             "Soft-delete SYSTEM queries whose lastModifiedAt is older than this many days. "
+            "Defaults to 180 days (~6 months), a conservative window that avoids touching "
+            "queries still within any reasonable connector ingestion window. "
             "Set this to at least the largest connector ingestion window: a live query's "
             "lastModifiedAt is refreshed on every re-observation, so only queries that have "
             "aged out of every ingestion window can cross the cutoff. This is a distinct clock "
@@ -50,7 +52,10 @@ class QueryCleanupConfig(ConfigModel):
     limit_entities_delete: Optional[int] = Field(
         25000,
         ge=1,
-        description="Approximate max number of queries to soft-delete in a single run.",
+        description=(
+            "Approximate max number of queries to soft-delete in a single run. "
+            "Set to null to disable the cap."
+        ),
     )
 
     runtime_limit_seconds: int = Field(
@@ -138,12 +143,11 @@ class QueryCleanup:
             return True
         return False
 
-    def _deletion_limit_reached(self) -> bool:
+    def _deletion_limit_reached(self, num_candidates_handled: int) -> bool:
         # limit_entities_delete is None when the cap is disabled (see field description).
         if (
             self.config.limit_entities_delete is not None
-            and self.report.num_queries_soft_deleted
-            >= self.config.limit_entities_delete
+            and num_candidates_handled >= self.config.limit_entities_delete
         ):
             self.report.qc_deletion_limit_reached = True
             return True
@@ -165,8 +169,10 @@ class QueryCleanup:
             yield query_urn
 
     def _preview_candidates(self) -> None:
-        for query_urn in self._iter_candidate_urns():
-            if self._deletion_limit_reached() or self._times_up():
+        # num_previewed = candidates previewed before this iteration, so it feeds the
+        # deletion-limit check the same way num_queries_soft_deleted does in a real run.
+        for num_previewed, query_urn in enumerate(self._iter_candidate_urns()):
+            if self._deletion_limit_reached(num_previewed) or self._times_up():
                 break
             logger.info(f"Dry run is on, otherwise it would have deleted {query_urn}")
             # Record the candidate so a dry run still previews what would go.
@@ -184,7 +190,10 @@ class QueryCleanup:
         # Soft delete is a plain status write, so hand each to the sink as a workunit
         # and let it batch/async the write (like stale-entity removal).
         for query_urn in self._iter_candidate_urns():
-            if self._deletion_limit_reached() or self._times_up():
+            if (
+                self._deletion_limit_reached(self.report.num_queries_soft_deleted)
+                or self._times_up()
+            ):
                 break
             self.report.report_query_soft_deleted(query_urn.urn())
             yield MetadataChangeProposalWrapper(

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
@@ -94,6 +94,7 @@ class QueryCleanupReport(SourceReport):
     num_queries_invalid_urn: int = 0
     num_queries_soft_deleted: int = 0
     num_queries_hard_deleted: int = 0
+    num_queries_processed: int = 0
     sample_deleted_queries: LossyList[str] = field(
         default_factory=lambda: LossyList(max_elements=get_report_info_sample_size())
     )
@@ -120,7 +121,6 @@ class QueryCleanup:
             raise ValueError("Datahub API is required")
 
         self.graph: DataHubGraph = ctx.graph
-        self.ctx = ctx
         self.config = config
         self.report = report
         self.dry_run = dry_run
@@ -194,15 +194,21 @@ class QueryCleanup:
                     context=futures[future].urn(),
                     exc=future.exception(),
                 )
+            self.report.num_queries_processed += 1
+            # Throttle once every batch_size completions rather than on every
+            # wait() return, so `delay` matches its documented per-batch meaning.
+            if (
+                self.config.delay
+                and self.report.num_queries_processed % self.config.batch_size == 0
+            ):
+                logger.debug(
+                    f"Sleeping for {self.config.delay} seconds before processing next batch"
+                )
+                time.sleep(self.config.delay)
 
         remaining = {
             future: urn for future, urn in futures.items() if future in not_done
         }
-        if done and self.config.delay:
-            logger.debug(
-                f"Sleeping for {self.config.delay} seconds before processing next batch"
-            )
-            time.sleep(self.config.delay)
         return remaining
 
     def _times_up(self) -> bool:

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
@@ -1,0 +1,255 @@
+import logging
+import time
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from threading import Lock
+from typing import Dict, Iterable, Optional
+
+from pydantic import Field
+
+from datahub.configuration import ConfigModel
+from datahub.configuration.env_vars import get_report_info_sample_size
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.source import SourceReport
+from datahub.ingestion.graph.client import DataHubGraph
+from datahub.ingestion.graph.filters import RemovedStatusFilter, SearchFilterRule
+from datahub.utilities.lossy_collections import LossyList
+from datahub.utilities.urns._urn_base import Urn
+from datahub.utilities.urns.error import InvalidUrnError
+
+logger = logging.getLogger(__name__)
+
+
+class QueryCleanupConfig(ConfigModel):
+    enabled: bool = Field(
+        default=False,
+        description="Whether to do query cleanup or not.",
+    )
+
+    retention_days: int = Field(
+        30,
+        description=(
+            "Soft-delete SYSTEM queries whose lastModifiedAt is older than this many days. "
+            "Set this to at least the largest connector ingestion window: a live query's "
+            "lastModifiedAt is refreshed on every re-observation, so only queries that have "
+            "aged out of every ingestion window can cross the cutoff. This is a distinct clock "
+            "from soft_deleted_entities_cleanup.retention_days (which measures time since "
+            "soft-deletion)."
+        ),
+    )
+
+    hard_delete_entities: bool = Field(
+        False,
+        description=(
+            "Hard-delete matched queries directly instead of soft-deleting them. The default "
+            "(False) soft-deletes here and lets soft_deleted_entities_cleanup hard-delete them "
+            "on a later run, which additionally calls deleteReferences to clear inbound pointers. "
+            "This shortcut skips that step, so `via` pointers on lineage aspects are left "
+            "pointing at the deleted query."
+        ),
+    )
+
+    batch_size: int = Field(
+        500,
+        description="The number of entities to fetch in a batch from search.",
+    )
+
+    max_workers: int = Field(
+        10,
+        description="The number of workers to use for deletion.",
+    )
+
+    delay: Optional[float] = Field(
+        0.25,
+        description="Delay between each batch.",
+    )
+
+    futures_max_at_time: int = Field(
+        1000,
+        description=(
+            "Max number of in-flight delete operations to have pending at a time. "
+            "Bounds memory when streaming a large candidate set; the selection loop "
+            "throttles once this many deletes are outstanding."
+        ),
+    )
+
+    limit_entities_delete: Optional[int] = Field(
+        25000,
+        description="Max number of queries to delete in a single run.",
+    )
+
+    runtime_limit_seconds: int = Field(
+        7200,  # 2 hours by default
+        description="Runtime limit in seconds for a single run.",
+    )
+
+
+@dataclass
+class QueryCleanupReport(SourceReport):
+    num_queries_found: int = 0
+    num_system_queries_found: int = 0
+    num_queries_soft_deleted: int = 0
+    num_queries_hard_deleted: int = 0
+    sample_deleted_queries: LossyList[str] = field(
+        default_factory=lambda: LossyList(max_elements=get_report_info_sample_size())
+    )
+    runtime_limit_reached: bool = False
+    deletion_limit_reached: bool = False
+
+
+class QueryCleanup:
+    """
+    Maintenance source that soft-deletes old SYSTEM queries by age alone (aggressive policy).
+
+    Selection is a single server-side filter on `source == SYSTEM` and
+    `lastModifiedAt < cutoff`. The existing SoftDeletedEntitiesCleanup completes the hard-delete second pass.
+    """
+
+    def __init__(
+        self,
+        ctx: PipelineContext,
+        config: QueryCleanupConfig,
+        report: QueryCleanupReport,
+        dry_run: bool = False,
+    ):
+        if not ctx.graph:
+            raise ValueError("Datahub API is required")
+
+        self.graph: DataHubGraph = ctx.graph
+        self.ctx = ctx
+        self.config = config
+        self.report = report
+        self.dry_run = dry_run
+        self.start_time = time.time()
+        self._report_lock: Lock = Lock()
+        self.last_print_time = 0.0
+
+    def _get_urns(self) -> Iterable[str]:
+        cutoff_millis = int(
+            (
+                datetime.now(timezone.utc).timestamp()
+                - self.config.retention_days * 24 * 60 * 60
+            )
+            * 1000
+        )
+        yield from self.graph.get_urns_by_filter(
+            entity_types=["query"],
+            status=RemovedStatusFilter.NOT_SOFT_DELETED,
+            batch_size=self.config.batch_size,
+            extraFilters=[
+                SearchFilterRule(
+                    field="source",
+                    condition="EQUAL",
+                    values=["SYSTEM"],
+                ).to_raw(),
+                SearchFilterRule(
+                    field="lastModifiedAt",
+                    condition="LESS_THAN",
+                    values=[f"{cutoff_millis}"],
+                ).to_raw(),
+            ],
+        )
+
+    def _update_report(self, urn: str) -> None:
+        """Thread-safe method to update report fields after a delete."""
+        with self._report_lock:
+            if self.config.hard_delete_entities:
+                self.report.num_queries_hard_deleted += 1
+            else:
+                self.report.num_queries_soft_deleted += 1
+            self.report.sample_deleted_queries.append(urn)
+
+    def delete_query(self, urn: Urn) -> None:
+        if self.dry_run:
+            logger.info(
+                f"Dry run is on, otherwise it would have deleted {urn} "
+                f"(hard_delete={self.config.hard_delete_entities})"
+            )
+            return
+        if self._deletion_limit_reached() or self._times_up():
+            return
+        self.graph.delete_entity(urn=urn.urn(), hard=self.config.hard_delete_entities)
+        self._update_report(urn.urn())
+
+    def _print_report(self) -> None:
+        time_taken = round(time.time() - self.last_print_time, 1)
+        # Print report every 2 minutes
+        if time_taken > 120:
+            self.last_print_time = time.time()
+            logger.info(f"\n{self.report.as_string()}")
+
+    def _process_futures(self, futures: Dict[Future, Urn]) -> Dict[Future, Urn]:
+        done, not_done = wait(futures, return_when=FIRST_COMPLETED)
+
+        for future in done:
+            self._print_report()
+            if future.exception():
+                self.report.failure(
+                    title="Failed to delete query",
+                    message="Failed to delete query",
+                    context=futures[future].urn(),
+                    exc=future.exception(),
+                )
+
+        remaining = {
+            future: urn for future, urn in futures.items() if future in not_done
+        }
+        if done and self.config.delay:
+            logger.debug(
+                f"Sleeping for {self.config.delay} seconds before processing next batch"
+            )
+            time.sleep(self.config.delay)
+        return remaining
+
+    def _times_up(self) -> bool:
+        if (
+            self.config.runtime_limit_seconds
+            and time.time() - self.start_time > self.config.runtime_limit_seconds
+        ):
+            with self._report_lock:
+                self.report.runtime_limit_reached = True
+            return True
+        return False
+
+    def _deletion_limit_reached(self) -> bool:
+        num_deleted = (
+            self.report.num_queries_soft_deleted + self.report.num_queries_hard_deleted
+        )
+        if (
+            self.config.limit_entities_delete
+            and num_deleted > self.config.limit_entities_delete
+        ):
+            with self._report_lock:
+                self.report.deletion_limit_reached = True
+            return True
+        return False
+
+    def cleanup_queries(self) -> None:
+        if not self.config.enabled:
+            return
+        self.start_time = time.time()
+
+        futures: Dict[Future, Urn] = dict()
+        with ThreadPoolExecutor(max_workers=self.config.max_workers) as executor:
+            for urn in self._get_urns():
+                try:
+                    self.report.num_queries_found += 1
+                    self.report.num_system_queries_found += 1
+                    query_urn = Urn.from_string(urn)
+                except InvalidUrnError as e:
+                    logger.error(f"Failed to parse urn {urn} with error {e}")
+                    continue
+
+                self._print_report()
+                while len(futures) >= self.config.futures_max_at_time:
+                    futures = self._process_futures(futures)
+                if self._deletion_limit_reached() or self._times_up():
+                    break
+                future = executor.submit(self.delete_query, query_urn)
+                futures[future] = query_urn
+
+            logger.info(f"Waiting for {len(futures)} futures to complete")
+            while len(futures) > 0:
+                self._print_report()
+                futures = self._process_futures(futures)

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
@@ -82,7 +82,8 @@ class QueryCleanupReport(SourceReport):
 
 class QueryCleanup:
     """
-    Maintenance source that soft-deletes old SYSTEM queries by age alone (aggressive policy).
+    Maintenance source that soft-deletes old SYSTEM queries by `lastModifiedAt` age alone,
+    regardless of whether the query is still referenced.
 
     Selection uses server-side search filters on `source == SYSTEM` and
     `lastModifiedAt < cutoff`. Soft deletes are emitted as status workunits and left to the
@@ -148,7 +149,6 @@ class QueryCleanup:
         return False
 
     def _deletion_limit_reached(self, num_candidates_handled: int) -> bool:
-        # None disables the cap.
         if (
             self.config.limit_entities_delete is not None
             and num_candidates_handled >= self.config.limit_entities_delete
@@ -177,8 +177,8 @@ class QueryCleanup:
             yield query_urn
 
     def _preview_candidates(self) -> None:
-        # num_previewed = candidates previewed before this iteration, so it feeds the
-        # deletion-limit check the same way num_queries_soft_deleted does in a real run.
+        # enumerate gives the count previewed before this iteration, matching the real run's
+        # deletion-limit semantics (which counts already-deleted queries).
         for num_previewed, query_urn in enumerate(self._iter_candidate_urns()):
             if self._deletion_limit_reached(num_previewed) or self._times_up():
                 break

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
@@ -84,7 +84,7 @@ class QueryCleanup:
     """
     Maintenance source that soft-deletes old SYSTEM queries by age alone (aggressive policy).
 
-    Selection is a single server-side filter on `source == SYSTEM` and
+    Selection uses server-side search filters on `source == SYSTEM` and
     `lastModifiedAt < cutoff`. Soft deletes are emitted as status workunits and left to the
     sink to batch and write (the same mechanism as stale-entity removal); the existing
     SoftDeletedEntitiesCleanup completes the hard-delete second pass.
@@ -139,16 +139,24 @@ class QueryCleanup:
 
     def _times_up(self) -> bool:
         if time.time() - self.start_time > self.config.runtime_limit_seconds:
+            logger.info(
+                f"Stopping query cleanup: runtime limit of "
+                f"{self.config.runtime_limit_seconds}s reached."
+            )
             self.report.qc_runtime_limit_reached = True
             return True
         return False
 
     def _deletion_limit_reached(self, num_candidates_handled: int) -> bool:
-        # limit_entities_delete is None when the cap is disabled (see field description).
+        # None disables the cap.
         if (
             self.config.limit_entities_delete is not None
             and num_candidates_handled >= self.config.limit_entities_delete
         ):
+            logger.info(
+                f"Stopping query cleanup: deletion limit of "
+                f"{self.config.limit_entities_delete} reached."
+            )
             self.report.qc_deletion_limit_reached = True
             return True
         return False
@@ -175,7 +183,6 @@ class QueryCleanup:
             if self._deletion_limit_reached(num_previewed) or self._times_up():
                 break
             logger.info(f"Dry run is on, otherwise it would have deleted {query_urn}")
-            # Record the candidate so a dry run still previews what would go.
             self.report.sample_deleted_queries.append(query_urn.urn())
 
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
@@ -30,6 +30,7 @@ class QueryCleanupConfig(ConfigModel):
 
     retention_days: int = Field(
         30,
+        ge=1,
         description=(
             "Soft-delete SYSTEM queries whose lastModifiedAt is older than this many days. "
             "Set this to at least the largest connector ingestion window: a live query's "
@@ -42,16 +43,19 @@ class QueryCleanupConfig(ConfigModel):
 
     batch_size: int = Field(
         500,
+        ge=1,
         description="The number of entities to fetch in a batch from search.",
     )
 
     limit_entities_delete: Optional[int] = Field(
         25000,
+        ge=1,
         description="Approximate max number of queries to soft-delete in a single run.",
     )
 
     runtime_limit_seconds: int = Field(
         7200,  # 2 hours by default
+        ge=1,
         description="Runtime limit in seconds for a single run.",
     )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
@@ -29,7 +29,7 @@ class QueryCleanupConfig(ConfigModel):
     )
 
     retention_days: int = Field(
-        30,
+        90,
         ge=1,
         description=(
             "Soft-delete SYSTEM queries whose lastModifiedAt is older than this many days. "

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
@@ -234,15 +234,22 @@ class QueryCleanup:
         # thread, so report updates need no locking.
         futures: Dict["Future[None]", Urn] = {}
         with ThreadPoolExecutor(max_workers=self.config.max_workers) as executor:
-            for query_urn in self._iter_candidate_urns():
-                if self._deletion_limit_reached() or self._times_up():
-                    break
-                futures[executor.submit(self._hard_delete_one, query_urn)] = query_urn
-                # Bound in-flight work and let completed deletes advance the report so
-                # the deletion/runtime caps can trip mid-stream.
-                if len(futures) >= self.config.max_workers:
-                    futures = self._collect_hard_deletes(futures, FIRST_COMPLETED)
-            self._collect_hard_deletes(futures, ALL_COMPLETED)
+            try:
+                for query_urn in self._iter_candidate_urns():
+                    if self._deletion_limit_reached() or self._times_up():
+                        break
+                    futures[executor.submit(self._hard_delete_one, query_urn)] = (
+                        query_urn
+                    )
+                    # Bound in-flight work and let completed deletes advance the report
+                    # so the deletion/runtime caps can trip mid-stream.
+                    if len(futures) >= self.config.max_workers:
+                        futures = self._collect_hard_deletes(futures, FIRST_COMPLETED)
+            finally:
+                # Drain in-flight futures even if enumeration raises mid-stream, so
+                # deletes that already completed are still recorded in the report.
+                if futures:
+                    self._collect_hard_deletes(futures, ALL_COMPLETED)
 
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:
         if not self.config.enabled:

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/query_cleanup.py
@@ -1,19 +1,20 @@
 import logging
 import time
-from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from threading import Lock
-from typing import Dict, Iterable, Optional
+from typing import Iterable, Optional
 
 from pydantic import Field
 
 from datahub.configuration import ConfigModel
 from datahub.configuration.env_vars import get_report_info_sample_size
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.source import SourceReport
+from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.ingestion.graph.filters import RemovedStatusFilter, SearchFilterRule
+from datahub.metadata.schema_classes import StatusClass
 from datahub.utilities.lossy_collections import LossyList
 from datahub.utilities.urns._urn_base import Urn
 from datahub.utilities.urns.error import InvalidUrnError
@@ -46,7 +47,8 @@ class QueryCleanupConfig(ConfigModel):
             "(False) soft-deletes here and lets soft_deleted_entities_cleanup hard-delete them "
             "on a later run, which additionally calls deleteReferences to clear inbound pointers. "
             "This shortcut skips that step, so `via` pointers on lineage aspects are left "
-            "pointing at the deleted query."
+            "pointing at the deleted query. Hard deletes are issued one at a time; soft deletes "
+            "are emitted as workunits and batched by the sink."
         ),
     )
 
@@ -55,31 +57,9 @@ class QueryCleanupConfig(ConfigModel):
         description="The number of entities to fetch in a batch from search.",
     )
 
-    max_workers: int = Field(
-        10,
-        description="The number of workers to use for deletion.",
-    )
-
-    delay: Optional[float] = Field(
-        0.25,
-        description="Delay between each batch.",
-    )
-
-    futures_max_at_time: int = Field(
-        1000,
-        description=(
-            "Max number of in-flight delete operations to have pending at a time. "
-            "Bounds memory when streaming a large candidate set; the selection loop "
-            "throttles once this many deletes are outstanding."
-        ),
-    )
-
     limit_entities_delete: Optional[int] = Field(
         25000,
-        description=(
-            "Approximate max number of queries to delete in a single run. "
-            "Concurrent workers may overshoot this by up to max_workers entities."
-        ),
+        description="Approximate max number of queries to delete in a single run.",
     )
 
     runtime_limit_seconds: int = Field(
@@ -91,15 +71,21 @@ class QueryCleanupConfig(ConfigModel):
 @dataclass
 class QueryCleanupReport(SourceReport):
     num_queries_found: int = 0
-    num_queries_invalid_urn: int = 0
     num_queries_soft_deleted: int = 0
     num_queries_hard_deleted: int = 0
-    num_queries_processed: int = 0
     sample_deleted_queries: LossyList[str] = field(
         default_factory=lambda: LossyList(max_elements=get_report_info_sample_size())
     )
     qc_runtime_limit_reached: bool = False
     qc_deletion_limit_reached: bool = False
+
+    def report_query_soft_deleted(self, urn: str) -> None:
+        self.num_queries_soft_deleted += 1
+        self.sample_deleted_queries.append(urn)
+
+    def report_query_hard_deleted(self, urn: str) -> None:
+        self.num_queries_hard_deleted += 1
+        self.sample_deleted_queries.append(urn)
 
 
 class QueryCleanup:
@@ -107,7 +93,10 @@ class QueryCleanup:
     Maintenance source that soft-deletes old SYSTEM queries by age alone (aggressive policy).
 
     Selection is a single server-side filter on `source == SYSTEM` and
-    `lastModifiedAt < cutoff`. The existing SoftDeletedEntitiesCleanup completes the hard-delete second pass.
+    `lastModifiedAt < cutoff`. Soft deletes are emitted as status workunits and left to the
+    sink to batch and write (the same mechanism as stale-entity removal); the existing
+    SoftDeletedEntitiesCleanup completes the hard-delete second pass. Hard deletes, when
+    enabled, have no bulk endpoint and are issued imperatively one at a time.
     """
 
     def __init__(
@@ -125,8 +114,6 @@ class QueryCleanup:
         self.report = report
         self.dry_run = dry_run
         self.start_time = time.time()
-        self._report_lock: Lock = Lock()
-        self.last_print_time = 0.0
 
     def _get_urns(self) -> Iterable[str]:
         cutoff_millis = int(
@@ -154,77 +141,16 @@ class QueryCleanup:
             ],
         )
 
-    def _update_report(self, urn: str) -> None:
-        """Thread-safe method to update report fields after a delete."""
-        with self._report_lock:
-            if self.config.hard_delete_entities:
-                self.report.num_queries_hard_deleted += 1
-            else:
-                self.report.num_queries_soft_deleted += 1
-            self.report.sample_deleted_queries.append(urn)
-
-    def delete_query(self, urn: Urn) -> None:
-        if self.dry_run:
-            logger.info(
-                f"Dry run is on, otherwise it would have deleted {urn} "
-                f"(hard_delete={self.config.hard_delete_entities})"
-            )
-            return
-        if self._deletion_limit_reached() or self._times_up():
-            return
-        self.graph.delete_entity(urn=urn.urn(), hard=self.config.hard_delete_entities)
-        self._update_report(urn.urn())
-
-    def _print_report(self) -> None:
-        time_taken = round(time.time() - self.last_print_time, 1)
-        # Print report every 2 minutes
-        if time_taken > 120:
-            self.last_print_time = time.time()
-            logger.info(f"\n{self.report.as_string()}")
-
-    def _process_futures(self, futures: Dict[Future, Urn]) -> Dict[Future, Urn]:
-        done, not_done = wait(futures, return_when=FIRST_COMPLETED)
-
-        for future in done:
-            self._print_report()
-            if future.exception():
-                self.report.failure(
-                    title="Failed to delete query",
-                    message="Failed to delete query",
-                    context=futures[future].urn(),
-                    exc=future.exception(),
-                )
-            self.report.num_queries_processed += 1
-            # Throttle once every batch_size completions rather than on every
-            # wait() return, so `delay` matches its documented per-batch meaning.
-            if (
-                self.config.delay
-                and self.report.num_queries_processed % self.config.batch_size == 0
-            ):
-                logger.debug(
-                    f"Sleeping for {self.config.delay} seconds before processing next batch"
-                )
-                time.sleep(self.config.delay)
-
-        remaining = {
-            future: urn for future, urn in futures.items() if future in not_done
-        }
-        return remaining
-
     def _times_up(self) -> bool:
         if (
             self.config.runtime_limit_seconds
             and time.time() - self.start_time > self.config.runtime_limit_seconds
         ):
-            with self._report_lock:
-                self.report.qc_runtime_limit_reached = True
+            self.report.qc_runtime_limit_reached = True
             return True
         return False
 
     def _deletion_limit_reached(self) -> bool:
-        # Approximate cap: the counter reads need no lock (int reads are atomic
-        # under the GIL), but the check-then-delete gap means concurrent workers
-        # can overshoot the limit by up to max_workers entities.
         num_deleted = (
             self.report.num_queries_soft_deleted + self.report.num_queries_hard_deleted
         )
@@ -232,36 +158,50 @@ class QueryCleanup:
             self.config.limit_entities_delete
             and num_deleted >= self.config.limit_entities_delete
         ):
-            with self._report_lock:
-                self.report.qc_deletion_limit_reached = True
+            self.report.qc_deletion_limit_reached = True
             return True
         return False
 
-    def cleanup_queries(self) -> None:
+    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
         if not self.config.enabled:
             return
         self.start_time = time.time()
 
-        futures: Dict[Future, Urn] = dict()
-        with ThreadPoolExecutor(max_workers=self.config.max_workers) as executor:
-            for urn in self._get_urns():
-                try:
-                    self.report.num_queries_found += 1
-                    query_urn = Urn.from_string(urn)
-                except InvalidUrnError as e:
-                    logger.error(f"Failed to parse urn {urn} with error {e}")
-                    self.report.num_queries_invalid_urn += 1
-                    continue
+        for urn in self._get_urns():
+            try:
+                query_urn = Urn.from_string(urn)
+            except InvalidUrnError as e:
+                self.report.warning(
+                    title="Skipped query with unparseable urn",
+                    message="Search returned a query urn that could not be parsed; skipping it.",
+                    context=urn,
+                    exc=e,
+                )
+                continue
+            self.report.num_queries_found += 1
 
-                self._print_report()
-                while len(futures) >= self.config.futures_max_at_time:
-                    futures = self._process_futures(futures)
-                if self._deletion_limit_reached() or self._times_up():
-                    break
-                future = executor.submit(self.delete_query, query_urn)
-                futures[future] = query_urn
+            if self._deletion_limit_reached() or self._times_up():
+                break
 
-            logger.info(f"Waiting for {len(futures)} futures to complete")
-            while len(futures) > 0:
-                self._print_report()
-                futures = self._process_futures(futures)
+            if self.dry_run:
+                logger.info(
+                    f"Dry run is on, otherwise it would have deleted {query_urn} "
+                    f"(hard_delete={self.config.hard_delete_entities})"
+                )
+                # Record the candidate so a dry run still previews what would go.
+                self.report.sample_deleted_queries.append(query_urn.urn())
+                continue
+
+            if self.config.hard_delete_entities:
+                # There is no bulk hard-delete endpoint, so hard delete imperatively
+                # (one at a time) rather than through the workunit stream.
+                self.graph.delete_entity(urn=query_urn.urn(), hard=True)
+                self.report.report_query_hard_deleted(query_urn.urn())
+            else:
+                # Soft delete is a plain status write, so hand it to the sink as a
+                # workunit and let it batch/async the write (like stale-entity removal).
+                self.report.report_query_soft_deleted(query_urn.urn())
+                yield MetadataChangeProposalWrapper(
+                    entityUrn=query_urn.urn(),
+                    aspect=StatusClass(removed=True),
+                ).as_workunit()

--- a/metadata-ingestion/tests/unit/sdk_v2/test_search_client.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_search_client.py
@@ -777,6 +777,34 @@ def test_get_urns_with_skip_cache() -> None:
         )
 
 
+def test_get_urns_by_filter_with_sort() -> None:
+    graph = MockDataHubGraph()
+
+    with unittest.mock.patch.object(graph, "execute_graphql") as mock_execute_graphql:
+        result_urns = ["urn:li:query:1"]
+        mock_execute_graphql.return_value = {
+            "scrollAcrossEntities": {
+                "nextScrollId": None,
+                "searchResults": [{"entity": {"urn": urn}} for urn in result_urns],
+            }
+        }
+
+        urns = list(
+            graph.get_urns_by_filter(
+                entity_types=["query"],
+                sort_by="lastModifiedAt",
+                sort_order="DESCENDING",
+            )
+        )
+        assert urns == result_urns
+
+        assert mock_execute_graphql.call_count == 1
+        _, kwargs = mock_execute_graphql.call_args
+        assert kwargs["variables"]["sortInput"] == {
+            "sortCriteria": [{"field": "lastModifiedAt", "sortOrder": "DESCENDING"}]
+        }
+
+
 def test_get_document_urns() -> None:
     """Test searching for Document entities."""
     graph = MockDataHubGraph()

--- a/metadata-ingestion/tests/unit/sdk_v2/test_search_client.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_search_client.py
@@ -718,6 +718,7 @@ def test_get_urns() -> None:
                 "batchSize": unittest.mock.ANY,
                 "scrollId": None,
                 "skipCache": False,
+                "sortInput": None,
                 "includeSoftDeleted": None,
             },
         )
@@ -770,6 +771,7 @@ def test_get_urns_with_skip_cache() -> None:
                 "batchSize": unittest.mock.ANY,
                 "scrollId": None,
                 "skipCache": True,
+                "sortInput": None,
                 "includeSoftDeleted": None,
             },
         )

--- a/metadata-ingestion/tests/unit/test_query_cleanup.py
+++ b/metadata-ingestion/tests/unit/test_query_cleanup.py
@@ -1,8 +1,9 @@
+import logging
 import time
-import unittest
 from concurrent.futures import Future
 from unittest.mock import MagicMock, patch
 
+import pytest
 import time_machine
 
 from datahub.ingestion.api.common import PipelineContext
@@ -18,8 +19,8 @@ from datahub.utilities.urns._urn_base import Urn
 FROZEN_TIME = "2021-12-07 07:00:00"
 
 
-class TestQueryCleanup(unittest.TestCase):
-    def setUp(self) -> None:
+class TestQueryCleanup:
+    def setup_method(self) -> None:
         self.mock_graph = MagicMock(spec=DataHubGraph)
         self.mock_ctx = MagicMock(spec=PipelineContext)
         self.mock_ctx.graph = self.mock_graph
@@ -36,7 +37,7 @@ class TestQueryCleanup(unittest.TestCase):
 
     def test_init_requires_graph(self) -> None:
         self.mock_ctx.graph = None
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             QueryCleanup(self.mock_ctx, self.config, self.report)
 
     @time_machine.travel(FROZEN_TIME, tick=False)
@@ -70,8 +71,8 @@ class TestQueryCleanup(unittest.TestCase):
         self.mock_graph.delete_entity.assert_called_once_with(
             urn=self.sample_urn.urn(), hard=False
         )
-        self.assertEqual(self.report.num_queries_soft_deleted, 1)
-        self.assertEqual(self.report.num_queries_hard_deleted, 0)
+        assert self.report.num_queries_soft_deleted == 1
+        assert self.report.num_queries_hard_deleted == 0
 
     def test_delete_query_hard_delete(self) -> None:
         self.config.hard_delete_entities = True
@@ -81,8 +82,8 @@ class TestQueryCleanup(unittest.TestCase):
         self.mock_graph.delete_entity.assert_called_once_with(
             urn=self.sample_urn.urn(), hard=True
         )
-        self.assertEqual(self.report.num_queries_hard_deleted, 1)
-        self.assertEqual(self.report.num_queries_soft_deleted, 0)
+        assert self.report.num_queries_hard_deleted == 1
+        assert self.report.num_queries_soft_deleted == 0
 
     def test_delete_query_dry_run(self) -> None:
         self.cleanup.dry_run = True
@@ -90,7 +91,7 @@ class TestQueryCleanup(unittest.TestCase):
         self.cleanup.delete_query(self.sample_urn)
 
         self.mock_graph.delete_entity.assert_not_called()
-        self.assertEqual(self.report.num_queries_soft_deleted, 0)
+        assert self.report.num_queries_soft_deleted == 0
 
     def test_delete_query_respects_deletion_limit(self) -> None:
         self.config.limit_entities_delete = 5
@@ -99,7 +100,7 @@ class TestQueryCleanup(unittest.TestCase):
         self.cleanup.delete_query(self.sample_urn)
 
         self.mock_graph.delete_entity.assert_not_called()
-        self.assertTrue(self.report.deletion_limit_reached)
+        assert self.report.qc_deletion_limit_reached
 
     def test_delete_query_respects_time_limit(self) -> None:
         self.cleanup.start_time = time.time() - self.config.runtime_limit_seconds - 1
@@ -107,7 +108,7 @@ class TestQueryCleanup(unittest.TestCase):
         self.cleanup.delete_query(self.sample_urn)
 
         self.mock_graph.delete_entity.assert_not_called()
-        self.assertTrue(self.report.runtime_limit_reached)
+        assert self.report.qc_runtime_limit_reached
 
     def test_cleanup_disabled(self) -> None:
         self.config.enabled = False
@@ -123,21 +124,22 @@ class TestQueryCleanup(unittest.TestCase):
 
         self.cleanup.cleanup_queries()
 
-        self.assertEqual(self.report.num_system_queries_found, 3)
-        self.assertEqual(self.report.num_queries_soft_deleted, 3)
-        self.assertEqual(self.mock_graph.delete_entity.call_count, 3)
+        assert self.report.num_queries_found == 3
+        assert self.report.num_queries_soft_deleted == 3
+        assert self.mock_graph.delete_entity.call_count == 3
 
-    def test_cleanup_skips_invalid_urn(self) -> None:
+    def test_cleanup_skips_invalid_urn(self, caplog: pytest.LogCaptureFixture) -> None:
         self.mock_graph.get_urns_by_filter.return_value = [
             "urn:li:query:1",
             "invalid:urn",
         ]
 
-        with self.assertLogs(level="ERROR") as log_context:
+        with caplog.at_level(logging.ERROR):
             self.cleanup.cleanup_queries()
 
-        self.assertTrue(any("Failed to parse urn" in msg for msg in log_context.output))
-        self.assertEqual(self.report.num_queries_soft_deleted, 1)
+        assert any("Failed to parse urn" in r.message for r in caplog.records)
+        assert self.report.num_queries_soft_deleted == 1
+        assert self.report.num_queries_invalid_urn == 1
 
     def test_process_futures_reports_failure(self) -> None:
         good = MagicMock(spec=Future)
@@ -154,9 +156,5 @@ class TestQueryCleanup(unittest.TestCase):
                 {good: self.sample_urn, bad: self.sample_urn}
             )
 
-        self.assertEqual(remaining, {})
-        self.assertEqual(len(self.report.failures), 1)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert remaining == {}
+        assert len(self.report.failures) == 1

--- a/metadata-ingestion/tests/unit/test_query_cleanup.py
+++ b/metadata-ingestion/tests/unit/test_query_cleanup.py
@@ -53,6 +53,8 @@ class TestQueryCleanup:
             entity_types=["query"],
             status=RemovedStatusFilter.NOT_SOFT_DELETED,
             batch_size=self.config.batch_size,
+            sort_by="lastModifiedAt",
+            sort_order="ASCENDING",
             extraFilters=[
                 SearchFilterRule(
                     field="source", condition="EQUAL", values=["SYSTEM"]

--- a/metadata-ingestion/tests/unit/test_query_cleanup.py
+++ b/metadata-ingestion/tests/unit/test_query_cleanup.py
@@ -14,7 +14,6 @@ from datahub.ingestion.source.gc.query_cleanup import (
     QueryCleanupReport,
 )
 from datahub.metadata.schema_classes import StatusClass
-from datahub.utilities.urns._urn_base import Urn
 
 FROZEN_TIME = "2021-12-07 07:00:00"
 
@@ -33,7 +32,6 @@ class TestQueryCleanup:
             report=self.report,
             dry_run=False,
         )
-        self.sample_urn = Urn.from_string("urn:li:query:query-1")
 
     def test_init_requires_graph(self) -> None:
         self.mock_ctx.graph = None

--- a/metadata-ingestion/tests/unit/test_query_cleanup.py
+++ b/metadata-ingestion/tests/unit/test_query_cleanup.py
@@ -1,0 +1,162 @@
+import time
+import unittest
+from concurrent.futures import Future
+from unittest.mock import MagicMock, patch
+
+import time_machine
+
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.graph.client import DataHubGraph
+from datahub.ingestion.graph.filters import RemovedStatusFilter, SearchFilterRule
+from datahub.ingestion.source.gc.query_cleanup import (
+    QueryCleanup,
+    QueryCleanupConfig,
+    QueryCleanupReport,
+)
+from datahub.utilities.urns._urn_base import Urn
+
+FROZEN_TIME = "2021-12-07 07:00:00"
+
+
+class TestQueryCleanup(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mock_graph = MagicMock(spec=DataHubGraph)
+        self.mock_ctx = MagicMock(spec=PipelineContext)
+        self.mock_ctx.graph = self.mock_graph
+
+        self.config = QueryCleanupConfig(enabled=True, retention_days=30)
+        self.report = QueryCleanupReport()
+        self.cleanup = QueryCleanup(
+            ctx=self.mock_ctx,
+            config=self.config,
+            report=self.report,
+            dry_run=False,
+        )
+        self.sample_urn = Urn.from_string("urn:li:query:query-1")
+
+    def test_init_requires_graph(self) -> None:
+        self.mock_ctx.graph = None
+        with self.assertRaises(ValueError):
+            QueryCleanup(self.mock_ctx, self.config, self.report)
+
+    @time_machine.travel(FROZEN_TIME, tick=False)
+    def test_get_urns_filters_by_system_and_age(self) -> None:
+        self.mock_graph.get_urns_by_filter.return_value = ["urn:li:query:1"]
+
+        list(self.cleanup._get_urns())
+
+        cutoff_millis = int(
+            (time.time() - self.config.retention_days * 24 * 60 * 60) * 1000
+        )
+        self.mock_graph.get_urns_by_filter.assert_called_once_with(
+            entity_types=["query"],
+            status=RemovedStatusFilter.NOT_SOFT_DELETED,
+            batch_size=self.config.batch_size,
+            extraFilters=[
+                SearchFilterRule(
+                    field="source", condition="EQUAL", values=["SYSTEM"]
+                ).to_raw(),
+                SearchFilterRule(
+                    field="lastModifiedAt",
+                    condition="LESS_THAN",
+                    values=[f"{cutoff_millis}"],
+                ).to_raw(),
+            ],
+        )
+
+    def test_delete_query_soft_delete(self) -> None:
+        self.cleanup.delete_query(self.sample_urn)
+
+        self.mock_graph.delete_entity.assert_called_once_with(
+            urn=self.sample_urn.urn(), hard=False
+        )
+        self.assertEqual(self.report.num_queries_soft_deleted, 1)
+        self.assertEqual(self.report.num_queries_hard_deleted, 0)
+
+    def test_delete_query_hard_delete(self) -> None:
+        self.config.hard_delete_entities = True
+
+        self.cleanup.delete_query(self.sample_urn)
+
+        self.mock_graph.delete_entity.assert_called_once_with(
+            urn=self.sample_urn.urn(), hard=True
+        )
+        self.assertEqual(self.report.num_queries_hard_deleted, 1)
+        self.assertEqual(self.report.num_queries_soft_deleted, 0)
+
+    def test_delete_query_dry_run(self) -> None:
+        self.cleanup.dry_run = True
+
+        self.cleanup.delete_query(self.sample_urn)
+
+        self.mock_graph.delete_entity.assert_not_called()
+        self.assertEqual(self.report.num_queries_soft_deleted, 0)
+
+    def test_delete_query_respects_deletion_limit(self) -> None:
+        self.config.limit_entities_delete = 5
+        self.report.num_queries_soft_deleted = 6
+
+        self.cleanup.delete_query(self.sample_urn)
+
+        self.mock_graph.delete_entity.assert_not_called()
+        self.assertTrue(self.report.deletion_limit_reached)
+
+    def test_delete_query_respects_time_limit(self) -> None:
+        self.cleanup.start_time = time.time() - self.config.runtime_limit_seconds - 1
+
+        self.cleanup.delete_query(self.sample_urn)
+
+        self.mock_graph.delete_entity.assert_not_called()
+        self.assertTrue(self.report.runtime_limit_reached)
+
+    def test_cleanup_disabled(self) -> None:
+        self.config.enabled = False
+
+        self.cleanup.cleanup_queries()
+
+        self.mock_graph.get_urns_by_filter.assert_not_called()
+        self.mock_graph.delete_entity.assert_not_called()
+
+    def test_cleanup_deletes_all_candidates(self) -> None:
+        urns = ["urn:li:query:1", "urn:li:query:2", "urn:li:query:3"]
+        self.mock_graph.get_urns_by_filter.return_value = urns
+
+        self.cleanup.cleanup_queries()
+
+        self.assertEqual(self.report.num_system_queries_found, 3)
+        self.assertEqual(self.report.num_queries_soft_deleted, 3)
+        self.assertEqual(self.mock_graph.delete_entity.call_count, 3)
+
+    def test_cleanup_skips_invalid_urn(self) -> None:
+        self.mock_graph.get_urns_by_filter.return_value = [
+            "urn:li:query:1",
+            "invalid:urn",
+        ]
+
+        with self.assertLogs(level="ERROR") as log_context:
+            self.cleanup.cleanup_queries()
+
+        self.assertTrue(any("Failed to parse urn" in msg for msg in log_context.output))
+        self.assertEqual(self.report.num_queries_soft_deleted, 1)
+
+    def test_process_futures_reports_failure(self) -> None:
+        good = MagicMock(spec=Future)
+        good.exception.return_value = None
+        bad = MagicMock(spec=Future)
+        bad.exception.return_value = Exception("boom")
+
+        self.config.delay = None
+        with patch(
+            "datahub.ingestion.source.gc.query_cleanup.wait",
+            return_value=({good, bad}, set()),
+        ):
+            remaining = self.cleanup._process_futures(
+                {good: self.sample_urn, bad: self.sample_urn}
+            )
+
+        self.assertEqual(remaining, {})
+        self.assertEqual(len(self.report.failures), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/metadata-ingestion/tests/unit/test_query_cleanup.py
+++ b/metadata-ingestion/tests/unit/test_query_cleanup.py
@@ -128,6 +128,35 @@ class TestQueryCleanup:
         assert self.report.num_queries_soft_deleted == 3
         assert self.mock_graph.delete_entity.call_count == 3
 
+    def test_cleanup_dry_run_counts_found_but_not_deleted(self) -> None:
+        self.cleanup.dry_run = True
+        self.mock_graph.get_urns_by_filter.return_value = [
+            "urn:li:query:1",
+            "urn:li:query:2",
+        ]
+
+        self.cleanup.cleanup_queries()
+
+        assert self.report.num_queries_found == 2
+        assert self.report.num_queries_soft_deleted == 0
+        self.mock_graph.delete_entity.assert_not_called()
+
+    def test_cleanup_stops_submitting_when_limit_reached(self) -> None:
+        # Pre-seed the counter so the limit is already reached before the loop
+        # starts; this deterministically exercises the main-loop break, avoiding
+        # the worker-thread overshoot race a mid-stream limit would introduce.
+        self.config.limit_entities_delete = 2
+        self.report.num_queries_soft_deleted = 2
+        self.mock_graph.get_urns_by_filter.return_value = [
+            "urn:li:query:1",
+            "urn:li:query:2",
+        ]
+
+        self.cleanup.cleanup_queries()
+
+        self.mock_graph.delete_entity.assert_not_called()
+        assert self.report.qc_deletion_limit_reached
+
     def test_cleanup_skips_invalid_urn(self, caplog: pytest.LogCaptureFixture) -> None:
         self.mock_graph.get_urns_by_filter.return_value = [
             "urn:li:query:1",

--- a/metadata-ingestion/tests/unit/test_query_cleanup.py
+++ b/metadata-ingestion/tests/unit/test_query_cleanup.py
@@ -132,6 +132,18 @@ class TestQueryCleanup:
         assert self.report.num_queries_soft_deleted == 2
         assert self.report.qc_deletion_limit_reached
 
+    def test_uncapped_deletes_all(self) -> None:
+        self.config.limit_entities_delete = None
+        self.mock_graph.get_urns_by_filter.return_value = [
+            f"urn:li:query:{i}" for i in range(5)
+        ]
+
+        wus = list(self.cleanup.get_workunits())
+
+        assert len(wus) == 5
+        assert self.report.num_queries_soft_deleted == 5
+        assert not self.report.qc_deletion_limit_reached
+
     def test_times_up_sets_runtime_flag(self) -> None:
         self.cleanup.start_time = time.time() - self.config.runtime_limit_seconds - 1
 

--- a/metadata-ingestion/tests/unit/test_query_cleanup.py
+++ b/metadata-ingestion/tests/unit/test_query_cleanup.py
@@ -79,25 +79,10 @@ class TestQueryCleanup:
             aspect = mcp.aspect
             assert isinstance(aspect, StatusClass)
             assert aspect.removed
-        # Soft delete never touches the imperative hard-delete path.
+        # Soft delete never touches the imperative delete path.
         self.mock_graph.delete_entity.assert_not_called()
         assert self.report.num_queries_found == 3
         assert self.report.num_queries_soft_deleted == 3
-        assert self.report.num_queries_hard_deleted == 0
-
-    def test_hard_delete_uses_graph_delete_entity(self) -> None:
-        self.config.hard_delete_entities = True
-        urns = ["urn:li:query:1", "urn:li:query:2"]
-        self.mock_graph.get_urns_by_filter.return_value = urns
-
-        wus = list(self.cleanup.get_workunits())
-
-        # Hard delete runs through the worker pool, so it yields no workunits.
-        assert wus == []
-        assert self.mock_graph.delete_entity.call_count == 2
-        self.mock_graph.delete_entity.assert_any_call(urn=urns[0], hard=True)
-        assert self.report.num_queries_hard_deleted == 2
-        assert self.report.num_queries_soft_deleted == 0
 
     def test_dry_run_previews_without_deleting(self) -> None:
         self.cleanup.dry_run = True

--- a/metadata-ingestion/tests/unit/test_query_cleanup.py
+++ b/metadata-ingestion/tests/unit/test_query_cleanup.py
@@ -1,11 +1,10 @@
-import logging
 import time
-from concurrent.futures import Future
 from unittest.mock import MagicMock, patch
 
 import pytest
 import time_machine
 
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.ingestion.graph.filters import RemovedStatusFilter, SearchFilterRule
@@ -14,6 +13,7 @@ from datahub.ingestion.source.gc.query_cleanup import (
     QueryCleanupConfig,
     QueryCleanupReport,
 )
+from datahub.metadata.schema_classes import StatusClass
 from datahub.utilities.urns._urn_base import Urn
 
 FROZEN_TIME = "2021-12-07 07:00:00"
@@ -65,125 +65,101 @@ class TestQueryCleanup:
             ],
         )
 
-    def test_delete_query_soft_delete(self) -> None:
-        self.cleanup.delete_query(self.sample_urn)
-
-        self.mock_graph.delete_entity.assert_called_once_with(
-            urn=self.sample_urn.urn(), hard=False
-        )
-        assert self.report.num_queries_soft_deleted == 1
-        assert self.report.num_queries_hard_deleted == 0
-
-    def test_delete_query_hard_delete(self) -> None:
-        self.config.hard_delete_entities = True
-
-        self.cleanup.delete_query(self.sample_urn)
-
-        self.mock_graph.delete_entity.assert_called_once_with(
-            urn=self.sample_urn.urn(), hard=True
-        )
-        assert self.report.num_queries_hard_deleted == 1
-        assert self.report.num_queries_soft_deleted == 0
-
-    def test_delete_query_dry_run(self) -> None:
-        self.cleanup.dry_run = True
-
-        self.cleanup.delete_query(self.sample_urn)
-
-        self.mock_graph.delete_entity.assert_not_called()
-        assert self.report.num_queries_soft_deleted == 0
-
-    def test_delete_query_respects_deletion_limit(self) -> None:
-        self.config.limit_entities_delete = 5
-        self.report.num_queries_soft_deleted = 6
-
-        self.cleanup.delete_query(self.sample_urn)
-
-        self.mock_graph.delete_entity.assert_not_called()
-        assert self.report.qc_deletion_limit_reached
-
-    def test_delete_query_respects_time_limit(self) -> None:
-        self.cleanup.start_time = time.time() - self.config.runtime_limit_seconds - 1
-
-        self.cleanup.delete_query(self.sample_urn)
-
-        self.mock_graph.delete_entity.assert_not_called()
-        assert self.report.qc_runtime_limit_reached
-
-    def test_cleanup_disabled(self) -> None:
-        self.config.enabled = False
-
-        self.cleanup.cleanup_queries()
-
-        self.mock_graph.get_urns_by_filter.assert_not_called()
-        self.mock_graph.delete_entity.assert_not_called()
-
-    def test_cleanup_deletes_all_candidates(self) -> None:
+    def test_soft_delete_yields_status_workunits(self) -> None:
         urns = ["urn:li:query:1", "urn:li:query:2", "urn:li:query:3"]
         self.mock_graph.get_urns_by_filter.return_value = urns
 
-        self.cleanup.cleanup_queries()
+        wus = list(self.cleanup.get_workunits())
 
+        assert len(wus) == 3
+        for wu, expected_urn in zip(wus, urns, strict=True):
+            mcp = wu.metadata
+            assert isinstance(mcp, MetadataChangeProposalWrapper)
+            assert mcp.entityUrn == expected_urn
+            aspect = mcp.aspect
+            assert isinstance(aspect, StatusClass)
+            assert aspect.removed
+        # Soft delete never touches the imperative hard-delete path.
+        self.mock_graph.delete_entity.assert_not_called()
         assert self.report.num_queries_found == 3
         assert self.report.num_queries_soft_deleted == 3
-        assert self.mock_graph.delete_entity.call_count == 3
+        assert self.report.num_queries_hard_deleted == 0
 
-    def test_cleanup_dry_run_counts_found_but_not_deleted(self) -> None:
+    def test_hard_delete_uses_graph_delete_entity(self) -> None:
+        self.config.hard_delete_entities = True
+        urns = ["urn:li:query:1", "urn:li:query:2"]
+        self.mock_graph.get_urns_by_filter.return_value = urns
+
+        wus = list(self.cleanup.get_workunits())
+
+        # Hard delete is imperative, so it yields no workunits.
+        assert wus == []
+        assert self.mock_graph.delete_entity.call_count == 2
+        self.mock_graph.delete_entity.assert_any_call(urn=urns[0], hard=True)
+        assert self.report.num_queries_hard_deleted == 2
+        assert self.report.num_queries_soft_deleted == 0
+
+    def test_dry_run_previews_without_deleting(self) -> None:
         self.cleanup.dry_run = True
-        self.mock_graph.get_urns_by_filter.return_value = [
-            "urn:li:query:1",
-            "urn:li:query:2",
-        ]
+        urns = ["urn:li:query:1", "urn:li:query:2"]
+        self.mock_graph.get_urns_by_filter.return_value = urns
 
-        self.cleanup.cleanup_queries()
+        wus = list(self.cleanup.get_workunits())
 
+        assert wus == []
+        self.mock_graph.delete_entity.assert_not_called()
         assert self.report.num_queries_found == 2
         assert self.report.num_queries_soft_deleted == 0
-        self.mock_graph.delete_entity.assert_not_called()
+        # Dry run still previews the candidate urns.
+        assert len(self.report.sample_deleted_queries) == 2
 
-    def test_cleanup_stops_submitting_when_limit_reached(self) -> None:
-        # Pre-seed the counter so the limit is already reached before the loop
-        # starts; this deterministically exercises the main-loop break, avoiding
-        # the worker-thread overshoot race a mid-stream limit would introduce.
+    def test_disabled(self) -> None:
+        self.config.enabled = False
+
+        wus = list(self.cleanup.get_workunits())
+
+        assert wus == []
+        self.mock_graph.get_urns_by_filter.assert_not_called()
+
+    def test_respects_deletion_limit(self) -> None:
         self.config.limit_entities_delete = 2
-        self.report.num_queries_soft_deleted = 2
+        self.mock_graph.get_urns_by_filter.return_value = [
+            f"urn:li:query:{i}" for i in range(5)
+        ]
+
+        wus = list(self.cleanup.get_workunits())
+
+        assert len(wus) == 2
+        assert self.report.num_queries_soft_deleted == 2
+        assert self.report.qc_deletion_limit_reached
+
+    def test_times_up_sets_runtime_flag(self) -> None:
+        self.cleanup.start_time = time.time() - self.config.runtime_limit_seconds - 1
+
+        assert self.cleanup._times_up()
+        assert self.report.qc_runtime_limit_reached
+
+    def test_stops_when_runtime_limit_reached(self) -> None:
         self.mock_graph.get_urns_by_filter.return_value = [
             "urn:li:query:1",
             "urn:li:query:2",
         ]
 
-        self.cleanup.cleanup_queries()
+        with patch.object(self.cleanup, "_times_up", return_value=True):
+            wus = list(self.cleanup.get_workunits())
 
-        self.mock_graph.delete_entity.assert_not_called()
-        assert self.report.qc_deletion_limit_reached
+        assert wus == []
+        assert self.report.num_queries_soft_deleted == 0
 
-    def test_cleanup_skips_invalid_urn(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_skips_invalid_urn(self) -> None:
         self.mock_graph.get_urns_by_filter.return_value = [
             "urn:li:query:1",
             "invalid:urn",
         ]
 
-        with caplog.at_level(logging.ERROR):
-            self.cleanup.cleanup_queries()
+        wus = list(self.cleanup.get_workunits())
 
-        assert any("Failed to parse urn" in r.message for r in caplog.records)
+        assert len(wus) == 1
+        assert self.report.num_queries_found == 1
         assert self.report.num_queries_soft_deleted == 1
-        assert self.report.num_queries_invalid_urn == 1
-
-    def test_process_futures_reports_failure(self) -> None:
-        good = MagicMock(spec=Future)
-        good.exception.return_value = None
-        bad = MagicMock(spec=Future)
-        bad.exception.return_value = Exception("boom")
-
-        self.config.delay = None
-        with patch(
-            "datahub.ingestion.source.gc.query_cleanup.wait",
-            return_value=({good, bad}, set()),
-        ):
-            remaining = self.cleanup._process_futures(
-                {good: self.sample_urn, bad: self.sample_urn}
-            )
-
-        assert remaining == {}
-        assert len(self.report.failures) == 1
+        assert len(self.report.warnings) == 1

--- a/metadata-ingestion/tests/unit/test_query_cleanup.py
+++ b/metadata-ingestion/tests/unit/test_query_cleanup.py
@@ -162,6 +162,18 @@ class TestQueryCleanup:
         assert wus == []
         assert self.report.num_queries_soft_deleted == 0
 
+    def test_stops_mid_stream_on_runtime_limit(self) -> None:
+        self.mock_graph.get_urns_by_filter.return_value = [
+            f"urn:li:query:{i}" for i in range(5)
+        ]
+
+        # Runtime limit trips only after the first two queries are processed.
+        with patch.object(self.cleanup, "_times_up", side_effect=[False, False, True]):
+            wus = list(self.cleanup.get_workunits())
+
+        assert len(wus) == 2
+        assert self.report.num_queries_soft_deleted == 2
+
     def test_skips_invalid_urn(self) -> None:
         self.mock_graph.get_urns_by_filter.return_value = [
             "urn:li:query:1",

--- a/metadata-ingestion/tests/unit/test_query_cleanup.py
+++ b/metadata-ingestion/tests/unit/test_query_cleanup.py
@@ -92,7 +92,7 @@ class TestQueryCleanup:
 
         wus = list(self.cleanup.get_workunits())
 
-        # Hard delete is imperative, so it yields no workunits.
+        # Hard delete runs through the worker pool, so it yields no workunits.
         assert wus == []
         assert self.mock_graph.delete_entity.call_count == 2
         self.mock_graph.delete_entity.assert_any_call(urn=urns[0], hard=True)

--- a/metadata-ingestion/tests/unit/test_query_cleanup.py
+++ b/metadata-ingestion/tests/unit/test_query_cleanup.py
@@ -98,6 +98,20 @@ class TestQueryCleanup:
         # Dry run still previews the candidate urns.
         assert len(self.report.sample_deleted_queries) == 2
 
+    def test_dry_run_respects_deletion_limit(self) -> None:
+        self.cleanup.dry_run = True
+        self.config.limit_entities_delete = 2
+        self.mock_graph.get_urns_by_filter.return_value = [
+            f"urn:li:query:{i}" for i in range(5)
+        ]
+
+        wus = list(self.cleanup.get_workunits())
+
+        assert wus == []
+        self.mock_graph.delete_entity.assert_not_called()
+        assert len(self.report.sample_deleted_queries) == 2
+        assert self.report.qc_deletion_limit_reached
+
     def test_disabled(self) -> None:
         self.config.enabled = False
 

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
@@ -56,7 +56,7 @@ bootstrap:
 
     # Ingestion Recipes
     - name: ingestion-datahub-gc
-      version: v7
+      version: v8
       optional: false
       mcps_location: "bootstrap_mcps/ingestion-datahub-gc.yaml"
       values_env: "DATAHUB_GC_BOOTSTRAP_VALUES"

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/ingestion-datahub-gc.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/ingestion-datahub-gc.yaml
@@ -43,7 +43,6 @@
               retention_days: {{query_cleanup.retention_days}}{{^query_cleanup.retention_days}}30{{/query_cleanup.retention_days}}
               hard_delete_entities: {{query_cleanup.hard_delete_entities}}{{^query_cleanup.hard_delete_entities}}false{{/query_cleanup.hard_delete_entities}}
               batch_size: {{query_cleanup.batch_size}}{{^query_cleanup.batch_size}}500{{/query_cleanup.batch_size}}
-              max_workers: {{query_cleanup.max_workers}}{{^query_cleanup.max_workers}}10{{/query_cleanup.max_workers}}
               limit_entities_delete: {{query_cleanup.limit_entities_delete}}{{^query_cleanup.limit_entities_delete}}25000{{/query_cleanup.limit_entities_delete}}
               runtime_limit_seconds: {{query_cleanup.runtime_limit_seconds}}{{^query_cleanup.runtime_limit_seconds}}7200{{/query_cleanup.runtime_limit_seconds}}
             execution_request_cleanup:

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/ingestion-datahub-gc.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/ingestion-datahub-gc.yaml
@@ -41,9 +41,7 @@
             query_cleanup:
               enabled: {{query_cleanup.enabled}}{{^query_cleanup.enabled}}false{{/query_cleanup.enabled}}
               retention_days: {{query_cleanup.retention_days}}{{^query_cleanup.retention_days}}30{{/query_cleanup.retention_days}}
-              hard_delete_entities: {{query_cleanup.hard_delete_entities}}{{^query_cleanup.hard_delete_entities}}false{{/query_cleanup.hard_delete_entities}}
               batch_size: {{query_cleanup.batch_size}}{{^query_cleanup.batch_size}}500{{/query_cleanup.batch_size}}
-              max_workers: {{query_cleanup.max_workers}}{{^query_cleanup.max_workers}}10{{/query_cleanup.max_workers}}
               limit_entities_delete: {{query_cleanup.limit_entities_delete}}{{^query_cleanup.limit_entities_delete}}25000{{/query_cleanup.limit_entities_delete}}
               runtime_limit_seconds: {{query_cleanup.runtime_limit_seconds}}{{^query_cleanup.runtime_limit_seconds}}7200{{/query_cleanup.runtime_limit_seconds}}
             execution_request_cleanup:

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/ingestion-datahub-gc.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/ingestion-datahub-gc.yaml
@@ -39,8 +39,8 @@
               limit_entities_delete: {{soft_deleted_entities_cleanup.limit_entities_delete}}{{^soft_deleted_entities_cleanup.limit_entities_delete}}25000{{/soft_deleted_entities_cleanup.limit_entities_delete}}
               runtime_limit_seconds: {{soft_deleted_entities_cleanup.runtime_limit_seconds}}{{^soft_deleted_entities_cleanup.runtime_limit_seconds}}7200{{/soft_deleted_entities_cleanup.runtime_limit_seconds}}
             query_cleanup:
-              enabled: {{query_cleanup.enabled}}{{^query_cleanup.enabled}}false{{/query_cleanup.enabled}}
-              retention_days: {{query_cleanup.retention_days}}{{^query_cleanup.retention_days}}90{{/query_cleanup.retention_days}}
+              enabled: {{query_cleanup.enabled}}{{^query_cleanup.enabled}}true{{/query_cleanup.enabled}}
+              retention_days: {{query_cleanup.retention_days}}{{^query_cleanup.retention_days}}180{{/query_cleanup.retention_days}}
               batch_size: {{query_cleanup.batch_size}}{{^query_cleanup.batch_size}}500{{/query_cleanup.batch_size}}
               limit_entities_delete: {{query_cleanup.limit_entities_delete}}{{^query_cleanup.limit_entities_delete}}25000{{/query_cleanup.limit_entities_delete}}
               runtime_limit_seconds: {{query_cleanup.runtime_limit_seconds}}{{^query_cleanup.runtime_limit_seconds}}7200{{/query_cleanup.runtime_limit_seconds}}

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/ingestion-datahub-gc.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/ingestion-datahub-gc.yaml
@@ -40,7 +40,7 @@
               runtime_limit_seconds: {{soft_deleted_entities_cleanup.runtime_limit_seconds}}{{^soft_deleted_entities_cleanup.runtime_limit_seconds}}7200{{/soft_deleted_entities_cleanup.runtime_limit_seconds}}
             query_cleanup:
               enabled: {{query_cleanup.enabled}}{{^query_cleanup.enabled}}false{{/query_cleanup.enabled}}
-              retention_days: {{query_cleanup.retention_days}}{{^query_cleanup.retention_days}}30{{/query_cleanup.retention_days}}
+              retention_days: {{query_cleanup.retention_days}}{{^query_cleanup.retention_days}}90{{/query_cleanup.retention_days}}
               batch_size: {{query_cleanup.batch_size}}{{^query_cleanup.batch_size}}500{{/query_cleanup.batch_size}}
               limit_entities_delete: {{query_cleanup.limit_entities_delete}}{{^query_cleanup.limit_entities_delete}}25000{{/query_cleanup.limit_entities_delete}}
               runtime_limit_seconds: {{query_cleanup.runtime_limit_seconds}}{{^query_cleanup.runtime_limit_seconds}}7200{{/query_cleanup.runtime_limit_seconds}}

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/ingestion-datahub-gc.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/ingestion-datahub-gc.yaml
@@ -38,6 +38,14 @@
               max_workers: {{soft_deleted_entities_cleanup.max_workers}}{{^soft_deleted_entities_cleanup.max_workers}}10{{/soft_deleted_entities_cleanup.max_workers}}
               limit_entities_delete: {{soft_deleted_entities_cleanup.limit_entities_delete}}{{^soft_deleted_entities_cleanup.limit_entities_delete}}25000{{/soft_deleted_entities_cleanup.limit_entities_delete}}
               runtime_limit_seconds: {{soft_deleted_entities_cleanup.runtime_limit_seconds}}{{^soft_deleted_entities_cleanup.runtime_limit_seconds}}7200{{/soft_deleted_entities_cleanup.runtime_limit_seconds}}
+            query_cleanup:
+              enabled: {{query_cleanup.enabled}}{{^query_cleanup.enabled}}false{{/query_cleanup.enabled}}
+              retention_days: {{query_cleanup.retention_days}}{{^query_cleanup.retention_days}}30{{/query_cleanup.retention_days}}
+              hard_delete_entities: {{query_cleanup.hard_delete_entities}}{{^query_cleanup.hard_delete_entities}}false{{/query_cleanup.hard_delete_entities}}
+              batch_size: {{query_cleanup.batch_size}}{{^query_cleanup.batch_size}}500{{/query_cleanup.batch_size}}
+              max_workers: {{query_cleanup.max_workers}}{{^query_cleanup.max_workers}}10{{/query_cleanup.max_workers}}
+              limit_entities_delete: {{query_cleanup.limit_entities_delete}}{{^query_cleanup.limit_entities_delete}}25000{{/query_cleanup.limit_entities_delete}}
+              runtime_limit_seconds: {{query_cleanup.runtime_limit_seconds}}{{^query_cleanup.runtime_limit_seconds}}7200{{/query_cleanup.runtime_limit_seconds}}
             execution_request_cleanup:
               keep_history_min_count: {{execution_request_cleanup.keep_history_min_count}}{{^execution_request_cleanup.keep_history_min_count}}10{{/execution_request_cleanup.keep_history_min_count}}
               keep_history_max_count: {{execution_request_cleanup.keep_history_max_count}}{{^execution_request_cleanup.keep_history_max_count}}1000{{/execution_request_cleanup.keep_history_max_count}}

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/ingestion-datahub-gc.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/ingestion-datahub-gc.yaml
@@ -43,6 +43,7 @@
               retention_days: {{query_cleanup.retention_days}}{{^query_cleanup.retention_days}}30{{/query_cleanup.retention_days}}
               hard_delete_entities: {{query_cleanup.hard_delete_entities}}{{^query_cleanup.hard_delete_entities}}false{{/query_cleanup.hard_delete_entities}}
               batch_size: {{query_cleanup.batch_size}}{{^query_cleanup.batch_size}}500{{/query_cleanup.batch_size}}
+              max_workers: {{query_cleanup.max_workers}}{{^query_cleanup.max_workers}}10{{/query_cleanup.max_workers}}
               limit_entities_delete: {{query_cleanup.limit_entities_delete}}{{^query_cleanup.limit_entities_delete}}25000{{/query_cleanup.limit_entities_delete}}
               runtime_limit_seconds: {{query_cleanup.runtime_limit_seconds}}{{^query_cleanup.runtime_limit_seconds}}7200{{/query_cleanup.runtime_limit_seconds}}
             execution_request_cleanup:


### PR DESCRIPTION
## Summary

Adds a `QueryCleanup` first-pass to the `datahub-gc` source that **soft-deletes** old `SYSTEM` queries by age alone.

Query entities have no first-pass cleanup today, and `query` is excluded from stateful ingestion's stale-entity removal. As a result, stale `SYSTEM` queries accumulate as permanent orphans in Elasticsearch and primary storage, causing index bloat and search/UI noise.

## Approach

- **Selection by age alone, no reference gate.** Candidates come from a single server-side search filter: `source == SYSTEM` AND `lastModifiedAt < cutoff` (`cutoff = now - retention_days`). `lastModifiedAt` is already `@Searchable` on `queryProperties`, so no backend change or reindex is needed.
- **Oldest-first ordering.** Results are sorted by `lastModifiedAt` ascending, so a capped run deletes the *most-stale* queries (not an arbitrary scroll slice) and dry-run previews reflect what a real run would delete. This required threading an optional `sort_by`/`sort_order` through `get_urns_by_filter` into `scrollAcrossEntities`'s `sortInput`.
- **`SYSTEM`-only.** `MANUAL` queries are never touched; enforced in the filter, not a config option.
- **Soft delete via the workunit stream.** Each candidate yields a `Status(removed=true)` workunit — the same mechanism as stateful ingestion's stale-entity removal — and the sink batches/writes it (the default `datahub-rest` sink is `ASYNC_BATCH`, which provides built-in backpressure). The pass keeps no concurrency or emit-mode logic.
- **Two-pass lifecycle (no hard delete in this pass).** This pass only soft-deletes. The existing `SoftDeletedEntitiesCleanup` already lists `query` in its default entity types and performs the hard-delete second pass — with `deleteReferences` and its own throttling — on a later run. This mirrors the DataProcess cleanup pattern.
- **Run-bounding.** Stops once `limit_entities_delete` or `runtime_limit_seconds` is reached (including in dry-run), mirroring `SoftDeletedEntitiesCleanup`.

## Config

**Enabled by default** with a conservative **180-day (~6 month)** retention — a large safety margin over any realistic connector ingestion window, and a major improvement over keeping `SYSTEM` queries indefinitely.

| Option | Default | Notes |
|---|---|---|
| `enabled` | `true` | Enabled by default |
| `retention_days` | `180` | Age cutoff on `lastModifiedAt` (~6 months) |
| `batch_size` | `500` | Search fetch size |
| `limit_entities_delete` | `25000` | Approx. cap per run; set to `null` to disable |
| `runtime_limit_seconds` | `7200` | Per-run wall-clock limit |
