### PR TITLE
fix(auth): stop logging bearer tokens in DataHubOAuthAuthenticator

### DIFF
--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/authenticator/DataHubOAuthAuthenticator.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/authenticator/DataHubOAuthAuthenticator.java
@@ -168,8 +168,6 @@ public class DataHubOAuthAuthenticator implements Authenticator {
     try {
       String jwtToken = context.getRequestHeaders().get(AUTHORIZATION_HEADER_NAME);
 
-      log.info("Request headers are: {}", context.getRequestHeaders());
-
       if (jwtToken == null
           || (!jwtToken.startsWith("Bearer ") && !jwtToken.startsWith("bearer "))) {
         throw new AuthenticationException("Invalid Authorization header");


### PR DESCRIPTION
## Summary

`DataHubOAuthAuthenticator` logged the entire request header map at `INFO` on
every authentication attempt:

```java
log.info("Request headers are: {}", context.getRequestHeaders());
```

The header map includes the `Authorization` header — i.e. the full bearer JWT.
This wrote live credentials into normal application logs, which are commonly
shipped to centralized logging, retained, and indexed. The line was leftover
debug logging.

This PR removes the line entirely. No replacement is added: the token is never
needed in logs. If header diagnostics are ever wanted in the future, they should
be added at `DEBUG` with the `Authorization` value redacted.

**Impact:** any deployment with external OAuth authentication enabled was
exposing bearer tokens in its logs.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable) — N/A: pure removal of a debug log statement; no behavior change beyond suppressing the leak
- [ ] Docs related to the changes have been added/updated (if applicable) — N/A
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) — N/A: no breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
