### PR TITLE
docs(ingest): fix incorrect sync marker name in datahub sink docs

### DIFF
--- a/metadata-ingestion/sink_docs/datahub.md
+++ b/metadata-ingestion/sink_docs/datahub.md
@@ -73,24 +73,24 @@ If you are using [UI based ingestion](../../docs/ui-ingestion.md) then where GMS
 
 Note that a `.` is used to denote nested fields in the YAML recipe.
 
-| Field                      | Required | Default              | Description                                                                                                                                    |
-| -------------------------- | -------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `server`                   | ✅       |                      | URL of DataHub GMS endpoint.                                                                                                                   |
-| `token`                    |          |                      | Bearer token used for authentication.                                                                                                          |
-| `timeout_sec`              |          | 30                   | Per-HTTP request timeout.                                                                                                                      |
-| `retry_max_times`          |          | 1                    | Maximum times to retry if HTTP request fails. The delay between retries is increased exponentially                                             |
-| `retry_status_codes`       |          | [429, 502, 503, 504] | Retry HTTP request also on these status codes                                                                                                  |
-| `extra_headers`            |          |                      | Extra headers which will be added to the request.                                                                                              |
-| `max_threads`              |          | `15`                 | Max parallelism for REST API calls                                                                                                             |
-| `mode`                     |          | `ASYNC_BATCH`        | [Advanced] Mode of operation - `SYNC`, `ASYNC`, or `ASYNC_BATCH`                                                                               |
-| `ca_certificate_path`      |          |                      | Path to server's CA certificate for verification of HTTPS communications                                                                       |
-| `client_certificate_path`  |          |                      | Path to client's CA certificate for HTTPS communications                                                                                       |
-| `disable_ssl_verification` |          | false                | Disable ssl certificate validation                                                                                                             |
-| `respect_mcp_sync_marker`  |          | false                | [Advanced] Upgrade a batch to synchronous when any MCP carries the `syncIngest` system-metadata marker. See limitation and requirements below. |
+| Field                      | Required | Default              | Description                                                                                                                                             |
+| -------------------------- | -------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `server`                   | ✅       |                      | URL of DataHub GMS endpoint.                                                                                                                            |
+| `token`                    |          |                      | Bearer token used for authentication.                                                                                                                   |
+| `timeout_sec`              |          | 30                   | Per-HTTP request timeout.                                                                                                                               |
+| `retry_max_times`          |          | 1                    | Maximum times to retry if HTTP request fails. The delay between retries is increased exponentially                                                      |
+| `retry_status_codes`       |          | [429, 502, 503, 504] | Retry HTTP request also on these status codes                                                                                                           |
+| `extra_headers`            |          |                      | Extra headers which will be added to the request.                                                                                                       |
+| `max_threads`              |          | `15`                 | Max parallelism for REST API calls                                                                                                                      |
+| `mode`                     |          | `ASYNC_BATCH`        | [Advanced] Mode of operation - `SYNC`, `ASYNC`, or `ASYNC_BATCH`                                                                                        |
+| `ca_certificate_path`      |          |                      | Path to server's CA certificate for verification of HTTPS communications                                                                                |
+| `client_certificate_path`  |          |                      | Path to client's CA certificate for HTTPS communications                                                                                                |
+| `disable_ssl_verification` |          | false                | Disable ssl certificate validation                                                                                                                      |
+| `respect_mcp_sync_marker`  |          | false                | [Advanced] Upgrade a batch to synchronous when any MCP carries the `emitModeMarker=sync` system-metadata marker. See limitation and requirements below. |
 
 #### Marker-aware sync routing (`respect_mcp_sync_marker`)
 
-When enabled, a batch is upgraded to synchronous (`async=false`) if any of its MCPs carries the `syncIngest` marker in its system metadata; otherwise the configured `mode` is honored unchanged. It only ever forces more synchronicity, never less. The marker is read, not produced, by the sink: a producer must populate the `syncIngest` system-metadata property on the writes that must remain synchronous (e.g. via a custom aspect mutator/validator or an upstream processing step).
+When enabled, a batch is upgraded to synchronous (`async=false`) if any of its MCPs carries the `emitModeMarker=sync` marker in its system metadata; otherwise the configured `mode` is honored unchanged. It only ever forces more synchronicity, never less. The marker is read, not produced, by the sink: a producer must populate the `emitModeMarker` system-metadata property (to `sync`) on the writes that must remain synchronous (e.g. via a custom aspect mutator/validator or an upstream processing step).
 
 This feature is supported only in specific configurations of DataHub Cloud and only when adopted under specific direction of DataHub. This feature requires a dedicated pool of logical model propagation workers and that MCP throttling be enabled.
 


### PR DESCRIPTION
## Summary

The `datahub-rest` sink docs (`metadata-ingestion/sink_docs/datahub.md`) described the per-MCP sync-routing marker used by `respect_mcp_sync_marker` as `syncIngest`. That name is wrong — the property the sink actually reads is **`emitModeMarker`** (value `sync`).

Verified against the code:

- [`request_helper.py`](https://github.com/datahub-project/datahub/blob/master/metadata-ingestion/src/datahub/emitter/request_helper.py) — `EMIT_MODE_MARKER_KEY = "emitModeMarker"`, `EMIT_MODE_MARKER_SYNC = "sync"`; `has_sync_emit_marker()` reads `systemMetadata.properties.get("emitModeMarker")` and matches `sync` case-insensitively.
- Unit tests stamp `properties={"emitModeMarker": "sync"}`.
- `syncIngest` does not exist anywhere in the codebase as a system-metadata key.

This corrects the two references in the `respect_mcp_sync_marker` config row and the "Marker-aware sync routing" section to `emitModeMarker=sync`.

Follow-up to review feedback on #18105. Docs-only change; no code or behavior changes.
