### PR TITLE
feat(sql-parsing): opt-in multiprocessing for sqlglot parsing in SqlParsingAggregator

### DIFF
--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,7 +1,0 @@
-# Parallel SQL parsing — progress ledger
-Task 1: complete (cpu_detection.py, commits e8fc959..a9c4247, review clean, 18/18 tests)
-Task 2: complete (read-only ConnectionWrapper/FileBackedDict + SchemaResolver.snapshot_to/load_readonly, commits 48c566b..b20a13b, review clean incl H1 fix, 58/58 tests)
-Task 3: complete (ParallelSqlParser spawn pool + BackpressureAwareExecutor generalization, commit fcb1543c, review Spec✅/Approved, 45 tests)
-  MINOR for final review:
-  - M1: SqlParsingResult exception tracebacks dropped across pickle (parallel debug_info has no traceback vs serial); lineage unaffected. Consider a comment in _worker_parse.
-  - M2: DatahubClientConfig.token is plain str; ensure no future edit logs graph_config/initargs (no leak today).

--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,0 +1,7 @@
+# Parallel SQL parsing — progress ledger
+Task 1: complete (cpu_detection.py, commits e8fc959..a9c4247, review clean, 18/18 tests)
+Task 2: complete (read-only ConnectionWrapper/FileBackedDict + SchemaResolver.snapshot_to/load_readonly, commits 48c566b..b20a13b, review clean incl H1 fix, 58/58 tests)
+Task 3: complete (ParallelSqlParser spawn pool + BackpressureAwareExecutor generalization, commit fcb1543c, review Spec✅/Approved, 45 tests)
+  MINOR for final review:
+  - M1: SqlParsingResult exception tracebacks dropped across pickle (parallel debug_info has no traceback vs serial); lineage unaffected. Consider a comment in _worker_parse.
+  - M2: DatahubClientConfig.token is plain str; ensure no future edit logs graph_config/initargs (no leak today).

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/queries_extractor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/queries_extractor.py
@@ -49,6 +49,7 @@ from datahub.sql_parsing.schema_resolver import SchemaResolver
 from datahub.sql_parsing.sql_parsing_aggregator import (
     ObservedQuery,
     SqlParsingAggregator,
+    SqlParsingParallelismConfig,
 )
 from datahub.sql_parsing.sqlglot_utils import get_query_fingerprint
 from datahub.utilities.file_backed_collections import (
@@ -89,7 +90,7 @@ class BigQueryJob(TypedDict):
     # NOTE: This does not capture referenced_view unlike GCP Logging Event
 
 
-class BigQueryQueriesExtractorConfig(BigQueryBaseConfig):
+class BigQueryQueriesExtractorConfig(SqlParsingParallelismConfig, BigQueryBaseConfig):
     # TODO: Support stateful ingestion for the time windows.
     window: BaseTimeWindowConfig = BaseTimeWindowConfig()
 
@@ -221,6 +222,8 @@ class BigQueryQueriesExtractor(Closeable):
             is_temp_table=self.is_temp_table,
             is_allowed_table=self.is_allowed_table,
             format_queries=False,
+            use_parallel_sql_parsing=self.config.use_parallel_sql_parsing,
+            sql_parsing_workers=self.config.sql_parsing_workers,
         )
 
         self.report.sql_aggregator = self.aggregator.report
@@ -353,7 +356,11 @@ class BigQueryQueriesExtractor(Closeable):
             self.report.num_unique_queries = len(queries_deduped)
             logger.info(f"Found {self.report.num_unique_queries} unique queries")
 
-        with self.report.audit_log_load_timer, queries_deduped:
+        with (
+            self.report.audit_log_load_timer,
+            queries_deduped,
+            self.aggregator.parallel_sql_parsing_scope(),
+        ):
             log_timer = ProgressTimer(timedelta(minutes=1))
             report_timer = ProgressTimer(timedelta(minutes=5))
 

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/config.py
@@ -25,6 +25,7 @@ from datahub.ingestion.source.state.stateful_ingestion_base import (
     StatefulUsageConfigMixin,
 )
 from datahub.ingestion.source.usage.usage_common import BaseUsageConfig
+from datahub.sql_parsing.sql_parsing_aggregator import SqlParsingParallelismConfig
 
 logger = logging.Logger(__name__)
 
@@ -77,6 +78,7 @@ class RedshiftUsageConfig(BaseUsageConfig, StatefulUsageConfigMixin):
 
 
 class RedshiftConfig(
+    SqlParsingParallelismConfig,
     BasicSQLAlchemyConfig,
     DatasetLineageProviderConfigBase,
     S3DatasetLineageProviderConfigBase,

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/lineage.py
@@ -164,6 +164,8 @@ class RedshiftSqlLineage(Closeable):
             graph=self.context.graph,
             is_temp_table=self._is_temp_table,
             is_allowed_table=self._is_allowed_table,
+            use_parallel_sql_parsing=self.config.use_parallel_sql_parsing,
+            sql_parsing_workers=self.config.sql_parsing_workers,
         )
         self.report.sql_aggregator = self.aggregator.report
 
@@ -702,7 +704,10 @@ class RedshiftSqlLineage(Closeable):
                                 )
                             )
                         rows = cursor.fetchmany()
-                with self.report.usage_parsing_timer:
+                with (
+                    self.report.usage_parsing_timer,
+                    self.aggregator.parallel_sql_parsing_scope(),
+                ):
                     for observed_query in observed:
                         self.aggregator.add_observed_query(observed_query)
         except Exception as e:

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/lineage.py
@@ -151,6 +151,10 @@ class RedshiftSqlLineage(Closeable):
         # required for per-query usage stats (and for column-level dataset usage).
         self.run_unified_queries = self.generate_usage or self.generate_query_usage
         lineage_enabled = self.config.lineage_enabled
+        # Schema resolution is lazy via the DataHub graph (no pre-populated resolver).
+        # Under parallel mode, worker processes each hydrate schemas independently
+        # from the graph on demand. Without a configured graph, schema resolution
+        # is skipped entirely — identical behaviour to serial mode.
         self.aggregator = SqlParsingAggregator(
             platform=self.platform,
             platform_instance=self.config.platform_instance,

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/usage.py
@@ -249,7 +249,10 @@ class RedshiftUsageExtractor:
                             ):
                                 access_events.append(event)
 
-                        with self.report.usage_parsing_timer:
+                        with (
+                            self.report.usage_parsing_timer,
+                            aggregator.parallel_sql_parsing_scope(),
+                        ):
                             for event in access_events:
                                 aggregator.add_preparsed_query(
                                     self._access_event_to_preparsed_query(event)
@@ -466,6 +469,8 @@ class RedshiftUsageExtractor:
             usage_config=self.config,
             format_queries=False,
             is_allowed_table=self._is_allowed_table,
+            use_parallel_sql_parsing=self.config.use_parallel_sql_parsing,
+            sql_parsing_workers=self.config.sql_parsing_workers,
         )
 
     def _is_allowed_table(self, name: str) -> bool:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_queries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_queries.py
@@ -65,6 +65,7 @@ from datahub.sql_parsing.sql_parsing_aggregator import (
     PreparsedQuery,
     SqlAggregatorReport,
     SqlParsingAggregator,
+    SqlParsingParallelismConfig,
     TableRename,
     TableSwap,
     UrnStr,
@@ -126,7 +127,7 @@ UserEmail = str
 UsersMapping = Dict[UserName, UserEmail]
 
 
-class SnowflakeQueriesExtractorConfig(ConfigModel):
+class SnowflakeQueriesExtractorConfig(SqlParsingParallelismConfig, ConfigModel):
     # TODO: Support stateful ingestion for the time windows.
     window: BaseTimeWindowConfig = BaseTimeWindowConfig()
 
@@ -282,6 +283,8 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
                 is_temp_table=self.is_temp_table,
                 is_allowed_table=self.is_allowed_table,
                 format_queries=False,
+                use_parallel_sql_parsing=self.config.use_parallel_sql_parsing,
+                sql_parsing_workers=self.config.sql_parsing_workers,
             )
         )
         self.report.sql_aggregator = self.aggregator.report
@@ -421,7 +424,10 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
         )
         self.report.stored_proc_lineage = stored_proc_tracker.report
 
-        with self.report.audit_log_load_timer:
+        with (
+            self.report.audit_log_load_timer,
+            self.aggregator.parallel_sql_parsing_scope(),
+        ):
             for i, query in enumerate(queries):
                 if i % 1000 == 0:
                     logger.info(f"Added {i} query log entries to SQL aggregator")

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -41,6 +41,7 @@ from datahub.ingestion.source_config.operation_config import (
     OperationConfig,
     is_profiling_enabled,
 )
+from datahub.sql_parsing.sql_parsing_aggregator import SqlParsingParallelismConfig
 from datahub.utilities.global_warning_util import add_global_warning
 
 logger = logging.getLogger(__name__)
@@ -157,6 +158,7 @@ class UnityCatalogSQLAlchemyProfilerConfig(
 
 
 class UnityCatalogSourceConfig(
+    SqlParsingParallelismConfig,
     UnityCatalogConnectionConfig,
     SQLCommonConfig,
     StatefulIngestionConfigBase,

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
@@ -94,6 +94,8 @@ class UnityCatalogUsageExtractor:
             usage_config=self.config,
             format_queries=False,
             is_allowed_table=is_allowed_table,
+            use_parallel_sql_parsing=self.config.use_parallel_sql_parsing,
+            sql_parsing_workers=self.config.sql_parsing_workers,
         )
 
     def _audit_log_filename(self) -> str:
@@ -667,7 +669,10 @@ class UnityCatalogUsageExtractor:
                 # current-bucket zero, does not delete history.)
                 self._report_no_queries()
 
-            with self.report.usage_parsing_timer:
+            with (
+                self.report.usage_parsing_timer,
+                aggregator.parallel_sql_parsing_scope(),
+            ):
                 self._parse_buffered_queries(aggregator, buffered_queries, default_db)
             self._log_usage_routing_summary()
             self._report_usage_lineage_warnings()

--- a/metadata-ingestion/src/datahub/sql_parsing/parallel_sql_parser.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/parallel_sql_parser.py
@@ -67,20 +67,33 @@ def _worker_init(
     graph_config: Optional[DatahubClientConfig],
 ) -> None:
     global _WORKER_RESOLVER
-    resolver = SchemaResolver.load_readonly(
-        snapshot_path,
-        platform=platform,
-        platform_instance=platform_instance,
-        env=env,
-    )
     if graph_config is not None:
         # Rebuild a live graph client inside the worker from the picklable config
         # so cache-miss lazy hydration works in-worker exactly like the serial
         # path. The live DataHubGraph object itself is not safely picklable, so it
         # is constructed here rather than passed across the process boundary.
+        #
+        # Use for_worker: a two-tier resolver reads the bulk of schemas from the
+        # shared read-only snapshot but keeps graph-hydrated results (and None-miss
+        # dedup) in a small writable overlay. load_readonly's cache is read-only,
+        # so its writes are no-ops and graph-hydrated lineage would be lost.
         from datahub.ingestion.graph.client import DataHubGraph
 
-        resolver.graph = DataHubGraph(graph_config)
+        resolver = SchemaResolver.for_worker(
+            snapshot_path,
+            platform=platform,
+            platform_instance=platform_instance,
+            env=env,
+            graph=DataHubGraph(graph_config),
+        )
+    else:
+        # No graph → no hydration, no writes: the lowest-memory read-only path.
+        resolver = SchemaResolver.load_readonly(
+            snapshot_path,
+            platform=platform,
+            platform_instance=platform_instance,
+            env=env,
+        )
     _WORKER_RESOLVER = resolver
 
 

--- a/metadata-ingestion/src/datahub/sql_parsing/parallel_sql_parser.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/parallel_sql_parser.py
@@ -219,6 +219,22 @@ class ParallelSqlParser(Closeable):
         for future in concurrent.futures.as_completed(pending):
             yield drain(future)
 
+    def parse_one(self, task: ParseTask) -> ParseOutcome:
+        """Parse a single task in a worker process and block until its outcome.
+
+        Unlike :meth:`map_unordered`, this submits exactly one task and waits for
+        it, so the caller can drive its own per-task ordering (e.g. a
+        PartitionExecutor) rather than relying on the unordered stream. A dead
+        worker process is surfaced as a :class:`ParseOutcome` with ``error`` set,
+        mirroring the drain behavior of :meth:`map_unordered`.
+        """
+        executor = self._ensure_executor()
+        future = executor.submit(_worker_parse, task)
+        try:
+            return future.result()
+        except Exception as e:
+            return ParseOutcome(key=task.key, result=None, error=repr(e))
+
     def close(self) -> None:
         if self._closed:
             return

--- a/metadata-ingestion/src/datahub/sql_parsing/parallel_sql_parser.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/parallel_sql_parser.py
@@ -1,0 +1,215 @@
+import concurrent.futures
+import multiprocessing
+import pathlib
+from concurrent.futures import Future, ProcessPoolExecutor
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Iterator, Optional, Set
+
+from datahub.emitter.mce_builder import DEFAULT_ENV
+from datahub.ingestion.api.closeable import Closeable
+from datahub.ingestion.graph.config import DatahubClientConfig
+from datahub.sql_parsing.schema_resolver import (
+    SchemaResolver,
+    SchemaResolverInterface,
+)
+from datahub.sql_parsing.sqlglot_lineage import SqlParsingResult, sqlglot_lineage
+
+
+class ParallelParserUnavailable(Exception):
+    """Raised when the parallel parser process pool cannot be created.
+
+    The caller is expected to catch this and fall back to serial parsing.
+    """
+
+
+@dataclass
+class ParseTask:
+    """A single query to parse. ``key`` is an opaque correlation id the caller
+    uses to match the resulting :class:`ParseOutcome` back to its source, since
+    results are returned out of order."""
+
+    key: Any
+    query: str
+    default_db: Optional[str]
+    default_schema: Optional[str]
+    override_dialect: Optional[str] = None
+    generate_column_lineage: bool = True
+
+
+@dataclass
+class ParseOutcome:
+    """The result of parsing a single :class:`ParseTask`.
+
+    Exactly one of ``result`` / ``error`` is meaningful: a populated ``result``
+    (even one whose ``debug_info`` records a normal parse failure) means the
+    worker ran to completion; ``error`` is set only when the worker itself raised
+    (or its process died) so the caller can decide how to handle it."""
+
+    key: Any
+    result: Optional[SqlParsingResult]
+    error: Optional[str]
+
+
+# ---------------------------------------------------------------------------
+# Worker side. These are module-level so the spawn start method can pickle them.
+# ---------------------------------------------------------------------------
+
+# Populated once per worker process by _worker_init, then reused for every task
+# that worker handles. Process-local, so no cross-process sharing concerns.
+_WORKER_RESOLVER: Optional[SchemaResolverInterface] = None
+
+
+def _worker_init(
+    snapshot_path: pathlib.Path,
+    platform: str,
+    platform_instance: Optional[str],
+    env: str,
+    graph_config: Optional[DatahubClientConfig],
+) -> None:
+    global _WORKER_RESOLVER
+    resolver = SchemaResolver.load_readonly(
+        snapshot_path,
+        platform=platform,
+        platform_instance=platform_instance,
+        env=env,
+    )
+    if graph_config is not None:
+        # Rebuild a live graph client inside the worker from the picklable config
+        # so cache-miss lazy hydration works in-worker exactly like the serial
+        # path. The live DataHubGraph object itself is not safely picklable, so it
+        # is constructed here rather than passed across the process boundary.
+        from datahub.ingestion.graph.client import DataHubGraph
+
+        resolver.graph = DataHubGraph(graph_config)
+    _WORKER_RESOLVER = resolver
+
+
+def _worker_parse(task: ParseTask) -> ParseOutcome:
+    assert _WORKER_RESOLVER is not None, "worker resolver not initialized"
+    try:
+        result = sqlglot_lineage(
+            task.query,
+            schema_resolver=_WORKER_RESOLVER,
+            default_db=task.default_db,
+            default_schema=task.default_schema,
+            override_dialect=task.override_dialect,
+            generate_column_lineage=task.generate_column_lineage,
+        )
+        # Normal parse failures are already captured inside result.debug_info,
+        # so they are returned as a result, not an error.
+        return ParseOutcome(key=task.key, result=result, error=None)
+    except Exception as e:
+        # A worker-side exception becomes an error outcome rather than killing
+        # the pool.
+        return ParseOutcome(key=task.key, result=None, error=repr(e))
+
+
+# ---------------------------------------------------------------------------
+# Parent side.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ParallelSqlParser(Closeable):
+    """Parses SQL across worker processes to sidestep the GIL for pure-Python
+    sqlglot work.
+
+    The pool is created lazily on first use. Each worker opens the schema
+    snapshot read-only (and, if ``graph_config`` is provided, rebuilds a live
+    graph client for cache-miss hydration). Results are yielded unordered; the
+    caller correlates them via :attr:`ParseTask.key`.
+    """
+
+    num_workers: int
+    snapshot_path: pathlib.Path
+    platform: str
+    platform_instance: Optional[str]
+    env: str = DEFAULT_ENV
+    graph_config: Optional[DatahubClientConfig] = None
+    max_pending: Optional[int] = None
+
+    _executor: Optional[ProcessPoolExecutor] = field(
+        default=None, init=False, repr=False
+    )
+    _closed: bool = field(default=False, init=False, repr=False)
+
+    def _ensure_executor(self) -> ProcessPoolExecutor:
+        if self._executor is not None:
+            return self._executor
+        try:
+            # Spawn avoids inheriting the parent's threading.Lock / SQLite fds;
+            # fork-with-threads can deadlock. (macOS already defaults to spawn.)
+            mp_context = multiprocessing.get_context("spawn")
+            self._executor = ProcessPoolExecutor(
+                max_workers=self.num_workers,
+                mp_context=mp_context,
+                initializer=_worker_init,
+                initargs=(
+                    self.snapshot_path,
+                    self.platform,
+                    self.platform_instance,
+                    self.env,
+                    self.graph_config,
+                ),
+            )
+        except Exception as e:
+            raise ParallelParserUnavailable(
+                f"Failed to create parallel SQL parser process pool: {e!r}"
+            ) from e
+        return self._executor
+
+    def map_unordered(self, tasks: Iterable[ParseTask]) -> Iterator[ParseOutcome]:
+        """Parse each task in a worker process, yielding outcomes as they complete
+        (unordered). Pending futures are bounded (default ``2*num_workers``) so we
+        don't accumulate results in memory faster than the caller consumes them.
+
+        The bounded drain mirrors
+        :class:`datahub.utilities.backpressure_aware_executor.BackpressureAwareExecutor`.
+        It is inlined here (rather than reusing that helper) because we must map
+        each future back to its task ``key`` to synthesize a
+        ``ParseOutcome(error=...)`` if a worker process dies at the executor layer
+        — information the helper's future-only return type does not expose.
+        """
+        executor = self._ensure_executor()
+
+        max_pending = self.max_pending
+        if max_pending is None:
+            max_pending = 2 * self.num_workers
+        assert max_pending >= self.num_workers
+
+        future_to_key: Dict[Future, Any] = {}
+        pending: Set[Future] = set()
+
+        def drain(future: Future) -> ParseOutcome:
+            key = future_to_key.pop(future)
+            try:
+                return future.result()
+            except Exception as e:
+                # Executor-layer failure (e.g. the worker process died before it
+                # could return a ParseOutcome). Surface it as an error outcome
+                # instead of propagating.
+                return ParseOutcome(key=key, result=None, error=repr(e))
+
+        for task in tasks:
+            if len(pending) >= max_pending:
+                done, _ = concurrent.futures.wait(
+                    pending, return_when=concurrent.futures.FIRST_COMPLETED
+                )
+                for future in done:
+                    pending.remove(future)
+                    yield drain(future)
+
+            submitted = executor.submit(_worker_parse, task)
+            future_to_key[submitted] = task.key
+            pending.add(submitted)
+
+        for future in concurrent.futures.as_completed(pending):
+            yield drain(future)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._executor is not None:
+            self._executor.shutdown(wait=True)
+            self._executor = None

--- a/metadata-ingestion/src/datahub/sql_parsing/parallel_sql_parser.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/parallel_sql_parser.py
@@ -127,10 +127,13 @@ class ParallelSqlParser(Closeable):
     """Parses SQL across worker processes to sidestep the GIL for pure-Python
     sqlglot work.
 
-    The pool is created lazily on first use. Each worker opens the schema
-    snapshot read-only (and, if ``graph_config`` is provided, rebuilds a live
-    graph client for cache-miss hydration). Results are yielded unordered; the
-    caller correlates them via :attr:`ParseTask.key`.
+    The pool is created eagerly at construction so that a
+    :class:`ParallelParserUnavailable` failure is raised deterministically here
+    (where the caller already handles it) rather than on a racing first parse
+    from a worker thread. Each worker opens the schema snapshot read-only (and,
+    if ``graph_config`` is provided, rebuilds a live graph client for cache-miss
+    hydration). Results are yielded unordered; the caller correlates them via
+    :attr:`ParseTask.key`.
     """
 
     num_workers: int
@@ -146,9 +149,7 @@ class ParallelSqlParser(Closeable):
     )
     _closed: bool = field(default=False, init=False, repr=False)
 
-    def _ensure_executor(self) -> ProcessPoolExecutor:
-        if self._executor is not None:
-            return self._executor
+    def __post_init__(self) -> None:
         try:
             # Spawn avoids inheriting the parent's threading.Lock / SQLite fds;
             # fork-with-threads can deadlock. (macOS already defaults to spawn.)
@@ -169,6 +170,14 @@ class ParallelSqlParser(Closeable):
             raise ParallelParserUnavailable(
                 f"Failed to create parallel SQL parser process pool: {e!r}"
             ) from e
+
+    def _ensure_executor(self) -> ProcessPoolExecutor:
+        # The pool is created eagerly in __post_init__; a None executor here means
+        # the parser was already closed, which is a caller bug on the parse path.
+        if self._executor is None:
+            raise ParallelParserUnavailable(
+                "Parallel SQL parser process pool is not available (parser was closed)."
+            )
         return self._executor
 
     def map_unordered(self, tasks: Iterable[ParseTask]) -> Iterator[ParseOutcome]:

--- a/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
@@ -334,6 +334,11 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
         )
 
     def _save_to_cache(self, urn: str, schema_info: Optional[SchemaInfo]) -> None:
+        # Read-only resolvers have no graph and no persistent store to update;
+        # writing to the in-memory cache would only dirty it and trigger a write
+        # attempt (→ sqlite3.OperationalError) when the cache is flushed at close.
+        if self._schema_cache._conn.read_only:
+            return
         self._schema_cache[urn] = schema_info
 
     def _fetch_schema_info(
@@ -364,9 +369,13 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
 
         The resulting file is a self-contained SQLite database that worker processes
         can open read-only with ``immutable=1``, avoiding all locking overhead.
+
+        The source connection must be quiescent (no concurrent writers) when this is
+        called: we flush with ``synchronous=OFF`` so the OS page cache may not have
+        been synced to disk; copying mid-write could produce a corrupt snapshot.
         """
         self._schema_cache.flush()
-        shutil.copyfile(self._schema_cache._conn.filename, path)
+        shutil.copyfile(self._schema_cache.filename, path)
 
     @classmethod
     def load_readonly(

--- a/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
@@ -2,6 +2,7 @@ import contextlib
 import json
 import logging
 import pathlib
+import shutil
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Set, Tuple
 
@@ -357,6 +358,46 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
             # TODO: We can't generate lineage to columns nested within structs yet.
             if "." not in get_simple_field_path_from_v2_field_path(field["fieldPath"])
         }
+
+    def snapshot_to(self, path: pathlib.Path) -> None:
+        """Flush all in-memory cache entries to SQLite then copy the DB file to *path*.
+
+        The resulting file is a self-contained SQLite database that worker processes
+        can open read-only with ``immutable=1``, avoiding all locking overhead.
+        """
+        self._schema_cache.flush()
+        shutil.copyfile(self._schema_cache._conn.filename, path)
+
+    @classmethod
+    def load_readonly(
+        cls,
+        path: pathlib.Path,
+        *,
+        platform: str,
+        platform_instance: Optional[str] = None,
+        env: str = DEFAULT_ENV,
+    ) -> "SchemaResolver":
+        """Open a snapshot created by :meth:`snapshot_to` as a read-only resolver.
+
+        The returned resolver has ``graph=None`` so it never makes network calls.
+        Multiple processes may open the same snapshot file simultaneously via
+        ``immutable=1``, which bypasses SQLite locking entirely and allows the OS
+        to share the page cache across processes.
+        """
+        ro_conn = ConnectionWrapper(filename=path, read_only=True)
+        resolver = cls.__new__(cls)
+        # Bypass __init__ — we wire the components manually so we can inject the
+        # read-only connection without triggering the normal writable-setup path.
+        resolver._platform = DataPlatformUrn(platform).platform_name
+        resolver.platform_instance = platform_instance
+        resolver.env = env
+        resolver.graph = None
+        resolver.report = None
+        resolver._schema_cache = FileBackedDict(
+            shared_connection=ro_conn,
+            extra_columns={"is_missing": lambda v: v is None},
+        )
+        return resolver
 
     def close(self) -> None:
         self._schema_cache.close()

--- a/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
@@ -81,6 +81,12 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
         self.graph = graph
         self.report = report
 
+        # Optional read-only fallback cache consulted on a primary-cache miss.
+        # Used by worker resolvers (see for_worker) to read the bulk of schemas
+        # from a shared read-only snapshot while keeping graph-hydrated results and
+        # None-miss dedup in the writable primary cache. None → single-tier behavior.
+        self._readonly_fallback: Optional[FileBackedDict[Optional[SchemaInfo]]] = None
+
         # Init cache, potentially restoring from a previous run.
         shared_conn = None
         if _cache_filename:
@@ -175,15 +181,15 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
             urns_to_try.append(urn_mixed)
 
         for candidate_urn in urns_to_try:
-            if candidate_urn in self._schema_cache:
-                schema_info = self._schema_cache[candidate_urn]
+            if self._cache_contains(candidate_urn):
+                schema_info = self._cache_get(candidate_urn)
                 if schema_info is not None:
                     self._track_cache_hit()
                     return candidate_urn, schema_info
 
         if self.graph:
             # Skip URNs already in cache (None entries included) to avoid repeated API calls.
-            urns_to_fetch = [u for u in urns_to_try if u not in self._schema_cache]
+            urns_to_fetch = [u for u in urns_to_try if not self._cache_contains(u)]
 
             if urns_to_fetch:
                 try:
@@ -228,7 +234,7 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
                         self._save_to_cache(fetch_urn, None)
 
             for candidate_urn in urns_to_try:
-                schema_info = self._schema_cache.get(candidate_urn)
+                schema_info = self._cache_get(candidate_urn)
                 if schema_info is not None:
                     self._track_cache_hit()
                     return candidate_urn, schema_info
@@ -262,7 +268,7 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
         return self.platform not in PLATFORMS_WITH_CASE_SENSITIVE_TABLES
 
     def has_urn(self, urn: str) -> bool:
-        return self._schema_cache.get(urn) is not None
+        return self._cache_get(urn) is not None
 
     def _track_cache_hit(self) -> None:
         """Track a cache hit if reporting is enabled."""
@@ -274,9 +280,32 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
         if self.report is not None:
             self.report.num_schema_cache_misses += 1
 
-    def _resolve_schema_info(self, urn: str) -> Optional[SchemaInfo]:
+    def _cache_contains(self, urn: str) -> bool:
+        """Whether *urn* has an entry (including a cached None) in either tier.
+
+        Reads consult the writable primary cache first, then the optional
+        read-only fallback snapshot. Writes only ever touch the primary cache.
+        """
+        if urn in self._schema_cache:
+            return True
+        if self._readonly_fallback is not None and urn in self._readonly_fallback:
+            return True
+        return False
+
+    def _cache_get(self, urn: str) -> Optional[SchemaInfo]:
+        """Read *urn*'s schema from the primary cache, falling back to the
+        read-only snapshot. Returns None if absent or cached as a miss — callers
+        that must distinguish absence from a cached miss should use
+        :meth:`_cache_contains`."""
         if urn in self._schema_cache:
             return self._schema_cache[urn]
+        if self._readonly_fallback is not None and urn in self._readonly_fallback:
+            return self._readonly_fallback[urn]
+        return None
+
+    def _resolve_schema_info(self, urn: str) -> Optional[SchemaInfo]:
+        if self._cache_contains(urn):
+            return self._cache_get(urn)
 
         # TODO: For bigquery partitioned tables, add the pseudo-column _PARTITIONTIME
         # or _PARTITIONDATE where appropriate.
@@ -402,13 +431,57 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
         resolver.env = env
         resolver.graph = None
         resolver.report = None
+        resolver._readonly_fallback = None
         resolver._schema_cache = FileBackedDict(
             shared_connection=ro_conn,
             extra_columns={"is_missing": lambda v: v is None},
         )
         return resolver
 
+    @classmethod
+    def for_worker(
+        cls,
+        snapshot_path: pathlib.Path,
+        *,
+        platform: str,
+        platform_instance: Optional[str] = None,
+        env: str = DEFAULT_ENV,
+        graph: Optional["DataHubGraph"] = None,
+    ) -> "SchemaResolver":
+        """Build a two-tier resolver for a parallel-parsing worker process.
+
+        The bulk of schemas are read from the shared read-only *snapshot_path*
+        (opened ``immutable=1`` so the OS page cache is shared across workers,
+        keeping memory low). A small **writable** in-memory primary cache sits in
+        front of it to hold graph-hydrated results and None-miss dedup, so a
+        worker with a ``graph`` attached does not silently drop lineage — unlike
+        :meth:`load_readonly`, whose cache is read-only and cannot absorb fetches.
+
+        Use :meth:`load_readonly` instead when there is no graph: it avoids the
+        extra writable cache entirely (lowest memory, no writes).
+        """
+        ro_conn = ConnectionWrapper(filename=snapshot_path, read_only=True)
+        resolver = cls.__new__(cls)
+        # Bypass __init__ so we can wire a writable primary cache in front of a
+        # read-only fallback; mirror every attribute the writable __init__ sets.
+        resolver._platform = DataPlatformUrn(platform).platform_name
+        resolver.platform_instance = platform_instance
+        resolver.env = env
+        resolver.graph = graph
+        resolver.report = None
+        resolver._readonly_fallback = FileBackedDict(
+            shared_connection=ro_conn,
+            extra_columns={"is_missing": lambda v: v is None},
+        )
+        # Fresh writable in-memory cache (temp file) so _save_to_cache works.
+        resolver._schema_cache = FileBackedDict(
+            extra_columns={"is_missing": lambda v: v is None},
+        )
+        return resolver
+
     def close(self) -> None:
+        if self._readonly_fallback is not None:
+            self._readonly_fallback.close()
         self._schema_cache.close()
 
 

--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
@@ -10,7 +10,18 @@ import threading
 import uuid
 from collections import defaultdict
 from datetime import datetime, timezone
-from typing import Callable, Dict, Iterable, Iterator, List, Optional, Set, Union, cast
+from typing import (
+    Callable,
+    ContextManager,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Union,
+    cast,
+)
 
 import datahub.emitter.mce_builder as builder
 import datahub.metadata.schema_classes as models
@@ -639,6 +650,20 @@ class SqlParsingAggregator(Closeable):
         # runs concurrently on worker processes.
         self._apply_lock = threading.Lock()
 
+    def _maybe_apply_lock(self) -> ContextManager[object]:
+        """Return the apply-lock when parallel parsing is active, else a no-op.
+
+        On the parallel path every side effect on shared aggregator state
+        (report counters, the query log, shared ``PerfTimer``s) must be
+        serialized because tasks run on concurrent PartitionExecutor threads.
+        On the serial path there is only one thread, so acquiring a lock would
+        be pure overhead and could subtly change behavior — return a
+        ``nullcontext`` so the serial path is byte-for-byte unchanged.
+        """
+        if self._parallel_active:
+            return self._apply_lock
+        return contextlib.nullcontext()
+
     @contextlib.contextmanager
     def parallel_sql_parsing_scope(self) -> Iterator[None]:
         """Explicit query-processing boundary for parallel SQL parsing.
@@ -1180,12 +1205,16 @@ class SqlParsingAggregator(Closeable):
                     )
                 )
                 if outcome.error is not None or outcome.result is None:
-                    self.report.num_observed_queries_failed += 1
-                    self.report.observed_query_parse_failures.append(
-                        f"{outcome.error} on query: {observed.query[:100]}"
-                    )
+                    # Failure bookkeeping mutates shared report state (counter +
+                    # LossyList) from a worker thread, so serialize it.
+                    with self._apply_lock:
+                        self.report.num_observed_queries_failed += 1
+                        self.report.observed_query_parse_failures.append(
+                            f"{outcome.error} on query: {observed.query[:100]}"
+                        )
                     return
                 parsed = outcome.result
+                # _account_parsed_query takes the apply-lock internally.
                 self._account_parsed_query(
                     observed.query,
                     default_db=observed.default_db,
@@ -1195,18 +1224,25 @@ class SqlParsingAggregator(Closeable):
                     user=observed.user,
                     parsed=parsed,
                 )
+                with self._apply_lock:
+                    self.report.num_queries_parsed_in_parallel += 1
 
-            if parsed.debug_info.error:
-                self.report.observed_query_parse_failures.append(
-                    f"{parsed.debug_info.error} on query: {observed.query[:100]}"
-                )
-            if parsed.debug_info.table_error:
-                self.report.num_observed_queries_failed += 1
-                return
-            elif parsed.debug_info.column_error:
-                self.report.num_observed_queries_column_failed += 1
-                if isinstance(parsed.debug_info.column_error, CooperativeTimeoutError):
-                    self.report.num_observed_queries_column_timeout += 1
+            # Recording parse-quality counters mutates shared report state
+            # (counters + LossyList) from a worker thread, so serialize it.
+            with self._apply_lock:
+                if parsed.debug_info.error:
+                    self.report.observed_query_parse_failures.append(
+                        f"{parsed.debug_info.error} on query: {observed.query[:100]}"
+                    )
+                if parsed.debug_info.table_error:
+                    self.report.num_observed_queries_failed += 1
+                    return
+                elif parsed.debug_info.column_error:
+                    self.report.num_observed_queries_column_failed += 1
+                    if isinstance(
+                        parsed.debug_info.column_error, CooperativeTimeoutError
+                    ):
+                        self.report.num_observed_queries_column_timeout += 1
 
             with self._apply_lock:
                 self._apply_observed_parse_result(
@@ -1218,10 +1254,13 @@ class SqlParsingAggregator(Closeable):
                     require_out_table_schema,
                 )
         except Exception as e:
-            self.report.num_observed_queries_failed += 1
-            self.report.observed_query_parse_failures.append(
-                f"{e!r} on query: {observed.query[:100]}"
-            )
+            # Serialize the failure bookkeeping — this runs on a worker thread and
+            # mutates shared report state (counter + LossyList).
+            with self._apply_lock:
+                self.report.num_observed_queries_failed += 1
+                self.report.observed_query_parse_failures.append(
+                    f"{e!r} on query: {observed.query[:100]}"
+                )
             logger.debug("Parallel observed-query task failed", exc_info=e)
 
     def _account_parsed_query(
@@ -1238,25 +1277,32 @@ class SqlParsingAggregator(Closeable):
         """Update the same report counters / query log that ``_run_sql_parser``
         would, for a result produced by a worker process (which cannot mutate the
         parent's report or query log). Keeps parallel and serial book-keeping
-        identical. Callers hold no lock; ``num_sql_parsed`` is a plain int under
-        the GIL and the query log append is thread-safe."""
-        self.report.num_sql_parsed += 1
+        identical.
 
-        if self.query_log == QueryLogSetting.STORE_ALL or (
-            self.query_log == QueryLogSetting.STORE_FAILED and parsed.debug_info.error
-        ):
-            self._logged_queries.append(
-                LoggedQuery(
-                    query=query,
-                    session_id=(
-                        session_id if session_id != _MISSING_SESSION_ID else None
-                    ),
-                    timestamp=timestamp,
-                    user=user.urn() if user else None,
-                    default_db=default_db,
-                    default_schema=default_schema,
+        Runs on a PartitionExecutor thread on the parallel path, so both the
+        ``num_sql_parsed`` increment and the ``_logged_queries.append`` (neither
+        of which is thread-safe: the increment is a non-atomic read-modify-write
+        and ``FileBackedList.append`` mutates a shared length/cache and may write
+        to SQLite) are serialized under the apply-lock."""
+        with self._maybe_apply_lock():
+            self.report.num_sql_parsed += 1
+
+            if self.query_log == QueryLogSetting.STORE_ALL or (
+                self.query_log == QueryLogSetting.STORE_FAILED
+                and parsed.debug_info.error
+            ):
+                self._logged_queries.append(
+                    LoggedQuery(
+                        query=query,
+                        session_id=(
+                            session_id if session_id != _MISSING_SESSION_ID else None
+                        ),
+                        timestamp=timestamp,
+                        user=user.urn() if user else None,
+                        default_db=default_db,
+                        default_schema=default_schema,
+                    )
                 )
-            )
 
     def add_preparsed_query(
         self,
@@ -1618,29 +1664,40 @@ class SqlParsingAggregator(Closeable):
         user: Optional[Union[CorpUserUrn, CorpGroupUrn]] = None,
         override_dialect: Optional[DialectOrStr] = None,
     ) -> SqlParsingResult:
-        with self.report.sql_parsing_timer:
-            parsed = sqlglot_lineage(
-                query,
-                schema_resolver=schema_resolver,
-                default_db=default_db,
-                default_schema=default_schema,
-                override_dialect=override_dialect,
-            )
-        self.report.num_sql_parsed += 1
+        # On the parallel path this runs on a PartitionExecutor thread (the
+        # temp-session inline-parse case). The shared ``sql_parsing_timer`` is a
+        # non-reentrant ``PerfTimer`` and ``_logged_queries.append`` /
+        # ``num_sql_parsed`` are not thread-safe, so serialize the whole body
+        # under the apply-lock. Temp sessions are the minority and are inherently
+        # serial per session, so this adds no meaningful contention. On the serial
+        # path ``_maybe_apply_lock`` is a nullcontext, leaving behavior unchanged.
+        with self._maybe_apply_lock():
+            with self.report.sql_parsing_timer:
+                parsed = sqlglot_lineage(
+                    query,
+                    schema_resolver=schema_resolver,
+                    default_db=default_db,
+                    default_schema=default_schema,
+                    override_dialect=override_dialect,
+                )
+            self.report.num_sql_parsed += 1
 
-        # Conditionally log the query.
-        if self.query_log == QueryLogSetting.STORE_ALL or (
-            self.query_log == QueryLogSetting.STORE_FAILED and parsed.debug_info.error
-        ):
-            query_log_entry = LoggedQuery(
-                query=query,
-                session_id=session_id if session_id != _MISSING_SESSION_ID else None,
-                timestamp=timestamp,
-                user=user.urn() if user else None,
-                default_db=default_db,
-                default_schema=default_schema,
-            )
-            self._logged_queries.append(query_log_entry)
+            # Conditionally log the query.
+            if self.query_log == QueryLogSetting.STORE_ALL or (
+                self.query_log == QueryLogSetting.STORE_FAILED
+                and parsed.debug_info.error
+            ):
+                query_log_entry = LoggedQuery(
+                    query=query,
+                    session_id=(
+                        session_id if session_id != _MISSING_SESSION_ID else None
+                    ),
+                    timestamp=timestamp,
+                    user=user.urn() if user else None,
+                    default_db=default_db,
+                    default_schema=default_schema,
+                )
+                self._logged_queries.append(query_log_entry)
 
         # Also add some extra logging.
         if parsed.debug_info.error:

--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
@@ -23,8 +23,11 @@ from typing import (
     cast,
 )
 
+from pydantic import Field
+
 import datahub.emitter.mce_builder as builder
 import datahub.metadata.schema_classes as models
+from datahub.configuration import ConfigModel
 from datahub.configuration.env_vars import (
     get_report_info_sample_size,
     get_sql_agg_query_log,
@@ -113,6 +116,31 @@ _DEFAULT_QUERY_LOG_SETTING = QueryLogSetting[
 ]
 MAX_UPSTREAM_TABLES_COUNT = 300
 MAX_FINEGRAINEDLINEAGE_COUNT = 2000
+
+
+class SqlParsingParallelismConfig(ConfigModel):
+    """Mixin that adds parallel SQL-parsing fields to any connector config.
+
+    Inherit from (or embed in) a connector's config class to expose these two
+    fields to users.  Pass them straight through to ``SqlParsingAggregator``.
+    """
+
+    use_parallel_sql_parsing: bool = Field(
+        default=False,
+        description=(
+            "Parse SQL queries across multiple processes to speed up lineage/usage "
+            "extraction. Off by default. Worker count is auto-detected "
+            "(cgroup/CPU-aware) and clamped to available cores."
+        ),
+    )
+    sql_parsing_workers: Optional[int] = Field(
+        default=None,
+        description=(
+            "Explicit number of worker processes for parallel SQL parsing. "
+            "Defaults to an auto-detected safe value; values above detected "
+            "capacity are clamped down with a warning."
+        ),
+    )
 
 
 @dataclasses.dataclass

--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
@@ -6,10 +6,11 @@ import json
 import logging
 import pathlib
 import tempfile
+import threading
 import uuid
 from collections import defaultdict
 from datetime import datetime, timezone
-from typing import Callable, Dict, Iterable, List, Optional, Set, Union, cast
+from typing import Callable, Dict, Iterable, Iterator, List, Optional, Set, Union, cast
 
 import datahub.emitter.mce_builder as builder
 import datahub.metadata.schema_classes as models
@@ -36,6 +37,11 @@ from datahub.metadata.urns import (
     Urn,
 )
 from datahub.sql_parsing.fingerprint_utils import generate_hash
+from datahub.sql_parsing.parallel_sql_parser import (
+    ParallelParserUnavailable,
+    ParallelSqlParser,
+    ParseTask,
+)
 from datahub.sql_parsing.schema_resolver import (
     SchemaResolver,
     SchemaResolverInterface,
@@ -65,6 +71,7 @@ from datahub.sql_parsing.tool_meta_extractor import (
     ToolMetaExtractorReport,
 )
 from datahub.utilities.cooperative_timeout import CooperativeTimeoutError
+from datahub.utilities.cpu_detection import WorkerDecision, resolve_worker_count
 from datahub.utilities.dedup_list import deduplicate_list
 from datahub.utilities.file_backed_collections import (
     ConnectionWrapper,
@@ -74,6 +81,7 @@ from datahub.utilities.file_backed_collections import (
 from datahub.utilities.groupby import groupby_unsorted
 from datahub.utilities.lossy_collections import LossyDict, LossyList
 from datahub.utilities.ordered_set import OrderedSet
+from datahub.utilities.partition_executor import PartitionExecutor
 from datahub.utilities.perf_timer import PerfTimer
 
 logger = logging.getLogger(__name__)
@@ -332,6 +340,14 @@ class SqlAggregatorReport(Report):
     parse_statement_cache_stats: Optional[dict] = dataclasses.field(default=None)
     format_query_cache_stats: Optional[dict] = dataclasses.field(default=None)
 
+    # Parallel SQL parsing (multiprocessing). Off unless use_parallel_sql_parsing.
+    sql_parsing_parallel_enabled: bool = False
+    sql_parsing_parallelism: Optional[int] = None
+    sql_parsing_cpu_detected: Optional[int] = None
+    sql_parsing_workers_clamped: bool = False
+    sql_parsing_fell_back_to_serial: bool = False
+    num_queries_parsed_in_parallel: int = 0
+
     # Other lineage loading metrics.
     num_known_query_lineage: int = 0
     num_preparsed_queries: int = 0
@@ -418,10 +434,13 @@ class SqlParsingAggregator(Closeable):
         is_allowed_table: Optional[Callable[[str], bool]] = None,
         format_queries: bool = True,
         query_log: QueryLogSetting = _DEFAULT_QUERY_LOG_SETTING,
+        use_parallel_sql_parsing: bool = False,
+        sql_parsing_workers: Optional[int] = None,
     ) -> None:
         self.platform = DataPlatformUrn(platform)
         self.platform_instance = platform_instance
         self.env = env
+        self._graph = graph
 
         self.generate_lineage = generate_lineage
         self.generate_queries = generate_queries
@@ -601,11 +620,121 @@ class SqlParsingAggregator(Closeable):
         self._tool_meta_extractor = ToolMetaExtractor.create(graph)
         self.report.tool_meta_report = self._tool_meta_extractor.report
 
+        # Parallel SQL parsing. The process pool and thread-based partition
+        # executor are NOT built here — they are created lazily on entering
+        # parallel_sql_parsing_scope(). When disabled (or when the CPU budget
+        # forces serial), everything runs inline exactly as before.
+        self._use_parallel_sql_parsing = use_parallel_sql_parsing
+        self._worker_decision: Optional[WorkerDecision] = None
+        if use_parallel_sql_parsing:
+            self._worker_decision = resolve_worker_count(sql_parsing_workers)
+            logger.info(
+                "Parallel SQL parsing requested: %s", self._worker_decision.reason
+            )
+        self._parallel_parser: Optional[ParallelSqlParser] = None
+        self._partition_executor: Optional[PartitionExecutor] = None
+        self._parallel_active: bool = False
+        # Serializes the cheap classify/apply steps that mutate shared aggregator
+        # state (temp maps, query map, lineage map) while cross-session parse work
+        # runs concurrently on worker processes.
+        self._apply_lock = threading.Lock()
+
+    @contextlib.contextmanager
+    def parallel_sql_parsing_scope(self) -> Iterator[None]:
+        """Explicit query-processing boundary for parallel SQL parsing.
+
+        Connectors wrap their query loop in ``with aggregator.parallel_sql_parsing_scope():``.
+        Schema extraction must happen BEFORE entering so the snapshot handed to the
+        workers is complete; anything still missing is graph-hydrated in-worker.
+
+        When the feature is off (or the CPU budget forced serial), this is a no-op
+        and every query runs inline exactly as it does today.
+        """
+        decision = self._worker_decision
+        if (
+            not self._use_parallel_sql_parsing
+            or decision is None
+            or decision.fell_back_to_serial
+        ):
+            if decision is not None:
+                self._populate_parallel_report(decision, active=False)
+            yield
+            return
+
+        snapshot_path = pathlib.Path(tempfile.mkdtemp()) / "schema_snapshot.db"
+        self._schema_resolver.snapshot_to(snapshot_path)
+
+        try:
+            self._parallel_parser = ParallelSqlParser(
+                num_workers=decision.workers,
+                snapshot_path=snapshot_path,
+                platform=self.platform.platform_name,
+                platform_instance=self.platform_instance,
+                env=self.env,
+                graph_config=(self._graph.config if self._graph else None),
+            )
+        except ParallelParserUnavailable as e:
+            logger.warning(
+                "Parallel SQL parser unavailable (%s); running scope serially.", e
+            )
+            snapshot_path.unlink(missing_ok=True)
+            self._populate_parallel_report(decision, active=False)
+            yield
+            return
+
+        # A few tasks per worker in flight bounds memory while keeping workers busy.
+        self._partition_executor = PartitionExecutor(
+            max_workers=decision.workers,
+            max_pending=4 * decision.workers,
+        )
+        self._parallel_active = True
+        self._populate_parallel_report(decision, active=True)
+
+        try:
+            yield
+        finally:
+            try:
+                if self._partition_executor is not None:
+                    self._partition_executor.flush()
+                    self._partition_executor.close()
+            finally:
+                self._partition_executor = None
+                if self._parallel_parser is not None:
+                    self._parallel_parser.close()
+                    self._parallel_parser = None
+                self._parallel_active = False
+                snapshot_path.unlink(missing_ok=True)
+
+    def _populate_parallel_report(
+        self, decision: WorkerDecision, *, active: bool
+    ) -> None:
+        self.report.sql_parsing_parallel_enabled = active
+        self.report.sql_parsing_parallelism = decision.workers if active else None
+        self.report.sql_parsing_cpu_detected = decision.detected_cpus
+        self.report.sql_parsing_workers_clamped = decision.clamped
+        self.report.sql_parsing_fell_back_to_serial = decision.fell_back_to_serial
+
     def close(self) -> None:
+        # Defensively tear down the parallel machinery in case a connector never
+        # exited the scope (or bypassed it). Never leak worker processes.
+        self._teardown_parallel()
+
         # Compute stats once before closing connections
         self.report.compute_stats()
         self._closed = True
         self._exit_stack.close()
+
+    def _teardown_parallel(self) -> None:
+        if self._partition_executor is not None:
+            try:
+                self._partition_executor.flush()
+                self._partition_executor.close()
+            finally:
+                self._partition_executor = None
+        if self._parallel_parser is not None:
+            self._parallel_parser.close()
+            self._parallel_parser = None
+        self._parallel_active = False
 
     @property
     def _need_schemas(self) -> bool:
@@ -693,14 +822,39 @@ class SqlParsingAggregator(Closeable):
         """
         This assumes that queries come in order of increasing timestamps.
         """
+        if isinstance(item, (ObservedQuery, PreparsedQuery)):
+            # These flow through the per-session partition executor when parallel
+            # parsing is active; the routing lives in their own add_* methods.
+            if isinstance(item, PreparsedQuery):
+                self.add_preparsed_query(item)
+            else:
+                self.add_observed_query(item)
+            return
+
+        # Rarer items (renames, swaps, known lineage) mutate shared state and are
+        # infrequent in the query loop. To keep them correct relative to the
+        # in-flight parallel applies, drain all pending work first, then process
+        # inline under the apply lock so nothing races with them.
+        if self._parallel_active and self._partition_executor is not None:
+            self._partition_executor.flush()
+            with self._apply_lock:
+                self._add_rare_item(item)
+        else:
+            self._add_rare_item(item)
+
+    def _add_rare_item(
+        self,
+        item: Union[
+            KnownQueryLineageInfo,
+            KnownLineageMapping,
+            TableRename,
+            TableSwap,
+        ],
+    ) -> None:
         if isinstance(item, KnownQueryLineageInfo):
             self.add_known_query_lineage(item)
         elif isinstance(item, KnownLineageMapping):
             self.add_known_lineage_mapping(item.upstream_urn, item.downstream_urn)
-        elif isinstance(item, PreparsedQuery):
-            self.add_preparsed_query(item)
-        elif isinstance(item, ObservedQuery):
-            self.add_observed_query(item)
         elif isinstance(item, TableRename):
             self.add_table_rename(item)
         elif isinstance(item, TableSwap):
@@ -877,6 +1031,22 @@ class SqlParsingAggregator(Closeable):
         """
         self.report.num_observed_queries += 1
 
+        if self._parallel_active and self._partition_executor is not None:
+            # Route to the per-session partition executor. The task itself does
+            # classify -> parse -> apply on a worker thread. The PE guarantees at
+            # most one task per session runs at a time and submits the next
+            # same-session task only after this one's future completes, so a temp
+            # producer is always applied before its consumer is classified.
+            session_id = observed.session_id or _MISSING_SESSION_ID
+            self._partition_executor.submit(
+                session_id,
+                self._process_observed_task,
+                observed,
+                is_known_temp_table,
+                require_out_table_schema,
+            )
+            return
+
         # All queries with no session ID are assumed to be part of the same session.
         session_id = observed.session_id or _MISSING_SESSION_ID
 
@@ -910,6 +1080,24 @@ class SqlParsingAggregator(Closeable):
             if isinstance(parsed.debug_info.column_error, CooperativeTimeoutError):
                 self.report.num_observed_queries_column_timeout += 1
 
+        self._apply_observed_parse_result(
+            observed,
+            session_id,
+            session_has_temp_tables,
+            parsed,
+            is_known_temp_table,
+            require_out_table_schema,
+        )
+
+    def _apply_observed_parse_result(
+        self,
+        observed: ObservedQuery,
+        session_id: str,
+        session_has_temp_tables: bool,
+        parsed: SqlParsingResult,
+        is_known_temp_table: bool,
+        require_out_table_schema: bool,
+    ) -> None:
         query_fingerprint = observed.query_hash or parsed.query_fingerprint
 
         # Register the first output table (standard single-query behavior).
@@ -942,7 +1130,192 @@ class SqlParsingAggregator(Closeable):
             _is_internal=True,
         )
 
+    def _process_observed_task(
+        self,
+        observed: ObservedQuery,
+        is_known_temp_table: bool,
+        require_out_table_schema: bool,
+    ) -> None:
+        """Runs on a PartitionExecutor thread: classify -> parse -> apply.
+
+        Failures are recorded to the report exactly as the serial path would; we
+        never let an exception vanish into the (unused) future.
+        """
+        session_id = observed.session_id or _MISSING_SESSION_ID
+        try:
+            # Reading the session temp state touches shared maps, so hold the lock.
+            with self._apply_lock:
+                with self.report.make_schema_resolver_timer:
+                    schema_resolver: SchemaResolverInterface = (
+                        self._make_schema_resolver_for_session(session_id)
+                    )
+                    session_has_temp = schema_resolver.includes_temp_tables()
+
+            if session_has_temp:
+                # Temp resolvers hold in-memory temp schemas that cannot be
+                # shipped to a worker process, so parse inline on this thread.
+                parsed = self._run_sql_parser(
+                    observed.query,
+                    default_db=observed.default_db,
+                    default_schema=observed.default_schema,
+                    schema_resolver=schema_resolver,
+                    session_id=session_id,
+                    timestamp=observed.timestamp,
+                    user=observed.user,
+                    override_dialect=observed.override_dialect,
+                )
+            else:
+                assert self._parallel_parser is not None
+                outcome = self._parallel_parser.parse_one(
+                    ParseTask(
+                        key=None,
+                        query=observed.query,
+                        default_db=observed.default_db,
+                        default_schema=observed.default_schema,
+                        override_dialect=(
+                            str(observed.override_dialect)
+                            if observed.override_dialect is not None
+                            else None
+                        ),
+                    )
+                )
+                if outcome.error is not None or outcome.result is None:
+                    self.report.num_observed_queries_failed += 1
+                    self.report.observed_query_parse_failures.append(
+                        f"{outcome.error} on query: {observed.query[:100]}"
+                    )
+                    return
+                parsed = outcome.result
+                self._account_parsed_query(
+                    observed.query,
+                    default_db=observed.default_db,
+                    default_schema=observed.default_schema,
+                    session_id=session_id,
+                    timestamp=observed.timestamp,
+                    user=observed.user,
+                    parsed=parsed,
+                )
+
+            if parsed.debug_info.error:
+                self.report.observed_query_parse_failures.append(
+                    f"{parsed.debug_info.error} on query: {observed.query[:100]}"
+                )
+            if parsed.debug_info.table_error:
+                self.report.num_observed_queries_failed += 1
+                return
+            elif parsed.debug_info.column_error:
+                self.report.num_observed_queries_column_failed += 1
+                if isinstance(parsed.debug_info.column_error, CooperativeTimeoutError):
+                    self.report.num_observed_queries_column_timeout += 1
+
+            with self._apply_lock:
+                self._apply_observed_parse_result(
+                    observed,
+                    session_id,
+                    session_has_temp,
+                    parsed,
+                    is_known_temp_table,
+                    require_out_table_schema,
+                )
+        except Exception as e:
+            self.report.num_observed_queries_failed += 1
+            self.report.observed_query_parse_failures.append(
+                f"{e!r} on query: {observed.query[:100]}"
+            )
+            logger.debug("Parallel observed-query task failed", exc_info=e)
+
+    def _account_parsed_query(
+        self,
+        query: str,
+        *,
+        default_db: Optional[str],
+        default_schema: Optional[str],
+        session_id: str,
+        timestamp: Optional[datetime],
+        user: Optional[Union[CorpUserUrn, CorpGroupUrn]],
+        parsed: SqlParsingResult,
+    ) -> None:
+        """Update the same report counters / query log that ``_run_sql_parser``
+        would, for a result produced by a worker process (which cannot mutate the
+        parent's report or query log). Keeps parallel and serial book-keeping
+        identical. Callers hold no lock; ``num_sql_parsed`` is a plain int under
+        the GIL and the query log append is thread-safe."""
+        self.report.num_sql_parsed += 1
+
+        if self.query_log == QueryLogSetting.STORE_ALL or (
+            self.query_log == QueryLogSetting.STORE_FAILED and parsed.debug_info.error
+        ):
+            self._logged_queries.append(
+                LoggedQuery(
+                    query=query,
+                    session_id=(
+                        session_id if session_id != _MISSING_SESSION_ID else None
+                    ),
+                    timestamp=timestamp,
+                    user=user.urn() if user else None,
+                    default_db=default_db,
+                    default_schema=default_schema,
+                )
+            )
+
     def add_preparsed_query(
+        self,
+        parsed: PreparsedQuery,
+        is_known_temp_table: bool = False,
+        require_out_table_schema: bool = False,
+        session_has_temp_tables: bool = True,
+        _is_internal: bool = False,
+        _skip_parallel_routing: bool = False,
+    ) -> None:
+        # When parallel parsing is active, an externally-added PreparsedQuery is
+        # routed through the partition executor keyed by session, so it stays
+        # FIFO-ordered relative to the observed queries in the same session. The
+        # internal call from _apply_observed_parse_result sets _is_internal (it
+        # already runs under the apply-lock inside a task), so it is never
+        # re-routed. Rare-item internal calls set _skip_parallel_routing.
+        if (
+            self._parallel_active
+            and self._partition_executor is not None
+            and not _is_internal
+            and not _skip_parallel_routing
+        ):
+            self._partition_executor.submit(
+                parsed.session_id or _MISSING_SESSION_ID,
+                self._process_preparsed_task,
+                parsed,
+                is_known_temp_table,
+                require_out_table_schema,
+            )
+            return
+
+        self._add_preparsed_query_impl(
+            parsed,
+            is_known_temp_table=is_known_temp_table,
+            require_out_table_schema=require_out_table_schema,
+            session_has_temp_tables=session_has_temp_tables,
+            _is_internal=_is_internal,
+        )
+
+    def _process_preparsed_task(
+        self,
+        parsed: PreparsedQuery,
+        is_known_temp_table: bool,
+        require_out_table_schema: bool,
+    ) -> None:
+        try:
+            with self._apply_lock:
+                self._add_preparsed_query_impl(
+                    parsed,
+                    is_known_temp_table=is_known_temp_table,
+                    require_out_table_schema=require_out_table_schema,
+                    session_has_temp_tables=True,
+                    _is_internal=False,
+                )
+        except Exception as e:
+            self.report.num_observed_queries_failed += 1
+            logger.debug("Parallel preparsed-query task failed", exc_info=e)
+
+    def _add_preparsed_query_impl(
         self,
         parsed: PreparsedQuery,
         is_known_temp_table: bool = False,
@@ -1098,7 +1471,8 @@ class SqlParsingAggregator(Closeable):
                 ),
                 session_id=table_rename.session_id,
                 timestamp=table_rename.timestamp,
-            )
+            ),
+            _skip_parallel_routing=True,
         )
 
     def add_table_swap(self, table_swap: TableSwap) -> None:
@@ -1137,7 +1511,8 @@ class SqlParsingAggregator(Closeable):
                     ),
                     session_id=table_swap.session_id,
                     timestamp=table_swap.timestamp,
-                )
+                ),
+                _skip_parallel_routing=True,
             )
 
         if not self.is_temp_table(table_swap.urn1):
@@ -1153,7 +1528,8 @@ class SqlParsingAggregator(Closeable):
                     ),
                     session_id=table_swap.session_id,
                     timestamp=table_swap.timestamp,
-                )
+                ),
+                _skip_parallel_routing=True,
             )
 
     def _make_schema_resolver_for_session(
@@ -1323,6 +1699,11 @@ class SqlParsingAggregator(Closeable):
             self._query_map[query_fingerprint] = new
 
     def gen_metadata(self) -> Iterable[MetadataChangeProposalWrapper]:
+        # A connector may have forgotten to exit the parallel scope. Defensively
+        # drain and tear down so all queued applies land before we generate.
+        if self._parallel_active or self._partition_executor is not None:
+            self._teardown_parallel()
+
         queries_generated: Set[QueryId] = set()
 
         yield from self._gen_lineage_mcps(queries_generated)

--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
@@ -135,6 +135,7 @@ class SqlParsingParallelismConfig(ConfigModel):
     )
     sql_parsing_workers: Optional[int] = Field(
         default=None,
+        ge=1,
         description=(
             "Explicit number of worker processes for parallel SQL parsing. "
             "Defaults to an auto-detected safe value; values above detected "

--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
@@ -1746,10 +1746,20 @@ class SqlParsingAggregator(Closeable):
         if query_fingerprint in self._query_map:
             current = self._query_map.for_mutation(query_fingerprint)
 
-            # This assumes that queries come in order of increasing timestamps,
-            # so the current query is more authoritative than the previous one.
             current.formatted_query_string = new.formatted_query_string
-            current.latest_timestamp = new.latest_timestamp or current.latest_timestamp
+            # Take the maximum timestamp so that merge order does not matter.
+            # In serial mode timestamps arrive in ascending order, so max() is
+            # equivalent to the previous last-writer-wins behaviour; in the
+            # parallel path sessions may be applied out of global-timestamp order,
+            # making max() necessary for serial-vs-parallel equivalence.
+            if new.latest_timestamp is None:
+                pass  # keep current
+            elif current.latest_timestamp is None:
+                current.latest_timestamp = new.latest_timestamp
+            else:
+                current.latest_timestamp = max(
+                    current.latest_timestamp, new.latest_timestamp
+                )
             current.actor = new.actor or current.actor
 
             if current.used_temp_tables and not new.used_temp_tables:

--- a/metadata-ingestion/src/datahub/utilities/backpressure_aware_executor.py
+++ b/metadata-ingestion/src/datahub/utilities/backpressure_aware_executor.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import concurrent.futures
-from concurrent.futures import Future, ThreadPoolExecutor
+import contextlib
+from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from typing import Any, Callable, Iterable, Iterator, Optional, Set, Tuple, TypeVar
 
 _R = TypeVar("_R")
@@ -20,6 +21,7 @@ class BackpressureAwareExecutor:
         args_list: Iterable[Tuple[Any, ...]],
         max_workers: int,
         max_pending: Optional[int] = None,
+        executor: Optional[Executor] = None,
     ) -> Iterator[Future[_R]]:
         """Similar to concurrent.futures.ThreadPoolExecutor#map, except that it won't run ahead of the consumer.
 
@@ -34,6 +36,12 @@ class BackpressureAwareExecutor:
             max_workers: The maximum number of threads to use.
             max_pending: The maximum number of pending results to keep in memory.
                 If not set, it will be set to 2*max_workers.
+            executor: An optional executor to submit work to. When provided, it is
+                used as-is and NOT closed by this method (the caller owns its
+                lifecycle) — this lets callers reuse the bounded-drain logic with a
+                ProcessPoolExecutor or a shared pool. When None (the default), a
+                ThreadPoolExecutor with ``max_workers`` threads is created and
+                closed internally, preserving the original behavior.
 
         Returns:
             An iterable of futures.
@@ -53,7 +61,16 @@ class BackpressureAwareExecutor:
 
         pending_futures: Set[Future] = set()
 
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        # When the caller supplies an executor, it owns the lifecycle — we must not
+        # shut it down. Otherwise, create and own a ThreadPoolExecutor as before.
+        if executor is not None:
+            executor_cm: contextlib.AbstractContextManager[Executor] = (
+                contextlib.nullcontext(executor)
+            )
+        else:
+            executor_cm = ThreadPoolExecutor(max_workers=max_workers)
+
+        with executor_cm as active_executor:
             for args in args_list:
                 # If the pending list is full, wait until one is done.
                 if len(pending_futures) >= max_pending:
@@ -68,7 +85,7 @@ class BackpressureAwareExecutor:
                         yield future
 
                 # Now that there's space in the pending list, enqueue the next task.
-                pending_futures.add(executor.submit(fn, *args))
+                pending_futures.add(active_executor.submit(fn, *args))
 
             # Wait for all the remaining tasks to complete.
             for future in concurrent.futures.as_completed(pending_futures):

--- a/metadata-ingestion/src/datahub/utilities/cpu_detection.py
+++ b/metadata-ingestion/src/datahub/utilities/cpu_detection.py
@@ -1,0 +1,210 @@
+"""Cgroup-aware CPU detection for multiprocessing worker sizing.
+
+On virtualized EC2/K8s hosts, os.cpu_count() reports the host's physical core
+count (e.g. 64) rather than the container's CPU quota (e.g. 2). Spawning a
+process pool sized to os.cpu_count() on such a host causes severe CPU throttling
+and OOM. This module detects the actual usable CPU budget by consulting cgroup
+quotas and CPU affinity before falling back to os.cpu_count().
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_cgroup_v2_cpu_max(content: str) -> Optional[float]:
+    """Parse /sys/fs/cgroup/cpu.max content.
+
+    Returns None for unlimited ("max <period>"), or quota/period as float.
+    Returns None on malformed input.
+    """
+    parts = content.strip().split()
+    if len(parts) != 2:
+        return None
+    quota_str, period_str = parts
+    if quota_str == "max":
+        return None
+    try:
+        quota = float(quota_str)
+        period = float(period_str)
+        if period == 0:
+            return None
+        return quota / period
+    except ValueError:
+        return None
+
+
+def _parse_cgroup_v1_cpu_quota(quota_str: str, period_str: str) -> Optional[float]:
+    """Parse cgroup v1 cpu.cfs_quota_us and cpu.cfs_period_us values.
+
+    Returns None when quota is -1 (unlimited), or quota/period as float.
+    Returns None on malformed input.
+    """
+    try:
+        quota = int(quota_str.strip())
+        period = int(period_str.strip())
+    except ValueError:
+        return None
+    if quota == -1:
+        return None
+    if period == 0:
+        return None
+    return quota / period
+
+
+def _cgroup_cpu_limit() -> Optional[float]:
+    """Read the container CPU limit from cgroup files.
+
+    Tries cgroup v2 first (/sys/fs/cgroup/cpu.max), then cgroup v1
+    (/sys/fs/cgroup/cpu/cpu.cfs_quota_us + cpu.cfs_period_us).
+    Returns None on any file/OS error or when no limit is set.
+    """
+    # cgroup v2
+    try:
+        with open("/sys/fs/cgroup/cpu.max") as f:
+            return _parse_cgroup_v2_cpu_max(f.read())
+    except OSError:
+        pass
+
+    # cgroup v1
+    try:
+        with open("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") as f:
+            quota_str = f.read()
+        with open("/sys/fs/cgroup/cpu/cpu.cfs_period_us") as f:
+            period_str = f.read()
+        return _parse_cgroup_v1_cpu_quota(quota_str, period_str)
+    except OSError:
+        pass
+
+    return None
+
+
+def _affinity_cpu_count() -> Optional[int]:
+    """Return the number of CPUs in this process's CPU affinity set.
+
+    Uses os.sched_getaffinity (Linux only; respects cpuset/taskset).
+    Returns None on platforms where affinity is not available.
+    """
+    if hasattr(os, "sched_getaffinity"):
+        return len(os.sched_getaffinity(0))
+    return None
+
+
+def _os_cpu_count() -> Optional[int]:
+    """Thin wrapper over os.cpu_count()."""
+    return os.cpu_count()
+
+
+def get_available_cpu_count() -> int:
+    """Return the number of CPUs actually usable by this process.
+
+    Takes the minimum of all available signals — cgroup quota (floored),
+    CPU affinity count, and os.cpu_count() — ignoring any that are None.
+    Always returns at least 1.
+    """
+    candidates = []
+
+    cgroup_limit = _cgroup_cpu_limit()
+    if cgroup_limit is not None:
+        candidates.append(math.floor(cgroup_limit))
+
+    affinity = _affinity_cpu_count()
+    if affinity is not None:
+        candidates.append(affinity)
+
+    os_count = _os_cpu_count()
+    if os_count is not None:
+        candidates.append(os_count)
+
+    return max(1, min(candidates)) if candidates else 1
+
+
+@dataclass
+class WorkerDecision:
+    """Outcome of resolve_worker_count, including diagnostics for logging/debugging."""
+
+    workers: int
+    detected_cpus: int
+    requested: Optional[int]
+    clamped: bool
+    fell_back_to_serial: bool
+    reason: str
+
+
+def resolve_worker_count(
+    requested: Optional[int],
+    *,
+    reserve: int = 1,
+    detected_cpus: Optional[int] = None,
+) -> WorkerDecision:
+    """Decide how many worker processes to spawn, respecting the container's CPU budget.
+
+    Args:
+        requested: Caller-requested worker count, or None for auto-detection.
+        reserve: Number of cores to hold back for the main/aggregation process.
+        detected_cpus: Override for testing; uses get_available_cpu_count() when None.
+
+    Returns:
+        WorkerDecision with the final worker count and diagnostic fields.
+    """
+    detected = detected_cpus if detected_cpus is not None else get_available_cpu_count()
+    usable = max(1, detected - reserve)
+
+    # A single usable core makes multiprocessing pointless — stay serial.
+    if detected < 2:
+        return WorkerDecision(
+            workers=1,
+            detected_cpus=detected,
+            requested=requested,
+            clamped=False,
+            fell_back_to_serial=True,
+            reason=f"Only {detected} CPU(s) detected; falling back to serial execution.",
+        )
+
+    if requested is None:
+        return WorkerDecision(
+            workers=usable,
+            detected_cpus=detected,
+            requested=None,
+            clamped=False,
+            fell_back_to_serial=False,
+            reason=f"Auto-detected {detected} CPU(s); using {usable} worker(s) (reserving {reserve}).",
+        )
+
+    workers = min(requested, usable)
+    clamped = requested > usable
+    if clamped:
+        logger.warning(
+            "Requested %d workers but only %d are available after reserving %d core(s) "
+            "for the main process (detected %d CPU(s)). Clamping to %d workers. "
+            "This host may be a virtualized environment where os.cpu_count() over-reports.",
+            requested,
+            usable,
+            reserve,
+            detected,
+            workers,
+        )
+        reason = (
+            f"Requested {requested} workers clamped to {workers} "
+            f"(detected {detected} CPU(s), {reserve} reserved)."
+        )
+    else:
+        reason = (
+            f"Using {workers} of {requested} requested worker(s) "
+            f"(detected {detected} CPU(s), {reserve} reserved)."
+        )
+
+    return WorkerDecision(
+        workers=workers,
+        detected_cpus=detected,
+        requested=requested,
+        clamped=clamped,
+        fell_back_to_serial=False,
+        reason=reason,
+    )

--- a/metadata-ingestion/src/datahub/utilities/cpu_detection.py
+++ b/metadata-ingestion/src/datahub/utilities/cpu_detection.py
@@ -7,8 +7,6 @@ and OOM. This module detects the actual usable CPU budget by consulting cgroup
 quotas and CPU affinity before falling back to os.cpu_count().
 """
 
-from __future__ import annotations
-
 import logging
 import math
 import os
@@ -33,7 +31,7 @@ def _parse_cgroup_v2_cpu_max(content: str) -> Optional[float]:
     try:
         quota = float(quota_str)
         period = float(period_str)
-        if period == 0:
+        if quota <= 0 or period <= 0:
             return None
         return quota / period
     except ValueError:
@@ -51,7 +49,7 @@ def _parse_cgroup_v1_cpu_quota(quota_str: str, period_str: str) -> Optional[floa
         period = int(period_str.strip())
     except ValueError:
         return None
-    if quota == -1:
+    if quota <= 0:
         return None
     if period == 0:
         return None
@@ -156,7 +154,10 @@ def resolve_worker_count(
     detected = detected_cpus if detected_cpus is not None else get_available_cpu_count()
     usable = max(1, detected - reserve)
 
-    # A single usable core makes multiprocessing pointless — stay serial.
+    # Only fall back to serial when there is strictly fewer than 2 CPUs detected.
+    # With exactly 2 CPUs, usable=1 after reserving one core — callers treat
+    # workers=1 as a degenerate single-worker pool (not serial), which preserves
+    # the multiprocessing code path and avoids a special case in the caller.
     if detected < 2:
         return WorkerDecision(
             workers=1,

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -80,33 +80,60 @@ class ConnectionWrapper:
         Union["FileBackedList", "FileBackedDict", "FileBackedCounter"]
     ]
 
-    def __init__(self, filename: Optional[pathlib.Path] = None):
+    def __init__(
+        self,
+        filename: Optional[pathlib.Path] = None,
+        read_only: bool = False,
+    ):
         self._temp_directory = None
         self._dependent_objects = []
+        self._read_only = read_only
 
-        # Warning: If filename is provided, the file will not be automatically cleaned up.
-        if not filename:
-            self._temp_directory = tempfile.mkdtemp()
-            filename = pathlib.Path(self._temp_directory) / _DEFAULT_FILE_NAME
-        self.filename = filename
+        if read_only:
+            # A read-only connection must target an existing file; a temp dir makes
+            # no sense here.
+            if not filename:
+                raise ValueError("filename is required when read_only=True")
+            self.filename = filename
+        else:
+            # Warning: If filename is provided, the file will not be automatically cleaned up.
+            if not filename:
+                self._temp_directory = tempfile.mkdtemp()
+                filename = pathlib.Path(self._temp_directory) / _DEFAULT_FILE_NAME
+            self.filename = filename
 
         # SQLite connections are technically not supposed to be used from multiple threads.
         # We bypass this restriction by setting `check_same_thread=False`. However, we
         # still need to be careful to avoid concurrent access.
         self.conn_lock = threading.Lock()
-        self.conn = sqlite3.connect(
-            filename, isolation_level=None, check_same_thread=False
-        )
-        self.conn.row_factory = sqlite3.Row
 
-        # These settings are optimized for performance.
-        # See https://www.sqlite.org/pragma.html for more information.
-        # Because we're only using these dbs to offload data from memory, we don't need
-        # to worry about data integrity too much.
-        self.conn.execute('PRAGMA locking_mode = "EXCLUSIVE"')
-        self.conn.execute('PRAGMA synchronous = "OFF"')
-        self.conn.execute('PRAGMA journal_mode = "MEMORY"')
-        self.conn.execute(f"PRAGMA journal_size_limit = {100 * 1024 * 1024}")  # 100MB
+        if read_only:
+            # Open with the URI filename API so we can pass mode=ro&immutable=1.
+            # immutable=1 tells SQLite the file will not change, allowing concurrent
+            # readers with no locking overhead and shared OS page-cache.
+            uri = f"file:{filename}?mode=ro&immutable=1"
+            self.conn = sqlite3.connect(
+                uri, uri=True, isolation_level=None, check_same_thread=False
+            )
+            self.conn.row_factory = sqlite3.Row
+            # Do NOT set locking_mode / synchronous / journal_mode — they are
+            # invalid or meaningless on an immutable read-only connection.
+        else:
+            self.conn = sqlite3.connect(
+                filename, isolation_level=None, check_same_thread=False
+            )
+            self.conn.row_factory = sqlite3.Row
+
+            # These settings are optimized for performance.
+            # See https://www.sqlite.org/pragma.html for more information.
+            # Because we're only using these dbs to offload data from memory, we don't need
+            # to worry about data integrity too much.
+            self.conn.execute('PRAGMA locking_mode = "EXCLUSIVE"')
+            self.conn.execute('PRAGMA synchronous = "OFF"')
+            self.conn.execute('PRAGMA journal_mode = "MEMORY"')
+            self.conn.execute(
+                f"PRAGMA journal_size_limit = {100 * 1024 * 1024}"
+            )  # 100MB
 
     @property
     def allow_table_name_reuse(self) -> bool:
@@ -116,6 +143,10 @@ class ConnectionWrapper:
         # which happens when filename is passed explicitly, then we need to allow table name reuse.
 
         return self._temp_directory is None
+
+    @property
+    def read_only(self) -> bool:
+        return self._read_only
 
     def execute(
         self, sql: str, parameters: Union[Dict[str, Any], Sequence[Any]] = ()
@@ -248,15 +279,18 @@ class FileBackedDict(MutableMapping[str, _VT], Closeable, Generic[_VT]):
         # Create the table.
         # We could use the built-in sqlite `rowid` column, but that can get changed
         # if a VACUUM is performed and would break our ordering guarantees.
-        if_not_exists = "IF NOT EXISTS" if self._conn.allow_table_name_reuse else ""
-        self._conn.execute(
-            f"""CREATE TABLE {if_not_exists} {self.tablename} (
-                rowid INTEGER PRIMARY KEY AUTOINCREMENT,
-                key TEXT UNIQUE,
-                value BLOB
-                {"".join(f", {column_name} BLOB" for column_name in self.extra_columns)}
-            )"""
-        )
+        # Skip CREATE TABLE entirely when the underlying connection is read-only — the
+        # table already exists in the snapshot file and writes are not permitted.
+        if not self._conn.read_only:
+            if_not_exists = "IF NOT EXISTS" if self._conn.allow_table_name_reuse else ""
+            self._conn.execute(
+                f"""CREATE TABLE {if_not_exists} {self.tablename} (
+                    rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+                    key TEXT UNIQUE,
+                    value BLOB
+                    {"".join(f", {column_name} BLOB" for column_name in self.extra_columns)}
+                )"""
+            )
 
         if not self.delay_index_creation:
             self.create_indexes()
@@ -269,6 +303,10 @@ class FileBackedDict(MutableMapping[str, _VT], Closeable, Generic[_VT]):
 
     def create_indexes(self) -> None:
         if self.indexes_created:
+            return
+        if self._conn.read_only:
+            # Indexes already exist in the snapshot; writes are not allowed.
+            self.indexes_created = True
             return
         # The key column will automatically be indexed, but we need indexes for the extra columns.
         for column_name in self.extra_columns:

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -377,6 +377,11 @@ class FileBackedDict(MutableMapping[str, _VT], Closeable, Generic[_VT]):
                         (*item[1:], item[0]),
                     )
 
+    @property
+    def filename(self) -> pathlib.Path:
+        """Return the path of the backing SQLite file."""
+        return self._conn.filename
+
     def flush(self) -> None:
         self._prune_cache(len(self._active_object_cache))
 
@@ -528,7 +533,10 @@ class FileBackedDict(MutableMapping[str, _VT], Closeable, Generic[_VT]):
     def close(self) -> None:
         if self._conn:
             if self.shared_connection:  # Connection not owned by this object
-                self.flush()  # Ensure everything is written out
+                # Skip flush for read-only connections — writes are forbidden
+                # and there is nothing to persist anyway.
+                if not self._conn.read_only:
+                    self.flush()  # Ensure everything is written out
             else:
                 self._conn.close()
 

--- a/metadata-ingestion/tests/unit/sql_parsing/test_parallel_aggregator.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_parallel_aggregator.py
@@ -13,13 +13,16 @@ from typing import List, Union
 import pytest
 import time_machine
 
+import datahub.metadata.schema_classes as models
 from datahub.metadata.urns import DatasetUrn
 from datahub.sql_parsing.sql_parsing_aggregator import (
     ObservedQuery,
     PreparsedQuery,
     QueryLogSetting,
+    QueryMetadata,
     SqlParsingAggregator,
 )
+from datahub.sql_parsing.sql_parsing_common import QueryType
 from datahub.utilities import cpu_detection
 
 _StreamItem = Union[ObservedQuery, PreparsedQuery]
@@ -442,6 +445,72 @@ def test_high_volume_many_sessions_stress(run_idx: int) -> None:
     )
     assert report.num_queries_parsed_in_parallel > 0
     assert report.num_queries_parsed_in_parallel == num_pool_parsed_expected
+
+
+def test_add_to_query_map_latest_timestamp_is_max_not_last_written() -> None:
+    """_add_to_query_map must keep the maximum timestamp regardless of insertion order.
+
+    When the parallel path applies per-session results, the same query fingerprint
+    may be merged in a non-chronological order across sessions.  Before the fix,
+    ``current.latest_timestamp = new.latest_timestamp or current.latest_timestamp``
+    was last-writer-wins, so a later write with an EARLIER timestamp silently
+    replaced the correct (higher) value — a serial-vs-parallel divergence.
+
+    Regression test: insert LATER timestamp first, then EARLIER; assert the stored
+    value is the LATER one (the maximum).
+    """
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=True,
+        generate_usage_statistics=False,
+        generate_operations=False,
+        query_log=QueryLogSetting.DISABLED,
+    )
+
+    later_ts = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    earlier_ts = datetime(2024, 1, 1, 6, 0, 0, tzinfo=timezone.utc)
+
+    fingerprint = "test-fingerprint-order-independence"
+
+    first = QueryMetadata(
+        query_id=fingerprint,
+        formatted_query_string="SELECT 1",
+        session_id="session_a",
+        query_type=QueryType.UNKNOWN,
+        lineage_type=models.DatasetLineageTypeClass.TRANSFORMED,
+        latest_timestamp=later_ts,
+        actor=None,
+        upstreams=[],
+        column_lineage=[],
+        column_usage={},
+        confidence_score=1.0,
+    )
+    second = QueryMetadata(
+        query_id=fingerprint,
+        formatted_query_string="SELECT 1",
+        session_id="session_b",
+        query_type=QueryType.UNKNOWN,
+        lineage_type=models.DatasetLineageTypeClass.TRANSFORMED,
+        latest_timestamp=earlier_ts,
+        actor=None,
+        upstreams=[],
+        column_lineage=[],
+        column_usage={},
+        confidence_score=1.0,
+    )
+
+    # Insert later-timestamp first, then earlier-timestamp second.
+    # After the fix the stored value must be the maximum (later_ts).
+    aggregator._add_to_query_map(first)
+    aggregator._add_to_query_map(second)
+
+    stored = aggregator._query_map[fingerprint]
+    assert stored.latest_timestamp == later_ts, (
+        f"Expected the maximum timestamp ({later_ts}), "
+        f"got {stored.latest_timestamp} — last-writer-wins bug is present."
+    )
+
+    aggregator.close()
 
 
 def test_feature_off_is_default() -> None:

--- a/metadata-ingestion/tests/unit/sql_parsing/test_parallel_aggregator.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_parallel_aggregator.py
@@ -38,13 +38,14 @@ def _make_aggregator(
     *,
     use_parallel: bool,
     workers: int = 2,
+    query_log: QueryLogSetting = QueryLogSetting.DISABLED,
 ) -> SqlParsingAggregator:
     aggregator = SqlParsingAggregator(
         platform="redshift",
         generate_lineage=True,
         generate_usage_statistics=False,
         generate_operations=False,
-        query_log=QueryLogSetting.DISABLED,
+        query_log=query_log,
         use_parallel_sql_parsing=use_parallel,
         sql_parsing_workers=workers if use_parallel else None,
     )
@@ -250,6 +251,197 @@ def test_fallback_to_serial(monkeypatch: pytest.MonkeyPatch) -> None:
     parallel, report = _run_parallel(items)
     assert [_mcp_key(m) for m in parallel] == [_mcp_key(m) for m in serial]
     assert report.sql_parsing_fell_back_to_serial is True
+
+
+def _logged_query_tuples(aggregator: SqlParsingAggregator) -> list:
+    """Snapshot the aggregator's logged queries as comparable tuples, sorted so
+    that concurrent-append ordering does not affect the comparison."""
+    entries = [
+        (
+            lq.query,
+            lq.session_id,
+            lq.timestamp,
+            lq.user,
+            lq.default_db,
+            lq.default_schema,
+        )
+        for lq in aggregator._logged_queries
+    ]
+    return sorted(entries, key=repr)
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def _run_with_query_log(items: List[_StreamItem], *, use_parallel: bool) -> tuple:
+    aggregator = _make_aggregator(
+        use_parallel=use_parallel,
+        query_log=QueryLogSetting.STORE_ALL,
+    )
+    if use_parallel:
+        with aggregator.parallel_sql_parsing_scope():
+            for item in items:
+                aggregator.add(item)
+    else:
+        for item in items:
+            aggregator.add(item)
+    mcps = sorted(list(aggregator.gen_metadata()), key=_mcp_key)
+    logged = _logged_query_tuples(aggregator)
+    report = aggregator.report
+    aggregator.close()
+    return mcps, logged, report
+
+
+def test_equivalence_with_query_logging() -> None:
+    """Covers C1: with STORE_ALL query logging, the parallel path appends to the
+    shared FileBackedList query log from worker threads. Serial and parallel must
+    produce identical MCPs AND an identical set of logged queries (no lost or
+    corrupted log entries)."""
+    items: List[_StreamItem] = [
+        ObservedQuery(
+            query="create table foo as select a, b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s1",
+            timestamp=_ts(10),
+        ),
+        ObservedQuery(
+            query="insert into downstream (a, b) select a, b from upstream1",
+            default_db="dev",
+            default_schema="public",
+            session_id="s2",
+            timestamp=_ts(20),
+        ),
+        ObservedQuery(
+            query="insert into downstream (a, c) select a, c from upstream2",
+            default_db="dev",
+            default_schema="public",
+            session_id="s3",
+            timestamp=_ts(25),
+        ),
+        ObservedQuery(
+            query="create table baz as select a, 2*b as b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s4",
+            timestamp=_ts(40),
+        ),
+    ]
+
+    serial_mcps, serial_logged, serial_report = _run_with_query_log(
+        items, use_parallel=False
+    )
+    parallel_mcps, parallel_logged, parallel_report = _run_with_query_log(
+        items, use_parallel=True
+    )
+
+    assert [_mcp_key(m) for m in parallel_mcps] == [_mcp_key(m) for m in serial_mcps]
+    assert len(parallel_logged) == len(serial_logged)
+    assert parallel_logged == serial_logged
+    assert parallel_report.num_sql_parsed == serial_report.num_sql_parsed
+
+
+def _make_stress_items() -> List[_StreamItem]:
+    """Dozens of sessions, several queries each: a mix of temp producer/consumer
+    sessions and plain non-temp sessions, interleaved by timestamp."""
+    items: List[_StreamItem] = []
+    ts = 0
+    num_temp_sessions = 12
+    num_plain_sessions = 12
+
+    # Interleave: for each "round", emit one query from several sessions.
+    for round_idx in range(3):
+        for s in range(num_plain_sessions):
+            ts += 1
+            # Distinct output table per (session, round) so there are no
+            # cross-session query-fingerprint collisions whose "latest timestamp"
+            # would be apply-order-dependent (that would make even a correct
+            # serial run non-deterministic vs parallel). Lineage still flows from
+            # a shared upstream, exercising the real parse path.
+            upstream = "upstream1" if round_idx % 2 == 0 else "upstream2"
+            cols = "a, b" if round_idx % 2 == 0 else "a, c"
+            items.append(
+                ObservedQuery(
+                    query=(
+                        f"create table out_{s}_{round_idx} as "
+                        f"select {cols} from {upstream}"
+                    ),
+                    default_db="dev",
+                    default_schema="public",
+                    session_id=f"plain_{s}",
+                    timestamp=_ts(ts),
+                )
+            )
+        for s in range(num_temp_sessions):
+            ts += 1
+            if round_idx == 0:
+                # Temp producer.
+                items.append(
+                    ObservedQuery(
+                        query="create temp table foo as select a, b+c as c from bar",
+                        default_db="dev",
+                        default_schema="public",
+                        session_id=f"temp_{s}",
+                        timestamp=_ts(ts),
+                    )
+                )
+            else:
+                # Temp consumer.
+                items.append(
+                    ObservedQuery(
+                        query=f"create table foo_{s}_{round_idx} as select * from foo",
+                        default_db="dev",
+                        default_schema="public",
+                        session_id=f"temp_{s}",
+                        timestamp=_ts(ts),
+                    )
+                )
+    return items
+
+
+@pytest.mark.parametrize("run_idx", range(3))
+def test_high_volume_many_sessions_stress(run_idx: int) -> None:
+    """Covers C2/I1/I2: a higher-volume, many-session interleaved stream with a
+    mix of temp and non-temp sessions and workers>=2. Asserts:
+
+    - serial-vs-parallel MCP equivalence (no lineage loss),
+    - report.num_sql_parsed matches the serial count (no lost/double accounting),
+    - report.num_queries_parsed_in_parallel equals the number of non-temp
+      observed queries that were actually pool-parsed (> 0), proving the
+      observability contract.
+
+    Repeated a few times via parametrization since races are timing-dependent.
+    """
+    items = _make_stress_items()
+
+    serial = _run_serial(items)
+    parallel, report = _run_parallel(items, workers=4)
+
+    assert [_mcp_key(m) for m in parallel] == [_mcp_key(m) for m in serial]
+
+    serial_report = _make_aggregator(use_parallel=False)
+    for item in items:
+        serial_report.add(item)
+    list(serial_report.gen_metadata())
+    expected_num_sql_parsed = serial_report.report.num_sql_parsed
+    serial_report.close()
+
+    assert report.num_sql_parsed == expected_num_sql_parsed
+
+    # A query is pool-parsed iff its session had no temp tables registered at the
+    # time it was classified. That is every plain_* query, plus the temp
+    # producer (the "create temp table foo" runs before the temp table exists in
+    # its session). The temp *consumers* parse inline because their session then
+    # holds an in-memory temp schema that cannot ship to a worker.
+    num_pool_parsed_expected = sum(
+        1
+        for item in items
+        if isinstance(item, ObservedQuery)
+        and (
+            (item.session_id or "").startswith("plain_")
+            or item.query.strip().lower().startswith("create temp table")
+        )
+    )
+    assert report.num_queries_parsed_in_parallel > 0
+    assert report.num_queries_parsed_in_parallel == num_pool_parsed_expected
 
 
 def test_feature_off_is_default() -> None:

--- a/metadata-ingestion/tests/unit/sql_parsing/test_parallel_aggregator.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_parallel_aggregator.py
@@ -1,0 +1,277 @@
+"""Equivalence tests for per-session-safe parallel SQL parsing in SqlParsingAggregator.
+
+The correctness bar: parallel output MUST be byte-identical to serial output
+(no lineage loss). Each test runs the same scripted stream of queries through a
+serial aggregator (feature off) and a parallel aggregator (feature on, wrapped in
+``parallel_sql_parsing_scope()``), then asserts the emitted MCPs are equal after
+normalizing ordering.
+"""
+
+from datetime import datetime, timezone
+from typing import List, Union
+
+import pytest
+import time_machine
+
+from datahub.metadata.urns import DatasetUrn
+from datahub.sql_parsing.sql_parsing_aggregator import (
+    ObservedQuery,
+    PreparsedQuery,
+    QueryLogSetting,
+    SqlParsingAggregator,
+)
+from datahub.utilities import cpu_detection
+
+_StreamItem = Union[ObservedQuery, PreparsedQuery]
+
+# Freeze wall-clock so audit stamps that fall back to datetime.now() (for
+# downstream tables with no explicit timestamp) are identical across the serial
+# and parallel runs being compared.
+FROZEN_TIME = "2024-02-06T01:23:45Z"
+
+
+def _ts(ts: int) -> datetime:
+    return datetime.fromtimestamp(ts, tz=timezone.utc)
+
+
+def _make_aggregator(
+    *,
+    use_parallel: bool,
+    workers: int = 2,
+) -> SqlParsingAggregator:
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=True,
+        generate_usage_statistics=False,
+        generate_operations=False,
+        query_log=QueryLogSetting.DISABLED,
+        use_parallel_sql_parsing=use_parallel,
+        sql_parsing_workers=workers if use_parallel else None,
+    )
+    aggregator._schema_resolver.add_raw_schema_info(
+        DatasetUrn("redshift", "dev.public.bar").urn(),
+        {"a": "int", "b": "int", "c": "int"},
+    )
+    aggregator._schema_resolver.add_raw_schema_info(
+        DatasetUrn("redshift", "dev.public.upstream1").urn(),
+        {"a": "int", "b": "int"},
+    )
+    aggregator._schema_resolver.add_raw_schema_info(
+        DatasetUrn("redshift", "dev.public.upstream2").urn(),
+        {"a": "int", "c": "int"},
+    )
+    return aggregator
+
+
+def _mcp_key(mcp: object) -> tuple:
+    return (
+        str(getattr(mcp, "entityUrn", None)),
+        str(getattr(mcp, "aspectName", None)),
+        str(getattr(mcp, "aspect", None)),
+    )
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def _run_serial(items: List[_StreamItem]) -> list:
+    aggregator = _make_aggregator(use_parallel=False)
+    for item in items:
+        aggregator.add(item)
+    mcps = list(aggregator.gen_metadata())
+    aggregator.close()
+    return sorted(mcps, key=_mcp_key)
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def _run_parallel(items: List[_StreamItem], workers: int = 2) -> tuple:
+    aggregator = _make_aggregator(use_parallel=True, workers=workers)
+    with aggregator.parallel_sql_parsing_scope():
+        for item in items:
+            aggregator.add(item)
+    mcps = list(aggregator.gen_metadata())
+    report = aggregator.report
+    aggregator.close()
+    return sorted(mcps, key=_mcp_key), report
+
+
+def _assert_equivalent(items: List[_StreamItem]) -> tuple:
+    serial = _run_serial(items)
+    parallel, report = _run_parallel(items)
+    serial_keys = [_mcp_key(m) for m in serial]
+    parallel_keys = [_mcp_key(m) for m in parallel]
+    assert parallel_keys == serial_keys
+    return parallel, report
+
+
+def test_equivalence_no_temp_tables() -> None:
+    """Core no-loss proof: a mix of observed + preparsed queries across sessions,
+    no temp tables. Parallel output must equal serial output."""
+    items: List[_StreamItem] = [
+        ObservedQuery(
+            query="create table foo as select a, b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s1",
+            timestamp=_ts(10),
+        ),
+        ObservedQuery(
+            query="insert into downstream (a, b) select a, b from upstream1",
+            default_db="dev",
+            default_schema="public",
+            session_id="s2",
+            timestamp=_ts(20),
+        ),
+        PreparsedQuery(
+            query_id=None,
+            query_text="select a, c from upstream2",
+            upstreams=[DatasetUrn("redshift", "dev.public.upstream2").urn()],
+            downstream=DatasetUrn("redshift", "dev.public.derived").urn(),
+            timestamp=_ts(30),
+            session_id="s1",
+        ),
+        ObservedQuery(
+            query="create table baz as select a, 2*b as b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s3",
+            timestamp=_ts(40),
+        ),
+    ]
+    _assert_equivalent(items)
+
+
+def test_equivalence_temp_producer_consumer_single_session() -> None:
+    """A temp-table-creating query followed by a consumer in the same session.
+
+    Mirrors the temp-table shapes in test_sql_aggregator.py. Proves the
+    PartitionExecutor per-session ordering guarantee: the temp producer must be
+    applied before the consumer is classified/parsed, so the consumer resolves
+    the temp table and lineage flows through to bar.
+    """
+    items: List[_StreamItem] = [
+        ObservedQuery(
+            query="create temp table foo as select a, b+c as c from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="session2",
+            timestamp=_ts(10),
+        ),
+        ObservedQuery(
+            query="create table foo_session2 as select * from foo",
+            default_db="dev",
+            default_schema="public",
+            session_id="session2",
+            timestamp=_ts(20),
+        ),
+    ]
+    _assert_equivalent(items)
+
+
+def test_equivalence_multiple_sessions_interleaved() -> None:
+    """Queries from multiple sessions (including _MISSING_SESSION) interleaved."""
+    items: List[_StreamItem] = [
+        ObservedQuery(
+            query="create temp table foo as select a, b+c as c from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="sessionA",
+            timestamp=_ts(10),
+        ),
+        ObservedQuery(
+            query="create table foo as select a, 2*b as b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="sessionB",
+            timestamp=_ts(15),
+        ),
+        # No session_id -> _MISSING_SESSION_ID
+        ObservedQuery(
+            query="insert into downstream (a, b) select a, b from upstream1",
+            default_db="dev",
+            default_schema="public",
+            timestamp=_ts(18),
+        ),
+        ObservedQuery(
+            query="create table foo_a as select * from foo",
+            default_db="dev",
+            default_schema="public",
+            session_id="sessionA",
+            timestamp=_ts(20),
+        ),
+        ObservedQuery(
+            query="insert into downstream (a, c) select a, c from upstream2",
+            default_db="dev",
+            default_schema="public",
+            timestamp=_ts(25),
+        ),
+        ObservedQuery(
+            query="create table baz as select a, 2*b as b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="sessionB",
+            timestamp=_ts(30),
+        ),
+    ]
+    _assert_equivalent(items)
+
+
+def test_fallback_to_serial(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With only 1 CPU detected, the feature falls back to serial and produces
+    output identical to a plain serial run; the report records the fallback."""
+
+    real_resolve = cpu_detection.resolve_worker_count
+
+    def _one_cpu(requested, **kwargs):
+        kwargs.pop("detected_cpus", None)
+        return real_resolve(requested, detected_cpus=1, **kwargs)
+
+    monkeypatch.setattr(
+        "datahub.sql_parsing.sql_parsing_aggregator.resolve_worker_count",
+        _one_cpu,
+    )
+
+    items: List[_StreamItem] = [
+        ObservedQuery(
+            query="create table foo as select a, b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s1",
+            timestamp=_ts(10),
+        ),
+        ObservedQuery(
+            query="insert into downstream (a, b) select a, b from upstream1",
+            default_db="dev",
+            default_schema="public",
+            session_id="s2",
+            timestamp=_ts(20),
+        ),
+    ]
+
+    serial = _run_serial(items)
+    parallel, report = _run_parallel(items)
+    assert [_mcp_key(m) for m in parallel] == [_mcp_key(m) for m in serial]
+    assert report.sql_parsing_fell_back_to_serial is True
+
+
+def test_feature_off_is_default() -> None:
+    """Feature is off by default and the parallel scope is a no-op."""
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=True,
+        generate_usage_statistics=False,
+        generate_operations=False,
+        query_log=QueryLogSetting.DISABLED,
+    )
+    assert aggregator.report.sql_parsing_parallel_enabled is False
+    # The scope must be a no-op when the feature is off.
+    with aggregator.parallel_sql_parsing_scope():
+        aggregator.add_observed_query(
+            ObservedQuery(
+                query="create table foo as select a, b from bar",
+                default_db="dev",
+                default_schema="public",
+            )
+        )
+    mcps = list(aggregator.gen_metadata())
+    aggregator.close()
+    assert len(mcps) > 0
+    assert aggregator.report.sql_parsing_parallel_enabled is False

--- a/metadata-ingestion/tests/unit/sql_parsing/test_parallel_sql_parser.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_parallel_sql_parser.py
@@ -1,0 +1,225 @@
+import pathlib
+
+import pytest
+
+from datahub.sql_parsing.parallel_sql_parser import (
+    ParallelSqlParser,
+    ParseOutcome,
+    ParseTask,
+)
+from datahub.sql_parsing.schema_resolver import SchemaResolver
+from datahub.sql_parsing.sqlglot_lineage import sqlglot_lineage
+
+
+def _make_writable_resolver(tmp_path: pathlib.Path) -> SchemaResolver:
+    """Build a file-backed writable SchemaResolver with two known schemas."""
+    cache_file = tmp_path / "schema_cache.db"
+    resolver = SchemaResolver(
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+        graph=None,
+        _cache_filename=cache_file,
+    )
+    resolver.add_raw_schema_info(
+        urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,prod.db.schema.orders,PROD)",
+        schema_info={"order_id": "int", "amount": "float", "customer_id": "int"},
+    )
+    resolver.add_raw_schema_info(
+        urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,prod.db.schema.customers,PROD)",
+        schema_info={"customer_id": "int", "name": "varchar"},
+    )
+    return resolver
+
+
+def test_parity_end_to_end(tmp_path: pathlib.Path) -> None:
+    """Parallel parsing must produce lineage identical to in-process serial parsing.
+
+    Proves cross-process pickling + snapshot resolution preserve lineage.
+    """
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+
+    queries = {
+        "q1": "SELECT order_id, amount FROM db.schema.orders",
+        "q2": (
+            "CREATE TABLE db.schema.summary AS "
+            "SELECT customer_id, amount FROM db.schema.orders"
+        ),
+        "q3": (
+            "SELECT o.order_id, c.name FROM db.schema.orders o "
+            "JOIN db.schema.customers c ON o.customer_id = c.customer_id"
+        ),
+    }
+
+    tasks = [
+        ParseTask(
+            key=key,
+            query=query,
+            default_db="db",
+            default_schema="schema",
+        )
+        for key, query in queries.items()
+    ]
+
+    expected = {
+        key: sqlglot_lineage(
+            query,
+            schema_resolver=writable,
+            default_db="db",
+            default_schema="schema",
+        )
+        for key, query in queries.items()
+    }
+
+    with ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+    ) as parser:
+        outcomes = list(parser.map_unordered(tasks))
+
+    assert len(outcomes) == len(queries)
+    for outcome in outcomes:
+        assert outcome.error is None, outcome.error
+        assert outcome.result is not None
+        exp = expected[outcome.key]
+        assert outcome.result.in_tables == exp.in_tables
+        assert outcome.result.out_tables == exp.out_tables
+        assert outcome.result.column_lineage == exp.column_lineage
+
+    writable.close()
+
+
+def test_unordered_correlation(tmp_path: pathlib.Path) -> None:
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+    writable.close()
+
+    tasks = [
+        ParseTask(
+            key=i,
+            query="SELECT order_id FROM db.schema.orders",
+            default_db="db",
+            default_schema="schema",
+        )
+        for i in range(25)
+    ]
+    submitted_keys = {task.key for task in tasks}
+
+    with ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+    ) as parser:
+        returned_keys = [outcome.key for outcome in parser.map_unordered(tasks)]
+
+    assert len(returned_keys) == len(submitted_keys)
+    assert set(returned_keys) == submitted_keys
+
+
+def test_malformed_query_returns_result_not_error(tmp_path: pathlib.Path) -> None:
+    """A genuinely unparseable query yields a ParseOutcome carrying a result whose
+    debug_info records the error, rather than raising or an outcome-level error."""
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+    writable.close()
+
+    task = ParseTask(
+        key="bad",
+        query="SELECT SELECT FROM WHERE ((((",
+        default_db="db",
+        default_schema="schema",
+    )
+
+    with ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+    ) as parser:
+        outcomes = list(parser.map_unordered([task]))
+
+    assert len(outcomes) == 1
+    outcome = outcomes[0]
+    assert outcome.key == "bad"
+    # Normal parse failures are captured inside SqlParsingResult.debug_info,
+    # so this is a returned result, not an outcome-level error.
+    assert outcome.error is None
+    assert outcome.result is not None
+    assert outcome.result.debug_info.error is not None
+
+
+def test_close_is_idempotent(tmp_path: pathlib.Path) -> None:
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+    writable.close()
+
+    parser = ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+    )
+    # Force pool creation so close() has something to shut down.
+    list(
+        parser.map_unordered(
+            [
+                ParseTask(
+                    key=1,
+                    query="SELECT order_id FROM db.schema.orders",
+                    default_db="db",
+                    default_schema="schema",
+                )
+            ]
+        )
+    )
+    parser.close()
+    parser.close()  # must be safe to call twice
+
+
+def test_context_manager(tmp_path: pathlib.Path) -> None:
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+    writable.close()
+
+    with ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+    ) as parser:
+        outcomes = list(
+            parser.map_unordered(
+                [
+                    ParseTask(
+                        key=1,
+                        query="SELECT order_id FROM db.schema.orders",
+                        default_db="db",
+                        default_schema="schema",
+                    )
+                ]
+            )
+        )
+    assert len(outcomes) == 1
+    assert outcomes[0].error is None
+
+
+@pytest.mark.parametrize("outcome_key", ["a", "b"])
+def test_parse_outcome_shape(outcome_key: str) -> None:
+    outcome = ParseOutcome(key=outcome_key, result=None, error="boom")
+    assert outcome.key == outcome_key
+    assert outcome.result is None
+    assert outcome.error == "boom"

--- a/metadata-ingestion/tests/unit/sql_parsing/test_parallel_sql_parser.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_parallel_sql_parser.py
@@ -217,6 +217,47 @@ def test_context_manager(tmp_path: pathlib.Path) -> None:
     assert outcomes[0].error is None
 
 
+def test_parse_one_blocking(tmp_path: pathlib.Path) -> None:
+    """parse_one submits a single task and blocks for its outcome, producing a
+    result identical to in-process serial parsing."""
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+
+    query = "SELECT order_id, amount FROM db.schema.orders"
+    expected = sqlglot_lineage(
+        query,
+        schema_resolver=writable,
+        default_db="db",
+        default_schema="schema",
+    )
+
+    with ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+    ) as parser:
+        outcome = parser.parse_one(
+            ParseTask(
+                key="only",
+                query=query,
+                default_db="db",
+                default_schema="schema",
+            )
+        )
+
+    assert outcome.key == "only"
+    assert outcome.error is None
+    assert outcome.result is not None
+    assert outcome.result.in_tables == expected.in_tables
+    assert outcome.result.out_tables == expected.out_tables
+    assert outcome.result.column_lineage == expected.column_lineage
+
+    writable.close()
+
+
 @pytest.mark.parametrize("outcome_key", ["a", "b"])
 def test_parse_outcome_shape(outcome_key: str) -> None:
     outcome = ParseOutcome(key=outcome_key, result=None, error="boom")

--- a/metadata-ingestion/tests/unit/sql_parsing/test_parallel_sql_parsing_config.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_parallel_sql_parsing_config.py
@@ -1,0 +1,138 @@
+"""Config-parse tests for the SqlParsingParallelismConfig mixin.
+
+Verifies that each connector's config correctly exposes use_parallel_sql_parsing
+and sql_parsing_workers, and that values round-trip without error.
+"""
+
+from datahub.sql_parsing.sql_parsing_aggregator import SqlParsingParallelismConfig
+
+# ---------------------------------------------------------------------------
+# Mixin standalone tests
+# ---------------------------------------------------------------------------
+
+
+def test_mixin_defaults() -> None:
+    class _Cfg(SqlParsingParallelismConfig):
+        pass
+
+    cfg = _Cfg()
+    assert cfg.use_parallel_sql_parsing is False
+    assert cfg.sql_parsing_workers is None
+
+
+def test_mixin_accepts_values() -> None:
+    class _Cfg(SqlParsingParallelismConfig):
+        pass
+
+    cfg = _Cfg(use_parallel_sql_parsing=True, sql_parsing_workers=4)
+    assert cfg.use_parallel_sql_parsing is True
+    assert cfg.sql_parsing_workers == 4
+
+
+# ---------------------------------------------------------------------------
+# Snowflake
+# ---------------------------------------------------------------------------
+
+
+def test_snowflake_queries_extractor_config_parallel_defaults() -> None:
+    from datahub.ingestion.source.snowflake.snowflake_queries import (
+        SnowflakeQueriesExtractorConfig,
+    )
+
+    cfg = SnowflakeQueriesExtractorConfig()
+    assert cfg.use_parallel_sql_parsing is False
+    assert cfg.sql_parsing_workers is None
+
+
+def test_snowflake_queries_extractor_config_parallel_values() -> None:
+    from datahub.ingestion.source.snowflake.snowflake_queries import (
+        SnowflakeQueriesExtractorConfig,
+    )
+
+    cfg = SnowflakeQueriesExtractorConfig(
+        use_parallel_sql_parsing=True, sql_parsing_workers=4
+    )
+    assert cfg.use_parallel_sql_parsing is True
+    assert cfg.sql_parsing_workers == 4
+
+
+# ---------------------------------------------------------------------------
+# BigQuery
+# ---------------------------------------------------------------------------
+
+
+def test_bigquery_queries_extractor_config_parallel_defaults() -> None:
+    from datahub.ingestion.source.bigquery_v2.queries_extractor import (
+        BigQueryQueriesExtractorConfig,
+    )
+
+    cfg = BigQueryQueriesExtractorConfig()
+    assert cfg.use_parallel_sql_parsing is False
+    assert cfg.sql_parsing_workers is None
+
+
+def test_bigquery_queries_extractor_config_parallel_values() -> None:
+    from datahub.ingestion.source.bigquery_v2.queries_extractor import (
+        BigQueryQueriesExtractorConfig,
+    )
+
+    cfg = BigQueryQueriesExtractorConfig(
+        use_parallel_sql_parsing=True, sql_parsing_workers=4
+    )
+    assert cfg.use_parallel_sql_parsing is True
+    assert cfg.sql_parsing_workers == 4
+
+
+# ---------------------------------------------------------------------------
+# Redshift
+# ---------------------------------------------------------------------------
+
+
+def test_redshift_config_parallel_defaults() -> None:
+    from datahub.ingestion.source.redshift.config import RedshiftConfig
+
+    cfg = RedshiftConfig(host_port="localhost:5439", database="test")
+    assert cfg.use_parallel_sql_parsing is False
+    assert cfg.sql_parsing_workers is None
+
+
+def test_redshift_config_parallel_values() -> None:
+    from datahub.ingestion.source.redshift.config import RedshiftConfig
+
+    cfg = RedshiftConfig(
+        host_port="localhost:5439",
+        database="test",
+        use_parallel_sql_parsing=True,
+        sql_parsing_workers=4,
+    )
+    assert cfg.use_parallel_sql_parsing is True
+    assert cfg.sql_parsing_workers == 4
+
+
+# ---------------------------------------------------------------------------
+# Unity Catalog / Databricks
+# ---------------------------------------------------------------------------
+
+
+def test_unity_catalog_config_parallel_defaults() -> None:
+    from datahub.ingestion.source.unity.config import UnityCatalogSourceConfig
+
+    cfg = UnityCatalogSourceConfig(
+        workspace_url="https://adb-123.azuredatabricks.net",
+        token="dapi-test-token",
+    )
+    assert cfg.use_parallel_sql_parsing is False
+    assert cfg.sql_parsing_workers is None
+
+
+def test_unity_catalog_config_parallel_values() -> None:
+    from datahub.ingestion.source.unity.config import UnityCatalogSourceConfig
+
+    cfg = UnityCatalogSourceConfig(
+        workspace_url="https://adb-123.azuredatabricks.net",
+        token="dapi-test-token",
+        use_parallel_sql_parsing=True,
+        sql_parsing_workers=4,
+    )
+    assert cfg.use_parallel_sql_parsing is True
+    assert cfg.sql_parsing_workers == 4

--- a/metadata-ingestion/tests/unit/sql_parsing/test_parallel_sql_parsing_config.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_parallel_sql_parsing_config.py
@@ -4,6 +4,9 @@ Verifies that each connector's config correctly exposes use_parallel_sql_parsing
 and sql_parsing_workers, and that values round-trip without error.
 """
 
+import pytest
+from pydantic import ValidationError
+
 from datahub.sql_parsing.sql_parsing_aggregator import SqlParsingParallelismConfig
 
 # ---------------------------------------------------------------------------
@@ -27,6 +30,27 @@ def test_mixin_accepts_values() -> None:
     cfg = _Cfg(use_parallel_sql_parsing=True, sql_parsing_workers=4)
     assert cfg.use_parallel_sql_parsing is True
     assert cfg.sql_parsing_workers == 4
+
+
+def test_mixin_accepts_none_workers() -> None:
+    """None (auto-detect) must remain valid after adding ge=1."""
+
+    class _Cfg(SqlParsingParallelismConfig):
+        pass
+
+    cfg = _Cfg(sql_parsing_workers=None)
+    assert cfg.sql_parsing_workers is None
+
+
+@pytest.mark.parametrize("bad_value", [0, -1])
+def test_mixin_rejects_non_positive_workers(bad_value: int) -> None:
+    """Values ≤ 0 must be rejected at config-parse time (ge=1 constraint)."""
+
+    class _Cfg(SqlParsingParallelismConfig):
+        pass
+
+    with pytest.raises(ValidationError):
+        _Cfg(sql_parsing_workers=bad_value)
 
 
 # ---------------------------------------------------------------------------

--- a/metadata-ingestion/tests/unit/sql_parsing/test_schemaresolver.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_schemaresolver.py
@@ -677,6 +677,154 @@ class TestSnapshotRoundTrip:
             ro.close()
 
 
+class TestForWorkerTwoTier:
+    """Two-tier worker resolver: reads schemas from the read-only snapshot but
+    can hold graph-hydrated results and None-miss dedup in a small writable overlay.
+
+    Regression guard: a worker with a graph attached must NOT silently drop
+    graph-hydrated lineage (the bug: writes were no-ops on the read-only snapshot).
+    """
+
+    def _make_snapshot_with_table_a(self, tmp_path: pathlib.Path) -> pathlib.Path:
+        """Snapshot containing only table A (orders)."""
+        cache_file = tmp_path / "schema_cache.db"
+        writable = SchemaResolver(
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+            graph=None,
+            _cache_filename=cache_file,
+        )
+        writable.add_raw_schema_info(
+            urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,prod.db.schema.orders,PROD)",
+            schema_info={"order_id": "int", "amount": "float"},
+        )
+        snap = tmp_path / "snapshot.db"
+        writable.snapshot_to(snap)
+        writable.close()
+        return snap
+
+    def _graph_returning_table_b(self):
+        """Mock graph whose get_entities returns a real SchemaMetadataClass for
+        table B (customers) only — table A is not in the graph."""
+        urn_b = "urn:li:dataset:(urn:li:dataPlatform:snowflake,prod.db.schema.customers,PROD)"
+        graph = MagicMock(spec=DataHubGraph)
+
+        def get_entities(entity_name, urns, aspects, with_system_metadata):
+            result: dict = {}
+            if urn_b in urns:
+                result[urn_b] = {
+                    "schemaMetadata": (
+                        create_mock_schema(
+                            [("customer_id", "int"), ("name", "varchar")]
+                        ),
+                        {},
+                    )
+                }
+            return result
+
+        graph.get_entities.side_effect = get_entities
+        return graph
+
+    def test_snapshot_hit_and_graph_hydration_parity(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Table A resolves from the snapshot (no graph call needed); table B
+        resolves via graph hydration (NOT None). Proves no lineage loss."""
+        snap = self._make_snapshot_with_table_a(tmp_path)
+        graph = self._graph_returning_table_b()
+
+        worker = SchemaResolver.for_worker(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+            graph=graph,
+        )
+        try:
+            _, info_a = worker.resolve_table(
+                _TableName(database="db", db_schema="schema", table="orders")
+            )
+            assert info_a is not None
+            assert info_a["order_id"] == "int"
+
+            _, info_b = worker.resolve_table(
+                _TableName(database="db", db_schema="schema", table="customers")
+            )
+            assert info_b is not None, "graph-hydrated schema was silently dropped"
+            assert info_b["customer_id"] == "int"
+        finally:
+            worker.close()
+
+    def test_graph_fetch_deduped_via_overlay(self, tmp_path: pathlib.Path) -> None:
+        """Resolving table B twice fetches from the graph only once; the second
+        call is served from the writable overlay."""
+        snap = self._make_snapshot_with_table_a(tmp_path)
+        graph = self._graph_returning_table_b()
+
+        worker = SchemaResolver.for_worker(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+            graph=graph,
+        )
+        try:
+            table_b = _TableName(database="db", db_schema="schema", table="customers")
+            _, info1 = worker.resolve_table(table_b)
+            assert info1 is not None
+            first_count = graph.get_entities.call_count
+
+            _, info2 = worker.resolve_table(table_b)
+            assert info2 == info1
+            assert graph.get_entities.call_count == first_count
+        finally:
+            worker.close()
+
+    def test_none_miss_deduped_via_overlay(self, tmp_path: pathlib.Path) -> None:
+        """Table C (in neither snapshot nor graph) returns None and is not re-fetched."""
+        snap = self._make_snapshot_with_table_a(tmp_path)
+        graph = self._graph_returning_table_b()
+
+        worker = SchemaResolver.for_worker(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+            graph=graph,
+        )
+        try:
+            table_c = _TableName(database="db", db_schema="schema", table="ghost")
+            _, info1 = worker.resolve_table(table_c)
+            assert info1 is None
+            first_count = graph.get_entities.call_count
+
+            _, info2 = worker.resolve_table(table_c)
+            assert info2 is None
+            assert graph.get_entities.call_count == first_count
+        finally:
+            worker.close()
+
+    def test_for_worker_no_graph_close_after_miss_does_not_raise(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """for_worker without a graph: snapshot reads work and close after a miss
+        does not raise (primary overlay is writable in-memory)."""
+        snap = self._make_snapshot_with_table_a(tmp_path)
+        worker = SchemaResolver.for_worker(
+            snap, platform="snowflake", platform_instance="prod", env="PROD", graph=None
+        )
+        _, info_a = worker.resolve_table(
+            _TableName(database="db", db_schema="schema", table="orders")
+        )
+        assert info_a is not None
+        _, info_miss = worker.resolve_table(
+            _TableName(database="db", db_schema="schema", table="nope")
+        )
+        assert info_miss is None
+        worker.close()
+
+
 class TestConcurrentReadonlyResolvers:
     def test_two_resolvers_same_snapshot(self, tmp_path: pathlib.Path) -> None:
         """Two independent read-only resolvers on the same snapshot file work without locking errors."""

--- a/metadata-ingestion/tests/unit/sql_parsing/test_schemaresolver.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_schemaresolver.py
@@ -720,3 +720,74 @@ class TestConcurrentReadonlyResolvers:
         finally:
             ro1.close()
             ro2.close()
+
+
+class TestReadOnlyResolverNoWriteOnClose:
+    """Regression test: read-only resolver must not write to SQLite at close/GC time.
+
+    H1 fix verification: FileBackedDict.close() must skip flush() for read-only
+    connections, and _save_to_cache must be a no-op for read-only resolvers so
+    cache-miss paths never dirty the in-memory cache.
+    """
+
+    def test_readonly_resolver_close_after_cache_miss_does_not_raise(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Build a writable resolver, snapshot it, open read-only, trigger a miss,
+        then close — no sqlite3.OperationalError should be raised."""
+        snapshot_path = tmp_path / "schema_cache.db"
+
+        # Build a writable resolver and populate it.
+        writable = SchemaResolver(platform="snowflake", env="PROD", graph=None)
+        writable.add_raw_schema_info(
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.known_table,PROD)",
+            {"col_a": "STRING"},
+        )
+        writable.snapshot_to(snapshot_path)
+        writable.close()
+
+        # Open read-only.
+        ro = SchemaResolver.load_readonly(
+            snapshot_path, platform="snowflake", env="PROD"
+        )
+
+        # Trigger a miss on resolve_table (unknown table) — this path calls
+        # _save_to_cache(urn, None) on the writable resolver but must be a no-op here.
+        _, info_table = ro.resolve_table(
+            _TableName(database="db", db_schema="schema", table="unknown_table")
+        )
+        assert info_table is None
+
+        # Trigger a miss on resolve_urn (also calls _resolve_schema_info).
+        _, info_urn = ro.resolve_urn(
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.also_missing,PROD)"
+        )
+        assert info_urn is None
+
+        # close() must NOT raise even though misses may have dirtied the in-memory cache
+        # on the old code path.
+        ro.close()  # This was the crash site before the fix.
+
+    def test_readonly_resolver_del_does_not_raise(self, tmp_path: pathlib.Path) -> None:
+        """Simulates GC path: explicitly calling close() after __del__ chain."""
+        snapshot_path = tmp_path / "schema_cache2.db"
+
+        writable = SchemaResolver(platform="redshift", env="PROD", graph=None)
+        writable.add_raw_schema_info(
+            "urn:li:dataset:(urn:li:dataPlatform:redshift,mydb.public.events,PROD)",
+            {"id": "INT"},
+        )
+        writable.snapshot_to(snapshot_path)
+        writable.close()
+
+        ro = SchemaResolver.load_readonly(
+            snapshot_path, platform="redshift", env="PROD"
+        )
+
+        # Miss path — used to dirty the cache, causing flush() → write → error at close.
+        ro.resolve_table(_TableName(database="mydb", db_schema="public", table="ghost"))
+
+        # Simulate what __del__ → close() does at GC time.
+        ro.close()
+        # Calling close() twice must also be safe (idempotent).
+        ro.close()

--- a/metadata-ingestion/tests/unit/sql_parsing/test_schemaresolver.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_schemaresolver.py
@@ -1,3 +1,4 @@
+import pathlib
 from unittest.mock import MagicMock
 
 import pytest
@@ -531,3 +532,191 @@ class TestTableNameParts:
         assert table_with_parts == table_without_parts, "Equality ignores parts field"
         assert table_with_parts.parts == ("source", "schema", "table")
         assert table_without_parts.parts is None
+
+
+# ---------------------------------------------------------------------------
+# Snapshot / read-only SchemaResolver tests
+# ---------------------------------------------------------------------------
+
+
+def _make_writable_resolver(tmp_path: pathlib.Path) -> SchemaResolver:
+    """Build a file-backed writable SchemaResolver with two known schemas."""
+    cache_file = tmp_path / "schema_cache.db"
+    resolver = SchemaResolver(
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+        graph=None,
+        _cache_filename=cache_file,
+    )
+    resolver.add_raw_schema_info(
+        urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,prod.db.schema.orders,PROD)",
+        schema_info={"order_id": "int", "amount": "float"},
+    )
+    resolver.add_raw_schema_info(
+        urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,prod.db.schema.customers,PROD)",
+        schema_info={"customer_id": "int", "name": "varchar"},
+    )
+    return resolver
+
+
+class TestSnapshotRoundTrip:
+    def test_snapshot_to_creates_file(self, tmp_path: pathlib.Path) -> None:
+        resolver = _make_writable_resolver(tmp_path)
+        snap = tmp_path / "snapshot.db"
+        resolver.snapshot_to(snap)
+        resolver.close()
+
+        assert snap.exists()
+        assert snap.stat().st_size > 0
+
+    def test_load_readonly_returns_same_schemas(self, tmp_path: pathlib.Path) -> None:
+        """load_readonly must return identical schema info for tables added to the original."""
+        resolver = _make_writable_resolver(tmp_path)
+        snap = tmp_path / "snapshot.db"
+        resolver.snapshot_to(snap)
+        resolver.close()
+
+        ro = SchemaResolver.load_readonly(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+        )
+        try:
+            urn, info = ro.resolve_table(
+                _TableName(database="db", db_schema="schema", table="orders")
+            )
+            assert info is not None
+            assert info["order_id"] == "int"
+            assert info["amount"] == "float"
+
+            urn2, info2 = ro.resolve_table(
+                _TableName(database="db", db_schema="schema", table="customers")
+            )
+            assert info2 is not None
+            assert info2["customer_id"] == "int"
+            assert info2["name"] == "varchar"
+        finally:
+            ro.close()
+
+    def test_load_readonly_unknown_table_returns_none(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Resolving an unknown table via a read-only resolver returns (urn, None)."""
+        resolver = _make_writable_resolver(tmp_path)
+        snap = tmp_path / "snapshot.db"
+        resolver.snapshot_to(snap)
+        resolver.close()
+
+        ro = SchemaResolver.load_readonly(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+        )
+        try:
+            urn, info = ro.resolve_table(
+                _TableName(database="db", db_schema="schema", table="nonexistent")
+            )
+            assert urn is not None  # URN is always synthesized
+            assert info is None
+        finally:
+            ro.close()
+
+    def test_load_readonly_has_no_graph(self, tmp_path: pathlib.Path) -> None:
+        """The read-only resolver must not make graph calls (graph=None)."""
+        resolver = _make_writable_resolver(tmp_path)
+        snap = tmp_path / "snapshot.db"
+        resolver.snapshot_to(snap)
+        resolver.close()
+
+        ro = SchemaResolver.load_readonly(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+        )
+        try:
+            assert ro.graph is None
+        finally:
+            ro.close()
+
+    def test_snapshot_flushes_in_memory_cache(self, tmp_path: pathlib.Path) -> None:
+        """snapshot_to must persist entries that are still in the in-memory LRU cache."""
+        cache_file = tmp_path / "schema_cache.db"
+        resolver = SchemaResolver(
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+            graph=None,
+            _cache_filename=cache_file,
+        )
+        # Add an entry — it may still be in the LRU cache, not yet written to SQLite.
+        resolver.add_raw_schema_info(
+            urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,prod.db.s.t,PROD)",
+            schema_info={"col": "text"},
+        )
+        snap = tmp_path / "snapshot.db"
+        resolver.snapshot_to(snap)
+        resolver.close()
+
+        ro = SchemaResolver.load_readonly(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+        )
+        try:
+            urn, info = ro.resolve_table(
+                _TableName(database="db", db_schema="s", table="t")
+            )
+            assert info is not None
+            assert info["col"] == "text"
+        finally:
+            ro.close()
+
+
+class TestConcurrentReadonlyResolvers:
+    def test_two_resolvers_same_snapshot(self, tmp_path: pathlib.Path) -> None:
+        """Two independent read-only resolvers on the same snapshot file work without locking errors."""
+        resolver = _make_writable_resolver(tmp_path)
+        snap = tmp_path / "snapshot.db"
+        resolver.snapshot_to(snap)
+        resolver.close()
+
+        ro1 = SchemaResolver.load_readonly(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+        )
+        ro2 = SchemaResolver.load_readonly(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+        )
+        try:
+            # Both open simultaneously — no locking error expected with immutable=1.
+            urn1, info1 = ro1.resolve_table(
+                _TableName(database="db", db_schema="schema", table="orders")
+            )
+            urn2, info2 = ro2.resolve_table(
+                _TableName(database="db", db_schema="schema", table="customers")
+            )
+            assert info1 is not None
+            assert info2 is not None
+
+            # Cross-check: each resolver can see both tables.
+            _, orders_from_ro2 = ro2.resolve_table(
+                _TableName(database="db", db_schema="schema", table="orders")
+            )
+            _, customers_from_ro1 = ro1.resolve_table(
+                _TableName(database="db", db_schema="schema", table="customers")
+            )
+            assert orders_from_ro2 is not None
+            assert customers_from_ro1 is not None
+        finally:
+            ro1.close()
+            ro2.close()

--- a/metadata-ingestion/tests/unit/test_unity_catalog_usage_join.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_usage_join.py
@@ -1,3 +1,4 @@
+import contextlib
 import pathlib
 from contextlib import closing
 from datetime import datetime, timedelta, timezone
@@ -22,6 +23,19 @@ from datahub.utilities.file_backed_collections import ConnectionWrapper, FileBac
 def _row(**kw):
     # Databricks Row supports attribute access; SimpleNamespace replicates that.
     return SimpleNamespace(**kw)
+
+
+class _FakeAggBase:
+    """Base for all FakeAgg test doubles.
+
+    Provides a no-op parallel_sql_parsing_scope() so tests that wrap the
+    query-feeding loop in ``with aggregator.parallel_sql_parsing_scope():``
+    do not fail with AttributeError.
+    """
+
+    @contextlib.contextmanager
+    def parallel_sql_parsing_scope(self):  # type: ignore[return]
+        yield
 
 
 # ---------------------------------------------------------------------------
@@ -270,7 +284,7 @@ def test_builds_aggregator_and_feeds_observed_queries(
     captured: dict = {}
     agg_instance: list = []  # single-element list so the closure can capture it
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             captured["kwargs"] = kw
             self.observed: list = []
@@ -338,7 +352,7 @@ def test_observed_query_timestamps_normalized_to_utc(
     """
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             agg_instance.append(self)
@@ -445,7 +459,7 @@ def test_is_allowed_table_predicate_scopes_to_ingested_tables(
     """
     captured: dict = {}
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             captured["kwargs"] = kw
 
@@ -522,7 +536,7 @@ def test_is_allowed_table_predicate_platform_instance_safe(
     """
     captured: dict = {}
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             captured["kwargs"] = kw
 
@@ -599,7 +613,7 @@ def test_schema_resolver_passed_to_aggregator(
     """
     captured: dict = {}
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             captured["kwargs"] = kw
 
@@ -646,7 +660,7 @@ def test_default_db_set_to_single_catalog(
     """When all table_refs share one catalog, every ObservedQuery.default_db must equal it."""
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             agg_instance.append(self)
@@ -703,7 +717,7 @@ def test_default_db_none_for_multi_catalog(
     """When table_refs span two catalogs, every ObservedQuery.default_db must be None."""
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             agg_instance.append(self)
@@ -753,7 +767,7 @@ def test_default_db_none_for_empty_table_refs(
     """When table_refs is empty, default_db must be None and no crash must occur."""
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             agg_instance.append(self)
@@ -801,7 +815,7 @@ def test_schema_resolver_explicit_empty_resolver_passed_through(
     """
     captured: dict = {}
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             captured["kwargs"] = kw
 
@@ -853,7 +867,7 @@ def test_auto_empty_usage_emitted_for_unqueried_tables(
     runs), then checks that the *unqueried* table still receives a zero-usage workunit.
     """
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         """Produces no metadata — simulates a window where no queries touched the table."""
 
         def __init__(self, **kw: object) -> None:
@@ -940,7 +954,7 @@ def test_zero_queries_emits_empty_usage_for_idle_window(
     (see test_fetch_failure_reports_failure_and_no_usage_workunits).
     """
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -1030,7 +1044,7 @@ def test_fetch_failure_reports_failure_and_no_usage_workunits(
     a normal empty-history run.
     """
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -1112,7 +1126,7 @@ def test_gen_metadata_raises_propagates_to_caller(
 
     closed_calls: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -1160,7 +1174,7 @@ def test_aggregator_close_raises_does_not_propagate(
     even when the main try-block completed normally.
     """
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -1203,7 +1217,7 @@ def test_single_bad_query_skipped_others_still_fed(
     observed: list = []
     call_count = [0]  # mutable cell so the closure can increment it
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -1275,7 +1289,7 @@ def test_fetch_queries_routes_through_api_when_system_tables_disabled(
     """
     observed: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -1328,7 +1342,7 @@ def test_midstream_fetch_failure_with_some_queries_reports_failure(
     a 'Failed to fetch query history' failure — not just the benign warning.
     """
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -1395,7 +1409,7 @@ def _run_flag_case(
     """Helper: run get_usage_workunits with the given flag values; return aggregator kwargs."""
     captured: dict = {}
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             captured["kwargs"] = kw
 
@@ -1474,7 +1488,7 @@ def test_preparsed_query_used_when_system_table_lineage_present(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -1528,7 +1542,7 @@ def test_fallback_to_observed_when_lineage_unresolvable(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -1579,7 +1593,7 @@ def test_sqlglot_when_no_system_table_lineage(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -1887,7 +1901,7 @@ def test_fetch_queries_passes_catalog_pattern_when_pushdown_enabled(
 ) -> None:
     """usage._fetch_queries must pass catalog_pattern when pushdown flag is on."""
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -1939,7 +1953,7 @@ def test_fetch_queries_omits_catalog_pattern_when_pushdown_disabled(
 ) -> None:
     """usage._fetch_queries must not pass catalog_pattern when pushdown flag is off."""
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -2137,7 +2151,7 @@ def test_preparsed_query_multi_target_fanout(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -2189,7 +2203,7 @@ def test_preparsed_query_target_only_lineage(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -2242,7 +2256,7 @@ def test_preparsed_query_partial_urn_resolution(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -2353,7 +2367,7 @@ def test_skip_sqlglot_when_system_table_lineage_missing_skips_query(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -2416,7 +2430,7 @@ def test_skip_sqlglot_when_system_table_lineage_missing_skips_query(
 def test_api_fetch_passes_include_operational_stats(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -2453,7 +2467,7 @@ def test_api_fetch_passes_include_operational_stats(
 def test_mixed_routing_counters(monkeypatch: pytest.MonkeyPatch) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -2742,7 +2756,7 @@ def test_preparsed_fingerprint_falls_back_to_statement_id(
 
 
 def _no_op_aggregator(monkeypatch: pytest.MonkeyPatch) -> None:
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -2837,7 +2851,7 @@ def test_include_column_usage_stats_forces_sqlglot_with_lineage(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -2890,7 +2904,7 @@ def test_include_column_usage_stats_overrides_skip_sqlglot(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -2946,7 +2960,7 @@ def test_include_column_usage_stats_overrides_skip_sqlglot(
 def test_fetch_queries_omits_catalog_pattern_when_column_usage_stats_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -3029,7 +3043,7 @@ def test_queries_drained_before_parsing(
         # Only set after the last item is yielded (generator fully consumed).
         fetch_exhausted[0] = True
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
 

--- a/metadata-ingestion/tests/unit/utilities/test_backpressure_aware_executor.py
+++ b/metadata-ingestion/tests/unit/utilities/test_backpressure_aware_executor.py
@@ -1,4 +1,5 @@
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 from datahub.utilities.backpressure_aware_executor import BackpressureAwareExecutor
 from datahub.utilities.perf_timer import PerfTimer
@@ -57,3 +58,28 @@ def test_backpressure_aware_executor_advanced():
         # Validate that the entire process took about 5-10x the task duration.
         # That's because we have 2 workers and 10 tasks.
         assert 5 * task_duration < timer.elapsed_seconds() < 10 * task_duration
+
+
+def test_backpressure_aware_executor_with_provided_executor():
+    """When an executor is passed in, map uses it and does NOT close it."""
+
+    def task(i):
+        return i
+
+    executor = ThreadPoolExecutor(max_workers=2)
+    try:
+        results = {
+            res.result()
+            for res in BackpressureAwareExecutor.map(
+                task,
+                ((i,) for i in range(10)),
+                max_workers=2,
+                executor=executor,
+            )
+        }
+        assert results == set(range(10))
+
+        # The provided executor must remain usable — map must not have shut it down.
+        assert executor.submit(task, 42).result() == 42
+    finally:
+        executor.shutdown(wait=True)

--- a/metadata-ingestion/tests/unit/utilities/test_cpu_detection.py
+++ b/metadata-ingestion/tests/unit/utilities/test_cpu_detection.py
@@ -1,3 +1,5 @@
+import logging
+
 from datahub.utilities import cpu_detection
 from datahub.utilities.cpu_detection import (
     WorkerDecision,
@@ -27,6 +29,15 @@ class TestCgroupParsing:
     def test_malformed_input_returns_none(self):
         assert cpu_detection._parse_cgroup_v2_cpu_max("garbage") is None
         assert cpu_detection._parse_cgroup_v1_cpu_quota("x", "y") is None
+
+    def test_cgroup_v2_negative_quota_returns_none(self):
+        assert cpu_detection._parse_cgroup_v2_cpu_max("-100 100000") is None
+
+    def test_cgroup_v1_zero_quota_returns_none(self):
+        assert cpu_detection._parse_cgroup_v1_cpu_quota("0", "100000") is None
+
+    def test_cgroup_v1_zero_period_returns_none(self):
+        assert cpu_detection._parse_cgroup_v1_cpu_quota("200000", "0") is None
 
 
 class TestGetAvailableCpuCount:
@@ -80,3 +91,8 @@ class TestResolveWorkerCount:
         decision = resolve_worker_count(4, detected_cpus=1)
         assert decision.workers == 1
         assert decision.fell_back_to_serial
+
+    def test_explicit_over_capacity_emits_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="datahub.utilities.cpu_detection"):
+            resolve_worker_count(100, detected_cpus=8)
+        assert "100" in caplog.text and "7" in caplog.text

--- a/metadata-ingestion/tests/unit/utilities/test_cpu_detection.py
+++ b/metadata-ingestion/tests/unit/utilities/test_cpu_detection.py
@@ -1,0 +1,82 @@
+from datahub.utilities import cpu_detection
+from datahub.utilities.cpu_detection import (
+    WorkerDecision,
+    get_available_cpu_count,
+    resolve_worker_count,
+)
+
+
+class TestCgroupParsing:
+    def test_cgroup_v2_unlimited_returns_none(self):
+        assert cpu_detection._parse_cgroup_v2_cpu_max("max 100000\n") is None
+
+    def test_cgroup_v2_quota_returns_cpu_fraction(self):
+        # "<quota> <period>" — 200000/100000 == 2 CPUs.
+        assert cpu_detection._parse_cgroup_v2_cpu_max("200000 100000") == 2.0
+
+    def test_cgroup_v2_fractional(self):
+        assert cpu_detection._parse_cgroup_v2_cpu_max("150000 100000") == 1.5
+
+    def test_cgroup_v1_unlimited_quota_returns_none(self):
+        # quota of -1 means no limit.
+        assert cpu_detection._parse_cgroup_v1_cpu_quota("-1", "100000") is None
+
+    def test_cgroup_v1_quota_returns_cpu_fraction(self):
+        assert cpu_detection._parse_cgroup_v1_cpu_quota("250000", "100000") == 2.5
+
+    def test_malformed_input_returns_none(self):
+        assert cpu_detection._parse_cgroup_v2_cpu_max("garbage") is None
+        assert cpu_detection._parse_cgroup_v1_cpu_quota("x", "y") is None
+
+
+class TestGetAvailableCpuCount:
+    def test_takes_minimum_of_all_signals(self, monkeypatch):
+        # A 2-CPU pod on a 64-core node: cgroup quota must win over cpu_count.
+        monkeypatch.setattr(cpu_detection, "_cgroup_cpu_limit", lambda: 2.0)
+        monkeypatch.setattr(cpu_detection, "_affinity_cpu_count", lambda: 8)
+        monkeypatch.setattr(cpu_detection, "_os_cpu_count", lambda: 64)
+        assert get_available_cpu_count() == 2
+
+    def test_fractional_cgroup_is_floored(self, monkeypatch):
+        monkeypatch.setattr(cpu_detection, "_cgroup_cpu_limit", lambda: 1.5)
+        monkeypatch.setattr(cpu_detection, "_affinity_cpu_count", lambda: 8)
+        monkeypatch.setattr(cpu_detection, "_os_cpu_count", lambda: 64)
+        assert get_available_cpu_count() == 1
+
+    def test_non_linux_fallback_to_cpu_count(self, monkeypatch):
+        # No cgroup, no affinity (e.g. macOS): fall back to os.cpu_count().
+        monkeypatch.setattr(cpu_detection, "_cgroup_cpu_limit", lambda: None)
+        monkeypatch.setattr(cpu_detection, "_affinity_cpu_count", lambda: None)
+        monkeypatch.setattr(cpu_detection, "_os_cpu_count", lambda: 8)
+        assert get_available_cpu_count() == 8
+
+    def test_always_at_least_one(self, monkeypatch):
+        monkeypatch.setattr(cpu_detection, "_cgroup_cpu_limit", lambda: None)
+        monkeypatch.setattr(cpu_detection, "_affinity_cpu_count", lambda: None)
+        monkeypatch.setattr(cpu_detection, "_os_cpu_count", lambda: None)
+        assert get_available_cpu_count() == 1
+
+
+class TestResolveWorkerCount:
+    def test_auto_detect_reserves_one_core(self):
+        decision = resolve_worker_count(None, detected_cpus=8)
+        assert isinstance(decision, WorkerDecision)
+        assert decision.workers == 7
+        assert not decision.clamped
+        assert not decision.fell_back_to_serial
+
+    def test_explicit_within_capacity_is_honored(self):
+        decision = resolve_worker_count(4, detected_cpus=8)
+        assert decision.workers == 4
+        assert not decision.clamped
+
+    def test_explicit_over_capacity_is_clamped(self):
+        # The virtualization footgun: user asks for 100 on an 8-core box.
+        decision = resolve_worker_count(100, detected_cpus=8)
+        assert decision.workers == 7  # 8 - 1 reserved
+        assert decision.clamped
+
+    def test_single_core_falls_back_to_serial(self):
+        decision = resolve_worker_count(4, detected_cpus=1)
+        assert decision.workers == 1
+        assert decision.fell_back_to_serial

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
@@ -431,3 +431,150 @@ def test_file_cleanup():
     assert filename.exists()
     cache.close()
     assert not filename.exists()
+
+
+# ---------------------------------------------------------------------------
+# Read-only ConnectionWrapper and FileBackedDict tests
+# ---------------------------------------------------------------------------
+
+
+def test_readonly_connection_wrapper_opens_immutable(tmp_path: pathlib.Path) -> None:
+    """A read-only ConnectionWrapper opens an existing file and allows SELECTs."""
+    db_path = tmp_path / "test.db"
+
+    # Create a writable DB with some data.
+    with ConnectionWrapper(filename=db_path) as writable:
+        writable.execute("CREATE TABLE items (key TEXT PRIMARY KEY, value INTEGER)")
+        writable.execute("INSERT INTO items VALUES ('a', 1)")
+        writable.execute("INSERT INTO items VALUES ('b', 2)")
+
+    # Open the same file read-only.
+    ro_conn = ConnectionWrapper(filename=db_path, read_only=True)
+    try:
+        cursor = ro_conn.execute("SELECT value FROM items WHERE key = 'a'")
+        row = cursor.fetchone()
+        assert row[0] == 1
+
+        cursor2 = ro_conn.execute("SELECT COUNT(*) FROM items")
+        assert cursor2.fetchone()[0] == 2
+    finally:
+        ro_conn.close()
+
+
+def test_readonly_connection_skips_writable_pragmas(tmp_path: pathlib.Path) -> None:
+    """Read-only connection should not error on open; writable pragmas are skipped."""
+    db_path = tmp_path / "test.db"
+
+    # Bootstrap a valid SQLite file.
+    with ConnectionWrapper(filename=db_path) as writable:
+        writable.execute("CREATE TABLE t (k TEXT)")
+
+    # Should not raise.
+    ro_conn = ConnectionWrapper(filename=db_path, read_only=True)
+    ro_conn.close()
+
+
+def test_readonly_file_backed_dict_reads(tmp_path: pathlib.Path) -> None:
+    """FileBackedDict on a read-only connection can read existing data."""
+    db_path = tmp_path / "snap.db"
+
+    # Write a writable dict with data.
+    with ConnectionWrapper(filename=db_path) as writable_conn:
+        d: FileBackedDict[int] = FileBackedDict(
+            shared_connection=writable_conn,
+            tablename="data",
+            serializer=str,
+            deserializer=int,
+        )
+        d["x"] = 10
+        d["y"] = 20
+        d.flush()
+
+    # Open read-only and verify reads work.
+    ro_conn = ConnectionWrapper(filename=db_path, read_only=True)
+    try:
+        ro_dict: FileBackedDict[int] = FileBackedDict(
+            shared_connection=ro_conn,
+            tablename="data",
+            serializer=str,
+            deserializer=int,
+        )
+        assert ro_dict["x"] == 10
+        assert ro_dict["y"] == 20
+        assert "x" in ro_dict
+        assert "z" not in ro_dict
+    finally:
+        ro_conn.close()
+
+
+def test_readonly_file_backed_dict_does_not_create_table(
+    tmp_path: pathlib.Path,
+) -> None:
+    """FileBackedDict on a read-only connection must NOT attempt CREATE TABLE."""
+    db_path = tmp_path / "snap.db"
+
+    # Bootstrap a file with the table already present.
+    with ConnectionWrapper(filename=db_path) as writable_conn:
+        d: FileBackedDict[str] = FileBackedDict(
+            shared_connection=writable_conn,
+            tablename="data",
+            serializer=str,
+            deserializer=str,
+        )
+        d["key"] = "value"
+        d.flush()
+
+    # Open read-only — should succeed without creating a second table.
+    ro_conn = ConnectionWrapper(filename=db_path, read_only=True)
+    try:
+        ro_dict: FileBackedDict[str] = FileBackedDict(
+            shared_connection=ro_conn,
+            tablename="data",
+            serializer=str,
+            deserializer=str,
+        )
+        # If CREATE TABLE was attempted on a read-only connection it would have raised.
+        assert ro_dict["key"] == "value"
+    finally:
+        ro_conn.close()
+
+
+def test_two_readonly_connections_same_file(tmp_path: pathlib.Path) -> None:
+    """Two independent read-only connections on the same file work concurrently."""
+    db_path = tmp_path / "shared.db"
+
+    with ConnectionWrapper(filename=db_path) as writable_conn:
+        d: FileBackedDict[int] = FileBackedDict(
+            shared_connection=writable_conn,
+            tablename="data",
+            serializer=str,
+            deserializer=int,
+        )
+        d["a"] = 100
+        d["b"] = 200
+        d.flush()
+
+    ro1 = ConnectionWrapper(filename=db_path, read_only=True)
+    ro2 = ConnectionWrapper(filename=db_path, read_only=True)
+    try:
+        d1: FileBackedDict[int] = FileBackedDict(
+            shared_connection=ro1,
+            tablename="data",
+            serializer=str,
+            deserializer=int,
+        )
+        d2: FileBackedDict[int] = FileBackedDict(
+            shared_connection=ro2,
+            tablename="data",
+            serializer=str,
+            deserializer=int,
+        )
+
+        # Both should be readable simultaneously — no locking error.
+        assert d1["a"] == 100
+        assert d2["b"] == 200
+        assert d1["b"] == 200
+        assert d2["a"] == 100
+    finally:
+        ro1.close()
+        ro2.close()


### PR DESCRIPTION
## 📋 Summary

Add opt-in, per-session-safe **multiprocessing** to `SqlParsingAggregator` so sqlglot SQL parsing can run across multiple CPU cores. Default **off**; benefits every connector that uses the aggregator (Snowflake, BigQuery, Redshift, Databricks/Unity, and others).

## 🎯 Motivation

On a large production run, of ~2.45M queries scanned, roughly half (~1.25M) fell back to the expensive sqlglot parse path — and that path alone accounted for **~8.75h of the ~9.4h total run** (~25ms/query). `SqlParsingAggregator` parses strictly single-process, so this CPU-bound work could not use additional cores.

sqlglot parsing is pure-Python CPU work, so Python's GIL means threads give ~zero speedup — real **worker processes** are required. Multiprocessing had never been added because the `SchemaResolver` isn't picklable (it wraps a live SQLite connection and optionally a `DataHubGraph` client), aggregator storage is single-writer, and temp-table lineage is sequential within a session. This PR resolves all three while guaranteeing parsing output is identical to the serial path.

## 🔧 Changes Overview

**New Features**
- **Parallel SQL parsing** in `SqlParsingAggregator`, exposed via a `parallel_sql_parsing_scope()` context manager that connectors wrap their query-feeding loop in. Opt-in through two config fields (default off): `use_parallel_sql_parsing` and `sql_parsing_workers`.
- **cgroup/CPU-aware worker sizing** (`utilities/cpu_detection.py`): the worker count is the *minimum* of the cgroup CPU quota (v2 `cpu.max` / v1 `cfs_quota`), the process's scheduling affinity, and `os.cpu_count()`. This prevents over-spawning on virtualized EC2/K8s hosts where `os.cpu_count()` reports the host's cores (e.g. 64 on a node backing a 2-CPU pod). Explicit overrides are clamped down to detected capacity with a warning; runs with < 2 usable cores fall back to serial.
- **Read-only schema snapshots** (`schema_resolver.py`, `file_backed_collections.py`): `SchemaResolver.snapshot_to()` / `load_readonly()` / `for_worker()` let worker processes read schemas from a frozen, `immutable` SQLite file shared via the OS page cache (low aggregate memory), with a small writable in-memory overlay for per-worker graph hydration.
- **New report fields** for observability: whether parallelism was enabled, chosen worker count, detected CPUs, whether the request was clamped, whether it fell back to serial, and how many queries were parsed in parallel.

**Modifications**
- Wired the two config fields (via a shared `SqlParsingParallelismConfig` mixin) and the scope into **Snowflake**, **BigQuery**, **Redshift** (lineage + usage), and **Databricks/Unity Catalog**.
- Generalized `BackpressureAwareExecutor.map` with an optional, backward-compatible `executor` parameter.

**Dependencies:** none (standard library `multiprocessing`/`concurrent.futures`; no new packages, no entry-point changes).

## 🏗️ Architecture / Design Notes

- **Parse in workers, aggregate on the main process.** Only the CPU-bound `sqlglot_lineage` call runs in a spawn-based `ProcessPoolExecutor`; all mutation of aggregator state stays serialized on the main side under an apply-lock.
- **Per-session-safe ordering — the no-loss guarantee.** Temp-table lineage is session-scoped and sequential (a query can create a temp table a later same-session query consumes). Queries are routed through `PartitionExecutor` keyed by `session_id`: at most one task per session runs at a time, and the next same-session task is dispatched only after the current one is fully applied — so a temp producer is always applied before its consumer is classified/parsed. Different sessions parse concurrently (temp state is session-local). Temp-consuming queries parse inline (their in-memory temp schemas can't be shipped to a worker).
- **Graph-hydration parity.** Workers rebuild a `DataHubGraph` from a picklable `DatahubClientConfig` and use a two-tier resolver (read-only snapshot + writable overlay), so schemas not present in the snapshot are hydrated per-worker exactly as the serial path does — no lineage is lost.
- **Spawn (not fork)** start method avoids inheriting the parent's locks / SQLite file descriptors.

## 🧪 Testing

- **Serial-vs-parallel equivalence** (the core correctness gate): byte-identical emitted MCPs across no-temp-table, temp producer/consumer within a session, interleaved multi-session (including no-session queries), and query-logging-enabled scenarios, plus a repeated high-volume many-session stress test.
- Unit tests for cgroup v1/v2 parsing + clamp/fallback math; read-only snapshot round-trip and concurrent readers; worker graph-hydration parity and fetch/miss dedup; cross-process pickling parity.
- Query `latest_timestamp` merge made order-independent (max) so parallel output matches serial even for a fingerprint seen across sessions.
- **~593 unit tests pass** across the touched areas; ruff + mypy clean.
- **Follow-up:** live real-source benchmark (Snowflake/Redshift/Databricks) to measure end-to-end speedup is pending and will be run against a DataHub instance.

## 📊 Impact Assessment

- **Affected components:** `sql_parsing/` aggregator + schema resolver, two shared utilities, and the four connectors listed above.
- **Breaking changes:** none. All new constructor args and config fields are additive with safe defaults; with the feature off the serial code path is byte-for-byte unchanged.
- **Performance:** large expected reduction in wall-clock for sqlglot-heavy runs (the parse path dominates such runs), scaling with usable cores; conservative, cgroup-aware sizing avoids CPU throttling / OOM on constrained pods.
- **Risk level:** Low — opt-in (default off), guarded by CPU/serial fallback and graceful degradation if a worker pool can't be created; extensively covered by equivalence tests.

## 🚀 Deployment Notes

- Enable per connector recipe with `use_parallel_sql_parsing: true`. Worker count auto-detects a safe value; optionally pin with `sql_parsing_workers: <n>` (values above detected capacity are clamped with a warning; `< 1` is rejected at config parse).
- No migrations, no schema/model changes, no feature-flag infra. Rollback = unset the flag.
- New report fields surface the chosen parallelism and any clamping/fallback for observability.

## ❓ Questions for Reviewers

- The per-session ordering intentionally serializes queries with no `session_id` (they collapse into one bucket) to preserve the no-loss guarantee — acceptable trade-off, or worth a follow-up for connectors where session ids are frequently absent?
- Temp-session inline parses currently hold the apply-lock for the full parse (globally serializing the temp minority). Fine for now; flagged as a possible future optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
