### PR TITLE
feat(unity): opt-in parallel SQL parsing

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -41,6 +41,7 @@ from datahub.ingestion.source_config.operation_config import (
     OperationConfig,
     is_profiling_enabled,
 )
+from datahub.sql_parsing.sql_parsing_aggregator import SqlParsingParallelismConfig
 from datahub.utilities.global_warning_util import add_global_warning
 
 logger = logging.getLogger(__name__)
@@ -157,6 +158,7 @@ class UnityCatalogSQLAlchemyProfilerConfig(
 
 
 class UnityCatalogSourceConfig(
+    SqlParsingParallelismConfig,
     UnityCatalogConnectionConfig,
     SQLCommonConfig,
     StatefulIngestionConfigBase,

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
@@ -94,6 +94,8 @@ class UnityCatalogUsageExtractor:
             usage_config=self.config,
             format_queries=False,
             is_allowed_table=is_allowed_table,
+            use_parallel_sql_parsing=self.config.use_parallel_sql_parsing,
+            sql_parsing_workers=self.config.sql_parsing_workers,
         )
 
     def _audit_log_filename(self) -> str:
@@ -667,7 +669,10 @@ class UnityCatalogUsageExtractor:
                 # current-bucket zero, does not delete history.)
                 self._report_no_queries()
 
-            with self.report.usage_parsing_timer:
+            with (
+                self.report.usage_parsing_timer,
+                aggregator.parallel_sql_parsing_scope(),
+            ):
                 self._parse_buffered_queries(aggregator, buffered_queries, default_db)
             self._log_usage_routing_summary()
             self._report_usage_lineage_warnings()

--- a/metadata-ingestion/tests/unit/sql_parsing/test_unity_parallel_config.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_unity_parallel_config.py
@@ -1,0 +1,25 @@
+"""Parallel-SQL-parsing config wiring for the unity catalog source."""
+
+
+def test_unity_catalog_config_parallel_defaults() -> None:
+    from datahub.ingestion.source.unity.config import UnityCatalogSourceConfig
+
+    cfg = UnityCatalogSourceConfig(
+        workspace_url="https://adb-123.azuredatabricks.net",
+        token="dapi-test-token",
+    )
+    assert cfg.use_parallel_sql_parsing is False
+    assert cfg.sql_parsing_workers is None
+
+
+def test_unity_catalog_config_parallel_values() -> None:
+    from datahub.ingestion.source.unity.config import UnityCatalogSourceConfig
+
+    cfg = UnityCatalogSourceConfig(
+        workspace_url="https://adb-123.azuredatabricks.net",
+        token="dapi-test-token",
+        use_parallel_sql_parsing=True,
+        sql_parsing_workers=4,
+    )
+    assert cfg.use_parallel_sql_parsing is True
+    assert cfg.sql_parsing_workers == 4

--- a/metadata-ingestion/tests/unit/test_unity_catalog_usage_join.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_usage_join.py
@@ -1,3 +1,4 @@
+import contextlib
 import pathlib
 from contextlib import closing
 from datetime import datetime, timedelta, timezone
@@ -22,6 +23,19 @@ from datahub.utilities.file_backed_collections import ConnectionWrapper, FileBac
 def _row(**kw):
     # Databricks Row supports attribute access; SimpleNamespace replicates that.
     return SimpleNamespace(**kw)
+
+
+class _FakeAggBase:
+    """Base for all FakeAgg test doubles.
+
+    Provides a no-op parallel_sql_parsing_scope() so tests that wrap the
+    query-feeding loop in ``with aggregator.parallel_sql_parsing_scope():``
+    do not fail with AttributeError.
+    """
+
+    @contextlib.contextmanager
+    def parallel_sql_parsing_scope(self):  # type: ignore[return]
+        yield
 
 
 # ---------------------------------------------------------------------------
@@ -270,7 +284,7 @@ def test_builds_aggregator_and_feeds_observed_queries(
     captured: dict = {}
     agg_instance: list = []  # single-element list so the closure can capture it
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             captured["kwargs"] = kw
             self.observed: list = []
@@ -338,7 +352,7 @@ def test_observed_query_timestamps_normalized_to_utc(
     """
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             agg_instance.append(self)
@@ -445,7 +459,7 @@ def test_is_allowed_table_predicate_scopes_to_ingested_tables(
     """
     captured: dict = {}
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             captured["kwargs"] = kw
 
@@ -522,7 +536,7 @@ def test_is_allowed_table_predicate_platform_instance_safe(
     """
     captured: dict = {}
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             captured["kwargs"] = kw
 
@@ -599,7 +613,7 @@ def test_schema_resolver_passed_to_aggregator(
     """
     captured: dict = {}
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             captured["kwargs"] = kw
 
@@ -646,7 +660,7 @@ def test_default_db_set_to_single_catalog(
     """When all table_refs share one catalog, every ObservedQuery.default_db must equal it."""
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             agg_instance.append(self)
@@ -703,7 +717,7 @@ def test_default_db_none_for_multi_catalog(
     """When table_refs span two catalogs, every ObservedQuery.default_db must be None."""
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             agg_instance.append(self)
@@ -753,7 +767,7 @@ def test_default_db_none_for_empty_table_refs(
     """When table_refs is empty, default_db must be None and no crash must occur."""
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             agg_instance.append(self)
@@ -801,7 +815,7 @@ def test_schema_resolver_explicit_empty_resolver_passed_through(
     """
     captured: dict = {}
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             captured["kwargs"] = kw
 
@@ -853,7 +867,7 @@ def test_auto_empty_usage_emitted_for_unqueried_tables(
     runs), then checks that the *unqueried* table still receives a zero-usage workunit.
     """
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         """Produces no metadata — simulates a window where no queries touched the table."""
 
         def __init__(self, **kw: object) -> None:
@@ -940,7 +954,7 @@ def test_zero_queries_emits_empty_usage_for_idle_window(
     (see test_fetch_failure_reports_failure_and_no_usage_workunits).
     """
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -1030,7 +1044,7 @@ def test_fetch_failure_reports_failure_and_no_usage_workunits(
     a normal empty-history run.
     """
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -1112,7 +1126,7 @@ def test_gen_metadata_raises_propagates_to_caller(
 
     closed_calls: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -1160,7 +1174,7 @@ def test_aggregator_close_raises_does_not_propagate(
     even when the main try-block completed normally.
     """
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -1203,7 +1217,7 @@ def test_single_bad_query_skipped_others_still_fed(
     observed: list = []
     call_count = [0]  # mutable cell so the closure can increment it
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -1275,7 +1289,7 @@ def test_fetch_queries_routes_through_api_when_system_tables_disabled(
     """
     observed: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -1328,7 +1342,7 @@ def test_midstream_fetch_failure_with_some_queries_reports_failure(
     a 'Failed to fetch query history' failure — not just the benign warning.
     """
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -1395,7 +1409,7 @@ def _run_flag_case(
     """Helper: run get_usage_workunits with the given flag values; return aggregator kwargs."""
     captured: dict = {}
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             captured["kwargs"] = kw
 
@@ -1474,7 +1488,7 @@ def test_preparsed_query_used_when_system_table_lineage_present(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -1528,7 +1542,7 @@ def test_fallback_to_observed_when_lineage_unresolvable(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -1579,7 +1593,7 @@ def test_sqlglot_when_no_system_table_lineage(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -1887,7 +1901,7 @@ def test_fetch_queries_passes_catalog_pattern_when_pushdown_enabled(
 ) -> None:
     """usage._fetch_queries must pass catalog_pattern when pushdown flag is on."""
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -1939,7 +1953,7 @@ def test_fetch_queries_omits_catalog_pattern_when_pushdown_disabled(
 ) -> None:
     """usage._fetch_queries must not pass catalog_pattern when pushdown flag is off."""
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -2137,7 +2151,7 @@ def test_preparsed_query_multi_target_fanout(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -2189,7 +2203,7 @@ def test_preparsed_query_target_only_lineage(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -2242,7 +2256,7 @@ def test_preparsed_query_partial_urn_resolution(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -2353,7 +2367,7 @@ def test_skip_sqlglot_when_system_table_lineage_missing_skips_query(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -2416,7 +2430,7 @@ def test_skip_sqlglot_when_system_table_lineage_missing_skips_query(
 def test_api_fetch_passes_include_operational_stats(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -2453,7 +2467,7 @@ def test_api_fetch_passes_include_operational_stats(
 def test_mixed_routing_counters(monkeypatch: pytest.MonkeyPatch) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -2742,7 +2756,7 @@ def test_preparsed_fingerprint_falls_back_to_statement_id(
 
 
 def _no_op_aggregator(monkeypatch: pytest.MonkeyPatch) -> None:
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -2837,7 +2851,7 @@ def test_include_column_usage_stats_forces_sqlglot_with_lineage(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -2890,7 +2904,7 @@ def test_include_column_usage_stats_overrides_skip_sqlglot(
 ) -> None:
     agg_instance: list = []
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
             self.preparsed: list = []
@@ -2946,7 +2960,7 @@ def test_include_column_usage_stats_overrides_skip_sqlglot(
 def test_fetch_queries_omits_catalog_pattern_when_column_usage_stats_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             pass
 
@@ -3029,7 +3043,7 @@ def test_queries_drained_before_parsing(
         # Only set after the last item is yielded (generator fully consumed).
         fetch_exhausted[0] = True
 
-    class FakeAgg:
+    class FakeAgg(_FakeAggBase):
         def __init__(self, **kw: object) -> None:
             self.observed: list = []
 


### PR DESCRIPTION
## Summary
Expose the opt-in parallel SQL parsing feature in this source: wire `use_parallel_sql_parsing` / `sql_parsing_workers` into UnityCatalogSourceConfig (usage aggregator), forward them to the `SqlParsingAggregator`, and wrap the query-feeding loop in `parallel_sql_parsing_scope()`. Default **off** — no behavior change unless enabled.

## Dependency
**Stacked on the core PR #18744** (`feat/psp-core`, the base branch of this PR). Merge core first; this diff shows only this connector's wiring.

## Testing
Config-parse tests confirm the fields are exposed and forwarded; existing unit tests for this source pass. Correctness of the parallel path itself is covered by the core PR's equivalence/stress tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)