### PR TITLE
fix(ingestion): emit fieldPath add op for editableSchemaMetadata field patches

### DIFF
--- a/metadata-ingestion/src/datahub/specific/dataset.py
+++ b/metadata-ingestion/src/datahub/specific/dataset.py
@@ -54,8 +54,25 @@ class FieldPatchHelper(Generic[_Parent]):
             else SchemaMetadataClass.ASPECT_NAME
         )
         self.aspect_field = "editableSchemaFieldInfo" if editable else "schemaFieldInfo"
+        self._field_path_op_added = False
+
+    def _ensure_field_path(self) -> None:
+        # The array element is keyed by fieldPath, but GMS's patch merge rebuilds the element
+        # from the map value and does not re-inject the key. Without an explicit fieldPath op,
+        # a newly created element fails server-side validation ("fieldPath is required").
+        # Emitted once per field; a repeated add of the same scalar is a harmless no-op.
+        if self._field_path_op_added:
+            return
+        self._parent._add_patch(
+            self.aspect_name,
+            "add",
+            path=(self.aspect_field, self.field_path, "fieldPath"),
+            value=self.field_path,
+        )
+        self._field_path_op_added = True
 
     def add_tag(self, tag: Tag) -> "FieldPatchHelper":
+        self._ensure_field_path()
         self._parent._add_patch(
             self.aspect_name,
             "add",
@@ -86,6 +103,7 @@ class FieldPatchHelper(Generic[_Parent]):
         return self
 
     def add_term(self, term: Term) -> "FieldPatchHelper":
+        self._ensure_field_path()
         self._parent._add_patch(
             self.aspect_name,
             "add",

--- a/metadata-ingestion/tests/unit/patch/complex_dataset_patch.json
+++ b/metadata-ingestion/tests/unit/patch/complex_dataset_patch.json
@@ -32,7 +32,10 @@
     "aspect": {
         "json": {
             "arrayPrimaryKeys": {
-                "tags": ["attribution\u241fsource", "tag"]
+                "tags": [
+                    "attribution\u241fsource",
+                    "tag"
+                ]
             },
             "patch": [
                 {
@@ -101,6 +104,11 @@
     "aspectName": "editableSchemaMetadata",
     "aspect": {
         "json": [
+            {
+                "op": "add",
+                "path": "/editableSchemaFieldInfo/field1/fieldPath",
+                "value": "field1"
+            },
             {
                 "op": "add",
                 "path": "/editableSchemaFieldInfo/field1/globalTags/tags/urn:li:tag:tag1",


### PR DESCRIPTION
## What

`FieldPatchHelper.add_tag` / `add_term` build a patch whose target array element is keyed by `fieldPath`. During patch merge, GMS rebuilds that element from the map value and does **not** re-inject the key. As a result, patching a tag or term onto a schema field that has no existing `editableSchemaFieldInfo` element fails server-side validation:

```
HTTP 422 - fieldPath is required
```

This affects any caller that adds field-level tags/terms via `DatasetPatchBuilder` when the field is not already present in `editableSchemaMetadata` (e.g. enrichment-only connectors that never emit the full schema aspect).

## Fix

Emit an explicit `fieldPath` add op once per field, before the first tag/term op, so the element always carries its key. The op is idempotent — a repeated add of the same scalar is a harmless no-op — so existing multi-op patches are unaffected.

## Testing

- Updated `tests/unit/patch/complex_dataset_patch.json` golden (semantic comparison via `check_golden_file`).
- `pytest tests/unit/patch/test_patch_builder.py` — 9 passed.

## Checklist

- [x] Tests updated
- [ ] Breaking changes (none — additive, idempotent op)

Made with [Cursor](https://cursor.com)