### PR TITLE
refactor(ingestion/dataplex): map entries to DataHub entities via per-type mapper classes

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex.py
@@ -116,11 +116,13 @@ class DataplexSource(StatefulIngestionSourceBase, TestableSource):
     """Source to ingest metadata from Google Dataplex Universal Catalog.
 
     To add support for a new Dataplex entry type, first define its identity model
-    in ``dataplex_ids.py`` by adding a SchemaKey class at the correct level in the
-    existing hierarchy (for example project -> instance -> database -> table). Then
-    register the entry type in ``DATAPLEX_ENTRY_TYPE_MAPPINGS`` with required fields:
-    DataHub platform, DataHub entity type (Container or Dataset), subtype constant
-    from ``subtypes.py``, FQN regex, parent-entry regex (if applicable), and key classes.
+    in ``dataplex_ids.py`` by adding a ContainerKey class at the correct level in
+    the existing hierarchy (for example project -> instance -> database -> table)
+    and the FQN / parent-entry regexes it needs. Then add a small ``EntryMapper``
+    subclass in ``dataplex_mappers.py`` that declares the DataHub platform, its
+    main entity type (Container or Dataset), the subtype constant from
+    ``subtypes.py``, and delegates to the shared ``build_dataset`` /
+    ``build_container`` helper; finally register the mapper in ``ENTRY_MAPPERS``.
     FQN formats and parent hierarchy must be derived from:
     https://cloud.google.com/dataplex/docs/fully-qualified-names
 

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
@@ -26,6 +26,7 @@ from datahub.utilities.lossy_collections import LossyList
 from datahub.utilities.perf_timer import PerfTimer
 
 if TYPE_CHECKING:
+    from datahub.ingestion.source.dataplex.dataplex_helpers import EntryDataTuple
     from datahub.sdk.entity import Entity
 
 
@@ -146,7 +147,7 @@ class DataplexEntriesProcessor:
         self._container_lock: threading.Lock = threading.Lock()
 
     @property
-    def entry_data(self) -> list:
+    def entry_data(self) -> List["EntryDataTuple"]:
         return self._ctx.entry_data
 
     # ------------------------------------------------------------------
@@ -359,8 +360,11 @@ class DataplexEntriesProcessor:
                     try:
                         detailed_entry = self._fetch_entry_detail(dataplex_entry.name)
                     except Exception as exc:
-                        logger.warning(
-                            f"Failed to fetch detail for Spanner entry {dataplex_entry.name}: {exc}"
+                        self.source_report.warning(
+                            title="Dataplex Spanner entry fetch failed",
+                            message="Failed to fetch detail for a Spanner entry. Skipping.",
+                            context=f"entry_name={dataplex_entry.name}",
+                            exc=exc,
                         )
                         continue
                     yield from self._build_entities_for_entry(detailed_entry, location)
@@ -368,8 +372,13 @@ class DataplexEntriesProcessor:
                 "search_entries", timer.elapsed_seconds()
             )
         except Exception as exc:
-            logger.warning(
-                f"Spanner workaround search failed for {project_id}/{location}: {exc}"
+            # Surfaced (not just logged) so a permissions gap does not read as a
+            # green run with zero Spanner entities.
+            self.source_report.warning(
+                title="Dataplex Spanner search failed",
+                message="search_entries workaround failed for a project/location. Skipping.",
+                context=f"project_id={project_id}, location={location}",
+                exc=exc,
             )
             return
 

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
@@ -4,46 +4,24 @@ import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from itertools import islice
 from typing import (
     TYPE_CHECKING,
     Iterable,
     List,
-    Optional,
     Tuple,
-    cast,
 )
 
 from google.cloud import dataplex_v1
 
-from datahub.emitter.mce_builder import make_dataset_urn_with_platform_instance
-from datahub.emitter.mcp_builder import ContainerKey
 from datahub.ingestion.api.report import Report
 from datahub.ingestion.api.source import SourceReport
-from datahub.ingestion.source.common.subtypes import DatasetContainerSubTypes
 from datahub.ingestion.source.dataplex.dataplex_config import DataplexConfig
 from datahub.ingestion.source.dataplex.dataplex_context import DataplexContext
-from datahub.ingestion.source.dataplex.dataplex_helpers import EntryDataTuple
-from datahub.ingestion.source.dataplex.dataplex_ids import (
-    DATAPLEX_ENTRY_TYPE_MAPPINGS,
-    DataplexEntryTypeMapping,
-    build_container_key_from_fqn,
-    build_parent_container_key,
-    build_project_schema_key_from_fqn,
-    extract_datahub_dataset_name_from_fqn,
-    extract_entry_type_short_name,
-    parse_fully_qualified_name,
+from datahub.ingestion.source.dataplex.dataplex_mappers import (
+    EntryMappingContext,
+    get_entry_mapper,
 )
-from datahub.ingestion.source.dataplex.dataplex_properties import (
-    extract_entry_custom_properties,
-)
-from datahub.ingestion.source.dataplex.dataplex_schema import (
-    extract_graph_schema_from_entry_aspects,
-    extract_schema_from_entry_aspects,
-)
-from datahub.sdk.container import Container
-from datahub.sdk.dataset import Dataset
 from datahub.utilities.lossy_collections import LossyList
 from datahub.utilities.perf_timer import PerfTimer
 
@@ -296,29 +274,49 @@ class DataplexEntriesProcessor:
     def _build_entities_for_entry(
         self, entry: dataplex_v1.Entry, location: str
     ) -> List["Entity"]:
-        """Build DataHub entities from a fully-fetched entry.
+        """Build DataHub entities from a fully-fetched entry via its type mapper.
+
+        The per-type transformation lives in ``dataplex_mappers``; this method
+        only orchestrates the two cross-entry concerns that cannot live in a pure
+        mapper: the global project-container dedup and the lineage side-channel.
 
         Safe to call from parallel worker threads:
         - Uses ``_container_lock`` for the atomic check+add on
           ``_emitted_project_containers``.
         - Uses ``ctx.append_entry`` (thread-safe) for appends to ``ctx.entry_data``.
-        - All other state accessed here (config, report methods) is either
+        - The mapper itself is pure; all shared state accessed here is either
           read-only or already lock-protected.
         """
+        mapper = get_entry_mapper(entry.entry_type, self.source_report, entry=entry)
+        if mapper is None:
+            return []
+
+        result = mapper.map(
+            entry,
+            EntryMappingContext(
+                config=self.config,
+                location=location,
+                report=self.source_report,
+            ),
+        )
+        if result is None:
+            return []
+
         results: List["Entity"] = []
 
-        project_container = self.build_project_container_for_entry(entry)
-        if project_container is not None:
+        # additional_entities (e.g. the owning project container) are global-dedup
+        # candidates: emit each unique one exactly once across all entries.
+        for extra in result.additional_entities:
             with self._container_lock:
-                project_container_urn = project_container.urn.urn()
-                if project_container_urn not in self._emitted_project_containers:
-                    self._emitted_project_containers.add(project_container_urn)
-                    results.append(project_container)
+                extra_urn = extra.urn.urn()
+                if extra_urn not in self._emitted_project_containers:
+                    self._emitted_project_containers.add(extra_urn)
+                    results.append(extra)
 
-        entity = self.build_entity_for_entry(entry)
-        if entity is not None:
-            self._track_entry_for_lineage(dataplex_location=location, entry=entry)
-            results.append(entity)
+        if result.main_entity is not None:
+            if result.lineage_entry is not None:
+                self._ctx.append_entry(result.lineage_entry)
+            results.append(result.main_entity)
 
         return results
 
@@ -375,53 +373,6 @@ class DataplexEntriesProcessor:
             )
             return
 
-    def _track_entry_for_lineage(
-        self, dataplex_location: str, entry: dataplex_v1.Entry
-    ) -> None:
-        """Register a dataset entry for lineage extraction.
-
-        Safe to call from parallel worker threads — delegates to
-        ``ctx.append_entry`` which is thread-safe.
-        """
-        if not entry.fully_qualified_name:
-            return
-
-        short_name = extract_entry_type_short_name(entry.entry_type)
-        if short_name is None:
-            self.source_report.warning(
-                title="Invalid Dataplex entry type format",
-                message="Failed to extract short entry type from Dataplex entry_type. Skipping lineage tracking.",
-                context=f"entry_type={entry.entry_type}, entry_name={entry.name}, entry_payload={entry}",
-            )
-            return
-        mapping = DATAPLEX_ENTRY_TYPE_MAPPINGS.get(short_name)
-        if mapping is None or mapping.datahub_entity_type != "Dataset":
-            return
-
-        dataset_name = extract_datahub_dataset_name_from_fqn(
-            entry_type_or_short_name=short_name,
-            fully_qualified_name=entry.fully_qualified_name,
-        )
-        if dataset_name is None:
-            return
-
-        entry_data_tuple = EntryDataTuple(
-            dataplex_entry_short_name=entry.name.split("/")[-1],
-            dataplex_entry_name=entry.name,
-            dataplex_location=dataplex_location,
-            dataplex_entry_fqn=entry.fully_qualified_name,
-            dataplex_entry_type_short_name=short_name,
-            datahub_platform=mapping.datahub_platform,
-            datahub_dataset_name=dataset_name,
-            datahub_dataset_urn=make_dataset_urn_with_platform_instance(
-                platform=mapping.datahub_platform,
-                name=dataset_name,
-                platform_instance=None,
-                env=self.config.env,
-            ),
-        )
-        self._ctx.append_entry(entry_data_tuple)
-
     def list_entry_groups(
         self, project_id: str, location: str
     ) -> Iterable[dataplex_v1.EntryGroup]:
@@ -473,244 +424,6 @@ class DataplexEntriesProcessor:
         )
         return not filtered_name and not filtered_fqn
 
-    def build_entity_for_entry(self, entry: dataplex_v1.Entry) -> Optional["Entity"]:
-        """Map Dataplex entry to DataHub SDK v2 Dataset/Container entity."""
-        if not entry.fully_qualified_name:
-            logger.debug(
-                "Skipping entity build for entry %s: missing fully_qualified_name",
-                entry.name,
-            )
-            return None
-
-        mapping_result = self._resolve_entry_type_mapping(entry)
-        if mapping_result is None:
-            logger.debug(
-                "Skipping entity build for entry %s: unresolved entry type mapping",
-                entry.name,
-            )
-            return None
-        short_name, mapping = mapping_result
-
-        entry_name = entry.name
-        display_name = self._extract_display_name(entry)
-        description = self._extract_description(entry)
-        created = self._extract_datetime(entry, "create_time")
-        last_modified = self._extract_datetime(entry, "update_time")
-        entry_group_id = self._extract_entry_group_id(entry.name)
-        custom_properties = extract_entry_custom_properties(
-            entry, entry_name, entry_group_id
-        )
-
-        if mapping.datahub_entity_type == "Dataset":
-            dataset_name = extract_datahub_dataset_name_from_fqn(
-                entry_type_or_short_name=short_name,
-                fully_qualified_name=entry.fully_qualified_name,
-            )
-            if dataset_name is None:
-                logger.debug(
-                    "Skipping dataset entity build for entry %s: unable to extract dataset name from FQN %s",
-                    entry.name,
-                    entry.fully_qualified_name,
-                )
-                return None
-
-            schema_metadata = None
-            if self.config.include_schema:
-                schema_metadata = (
-                    extract_schema_from_entry_aspects(
-                        entry, entry_name, mapping.datahub_platform
-                    )
-                    or extract_graph_schema_from_entry_aspects(  # cloud-spanner-graph entries store schema in a graph-schema aspect rather than the standard schema aspect
-                        entry, entry_name, mapping.datahub_platform
-                    )
-                )
-
-            parent_container_key: Optional[ContainerKey] = None
-            if (
-                mapping.parent_container_key_class is not None
-                and mapping.parent_entry_regex is not None
-            ):
-                if entry.parent_entry:
-                    parent_container_key = cast(
-                        Optional[ContainerKey],
-                        build_parent_container_key(
-                            entry_type_or_short_name=short_name,
-                            parent_entry=entry.parent_entry,
-                        ),
-                    )
-                else:
-                    self.source_report.warning(
-                        title="Missing Dataplex parent_entry",
-                        message="Dataplex mapping expects parent_entry for parent container derivation. Emitting dataset without parent container.",
-                        context=(
-                            f"entry_type={entry.entry_type}, "
-                            f"entry_name={entry.name}, "
-                            f"fully_qualified_name={entry.fully_qualified_name}"
-                        ),
-                    )
-            else:
-                parent_container_key = cast(
-                    Optional[ContainerKey],
-                    build_project_schema_key_from_fqn(
-                        entry_type_or_short_name=short_name,
-                        fully_qualified_name=entry.fully_qualified_name,
-                    ),
-                )
-            if parent_container_key is not None:
-                return Dataset(
-                    platform=mapping.datahub_platform,
-                    name=dataset_name,
-                    env=self.config.env,
-                    display_name=display_name,
-                    description=description or None,
-                    custom_properties=custom_properties,
-                    created=created,
-                    last_modified=last_modified,
-                    subtype=mapping.datahub_subtype,
-                    parent_container=parent_container_key,
-                    schema=schema_metadata,
-                )
-            return Dataset(
-                platform=mapping.datahub_platform,
-                name=dataset_name,
-                env=self.config.env,
-                display_name=display_name,
-                description=description or None,
-                custom_properties=custom_properties,
-                created=created,
-                last_modified=last_modified,
-                subtype=mapping.datahub_subtype,
-                schema=schema_metadata,
-            )
-
-        container_key = build_container_key_from_fqn(
-            entry_type_or_short_name=short_name,
-            fully_qualified_name=entry.fully_qualified_name,
-        )
-        if container_key is None:
-            logger.debug(
-                "Skipping container entity build for entry %s: unable to build container key from FQN %s",
-                entry.name,
-                entry.fully_qualified_name,
-            )
-            return None
-
-        # For containers, always derive parent linkage from Dataplex parent_entry.
-        container_parent_key: Optional[ContainerKey] = self.build_entry_container_key(
-            entry
-        )
-        if container_parent_key is None:
-            project_schema_key = build_project_schema_key_from_fqn(
-                entry_type_or_short_name=short_name,
-                fully_qualified_name=entry.fully_qualified_name,
-            )
-            if project_schema_key is not None:
-                container_parent_key = project_schema_key
-
-        return Container(
-            container_key=container_key,
-            display_name=display_name,
-            description=description or None,
-            created=created,
-            last_modified=last_modified,
-            parent_container=container_parent_key,
-            subtype=mapping.datahub_subtype,
-            extra_properties=custom_properties,
-        )
-
-    def build_project_container_for_entry(
-        self, entry: dataplex_v1.Entry
-    ) -> Optional[Container]:
-        """Build project-level container for an entry's owning project."""
-        if not entry.fully_qualified_name:
-            logger.debug(
-                "Skipping project container build for entry %s: missing fully_qualified_name",
-                entry.name,
-            )
-            return None
-
-        mapping_result = self._resolve_entry_type_mapping(entry)
-        if mapping_result is None:
-            logger.debug(
-                "Skipping project container build for entry %s: unresolved entry type mapping",
-                entry.name,
-            )
-            return None
-        short_name, mapping = mapping_result
-
-        project_schema_key = build_project_schema_key_from_fqn(
-            entry_type_or_short_name=short_name,
-            fully_qualified_name=entry.fully_qualified_name,
-        )
-        if project_schema_key is None:
-            logger.debug(
-                "Skipping project container build for entry %s: unable to build project schema key from FQN %s",
-                entry.name,
-                entry.fully_qualified_name,
-            )
-            return None
-
-        identity = parse_fully_qualified_name(short_name, entry.fully_qualified_name)
-        if identity is None:
-            logger.debug(
-                "Skipping project container build for entry %s: unable to parse FQN %s",
-                entry.name,
-                entry.fully_qualified_name,
-            )
-            return None
-        project_id = identity.get("project_id")
-        if project_id is None:
-            logger.debug(
-                "Skipping project container build for entry %s: parsed identity missing project_id (identity=%s)",
-                entry.name,
-                identity,
-            )
-            return None
-
-        return Container(
-            container_key=project_schema_key,
-            display_name=project_id,
-            parent_container=None,
-            subtype=DatasetContainerSubTypes.BIGQUERY_PROJECT,
-            extra_properties={
-                "dataplex_ingested": "true",
-                "dataplex_project_id": project_id,
-                "dataplex_entry_type": entry.entry_type,
-                "dataplex_source_platform": mapping.datahub_platform,
-            },
-        )
-
-    def build_entry_container_key(
-        self, entry: dataplex_v1.Entry
-    ) -> Optional[ContainerKey]:
-        """Build container-relationship parent key for entry parent."""
-        if not entry.parent_entry:
-            logger.debug(
-                "Skipping parent container key build for entry %s: missing parent_entry",
-                entry.name,
-            )
-            return None
-        short_name = extract_entry_type_short_name(entry.entry_type)
-        if short_name is None:
-            self.source_report.warning(
-                title="Invalid Dataplex entry type format",
-                message="Failed to extract short entry type from Dataplex entry_type. Skipping parent container link.",
-                context=f"entry_type={entry.entry_type}, entry_name={entry.name}, entry_payload={entry}",
-            )
-            return None
-        parent_schema_key = build_parent_container_key(
-            entry_type_or_short_name=short_name,
-            parent_entry=entry.parent_entry,
-        )
-        if parent_schema_key is None:
-            logger.debug(
-                "Skipping parent container key build for entry %s: unable to build parent key from parent_entry %s",
-                entry.name,
-                entry.parent_entry,
-            )
-            return None
-        return parent_schema_key
-
     def _entry_name_allowed(self, entry_name: str) -> bool:
         entries_filter = self.config.filter_config.entries
         return entries_filter.pattern.allowed(entry_name)
@@ -718,58 +431,3 @@ class DataplexEntriesProcessor:
     def _entry_fqn_allowed(self, fully_qualified_name: str) -> bool:
         entries_filter = self.config.filter_config.entries
         return entries_filter.fqn_pattern.allowed(fully_qualified_name)
-
-    def _extract_entry_group_id(self, entry_name: str) -> str:
-        parts = entry_name.split("/")
-        try:
-            entry_groups_index = parts.index("entryGroups")
-            return parts[entry_groups_index + 1]
-        except (ValueError, IndexError):
-            return "unknown"
-
-    def _extract_display_name(self, entry: dataplex_v1.Entry) -> str:
-        if entry.entry_source:
-            display_name = getattr(entry.entry_source, "display_name", None)
-            if isinstance(display_name, str) and display_name.strip():
-                return display_name
-        return entry.name.split("/")[-1]
-
-    def _extract_description(self, entry: dataplex_v1.Entry) -> str:
-        if entry.entry_source and entry.entry_source.description:
-            return entry.entry_source.description
-        return ""
-
-    def _extract_datetime(
-        self,
-        entry: dataplex_v1.Entry,
-        field_name: str,
-    ) -> Optional[datetime]:
-        if not entry.entry_source:
-            return None
-        value = getattr(entry.entry_source, field_name, None)
-        if value is None:
-            return None
-        return datetime.fromtimestamp(value.timestamp(), tz=timezone.utc)
-
-    def _resolve_entry_type_mapping(
-        self, entry: dataplex_v1.Entry
-    ) -> Optional[tuple[str, DataplexEntryTypeMapping]]:
-        short_name = extract_entry_type_short_name(entry.entry_type)
-        if short_name is None:
-            self.source_report.warning(
-                title="Invalid Dataplex entry type format",
-                message="Failed to extract short entry type from Dataplex entry_type. Skipping entry.",
-                context=f"entry_type={entry.entry_type}, entry_name={entry.name}, entry_payload={entry}",
-            )
-            return None
-
-        mapping = DATAPLEX_ENTRY_TYPE_MAPPINGS.get(short_name)
-        if mapping is None:
-            self.source_report.warning(
-                title="Unsupported Dataplex entry type",
-                message="Encountered Dataplex entry with unsupported entry_type. Skipping entry.",
-                context=f"entry_type={entry.entry_type}, entry_name={entry.name}, entry_payload={entry}",
-            )
-            return None
-
-        return short_name, mapping

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_ids.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_ids.py
@@ -239,8 +239,3 @@ def instantiate_key(
         if field_name in valid_fields
     }
     return key_class(**constructor_args)
-
-
-def build_lineage_parent(project_id: str, location: str) -> str:
-    """Build Data Lineage API parent for an explicit project/location pair."""
-    return f"projects/{project_id}/locations/{location}"

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_ids.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_ids.py
@@ -1,87 +1,46 @@
-"""Dataplex entry identity parsing and DataHub key mapping.
+"""Dataplex identity primitives.
 
-This module centralizes all Dataplex identity concerns:
-- Entry type identification from ``entry_type``
-- FQN parsing from ``fully_qualified_name``
-- Parent extraction from ``parent_entry``
-- Static Dataplex entry-type -> DataHub entity mapping
+This module centralizes the low-level *identity* building blocks used to turn a
+Dataplex entry into DataHub identifiers:
 
-Example Dataplex entry payload (anonymized):
+- ``extract_entry_type_short_name`` extracts the short entry type from a full
+  ``entry_type`` path (for example ``cloudsql-mysql-table``).
+- The compiled ``*_FQN_REGEX`` / ``*_PARENT_ENTRY_REGEX`` patterns parse a
+  ``fully_qualified_name`` / ``parent_entry`` into named identity fields.
+- The ``ContainerKey`` subclasses model the DataHub container hierarchy
+  (project -> instance -> database -> ...); ``PROJECT_SCHEMA_KEY_CLASS_BY_PLATFORM``
+  maps a platform to its project-level key class.
+- ``parse_with_regex`` and ``instantiate_key`` are the generic glue that turns a
+  regex + a key class into a populated ``ContainerKey``.
 
-.. code-block:: text
-
-   name: "projects/example-project-123456/locations/us-west2/entryGroups/@cloudsql/entries/cloudsql.googleapis.com/projects/example-project-123456/locations/us-west2/instances/example-instance/databases/example-db/tables/example_table"
-   entry_type: "projects/655216118709/locations/global/entryTypes/cloudsql-mysql-table"
-   create_time {
-     seconds: 1774092556
-     nanos: 511835000
-   }
-   update_time {
-     seconds: 1774092556
-     nanos: 511835000
-   }
-   parent_entry: "projects/example-project-123456/locations/us-west2/entryGroups/@cloudsql/entries/cloudsql.googleapis.com/projects/example-project-123456/locations/us-west2/instances/example-instance/databases/example-db"
-   fully_qualified_name: "cloudsql_mysql:example-project-123456.us-west2.example-instance.example-db.example_table"
-   entry_source {
-     resource: "projects/example-project-123456/locations/us-west2/instances/example-instance/databases/example-db/tables/example_table"
-     system: "CLOUD_SQL"
-     platform: "GCP"
-     display_name: "example_table"
-     ancestors {
-       name: "projects/example-project-123456/locations/us-west2/instances/example-instance/databases/example-db"
-       type_: "dataplex-types.global.cloudsql-mysql-database"
-     }
-     ancestors {
-       name: "projects/example-project-123456/locations/us-west2/instances/example-instance"
-       type_: "dataplex-types.global.cloudsql-mysql-instance"
-     }
-     location: "us-west2"
-   }
-
-How identity resolution works:
-- ``ENTRY_TYPE_SHORT_NAME_REGEX`` extracts the short entry type from ``entry_type``
-  (for example ``cloudsql-mysql-table``).
-- That short name indexes ``DATAPLEX_ENTRY_TYPE_MAPPINGS``, which determines the
-  target DataHub entity type (``Dataset`` or ``Container``) and emitted subtype.
-- The mapping's ``fqn_regex`` parses ``fully_qualified_name`` into identity fields
-  (for example project, location, instance, database, table). Those fields are used
-  to build DataHub entity identity (dataset name / key-class identity / URNs).
-- The mapping's ``parent_entry_regex`` plus ``parent_container_key_class`` parses
-  ``parent_entry`` to build the parent container key that is later emitted as the
-  parent-container relationship.
+The *mapping* from a Dataplex entry type to DataHub entities (which regex, which
+key class, which subtype) lives in ``dataplex_mappers.py``. Each mapper imports
+the primitives it needs from here.
 
 Primary reference for FQN structures:
 https://docs.cloud.google.com/dataplex/docs/fully-qualified-names
 
 Important observed deviations from public docs (based on real Dataplex entries):
 - Cloud Spanner FQNs use an ``instanceConfigId`` token like ``regional-us-west2``.
-  In this module we normalize that token into ``location=us-west2`` for key fields,
-  because ``parent_entry`` also exposes ``locations/{location}``.
+  We normalize that token into ``location=us-west2`` for key fields, because
+  ``parent_entry`` also exposes ``locations/{location}``.
 - Cloud SQL MySQL uses ``cloudsql-mysql-database`` entry types in practice, while
   docs may refer to the logical level as schema.
 
 Regex/ContainerKey contract:
-- Named capture groups in ``fqn_regex`` and ``parent_entry_regex`` are expected to
-  match field names on the target container-key classes.
-- Example: ``(?P<project_id>...)`` maps to ``DataplexProjectId.project_id``.
-- This contract is enforced by
-  ``test_mapping_regex_groups_match_container_key_fields`` in
-  ``test_dataplex_ids.py`` so new entry type mappings fail fast if regex groups
-  and key fields drift.
+- Named capture groups in the FQN / parent-entry regexes are expected to match
+  field names on the target container-key classes. Example: ``(?P<project_id>...)``
+  maps to ``DataplexProjectId.project_id``. This contract is enforced by a
+  registry-wide test in ``test_dataplex_mappers.py`` so new entry type mappings
+  fail fast if regex groups and key fields drift.
 """
 
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
-from typing import Literal, Optional, Pattern
+from typing import Optional, Pattern
 
-from datahub.emitter.mce_builder import make_dataset_urn_with_platform_instance
 from datahub.emitter.mcp_builder import ContainerKey
-from datahub.ingestion.source.common.subtypes import (
-    DatasetContainerSubTypes,
-    DatasetSubTypes,
-)
 
 
 class DataplexProjectId(ContainerKey):
@@ -160,86 +119,6 @@ PROJECT_KEY_CLASSES: tuple[type[DataplexProjectId], ...] = (
 )
 
 
-@dataclass(frozen=True)
-class DataplexEntryTypeMapping:
-    """Static mapping contract from Dataplex entry types to DataHub semantics."""
-
-    # Keep platform values strict because they feed URN generation.
-    # DataHub platform used for URN generation for mapped entities.
-    datahub_platform: Literal[
-        "bigquery", "cloudsql", "spanner", "pubsub", "bigtable", "vertexai"
-    ]
-    # Whether this Dataplex entry type maps to a DataHub Dataset or Container.
-    datahub_entity_type: Literal["Dataset", "Container"]
-    # DataHub subtype to emit for the mapped entity.
-    datahub_subtype: str
-    # Regex that parses fully_qualified_name into identity fields for this type.
-    fqn_regex: Pattern[str]
-    # Regex that parses parent_entry for Container-aspect hierarchy linkage.
-    parent_entry_regex: Optional[Pattern[str]]
-    # Parent key class used with parent_entry_regex for Container-aspect hierarchy.
-    parent_container_key_class: Optional[type[DataplexProjectId]]
-    # Key class used when this entry maps to a Container entity itself.
-    container_key_class: Optional[type[DataplexProjectId]]
-    # Required format string for dataset URN names from parsed identity fields.
-    # Example: "{project_id}.{location}.{dataset_id}".
-    datahub_dataset_name_format: Optional[str] = None
-
-    def __post_init__(self) -> None:
-        """Validate:
-        1) dataset/container field constraints,
-        2) parent linkage constraints,
-        3) regex group -> key field compatibility.
-        """
-        if (
-            self.datahub_entity_type == "Dataset"
-            and self.datahub_dataset_name_format is None
-        ):
-            raise ValueError("Dataset mappings must define datahub_dataset_name_format")
-        if (
-            self.datahub_entity_type == "Container"
-            and self.datahub_dataset_name_format is not None
-        ):
-            raise ValueError(
-                "Container mappings must not define datahub_dataset_name_format"
-            )
-        if self.datahub_entity_type == "Container" and self.container_key_class is None:
-            raise ValueError("Container mappings must define container_key_class")
-        if (
-            self.datahub_entity_type == "Dataset"
-            and self.container_key_class is not None
-        ):
-            raise ValueError("Dataset mappings must not define container_key_class")
-        if (
-            self.parent_entry_regex is not None
-            and self.parent_container_key_class is None
-        ):
-            raise ValueError(
-                "Mappings with parent_entry_regex must define parent_container_key_class"
-            )
-
-        fqn_group_names = set(self.fqn_regex.groupindex.keys())
-        if self.container_key_class is not None:
-            container_field_names = set(self.container_key_class.model_fields.keys())
-            if not fqn_group_names.issubset(container_field_names):
-                raise ValueError(
-                    f"fqn_regex groups {fqn_group_names} must be subset of "
-                    f"{self.container_key_class.__name__} fields {container_field_names}"
-                )
-
-        if self.parent_entry_regex is not None and self.parent_container_key_class:
-            parent_group_names = set(self.parent_entry_regex.groupindex.keys())
-            parent_container_field_names = set(
-                self.parent_container_key_class.model_fields.keys()
-            )
-            if not parent_group_names.issubset(parent_container_field_names):
-                raise ValueError(
-                    f"parent_entry_regex groups {parent_group_names} must be subset of "
-                    f"{self.parent_container_key_class.__name__} fields "
-                    f"{parent_container_field_names}"
-                )
-
-
 ENTRY_TYPE_SHORT_NAME_REGEX = re.compile(
     r"^projects/[^/]+/locations/[^/]+/entryTypes/(?P<entry_type_short_name>[^/]+)$"
 )
@@ -312,158 +191,9 @@ BIGTABLE_INSTANCE_PARENT_ENTRY_REGEX = re.compile(
 )
 
 
-DATAPLEX_ENTRY_TYPE_MAPPINGS: dict[str, DataplexEntryTypeMapping] = {
-    "bigquery-dataset": DataplexEntryTypeMapping(
-        datahub_platform="bigquery",
-        datahub_entity_type="Container",
-        datahub_subtype=DatasetContainerSubTypes.BIGQUERY_DATASET,
-        fqn_regex=BIGQUERY_DATASET_FQN_REGEX,
-        # Top-level in Dataplex entry hierarchy: no parent_entry on payload.
-        parent_entry_regex=None,
-        container_key_class=DataplexBigQueryDataset,
-        parent_container_key_class=None,
-    ),
-    "bigquery-table": DataplexEntryTypeMapping(
-        datahub_platform="bigquery",
-        datahub_entity_type="Dataset",
-        datahub_subtype=DatasetSubTypes.TABLE,
-        fqn_regex=BIGQUERY_TABLE_FQN_REGEX,
-        parent_entry_regex=BIGQUERY_DATASET_PARENT_ENTRY_REGEX,
-        container_key_class=None,
-        parent_container_key_class=DataplexBigQueryDataset,
-        datahub_dataset_name_format="{project_id}.{dataset_id}.{table_id}",
-    ),
-    "bigquery-view": DataplexEntryTypeMapping(
-        datahub_platform="bigquery",
-        datahub_entity_type="Dataset",
-        datahub_subtype=DatasetSubTypes.VIEW,
-        # BigQuery views share the same FQN and parent_entry shape as tables.
-        fqn_regex=BIGQUERY_TABLE_FQN_REGEX,
-        parent_entry_regex=BIGQUERY_DATASET_PARENT_ENTRY_REGEX,
-        container_key_class=None,
-        parent_container_key_class=DataplexBigQueryDataset,
-        datahub_dataset_name_format="{project_id}.{dataset_id}.{table_id}",
-    ),
-    "cloudsql-mysql-instance": DataplexEntryTypeMapping(
-        datahub_platform="cloudsql",
-        datahub_entity_type="Container",
-        datahub_subtype=DatasetContainerSubTypes.INSTANCE,
-        fqn_regex=MYSQL_INSTANCE_FQN_REGEX,
-        # Top-level in Dataplex entry hierarchy: no parent_entry on payload.
-        parent_entry_regex=None,
-        container_key_class=DataplexCloudSqlMySqlInstance,
-        parent_container_key_class=None,
-    ),
-    "cloudsql-mysql-database": DataplexEntryTypeMapping(
-        datahub_platform="cloudsql",
-        datahub_entity_type="Container",
-        datahub_subtype=DatasetContainerSubTypes.DATABASE,
-        fqn_regex=MYSQL_DATABASE_FQN_REGEX,
-        parent_entry_regex=MYSQL_INSTANCE_PARENT_ENTRY_REGEX,
-        container_key_class=DataplexCloudSqlMySqlDatabase,
-        parent_container_key_class=DataplexCloudSqlMySqlInstance,
-    ),
-    "cloudsql-mysql-table": DataplexEntryTypeMapping(
-        datahub_platform="cloudsql",
-        datahub_entity_type="Dataset",
-        datahub_subtype=DatasetSubTypes.TABLE,
-        fqn_regex=MYSQL_TABLE_FQN_REGEX,
-        parent_entry_regex=MYSQL_DATABASE_PARENT_ENTRY_REGEX,
-        container_key_class=None,
-        parent_container_key_class=DataplexCloudSqlMySqlDatabase,
-        datahub_dataset_name_format=(
-            "{project_id}.{location}.{instance_id}.{database_id}.{table_id}"
-        ),
-    ),
-    "cloud-spanner-instance": DataplexEntryTypeMapping(
-        datahub_platform="spanner",
-        datahub_entity_type="Container",
-        datahub_subtype=DatasetContainerSubTypes.INSTANCE,
-        fqn_regex=SPANNER_INSTANCE_FQN_REGEX,
-        # Top-level in Dataplex entry hierarchy: no parent_entry on payload.
-        parent_entry_regex=None,
-        container_key_class=DataplexCloudSpannerInstance,
-        parent_container_key_class=None,
-    ),
-    "cloud-spanner-database": DataplexEntryTypeMapping(
-        datahub_platform="spanner",
-        datahub_entity_type="Container",
-        datahub_subtype=DatasetContainerSubTypes.DATABASE,
-        fqn_regex=SPANNER_DATABASE_FQN_REGEX,
-        parent_entry_regex=SPANNER_INSTANCE_PARENT_ENTRY_REGEX,
-        container_key_class=DataplexCloudSpannerDatabase,
-        parent_container_key_class=DataplexCloudSpannerInstance,
-    ),
-    "cloud-spanner-table": DataplexEntryTypeMapping(
-        datahub_platform="spanner",
-        datahub_entity_type="Dataset",
-        datahub_subtype=DatasetSubTypes.TABLE,
-        fqn_regex=SPANNER_TABLE_FQN_REGEX,
-        parent_entry_regex=SPANNER_DATABASE_PARENT_ENTRY_REGEX,
-        container_key_class=None,
-        parent_container_key_class=DataplexCloudSpannerDatabase,
-        datahub_dataset_name_format=(
-            "{project_id}.regional-{location}.{instance_id}.{database_id}.{table_id}"
-        ),
-    ),
-    "cloud-spanner-graph": DataplexEntryTypeMapping(
-        datahub_platform="spanner",
-        datahub_entity_type="Dataset",
-        datahub_subtype=DatasetSubTypes.GRAPH,
-        fqn_regex=SPANNER_GRAPH_FQN_REGEX,
-        parent_entry_regex=SPANNER_DATABASE_PARENT_ENTRY_REGEX,
-        container_key_class=None,
-        parent_container_key_class=DataplexCloudSpannerDatabase,
-        datahub_dataset_name_format=(
-            "{project_id}.regional-{location}.{instance_id}.{database_id}.{graph_id}"
-        ),
-    ),
-    "pubsub-topic": DataplexEntryTypeMapping(
-        datahub_platform="pubsub",
-        datahub_entity_type="Dataset",
-        datahub_subtype=DatasetSubTypes.TOPIC,
-        fqn_regex=PUBSUB_TOPIC_FQN_REGEX,
-        parent_entry_regex=None,
-        container_key_class=None,
-        parent_container_key_class=DataplexPubSubProject,
-        datahub_dataset_name_format="{project_id}.{topic_id}",
-    ),
-    "cloud-bigtable-instance": DataplexEntryTypeMapping(
-        datahub_platform="bigtable",
-        datahub_entity_type="Container",
-        datahub_subtype=DatasetContainerSubTypes.INSTANCE,
-        fqn_regex=BIGTABLE_INSTANCE_FQN_REGEX,
-        # Top-level in Dataplex entry hierarchy: no parent_entry on payload.
-        parent_entry_regex=None,
-        container_key_class=DataplexBigtableInstance,
-        parent_container_key_class=None,
-    ),
-    "cloud-bigtable-table": DataplexEntryTypeMapping(
-        datahub_platform="bigtable",
-        datahub_entity_type="Dataset",
-        datahub_subtype=DatasetSubTypes.TABLE,
-        fqn_regex=BIGTABLE_TABLE_FQN_REGEX,
-        parent_entry_regex=BIGTABLE_INSTANCE_PARENT_ENTRY_REGEX,
-        container_key_class=None,
-        parent_container_key_class=DataplexBigtableInstance,
-        datahub_dataset_name_format="{project_id}.{instance_id}.{table_id}",
-    ),
-    "vertexai-dataset": DataplexEntryTypeMapping(
-        datahub_platform="vertexai",
-        datahub_entity_type="Dataset",
-        datahub_subtype=DatasetSubTypes.TABLE,
-        fqn_regex=VERTEX_AI_DATASET_FQN_REGEX,
-        parent_entry_regex=None,
-        container_key_class=None,
-        parent_container_key_class=DataplexVertexAiProject,
-        datahub_dataset_name_format="{project_id}.{location}.{dataset_id}",
-    ),
-}
-
-PROJECT_SCHEMA_KEY_CLASS_BY_PLATFORM: dict[
-    Literal["bigquery", "cloudsql", "spanner", "pubsub", "bigtable", "vertexai"],
-    type[DataplexProjectId],
-] = {
+# Platform -> project-level key class. Keyed by plain ``str`` because the
+# platform value flows through the mappers as a str (see dataplex_mappers).
+PROJECT_SCHEMA_KEY_CLASS_BY_PLATFORM: dict[str, type[DataplexProjectId]] = {
     "bigquery": DataplexBigQueryProject,
     "cloudsql": DataplexCloudSqlProject,
     "spanner": DataplexSpannerProject,
@@ -481,24 +211,12 @@ def extract_entry_type_short_name(entry_type: str) -> Optional[str]:
     return match.group("entry_type_short_name")
 
 
-def _normalize_entry_type_short_name(entry_type_or_short_name: str) -> str:
-    short_name = extract_entry_type_short_name(entry_type_or_short_name)
-    if short_name is not None:
-        return short_name
-    return entry_type_or_short_name
+def parse_with_regex(regex: Pattern[str], value: str) -> Optional[dict[str, str]]:
+    """Parse ``value`` with a named-group regex into identity fields.
 
-
-def _get_mapping(entry_type_or_short_name: str) -> Optional[DataplexEntryTypeMapping]:
-    return DATAPLEX_ENTRY_TYPE_MAPPINGS.get(
-        _normalize_entry_type_short_name(entry_type_or_short_name)
-    )
-
-
-def _parse_with_regex(regex: Pattern[str], value: str) -> Optional[dict[str, str]]:
-    """Parse value with named-group regex.
-
-    Note: regex named groups are expected to match fields on SchemaKey classes.
-    For example ``(?P<project_id>...)`` maps to ``DataplexProjectId.project_id``.
+    Note: regex named groups are expected to match fields on ``ContainerKey``
+    classes. For example ``(?P<project_id>...)`` maps to
+    ``DataplexProjectId.project_id``.
     """
     match = regex.match(value)
     if not match:
@@ -510,29 +228,10 @@ def _parse_with_regex(regex: Pattern[str], value: str) -> Optional[dict[str, str
     }
 
 
-def parse_fully_qualified_name(
-    entry_type_or_short_name: str, fully_qualified_name: str
-) -> Optional[dict[str, str]]:
-    """Parse ``fully_qualified_name`` into identity fields for a mapped entry type."""
-    mapping = _get_mapping(entry_type_or_short_name)
-    if mapping is None:
-        return None
-    return _parse_with_regex(mapping.fqn_regex, fully_qualified_name)
-
-
-def parse_parent_entry(
-    entry_type_or_short_name: str, parent_entry: str
-) -> Optional[dict[str, str]]:
-    """Parse ``parent_entry`` into parent identity fields for mapped entry types."""
-    mapping = _get_mapping(entry_type_or_short_name)
-    if mapping is None or mapping.parent_entry_regex is None:
-        return None
-    return _parse_with_regex(mapping.parent_entry_regex, parent_entry)
-
-
-def _instantiate_key(
+def instantiate_key(
     key_class: type[DataplexProjectId], identity_fields: dict[str, str]
 ) -> DataplexProjectId:
+    """Build a ``ContainerKey`` from identity fields, keeping only valid ones."""
     valid_fields = set(key_class.model_fields.keys())
     constructor_args = {
         field_name: field_value
@@ -542,195 +241,6 @@ def _instantiate_key(
     return key_class(**constructor_args)
 
 
-def build_container_key_from_fqn(
-    entry_type_or_short_name: str, fully_qualified_name: str
-) -> Optional[DataplexProjectId]:
-    """Build container-entity key from FQN for mappings that emit Containers."""
-    mapping = _get_mapping(entry_type_or_short_name)
-    if mapping is None or mapping.container_key_class is None:
-        return None
-
-    identity_fields = parse_fully_qualified_name(
-        entry_type_or_short_name=entry_type_or_short_name,
-        fully_qualified_name=fully_qualified_name,
-    )
-    if identity_fields is None:
-        return None
-
-    return _instantiate_key(mapping.container_key_class, identity_fields)
-
-
-def build_parent_container_key(
-    entry_type_or_short_name: str, parent_entry: str
-) -> Optional[DataplexProjectId]:
-    """Build parent-container key from ``parent_entry`` for dataset hierarchy links."""
-    mapping = _get_mapping(entry_type_or_short_name)
-    if mapping is None or mapping.parent_container_key_class is None:
-        return None
-
-    identity_fields = parse_parent_entry(
-        entry_type_or_short_name=entry_type_or_short_name,
-        parent_entry=parent_entry,
-    )
-    if identity_fields is None:
-        return None
-
-    return _instantiate_key(mapping.parent_container_key_class, identity_fields)
-
-
-def build_dataset_urn_from_fqn(
-    entry_type_or_short_name: str, fully_qualified_name: str, env: str
-) -> Optional[str]:
-    """Build dataset URN from mapped entry type, FQN, and target environment."""
-    mapping = _get_mapping(entry_type_or_short_name)
-    if mapping is None or mapping.datahub_entity_type != "Dataset":
-        return None
-    dataset_name = extract_datahub_dataset_name_from_fqn(
-        entry_type_or_short_name=entry_type_or_short_name,
-        fully_qualified_name=fully_qualified_name,
-    )
-    if dataset_name is None:
-        return None
-
-    return make_dataset_urn_with_platform_instance(
-        platform=mapping.datahub_platform,
-        name=dataset_name,
-        platform_instance=None,
-        env=env,
-    )
-
-
-def extract_datahub_dataset_name_from_fqn(
-    entry_type_or_short_name: str, fully_qualified_name: str
-) -> Optional[str]:
-    """Extract DataHub dataset name from Dataplex FQN with mapping validation."""
-    mapping = _get_mapping(entry_type_or_short_name)
-    if mapping is None or mapping.datahub_entity_type != "Dataset":
-        return None
-    return _extract_dataset_name_from_fqn(
-        entry_type_or_short_name=entry_type_or_short_name,
-        fully_qualified_name=fully_qualified_name,
-    )
-
-
-def build_dataset_urn_from_fqn_only(
-    fully_qualified_name: str, env: str
-) -> Optional[str]:
-    """Extract DataHub dataset URN by matching FQN against dataset mappings."""
-    for entry_type_short_name, mapping in DATAPLEX_ENTRY_TYPE_MAPPINGS.items():
-        if mapping.datahub_entity_type != "Dataset":
-            continue
-        dataset_name = _extract_dataset_name_from_fqn(
-            entry_type_or_short_name=entry_type_short_name,
-            fully_qualified_name=fully_qualified_name,
-        )
-        if dataset_name is None:
-            continue
-        return make_dataset_urn_with_platform_instance(
-            platform=mapping.datahub_platform,
-            name=dataset_name,
-            platform_instance=None,
-            env=env,
-        )
-
-    return None
-
-
-def _extract_dataset_name_from_fqn(
-    entry_type_or_short_name: str, fully_qualified_name: str
-) -> Optional[str]:
-    """Validate FQN against mapping regex and return DataHub dataset name."""
-    mapping = _get_mapping(entry_type_or_short_name)
-    if mapping is None or mapping.datahub_entity_type != "Dataset":
-        return None
-
-    identity_fields = parse_fully_qualified_name(
-        entry_type_or_short_name, fully_qualified_name
-    )
-    if identity_fields is None:
-        return None
-
-    if mapping.datahub_dataset_name_format is None:
-        return None
-    try:
-        dataset_name = mapping.datahub_dataset_name_format.format(**identity_fields)
-    except KeyError:
-        return None
-    return dataset_name or None
-
-
-def is_supported_lineage_entry_type(entry_type_short_name: str) -> bool:
-    """Return whether an entry type is supported as a lineage dataset node."""
-    mapping = DATAPLEX_ENTRY_TYPE_MAPPINGS.get(entry_type_short_name)
-    return bool(mapping and mapping.datahub_entity_type == "Dataset")
-
-
 def build_lineage_parent(project_id: str, location: str) -> str:
     """Build Data Lineage API parent for an explicit project/location pair."""
     return f"projects/{project_id}/locations/{location}"
-
-
-def build_container_urn_from_fqn(
-    entry_type_or_short_name: str, fully_qualified_name: str
-) -> Optional[str]:
-    """Build container URN from FQN for mappings that emit Container entities."""
-    mapping = _get_mapping(entry_type_or_short_name)
-    if mapping is None or mapping.datahub_entity_type != "Container":
-        return None
-
-    schema_key = build_container_key_from_fqn(
-        entry_type_or_short_name, fully_qualified_name
-    )
-    if schema_key is None:
-        return None
-    return schema_key.as_urn()
-
-
-def build_project_schema_key_from_fqn(
-    entry_type_or_short_name: str, fully_qualified_name: str
-) -> Optional[DataplexProjectId]:
-    """Build project-level container key from FQN using mapped DataHub platform."""
-    mapping = _get_mapping(entry_type_or_short_name)
-    if mapping is None:
-        return None
-
-    identity_fields = parse_fully_qualified_name(
-        entry_type_or_short_name=entry_type_or_short_name,
-        fully_qualified_name=fully_qualified_name,
-    )
-    if identity_fields is None:
-        return None
-
-    project_key_class = PROJECT_SCHEMA_KEY_CLASS_BY_PLATFORM.get(
-        mapping.datahub_platform
-    )
-    if project_key_class is None:
-        return None
-
-    return _instantiate_key(project_key_class, identity_fields)
-
-
-def build_project_container_urn_from_fqn(
-    entry_type_or_short_name: str, fully_qualified_name: str
-) -> Optional[str]:
-    """Build project container URN from FQN for a mapped Dataplex entry type."""
-    project_key = build_project_schema_key_from_fqn(
-        entry_type_or_short_name=entry_type_or_short_name,
-        fully_qualified_name=fully_qualified_name,
-    )
-    if project_key is None:
-        return None
-    return project_key.as_urn()
-
-
-def build_parent_container_urn(
-    entry_type_or_short_name: str, parent_entry: str
-) -> Optional[str]:
-    """Build parent container URN from a Dataplex ``parent_entry`` reference."""
-    parent_schema_key = build_parent_container_key(
-        entry_type_or_short_name=entry_type_or_short_name,
-        parent_entry=parent_entry,
-    )
-    if parent_schema_key is None:
-        return None
-    return parent_schema_key.as_urn()

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_lineage.py
@@ -32,9 +32,6 @@ from datahub.ingestion.api.source import SourceReport
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.dataplex.dataplex_config import DataplexConfig
 from datahub.ingestion.source.dataplex.dataplex_helpers import EntryDataTuple
-from datahub.ingestion.source.dataplex.dataplex_ids import (
-    build_lineage_parent,
-)
 from datahub.ingestion.source.dataplex.dataplex_mappers import (
     dataset_urn_from_fqn_only,
     is_lineage_supported,
@@ -57,6 +54,11 @@ logger = logging.getLogger(__name__)
 # Prevents O(N) memory growth when there are thousands of entries.
 # TODO: replace with proper backpressure (e.g. bounded queue / semaphore).
 WORKERS_BATCH_SIZE = 200
+
+
+def build_lineage_parent(project_id: str, location: str) -> str:
+    """Build the Data Lineage API parent for an explicit project/location pair."""
+    return f"projects/{project_id}/locations/{location}"
 
 
 @dataclass(order=True, eq=True, frozen=True)

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_lineage.py
@@ -33,9 +33,11 @@ from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.dataplex.dataplex_config import DataplexConfig
 from datahub.ingestion.source.dataplex.dataplex_helpers import EntryDataTuple
 from datahub.ingestion.source.dataplex.dataplex_ids import (
-    build_dataset_urn_from_fqn_only,
     build_lineage_parent,
-    is_supported_lineage_entry_type,
+)
+from datahub.ingestion.source.dataplex.dataplex_mappers import (
+    dataset_urn_from_fqn_only,
+    is_lineage_supported,
 )
 from datahub.ingestion.source.state.redundant_run_skip_handler import (
     RedundantLineageRunSkipHandler,
@@ -516,7 +518,7 @@ class DataplexLineageExtractor:
             )
             return set()
 
-        if not is_supported_lineage_entry_type(entry.dataplex_entry_type_short_name):
+        if not is_lineage_supported(entry.dataplex_entry_type_short_name):
             self.report.report_lineage_entry_skipped_unsupported_type(
                 entry_name=entry.dataplex_entry_name,
                 entry_type=entry.dataplex_entry_type_short_name,
@@ -527,7 +529,7 @@ class DataplexLineageExtractor:
         for upstream_fqn in lineage_data.get("upstream", []):
             # Upstream FQN may be cross-platform (e.g. pubsub->bigquery), so
             # normalize to DataHub URN using a mapping lookup driven only by FQN shape.
-            upstream_dataset_urn = build_dataset_urn_from_fqn_only(
+            upstream_dataset_urn = dataset_urn_from_fqn_only(
                 fully_qualified_name=upstream_fqn,
                 env=self.config.env,
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
@@ -176,6 +176,12 @@ class EntryMapper(ABC):
 
 
 def _extract_display_name(entry: dataplex_v1.Entry) -> str:
+    """Return the entry's display name, falling back to the last name segment.
+
+    Dataplex only populates ``entry_source.display_name`` for some systems, so
+    when it is missing (or not a real string) we use the trailing segment of the
+    entry resource name as a stable human-readable label.
+    """
     if entry.entry_source:
         display_name = getattr(entry.entry_source, "display_name", None)
         if isinstance(display_name, str) and display_name.strip():
@@ -184,12 +190,19 @@ def _extract_display_name(entry: dataplex_v1.Entry) -> str:
 
 
 def _extract_description(entry: dataplex_v1.Entry) -> str:
+    """Return the entry's description, or an empty string when absent."""
     if entry.entry_source and entry.entry_source.description:
         return entry.entry_source.description
     return ""
 
 
 def _extract_datetime(entry: dataplex_v1.Entry, field_name: str) -> Optional[datetime]:
+    """Read a timestamp field off ``entry_source`` as a UTC ``datetime``.
+
+    ``field_name`` is a proto timestamp attribute such as ``create_time`` or
+    ``update_time``. Returns ``None`` when there is no ``entry_source`` or the
+    field is unset.
+    """
     if not entry.entry_source:
         return None
     value = getattr(entry.entry_source, field_name, None)
@@ -199,6 +212,15 @@ def _extract_datetime(entry: dataplex_v1.Entry, field_name: str) -> Optional[dat
 
 
 def _extract_entry_group_id(entry_name: str) -> str:
+    """Extract the entry group id from a Dataplex entry resource name.
+
+    The id is the path segment immediately after ``entryGroups``. Returns
+    ``"unknown"`` when the name does not follow the expected shape.
+
+    Example:
+        ``projects/my-project/locations/us/entryGroups/@bigquery/entries/foo``
+        -> ``"@bigquery"``
+    """
     parts = entry_name.split("/")
     try:
         entry_groups_index = parts.index("entryGroups")

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
@@ -25,7 +25,6 @@ classes, project-key lookup) live in ``dataplex_ids.py``.
 
 from __future__ import annotations
 
-import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -84,9 +83,6 @@ from datahub.metadata.schema_classes import SchemaMetadataClass
 from datahub.sdk.container import Container
 from datahub.sdk.dataset import Dataset
 from datahub.sdk.entity import Entity
-
-logger = logging.getLogger(__name__)
-
 
 # ----------------------------------------------------------------------------
 # Context + result
@@ -377,13 +373,20 @@ def build_dataset(
         fqn_regex, name_format, entry.fully_qualified_name
     )
     if dataset_name is None:
-        logger.debug(
-            "Skipping dataset build for entry %s: unable to extract dataset name from FQN %s",
-            entry.name,
-            entry.fully_qualified_name,
+        ctx.report.warning(
+            title="Unparseable Dataplex fully_qualified_name",
+            message=(
+                "Recognized the entry type but could not derive a dataset name "
+                "from its fully_qualified_name. Skipping the dataset."
+            ),
+            context=(
+                f"entry_type={entry.entry_type}, "
+                f"entry_name={entry.name}, "
+                f"fully_qualified_name={entry.fully_qualified_name}"
+            ),
         )
-        # Preserve prior behavior: a project container may still be emitted even
-        # when the primary entity cannot be built.
+        # A project container may still be emitted even when the primary entity
+        # cannot be built (matches the prior independent-emission behavior).
         if additional:
             return EntryMappingResult(additional_entities=additional)
         return None
@@ -487,11 +490,20 @@ def build_container(
 
     identity_fields = parse_with_regex(fqn_regex, entry.fully_qualified_name)
     if identity_fields is None:
-        logger.debug(
-            "Skipping container build for entry %s: unable to build container key from FQN %s",
-            entry.name,
-            entry.fully_qualified_name,
+        ctx.report.warning(
+            title="Unparseable Dataplex fully_qualified_name",
+            message=(
+                "Recognized the entry type but could not build a container key "
+                "from its fully_qualified_name. Skipping the container."
+            ),
+            context=(
+                f"entry_type={entry.entry_type}, "
+                f"entry_name={entry.name}, "
+                f"fully_qualified_name={entry.fully_qualified_name}"
+            ),
         )
+        # A project container may still be emitted even when the primary entity
+        # cannot be built (matches the prior independent-emission behavior).
         if additional:
             return EntryMappingResult(additional_entities=additional)
         return None

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
@@ -1,0 +1,907 @@
+"""Dataplex entry -> DataHub entity mappers (factory / strategy).
+
+Each Dataplex entry type maps to DataHub entities through a dedicated
+:class:`EntryMapper` implementation. A mapper is a pure function of
+``(entry, EntryMappingContext)``: given a Dataplex entry payload it returns an
+:class:`EntryMappingResult` describing the *main* DataHub entity it produces
+(Dataset or Container), any *additional* entities it may emit alongside it (the
+owning project Container), and — for dataset-producing types — a lineage record.
+
+Cross-entry / stateful concerns are deliberately kept OUT of mappers and live in
+``DataplexEntriesProcessor``:
+
+* the project Container is emitted once per project (global dedup), and
+* lineage records are appended to a shared side-channel.
+
+Mappers only *declare* those as data on the result; the orchestrator performs the
+dedup and the append. This keeps mappers trivially unit-testable
+(payload -> result) with no locks, report accumulation, or shared context.
+
+Adding support for a new Dataplex entry type means adding one small
+:class:`EntryMapper` subclass here and registering it in ``ENTRY_MAPPERS``. The
+identity primitives it needs (FQN / parent-entry regexes, ``ContainerKey``
+classes, project-key lookup) live in ``dataplex_ids.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional, Pattern
+
+from google.cloud import dataplex_v1
+
+from datahub.emitter.mce_builder import make_dataset_urn_with_platform_instance
+from datahub.ingestion.api.source import SourceReport
+from datahub.ingestion.source.common.subtypes import (
+    DatasetContainerSubTypes,
+    DatasetSubTypes,
+)
+from datahub.ingestion.source.dataplex.dataplex_config import DataplexConfig
+from datahub.ingestion.source.dataplex.dataplex_helpers import EntryDataTuple
+from datahub.ingestion.source.dataplex.dataplex_ids import (
+    BIGQUERY_DATASET_FQN_REGEX,
+    BIGQUERY_DATASET_PARENT_ENTRY_REGEX,
+    BIGQUERY_TABLE_FQN_REGEX,
+    BIGTABLE_INSTANCE_FQN_REGEX,
+    BIGTABLE_INSTANCE_PARENT_ENTRY_REGEX,
+    BIGTABLE_TABLE_FQN_REGEX,
+    MYSQL_DATABASE_FQN_REGEX,
+    MYSQL_DATABASE_PARENT_ENTRY_REGEX,
+    MYSQL_INSTANCE_FQN_REGEX,
+    MYSQL_INSTANCE_PARENT_ENTRY_REGEX,
+    MYSQL_TABLE_FQN_REGEX,
+    PROJECT_SCHEMA_KEY_CLASS_BY_PLATFORM,
+    PUBSUB_TOPIC_FQN_REGEX,
+    SPANNER_DATABASE_FQN_REGEX,
+    SPANNER_DATABASE_PARENT_ENTRY_REGEX,
+    SPANNER_GRAPH_FQN_REGEX,
+    SPANNER_INSTANCE_FQN_REGEX,
+    SPANNER_INSTANCE_PARENT_ENTRY_REGEX,
+    SPANNER_TABLE_FQN_REGEX,
+    VERTEX_AI_DATASET_FQN_REGEX,
+    DataplexBigQueryDataset,
+    DataplexBigtableInstance,
+    DataplexCloudSpannerDatabase,
+    DataplexCloudSpannerInstance,
+    DataplexCloudSqlMySqlDatabase,
+    DataplexCloudSqlMySqlInstance,
+    DataplexProjectId,
+    extract_entry_type_short_name,
+    instantiate_key,
+    parse_with_regex,
+)
+from datahub.ingestion.source.dataplex.dataplex_properties import (
+    extract_entry_custom_properties,
+)
+from datahub.ingestion.source.dataplex.dataplex_schema import (
+    extract_graph_schema_from_entry_aspects,
+    extract_schema_from_entry_aspects,
+)
+from datahub.metadata.schema_classes import SchemaMetadataClass
+from datahub.sdk.container import Container
+from datahub.sdk.dataset import Dataset
+from datahub.sdk.entity import Entity
+
+logger = logging.getLogger(__name__)
+
+
+# ----------------------------------------------------------------------------
+# Context + result
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EntryMappingContext:
+    """Everything a mapper legitimately needs beyond the entry payload itself.
+
+    ``config`` (rather than individual fields) keeps this stable as new config
+    knobs appear; the mapper reads ``config.env`` and ``config.include_schema``.
+    ``location`` is the Dataplex scan location — not reliably present in the
+    payload, so it is threaded in from the scan loop and used only to build the
+    lineage record. ``report`` lets mappers emit warnings for malformed payloads.
+    """
+
+    config: DataplexConfig
+    location: str
+    report: SourceReport
+
+
+@dataclass
+class EntryMappingResult:
+    """The DataHub entities a mapper produced for a single Dataplex entry.
+
+    ``additional_entities`` (e.g. the owning project Container) are global-dedup
+    candidates handled by the orchestrator. ``main_entity`` is ``None`` only in
+    the edge case where the primary entity could not be built but an additional
+    entity still could, mirroring the previous independent-emission behavior.
+    """
+
+    main_entity: Optional[Entity] = None
+    additional_entities: list[Entity] = field(default_factory=list)
+    lineage_entry: Optional[EntryDataTuple] = None
+
+
+# ----------------------------------------------------------------------------
+# Mapper interface
+# ----------------------------------------------------------------------------
+
+
+class EntryMapper(ABC):
+    """Maps one Dataplex entry type to DataHub entities.
+
+    Pure: reads only the entry + context, never touches locks, dedup state, or
+    the shared ingestion context. The required contract descriptors are abstract
+    properties so a mapper that forgets one cannot be instantiated (it fails when
+    ``ENTRY_MAPPERS`` is built at import). Concrete classes satisfy them with
+    plain class attributes.
+    """
+
+    @property
+    @abstractmethod
+    def dataplex_entry_type_short_name(self) -> str:
+        """Dataplex entry-type short name this mapper handles (e.g. ``bigquery-table``)."""
+
+    @property
+    @abstractmethod
+    def datahub_platform(self) -> str:
+        """DataHub platform for URN generation (e.g. ``bigquery``)."""
+
+    @property
+    @abstractmethod
+    def datahub_main_entity_type(self) -> type[Entity]:
+        """The DataHub entity this entry maps to directly — Dataset or Container."""
+
+    @property
+    def datahub_additional_entity_types(self) -> tuple[type[Entity], ...]:
+        """Entities this mapper may also emit alongside the main one.
+
+        Declarative; the orchestrator dedups them. Every mapper emits the owning
+        project Container, hence the default.
+        """
+        return (Container,)
+
+    @abstractmethod
+    def map(
+        self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
+    ) -> Optional[EntryMappingResult]:
+        """Build DataHub entities for ``entry``; ``None`` when nothing is produced."""
+
+
+# ----------------------------------------------------------------------------
+# Shared payload extraction helpers
+# ----------------------------------------------------------------------------
+
+
+def _extract_display_name(entry: dataplex_v1.Entry) -> str:
+    if entry.entry_source:
+        display_name = getattr(entry.entry_source, "display_name", None)
+        if isinstance(display_name, str) and display_name.strip():
+            return display_name
+    return entry.name.split("/")[-1]
+
+
+def _extract_description(entry: dataplex_v1.Entry) -> str:
+    if entry.entry_source and entry.entry_source.description:
+        return entry.entry_source.description
+    return ""
+
+
+def _extract_datetime(entry: dataplex_v1.Entry, field_name: str) -> Optional[datetime]:
+    if not entry.entry_source:
+        return None
+    value = getattr(entry.entry_source, field_name, None)
+    if value is None:
+        return None
+    return datetime.fromtimestamp(value.timestamp(), tz=timezone.utc)
+
+
+def _extract_entry_group_id(entry_name: str) -> str:
+    parts = entry_name.split("/")
+    try:
+        entry_groups_index = parts.index("entryGroups")
+        return parts[entry_groups_index + 1]
+    except (ValueError, IndexError):
+        return "unknown"
+
+
+@dataclass(frozen=True)
+class _CommonFields:
+    """Fields shared by every mapped entity, extracted once per entry."""
+
+    display_name: str
+    description: str
+    created: Optional[datetime]
+    last_modified: Optional[datetime]
+    custom_properties: dict[str, str]
+
+
+def _extract_common_fields(entry: dataplex_v1.Entry) -> _CommonFields:
+    entry_group_id = _extract_entry_group_id(entry.name)
+    return _CommonFields(
+        display_name=_extract_display_name(entry),
+        description=_extract_description(entry),
+        created=_extract_datetime(entry, "create_time"),
+        last_modified=_extract_datetime(entry, "update_time"),
+        custom_properties=extract_entry_custom_properties(
+            entry, entry.name, entry_group_id
+        ),
+    )
+
+
+# ----------------------------------------------------------------------------
+# Shared identity helpers (explicit regex/key inputs, no table lookup)
+# ----------------------------------------------------------------------------
+
+
+def _dataset_name_from_fqn(
+    fqn_regex: Pattern[str], name_format: str, fully_qualified_name: str
+) -> Optional[str]:
+    identity_fields = parse_with_regex(fqn_regex, fully_qualified_name)
+    if identity_fields is None:
+        return None
+    try:
+        dataset_name = name_format.format(**identity_fields)
+    except KeyError:
+        return None
+    return dataset_name or None
+
+
+def dataset_urn_from_fqn(
+    fully_qualified_name: str,
+    fqn_regex: Pattern[str],
+    name_format: str,
+    platform: str,
+    env: str,
+) -> Optional[str]:
+    """Build a dataset URN from an FQN using an explicit regex + name format."""
+    dataset_name = _dataset_name_from_fqn(fqn_regex, name_format, fully_qualified_name)
+    if dataset_name is None:
+        return None
+    return make_dataset_urn_with_platform_instance(
+        platform=platform,
+        name=dataset_name,
+        platform_instance=None,
+        env=env,
+    )
+
+
+def _project_schema_key(
+    fqn_regex: Pattern[str], platform: str, fully_qualified_name: str
+) -> Optional[DataplexProjectId]:
+    identity_fields = parse_with_regex(fqn_regex, fully_qualified_name)
+    if identity_fields is None:
+        return None
+    project_key_class = PROJECT_SCHEMA_KEY_CLASS_BY_PLATFORM.get(platform)
+    if project_key_class is None:
+        return None
+    return instantiate_key(project_key_class, identity_fields)
+
+
+def _parent_container_key(
+    parent_entry_regex: Pattern[str],
+    parent_key_class: type[DataplexProjectId],
+    parent_entry: str,
+) -> Optional[DataplexProjectId]:
+    identity_fields = parse_with_regex(parent_entry_regex, parent_entry)
+    if identity_fields is None:
+        return None
+    return instantiate_key(parent_key_class, identity_fields)
+
+
+def _build_project_container(
+    entry: dataplex_v1.Entry, fqn_regex: Pattern[str], platform: str
+) -> Optional[Container]:
+    """Build the project-level Container that owns ``entry`` (dedup by caller)."""
+    if not entry.fully_qualified_name:
+        return None
+    identity_fields = parse_with_regex(fqn_regex, entry.fully_qualified_name)
+    if identity_fields is None:
+        return None
+    project_id = identity_fields.get("project_id")
+    if project_id is None:
+        return None
+    project_schema_key = _project_schema_key(
+        fqn_regex, platform, entry.fully_qualified_name
+    )
+    if project_schema_key is None:
+        return None
+    return Container(
+        container_key=project_schema_key,
+        display_name=project_id,
+        parent_container=None,
+        # BIGQUERY_PROJECT is used for every platform's project container by
+        # historical convention; keep it to preserve emitted metadata.
+        subtype=DatasetContainerSubTypes.BIGQUERY_PROJECT,
+        extra_properties={
+            "dataplex_ingested": "true",
+            "dataplex_project_id": project_id,
+            "dataplex_entry_type": entry.entry_type,
+            "dataplex_source_platform": platform,
+        },
+    )
+
+
+# ----------------------------------------------------------------------------
+# Shared build algorithms (Dataset / Container)
+# ----------------------------------------------------------------------------
+
+
+def build_dataset(
+    entry: dataplex_v1.Entry,
+    ctx: EntryMappingContext,
+    *,
+    short_name: str,
+    platform: str,
+    subtype: str,
+    fqn_regex: Pattern[str],
+    name_format: str,
+    parent_entry_regex: Optional[Pattern[str]],
+    parent_key_class: Optional[type[DataplexProjectId]],
+    include_graph_schema_fallback: bool = False,
+) -> Optional[EntryMappingResult]:
+    """Map a Dataplex entry to a DataHub Dataset (+ project container + lineage)."""
+    if not entry.fully_qualified_name:
+        return None
+
+    project_container = _build_project_container(entry, fqn_regex, platform)
+    additional: list[Entity] = (
+        [project_container] if project_container is not None else []
+    )
+
+    dataset_name = _dataset_name_from_fqn(
+        fqn_regex, name_format, entry.fully_qualified_name
+    )
+    if dataset_name is None:
+        logger.debug(
+            "Skipping dataset build for entry %s: unable to extract dataset name from FQN %s",
+            entry.name,
+            entry.fully_qualified_name,
+        )
+        # Preserve prior behavior: a project container may still be emitted even
+        # when the primary entity cannot be built.
+        if additional:
+            return EntryMappingResult(additional_entities=additional)
+        return None
+
+    schema_metadata: Optional[SchemaMetadataClass] = None
+    if ctx.config.include_schema:
+        schema_metadata = extract_schema_from_entry_aspects(entry, entry.name, platform)
+        if schema_metadata is None and include_graph_schema_fallback:
+            # cloud-spanner-graph entries store schema in a graph-schema aspect
+            # rather than the standard schema aspect.
+            schema_metadata = extract_graph_schema_from_entry_aspects(
+                entry, entry.name, platform
+            )
+
+    parent_container_key: Optional[DataplexProjectId] = None
+    if parent_entry_regex is not None and parent_key_class is not None:
+        if entry.parent_entry:
+            parent_container_key = _parent_container_key(
+                parent_entry_regex, parent_key_class, entry.parent_entry
+            )
+        else:
+            ctx.report.warning(
+                title="Missing Dataplex parent_entry",
+                message=(
+                    "Dataplex mapping expects parent_entry for parent container "
+                    "derivation. Emitting dataset without parent container."
+                ),
+                context=(
+                    f"entry_type={entry.entry_type}, "
+                    f"entry_name={entry.name}, "
+                    f"fully_qualified_name={entry.fully_qualified_name}"
+                ),
+            )
+    else:
+        parent_container_key = _project_schema_key(
+            fqn_regex, platform, entry.fully_qualified_name
+        )
+
+    common = _extract_common_fields(entry)
+    dataset_kwargs: dict = dict(
+        platform=platform,
+        name=dataset_name,
+        env=ctx.config.env,
+        display_name=common.display_name,
+        description=common.description or None,
+        custom_properties=common.custom_properties,
+        created=common.created,
+        last_modified=common.last_modified,
+        subtype=subtype,
+        schema=schema_metadata,
+    )
+    # Only pass parent_container when we resolved one: the SDK emits a
+    # (empty) browsePathsV2 aspect when the kwarg is provided even as None,
+    # so omitting it preserves the exact emitted metadata.
+    if parent_container_key is not None:
+        dataset_kwargs["parent_container"] = parent_container_key
+    dataset = Dataset(**dataset_kwargs)
+
+    lineage_entry = EntryDataTuple(
+        dataplex_entry_short_name=entry.name.split("/")[-1],
+        dataplex_entry_name=entry.name,
+        dataplex_location=ctx.location,
+        dataplex_entry_fqn=entry.fully_qualified_name,
+        dataplex_entry_type_short_name=short_name,
+        datahub_platform=platform,
+        datahub_dataset_name=dataset_name,
+        datahub_dataset_urn=make_dataset_urn_with_platform_instance(
+            platform=platform,
+            name=dataset_name,
+            platform_instance=None,
+            env=ctx.config.env,
+        ),
+    )
+
+    return EntryMappingResult(
+        main_entity=dataset,
+        additional_entities=additional,
+        lineage_entry=lineage_entry,
+    )
+
+
+def build_container(
+    entry: dataplex_v1.Entry,
+    ctx: EntryMappingContext,
+    *,
+    platform: str,
+    subtype: str,
+    fqn_regex: Pattern[str],
+    container_key_class: type[DataplexProjectId],
+    parent_entry_regex: Optional[Pattern[str]],
+    parent_key_class: Optional[type[DataplexProjectId]],
+) -> Optional[EntryMappingResult]:
+    """Map a Dataplex entry to a DataHub Container (+ project container)."""
+    if not entry.fully_qualified_name:
+        return None
+
+    project_container = _build_project_container(entry, fqn_regex, platform)
+    additional: list[Entity] = (
+        [project_container] if project_container is not None else []
+    )
+
+    identity_fields = parse_with_regex(fqn_regex, entry.fully_qualified_name)
+    if identity_fields is None:
+        logger.debug(
+            "Skipping container build for entry %s: unable to build container key from FQN %s",
+            entry.name,
+            entry.fully_qualified_name,
+        )
+        if additional:
+            return EntryMappingResult(additional_entities=additional)
+        return None
+    container_key = instantiate_key(container_key_class, identity_fields)
+
+    # Prefer parent linkage from Dataplex parent_entry; fall back to project key.
+    container_parent_key: Optional[DataplexProjectId] = None
+    if (
+        parent_entry_regex is not None
+        and parent_key_class is not None
+        and entry.parent_entry
+    ):
+        container_parent_key = _parent_container_key(
+            parent_entry_regex, parent_key_class, entry.parent_entry
+        )
+    if container_parent_key is None:
+        container_parent_key = _project_schema_key(
+            fqn_regex, platform, entry.fully_qualified_name
+        )
+
+    common = _extract_common_fields(entry)
+    container = Container(
+        container_key=container_key,
+        display_name=common.display_name,
+        description=common.description or None,
+        created=common.created,
+        last_modified=common.last_modified,
+        parent_container=container_parent_key,
+        subtype=subtype,
+        extra_properties=common.custom_properties,
+    )
+    return EntryMappingResult(main_entity=container, additional_entities=additional)
+
+
+# ----------------------------------------------------------------------------
+# Concrete mappers — one per Dataplex entry type
+# ----------------------------------------------------------------------------
+
+
+class BigQueryDatasetMapper(EntryMapper):
+    dataplex_entry_type_short_name = "bigquery-dataset"
+    datahub_platform = "bigquery"
+    datahub_main_entity_type = Container
+
+    def map(
+        self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
+    ) -> Optional[EntryMappingResult]:
+        return build_container(
+            entry,
+            ctx,
+            platform=self.datahub_platform,
+            subtype=DatasetContainerSubTypes.BIGQUERY_DATASET,
+            fqn_regex=BIGQUERY_DATASET_FQN_REGEX,
+            container_key_class=DataplexBigQueryDataset,
+            parent_entry_regex=None,
+            parent_key_class=None,
+        )
+
+
+class BigQueryTableMapper(EntryMapper):
+    dataplex_entry_type_short_name = "bigquery-table"
+    datahub_platform = "bigquery"
+    datahub_main_entity_type = Dataset
+    fqn_regex = BIGQUERY_TABLE_FQN_REGEX
+    datahub_dataset_name_format = "{project_id}.{dataset_id}.{table_id}"
+
+    def map(
+        self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
+    ) -> Optional[EntryMappingResult]:
+        return build_dataset(
+            entry,
+            ctx,
+            short_name=self.dataplex_entry_type_short_name,
+            platform=self.datahub_platform,
+            subtype=DatasetSubTypes.TABLE,
+            fqn_regex=self.fqn_regex,
+            name_format=self.datahub_dataset_name_format,
+            parent_entry_regex=BIGQUERY_DATASET_PARENT_ENTRY_REGEX,
+            parent_key_class=DataplexBigQueryDataset,
+        )
+
+
+class BigQueryViewMapper(EntryMapper):
+    # Views share the FQN and parent_entry shape of tables; only the subtype differs.
+    dataplex_entry_type_short_name = "bigquery-view"
+    datahub_platform = "bigquery"
+    datahub_main_entity_type = Dataset
+    fqn_regex = BIGQUERY_TABLE_FQN_REGEX
+    datahub_dataset_name_format = "{project_id}.{dataset_id}.{table_id}"
+
+    def map(
+        self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
+    ) -> Optional[EntryMappingResult]:
+        return build_dataset(
+            entry,
+            ctx,
+            short_name=self.dataplex_entry_type_short_name,
+            platform=self.datahub_platform,
+            subtype=DatasetSubTypes.VIEW,
+            fqn_regex=self.fqn_regex,
+            name_format=self.datahub_dataset_name_format,
+            parent_entry_regex=BIGQUERY_DATASET_PARENT_ENTRY_REGEX,
+            parent_key_class=DataplexBigQueryDataset,
+        )
+
+
+class CloudSqlMySqlInstanceMapper(EntryMapper):
+    dataplex_entry_type_short_name = "cloudsql-mysql-instance"
+    datahub_platform = "cloudsql"
+    datahub_main_entity_type = Container
+
+    def map(
+        self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
+    ) -> Optional[EntryMappingResult]:
+        return build_container(
+            entry,
+            ctx,
+            platform=self.datahub_platform,
+            subtype=DatasetContainerSubTypes.INSTANCE,
+            fqn_regex=MYSQL_INSTANCE_FQN_REGEX,
+            container_key_class=DataplexCloudSqlMySqlInstance,
+            parent_entry_regex=None,
+            parent_key_class=None,
+        )
+
+
+class CloudSqlMySqlDatabaseMapper(EntryMapper):
+    dataplex_entry_type_short_name = "cloudsql-mysql-database"
+    datahub_platform = "cloudsql"
+    datahub_main_entity_type = Container
+
+    def map(
+        self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
+    ) -> Optional[EntryMappingResult]:
+        return build_container(
+            entry,
+            ctx,
+            platform=self.datahub_platform,
+            subtype=DatasetContainerSubTypes.DATABASE,
+            fqn_regex=MYSQL_DATABASE_FQN_REGEX,
+            container_key_class=DataplexCloudSqlMySqlDatabase,
+            parent_entry_regex=MYSQL_INSTANCE_PARENT_ENTRY_REGEX,
+            parent_key_class=DataplexCloudSqlMySqlInstance,
+        )
+
+
+class CloudSqlMySqlTableMapper(EntryMapper):
+    dataplex_entry_type_short_name = "cloudsql-mysql-table"
+    datahub_platform = "cloudsql"
+    datahub_main_entity_type = Dataset
+    fqn_regex = MYSQL_TABLE_FQN_REGEX
+    datahub_dataset_name_format = (
+        "{project_id}.{location}.{instance_id}.{database_id}.{table_id}"
+    )
+
+    def map(
+        self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
+    ) -> Optional[EntryMappingResult]:
+        return build_dataset(
+            entry,
+            ctx,
+            short_name=self.dataplex_entry_type_short_name,
+            platform=self.datahub_platform,
+            subtype=DatasetSubTypes.TABLE,
+            fqn_regex=self.fqn_regex,
+            name_format=self.datahub_dataset_name_format,
+            parent_entry_regex=MYSQL_DATABASE_PARENT_ENTRY_REGEX,
+            parent_key_class=DataplexCloudSqlMySqlDatabase,
+        )
+
+
+class CloudSpannerInstanceMapper(EntryMapper):
+    dataplex_entry_type_short_name = "cloud-spanner-instance"
+    datahub_platform = "spanner"
+    datahub_main_entity_type = Container
+
+    def map(
+        self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
+    ) -> Optional[EntryMappingResult]:
+        return build_container(
+            entry,
+            ctx,
+            platform=self.datahub_platform,
+            subtype=DatasetContainerSubTypes.INSTANCE,
+            fqn_regex=SPANNER_INSTANCE_FQN_REGEX,
+            container_key_class=DataplexCloudSpannerInstance,
+            parent_entry_regex=None,
+            parent_key_class=None,
+        )
+
+
+class CloudSpannerDatabaseMapper(EntryMapper):
+    dataplex_entry_type_short_name = "cloud-spanner-database"
+    datahub_platform = "spanner"
+    datahub_main_entity_type = Container
+
+    def map(
+        self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
+    ) -> Optional[EntryMappingResult]:
+        return build_container(
+            entry,
+            ctx,
+            platform=self.datahub_platform,
+            subtype=DatasetContainerSubTypes.DATABASE,
+            fqn_regex=SPANNER_DATABASE_FQN_REGEX,
+            container_key_class=DataplexCloudSpannerDatabase,
+            parent_entry_regex=SPANNER_INSTANCE_PARENT_ENTRY_REGEX,
+            parent_key_class=DataplexCloudSpannerInstance,
+        )
+
+
+class CloudSpannerTableMapper(EntryMapper):
+    dataplex_entry_type_short_name = "cloud-spanner-table"
+    datahub_platform = "spanner"
+    datahub_main_entity_type = Dataset
+    fqn_regex = SPANNER_TABLE_FQN_REGEX
+    datahub_dataset_name_format = (
+        "{project_id}.regional-{location}.{instance_id}.{database_id}.{table_id}"
+    )
+
+    def map(
+        self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
+    ) -> Optional[EntryMappingResult]:
+        return build_dataset(
+            entry,
+            ctx,
+            short_name=self.dataplex_entry_type_short_name,
+            platform=self.datahub_platform,
+            subtype=DatasetSubTypes.TABLE,
+            fqn_regex=self.fqn_regex,
+            name_format=self.datahub_dataset_name_format,
+            parent_entry_regex=SPANNER_DATABASE_PARENT_ENTRY_REGEX,
+            parent_key_class=DataplexCloudSpannerDatabase,
+        )
+
+
+class CloudSpannerGraphMapper(EntryMapper):
+    dataplex_entry_type_short_name = "cloud-spanner-graph"
+    datahub_platform = "spanner"
+    datahub_main_entity_type = Dataset
+    fqn_regex = SPANNER_GRAPH_FQN_REGEX
+    # Spanner tables and graphs share a namespace so names never collide.
+    datahub_dataset_name_format = (
+        "{project_id}.regional-{location}.{instance_id}.{database_id}.{graph_id}"
+    )
+
+    def map(
+        self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
+    ) -> Optional[EntryMappingResult]:
+        return build_dataset(
+            entry,
+            ctx,
+            short_name=self.dataplex_entry_type_short_name,
+            platform=self.datahub_platform,
+            subtype=DatasetSubTypes.GRAPH,
+            fqn_regex=self.fqn_regex,
+            name_format=self.datahub_dataset_name_format,
+            parent_entry_regex=SPANNER_DATABASE_PARENT_ENTRY_REGEX,
+            parent_key_class=DataplexCloudSpannerDatabase,
+            include_graph_schema_fallback=True,
+        )
+
+
+class CloudBigtableInstanceMapper(EntryMapper):
+    dataplex_entry_type_short_name = "cloud-bigtable-instance"
+    datahub_platform = "bigtable"
+    datahub_main_entity_type = Container
+
+    def map(
+        self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
+    ) -> Optional[EntryMappingResult]:
+        return build_container(
+            entry,
+            ctx,
+            platform=self.datahub_platform,
+            subtype=DatasetContainerSubTypes.INSTANCE,
+            fqn_regex=BIGTABLE_INSTANCE_FQN_REGEX,
+            container_key_class=DataplexBigtableInstance,
+            parent_entry_regex=None,
+            parent_key_class=None,
+        )
+
+
+class CloudBigtableTableMapper(EntryMapper):
+    dataplex_entry_type_short_name = "cloud-bigtable-table"
+    datahub_platform = "bigtable"
+    datahub_main_entity_type = Dataset
+    fqn_regex = BIGTABLE_TABLE_FQN_REGEX
+    datahub_dataset_name_format = "{project_id}.{instance_id}.{table_id}"
+
+    def map(
+        self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
+    ) -> Optional[EntryMappingResult]:
+        return build_dataset(
+            entry,
+            ctx,
+            short_name=self.dataplex_entry_type_short_name,
+            platform=self.datahub_platform,
+            subtype=DatasetSubTypes.TABLE,
+            fqn_regex=self.fqn_regex,
+            name_format=self.datahub_dataset_name_format,
+            parent_entry_regex=BIGTABLE_INSTANCE_PARENT_ENTRY_REGEX,
+            parent_key_class=DataplexBigtableInstance,
+        )
+
+
+class PubSubTopicMapper(EntryMapper):
+    dataplex_entry_type_short_name = "pubsub-topic"
+    datahub_platform = "pubsub"
+    datahub_main_entity_type = Dataset
+    fqn_regex = PUBSUB_TOPIC_FQN_REGEX
+    datahub_dataset_name_format = "{project_id}.{topic_id}"
+
+    def map(
+        self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
+    ) -> Optional[EntryMappingResult]:
+        # Top-level dataset: no parent_entry, parent linkage is the project key.
+        return build_dataset(
+            entry,
+            ctx,
+            short_name=self.dataplex_entry_type_short_name,
+            platform=self.datahub_platform,
+            subtype=DatasetSubTypes.TOPIC,
+            fqn_regex=self.fqn_regex,
+            name_format=self.datahub_dataset_name_format,
+            parent_entry_regex=None,
+            parent_key_class=None,
+        )
+
+
+class VertexAiDatasetMapper(EntryMapper):
+    dataplex_entry_type_short_name = "vertexai-dataset"
+    datahub_platform = "vertexai"
+    datahub_main_entity_type = Dataset
+    fqn_regex = VERTEX_AI_DATASET_FQN_REGEX
+    datahub_dataset_name_format = "{project_id}.{location}.{dataset_id}"
+
+    def map(
+        self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
+    ) -> Optional[EntryMappingResult]:
+        return build_dataset(
+            entry,
+            ctx,
+            short_name=self.dataplex_entry_type_short_name,
+            platform=self.datahub_platform,
+            subtype=DatasetSubTypes.TABLE,
+            fqn_regex=self.fqn_regex,
+            name_format=self.datahub_dataset_name_format,
+            parent_entry_regex=None,
+            parent_key_class=None,
+        )
+
+
+# ----------------------------------------------------------------------------
+# Registry (the factory)
+# ----------------------------------------------------------------------------
+
+_ALL_MAPPERS: list[EntryMapper] = [
+    BigQueryDatasetMapper(),
+    BigQueryTableMapper(),
+    BigQueryViewMapper(),
+    CloudSqlMySqlInstanceMapper(),
+    CloudSqlMySqlDatabaseMapper(),
+    CloudSqlMySqlTableMapper(),
+    CloudSpannerInstanceMapper(),
+    CloudSpannerDatabaseMapper(),
+    CloudSpannerTableMapper(),
+    CloudSpannerGraphMapper(),
+    CloudBigtableInstanceMapper(),
+    CloudBigtableTableMapper(),
+    PubSubTopicMapper(),
+    VertexAiDatasetMapper(),
+]
+
+ENTRY_MAPPERS: dict[str, EntryMapper] = {
+    mapper.dataplex_entry_type_short_name: mapper for mapper in _ALL_MAPPERS
+}
+
+
+def get_entry_mapper(
+    entry_type: str, report: SourceReport, *, entry: Optional[dataplex_v1.Entry] = None
+) -> Optional[EntryMapper]:
+    """Resolve the mapper for a Dataplex ``entry_type`` path, or warn and return None.
+
+    ``entry`` is optional and only enriches warning context.
+    """
+    context = (
+        f"entry_type={entry_type}, entry_name={entry.name}, entry_payload={entry}"
+        if entry is not None
+        else f"entry_type={entry_type}"
+    )
+    short_name = extract_entry_type_short_name(entry_type)
+    if short_name is None:
+        report.warning(
+            title="Invalid Dataplex entry type format",
+            message="Failed to extract short entry type from Dataplex entry_type. Skipping entry.",
+            context=context,
+        )
+        return None
+
+    mapper = ENTRY_MAPPERS.get(short_name)
+    if mapper is None:
+        report.warning(
+            title="Unsupported Dataplex entry type",
+            message="Encountered Dataplex entry with unsupported entry_type. Skipping entry.",
+            context=context,
+        )
+        return None
+    return mapper
+
+
+def is_lineage_supported(entry_type_short_name: str) -> bool:
+    """Return whether an entry type is a lineage (dataset) node."""
+    mapper = ENTRY_MAPPERS.get(entry_type_short_name)
+    return bool(mapper and mapper.datahub_main_entity_type is Dataset)
+
+
+def dataset_urn_from_fqn_only(fully_qualified_name: str, env: str) -> Optional[str]:
+    """Resolve a dataset URN from an FQN alone by trying every dataset mapper.
+
+    Used for cross-platform upstream lineage where only the FQN shape is known.
+    """
+    for mapper in ENTRY_MAPPERS.values():
+        if mapper.datahub_main_entity_type is not Dataset:
+            continue
+        urn = dataset_urn_from_fqn(
+            fully_qualified_name,
+            mapper.fqn_regex,  # type: ignore[attr-defined]
+            mapper.datahub_dataset_name_format,  # type: ignore[attr-defined]
+            mapper.datahub_platform,
+            env,
+        )
+        if urn:
+            return urn
+    return None

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
@@ -553,9 +553,7 @@ def build_dataset(
 
     parent_container_key: Optional[DataplexProjectId] = None
     if parent is not None:
-        if entry.parent_entry:
-            parent_container_key = parent.container_key(entry.parent_entry)
-        else:
+        if not entry.parent_entry:
             ctx.report.warning(
                 title="Missing Dataplex parent_entry",
                 message=(
@@ -568,30 +566,58 @@ def build_dataset(
                     f"fully_qualified_name={entry.fully_qualified_name}"
                 ),
             )
+        else:
+            parent_container_key = parent.container_key(entry.parent_entry)
+            if parent_container_key is None:
+                ctx.report.warning(
+                    title="Unparseable Dataplex parent_entry",
+                    message=(
+                        "Could not parse parent_entry into a parent container. "
+                        "Emitting dataset without parent container."
+                    ),
+                    context=(
+                        f"entry_type={entry.entry_type}, "
+                        f"entry_name={entry.name}, "
+                        f"parent_entry={entry.parent_entry}"
+                    ),
+                )
     else:
         parent_container_key = _project_schema_key(
             fqn_regex, platform, entry.fully_qualified_name
         )
 
     common = _extract_common_fields(entry)
-    dataset_kwargs: dict = dict(
-        platform=platform,
-        name=dataset_name,
-        env=ctx.config.env,
-        display_name=common.display_name,
-        description=common.description or None,
-        custom_properties=common.custom_properties,
-        created=common.created,
-        last_modified=common.last_modified,
-        subtype=subtype,
-        schema=schema_metadata,
-    )
-    # Only pass parent_container when we resolved one: the SDK emits a
-    # (empty) browsePathsV2 aspect when the kwarg is provided even as None,
-    # so omitting it preserves the exact emitted metadata.
+    # Only pass parent_container when resolved: the SDK emits an (empty)
+    # browsePathsV2 aspect when the kwarg is provided even as None, so omitting
+    # it preserves the exact emitted metadata. Two explicit calls (rather than a
+    # **kwargs splat) keep the whole SDK signature type-checked.
     if parent_container_key is not None:
-        dataset_kwargs["parent_container"] = parent_container_key
-    dataset = Dataset(**dataset_kwargs)
+        dataset = Dataset(
+            platform=platform,
+            name=dataset_name,
+            env=ctx.config.env,
+            display_name=common.display_name,
+            description=common.description or None,
+            custom_properties=common.custom_properties,
+            created=common.created,
+            last_modified=common.last_modified,
+            subtype=subtype,
+            schema=schema_metadata,
+            parent_container=parent_container_key,
+        )
+    else:
+        dataset = Dataset(
+            platform=platform,
+            name=dataset_name,
+            env=ctx.config.env,
+            display_name=common.display_name,
+            description=common.description or None,
+            custom_properties=common.custom_properties,
+            created=common.created,
+            last_modified=common.last_modified,
+            subtype=subtype,
+            schema=schema_metadata,
+        )
 
     lineage_entry = EntryDataTuple(
         dataplex_entry_short_name=entry.name.split("/")[-1],
@@ -666,6 +692,10 @@ def build_container(
         )
 
     common = _extract_common_fields(entry)
+    # container_parent_key is effectively always set here — the project key is
+    # the fallback and only fails to build when the FQN is unparseable, in which
+    # case the container key above already failed and we returned. Passed
+    # directly (as the pre-refactor code did) so the SDK signature stays checked.
     container = Container(
         container_key=container_key,
         display_name=common.display_name,
@@ -1075,7 +1105,9 @@ def get_entry_mapper(
 def is_lineage_supported(entry_type_short_name: str) -> bool:
     """Return whether an entry type is a lineage (dataset) node."""
     mapper = ENTRY_MAPPERS.get(entry_type_short_name)
-    return bool(mapper and isinstance(mapper.datahub_identity, DatasetIdentity))
+    # Route through datahub_main_entity_type (assert_never-guarded) so a future
+    # identity variant is handled explicitly rather than silently dropped.
+    return bool(mapper and mapper.datahub_main_entity_type is Dataset)
 
 
 def dataset_urn_from_fqn_only(fully_qualified_name: str, env: str) -> Optional[str]:
@@ -1084,9 +1116,12 @@ def dataset_urn_from_fqn_only(fully_qualified_name: str, env: str) -> Optional[s
     Used for cross-platform upstream lineage where only the FQN shape is known.
     """
     for mapper in ENTRY_MAPPERS.values():
-        identity = mapper.datahub_identity
-        if not isinstance(identity, DatasetIdentity):
+        if mapper.datahub_main_entity_type is not Dataset:
             continue
+        # A Dataset-producing mapper must carry a DatasetIdentity; assert to
+        # surface (loudly) any future variant that breaks this coupling.
+        identity = mapper.datahub_identity
+        assert isinstance(identity, DatasetIdentity)
         urn = dataset_urn_from_fqn(
             fully_qualified_name,
             mapper.dataplex_fqn_regex,

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
@@ -683,6 +683,21 @@ def build_container(
     container_parent_key: Optional[DataplexProjectId] = None
     if parent is not None and entry.parent_entry:
         container_parent_key = parent.container_key(entry.parent_entry)
+        if container_parent_key is None:
+            # Mirror build_dataset: a present-but-unparseable parent_entry should
+            # not silently reparent the container under its project root.
+            ctx.report.warning(
+                title="Unparseable Dataplex parent_entry",
+                message=(
+                    "Could not parse parent_entry into a parent container. "
+                    "Falling back to the project container."
+                ),
+                context=(
+                    f"entry_type={entry.entry_type}, "
+                    f"entry_name={entry.name}, "
+                    f"parent_entry={entry.parent_entry}"
+                ),
+            )
     if container_parent_key is None:
         container_parent_key = _project_schema_key(
             fqn_regex, platform, entry.fully_qualified_name

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
@@ -120,6 +120,28 @@ class EntryMappingResult:
     lineage_entry: Optional[EntryDataTuple] = None
 
 
+@dataclass(frozen=True)
+class ParentEntryLink:
+    """How to derive a mapped entry's parent container from its Dataplex parent_entry.
+
+    ``dataplex_parent_entry_regex`` parses the ``parent_entry`` path; its named
+    groups populate ``datahub_schemakey_class``. The two are inseparable, so they
+    travel together and cannot drift apart. A mapper with no ``ParentEntryLink``
+    (the property returns ``None``) has no parent container finer than its owning
+    project; parent linkage then falls back to the project key.
+    """
+
+    dataplex_parent_entry_regex: Pattern[str]
+    datahub_schemakey_class: type[DataplexProjectId]
+
+    def container_key(self, parent_entry: str) -> Optional[DataplexProjectId]:
+        """Build the parent ``ContainerKey`` from a ``parent_entry`` path."""
+        fields = parse_with_regex(self.dataplex_parent_entry_regex, parent_entry)
+        if fields is None:
+            return None
+        return instantiate_key(self.datahub_schemakey_class, fields)
+
+
 # ----------------------------------------------------------------------------
 # Mapper interface
 # ----------------------------------------------------------------------------
@@ -207,6 +229,17 @@ class EntryMapper(ABC):
         FQN for identity), so it is part of the contract rather than an inline
         argument. Named groups must match the target ``ContainerKey`` fields.
         """
+
+    @property
+    def dataplex_parent_entry(self) -> Optional[ParentEntryLink]:
+        """How to derive the parent container from the entry's ``parent_entry``.
+
+        Defaults to ``None``, meaning the entry has no parent container finer than
+        its owning project — parent linkage falls back to the project key. Mappers
+        with an intermediate parent override it with a single ``ParentEntryLink``,
+        keeping the parent-entry regex and schema-key class together.
+        """
+        return None
 
     @property
     def datahub_additional_entity_types(self) -> tuple[type[Entity], ...]:
@@ -356,17 +389,6 @@ def _project_schema_key(
     return instantiate_key(project_key_class, identity_fields)
 
 
-def _parent_container_key(
-    parent_entry_regex: Pattern[str],
-    parent_key_class: type[DataplexProjectId],
-    parent_entry: str,
-) -> Optional[DataplexProjectId]:
-    identity_fields = parse_with_regex(parent_entry_regex, parent_entry)
-    if identity_fields is None:
-        return None
-    return instantiate_key(parent_key_class, identity_fields)
-
-
 def _build_project_container(
     entry: dataplex_v1.Entry, fqn_regex: Pattern[str], platform: str
 ) -> Optional[Container]:
@@ -414,8 +436,7 @@ def build_dataset(
     subtype: str,
     fqn_regex: Pattern[str],
     name_format: str,
-    parent_entry_regex: Optional[Pattern[str]],
-    parent_key_class: Optional[type[DataplexProjectId]],
+    parent: Optional[ParentEntryLink],
     include_graph_schema_fallback: bool = False,
 ) -> Optional[EntryMappingResult]:
     """Map a Dataplex entry to a DataHub Dataset (+ project container + lineage)."""
@@ -460,11 +481,9 @@ def build_dataset(
             )
 
     parent_container_key: Optional[DataplexProjectId] = None
-    if parent_entry_regex is not None and parent_key_class is not None:
+    if parent is not None:
         if entry.parent_entry:
-            parent_container_key = _parent_container_key(
-                parent_entry_regex, parent_key_class, entry.parent_entry
-            )
+            parent_container_key = parent.container_key(entry.parent_entry)
         else:
             ctx.report.warning(
                 title="Missing Dataplex parent_entry",
@@ -534,8 +553,7 @@ def build_container(
     subtype: str,
     fqn_regex: Pattern[str],
     container_key_class: type[DataplexProjectId],
-    parent_entry_regex: Optional[Pattern[str]],
-    parent_key_class: Optional[type[DataplexProjectId]],
+    parent: Optional[ParentEntryLink],
 ) -> Optional[EntryMappingResult]:
     """Map a Dataplex entry to a DataHub Container (+ project container)."""
     if not entry.fully_qualified_name:
@@ -569,14 +587,8 @@ def build_container(
 
     # Prefer parent linkage from Dataplex parent_entry; fall back to project key.
     container_parent_key: Optional[DataplexProjectId] = None
-    if (
-        parent_entry_regex is not None
-        and parent_key_class is not None
-        and entry.parent_entry
-    ):
-        container_parent_key = _parent_container_key(
-            parent_entry_regex, parent_key_class, entry.parent_entry
-        )
+    if parent is not None and entry.parent_entry:
+        container_parent_key = parent.container_key(entry.parent_entry)
     if container_parent_key is None:
         container_parent_key = _project_schema_key(
             fqn_regex, platform, entry.fully_qualified_name
@@ -617,8 +629,7 @@ class BigQueryDatasetMapper(EntryMapper):
             subtype=DatasetContainerSubTypes.BIGQUERY_DATASET,
             fqn_regex=self.dataplex_fqn_regex,
             container_key_class=DataplexBigQueryDataset,
-            parent_entry_regex=None,
-            parent_key_class=None,
+            parent=self.dataplex_parent_entry,
         )
 
 
@@ -628,6 +639,10 @@ class BigQueryTableMapper(EntryMapper):
     datahub_main_entity_type = Dataset
     dataplex_fqn_regex = BIGQUERY_TABLE_FQN_REGEX
     datahub_dataset_name_format = "{project_id}.{dataset_id}.{table_id}"
+    dataplex_parent_entry = ParentEntryLink(
+        dataplex_parent_entry_regex=BIGQUERY_DATASET_PARENT_ENTRY_REGEX,
+        datahub_schemakey_class=DataplexBigQueryDataset,
+    )
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -640,8 +655,7 @@ class BigQueryTableMapper(EntryMapper):
             subtype=DatasetSubTypes.TABLE,
             fqn_regex=self.dataplex_fqn_regex,
             name_format=self.datahub_dataset_name_format,
-            parent_entry_regex=BIGQUERY_DATASET_PARENT_ENTRY_REGEX,
-            parent_key_class=DataplexBigQueryDataset,
+            parent=self.dataplex_parent_entry,
         )
 
 
@@ -652,6 +666,10 @@ class BigQueryViewMapper(EntryMapper):
     datahub_main_entity_type = Dataset
     dataplex_fqn_regex = BIGQUERY_TABLE_FQN_REGEX
     datahub_dataset_name_format = "{project_id}.{dataset_id}.{table_id}"
+    dataplex_parent_entry = ParentEntryLink(
+        dataplex_parent_entry_regex=BIGQUERY_DATASET_PARENT_ENTRY_REGEX,
+        datahub_schemakey_class=DataplexBigQueryDataset,
+    )
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -664,8 +682,7 @@ class BigQueryViewMapper(EntryMapper):
             subtype=DatasetSubTypes.VIEW,
             fqn_regex=self.dataplex_fqn_regex,
             name_format=self.datahub_dataset_name_format,
-            parent_entry_regex=BIGQUERY_DATASET_PARENT_ENTRY_REGEX,
-            parent_key_class=DataplexBigQueryDataset,
+            parent=self.dataplex_parent_entry,
         )
 
 
@@ -685,8 +702,7 @@ class CloudSqlMySqlInstanceMapper(EntryMapper):
             subtype=DatasetContainerSubTypes.INSTANCE,
             fqn_regex=self.dataplex_fqn_regex,
             container_key_class=DataplexCloudSqlMySqlInstance,
-            parent_entry_regex=None,
-            parent_key_class=None,
+            parent=self.dataplex_parent_entry,
         )
 
 
@@ -695,6 +711,10 @@ class CloudSqlMySqlDatabaseMapper(EntryMapper):
     datahub_platform = "cloudsql"
     datahub_main_entity_type = Container
     dataplex_fqn_regex = MYSQL_DATABASE_FQN_REGEX
+    dataplex_parent_entry = ParentEntryLink(
+        dataplex_parent_entry_regex=MYSQL_INSTANCE_PARENT_ENTRY_REGEX,
+        datahub_schemakey_class=DataplexCloudSqlMySqlInstance,
+    )
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -706,8 +726,7 @@ class CloudSqlMySqlDatabaseMapper(EntryMapper):
             subtype=DatasetContainerSubTypes.DATABASE,
             fqn_regex=self.dataplex_fqn_regex,
             container_key_class=DataplexCloudSqlMySqlDatabase,
-            parent_entry_regex=MYSQL_INSTANCE_PARENT_ENTRY_REGEX,
-            parent_key_class=DataplexCloudSqlMySqlInstance,
+            parent=self.dataplex_parent_entry,
         )
 
 
@@ -718,6 +737,10 @@ class CloudSqlMySqlTableMapper(EntryMapper):
     dataplex_fqn_regex = MYSQL_TABLE_FQN_REGEX
     datahub_dataset_name_format = (
         "{project_id}.{location}.{instance_id}.{database_id}.{table_id}"
+    )
+    dataplex_parent_entry = ParentEntryLink(
+        dataplex_parent_entry_regex=MYSQL_DATABASE_PARENT_ENTRY_REGEX,
+        datahub_schemakey_class=DataplexCloudSqlMySqlDatabase,
     )
 
     def map(
@@ -731,8 +754,7 @@ class CloudSqlMySqlTableMapper(EntryMapper):
             subtype=DatasetSubTypes.TABLE,
             fqn_regex=self.dataplex_fqn_regex,
             name_format=self.datahub_dataset_name_format,
-            parent_entry_regex=MYSQL_DATABASE_PARENT_ENTRY_REGEX,
-            parent_key_class=DataplexCloudSqlMySqlDatabase,
+            parent=self.dataplex_parent_entry,
         )
 
 
@@ -752,8 +774,7 @@ class CloudSpannerInstanceMapper(EntryMapper):
             subtype=DatasetContainerSubTypes.INSTANCE,
             fqn_regex=self.dataplex_fqn_regex,
             container_key_class=DataplexCloudSpannerInstance,
-            parent_entry_regex=None,
-            parent_key_class=None,
+            parent=self.dataplex_parent_entry,
         )
 
 
@@ -762,6 +783,10 @@ class CloudSpannerDatabaseMapper(EntryMapper):
     datahub_platform = "spanner"
     datahub_main_entity_type = Container
     dataplex_fqn_regex = SPANNER_DATABASE_FQN_REGEX
+    dataplex_parent_entry = ParentEntryLink(
+        dataplex_parent_entry_regex=SPANNER_INSTANCE_PARENT_ENTRY_REGEX,
+        datahub_schemakey_class=DataplexCloudSpannerInstance,
+    )
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -773,8 +798,7 @@ class CloudSpannerDatabaseMapper(EntryMapper):
             subtype=DatasetContainerSubTypes.DATABASE,
             fqn_regex=self.dataplex_fqn_regex,
             container_key_class=DataplexCloudSpannerDatabase,
-            parent_entry_regex=SPANNER_INSTANCE_PARENT_ENTRY_REGEX,
-            parent_key_class=DataplexCloudSpannerInstance,
+            parent=self.dataplex_parent_entry,
         )
 
 
@@ -785,6 +809,10 @@ class CloudSpannerTableMapper(EntryMapper):
     dataplex_fqn_regex = SPANNER_TABLE_FQN_REGEX
     datahub_dataset_name_format = (
         "{project_id}.regional-{location}.{instance_id}.{database_id}.{table_id}"
+    )
+    dataplex_parent_entry = ParentEntryLink(
+        dataplex_parent_entry_regex=SPANNER_DATABASE_PARENT_ENTRY_REGEX,
+        datahub_schemakey_class=DataplexCloudSpannerDatabase,
     )
 
     def map(
@@ -798,8 +826,7 @@ class CloudSpannerTableMapper(EntryMapper):
             subtype=DatasetSubTypes.TABLE,
             fqn_regex=self.dataplex_fqn_regex,
             name_format=self.datahub_dataset_name_format,
-            parent_entry_regex=SPANNER_DATABASE_PARENT_ENTRY_REGEX,
-            parent_key_class=DataplexCloudSpannerDatabase,
+            parent=self.dataplex_parent_entry,
         )
 
 
@@ -811,6 +838,10 @@ class CloudSpannerGraphMapper(EntryMapper):
     # Spanner tables and graphs share a namespace so names never collide.
     datahub_dataset_name_format = (
         "{project_id}.regional-{location}.{instance_id}.{database_id}.{graph_id}"
+    )
+    dataplex_parent_entry = ParentEntryLink(
+        dataplex_parent_entry_regex=SPANNER_DATABASE_PARENT_ENTRY_REGEX,
+        datahub_schemakey_class=DataplexCloudSpannerDatabase,
     )
 
     def map(
@@ -824,8 +855,7 @@ class CloudSpannerGraphMapper(EntryMapper):
             subtype=DatasetSubTypes.GRAPH,
             fqn_regex=self.dataplex_fqn_regex,
             name_format=self.datahub_dataset_name_format,
-            parent_entry_regex=SPANNER_DATABASE_PARENT_ENTRY_REGEX,
-            parent_key_class=DataplexCloudSpannerDatabase,
+            parent=self.dataplex_parent_entry,
             include_graph_schema_fallback=True,
         )
 
@@ -846,8 +876,7 @@ class CloudBigtableInstanceMapper(EntryMapper):
             subtype=DatasetContainerSubTypes.INSTANCE,
             fqn_regex=self.dataplex_fqn_regex,
             container_key_class=DataplexBigtableInstance,
-            parent_entry_regex=None,
-            parent_key_class=None,
+            parent=self.dataplex_parent_entry,
         )
 
 
@@ -857,6 +886,10 @@ class CloudBigtableTableMapper(EntryMapper):
     datahub_main_entity_type = Dataset
     dataplex_fqn_regex = BIGTABLE_TABLE_FQN_REGEX
     datahub_dataset_name_format = "{project_id}.{instance_id}.{table_id}"
+    dataplex_parent_entry = ParentEntryLink(
+        dataplex_parent_entry_regex=BIGTABLE_INSTANCE_PARENT_ENTRY_REGEX,
+        datahub_schemakey_class=DataplexBigtableInstance,
+    )
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -869,8 +902,7 @@ class CloudBigtableTableMapper(EntryMapper):
             subtype=DatasetSubTypes.TABLE,
             fqn_regex=self.dataplex_fqn_regex,
             name_format=self.datahub_dataset_name_format,
-            parent_entry_regex=BIGTABLE_INSTANCE_PARENT_ENTRY_REGEX,
-            parent_key_class=DataplexBigtableInstance,
+            parent=self.dataplex_parent_entry,
         )
 
 
@@ -893,8 +925,7 @@ class PubSubTopicMapper(EntryMapper):
             subtype=DatasetSubTypes.TOPIC,
             fqn_regex=self.dataplex_fqn_regex,
             name_format=self.datahub_dataset_name_format,
-            parent_entry_regex=None,
-            parent_key_class=None,
+            parent=self.dataplex_parent_entry,
         )
 
 
@@ -916,8 +947,7 @@ class VertexAiDatasetMapper(EntryMapper):
             subtype=DatasetSubTypes.TABLE,
             fqn_regex=self.dataplex_fqn_regex,
             name_format=self.datahub_dataset_name_format,
-            parent_entry_regex=None,
-            parent_key_class=None,
+            parent=self.dataplex_parent_entry,
         )
 
 

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
@@ -31,7 +31,7 @@ from datetime import datetime, timezone
 from typing import Optional, Pattern, Union
 
 from google.cloud import dataplex_v1
-from typing_extensions import assert_never
+from typing_extensions import TypeAlias, assert_never
 
 from datahub.emitter.mce_builder import make_dataset_urn_with_platform_instance
 from datahub.ingestion.api.source import SourceReport
@@ -121,20 +121,8 @@ class EntryMappingResult:
     lineage_entry: Optional[EntryDataTuple] = None
 
 
-class DatahubIdentity:
-    """How a mapper turns parsed FQN identity fields into its main entity's id.
-
-    Shared base for the two per-family variants — see :class:`DatasetIdentity`
-    and :class:`ContainerIdentity`. The variant a mapper carries also determines
-    ``EntryMapper.datahub_main_entity_type``. It is a plain base (not an ABC): the
-    variants expose different builders (``dataset_name`` vs ``container_key``), so
-    there is no shared abstract method. New identity shapes are added by
-    subclassing this and extending the ``datahub_main_entity_type`` dispatch.
-    """
-
-
 @dataclass(frozen=True)
-class DatasetIdentity(DatahubIdentity):
+class DatasetIdentity:
     """Dataset identity: a dotted name built from FQN fields via a format string.
 
     ``name_format`` references FQN named groups, e.g.
@@ -159,7 +147,7 @@ class DatasetIdentity(DatahubIdentity):
 
 
 @dataclass(frozen=True)
-class ContainerIdentity(DatahubIdentity):
+class ContainerIdentity:
     """Container identity: a ``ContainerKey`` built directly from FQN fields.
 
     ``key_class`` fields map 1:1 to FQN named groups (project_id, dataset_id, …).
@@ -175,6 +163,13 @@ class ContainerIdentity(DatahubIdentity):
         their names must match ``key_class`` fields.
         """
         return instantiate_key(self.key_class, identity_fields)
+
+
+# A mapper's identity is exactly one of these two variants. Modeled as a union
+# (not a shared base class) — the variants expose different builders
+# (dataset_name vs container_key), so there is no shared method, and the union
+# gives assert_never exhaustiveness in datahub_main_entity_type.
+DatahubIdentity: TypeAlias = Union[DatasetIdentity, ContainerIdentity]
 
 
 @dataclass(frozen=True)
@@ -274,7 +269,7 @@ class EntryMapper(ABC):
 
     @property
     @abstractmethod
-    def datahub_identity(self) -> Union[DatasetIdentity, ContainerIdentity]:
+    def datahub_identity(self) -> DatahubIdentity:
         """How this entry's parsed FQN fields become the main entity's DataHub id.
 
         A :class:`DatasetIdentity` (name built from a format string) or a

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
@@ -313,10 +313,12 @@ class EntryMapper(ABC):
 
     @property
     def datahub_additional_entity_types(self) -> tuple[type[Entity], ...]:
-        """Entities this mapper may also emit alongside the main one.
+        """Entity types this mapper may emit besides the main one (the owning
+        project Container, hence the default).
 
-        Declarative; the orchestrator dedups them. Every mapper emits the owning
-        project Container, hence the default.
+        Descriptive contract surface only — it documents the mapper's outputs and
+        is **not** consumed at runtime: the orchestrator dedups the concrete
+        ``result.additional_entities`` instances, not this declaration.
         """
         return (Container,)
 

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
@@ -106,7 +106,7 @@ class EntryMappingContext:
     report: SourceReport
 
 
-@dataclass
+@dataclass(frozen=True)
 class EntryMappingResult:
     """The DataHub entities a mapper produced for a single Dataplex entry.
 

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
@@ -133,6 +133,54 @@ class EntryMapper(ABC):
     properties so a mapper that forgets one cannot be instantiated (it fails when
     ``ENTRY_MAPPERS`` is built at import). Concrete classes satisfy them with
     plain class attributes.
+
+    Example Dataplex entry payload (anonymized) and how its fields drive mapping:
+
+    .. code-block:: text
+
+       name: "projects/example-project-123456/locations/us-west2/entryGroups/@cloudsql/entries/cloudsql.googleapis.com/projects/example-project-123456/locations/us-west2/instances/example-instance/databases/example-db/tables/example_table"
+       entry_type: "projects/655216118709/locations/global/entryTypes/cloudsql-mysql-table"
+       create_time { seconds: 1774092556 nanos: 511835000 }
+       update_time { seconds: 1774092556 nanos: 511835000 }
+       parent_entry: "projects/example-project-123456/locations/us-west2/entryGroups/@cloudsql/entries/cloudsql.googleapis.com/projects/example-project-123456/locations/us-west2/instances/example-instance/databases/example-db"
+       fully_qualified_name: "cloudsql_mysql:example-project-123456.us-west2.example-instance.example-db.example_table"
+       entry_source {
+         resource: "projects/example-project-123456/locations/us-west2/instances/example-instance/databases/example-db/tables/example_table"
+         system: "CLOUD_SQL"
+         platform: "GCP"
+         display_name: "example_table"
+         ancestors {
+           name: "projects/example-project-123456/locations/us-west2/instances/example-instance/databases/example-db"
+           type_: "dataplex-types.global.cloudsql-mysql-database"
+         }
+         ancestors {
+           name: "projects/example-project-123456/locations/us-west2/instances/example-instance"
+           type_: "dataplex-types.global.cloudsql-mysql-instance"
+         }
+         location: "us-west2"
+       }
+
+    Field -> mapping:
+
+    - ``entry_type``: its short name (``cloudsql-mysql-table``, extracted by
+      ``extract_entry_type_short_name``) selects which mapper handles the entry
+      via ``ENTRY_MAPPERS``. Matches ``dataplex_entry_type_short_name``.
+    - ``fully_qualified_name``: parsed by ``dataplex_fqn_regex`` into identity
+      fields (project/location/instance/database/table). Those fields build the
+      dataset name (dataset entries), the container key (container entries), and
+      always the owning project container key.
+    - ``parent_entry``: parsed by the type's parent-entry regex to build the
+      parent container key (dataset -> its containing dataset/database; container
+      -> its parent container). When absent, parent linkage falls back to the
+      project key.
+    - ``entry_source.display_name`` / ``description`` / ``create_time`` /
+      ``update_time``: become the DataHub display name, description, and
+      created/last-modified timestamps (see the ``_extract_*`` helpers).
+    - ``name``: its ``entryGroups/<id>`` segment and trailing segment provide the
+      entry group id (custom property) and the display-name fallback.
+
+    Authoritative FQN formats:
+    https://docs.cloud.google.com/dataplex/docs/fully-qualified-names
     """
 
     @property

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
@@ -152,8 +152,8 @@ class EntryMapper(ABC):
 
     @property
     @abstractmethod
-    def fqn_regex(self) -> Pattern[str]:
-        """Regex that parses this entry type's ``fully_qualified_name``.
+    def dataplex_fqn_regex(self) -> Pattern[str]:
+        """Regex that parses this entry type's Dataplex ``fully_qualified_name``.
 
         Universal to every mapper (both Dataset and Container entries parse the
         FQN for identity), so it is part of the contract rather than an inline
@@ -557,7 +557,7 @@ class BigQueryDatasetMapper(EntryMapper):
     dataplex_entry_type_short_name = "bigquery-dataset"
     datahub_platform = "bigquery"
     datahub_main_entity_type = Container
-    fqn_regex = BIGQUERY_DATASET_FQN_REGEX
+    dataplex_fqn_regex = BIGQUERY_DATASET_FQN_REGEX
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -567,7 +567,7 @@ class BigQueryDatasetMapper(EntryMapper):
             ctx,
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.BIGQUERY_DATASET,
-            fqn_regex=self.fqn_regex,
+            fqn_regex=self.dataplex_fqn_regex,
             container_key_class=DataplexBigQueryDataset,
             parent_entry_regex=None,
             parent_key_class=None,
@@ -578,7 +578,7 @@ class BigQueryTableMapper(EntryMapper):
     dataplex_entry_type_short_name = "bigquery-table"
     datahub_platform = "bigquery"
     datahub_main_entity_type = Dataset
-    fqn_regex = BIGQUERY_TABLE_FQN_REGEX
+    dataplex_fqn_regex = BIGQUERY_TABLE_FQN_REGEX
     datahub_dataset_name_format = "{project_id}.{dataset_id}.{table_id}"
 
     def map(
@@ -590,7 +590,7 @@ class BigQueryTableMapper(EntryMapper):
             short_name=self.dataplex_entry_type_short_name,
             platform=self.datahub_platform,
             subtype=DatasetSubTypes.TABLE,
-            fqn_regex=self.fqn_regex,
+            fqn_regex=self.dataplex_fqn_regex,
             name_format=self.datahub_dataset_name_format,
             parent_entry_regex=BIGQUERY_DATASET_PARENT_ENTRY_REGEX,
             parent_key_class=DataplexBigQueryDataset,
@@ -602,7 +602,7 @@ class BigQueryViewMapper(EntryMapper):
     dataplex_entry_type_short_name = "bigquery-view"
     datahub_platform = "bigquery"
     datahub_main_entity_type = Dataset
-    fqn_regex = BIGQUERY_TABLE_FQN_REGEX
+    dataplex_fqn_regex = BIGQUERY_TABLE_FQN_REGEX
     datahub_dataset_name_format = "{project_id}.{dataset_id}.{table_id}"
 
     def map(
@@ -614,7 +614,7 @@ class BigQueryViewMapper(EntryMapper):
             short_name=self.dataplex_entry_type_short_name,
             platform=self.datahub_platform,
             subtype=DatasetSubTypes.VIEW,
-            fqn_regex=self.fqn_regex,
+            fqn_regex=self.dataplex_fqn_regex,
             name_format=self.datahub_dataset_name_format,
             parent_entry_regex=BIGQUERY_DATASET_PARENT_ENTRY_REGEX,
             parent_key_class=DataplexBigQueryDataset,
@@ -625,7 +625,7 @@ class CloudSqlMySqlInstanceMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloudsql-mysql-instance"
     datahub_platform = "cloudsql"
     datahub_main_entity_type = Container
-    fqn_regex = MYSQL_INSTANCE_FQN_REGEX
+    dataplex_fqn_regex = MYSQL_INSTANCE_FQN_REGEX
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -635,7 +635,7 @@ class CloudSqlMySqlInstanceMapper(EntryMapper):
             ctx,
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.INSTANCE,
-            fqn_regex=self.fqn_regex,
+            fqn_regex=self.dataplex_fqn_regex,
             container_key_class=DataplexCloudSqlMySqlInstance,
             parent_entry_regex=None,
             parent_key_class=None,
@@ -646,7 +646,7 @@ class CloudSqlMySqlDatabaseMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloudsql-mysql-database"
     datahub_platform = "cloudsql"
     datahub_main_entity_type = Container
-    fqn_regex = MYSQL_DATABASE_FQN_REGEX
+    dataplex_fqn_regex = MYSQL_DATABASE_FQN_REGEX
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -656,7 +656,7 @@ class CloudSqlMySqlDatabaseMapper(EntryMapper):
             ctx,
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.DATABASE,
-            fqn_regex=self.fqn_regex,
+            fqn_regex=self.dataplex_fqn_regex,
             container_key_class=DataplexCloudSqlMySqlDatabase,
             parent_entry_regex=MYSQL_INSTANCE_PARENT_ENTRY_REGEX,
             parent_key_class=DataplexCloudSqlMySqlInstance,
@@ -667,7 +667,7 @@ class CloudSqlMySqlTableMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloudsql-mysql-table"
     datahub_platform = "cloudsql"
     datahub_main_entity_type = Dataset
-    fqn_regex = MYSQL_TABLE_FQN_REGEX
+    dataplex_fqn_regex = MYSQL_TABLE_FQN_REGEX
     datahub_dataset_name_format = (
         "{project_id}.{location}.{instance_id}.{database_id}.{table_id}"
     )
@@ -681,7 +681,7 @@ class CloudSqlMySqlTableMapper(EntryMapper):
             short_name=self.dataplex_entry_type_short_name,
             platform=self.datahub_platform,
             subtype=DatasetSubTypes.TABLE,
-            fqn_regex=self.fqn_regex,
+            fqn_regex=self.dataplex_fqn_regex,
             name_format=self.datahub_dataset_name_format,
             parent_entry_regex=MYSQL_DATABASE_PARENT_ENTRY_REGEX,
             parent_key_class=DataplexCloudSqlMySqlDatabase,
@@ -692,7 +692,7 @@ class CloudSpannerInstanceMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloud-spanner-instance"
     datahub_platform = "spanner"
     datahub_main_entity_type = Container
-    fqn_regex = SPANNER_INSTANCE_FQN_REGEX
+    dataplex_fqn_regex = SPANNER_INSTANCE_FQN_REGEX
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -702,7 +702,7 @@ class CloudSpannerInstanceMapper(EntryMapper):
             ctx,
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.INSTANCE,
-            fqn_regex=self.fqn_regex,
+            fqn_regex=self.dataplex_fqn_regex,
             container_key_class=DataplexCloudSpannerInstance,
             parent_entry_regex=None,
             parent_key_class=None,
@@ -713,7 +713,7 @@ class CloudSpannerDatabaseMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloud-spanner-database"
     datahub_platform = "spanner"
     datahub_main_entity_type = Container
-    fqn_regex = SPANNER_DATABASE_FQN_REGEX
+    dataplex_fqn_regex = SPANNER_DATABASE_FQN_REGEX
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -723,7 +723,7 @@ class CloudSpannerDatabaseMapper(EntryMapper):
             ctx,
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.DATABASE,
-            fqn_regex=self.fqn_regex,
+            fqn_regex=self.dataplex_fqn_regex,
             container_key_class=DataplexCloudSpannerDatabase,
             parent_entry_regex=SPANNER_INSTANCE_PARENT_ENTRY_REGEX,
             parent_key_class=DataplexCloudSpannerInstance,
@@ -734,7 +734,7 @@ class CloudSpannerTableMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloud-spanner-table"
     datahub_platform = "spanner"
     datahub_main_entity_type = Dataset
-    fqn_regex = SPANNER_TABLE_FQN_REGEX
+    dataplex_fqn_regex = SPANNER_TABLE_FQN_REGEX
     datahub_dataset_name_format = (
         "{project_id}.regional-{location}.{instance_id}.{database_id}.{table_id}"
     )
@@ -748,7 +748,7 @@ class CloudSpannerTableMapper(EntryMapper):
             short_name=self.dataplex_entry_type_short_name,
             platform=self.datahub_platform,
             subtype=DatasetSubTypes.TABLE,
-            fqn_regex=self.fqn_regex,
+            fqn_regex=self.dataplex_fqn_regex,
             name_format=self.datahub_dataset_name_format,
             parent_entry_regex=SPANNER_DATABASE_PARENT_ENTRY_REGEX,
             parent_key_class=DataplexCloudSpannerDatabase,
@@ -759,7 +759,7 @@ class CloudSpannerGraphMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloud-spanner-graph"
     datahub_platform = "spanner"
     datahub_main_entity_type = Dataset
-    fqn_regex = SPANNER_GRAPH_FQN_REGEX
+    dataplex_fqn_regex = SPANNER_GRAPH_FQN_REGEX
     # Spanner tables and graphs share a namespace so names never collide.
     datahub_dataset_name_format = (
         "{project_id}.regional-{location}.{instance_id}.{database_id}.{graph_id}"
@@ -774,7 +774,7 @@ class CloudSpannerGraphMapper(EntryMapper):
             short_name=self.dataplex_entry_type_short_name,
             platform=self.datahub_platform,
             subtype=DatasetSubTypes.GRAPH,
-            fqn_regex=self.fqn_regex,
+            fqn_regex=self.dataplex_fqn_regex,
             name_format=self.datahub_dataset_name_format,
             parent_entry_regex=SPANNER_DATABASE_PARENT_ENTRY_REGEX,
             parent_key_class=DataplexCloudSpannerDatabase,
@@ -786,7 +786,7 @@ class CloudBigtableInstanceMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloud-bigtable-instance"
     datahub_platform = "bigtable"
     datahub_main_entity_type = Container
-    fqn_regex = BIGTABLE_INSTANCE_FQN_REGEX
+    dataplex_fqn_regex = BIGTABLE_INSTANCE_FQN_REGEX
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -796,7 +796,7 @@ class CloudBigtableInstanceMapper(EntryMapper):
             ctx,
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.INSTANCE,
-            fqn_regex=self.fqn_regex,
+            fqn_regex=self.dataplex_fqn_regex,
             container_key_class=DataplexBigtableInstance,
             parent_entry_regex=None,
             parent_key_class=None,
@@ -807,7 +807,7 @@ class CloudBigtableTableMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloud-bigtable-table"
     datahub_platform = "bigtable"
     datahub_main_entity_type = Dataset
-    fqn_regex = BIGTABLE_TABLE_FQN_REGEX
+    dataplex_fqn_regex = BIGTABLE_TABLE_FQN_REGEX
     datahub_dataset_name_format = "{project_id}.{instance_id}.{table_id}"
 
     def map(
@@ -819,7 +819,7 @@ class CloudBigtableTableMapper(EntryMapper):
             short_name=self.dataplex_entry_type_short_name,
             platform=self.datahub_platform,
             subtype=DatasetSubTypes.TABLE,
-            fqn_regex=self.fqn_regex,
+            fqn_regex=self.dataplex_fqn_regex,
             name_format=self.datahub_dataset_name_format,
             parent_entry_regex=BIGTABLE_INSTANCE_PARENT_ENTRY_REGEX,
             parent_key_class=DataplexBigtableInstance,
@@ -830,7 +830,7 @@ class PubSubTopicMapper(EntryMapper):
     dataplex_entry_type_short_name = "pubsub-topic"
     datahub_platform = "pubsub"
     datahub_main_entity_type = Dataset
-    fqn_regex = PUBSUB_TOPIC_FQN_REGEX
+    dataplex_fqn_regex = PUBSUB_TOPIC_FQN_REGEX
     datahub_dataset_name_format = "{project_id}.{topic_id}"
 
     def map(
@@ -843,7 +843,7 @@ class PubSubTopicMapper(EntryMapper):
             short_name=self.dataplex_entry_type_short_name,
             platform=self.datahub_platform,
             subtype=DatasetSubTypes.TOPIC,
-            fqn_regex=self.fqn_regex,
+            fqn_regex=self.dataplex_fqn_regex,
             name_format=self.datahub_dataset_name_format,
             parent_entry_regex=None,
             parent_key_class=None,
@@ -854,7 +854,7 @@ class VertexAiDatasetMapper(EntryMapper):
     dataplex_entry_type_short_name = "vertexai-dataset"
     datahub_platform = "vertexai"
     datahub_main_entity_type = Dataset
-    fqn_regex = VERTEX_AI_DATASET_FQN_REGEX
+    dataplex_fqn_regex = VERTEX_AI_DATASET_FQN_REGEX
     datahub_dataset_name_format = "{project_id}.{location}.{dataset_id}"
 
     def map(
@@ -866,7 +866,7 @@ class VertexAiDatasetMapper(EntryMapper):
             short_name=self.dataplex_entry_type_short_name,
             platform=self.datahub_platform,
             subtype=DatasetSubTypes.TABLE,
-            fqn_regex=self.fqn_regex,
+            fqn_regex=self.dataplex_fqn_regex,
             name_format=self.datahub_dataset_name_format,
             parent_entry_regex=None,
             parent_key_class=None,
@@ -947,7 +947,7 @@ def dataset_urn_from_fqn_only(fully_qualified_name: str, env: str) -> Optional[s
             continue
         urn = dataset_urn_from_fqn(
             fully_qualified_name,
-            mapper.fqn_regex,
+            mapper.dataplex_fqn_regex,
             # dataset_name_format only exists on dataset mappers, guarded above.
             mapper.datahub_dataset_name_format,  # type: ignore[attr-defined]
             mapper.datahub_platform,

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
@@ -151,6 +151,16 @@ class EntryMapper(ABC):
         """The DataHub entity this entry maps to directly — Dataset or Container."""
 
     @property
+    @abstractmethod
+    def fqn_regex(self) -> Pattern[str]:
+        """Regex that parses this entry type's ``fully_qualified_name``.
+
+        Universal to every mapper (both Dataset and Container entries parse the
+        FQN for identity), so it is part of the contract rather than an inline
+        argument. Named groups must match the target ``ContainerKey`` fields.
+        """
+
+    @property
     def datahub_additional_entity_types(self) -> tuple[type[Entity], ...]:
         """Entities this mapper may also emit alongside the main one.
 
@@ -547,6 +557,7 @@ class BigQueryDatasetMapper(EntryMapper):
     dataplex_entry_type_short_name = "bigquery-dataset"
     datahub_platform = "bigquery"
     datahub_main_entity_type = Container
+    fqn_regex = BIGQUERY_DATASET_FQN_REGEX
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -556,7 +567,7 @@ class BigQueryDatasetMapper(EntryMapper):
             ctx,
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.BIGQUERY_DATASET,
-            fqn_regex=BIGQUERY_DATASET_FQN_REGEX,
+            fqn_regex=self.fqn_regex,
             container_key_class=DataplexBigQueryDataset,
             parent_entry_regex=None,
             parent_key_class=None,
@@ -614,6 +625,7 @@ class CloudSqlMySqlInstanceMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloudsql-mysql-instance"
     datahub_platform = "cloudsql"
     datahub_main_entity_type = Container
+    fqn_regex = MYSQL_INSTANCE_FQN_REGEX
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -623,7 +635,7 @@ class CloudSqlMySqlInstanceMapper(EntryMapper):
             ctx,
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.INSTANCE,
-            fqn_regex=MYSQL_INSTANCE_FQN_REGEX,
+            fqn_regex=self.fqn_regex,
             container_key_class=DataplexCloudSqlMySqlInstance,
             parent_entry_regex=None,
             parent_key_class=None,
@@ -634,6 +646,7 @@ class CloudSqlMySqlDatabaseMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloudsql-mysql-database"
     datahub_platform = "cloudsql"
     datahub_main_entity_type = Container
+    fqn_regex = MYSQL_DATABASE_FQN_REGEX
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -643,7 +656,7 @@ class CloudSqlMySqlDatabaseMapper(EntryMapper):
             ctx,
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.DATABASE,
-            fqn_regex=MYSQL_DATABASE_FQN_REGEX,
+            fqn_regex=self.fqn_regex,
             container_key_class=DataplexCloudSqlMySqlDatabase,
             parent_entry_regex=MYSQL_INSTANCE_PARENT_ENTRY_REGEX,
             parent_key_class=DataplexCloudSqlMySqlInstance,
@@ -679,6 +692,7 @@ class CloudSpannerInstanceMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloud-spanner-instance"
     datahub_platform = "spanner"
     datahub_main_entity_type = Container
+    fqn_regex = SPANNER_INSTANCE_FQN_REGEX
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -688,7 +702,7 @@ class CloudSpannerInstanceMapper(EntryMapper):
             ctx,
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.INSTANCE,
-            fqn_regex=SPANNER_INSTANCE_FQN_REGEX,
+            fqn_regex=self.fqn_regex,
             container_key_class=DataplexCloudSpannerInstance,
             parent_entry_regex=None,
             parent_key_class=None,
@@ -699,6 +713,7 @@ class CloudSpannerDatabaseMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloud-spanner-database"
     datahub_platform = "spanner"
     datahub_main_entity_type = Container
+    fqn_regex = SPANNER_DATABASE_FQN_REGEX
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -708,7 +723,7 @@ class CloudSpannerDatabaseMapper(EntryMapper):
             ctx,
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.DATABASE,
-            fqn_regex=SPANNER_DATABASE_FQN_REGEX,
+            fqn_regex=self.fqn_regex,
             container_key_class=DataplexCloudSpannerDatabase,
             parent_entry_regex=SPANNER_INSTANCE_PARENT_ENTRY_REGEX,
             parent_key_class=DataplexCloudSpannerInstance,
@@ -771,6 +786,7 @@ class CloudBigtableInstanceMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloud-bigtable-instance"
     datahub_platform = "bigtable"
     datahub_main_entity_type = Container
+    fqn_regex = BIGTABLE_INSTANCE_FQN_REGEX
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -780,7 +796,7 @@ class CloudBigtableInstanceMapper(EntryMapper):
             ctx,
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.INSTANCE,
-            fqn_regex=BIGTABLE_INSTANCE_FQN_REGEX,
+            fqn_regex=self.fqn_regex,
             container_key_class=DataplexBigtableInstance,
             parent_entry_regex=None,
             parent_key_class=None,
@@ -931,7 +947,8 @@ def dataset_urn_from_fqn_only(fully_qualified_name: str, env: str) -> Optional[s
             continue
         urn = dataset_urn_from_fqn(
             fully_qualified_name,
-            mapper.fqn_regex,  # type: ignore[attr-defined]
+            mapper.fqn_regex,
+            # dataset_name_format only exists on dataset mappers, guarded above.
             mapper.datahub_dataset_name_format,  # type: ignore[attr-defined]
             mapper.datahub_platform,
             env,

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
@@ -28,9 +28,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Optional, Pattern
+from typing import Optional, Pattern, Union
 
 from google.cloud import dataplex_v1
+from typing_extensions import assert_never
 
 from datahub.emitter.mce_builder import make_dataset_urn_with_platform_instance
 from datahub.ingestion.api.source import SourceReport
@@ -118,6 +119,62 @@ class EntryMappingResult:
     main_entity: Optional[Entity] = None
     additional_entities: list[Entity] = field(default_factory=list)
     lineage_entry: Optional[EntryDataTuple] = None
+
+
+class DatahubIdentity:
+    """How a mapper turns parsed FQN identity fields into its main entity's id.
+
+    Shared base for the two per-family variants — see :class:`DatasetIdentity`
+    and :class:`ContainerIdentity`. The variant a mapper carries also determines
+    ``EntryMapper.datahub_main_entity_type``. It is a plain base (not an ABC): the
+    variants expose different builders (``dataset_name`` vs ``container_key``), so
+    there is no shared abstract method. New identity shapes are added by
+    subclassing this and extending the ``datahub_main_entity_type`` dispatch.
+    """
+
+
+@dataclass(frozen=True)
+class DatasetIdentity(DatahubIdentity):
+    """Dataset identity: a dotted name built from FQN fields via a format string.
+
+    ``name_format`` references FQN named groups, e.g.
+    ``"{project_id}.{dataset_id}.{table_id}"``. The DataHub platform and env are
+    supplied at build time (they are not part of the FQN), so this only owns the
+    name.
+    """
+
+    name_format: str
+
+    def dataset_name(self, identity_fields: dict[str, str]) -> Optional[str]:
+        """Build the dataset name from FQN identity fields.
+
+        ``identity_fields`` are the named-group matches produced by parsing the
+        entry's ``fully_qualified_name`` with the mapper's ``dataplex_fqn_regex``
+        (e.g. ``{"project_id": ..., "dataset_id": ..., "table_id": ...}``).
+        """
+        try:
+            return self.name_format.format(**identity_fields) or None
+        except KeyError:
+            return None
+
+
+@dataclass(frozen=True)
+class ContainerIdentity(DatahubIdentity):
+    """Container identity: a ``ContainerKey`` built directly from FQN fields.
+
+    ``key_class`` fields map 1:1 to FQN named groups (project_id, dataset_id, …).
+    """
+
+    key_class: type[DataplexProjectId]
+
+    def container_key(self, identity_fields: dict[str, str]) -> DataplexProjectId:
+        """Build the ``ContainerKey`` from FQN identity fields.
+
+        ``identity_fields`` are the named-group matches produced by parsing the
+        entry's ``fully_qualified_name`` with the mapper's ``dataplex_fqn_regex``;
+        their names must match ``key_class`` fields.
+        """
+        return instantiate_key(self.key_class, identity_fields)
 
 
 @dataclass(frozen=True)
@@ -217,8 +274,24 @@ class EntryMapper(ABC):
 
     @property
     @abstractmethod
+    def datahub_identity(self) -> Union[DatasetIdentity, ContainerIdentity]:
+        """How this entry's parsed FQN fields become the main entity's DataHub id.
+
+        A :class:`DatasetIdentity` (name built from a format string) or a
+        :class:`ContainerIdentity` (``ContainerKey`` built from the fields). The
+        variant also determines :attr:`datahub_main_entity_type`.
+        """
+
+    @property
     def datahub_main_entity_type(self) -> type[Entity]:
-        """The DataHub entity this entry maps to directly — Dataset or Container."""
+        """The DataHub entity this entry maps to directly — derived from the identity."""
+        identity = self.datahub_identity
+        if isinstance(identity, DatasetIdentity):
+            return Dataset
+        elif isinstance(identity, ContainerIdentity):
+            return Container
+        else:
+            assert_never(identity)
 
     @property
     @abstractmethod
@@ -227,7 +300,9 @@ class EntryMapper(ABC):
 
         Universal to every mapper (both Dataset and Container entries parse the
         FQN for identity), so it is part of the contract rather than an inline
-        argument. Named groups must match the target ``ContainerKey`` fields.
+        argument. Its named groups must supply whatever ``datahub_identity``
+        consumes: the ``ContainerKey`` fields for a :class:`ContainerIdentity`, or
+        the name-format fields for a :class:`DatasetIdentity`.
         """
 
     @property
@@ -346,27 +421,23 @@ def _extract_common_fields(entry: dataplex_v1.Entry) -> _CommonFields:
 
 
 def _dataset_name_from_fqn(
-    fqn_regex: Pattern[str], name_format: str, fully_qualified_name: str
+    fqn_regex: Pattern[str], identity: DatasetIdentity, fully_qualified_name: str
 ) -> Optional[str]:
     identity_fields = parse_with_regex(fqn_regex, fully_qualified_name)
     if identity_fields is None:
         return None
-    try:
-        dataset_name = name_format.format(**identity_fields)
-    except KeyError:
-        return None
-    return dataset_name or None
+    return identity.dataset_name(identity_fields)
 
 
 def dataset_urn_from_fqn(
     fully_qualified_name: str,
     fqn_regex: Pattern[str],
-    name_format: str,
+    identity: DatasetIdentity,
     platform: str,
     env: str,
 ) -> Optional[str]:
-    """Build a dataset URN from an FQN using an explicit regex + name format."""
-    dataset_name = _dataset_name_from_fqn(fqn_regex, name_format, fully_qualified_name)
+    """Build a dataset URN from an FQN using an explicit regex + dataset identity."""
+    dataset_name = _dataset_name_from_fqn(fqn_regex, identity, fully_qualified_name)
     if dataset_name is None:
         return None
     return make_dataset_urn_with_platform_instance(
@@ -435,7 +506,7 @@ def build_dataset(
     platform: str,
     subtype: str,
     fqn_regex: Pattern[str],
-    name_format: str,
+    identity: DatasetIdentity,
     parent: Optional[ParentEntryLink],
     include_graph_schema_fallback: bool = False,
 ) -> Optional[EntryMappingResult]:
@@ -449,7 +520,7 @@ def build_dataset(
     )
 
     dataset_name = _dataset_name_from_fqn(
-        fqn_regex, name_format, entry.fully_qualified_name
+        fqn_regex, identity, entry.fully_qualified_name
     )
     if dataset_name is None:
         ctx.report.warning(
@@ -552,7 +623,7 @@ def build_container(
     platform: str,
     subtype: str,
     fqn_regex: Pattern[str],
-    container_key_class: type[DataplexProjectId],
+    identity: ContainerIdentity,
     parent: Optional[ParentEntryLink],
 ) -> Optional[EntryMappingResult]:
     """Map a Dataplex entry to a DataHub Container (+ project container)."""
@@ -583,7 +654,7 @@ def build_container(
         if additional:
             return EntryMappingResult(additional_entities=additional)
         return None
-    container_key = instantiate_key(container_key_class, identity_fields)
+    container_key = identity.container_key(identity_fields)
 
     # Prefer parent linkage from Dataplex parent_entry; fall back to project key.
     container_parent_key: Optional[DataplexProjectId] = None
@@ -616,8 +687,8 @@ def build_container(
 class BigQueryDatasetMapper(EntryMapper):
     dataplex_entry_type_short_name = "bigquery-dataset"
     datahub_platform = "bigquery"
-    datahub_main_entity_type = Container
     dataplex_fqn_regex = BIGQUERY_DATASET_FQN_REGEX
+    datahub_identity = ContainerIdentity(DataplexBigQueryDataset)
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -628,7 +699,7 @@ class BigQueryDatasetMapper(EntryMapper):
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.BIGQUERY_DATASET,
             fqn_regex=self.dataplex_fqn_regex,
-            container_key_class=DataplexBigQueryDataset,
+            identity=self.datahub_identity,
             parent=self.dataplex_parent_entry,
         )
 
@@ -636,9 +707,8 @@ class BigQueryDatasetMapper(EntryMapper):
 class BigQueryTableMapper(EntryMapper):
     dataplex_entry_type_short_name = "bigquery-table"
     datahub_platform = "bigquery"
-    datahub_main_entity_type = Dataset
     dataplex_fqn_regex = BIGQUERY_TABLE_FQN_REGEX
-    datahub_dataset_name_format = "{project_id}.{dataset_id}.{table_id}"
+    datahub_identity = DatasetIdentity("{project_id}.{dataset_id}.{table_id}")
     dataplex_parent_entry = ParentEntryLink(
         dataplex_parent_entry_regex=BIGQUERY_DATASET_PARENT_ENTRY_REGEX,
         datahub_schemakey_class=DataplexBigQueryDataset,
@@ -654,7 +724,7 @@ class BigQueryTableMapper(EntryMapper):
             platform=self.datahub_platform,
             subtype=DatasetSubTypes.TABLE,
             fqn_regex=self.dataplex_fqn_regex,
-            name_format=self.datahub_dataset_name_format,
+            identity=self.datahub_identity,
             parent=self.dataplex_parent_entry,
         )
 
@@ -663,9 +733,8 @@ class BigQueryViewMapper(EntryMapper):
     # Views share the FQN and parent_entry shape of tables; only the subtype differs.
     dataplex_entry_type_short_name = "bigquery-view"
     datahub_platform = "bigquery"
-    datahub_main_entity_type = Dataset
     dataplex_fqn_regex = BIGQUERY_TABLE_FQN_REGEX
-    datahub_dataset_name_format = "{project_id}.{dataset_id}.{table_id}"
+    datahub_identity = DatasetIdentity("{project_id}.{dataset_id}.{table_id}")
     dataplex_parent_entry = ParentEntryLink(
         dataplex_parent_entry_regex=BIGQUERY_DATASET_PARENT_ENTRY_REGEX,
         datahub_schemakey_class=DataplexBigQueryDataset,
@@ -681,7 +750,7 @@ class BigQueryViewMapper(EntryMapper):
             platform=self.datahub_platform,
             subtype=DatasetSubTypes.VIEW,
             fqn_regex=self.dataplex_fqn_regex,
-            name_format=self.datahub_dataset_name_format,
+            identity=self.datahub_identity,
             parent=self.dataplex_parent_entry,
         )
 
@@ -689,8 +758,8 @@ class BigQueryViewMapper(EntryMapper):
 class CloudSqlMySqlInstanceMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloudsql-mysql-instance"
     datahub_platform = "cloudsql"
-    datahub_main_entity_type = Container
     dataplex_fqn_regex = MYSQL_INSTANCE_FQN_REGEX
+    datahub_identity = ContainerIdentity(DataplexCloudSqlMySqlInstance)
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -701,7 +770,7 @@ class CloudSqlMySqlInstanceMapper(EntryMapper):
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.INSTANCE,
             fqn_regex=self.dataplex_fqn_regex,
-            container_key_class=DataplexCloudSqlMySqlInstance,
+            identity=self.datahub_identity,
             parent=self.dataplex_parent_entry,
         )
 
@@ -709,8 +778,8 @@ class CloudSqlMySqlInstanceMapper(EntryMapper):
 class CloudSqlMySqlDatabaseMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloudsql-mysql-database"
     datahub_platform = "cloudsql"
-    datahub_main_entity_type = Container
     dataplex_fqn_regex = MYSQL_DATABASE_FQN_REGEX
+    datahub_identity = ContainerIdentity(DataplexCloudSqlMySqlDatabase)
     dataplex_parent_entry = ParentEntryLink(
         dataplex_parent_entry_regex=MYSQL_INSTANCE_PARENT_ENTRY_REGEX,
         datahub_schemakey_class=DataplexCloudSqlMySqlInstance,
@@ -725,7 +794,7 @@ class CloudSqlMySqlDatabaseMapper(EntryMapper):
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.DATABASE,
             fqn_regex=self.dataplex_fqn_regex,
-            container_key_class=DataplexCloudSqlMySqlDatabase,
+            identity=self.datahub_identity,
             parent=self.dataplex_parent_entry,
         )
 
@@ -733,9 +802,8 @@ class CloudSqlMySqlDatabaseMapper(EntryMapper):
 class CloudSqlMySqlTableMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloudsql-mysql-table"
     datahub_platform = "cloudsql"
-    datahub_main_entity_type = Dataset
     dataplex_fqn_regex = MYSQL_TABLE_FQN_REGEX
-    datahub_dataset_name_format = (
+    datahub_identity = DatasetIdentity(
         "{project_id}.{location}.{instance_id}.{database_id}.{table_id}"
     )
     dataplex_parent_entry = ParentEntryLink(
@@ -753,7 +821,7 @@ class CloudSqlMySqlTableMapper(EntryMapper):
             platform=self.datahub_platform,
             subtype=DatasetSubTypes.TABLE,
             fqn_regex=self.dataplex_fqn_regex,
-            name_format=self.datahub_dataset_name_format,
+            identity=self.datahub_identity,
             parent=self.dataplex_parent_entry,
         )
 
@@ -761,8 +829,8 @@ class CloudSqlMySqlTableMapper(EntryMapper):
 class CloudSpannerInstanceMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloud-spanner-instance"
     datahub_platform = "spanner"
-    datahub_main_entity_type = Container
     dataplex_fqn_regex = SPANNER_INSTANCE_FQN_REGEX
+    datahub_identity = ContainerIdentity(DataplexCloudSpannerInstance)
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -773,7 +841,7 @@ class CloudSpannerInstanceMapper(EntryMapper):
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.INSTANCE,
             fqn_regex=self.dataplex_fqn_regex,
-            container_key_class=DataplexCloudSpannerInstance,
+            identity=self.datahub_identity,
             parent=self.dataplex_parent_entry,
         )
 
@@ -781,8 +849,8 @@ class CloudSpannerInstanceMapper(EntryMapper):
 class CloudSpannerDatabaseMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloud-spanner-database"
     datahub_platform = "spanner"
-    datahub_main_entity_type = Container
     dataplex_fqn_regex = SPANNER_DATABASE_FQN_REGEX
+    datahub_identity = ContainerIdentity(DataplexCloudSpannerDatabase)
     dataplex_parent_entry = ParentEntryLink(
         dataplex_parent_entry_regex=SPANNER_INSTANCE_PARENT_ENTRY_REGEX,
         datahub_schemakey_class=DataplexCloudSpannerInstance,
@@ -797,7 +865,7 @@ class CloudSpannerDatabaseMapper(EntryMapper):
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.DATABASE,
             fqn_regex=self.dataplex_fqn_regex,
-            container_key_class=DataplexCloudSpannerDatabase,
+            identity=self.datahub_identity,
             parent=self.dataplex_parent_entry,
         )
 
@@ -805,9 +873,8 @@ class CloudSpannerDatabaseMapper(EntryMapper):
 class CloudSpannerTableMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloud-spanner-table"
     datahub_platform = "spanner"
-    datahub_main_entity_type = Dataset
     dataplex_fqn_regex = SPANNER_TABLE_FQN_REGEX
-    datahub_dataset_name_format = (
+    datahub_identity = DatasetIdentity(
         "{project_id}.regional-{location}.{instance_id}.{database_id}.{table_id}"
     )
     dataplex_parent_entry = ParentEntryLink(
@@ -825,7 +892,7 @@ class CloudSpannerTableMapper(EntryMapper):
             platform=self.datahub_platform,
             subtype=DatasetSubTypes.TABLE,
             fqn_regex=self.dataplex_fqn_regex,
-            name_format=self.datahub_dataset_name_format,
+            identity=self.datahub_identity,
             parent=self.dataplex_parent_entry,
         )
 
@@ -833,10 +900,9 @@ class CloudSpannerTableMapper(EntryMapper):
 class CloudSpannerGraphMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloud-spanner-graph"
     datahub_platform = "spanner"
-    datahub_main_entity_type = Dataset
     dataplex_fqn_regex = SPANNER_GRAPH_FQN_REGEX
     # Spanner tables and graphs share a namespace so names never collide.
-    datahub_dataset_name_format = (
+    datahub_identity = DatasetIdentity(
         "{project_id}.regional-{location}.{instance_id}.{database_id}.{graph_id}"
     )
     dataplex_parent_entry = ParentEntryLink(
@@ -854,7 +920,7 @@ class CloudSpannerGraphMapper(EntryMapper):
             platform=self.datahub_platform,
             subtype=DatasetSubTypes.GRAPH,
             fqn_regex=self.dataplex_fqn_regex,
-            name_format=self.datahub_dataset_name_format,
+            identity=self.datahub_identity,
             parent=self.dataplex_parent_entry,
             include_graph_schema_fallback=True,
         )
@@ -863,8 +929,8 @@ class CloudSpannerGraphMapper(EntryMapper):
 class CloudBigtableInstanceMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloud-bigtable-instance"
     datahub_platform = "bigtable"
-    datahub_main_entity_type = Container
     dataplex_fqn_regex = BIGTABLE_INSTANCE_FQN_REGEX
+    datahub_identity = ContainerIdentity(DataplexBigtableInstance)
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -875,7 +941,7 @@ class CloudBigtableInstanceMapper(EntryMapper):
             platform=self.datahub_platform,
             subtype=DatasetContainerSubTypes.INSTANCE,
             fqn_regex=self.dataplex_fqn_regex,
-            container_key_class=DataplexBigtableInstance,
+            identity=self.datahub_identity,
             parent=self.dataplex_parent_entry,
         )
 
@@ -883,9 +949,8 @@ class CloudBigtableInstanceMapper(EntryMapper):
 class CloudBigtableTableMapper(EntryMapper):
     dataplex_entry_type_short_name = "cloud-bigtable-table"
     datahub_platform = "bigtable"
-    datahub_main_entity_type = Dataset
     dataplex_fqn_regex = BIGTABLE_TABLE_FQN_REGEX
-    datahub_dataset_name_format = "{project_id}.{instance_id}.{table_id}"
+    datahub_identity = DatasetIdentity("{project_id}.{instance_id}.{table_id}")
     dataplex_parent_entry = ParentEntryLink(
         dataplex_parent_entry_regex=BIGTABLE_INSTANCE_PARENT_ENTRY_REGEX,
         datahub_schemakey_class=DataplexBigtableInstance,
@@ -901,7 +966,7 @@ class CloudBigtableTableMapper(EntryMapper):
             platform=self.datahub_platform,
             subtype=DatasetSubTypes.TABLE,
             fqn_regex=self.dataplex_fqn_regex,
-            name_format=self.datahub_dataset_name_format,
+            identity=self.datahub_identity,
             parent=self.dataplex_parent_entry,
         )
 
@@ -909,9 +974,8 @@ class CloudBigtableTableMapper(EntryMapper):
 class PubSubTopicMapper(EntryMapper):
     dataplex_entry_type_short_name = "pubsub-topic"
     datahub_platform = "pubsub"
-    datahub_main_entity_type = Dataset
     dataplex_fqn_regex = PUBSUB_TOPIC_FQN_REGEX
-    datahub_dataset_name_format = "{project_id}.{topic_id}"
+    datahub_identity = DatasetIdentity("{project_id}.{topic_id}")
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -924,7 +988,7 @@ class PubSubTopicMapper(EntryMapper):
             platform=self.datahub_platform,
             subtype=DatasetSubTypes.TOPIC,
             fqn_regex=self.dataplex_fqn_regex,
-            name_format=self.datahub_dataset_name_format,
+            identity=self.datahub_identity,
             parent=self.dataplex_parent_entry,
         )
 
@@ -932,9 +996,8 @@ class PubSubTopicMapper(EntryMapper):
 class VertexAiDatasetMapper(EntryMapper):
     dataplex_entry_type_short_name = "vertexai-dataset"
     datahub_platform = "vertexai"
-    datahub_main_entity_type = Dataset
     dataplex_fqn_regex = VERTEX_AI_DATASET_FQN_REGEX
-    datahub_dataset_name_format = "{project_id}.{location}.{dataset_id}"
+    datahub_identity = DatasetIdentity("{project_id}.{location}.{dataset_id}")
 
     def map(
         self, entry: dataplex_v1.Entry, ctx: EntryMappingContext
@@ -946,7 +1009,7 @@ class VertexAiDatasetMapper(EntryMapper):
             platform=self.datahub_platform,
             subtype=DatasetSubTypes.TABLE,
             fqn_regex=self.dataplex_fqn_regex,
-            name_format=self.datahub_dataset_name_format,
+            identity=self.datahub_identity,
             parent=self.dataplex_parent_entry,
         )
 
@@ -1012,7 +1075,7 @@ def get_entry_mapper(
 def is_lineage_supported(entry_type_short_name: str) -> bool:
     """Return whether an entry type is a lineage (dataset) node."""
     mapper = ENTRY_MAPPERS.get(entry_type_short_name)
-    return bool(mapper and mapper.datahub_main_entity_type is Dataset)
+    return bool(mapper and isinstance(mapper.datahub_identity, DatasetIdentity))
 
 
 def dataset_urn_from_fqn_only(fully_qualified_name: str, env: str) -> Optional[str]:
@@ -1021,13 +1084,13 @@ def dataset_urn_from_fqn_only(fully_qualified_name: str, env: str) -> Optional[s
     Used for cross-platform upstream lineage where only the FQN shape is known.
     """
     for mapper in ENTRY_MAPPERS.values():
-        if mapper.datahub_main_entity_type is not Dataset:
+        identity = mapper.datahub_identity
+        if not isinstance(identity, DatasetIdentity):
             continue
         urn = dataset_urn_from_fqn(
             fully_qualified_name,
             mapper.dataplex_fqn_regex,
-            # dataset_name_format only exists on dataset mappers, guarded above.
-            mapper.datahub_dataset_name_format,  # type: ignore[attr-defined]
+            identity,
             mapper.datahub_platform,
             env,
         )

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_entries.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_entries.py
@@ -1,8 +1,14 @@
-"""Unit tests for Dataplex entry processing."""
+"""Unit tests for Dataplex entry processing (orchestration).
+
+Per-entry-type mapping behavior lives in ``test_dataplex_mappers.py``. This
+module covers the orchestration in ``DataplexEntriesProcessor``: filtering,
+reporting, parallel processing, project-container dedup, and the lineage
+side-channel.
+"""
 
 import threading
 from concurrent.futures import ThreadPoolExecutor
-from typing import List, cast
+from typing import List, Optional, cast
 from unittest.mock import Mock, patch
 
 import pytest
@@ -14,9 +20,22 @@ from datahub.ingestion.source.dataplex.dataplex_entries import (
     DataplexEntriesProcessor,
     DataplexEntriesReport,
 )
-from datahub.ingestion.source.dataplex.dataplex_ids import DataplexCloudSqlMySqlDatabase
+from datahub.ingestion.source.dataplex.dataplex_mappers import EntryMappingResult
 from datahub.sdk.container import Container
 from datahub.sdk.dataset import Dataset
+
+
+def _make_entry(
+    *, short_name: str, fqn: str, parent_entry: str = "", name: Optional[str] = None
+) -> dataplex_v1.Entry:
+    entry = Mock(spec=dataplex_v1.Entry)
+    entry.name = name or f"projects/p/locations/us/entryGroups/g/entries/{short_name}"
+    entry.entry_type = f"projects/123/locations/global/entryTypes/{short_name}"
+    entry.fully_qualified_name = fqn
+    entry.parent_entry = parent_entry
+    entry.entry_source = None
+    entry.aspects = {}
+    return entry
 
 
 class TestDataplexEntriesProcessorDesign:
@@ -81,59 +100,23 @@ class TestDataplexEntriesProcessorDesign:
         assert report.entry_groups_filtered == 12
         assert report.entry_group_filtered_samples.total_elements == 12
         assert len(list(report.entry_group_filtered_samples)) == 10
-        assert set(report.entry_group_filtered_samples).issubset(
-            {f"eg-{index}" for index in range(12)}
-        )
         assert report.entry_groups_processed == 1
-        assert report.entry_group_processed_samples.total_elements == 1
         assert list(report.entry_group_processed_samples) == ["eg-pass"]
 
         assert report.entries_seen == 48
         assert report.entries_filtered_by_pattern == 12
-        assert report.entry_pattern_filtered_samples.total_elements == 12
-        assert len(list(report.entry_pattern_filtered_samples)) == 10
-        assert set(report.entry_pattern_filtered_samples).issubset(
-            {f"entry-{index}" for index in range(12)}
-        )
-
         assert report.entries_filtered_by_missing_fqn == 12
-        assert report.entry_missing_fqn_samples.total_elements == 12
-        assert len(list(report.entry_missing_fqn_samples)) == 10
-        assert set(report.entry_missing_fqn_samples).issubset(
-            {f"missing-fqn-{index}" for index in range(12)}
-        )
-
         assert report.entries_filtered_by_fqn_pattern == 12
-        assert report.entry_fqn_filtered_samples.total_elements == 12
-        assert len(list(report.entry_fqn_filtered_samples)) == 10
-        assert set(report.entry_fqn_filtered_samples).issubset(
-            {f"fqn-{index}" for index in range(12)}
-        )
-
         assert report.entries_processed == 12
         assert report.entries_processed_samples.total_elements == 12
         assert len(list(report.entries_processed_samples)) == 10
-        assert set(report.entries_processed_samples).issubset(
-            {f"processed-{index}" for index in range(12)}
-        )
 
-    def test_processor_utility_methods(
+    def test_should_process_entry_group_defaults_to_allow(
         self, processor: DataplexEntriesProcessor
     ) -> None:
-        entry = Mock(spec=dataplex_v1.Entry)
-        entry.name = "projects/p/locations/us/entryGroups/g/entries/e1"
-        entry.entry_type = "projects/p/locations/global/entryTypes/unknown-type"
-        entry.fully_qualified_name = ""
-        entry.parent_entry = ""
-
-        # No entry_groups filter configured yet -> allow all.
         assert processor.should_process_entry_group(
             "projects/p/locations/us/entryGroups/g"
         )
-
-        # Unsupported/invalid entries should be skipped safely.
-        assert processor.build_entity_for_entry(entry) is None
-        assert processor.build_entry_container_key(entry) is None
 
     def test_should_process_entry_uses_full_entry_name_for_pattern(self) -> None:
         config = DataplexConfig(
@@ -157,387 +140,55 @@ class TestDataplexEntriesProcessorDesign:
         entry.fully_qualified_name = ""
         assert not processor.should_process_entry(entry)
 
-    def test_extract_display_name_falls_back_to_last_name_segment(
+    def test_build_entities_for_unsupported_type_returns_empty_and_warns(
         self, processor: DataplexEntriesProcessor
     ) -> None:
-        entry = Mock(spec=dataplex_v1.Entry)
-        entry.name = "projects/p/locations/us/entryGroups/g/entries/e1"
-        entry_source = Mock()
-        entry_source.display_name = ""
-        entry.entry_source = entry_source
+        entry = _make_entry(short_name="unknown-type", fqn="unknown:p.ds.t")
+        assert processor._build_entities_for_entry(entry, "us") == []
+        cast(Mock, processor.source_report).warning.assert_called_once()
 
-        assert processor._extract_display_name(entry) == "e1"
-
-    def test_extract_display_name_falls_back_when_display_name_is_non_string(
-        self,
-        processor: DataplexEntriesProcessor,
-    ) -> None:
-        entry = Mock(spec=dataplex_v1.Entry)
-        entry.name = "projects/p/locations/us/entryGroups/g/entries/e1"
-        entry_source = Mock()
-        entry_source.display_name = Mock()
-        entry.entry_source = entry_source
-
-        assert processor._extract_display_name(entry) == "e1"
-
-    def test_build_entity_for_entry_dataset_and_container_paths(
+    def test_build_entities_emits_project_container_and_dataset_with_lineage(
         self, processor: DataplexEntriesProcessor
     ) -> None:
-        processor.config.include_schema = True
-
-        dataset_entry = Mock(spec=dataplex_v1.Entry)
-        dataset_entry.name = (
-            "projects/p/locations/us/entryGroups/@bigquery/entries/"
-            "bigquery.googleapis.com/projects/p/datasets/ds/tables/t"
-        )
-        dataset_entry.entry_type = (
-            "projects/123/locations/global/entryTypes/bigquery-table"
-        )
-        dataset_entry.fully_qualified_name = "bigquery:p.ds.t"
-        dataset_entry.parent_entry = (
-            "projects/p/locations/us/entryGroups/@bigquery/entries/"
-            "bigquery.googleapis.com/projects/p/datasets/ds"
-        )
-        dataset_entry.entry_source = None
-
-        with (
-            patch(
-                "datahub.ingestion.source.dataplex.dataplex_entries.extract_entry_custom_properties",
-                return_value={"k": "v"},
+        entry = _make_entry(
+            short_name="bigquery-table",
+            fqn="bigquery:my-project.my_dataset.my_table",
+            parent_entry=(
+                "projects/my-project/locations/us/entryGroups/@bigquery/entries/"
+                "bigquery.googleapis.com/projects/my-project/datasets/my_dataset"
             ),
-            patch(
-                "datahub.ingestion.source.dataplex.dataplex_entries.extract_schema_from_entry_aspects",
-                return_value=None,
-            ),
-            patch(
-                "datahub.ingestion.source.dataplex.dataplex_entries.extract_graph_schema_from_entry_aspects",
-                return_value=None,
-            ),
-        ):
-            dataset_entity = processor.build_entity_for_entry(dataset_entry)
-
-        assert isinstance(dataset_entity, Dataset)
-        assert str(dataset_entity.parent_container).startswith("urn:li:container:")
-
-        container_entry = Mock(spec=dataplex_v1.Entry)
-        container_entry.name = (
-            "projects/p/locations/us/entryGroups/@bigquery/entries/"
-            "bigquery.googleapis.com/projects/p/datasets/ds"
-        )
-        container_entry.entry_type = (
-            "projects/123/locations/global/entryTypes/bigquery-dataset"
-        )
-        container_entry.fully_qualified_name = "bigquery:p.ds"
-        container_entry.parent_entry = ""
-        container_entry.entry_source = None
-
-        with patch(
-            "datahub.ingestion.source.dataplex.dataplex_entries.extract_entry_custom_properties",
-            return_value={"k": "v"},
-        ):
-            container_entity = processor.build_entity_for_entry(container_entry)
-        assert isinstance(container_entity, Container)
-        assert str(container_entity.parent_container).startswith("urn:li:container:")
-
-        cloudsql_database_container = Mock(spec=dataplex_v1.Entry)
-        cloudsql_database_container.name = (
-            "projects/p/locations/us-west2/entryGroups/@cloudsql/entries/"
-            "cloudsql.googleapis.com/projects/p/locations/us-west2/instances/i/databases/d"
-        )
-        cloudsql_database_container.entry_type = (
-            "projects/123/locations/global/entryTypes/cloudsql-mysql-database"
-        )
-        cloudsql_database_container.fully_qualified_name = (
-            "cloudsql_mysql:p.us-west2.i.d"
-        )
-        cloudsql_database_container.parent_entry = (
-            "projects/p/locations/us-west2/entryGroups/@cloudsql/entries/"
-            "cloudsql.googleapis.com/projects/p/locations/us-west2/instances/i"
-        )
-        cloudsql_database_container.entry_source = None
-
-        with patch(
-            "datahub.ingestion.source.dataplex.dataplex_entries.extract_entry_custom_properties",
-            return_value={"k": "v"},
-        ):
-            cloudsql_container_entity = processor.build_entity_for_entry(
-                cloudsql_database_container
-            )
-        assert isinstance(cloudsql_container_entity, Container)
-        assert str(cloudsql_container_entity.parent_container).startswith(
-            "urn:li:container:"
         )
 
-    def test_build_project_container_for_entry(
-        self, processor: DataplexEntriesProcessor
-    ) -> None:
-        entry = Mock(spec=dataplex_v1.Entry)
-        entry.entry_type = (
-            "projects/123/locations/global/entryTypes/cloud-spanner-table"
-        )
-        entry.fully_qualified_name = "spanner:harshal-playground-306419.regional-us-west2.sergio-test.cymbal.Users"
+        results = processor._build_entities_for_entry(entry, "us-west2")
 
-        project_container = processor.build_project_container_for_entry(entry)
-        assert isinstance(project_container, Container)
-        assert project_container.display_name == "harshal-playground-306419"
-        assert project_container.parent_container is None
-
-    def test_build_entity_for_entry_handles_invalid_and_unsupported_inputs(
-        self,
-        processor: DataplexEntriesProcessor,
-    ) -> None:
-        missing_fqn = Mock(spec=dataplex_v1.Entry)
-        missing_fqn.name = "projects/p/locations/us/entryGroups/g/entries/e1"
-        missing_fqn.entry_type = (
-            "projects/123/locations/global/entryTypes/bigquery-table"
-        )
-        missing_fqn.fully_qualified_name = ""
-        missing_fqn.parent_entry = ""
-        assert processor.build_entity_for_entry(missing_fqn) is None
-
-        unsupported = Mock(spec=dataplex_v1.Entry)
-        unsupported.name = "projects/p/locations/us/entryGroups/g/entries/e2"
-        unsupported.entry_type = "projects/123/locations/global/entryTypes/unknown"
-        unsupported.fully_qualified_name = "unknown:p.ds.t"
-        unsupported.parent_entry = ""
-        assert processor.build_entity_for_entry(unsupported) is None
-
-        invalid_dataset_fqn = Mock(spec=dataplex_v1.Entry)
-        invalid_dataset_fqn.name = "projects/p/locations/us/entryGroups/g/entries/e3"
-        invalid_dataset_fqn.entry_type = (
-            "projects/123/locations/global/entryTypes/bigquery-table"
-        )
-        invalid_dataset_fqn.fully_qualified_name = "bigquery"
-        invalid_dataset_fqn.parent_entry = ""
-        invalid_dataset_fqn.entry_source = None
-        with patch(
-            "datahub.ingestion.source.dataplex.dataplex_entries.extract_entry_custom_properties",
-            return_value={},
-        ):
-            assert processor.build_entity_for_entry(invalid_dataset_fqn) is None
-
-    def test_build_entity_for_entry_dataset_without_parent_container(
-        self, processor: DataplexEntriesProcessor
-    ) -> None:
-        processor.config.include_schema = False
-
-        dataset_entry = Mock(spec=dataplex_v1.Entry)
-        dataset_entry.name = (
-            "projects/p/locations/us/entryGroups/@bigquery/entries/"
-            "bigquery.googleapis.com/projects/p/datasets/ds/tables/t"
-        )
-        dataset_entry.entry_type = (
-            "projects/123/locations/global/entryTypes/bigquery-table"
-        )
-        dataset_entry.fully_qualified_name = "bigquery:p.ds.t"
-        dataset_entry.parent_entry = ""
-        dataset_entry.entry_source = None
-
-        with patch(
-            "datahub.ingestion.source.dataplex.dataplex_entries.extract_entry_custom_properties",
-            return_value={"k": "v"},
-        ):
-            dataset_entity = processor.build_entity_for_entry(dataset_entry)
-
-        assert isinstance(dataset_entity, Dataset)
-        assert dataset_entity.parent_container is None
-
-    def test_build_entity_for_entry_warns_when_parent_expected_but_missing(
-        self, processor: DataplexEntriesProcessor
-    ) -> None:
-        processor.config.include_schema = False
-
-        dataset_entry = Mock(spec=dataplex_v1.Entry)
-        dataset_entry.name = (
-            "projects/p/locations/us/entryGroups/@bigquery/entries/"
-            "bigquery.googleapis.com/projects/p/datasets/ds/tables/t"
-        )
-        dataset_entry.entry_type = (
-            "projects/123/locations/global/entryTypes/bigquery-table"
-        )
-        dataset_entry.fully_qualified_name = "bigquery:p.ds.t"
-        dataset_entry.parent_entry = ""
-        dataset_entry.entry_source = None
-
-        with patch(
-            "datahub.ingestion.source.dataplex.dataplex_entries.extract_entry_custom_properties",
-            return_value={"k": "v"},
-        ):
-            dataset_entity = processor.build_entity_for_entry(dataset_entry)
-
-        assert isinstance(dataset_entity, Dataset)
-        assert dataset_entity.parent_container is None
-        source_report = cast(Mock, processor.source_report)
-        source_report.warning.assert_called_once()
-        warning_kwargs = source_report.warning.call_args.kwargs
-        assert warning_kwargs["title"] == "Missing Dataplex parent_entry"
-
-    def test_build_entity_for_vertexai_dataset_uses_project_parent_and_display_name(
-        self, processor: DataplexEntriesProcessor
-    ) -> None:
-        processor.config.include_schema = False
-
-        dataset_entry = Mock(spec=dataplex_v1.Entry)
-        dataset_entry.name = (
-            "projects/p/locations/us-west2/entryGroups/@vertexai/entries/"
-            "aiplatform.googleapis.com/projects/p/locations/us-west2/datasets/5135361416504541184"
-        )
-        dataset_entry.entry_type = (
-            "projects/123/locations/global/entryTypes/vertexai-dataset"
-        )
-        dataset_entry.fully_qualified_name = (
-            "vertex_ai:dataset:p.us-west2.5135361416504541184"
-        )
-        dataset_entry.parent_entry = ""
-        dataset_entry.entry_source = Mock()
-        dataset_entry.entry_source.display_name = "sergio-dataplex-test"
-        dataset_entry.entry_source.description = ""
-        dataset_entry.entry_source.create_time = None
-        dataset_entry.entry_source.update_time = None
-
-        with patch(
-            "datahub.ingestion.source.dataplex.dataplex_entries.extract_entry_custom_properties",
-            return_value={"k": "v"},
-        ):
-            dataset_entity = processor.build_entity_for_entry(dataset_entry)
-
-        assert isinstance(dataset_entity, Dataset)
-        assert dataset_entity.urn.urn() == (
-            "urn:li:dataset:(urn:li:dataPlatform:vertexai,"
-            "p.us-west2.5135361416504541184,PROD)"
-        )
-        assert dataset_entity.display_name == "sergio-dataplex-test"
-        assert dataset_entity.parent_container is not None
-        assert str(dataset_entity.parent_container).startswith("urn:li:container:")
-
-    def test_build_entity_for_pubsub_topic_uses_project_parent_container(
-        self, processor: DataplexEntriesProcessor
-    ) -> None:
-        processor.config.include_schema = False
-
-        dataset_entry = Mock(spec=dataplex_v1.Entry)
-        dataset_entry.name = (
-            "projects/p/locations/us-west2/entryGroups/@pubsub/entries/"
-            "pubsub.googleapis.com/projects/acryl-staging/topics/observe-staging-obs"
-        )
-        dataset_entry.entry_type = (
-            "projects/123/locations/global/entryTypes/pubsub-topic"
-        )
-        dataset_entry.fully_qualified_name = (
-            "pubsub:topic:acryl-staging.observe-staging-obs"
-        )
-        dataset_entry.parent_entry = ""
-        dataset_entry.entry_source = None
-
-        with patch(
-            "datahub.ingestion.source.dataplex.dataplex_entries.extract_entry_custom_properties",
-            return_value={"k": "v"},
-        ):
-            dataset_entity = processor.build_entity_for_entry(dataset_entry)
-
-        assert isinstance(dataset_entity, Dataset)
-        assert dataset_entity.urn.urn() == (
-            "urn:li:dataset:(urn:li:dataPlatform:pubsub,"
-            "acryl-staging.observe-staging-obs,PROD)"
-        )
-        assert dataset_entity.parent_container is not None
-        assert str(dataset_entity.parent_container).startswith("urn:li:container:")
-
-    def test_extract_helpers_cover_display_description_datetime_and_group_id(
-        self,
-        processor: DataplexEntriesProcessor,
-    ) -> None:
-        entry = Mock(spec=dataplex_v1.Entry)
-        entry.name = "projects/p/locations/us/entryGroups/g/entries/e1"
-        entry.entry_source = Mock()
-        entry.entry_source.display_name = "Display"
-        entry.entry_source.description = "Description"
-        ts = Mock()
-        ts.timestamp.return_value = 123.0
-        entry.entry_source.create_time = ts
-        entry.entry_source.update_time = ts
-
-        assert processor._extract_display_name(entry) == "Display"
-        assert processor._extract_description(entry) == "Description"
-        assert processor._extract_entry_group_id(entry.name) == "g"
-        assert processor._extract_datetime(entry, "create_time") is not None
-        assert processor._extract_datetime(entry, "update_time") is not None
-
-        no_source_entry = Mock(spec=dataplex_v1.Entry)
-        no_source_entry.name = "projects/p/locations/us/entries/e2"
-        no_source_entry.entry_source = None
-        assert processor._extract_description(no_source_entry) == ""
-        assert processor._extract_datetime(no_source_entry, "create_time") is None
-        assert processor._extract_entry_group_id(no_source_entry.name) == "unknown"
-
-    def test_build_entry_container_key_warns_for_invalid_entry_type(
-        self, processor: DataplexEntriesProcessor
-    ) -> None:
-        entry = Mock(spec=dataplex_v1.Entry)
-        entry.name = "projects/p/locations/us/entryGroups/g/entries/e1"
-        entry.entry_type = "invalid-entry-type"
-        entry.parent_entry = "projects/p/locations/us/entryGroups/g/entries/parent"
-
-        assert processor.build_entry_container_key(entry) is None
-        source_report = cast(Mock, processor.source_report)
-        source_report.warning.assert_called_once()
-
-    def test_track_entry_for_lineage_warns_for_invalid_entry_type(
-        self, processor: DataplexEntriesProcessor
-    ) -> None:
-        entry = Mock(spec=dataplex_v1.Entry)
-        entry.name = "projects/p/locations/us/entryGroups/g/entries/e1"
-        entry.entry_type = "invalid-entry-type"
-        entry.fully_qualified_name = "bigquery:p.ds.table"
-
-        processor._track_entry_for_lineage("us", entry)
-
-        source_report = cast(Mock, processor.source_report)
-        source_report.warning.assert_called_once()
-        assert len(processor.entry_data) == 0
-
-    def test_build_entry_container_key_and_lineage_tracking(
-        self, processor: DataplexEntriesProcessor
-    ) -> None:
-        no_parent = Mock(spec=dataplex_v1.Entry)
-        no_parent.name = "projects/p/locations/us/entryGroups/g/entries/no-parent"
-        no_parent.entry_type = "projects/123/locations/global/entryTypes/bigquery-table"
-        no_parent.parent_entry = ""
-        assert processor.build_entry_container_key(no_parent) is None
-
-        with_parent = Mock(spec=dataplex_v1.Entry)
-        with_parent.entry_type = (
-            "projects/123/locations/global/entryTypes/cloudsql-mysql-table"
-        )
-        with_parent.parent_entry = (
-            "projects/p/locations/us-west2/entryGroups/@cloudsql/entries/"
-            "cloudsql.googleapis.com/projects/p/locations/us-west2/instances/i/databases/d"
-        )
-        parent_key = processor.build_entry_container_key(with_parent)
-        assert isinstance(parent_key, DataplexCloudSqlMySqlDatabase)
-        assert parent_key.as_urn().startswith("urn:li:container:")
-
-        dataset_entry = Mock(spec=dataplex_v1.Entry)
-        dataset_entry.name = "projects/p/locations/us/entryGroups/g/entries/e1"
-        dataset_entry.entry_type = (
-            "projects/123/locations/global/entryTypes/bigquery-table"
-        )
-        dataset_entry.fully_qualified_name = "bigquery:p.ds.table1"
-        processor._track_entry_for_lineage("us", dataset_entry)
+        containers = [e for e in results if isinstance(e, Container)]
+        datasets = [e for e in results if isinstance(e, Dataset)]
+        assert len(containers) == 1
+        assert len(datasets) == 1
+        # Lineage side-channel populated for the dataset entry.
         assert len(processor.entry_data) == 1
-        tracked = processor.entry_data[0]
-        assert tracked.datahub_dataset_name == "p.ds.table1"
-        assert tracked.datahub_platform == "bigquery"
-        assert tracked.dataplex_entry_fqn == "bigquery:p.ds.table1"
-
-        non_dataset_entry = Mock(spec=dataplex_v1.Entry)
-        non_dataset_entry.name = "projects/p/locations/us/entryGroups/g/entries/e2"
-        non_dataset_entry.entry_type = (
-            "projects/123/locations/global/entryTypes/bigquery-dataset"
+        assert processor.entry_data[0].datahub_dataset_name == (
+            "my-project.my_dataset.my_table"
         )
-        non_dataset_entry.fully_qualified_name = "bigquery:p.ds"
-        processor._track_entry_for_lineage("us", non_dataset_entry)
-        assert len(processor.entry_data) == 1
+        assert processor.entry_data[0].dataplex_location == "us-west2"
+
+    def test_build_entities_dedups_project_container_across_entries(
+        self, processor: DataplexEntriesProcessor
+    ) -> None:
+        first = _make_entry(
+            short_name="bigquery-dataset", fqn="bigquery:my-project.dataset_a"
+        )
+        second = _make_entry(
+            short_name="bigquery-dataset", fqn="bigquery:my-project.dataset_b"
+        )
+
+        first_results = processor._build_entities_for_entry(first, "us")
+        second_results = processor._build_entities_for_entry(second, "us")
+
+        # First entry emits project container + its own container.
+        assert sum(isinstance(e, Container) for e in first_results) == 2
+        # Second entry (same project) drops the already-emitted project container.
+        assert len(second_results) == 1
 
 
 class TestDataplexParallelEntries:
@@ -669,23 +320,25 @@ class TestDataplexParallelEntries:
 
         project_container = Mock()
         project_container.urn.urn.return_value = "urn:li:container:same-project"
-        entity_1 = Mock()
-        entity_2 = Mock()
-        entry_1 = Mock(spec=dataplex_v1.Entry)
-        entry_2 = Mock(spec=dataplex_v1.Entry)
+        main_1 = Mock()
+        main_2 = Mock()
 
-        with (
-            patch.object(
-                processor,
-                "build_project_container_for_entry",
-                return_value=project_container,
+        fake_mapper = Mock()
+        fake_mapper.map.side_effect = [
+            EntryMappingResult(
+                main_entity=main_1, additional_entities=[project_container]
             ),
-            patch.object(
-                processor,
-                "build_entity_for_entry",
-                side_effect=[entity_1, entity_2],
+            EntryMappingResult(
+                main_entity=main_2, additional_entities=[project_container]
             ),
-            patch.object(processor, "_track_entry_for_lineage"),
+        ]
+
+        entry_1 = _make_entry(short_name="bigquery-table", fqn="bigquery:p.d.t1")
+        entry_2 = _make_entry(short_name="bigquery-table", fqn="bigquery:p.d.t2")
+
+        with patch(
+            "datahub.ingestion.source.dataplex.dataplex_entries.get_entry_mapper",
+            return_value=fake_mapper,
         ):
             barrier = threading.Barrier(2)
 
@@ -700,8 +353,8 @@ class TestDataplexParallelEntries:
 
         containers = [e for e in results if e is project_container]
         assert len(containers) == 1
-        assert entity_1 in results
-        assert entity_2 in results
+        assert main_1 in results
+        assert main_2 in results
 
     def test_report_thread_safety(self) -> None:
         """Concurrent calls to report methods produce consistent counter totals."""

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_ids.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_ids.py
@@ -1,51 +1,23 @@
-"""Unit tests for Dataplex identity and entry-type mapping utilities."""
+"""Unit tests for Dataplex identity primitives.
 
-from typing import Any
+Mapping-oriented behavior (entry type -> DataHub entities) is tested in
+``test_dataplex_mappers.py``; this module covers only the low-level identity
+building blocks that live in ``dataplex_ids.py``.
+"""
 
 import pytest
 
 from datahub.ingestion.source.dataplex.dataplex_ids import (
-    BIGQUERY_DATASET_PARENT_ENTRY_REGEX,
     BIGQUERY_TABLE_FQN_REGEX,
-    DATAPLEX_ENTRY_TYPE_MAPPINGS,
     PROJECT_SCHEMA_KEY_CLASS_BY_PLATFORM,
-    DataplexBigQueryDataset,
-    DataplexBigtableInstance,
-    DataplexCloudSpannerDatabase,
-    DataplexCloudSpannerInstance,
-    DataplexCloudSqlMySqlInstance,
-    DataplexEntryTypeMapping,
+    DataplexBigQueryProject,
+    DataplexCloudSqlMySqlDatabase,
     DataplexProjectId,
-    _extract_dataset_name_from_fqn,
-    build_container_key_from_fqn,
-    build_container_urn_from_fqn,
-    build_dataset_urn_from_fqn,
-    build_dataset_urn_from_fqn_only,
     build_lineage_parent,
-    build_parent_container_key,
-    build_parent_container_urn,
-    build_project_container_urn_from_fqn,
-    build_project_schema_key_from_fqn,
-    extract_datahub_dataset_name_from_fqn,
     extract_entry_type_short_name,
-    is_supported_lineage_entry_type,
-    parse_fully_qualified_name,
-    parse_parent_entry,
+    instantiate_key,
+    parse_with_regex,
 )
-
-
-def test_schema_key_parent_chain_for_project_has_no_duplicate_step() -> None:
-    database_key = build_container_key_from_fqn(
-        "cloudsql-mysql-database",
-        "cloudsql_mysql:harshal-playground-306419.us-west2.sergio-test.sergio-db",
-    )
-    assert database_key is not None
-    instance_key = database_key.parent_key()
-    assert instance_key is not None
-    project_key = instance_key.parent_key()
-    assert project_key is not None
-    # Project key should terminate immediately after one parent_key() call.
-    assert project_key.parent_key() is None
 
 
 @pytest.mark.parametrize(
@@ -56,28 +28,12 @@ def test_schema_key_parent_chain_for_project_has_no_duplicate_step() -> None:
             "bigquery-table",
         ),
         (
-            "projects/655216118709/locations/global/entryTypes/bigquery-view",
-            "bigquery-view",
-        ),
-        (
             "projects/655216118709/locations/global/entryTypes/cloud-spanner-instance",
             "cloud-spanner-instance",
         ),
         (
-            "projects/655216118709/locations/global/entryTypes/cloud-bigtable-instance",
-            "cloud-bigtable-instance",
-        ),
-        (
-            "projects/655216118709/locations/global/entryTypes/cloud-bigtable-table",
-            "cloud-bigtable-table",
-        ),
-        (
             "projects/655216118709/locations/global/entryTypes/pubsub-topic",
             "pubsub-topic",
-        ),
-        (
-            "projects/655216118709/locations/global/entryTypes/vertexai-dataset",
-            "vertexai-dataset",
         ),
     ],
 )
@@ -98,659 +54,54 @@ def test_build_lineage_parent() -> None:
     )
 
 
-def test_supported_entry_type_mapping_keys() -> None:
-    assert set(DATAPLEX_ENTRY_TYPE_MAPPINGS.keys()) == {
-        "bigquery-dataset",
-        "bigquery-table",
-        "bigquery-view",
-        "cloudsql-mysql-instance",
-        "cloudsql-mysql-database",
-        "cloudsql-mysql-table",
-        "cloud-spanner-instance",
-        "cloud-spanner-database",
-        "cloud-spanner-table",
-        "cloud-spanner-graph",
-        "cloud-bigtable-instance",
-        "cloud-bigtable-table",
-        "pubsub-topic",
-        "vertexai-dataset",
+def test_parse_with_regex_named_groups() -> None:
+    assert parse_with_regex(BIGQUERY_TABLE_FQN_REGEX, "bigquery:proj.ds.tbl") == {
+        "project_id": "proj",
+        "dataset_id": "ds",
+        "table_id": "tbl",
     }
 
 
-@pytest.mark.parametrize(
-    "mapping_kwargs,expected_error",
-    [
-        (
-            {
-                "datahub_platform": "bigquery",
-                "datahub_entity_type": "Dataset",
-                "datahub_subtype": "table",
-                "fqn_regex": BIGQUERY_TABLE_FQN_REGEX,
-                "parent_entry_regex": BIGQUERY_DATASET_PARENT_ENTRY_REGEX,
-                "container_key_class": None,
-                "parent_container_key_class": DataplexBigQueryDataset,
-                "datahub_dataset_name_format": None,
-            },
-            "Dataset mappings must define datahub_dataset_name_format",
-        ),
-        (
-            {
-                "datahub_platform": "bigquery",
-                "datahub_entity_type": "Container",
-                "datahub_subtype": "dataset",
-                "fqn_regex": BIGQUERY_TABLE_FQN_REGEX,
-                "parent_entry_regex": None,
-                "container_key_class": DataplexBigQueryDataset,
-                "parent_container_key_class": None,
-                "datahub_dataset_name_format": "{project_id}.{dataset_id}",
-            },
-            "Container mappings must not define datahub_dataset_name_format",
-        ),
-        (
-            {
-                "datahub_platform": "bigquery",
-                "datahub_entity_type": "Dataset",
-                "datahub_subtype": "table",
-                "fqn_regex": BIGQUERY_TABLE_FQN_REGEX,
-                "parent_entry_regex": BIGQUERY_DATASET_PARENT_ENTRY_REGEX,
-                "container_key_class": None,
-                "parent_container_key_class": None,
-                "datahub_dataset_name_format": "{project_id}.{dataset_id}.{table_id}",
-            },
-            "Mappings with parent_entry_regex must define parent_container_key_class",
-        ),
-        (
-            {
-                "datahub_platform": "bigquery",
-                "datahub_entity_type": "Dataset",
-                "datahub_subtype": "table",
-                "fqn_regex": BIGQUERY_TABLE_FQN_REGEX,
-                "parent_entry_regex": BIGQUERY_DATASET_PARENT_ENTRY_REGEX,
-                "container_key_class": None,
-                "parent_container_key_class": DataplexCloudSqlMySqlInstance,
-                "datahub_dataset_name_format": "{project_id}.{dataset_id}.{table_id}",
-            },
-            "parent_entry_regex groups",
-        ),
-        (
-            {
-                "datahub_platform": "bigquery",
-                "datahub_entity_type": "Container",
-                "datahub_subtype": "dataset",
-                "fqn_regex": BIGQUERY_TABLE_FQN_REGEX,
-                "parent_entry_regex": None,
-                "container_key_class": None,
-                "parent_container_key_class": None,
-                "datahub_dataset_name_format": None,
-            },
-            "Container mappings must define container_key_class",
-        ),
-        (
-            {
-                "datahub_platform": "bigquery",
-                "datahub_entity_type": "Dataset",
-                "datahub_subtype": "table",
-                "fqn_regex": BIGQUERY_TABLE_FQN_REGEX,
-                "parent_entry_regex": None,
-                "container_key_class": DataplexBigQueryDataset,
-                "parent_container_key_class": None,
-                "datahub_dataset_name_format": "{project_id}.{dataset_id}.{table_id}",
-            },
-            "Dataset mappings must not define container_key_class",
-        ),
-        (
-            {
-                "datahub_platform": "bigquery",
-                "datahub_entity_type": "Container",
-                "datahub_subtype": "dataset",
-                "fqn_regex": BIGQUERY_TABLE_FQN_REGEX,
-                "parent_entry_regex": None,
-                "container_key_class": DataplexBigQueryDataset,
-                "parent_container_key_class": None,
-                "datahub_dataset_name_format": None,
-            },
-            "fqn_regex groups",
-        ),
-    ],
-)
-def test_dataplex_entry_type_mapping_validation_errors(
-    mapping_kwargs: dict[str, Any], expected_error: str
-) -> None:
-    with pytest.raises(ValueError, match=expected_error):
-        # Intentionally bypass strict constructor typing to validate runtime guards.
-        DataplexEntryTypeMapping(**mapping_kwargs)
+def test_parse_with_regex_no_match() -> None:
+    assert parse_with_regex(BIGQUERY_TABLE_FQN_REGEX, "bigquery:proj.ds") is None
 
 
-@pytest.mark.parametrize(
-    "entry_type_short_name", list(DATAPLEX_ENTRY_TYPE_MAPPINGS.keys())
-)
-def test_dataplex_entry_type_mapping_instances_are_valid(
-    entry_type_short_name: str,
-) -> None:
-    mapping = DATAPLEX_ENTRY_TYPE_MAPPINGS[entry_type_short_name]
-    assert mapping.datahub_entity_type in {"Dataset", "Container"}
-    if mapping.datahub_entity_type == "Dataset":
-        assert mapping.datahub_dataset_name_format is not None
-    else:
-        assert mapping.datahub_dataset_name_format is None
-
-
-@pytest.mark.parametrize(
-    "entry_type_short_name,fqn,expected",
-    [
-        (
-            "bigquery-table",
-            "bigquery:harshal-playground-306419.fivetran_smoke_test.destination_schema_metadata",
-            {
-                "project_id": "harshal-playground-306419",
-                "dataset_id": "fivetran_smoke_test",
-                "table_id": "destination_schema_metadata",
-            },
-        ),
-        (
-            "bigquery-view",
-            "bigquery:harshal-playground-306419.fivetran_smoke_test.destination_schema_view",
-            {
-                "project_id": "harshal-playground-306419",
-                "dataset_id": "fivetran_smoke_test",
-                "table_id": "destination_schema_view",
-            },
-        ),
-        (
-            "bigquery-dataset",
-            "bigquery:harshal-playground-306419.big_tables",
-            {
-                "project_id": "harshal-playground-306419",
-                "dataset_id": "big_tables",
-            },
-        ),
-        (
-            "cloud-spanner-table",
-            "spanner:harshal-playground-306419.regional-us-west2.sergio-test.cymbal.ShoppingCarts",
-            {
-                "project_id": "harshal-playground-306419",
-                "location": "us-west2",
-                "instance_id": "sergio-test",
-                "database_id": "cymbal",
-                "table_id": "ShoppingCarts",
-            },
-        ),
-        (
-            "cloud-spanner-graph",
-            "spanner:graph:harshal-playground-306419.regional-us-west2.sergio-test.cymbal.ECommerceGraph",
-            {
-                "project_id": "harshal-playground-306419",
-                "location": "us-west2",
-                "instance_id": "sergio-test",
-                "database_id": "cymbal",
-                "graph_id": "ECommerceGraph",
-            },
-        ),
-        (
-            "cloudsql-mysql-table",
-            "cloudsql_mysql:harshal-playground-306419.us-west2.sergio-test.sergio-db.your_table",
-            {
-                "project_id": "harshal-playground-306419",
-                "location": "us-west2",
-                "instance_id": "sergio-test",
-                "database_id": "sergio-db",
-                "table_id": "your_table",
-            },
-        ),
-        (
-            "cloud-bigtable-instance",
-            "bigtable:trustedplatform-pl-production.feature-store",
-            {
-                "project_id": "trustedplatform-pl-production",
-                "instance_id": "feature-store",
-            },
-        ),
-        (
-            "cloud-bigtable-table",
-            "bigtable:trustedplatform-pl-production.feature-store.counts",
-            {
-                "project_id": "trustedplatform-pl-production",
-                "instance_id": "feature-store",
-                "table_id": "counts",
-            },
-        ),
-        (
-            "pubsub-topic",
-            "pubsub:topic:acryl-staging.observe-staging-obs",
-            {
-                "project_id": "acryl-staging",
-                "topic_id": "observe-staging-obs",
-            },
-        ),
-        (
-            "vertexai-dataset",
-            "vertex_ai:dataset:harshal-playground-306419.us-west2.5135361416504541184",
-            {
-                "project_id": "harshal-playground-306419",
-                "location": "us-west2",
-                "dataset_id": "5135361416504541184",
-            },
-        ),
-    ],
-)
-def test_parse_fully_qualified_name_examples(
-    entry_type_short_name: str, fqn: str, expected: dict[str, str]
-) -> None:
-    assert parse_fully_qualified_name(entry_type_short_name, fqn) == expected
-
-
-def test_parse_fully_qualified_name_invalid() -> None:
-    assert (
-        parse_fully_qualified_name(
-            "cloud-spanner-table", "spanner:missing.regional-us-west2.parts"
-        )
-        is None
+def test_instantiate_key_ignores_unknown_fields() -> None:
+    key = instantiate_key(
+        DataplexBigQueryProject,
+        {"project_id": "proj", "table_id": "ignored"},
     )
+    assert isinstance(key, DataplexBigQueryProject)
+    assert key.project_id == "proj"
+    assert key.as_urn().startswith("urn:li:container:")
 
 
-@pytest.mark.parametrize(
-    "entry_type_short_name,parent_entry,expected",
-    [
-        (
-            "bigquery-table",
-            "projects/harshal-playground-306419/locations/us/entryGroups/@bigquery/entries/"
-            "bigquery.googleapis.com/projects/harshal-playground-306419/datasets/fivetran_smoke_test",
-            {
-                "project_id": "harshal-playground-306419",
-                "dataset_id": "fivetran_smoke_test",
-            },
-        ),
-        (
-            "bigquery-view",
-            "projects/harshal-playground-306419/locations/us/entryGroups/@bigquery/entries/"
-            "bigquery.googleapis.com/projects/harshal-playground-306419/datasets/fivetran_smoke_test",
-            {
-                "project_id": "harshal-playground-306419",
-                "dataset_id": "fivetran_smoke_test",
-            },
-        ),
-        (
-            "cloud-spanner-table",
-            "projects/harshal-playground-306419/locations/us-west2/entryGroups/@spanner/entries/"
-            "spanner.googleapis.com/projects/harshal-playground-306419/instances/sergio-test/databases/cymbal",
-            {
-                "project_id": "harshal-playground-306419",
-                "location": "us-west2",
-                "instance_id": "sergio-test",
-                "database_id": "cymbal",
-            },
-        ),
-        (
-            "cloud-spanner-graph",
-            "projects/harshal-playground-306419/locations/us-west2/entryGroups/@spanner/entries/"
-            "spanner.googleapis.com/projects/harshal-playground-306419/instances/sergio-test/databases/cymbal",
-            {
-                "project_id": "harshal-playground-306419",
-                "location": "us-west2",
-                "instance_id": "sergio-test",
-                "database_id": "cymbal",
-            },
-        ),
-        (
-            "cloudsql-mysql-table",
-            "projects/harshal-playground-306419/locations/us-west2/entryGroups/@cloudsql/entries/"
-            "cloudsql.googleapis.com/projects/harshal-playground-306419/locations/us-west2/instances/sergio-test/"
-            "databases/sergio-db",
-            {
-                "project_id": "harshal-playground-306419",
-                "location": "us-west2",
-                "instance_id": "sergio-test",
-                "database_id": "sergio-db",
-            },
-        ),
-        (
-            "cloud-bigtable-table",
-            "projects/trustedplatform-pl-production/locations/global/entryGroups/@bigtable/entries/"
-            "bigtable.googleapis.com/projects/trustedplatform-pl-production/instances/feature-store",
-            {
-                "project_id": "trustedplatform-pl-production",
-                "instance_id": "feature-store",
-            },
-        ),
-    ],
-)
-def test_parse_parent_entry_examples(
-    entry_type_short_name: str, parent_entry: str, expected: dict[str, str]
-) -> None:
-    assert parse_parent_entry(entry_type_short_name, parent_entry) == expected
-
-
-def test_build_container_key_from_fqn_container_types() -> None:
-    bq_key = build_container_key_from_fqn(
-        "bigquery-dataset",
-        "bigquery:harshal-playground-306419.big_tables",
+def test_schema_key_parent_chain_terminates_at_project() -> None:
+    database_key = instantiate_key(
+        DataplexCloudSqlMySqlDatabase,
+        {
+            "project_id": "proj",
+            "location": "us-west2",
+            "instance_id": "inst",
+            "database_id": "db",
+        },
     )
-    assert isinstance(bq_key, DataplexBigQueryDataset)
-    assert bq_key.project_id == "harshal-playground-306419"
-    assert bq_key.dataset_id == "big_tables"
-
-    spanner_key = build_container_key_from_fqn(
-        "cloud-spanner-database",
-        "spanner:harshal-playground-306419.regional-us-west2.sergio-test.cymbal",
-    )
-    assert isinstance(spanner_key, DataplexCloudSpannerDatabase)
-    assert spanner_key.instance_id == "sergio-test"
-
-    bigtable_key = build_container_key_from_fqn(
-        "cloud-bigtable-instance",
-        "bigtable:trustedplatform-pl-production.feature-store",
-    )
-    assert isinstance(bigtable_key, DataplexBigtableInstance)
-    assert bigtable_key.instance_id == "feature-store"
-
-
-def test_build_container_key_from_fqn_dataset_types_returns_none() -> None:
-    mysql_table_key = build_container_key_from_fqn(
-        "cloudsql-mysql-table",
-        "cloudsql_mysql:harshal-playground-306419.us-west2.sergio-test.sergio-db.your_table",
-    )
-    assert mysql_table_key is None
-
-    pubsub_key = build_container_key_from_fqn(
-        "pubsub-topic",
-        "pubsub:topic:acryl-staging.observe-staging-obs",
-    )
-    assert pubsub_key is None
-
-
-def test_build_parent_container_key() -> None:
-    parent_key = build_parent_container_key(
-        "cloud-spanner-table",
-        "projects/harshal-playground-306419/locations/us-west2/entryGroups/@spanner/entries/"
-        "spanner.googleapis.com/projects/harshal-playground-306419/instances/sergio-test/databases/cymbal",
-    )
-    assert isinstance(parent_key, DataplexCloudSpannerDatabase)
-    assert parent_key.database_id == "cymbal"
-
-
-def test_build_dataset_urn_from_fqn_spanner_graph() -> None:
-    graph_urn = build_dataset_urn_from_fqn(
-        "cloud-spanner-graph",
-        "spanner:graph:harshal-playground-306419.regional-us-west2.sergio-test.cymbal.ECommerceGraph",
-        env="PROD",
-    )
-    assert graph_urn is not None
-    assert "urn:li:dataPlatform:spanner" in graph_urn
-    # Spanner tables and graphs share the same namespace so names never collide;
-    # the URN format mirrors cloud-spanner-table.
-    assert (
-        "harshal-playground-306419.regional-us-west2.sergio-test.cymbal.ECommerceGraph"
-        in graph_urn
-    )
-    assert "graph:" not in graph_urn
-
-
-def test_build_dataset_urn_from_fqn() -> None:
-    bq_urn = build_dataset_urn_from_fqn(
-        "bigquery-table",
-        "bigquery:harshal-playground-306419.fivetran_smoke_test.destination_schema_metadata",
-        env="PROD",
-    )
-    assert bq_urn is not None
-    assert "urn:li:dataPlatform:bigquery" in bq_urn
-    assert (
-        "harshal-playground-306419.fivetran_smoke_test.destination_schema_metadata"
-        in bq_urn
-    )
-
-    pubsub_urn = build_dataset_urn_from_fqn(
-        "pubsub-topic",
-        "pubsub:topic:acryl-staging.observe-staging-obs",
-        env="PROD",
-    )
-    assert pubsub_urn is not None
-    assert "urn:li:dataPlatform:pubsub" in pubsub_urn
-    assert "acryl-staging.observe-staging-obs" in pubsub_urn
-    assert "topic:acryl-staging.observe-staging-obs" not in pubsub_urn
-
-    vertexai_urn = build_dataset_urn_from_fqn(
-        "vertexai-dataset",
-        "vertex_ai:dataset:harshal-playground-306419.us-west2.5135361416504541184",
-        env="PROD",
-    )
-    assert vertexai_urn is not None
-    assert "urn:li:dataPlatform:vertexai" in vertexai_urn
-    assert "harshal-playground-306419.us-west2.5135361416504541184" in vertexai_urn
-    assert "dataset:harshal-playground-306419.us-west2.5135361416504541184" not in (
-        vertexai_urn
-    )
-
-
-def test_build_container_urn_from_fqn() -> None:
-    container_urn = build_container_urn_from_fqn(
-        "cloudsql-mysql-instance",
-        "cloudsql_mysql:harshal-playground-306419.us-west2.sergio-test",
-    )
-    assert container_urn is not None
-    assert container_urn.startswith("urn:li:container:")
-
-    assert (
-        build_container_urn_from_fqn(
-            "pubsub-topic", "pubsub:topic:acryl-staging.observe-staging-obs"
-        )
-        is None
-    )
-
-
-def test_build_parent_container_urn() -> None:
-    parent_container_urn = build_parent_container_urn(
-        "bigquery-table",
-        "projects/harshal-playground-306419/locations/us/entryGroups/@bigquery/entries/"
-        "bigquery.googleapis.com/projects/harshal-playground-306419/datasets/fivetran_smoke_test",
-    )
-    assert parent_container_urn is not None
-    assert parent_container_urn.startswith("urn:li:container:")
-
-
-def test_build_project_schema_key_from_fqn() -> None:
-    project_key = build_project_schema_key_from_fqn(
-        "cloud-spanner-table",
-        "spanner:harshal-playground-306419.regional-us-west2.sergio-test.cymbal.ShoppingCarts",
-    )
+    instance_key = database_key.parent_key()
+    assert instance_key is not None
+    project_key = instance_key.parent_key()
     assert project_key is not None
-    assert isinstance(project_key, DataplexProjectId)
-    assert project_key.project_id == "harshal-playground-306419"
+    # Project key is the root of the platform-specific hierarchy.
+    assert project_key.parent_key() is None
 
 
-def test_build_project_container_urn_from_fqn() -> None:
-    project_urn = build_project_container_urn_from_fqn(
-        "bigquery-table",
-        "bigquery:harshal-playground-306419.fivetran_smoke_test.destination_schema_metadata",
-    )
-    assert project_urn is not None
-    assert project_urn.startswith("urn:li:container:")
-
-
-def test_identity_helpers_return_none_for_unsupported_or_invalid_inputs() -> None:
-    assert parse_fully_qualified_name("unsupported-type", "bigquery:p.ds.t") is None
-    assert parse_parent_entry("unsupported-type", "projects/p/...") is None
-    assert build_container_key_from_fqn("unsupported-type", "bigquery:p.ds") is None
-    assert build_parent_container_key("unsupported-type", "projects/p/...") is None
-    assert (
-        build_parent_container_key(
-            "bigquery-table", "projects/p/locations/us/entryGroups/g/entries/invalid"
-        )
-        is None
-    )
-
-    assert (
-        build_dataset_urn_from_fqn("unsupported-type", "bigquery:p.ds.t", "PROD")
-        is None
-    )
-    assert build_dataset_urn_from_fqn("bigquery-table", "bigquery", "PROD") is None
-    assert build_container_urn_from_fqn("bigquery-table", "bigquery:p.ds.t") is None
-    assert (
-        build_container_urn_from_fqn("cloudsql-mysql-instance", "cloudsql_mysql")
-        is None
-    )
-    assert (
-        build_project_schema_key_from_fqn("unsupported-type", "bigquery:p.ds") is None
-    )
-    assert (
-        build_project_container_urn_from_fqn("unsupported-type", "bigquery:p.ds")
-        is None
-    )
-    assert build_parent_container_urn("bigquery-dataset", "projects/p/...") is None
-
-
-def test_build_parent_container_key_for_dataset_entry_types() -> None:
-    bq_parent = build_parent_container_key(
-        "bigquery-table",
-        "projects/harshal-playground-306419/locations/us/entryGroups/@bigquery/entries/"
-        "bigquery.googleapis.com/projects/harshal-playground-306419/datasets/fivetran_smoke_test",
-    )
-    assert isinstance(bq_parent, DataplexBigQueryDataset)
-
-    cloudsql_parent = build_parent_container_key(
-        "cloudsql-mysql-table",
-        "projects/harshal-playground-306419/locations/us-west2/entryGroups/@cloudsql/entries/"
-        "cloudsql.googleapis.com/projects/harshal-playground-306419/locations/us-west2/instances/sergio-test/"
-        "databases/sergio-db",
-    )
-    assert isinstance(cloudsql_parent, DataplexCloudSqlMySqlInstance)
-
-    spanner_parent = build_parent_container_key(
-        "cloud-spanner-database",
-        "projects/harshal-playground-306419/locations/us-west2/entryGroups/@spanner/entries/"
-        "spanner.googleapis.com/projects/harshal-playground-306419/instances/sergio-test",
-    )
-    assert isinstance(spanner_parent, DataplexCloudSpannerInstance)
-
-    bigtable_parent = build_parent_container_key(
-        "cloud-bigtable-table",
-        "projects/trustedplatform-pl-production/locations/global/entryGroups/@bigtable/entries/"
-        "bigtable.googleapis.com/projects/trustedplatform-pl-production/instances/feature-store",
-    )
-    assert isinstance(bigtable_parent, DataplexBigtableInstance)
-
-
-def test_is_supported_lineage_entry_type_helper() -> None:
-    assert is_supported_lineage_entry_type("bigquery-table")
-    assert is_supported_lineage_entry_type("bigquery-view")
-    assert is_supported_lineage_entry_type("cloudsql-mysql-table")
-    assert is_supported_lineage_entry_type("cloud-spanner-table")
-    assert is_supported_lineage_entry_type("cloud-spanner-graph")
-    assert is_supported_lineage_entry_type("cloud-bigtable-table")
-    assert is_supported_lineage_entry_type("pubsub-topic")
-    assert is_supported_lineage_entry_type("vertexai-dataset")
-    assert not is_supported_lineage_entry_type("bigquery-dataset")
-    assert not is_supported_lineage_entry_type("cloud-bigtable-instance")
-    assert not is_supported_lineage_entry_type("cloudsql-mysql-database")
-    assert not is_supported_lineage_entry_type("unknown-entry-type")
-
-
-@pytest.mark.parametrize(
-    "fully_qualified_name,expected_dataset_urn",
-    [
-        (
-            "bigquery:test-project.analytics.customers",
-            "urn:li:dataset:(urn:li:dataPlatform:bigquery,test-project.analytics.customers,PROD)",
-        ),
-        (
-            "pubsub:topic:acryl-staging.observe-staging-obs",
-            "urn:li:dataset:(urn:li:dataPlatform:pubsub,acryl-staging.observe-staging-obs,PROD)",
-        ),
-        (
-            "bigtable:trustedplatform-pl-production.feature-store.counts",
-            "urn:li:dataset:(urn:li:dataPlatform:bigtable,trustedplatform-pl-production.feature-store.counts,PROD)",
-        ),
-        (
-            "vertex_ai:dataset:harshal-playground-306419.us-west2.5135361416504541184",
-            "urn:li:dataset:(urn:li:dataPlatform:vertexai,harshal-playground-306419.us-west2.5135361416504541184,PROD)",
-        ),
-        ("unknown:project.dataset.table", None),
-        ("invalid", None),
-    ],
-)
-def test_build_dataset_urn_from_fqn_only_cross_platform(
-    fully_qualified_name: str, expected_dataset_urn: str | None
-) -> None:
-    assert (
-        build_dataset_urn_from_fqn_only(fully_qualified_name, env="PROD")
-        == expected_dataset_urn
-    )
-
-
-def test_extract_datahub_dataset_name_from_fqn_uses_mapping_format() -> None:
-    dataset_name = extract_datahub_dataset_name_from_fqn(
-        "vertexai-dataset",
-        "vertex_ai:dataset:harshal-playground-306419.us-west2.5135361416504541184",
-    )
-    assert dataset_name == "harshal-playground-306419.us-west2.5135361416504541184"
-
-
-def test_extract_dataset_name_from_fqn_returns_none_for_container_mapping() -> None:
-    assert (
-        _extract_dataset_name_from_fqn(
-            "bigquery-dataset", "bigquery:test-project.analytics"
-        )
-        is None
-    )
-
-
-def test_extract_datahub_dataset_name_from_fqn_handles_format_key_errors(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    mapping = DataplexEntryTypeMapping(
-        datahub_platform="bigquery",
-        datahub_entity_type="Dataset",
-        datahub_subtype="table",
-        fqn_regex=BIGQUERY_TABLE_FQN_REGEX,
-        parent_entry_regex=None,
-        container_key_class=None,
-        parent_container_key_class=None,
-        datahub_dataset_name_format="{missing_field}",
-    )
-    monkeypatch.setitem(DATAPLEX_ENTRY_TYPE_MAPPINGS, "test-key-error", mapping)
-
-    assert (
-        extract_datahub_dataset_name_from_fqn(
-            "test-key-error",
-            "bigquery:test-project.analytics.customers",
-        )
-        is None
-    )
-
-
-def test_extract_datahub_dataset_name_from_fqn_handles_missing_format(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    mapping = DataplexEntryTypeMapping(
-        datahub_platform="bigquery",
-        datahub_entity_type="Dataset",
-        datahub_subtype="table",
-        fqn_regex=BIGQUERY_TABLE_FQN_REGEX,
-        parent_entry_regex=None,
-        container_key_class=None,
-        parent_container_key_class=None,
-        datahub_dataset_name_format="{project_id}.{dataset_id}.{table_id}",
-    )
-    object.__setattr__(mapping, "datahub_dataset_name_format", None)
-    monkeypatch.setitem(DATAPLEX_ENTRY_TYPE_MAPPINGS, "test-missing-format", mapping)
-
-    assert (
-        extract_datahub_dataset_name_from_fqn(
-            "test-missing-format",
-            "bigquery:test-project.analytics.customers",
-        )
-        is None
-    )
-
-
-def test_build_project_schema_key_from_fqn_returns_none_when_project_class_missing(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delitem(PROJECT_SCHEMA_KEY_CLASS_BY_PLATFORM, "bigquery")
-
-    assert (
-        build_project_schema_key_from_fqn(
-            "bigquery-table",
-            "bigquery:test-project.analytics.customers",
-        )
-        is None
-    )
+def test_project_schema_key_class_by_platform_covers_supported_platforms() -> None:
+    assert set(PROJECT_SCHEMA_KEY_CLASS_BY_PLATFORM.keys()) == {
+        "bigquery",
+        "cloudsql",
+        "spanner",
+        "pubsub",
+        "bigtable",
+        "vertexai",
+    }
+    for key_class in PROJECT_SCHEMA_KEY_CLASS_BY_PLATFORM.values():
+        assert issubclass(key_class, DataplexProjectId)

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_ids.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_ids.py
@@ -13,7 +13,6 @@ from datahub.ingestion.source.dataplex.dataplex_ids import (
     DataplexBigQueryProject,
     DataplexCloudSqlMySqlDatabase,
     DataplexProjectId,
-    build_lineage_parent,
     extract_entry_type_short_name,
     instantiate_key,
     parse_with_regex,
@@ -45,13 +44,6 @@ def test_extract_entry_type_short_name(
 
 def test_extract_entry_type_short_name_invalid() -> None:
     assert extract_entry_type_short_name("bigquery-table") is None
-
-
-def test_build_lineage_parent() -> None:
-    assert (
-        build_lineage_parent(project_id="test-project", location="us-central1")
-        == "projects/test-project/locations/us-central1"
-    )
 
 
 def test_parse_with_regex_named_groups() -> None:

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_lineage.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_lineage.py
@@ -11,9 +11,17 @@ from datahub.ingestion.source.dataplex.dataplex_helpers import EntryDataTuple
 from datahub.ingestion.source.dataplex.dataplex_lineage import (
     DataplexLineageExtractor,
     LineageEdge,
+    build_lineage_parent,
 )
 from datahub.ingestion.source.dataplex.dataplex_report import DataplexReport
 from datahub.metadata.schema_classes import DatasetLineageTypeClass
+
+
+def test_build_lineage_parent() -> None:
+    assert (
+        build_lineage_parent(project_id="test-project", location="us-central1")
+        == "projects/test-project/locations/us-central1"
+    )
 
 
 @pytest.fixture

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
@@ -218,6 +218,7 @@ def test_parent_entry_link_present_iff_entry_has_parent(
         _make_entry(short_name=short_name, fqn=fqn, parent_entry=parent_entry), _ctx()
     )
     assert result is not None and result.main_entity is not None
+    assert isinstance(result.main_entity, (Dataset, Container))
     assert str(result.main_entity.parent_container).startswith("urn:li:container:")
 
 
@@ -267,6 +268,7 @@ def test_dataset_unparseable_parent_entry_warns_and_omits_parent() -> None:
         ctx,
     )
     assert result is not None and result.main_entity is not None
+    assert isinstance(result.main_entity, Dataset)
     assert result.main_entity.parent_container is None
     assert (
         cast(Mock, ctx.report.warning).call_args.kwargs["title"]

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
@@ -1,6 +1,7 @@
 """Unit tests for Dataplex entry-type mappers (payload -> DataHub entities)."""
 
 import string
+from datetime import datetime, timezone
 from typing import Optional, cast
 from unittest.mock import Mock, patch
 
@@ -13,6 +14,10 @@ from datahub.ingestion.source.dataplex.dataplex_mappers import (
     ContainerIdentity,
     DatasetIdentity,
     EntryMappingContext,
+    _extract_datetime,
+    _extract_description,
+    _extract_display_name,
+    _extract_entry_group_id,
     dataset_urn_from_fqn_only,
     get_entry_mapper,
     is_lineage_supported,
@@ -375,6 +380,24 @@ def test_dataset_name_format_fields_are_captured_by_fqn_regex(short_name: str) -
     )
 
 
+PARENT_TYPES = [c[0] for c in CASES if c[2]]  # entries with a parent_entry
+
+
+@pytest.mark.parametrize("short_name", PARENT_TYPES)
+def test_parent_entry_regex_groups_are_parent_key_fields(short_name: str) -> None:
+    """Guardrail for the parent-entry regex↔key-field contract the docstring
+    claims: every named group of a ParentEntryLink's regex must be a field on its
+    schema-key class (instantiate_key silently drops unknown groups, so a
+    renamed/superfluous group would otherwise build a wrong-but-valid key)."""
+    link = ENTRY_MAPPERS[short_name].dataplex_parent_entry
+    assert link is not None
+    regex_groups = set(link.dataplex_parent_entry_regex.groupindex.keys())
+    key_fields = set(link.datahub_schemakey_class.model_fields.keys())
+    assert regex_groups <= key_fields, (
+        f"{short_name}: parent regex groups {regex_groups} not all key fields {key_fields}"
+    )
+
+
 CONTAINER_TYPES = {c[0] for c in CASES if c[3] == "Container"}
 
 
@@ -439,3 +462,66 @@ def test_graph_schema_fallback_used_only_for_spanner_graph() -> None:
             _ctx(include_schema=True),
         )
         assert not mock_graph.called
+
+
+# ---------------------------------------------------------------------------
+# Payload-extraction helpers (partial-payload branches not covered by goldens)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_display_name_prefers_source_then_falls_back() -> None:
+    entry = Mock(spec=dataplex_v1.Entry)
+    entry.name = "projects/p/locations/us/entryGroups/g/entries/e1"
+
+    source = Mock()
+    source.display_name = "Nice Name"
+    entry.entry_source = source
+    assert _extract_display_name(entry) == "Nice Name"
+
+    # Non-string display_name falls back to the last name segment.
+    source.display_name = Mock()
+    assert _extract_display_name(entry) == "e1"
+
+    # Missing entry_source also falls back.
+    entry.entry_source = None
+    assert _extract_display_name(entry) == "e1"
+
+
+def test_extract_description_defaults_to_empty() -> None:
+    entry = Mock(spec=dataplex_v1.Entry)
+    source = Mock()
+    source.description = "some description"
+    entry.entry_source = source
+    assert _extract_description(entry) == "some description"
+
+    entry.entry_source = None
+    assert _extract_description(entry) == ""
+
+
+def test_extract_datetime_converts_to_utc_and_guards() -> None:
+    entry = Mock(spec=dataplex_v1.Entry)
+
+    entry.entry_source = None
+    assert _extract_datetime(entry, "create_time") is None
+
+    source = Mock()
+    ts = Mock()
+    ts.timestamp.return_value = 1_700_000_000.0
+    source.create_time = ts
+    source.update_time = None
+    entry.entry_source = source
+    assert _extract_datetime(entry, "create_time") == datetime.fromtimestamp(
+        1_700_000_000.0, tz=timezone.utc
+    )
+    assert _extract_datetime(entry, "update_time") is None
+
+
+def test_extract_entry_group_id_and_unknown_fallback() -> None:
+    assert (
+        _extract_entry_group_id(
+            "projects/p/locations/us/entryGroups/@bigquery/entries/e"
+        )
+        == "@bigquery"
+    )
+    # No entryGroups segment -> "unknown".
+    assert _extract_entry_group_id("projects/p/locations/us/entries/e") == "unknown"

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
@@ -325,7 +325,7 @@ def test_dataset_name_format_fields_are_captured_by_fqn_regex(short_name: str) -
     group in that mapper's FQN regex, else name extraction silently fails."""
     mapper = ENTRY_MAPPERS[short_name]
     fmt_fields = _format_fields(mapper.datahub_dataset_name_format)  # type: ignore[attr-defined]
-    regex_groups = set(mapper.fqn_regex.groupindex.keys())  # type: ignore[attr-defined]
+    regex_groups = set(mapper.fqn_regex.groupindex.keys())
     assert fmt_fields.issubset(regex_groups), (
         f"{short_name}: format fields {fmt_fields} not all in regex groups {regex_groups}"
     )

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
@@ -2,7 +2,7 @@
 
 import string
 from typing import Optional, cast
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from google.cloud import dataplex_v1
@@ -10,6 +10,7 @@ from google.cloud import dataplex_v1
 from datahub.ingestion.source.dataplex.dataplex_config import DataplexConfig
 from datahub.ingestion.source.dataplex.dataplex_mappers import (
     ENTRY_MAPPERS,
+    ContainerIdentity,
     DatasetIdentity,
     EntryMappingContext,
     dataset_urn_from_fqn_only,
@@ -152,7 +153,6 @@ CASES = [
 
 def test_registry_covers_all_supported_entry_types() -> None:
     assert set(ENTRY_MAPPERS.keys()) == {case[0] for case in CASES}
-    assert len(ENTRY_MAPPERS) == 14
 
 
 @pytest.mark.parametrize("short_name,fqn,parent_entry,main_type,dataset_name", CASES)
@@ -203,22 +203,21 @@ def test_parent_entry_link_present_iff_entry_has_parent(
     dataset_name: Optional[str],
 ) -> None:
     """A mapper declares a ParentEntryLink exactly when the entry has a
-    parent_entry finer than its project; otherwise the property is None."""
+    parent_entry finer than its project; otherwise the property is None.
+
+    When present, build the entry and assert the parent-entry regex actually
+    resolves a parent container URN — this pins every platform's parent-entry
+    pattern (a regression would silently emit an entity with no parent)."""
     mapper = ENTRY_MAPPERS[short_name]
-    if parent_entry:
-        assert mapper.dataplex_parent_entry is not None
-    else:
+    if not parent_entry:
         assert mapper.dataplex_parent_entry is None
+        return
 
-
-def test_dataset_with_parent_entry_links_parent_container() -> None:
-    short_name, fqn, parent_entry = CASES[1][:3]  # bigquery-table
-    result = ENTRY_MAPPERS[short_name].map(
+    assert mapper.dataplex_parent_entry is not None
+    result = mapper.map(
         _make_entry(short_name=short_name, fqn=fqn, parent_entry=parent_entry), _ctx()
     )
     assert result is not None and result.main_entity is not None
-    assert isinstance(result.main_entity, Dataset)
-    assert result.main_entity.parent_container is not None
     assert str(result.main_entity.parent_container).startswith("urn:li:container:")
 
 
@@ -254,6 +253,25 @@ def test_top_level_dataset_uses_project_parent_without_warning() -> None:
     assert str(result.main_entity.parent_container).startswith("urn:li:container:")
     mock_warning = cast(Mock, ctx.report.warning)
     mock_warning.assert_not_called()
+
+
+def test_dataset_unparseable_parent_entry_warns_and_omits_parent() -> None:
+    ctx = _ctx()
+    # parent_entry is present but does not match the parent-entry regex.
+    result = ENTRY_MAPPERS["bigquery-table"].map(
+        _make_entry(
+            short_name="bigquery-table",
+            fqn="bigquery:my-project.my_dataset.my_table",
+            parent_entry="not-a-valid-parent-entry-path",
+        ),
+        ctx,
+    )
+    assert result is not None and result.main_entity is not None
+    assert result.main_entity.parent_container is None
+    assert (
+        cast(Mock, ctx.report.warning).call_args.kwargs["title"]
+        == "Unparseable Dataplex parent_entry"
+    )
 
 
 def test_map_returns_none_for_missing_fqn() -> None:
@@ -353,3 +371,69 @@ def test_dataset_name_format_fields_are_captured_by_fqn_regex(short_name: str) -
     assert fmt_fields.issubset(regex_groups), (
         f"{short_name}: format fields {fmt_fields} not all in regex groups {regex_groups}"
     )
+
+
+CONTAINER_TYPES = {c[0] for c in CASES if c[3] == "Container"}
+
+
+@pytest.mark.parametrize("short_name", sorted(CONTAINER_TYPES))
+def test_container_fqn_regex_groups_are_key_fields(short_name: str) -> None:
+    """Guardrail: every FQN named group of a container mapper must be a field on
+    its ContainerKey class, else key identity silently drops fields. Also pins the
+    Spanner ``regional-{location}`` -> ``location`` normalization."""
+    mapper = ENTRY_MAPPERS[short_name]
+    identity = mapper.datahub_identity
+    assert isinstance(identity, ContainerIdentity)
+    regex_groups = set(mapper.dataplex_fqn_regex.groupindex.keys())
+    key_fields = set(identity.key_class.model_fields.keys())
+    assert regex_groups <= key_fields, (
+        f"{short_name}: regex groups {regex_groups} not all key fields {key_fields}"
+    )
+
+
+def test_container_builds_expected_key_urn_for_non_bigquery_types() -> None:
+    """Concrete container-identity checks for non-BigQuery platforms (the golden
+    files are BigQuery-only), incl. the Spanner regional- location normalization."""
+    for short_name, fqn, parent_entry, _, _ in CASES:
+        if short_name not in {"cloud-spanner-database", "cloudsql-mysql-database"}:
+            continue
+        result = ENTRY_MAPPERS[short_name].map(
+            _make_entry(short_name=short_name, fqn=fqn, parent_entry=parent_entry),
+            _ctx(),
+        )
+        assert result is not None
+        assert isinstance(result.main_entity, Container)
+        # container's own key and its parent both resolve to container URNs
+        assert result.main_entity.urn.urn().startswith("urn:li:container:")
+        assert str(result.main_entity.parent_container).startswith("urn:li:container:")
+
+
+def test_graph_schema_fallback_used_only_for_spanner_graph() -> None:
+    """The graph-schema aspect fallback is scoped to cloud-spanner-graph; other
+    dataset types use only the standard schema aspect."""
+    mappers_module = "datahub.ingestion.source.dataplex.dataplex_mappers"
+    with (
+        patch(f"{mappers_module}.extract_schema_from_entry_aspects", return_value=None),
+        patch(
+            f"{mappers_module}.extract_graph_schema_from_entry_aspects",
+            return_value=None,
+        ) as mock_graph,
+    ):
+        ENTRY_MAPPERS["cloud-spanner-graph"].map(
+            _make_entry(
+                short_name="cloud-spanner-graph",
+                fqn="spanner:graph:my-project.regional-us-west2.my-instance.my-db.MyGraph",
+            ),
+            _ctx(include_schema=True),
+        )
+        assert mock_graph.called
+
+        mock_graph.reset_mock()
+        ENTRY_MAPPERS["cloud-spanner-table"].map(
+            _make_entry(
+                short_name="cloud-spanner-table",
+                fqn="spanner:my-project.regional-us-west2.my-instance.my-db.my_table",
+            ),
+            _ctx(include_schema=True),
+        )
+        assert not mock_graph.called

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
@@ -1,7 +1,7 @@
 """Unit tests for Dataplex entry-type mappers (payload -> DataHub entities)."""
 
 import string
-from typing import Optional
+from typing import Optional, cast
 from unittest.mock import Mock
 
 import pytest
@@ -199,6 +199,8 @@ def test_dataset_with_parent_entry_links_parent_container() -> None:
         _make_entry(short_name=short_name, fqn=fqn, parent_entry=parent_entry), _ctx()
     )
     assert result is not None and result.main_entity is not None
+    assert isinstance(result.main_entity, Dataset)
+    assert result.main_entity.parent_container is not None
     assert str(result.main_entity.parent_container).startswith("urn:li:container:")
 
 
@@ -214,11 +216,11 @@ def test_dataset_missing_expected_parent_warns_and_omits_parent() -> None:
         ctx,
     )
     assert result is not None and result.main_entity is not None
+    assert isinstance(result.main_entity, Dataset)
     assert result.main_entity.parent_container is None
-    ctx.report.warning.assert_called_once()
-    assert (
-        ctx.report.warning.call_args.kwargs["title"] == "Missing Dataplex parent_entry"
-    )
+    mock_warning = cast(Mock, ctx.report.warning)
+    mock_warning.assert_called_once()
+    assert mock_warning.call_args.kwargs["title"] == "Missing Dataplex parent_entry"
 
 
 def test_top_level_dataset_uses_project_parent_without_warning() -> None:
@@ -229,9 +231,11 @@ def test_top_level_dataset_uses_project_parent_without_warning() -> None:
         ctx,
     )
     assert result is not None and result.main_entity is not None
+    assert isinstance(result.main_entity, Dataset)
     assert result.main_entity.parent_container is not None
     assert str(result.main_entity.parent_container).startswith("urn:li:container:")
-    ctx.report.warning.assert_not_called()
+    mock_warning = cast(Mock, ctx.report.warning)
+    mock_warning.assert_not_called()
 
 
 def test_map_returns_none_for_missing_fqn() -> None:

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
@@ -193,6 +193,23 @@ def test_mapper_builds_expected_entity(
         assert result.lineage_entry is None
 
 
+@pytest.mark.parametrize("short_name,fqn,parent_entry,main_type,dataset_name", CASES)
+def test_parent_entry_link_present_iff_entry_has_parent(
+    short_name: str,
+    fqn: str,
+    parent_entry: str,
+    main_type: str,
+    dataset_name: Optional[str],
+) -> None:
+    """A mapper declares a ParentEntryLink exactly when the entry has a
+    parent_entry finer than its project; otherwise the property is None."""
+    mapper = ENTRY_MAPPERS[short_name]
+    if parent_entry:
+        assert mapper.dataplex_parent_entry is not None
+    else:
+        assert mapper.dataplex_parent_entry is None
+
+
 def test_dataset_with_parent_entry_links_parent_container() -> None:
     short_name, fqn, parent_entry = CASES[1][:3]  # bigquery-table
     result = ENTRY_MAPPERS[short_name].map(

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
@@ -10,6 +10,7 @@ from google.cloud import dataplex_v1
 from datahub.ingestion.source.dataplex.dataplex_config import DataplexConfig
 from datahub.ingestion.source.dataplex.dataplex_mappers import (
     ENTRY_MAPPERS,
+    DatasetIdentity,
     EntryMappingContext,
     dataset_urn_from_fqn_only,
     get_entry_mapper,
@@ -345,7 +346,9 @@ def test_dataset_name_format_fields_are_captured_by_fqn_regex(short_name: str) -
     """Guardrail: every field referenced by a dataset name format must be a named
     group in that mapper's FQN regex, else name extraction silently fails."""
     mapper = ENTRY_MAPPERS[short_name]
-    fmt_fields = _format_fields(mapper.datahub_dataset_name_format)  # type: ignore[attr-defined]
+    identity = mapper.datahub_identity
+    assert isinstance(identity, DatasetIdentity)
+    fmt_fields = _format_fields(identity.name_format)
     regex_groups = set(mapper.dataplex_fqn_regex.groupindex.keys())
     assert fmt_fields.issubset(regex_groups), (
         f"{short_name}: format fields {fmt_fields} not all in regex groups {regex_groups}"

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
@@ -325,7 +325,7 @@ def test_dataset_name_format_fields_are_captured_by_fqn_regex(short_name: str) -
     group in that mapper's FQN regex, else name extraction silently fails."""
     mapper = ENTRY_MAPPERS[short_name]
     fmt_fields = _format_fields(mapper.datahub_dataset_name_format)  # type: ignore[attr-defined]
-    regex_groups = set(mapper.fqn_regex.groupindex.keys())
+    regex_groups = set(mapper.dataplex_fqn_regex.groupindex.keys())
     assert fmt_fields.issubset(regex_groups), (
         f"{short_name}: format fields {fmt_fields} not all in regex groups {regex_groups}"
     )

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_mappers.py
@@ -1,0 +1,331 @@
+"""Unit tests for Dataplex entry-type mappers (payload -> DataHub entities)."""
+
+import string
+from typing import Optional
+from unittest.mock import Mock
+
+import pytest
+from google.cloud import dataplex_v1
+
+from datahub.ingestion.source.dataplex.dataplex_config import DataplexConfig
+from datahub.ingestion.source.dataplex.dataplex_mappers import (
+    ENTRY_MAPPERS,
+    EntryMappingContext,
+    dataset_urn_from_fqn_only,
+    get_entry_mapper,
+    is_lineage_supported,
+)
+from datahub.sdk.container import Container
+from datahub.sdk.dataset import Dataset
+
+ENTRY_TYPE_PREFIX = "projects/123/locations/global/entryTypes/"
+
+
+def _make_entry(
+    *,
+    short_name: str,
+    fqn: str,
+    parent_entry: str = "",
+    name: Optional[str] = None,
+) -> dataplex_v1.Entry:
+    entry = Mock(spec=dataplex_v1.Entry)
+    entry.name = name or f"projects/p/locations/us/entryGroups/g/entries/{short_name}"
+    entry.entry_type = f"{ENTRY_TYPE_PREFIX}{short_name}"
+    entry.fully_qualified_name = fqn
+    entry.parent_entry = parent_entry
+    entry.entry_source = None
+    entry.aspects = {}
+    return entry
+
+
+def _ctx(include_schema: bool = False) -> EntryMappingContext:
+    config = DataplexConfig(project_ids=["my-project"], env="PROD")
+    config.include_schema = include_schema
+    return EntryMappingContext(config=config, location="us-west2", report=Mock())
+
+
+# (short_name, fqn, parent_entry, expected main type, expected dataset name or None)
+CASES = [
+    ("bigquery-dataset", "bigquery:my-project.my_dataset", "", "Container", None),
+    (
+        "bigquery-table",
+        "bigquery:my-project.my_dataset.my_table",
+        "projects/my-project/locations/us/entryGroups/@bigquery/entries/"
+        "bigquery.googleapis.com/projects/my-project/datasets/my_dataset",
+        "Dataset",
+        "my-project.my_dataset.my_table",
+    ),
+    (
+        "bigquery-view",
+        "bigquery:my-project.my_dataset.my_view",
+        "projects/my-project/locations/us/entryGroups/@bigquery/entries/"
+        "bigquery.googleapis.com/projects/my-project/datasets/my_dataset",
+        "Dataset",
+        "my-project.my_dataset.my_view",
+    ),
+    (
+        "cloudsql-mysql-instance",
+        "cloudsql_mysql:my-project.us-west2.my-instance",
+        "",
+        "Container",
+        None,
+    ),
+    (
+        "cloudsql-mysql-database",
+        "cloudsql_mysql:my-project.us-west2.my-instance.my-db",
+        "projects/my-project/locations/us-west2/entryGroups/@cloudsql/entries/"
+        "cloudsql.googleapis.com/projects/my-project/locations/us-west2/instances/my-instance",
+        "Container",
+        None,
+    ),
+    (
+        "cloudsql-mysql-table",
+        "cloudsql_mysql:my-project.us-west2.my-instance.my-db.my_table",
+        "projects/my-project/locations/us-west2/entryGroups/@cloudsql/entries/"
+        "cloudsql.googleapis.com/projects/my-project/locations/us-west2/instances/my-instance/databases/my-db",
+        "Dataset",
+        "my-project.us-west2.my-instance.my-db.my_table",
+    ),
+    (
+        "cloud-spanner-instance",
+        "spanner:my-project.regional-us-west2.my-instance",
+        "",
+        "Container",
+        None,
+    ),
+    (
+        "cloud-spanner-database",
+        "spanner:my-project.regional-us-west2.my-instance.my-db",
+        "projects/my-project/locations/us-west2/entryGroups/@spanner/entries/"
+        "spanner.googleapis.com/projects/my-project/instances/my-instance",
+        "Container",
+        None,
+    ),
+    (
+        "cloud-spanner-table",
+        "spanner:my-project.regional-us-west2.my-instance.my-db.my_table",
+        "projects/my-project/locations/us-west2/entryGroups/@spanner/entries/"
+        "spanner.googleapis.com/projects/my-project/instances/my-instance/databases/my-db",
+        "Dataset",
+        "my-project.regional-us-west2.my-instance.my-db.my_table",
+    ),
+    (
+        "cloud-spanner-graph",
+        "spanner:graph:my-project.regional-us-west2.my-instance.my-db.MyGraph",
+        "projects/my-project/locations/us-west2/entryGroups/@spanner/entries/"
+        "spanner.googleapis.com/projects/my-project/instances/my-instance/databases/my-db",
+        "Dataset",
+        "my-project.regional-us-west2.my-instance.my-db.MyGraph",
+    ),
+    (
+        "cloud-bigtable-instance",
+        "bigtable:my-project.my-instance",
+        "",
+        "Container",
+        None,
+    ),
+    (
+        "cloud-bigtable-table",
+        "bigtable:my-project.my-instance.my_table",
+        "projects/my-project/locations/global/entryGroups/@bigtable/entries/"
+        "bigtable.googleapis.com/projects/my-project/instances/my-instance",
+        "Dataset",
+        "my-project.my-instance.my_table",
+    ),
+    (
+        "pubsub-topic",
+        "pubsub:topic:my-project.my-topic",
+        "",
+        "Dataset",
+        "my-project.my-topic",
+    ),
+    (
+        "vertexai-dataset",
+        "vertex_ai:dataset:my-project.us-west2.123456",
+        "",
+        "Dataset",
+        "my-project.us-west2.123456",
+    ),
+]
+
+
+def test_registry_covers_all_supported_entry_types() -> None:
+    assert set(ENTRY_MAPPERS.keys()) == {case[0] for case in CASES}
+    assert len(ENTRY_MAPPERS) == 14
+
+
+@pytest.mark.parametrize("short_name,fqn,parent_entry,main_type,dataset_name", CASES)
+def test_mapper_builds_expected_entity(
+    short_name: str,
+    fqn: str,
+    parent_entry: str,
+    main_type: str,
+    dataset_name: Optional[str],
+) -> None:
+    mapper = ENTRY_MAPPERS[short_name]
+    result = mapper.map(
+        _make_entry(short_name=short_name, fqn=fqn, parent_entry=parent_entry), _ctx()
+    )
+
+    assert result is not None
+    assert result.main_entity is not None
+
+    # Every entry also emits its owning project container as an additional entity.
+    assert len(result.additional_entities) == 1
+    project_container = result.additional_entities[0]
+    assert isinstance(project_container, Container)
+    assert project_container.display_name == "my-project"
+    assert project_container.parent_container is None
+
+    if main_type == "Dataset":
+        assert isinstance(result.main_entity, Dataset)
+        assert dataset_name is not None
+        expected_platform = mapper.datahub_platform
+        assert result.main_entity.urn.urn() == (
+            f"urn:li:dataset:(urn:li:dataPlatform:{expected_platform},{dataset_name},PROD)"
+        )
+        # Dataset entries produce a lineage record with the same identity.
+        assert result.lineage_entry is not None
+        assert result.lineage_entry.datahub_dataset_name == dataset_name
+        assert result.lineage_entry.dataplex_location == "us-west2"
+    else:
+        assert isinstance(result.main_entity, Container)
+        assert result.lineage_entry is None
+
+
+def test_dataset_with_parent_entry_links_parent_container() -> None:
+    short_name, fqn, parent_entry = CASES[1][:3]  # bigquery-table
+    result = ENTRY_MAPPERS[short_name].map(
+        _make_entry(short_name=short_name, fqn=fqn, parent_entry=parent_entry), _ctx()
+    )
+    assert result is not None and result.main_entity is not None
+    assert str(result.main_entity.parent_container).startswith("urn:li:container:")
+
+
+def test_dataset_missing_expected_parent_warns_and_omits_parent() -> None:
+    ctx = _ctx()
+    # bigquery-table expects a parent_entry; empty one triggers a warning + fallback.
+    result = ENTRY_MAPPERS["bigquery-table"].map(
+        _make_entry(
+            short_name="bigquery-table",
+            fqn="bigquery:my-project.my_dataset.my_table",
+            parent_entry="",
+        ),
+        ctx,
+    )
+    assert result is not None and result.main_entity is not None
+    assert result.main_entity.parent_container is None
+    ctx.report.warning.assert_called_once()
+    assert (
+        ctx.report.warning.call_args.kwargs["title"] == "Missing Dataplex parent_entry"
+    )
+
+
+def test_top_level_dataset_uses_project_parent_without_warning() -> None:
+    ctx = _ctx()
+    # pubsub-topic has no parent_entry regex: parent linkage is the project key.
+    result = ENTRY_MAPPERS["pubsub-topic"].map(
+        _make_entry(short_name="pubsub-topic", fqn="pubsub:topic:my-project.my-topic"),
+        ctx,
+    )
+    assert result is not None and result.main_entity is not None
+    assert result.main_entity.parent_container is not None
+    assert str(result.main_entity.parent_container).startswith("urn:li:container:")
+    ctx.report.warning.assert_not_called()
+
+
+def test_map_returns_none_for_missing_fqn() -> None:
+    result = ENTRY_MAPPERS["bigquery-table"].map(
+        _make_entry(short_name="bigquery-table", fqn=""), _ctx()
+    )
+    assert result is None
+
+
+def test_map_returns_none_for_unparseable_fqn() -> None:
+    result = ENTRY_MAPPERS["bigquery-table"].map(
+        _make_entry(short_name="bigquery-table", fqn="bigquery"), _ctx()
+    )
+    assert result is None
+
+
+def test_include_schema_toggle_does_not_break_build() -> None:
+    # With no aspects present, schema extraction returns None regardless.
+    result = ENTRY_MAPPERS["bigquery-table"].map(
+        _make_entry(
+            short_name="bigquery-table",
+            fqn="bigquery:my-project.my_dataset.my_table",
+        ),
+        _ctx(include_schema=True),
+    )
+    assert result is not None and isinstance(result.main_entity, Dataset)
+
+
+def test_get_entry_mapper_resolves_and_warns() -> None:
+    report = Mock()
+    assert get_entry_mapper(f"{ENTRY_TYPE_PREFIX}bigquery-table", report) is not None
+    report.warning.assert_not_called()
+
+    # Invalid entry_type format (not a full path).
+    assert get_entry_mapper("bigquery-table", report) is None
+    assert (
+        report.warning.call_args.kwargs["title"] == "Invalid Dataplex entry type format"
+    )
+
+    # Well-formed path but unsupported short name.
+    assert get_entry_mapper(f"{ENTRY_TYPE_PREFIX}unknown-type", report) is None
+    assert report.warning.call_args.kwargs["title"] == "Unsupported Dataplex entry type"
+
+
+DATASET_TYPES = {c[0] for c in CASES if c[3] == "Dataset"}
+
+
+@pytest.mark.parametrize("short_name", [c[0] for c in CASES])
+def test_is_lineage_supported_matches_dataset_types(short_name: str) -> None:
+    assert is_lineage_supported(short_name) == (short_name in DATASET_TYPES)
+
+
+def test_is_lineage_supported_unknown_type() -> None:
+    assert not is_lineage_supported("unknown-entry-type")
+
+
+@pytest.mark.parametrize(
+    "fqn,expected_urn",
+    [
+        (
+            "bigquery:my-project.my_dataset.my_table",
+            "urn:li:dataset:(urn:li:dataPlatform:bigquery,my-project.my_dataset.my_table,PROD)",
+        ),
+        (
+            "pubsub:topic:my-project.my-topic",
+            "urn:li:dataset:(urn:li:dataPlatform:pubsub,my-project.my-topic,PROD)",
+        ),
+        (
+            "bigtable:my-project.my-instance.my_table",
+            "urn:li:dataset:(urn:li:dataPlatform:bigtable,my-project.my-instance.my_table,PROD)",
+        ),
+        ("unknown:project.dataset.table", None),
+        ("invalid", None),
+    ],
+)
+def test_dataset_urn_from_fqn_only(fqn: str, expected_urn: Optional[str]) -> None:
+    assert dataset_urn_from_fqn_only(fqn, env="PROD") == expected_urn
+
+
+def _format_fields(fmt: str) -> set[str]:
+    return {
+        field_name
+        for _, field_name, _, _ in string.Formatter().parse(fmt)
+        if field_name
+    }
+
+
+@pytest.mark.parametrize("short_name", sorted(DATASET_TYPES))
+def test_dataset_name_format_fields_are_captured_by_fqn_regex(short_name: str) -> None:
+    """Guardrail: every field referenced by a dataset name format must be a named
+    group in that mapper's FQN regex, else name extraction silently fails."""
+    mapper = ENTRY_MAPPERS[short_name]
+    fmt_fields = _format_fields(mapper.datahub_dataset_name_format)  # type: ignore[attr-defined]
+    regex_groups = set(mapper.fqn_regex.groupindex.keys())  # type: ignore[attr-defined]
+    assert fmt_fields.issubset(regex_groups), (
+        f"{short_name}: format fields {fmt_fields} not all in regex groups {regex_groups}"
+    )


### PR DESCRIPTION
## Motivation

The Dataplex connector mapped each Universal Catalog entry to DataHub entities through a static declarative table (`DATAPLEX_ENTRY_TYPE_MAPPINGS`) plus one large branching build method and a set of table-driven free functions. Adding or reasoning about a single entry type meant touching several places, and per-type behavior was hard to unit-test in isolation.

## Design

Replace the table with a factory/strategy: one small `EntryMapper` class per Dataplex entry type, registered in `ENTRY_MAPPERS` (keyed by entry-type short name). Each mapper is a pure function of `(entry, EntryMappingContext)` returning an `EntryMappingResult` (main entity + additional entities + optional lineage record); shared logic lives in `build_dataset` / `build_container` helpers (composition, flat hierarchy — no family base classes).

Key modeling choices:

- **Contract as declarative data.** A mapper declares `dataplex_entry_type_short_name`, `datahub_platform`, `dataplex_fqn_regex`, an optional `dataplex_parent_entry`, and a `datahub_identity`.
- **`datahub_identity`** captures the one real difference between families — Dataset builds a name from a format string (`DatasetIdentity`), Container builds a `ContainerKey` from the parsed FQN fields (`ContainerIdentity`). `datahub_main_entity_type` is derived from it.
- **`ParentEntryLink`** bundles the parent-entry regex + parent key class as one optional unit (`None` = parent is just the owning project).
- **Cross-entry concerns stay in the orchestrator.** `DataplexEntriesProcessor` keeps the global project-container dedup and the lineage side-channel; mappers only declare/return that data, keeping them trivially testable.
- `dataplex_ids.py` is reduced to identity primitives (regexes, `ContainerKey` classes, parse/instantiate helpers); `dataplex_lineage.py` reads the registry.

Behavior-preserving: the integration golden files are unchanged and the dataplex unit + integration tests pass.

<!--
- [ ] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in Updating DataHub
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pr2RizugDza6N8YT313f6c)_