### PR TITLE
fix(ingestion/redshift): handle COPY CREDENTIALS in query fingerprinting

### DIFF
--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_utils.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_utils.py
@@ -342,6 +342,20 @@ def generalize_query(expression: sqlglot.exp.ExpOrStr, dialect: DialectOrStr) ->
         if isinstance(node, (sqlglot.exp.In, sqlglot.exp.Values)):
             _simplify_node_expressions(node)
         elif isinstance(node, sqlglot.exp.Literal):
+            # A Redshift `COPY ... CREDENTIALS '<secret>'` parses the credentials
+            # as a Literal directly under a Credentials node. sqlglot's
+            # credentials_sql generator dispatches on isinstance(child, Literal)
+            # to choose the Redshift scalar form over the Snowflake key=value
+            # list; a Placeholder there routes into the list path that iterates
+            # the node and raises "TypeError: 'Placeholder' object is not
+            # iterable". Redact to a constant literal instead: serialization
+            # stays on the scalar path, the secret never lands in the generalized
+            # query text, and fingerprints stay independent of the credentials.
+            if (
+                isinstance(node.parent, sqlglot.exp.Credentials)
+                and node.arg_key == "credentials"
+            ):
+                return sqlglot.exp.Literal.string("**REDACTED**")
             return sqlglot.exp.Placeholder()
 
         return node
@@ -367,7 +381,11 @@ def get_query_fingerprint_debug(
             )
         else:
             expression_sql = generalize_query_fast(expression, dialect=platform)
-    except (ValueError, sqlglot.errors.SqlglotError) as e:
+    except (ValueError, TypeError, sqlglot.errors.SqlglotError) as e:
+        # TypeError guards against sqlglot generator bugs that fail to serialize
+        # an otherwise-parseable statement (e.g. exotic COPY / credentials
+        # forms). Fingerprinting is best-effort with a raw-text fallback, so it
+        # must never propagate and abort ingestion.
         if not isinstance(expression, str):
             raise
 

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_utils.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_utils.py
@@ -215,6 +215,51 @@ def test_redshift_query_fingerprint():
     )
 
 
+def test_redshift_copy_credentials_generalization():
+    # Regression: `COPY ... CREDENTIALS '<secret>'` used to crash generalization
+    # with `TypeError: 'Placeholder' object is not iterable`. The credentials
+    # literal was replaced with a Placeholder, which flips sqlglot's
+    # credentials_sql dispatch onto the Snowflake key=value path that iterates
+    # the node.
+    copy_sql = (
+        "COPY my_schema.my_table FROM 's3://my-bucket/data' "
+        "CREDENTIALS 'aws_access_key_id=EXAMPLE;aws_secret_access_key=EXAMPLESECRET' "
+        "FORMAT AS PARQUET"
+    )
+
+    generalized = generalize_query(copy_sql, dialect="redshift")
+
+    # The secret must never leak into the generalized (stored) query text.
+    assert "EXAMPLESECRET" not in generalized
+    assert "CREDENTIALS" in generalized
+
+    # Fingerprinting must succeed and be independent of the actual secret, so
+    # two COPYs differing only in credentials share a fingerprint.
+    other_creds_sql = (
+        "COPY my_schema.my_table FROM 's3://my-bucket/data' "
+        "CREDENTIALS 'aws_access_key_id=OTHER;aws_secret_access_key=OTHERSECRET' "
+        "FORMAT AS PARQUET"
+    )
+    assert get_query_fingerprint(copy_sql, "redshift") == get_query_fingerprint(
+        other_creds_sql, "redshift"
+    )
+
+
+def test_get_query_fingerprint_survives_generalization_error(monkeypatch):
+    # Defense in depth: if generalization raises an unexpected error (e.g. a
+    # sqlglot generator bug on an exotic statement), fingerprinting must fall
+    # back to the raw text rather than propagating and killing the pipeline.
+    import datahub.sql_parsing.sqlglot_utils as sqlglot_utils
+
+    def _boom(*args: object, **kwargs: object) -> str:
+        raise TypeError("simulated sqlglot generator failure")
+
+    monkeypatch.setattr(sqlglot_utils, "generalize_query", _boom)
+
+    fingerprint = get_query_fingerprint("SELECT * FROM my_table", "redshift")
+    assert fingerprint
+
+
 def test_query_fingerprint_with_secondary_id():
     query = "SELECT * FROM users WHERE id = 123"
 

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_utils.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_utils.py
@@ -5,6 +5,8 @@ from enum import Enum
 import pytest
 import sqlglot
 
+from datahub.sql_parsing import sqlglot_utils
+from datahub.sql_parsing.fingerprint_utils import generate_hash
 from datahub.sql_parsing.query_types import get_query_type_of_sql
 from datahub.sql_parsing.schema_resolver import SchemaResolver
 from datahub.sql_parsing.sql_parsing_common import QueryType
@@ -249,15 +251,16 @@ def test_get_query_fingerprint_survives_generalization_error(monkeypatch):
     # Defense in depth: if generalization raises an unexpected error (e.g. a
     # sqlglot generator bug on an exotic statement), fingerprinting must fall
     # back to the raw text rather than propagating and killing the pipeline.
-    import datahub.sql_parsing.sqlglot_utils as sqlglot_utils
-
     def _boom(*args: object, **kwargs: object) -> str:
         raise TypeError("simulated sqlglot generator failure")
 
     monkeypatch.setattr(sqlglot_utils, "generalize_query", _boom)
 
-    fingerprint = get_query_fingerprint("SELECT * FROM my_table", "redshift")
-    assert fingerprint
+    raw_query = "SELECT * FROM my_table"
+    fingerprint = get_query_fingerprint(raw_query, "redshift")
+    # Pin the fallback path: the fingerprint must be the hash of the raw text,
+    # proving generalization was bypassed rather than merely "didn't raise".
+    assert fingerprint == generate_hash(raw_query)
 
 
 def test_query_fingerprint_with_secondary_id():


### PR DESCRIPTION
## Summary

Redshift `COPY ... CREDENTIALS '<secret>'` statements (seen on the `stl_scan` usage path) crashed query fingerprinting with `TypeError: 'Placeholder' object is not iterable`, which aborted the entire usage-extraction batch. Two independent defects combined to make this fatal; this PR fixes both.

**Defect 1 — `generalize_query` corrupts COPY credentials.**
`_strip_expression` replaced *every* literal with a `Placeholder`. For a Redshift COPY, the credentials are parsed as a single `Literal` directly under a `Credentials` node. sqlglot's `credentials_sql` generator dispatches on `isinstance(child, Literal)` to choose the Redshift scalar form (`CREDENTIALS '<value>'`) over the Snowflake key=value list form. A `Placeholder` flips that check onto the Snowflake list path, which *iterates* the credentials node — and a `Placeholder` isn't iterable, so it raises.

Fix: when the literal is the `credentials` child of a `Credentials` node, redact it to a constant literal instead of a placeholder. Serialization stays on the scalar path, the secret never lands in the generalized (stored) query text, and fingerprints stay independent of the credential value. Snowflake key=value credentials and Redshift `IAM_ROLE` forms are unaffected.

**Defect 2 — the fingerprint safety net was too narrow.**
`get_query_fingerprint_debug` only caught `ValueError` / `SqlglotError`, so the `TypeError` propagated past the usage extractor and killed the pipeline. Widened the catch to include `TypeError` so fingerprinting degrades to its raw-text fallback rather than aborting ingestion.

## Testing

- Added `test_redshift_copy_credentials_generalization` — COPY with credentials generalizes without raising, the secret is absent from the output, and two COPYs differing only in credentials share a fingerprint.
- Added `test_get_query_fingerprint_survives_generalization_error` — a generalization `TypeError` falls back to raw-text fingerprinting instead of propagating.
- Full `tests/unit/sql_parsing/` suite passes (445 tests); ruff + mypy clean on the changed files.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing/#commit-message-format))
- [x] Tests added/updated
- [ ] Docs updated (n/a — internal bugfix)