### PR TITLE
fix(ci): stop dropping security scan ref history and foreign comment

### DIFF
--- a/.github/scripts/test/test_security_scan_linear_sync_utils.py
+++ b/.github/scripts/test/test_security_scan_linear_sync_utils.py
@@ -200,6 +200,57 @@ def test_merge_refs_comment_is_deduplicated():
     assert "<!--" not in second
 
 
+def test_merge_refs_comment_accumulates_multiple_refs():
+    body = utils.merge_refs_comment(
+        None, "tag", "v1.0.0", "aaa1111", "https://github.com/acryldata/datahub/actions/runs/1"
+    )
+    body = utils.merge_refs_comment(
+        body, "tag", "v1.0.1", "bbb2222", "https://github.com/acryldata/datahub/actions/runs/2"
+    )
+    body = utils.merge_refs_comment(
+        body, "branch", "acryl-main", "ccc3333", "https://github.com/acryldata/datahub/actions/runs/3"
+    )
+    assert "v1.0.0" in body
+    assert "v1.0.1" in body
+    assert "acryl-main" in body
+    assert body.count("**Tag**") == 2
+    assert body.count("**Branch**") == 1
+
+
+def test_merge_refs_comment_preserves_foreign_section_when_adding_new_ref():
+    # Other automation sharing this Linear issue appended a section this codebase doesn't
+    # know about after the refs block.
+    body_with_section = utils.merge_refs_comment(
+        None, "tag", "v1.0.0", "abc1234", "https://github.com/o/r/actions/runs/1"
+    )
+    body_with_section = (
+        body_with_section.rstrip() + "\n\n" + utils.SLACK_NOTIFIED_SECTION_HEADER
+        + "\n\n- notified 2026-01-01T00:00:00Z\n"
+    )
+
+    updated = utils.merge_refs_comment(
+        body_with_section, "tag", "v1.0.1", "def5678", "https://github.com/o/r/actions/runs/2"
+    )
+    assert utils.SLACK_NOTIFIED_SECTION_HEADER in updated, "foreign section was dropped when a new ref was added"
+    assert "v1.0.0" in updated
+    assert "v1.0.1" in updated
+
+
+def test_merge_refs_comment_preserves_foreign_section_on_dedup():
+    # Same ref scanned again (dedup path) — foreign section must also survive.
+    body_with_section = utils.merge_refs_comment(
+        None, "branch", "acryl-main", "abc1234", "https://github.com/o/r/actions/runs/1"
+    )
+    body_with_section = (
+        body_with_section.rstrip() + "\n\n" + utils.SLACK_NOTIFIED_SECTION_HEADER + "\n\n- notified\n"
+    )
+
+    updated = utils.merge_refs_comment(
+        body_with_section, "branch", "acryl-main", "abc1234", "https://github.com/o/r/actions/runs/2"
+    )
+    assert utils.SLACK_NOTIFIED_SECTION_HEADER in updated, "foreign section was dropped on dedup path"
+
+
 def test_comment_has_refs_anchor_still_finds_legacy_html_block():
     body = "<!-- datahub-security-scan-refs\n### Git branch/tag scan history\n-->\n"
     assert utils.comment_has_refs_anchor(body)

--- a/.github/scripts/utils/security_scan_utils.py
+++ b/.github/scripts/utils/security_scan_utils.py
@@ -402,6 +402,9 @@ LEGACY_REFS_HEADERS = (
     "### DataHub security scans: git branch/tag",
 )
 LEGACY_REFS_MARKER = "<!-- datahub-trivy-refs -->"
+# Other automation sharing this Linear workspace may append this section to the same
+# comment; rebuilding the comment from ref keys alone would silently erase it.
+SLACK_NOTIFIED_SECTION_HEADER = "### Slack notifications"
 
 
 def plain_scalar_for_cell(val: Any) -> str:
@@ -671,7 +674,7 @@ def build_description(
 def parse_existing_ref_keys(comment_body: str) -> dict[str, str]:
     keys: dict[str, str] = {}
     for line in comment_body.splitlines():
-        m = re.match(r"^\s*-\s+\*\*(Branch|Tag)\*\*:\s+`([^`]+)`\b", line)
+        m = re.match(r"^\s*-\s+\*\*(Branch|Tag)\*\*:\s+`([^`]+)`", line)
         if not m:
             continue
         kind = m.group(1).lower()
@@ -718,10 +721,15 @@ def merge_refs_comment(
     if previous_body:
         keys = parse_existing_ref_keys(previous_body)
     key = f"{scan_ref_kind}:{scan_ref_name}"
-    if key in keys:
-        return format_refs_comment_body(keys)
-    keys[key] = new_line
-    return format_refs_comment_body(keys)
+    if key not in keys:
+        keys[key] = new_line
+    new_body = format_refs_comment_body(keys)
+    # format_refs_comment_body rebuilds from scratch, so re-append any trailing section this
+    # comment already had that we don't own (e.g. a Slack-notified stamp from another deployment).
+    if previous_body and SLACK_NOTIFIED_SECTION_HEADER in previous_body:
+        idx = previous_body.index(SLACK_NOTIFIED_SECTION_HEADER)
+        new_body = new_body.rstrip() + "\n\n" + previous_body[idx:].rstrip() + "\n"
+    return new_body
 
 
 def comment_has_refs_anchor(body: str) -> bool:


### PR DESCRIPTION

parse_existing_ref_keys used a regex with a trailing \b that never matched after a closing backtick, so merge_refs_comment silently kept only the most recent branch/tag ref on every update. merge_refs_comment also rebuilt the tracking comment from scratch, which would wipe out any section appended by other automation sharing the same Linear issue.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x ] Links to related issues (if applicable)
- [ x] Tests for the changes have been added/updated (if applicable)
- [ x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
