### PR TITLE
fix(ingestion/snowflake): retry transient connection-establishment failures

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_connection.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_connection.py
@@ -54,6 +54,14 @@ logger = logging.getLogger(__name__)
 
 _APPLICATION_NAME: str = "acryl_datahub"
 
+# Retry connection establishment on transient handshake failures (e.g. network
+# blips or a rejected JWT under key-pair auth caused by clock skew) -- a fresh
+# connect attempt regenerates the JWT, so retrying can succeed where the first
+# attempt failed. Distinct from the ACCOUNT_USAGE query retry below.
+_CONNECTION_RETRY_MAX_ATTEMPTS = 3
+_CONNECTION_RETRY_MIN_WAIT_SEC = 1
+_CONNECTION_RETRY_MAX_WAIT_SEC = 10
+
 _VALID_AUTH_TYPES: Dict[str, str] = {
     "DEFAULT_AUTHENTICATOR": DEFAULT_AUTHENTICATOR,
     "EXTERNAL_BROWSER_AUTHENTICATOR": EXTERNAL_BROWSER_AUTHENTICATOR,
@@ -376,6 +384,29 @@ class SnowflakeConnectionConfig(ConfigModel):
         )
 
     def get_native_connection(self) -> NativeSnowflakeConnection:
+        """
+        Establish a native Snowflake connection, retrying on transient connect
+        failures (250001 / SQLSTATE 08001). This covers both the main ingestion
+        path and the profiler, which calls this method directly as its SQLAlchemy
+        pool `creator` whenever the pool needs a new connection.
+        """
+        retryer = Retrying(
+            retry=retry_if_exception(_is_retryable_connection_error),
+            stop=stop_after_attempt(_CONNECTION_RETRY_MAX_ATTEMPTS),
+            wait=wait_exponential(
+                multiplier=1,
+                min=_CONNECTION_RETRY_MIN_WAIT_SEC,
+                max=_CONNECTION_RETRY_MAX_WAIT_SEC,
+            ),
+            before_sleep=before_sleep_log(logger, logging.WARNING),
+            reraise=True,
+        )
+        for attempt in retryer:
+            with attempt:
+                return self._create_native_connection()
+        raise AssertionError("unreachable")  # satisfies mypy return-type checking
+
+    def _create_native_connection(self) -> NativeSnowflakeConnection:
         connect_args = self.get_options()["connect_args"]
         if self.authentication_type == "DEFAULT_AUTHENTICATOR":
             return snowflake.connector.connect(
@@ -543,3 +574,25 @@ def _is_retryable_account_usage_error(e: BaseException, query: str) -> bool:
     ) and "002003" in msg
 
     return is_account_usage_query and is_permission_error
+
+
+def _is_retryable_connection_error(e: BaseException) -> bool:
+    """
+    Check if a Snowflake connect-time error is a transient connection-establishment
+    failure that is worth retrying.
+
+    250001 / SQLSTATE 08001 indicates the connector failed to complete the connection
+    handshake. This can be a genuine network blip, or -- under key-pair authentication --
+    a rejected JWT caused by clock skew between the client and Snowflake at the moment the
+    JWT was generated. Since the connector generates a fresh, short-lived JWT on every
+    connect attempt, retrying can succeed even though the first attempt failed. This check
+    is authenticator-agnostic: it matches on the error code/state, not on why the handshake
+    failed, so it does not retry genuinely bad credentials (which fail with a different
+    errno/sqlstate).
+    """
+    errno = getattr(e, "errno", None)
+    sqlstate = getattr(e, "sqlstate", None)
+    if errno == 250001 or sqlstate == "08001":
+        return True
+    msg = str(e)
+    return "250001" in msg and "Failed to connect" in msg

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_connection.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_connection.py
@@ -389,6 +389,15 @@ class SnowflakeConnectionConfig(ConfigModel):
         failures (250001 / SQLSTATE 08001). This covers both the main ingestion
         path and the profiler, which calls this method directly as its SQLAlchemy
         pool `creator` whenever the pool needs a new connection.
+
+        The retry wraps the full authenticator dispatch, so it applies uniformly
+        regardless of `authentication_type` -- this is intentional, since a 250001
+        can occur under any authenticator. Two side effects of that choice are
+        accepted as a bounded cost (at most 3 attempts):
+        - EXTERNAL_BROWSER_AUTHENTICATOR: a retry re-opens the SSO browser prompt.
+        - OAUTH_AUTHENTICATOR: a retry re-runs the token exchange against the IdP.
+          IdP-side failures raise their own exception types (not a 250001), so
+          those are not retried.
         """
         retryer = Retrying(
             retry=retry_if_exception(_is_retryable_connection_error),
@@ -585,10 +594,14 @@ def _is_retryable_connection_error(e: BaseException) -> bool:
     handshake. This can be a genuine network blip, or -- under key-pair authentication --
     a rejected JWT caused by clock skew between the client and Snowflake at the moment the
     JWT was generated. Since the connector generates a fresh, short-lived JWT on every
-    connect attempt, retrying can succeed even though the first attempt failed. This check
-    is authenticator-agnostic: it matches on the error code/state, not on why the handshake
-    failed, so it does not retry genuinely bad credentials (which fail with a different
-    errno/sqlstate).
+    connect attempt, retrying can succeed even though the first attempt failed.
+
+    This is a broad error code/state match, not a precise transient/persistent
+    classifier: a wrong password fails with a different errno/sqlstate (e.g. 390100 /
+    08004) and is correctly excluded, but a misconfigured account_id, a permanently
+    invalid key pair, or a TLS/proxy issue can also surface as 250001/08001 and will be
+    retried too. That's an accepted trade-off -- with only 3 attempts, the wasted retries
+    on a persistent misconfiguration cost a few seconds before the real error surfaces.
     """
     errno = getattr(e, "errno", None)
     sqlstate = getattr(e, "sqlstate", None)

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_connection.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_connection.py
@@ -590,22 +590,31 @@ def _is_retryable_connection_error(e: BaseException) -> bool:
     Check if a Snowflake connect-time error is a transient connection-establishment
     failure that is worth retrying.
 
-    250001 / SQLSTATE 08001 indicates the connector failed to complete the connection
-    handshake. This can be a genuine network blip, or -- under key-pair authentication --
-    a rejected JWT caused by clock skew between the client and Snowflake at the moment the
-    JWT was generated. Since the connector generates a fresh, short-lived JWT on every
-    connect attempt, retrying can succeed even though the first attempt failed.
+    SQLSTATE 08001 (connection was not established) indicates the connector failed to
+    complete the connection handshake. This can be a genuine network blip, or -- under
+    key-pair authentication -- a rejected JWT caused by clock skew between the client and
+    Snowflake at the moment the JWT was generated. Since the connector generates a fresh,
+    short-lived JWT on every connect attempt, retrying can succeed even though the first
+    attempt failed.
 
-    This is a broad error code/state match, not a precise transient/persistent
-    classifier: a wrong password fails with a different errno/sqlstate (e.g. 390100 /
-    08004) and is correctly excluded, but a misconfigured account_id, a permanently
-    invalid key pair, or a TLS/proxy issue can also surface as 250001/08001 and will be
-    retried too. That's an accepted trade-off -- with only 3 attempts, the wasted retries
-    on a persistent misconfiguration cost a few seconds before the real error surfaces.
+    sqlstate, not errno, is the primary signal: errno 250001 (ER_FAILED_TO_CONNECT_TO_DB)
+    is a generic "failed to connect" code that the connector also raises for deterministic,
+    non-transient auth rejections under a *different* sqlstate -- e.g. an Okta-unauthorized
+    response carries errno=250001 but sqlstate="08004" (connection rejected). Matching on
+    errno alone would retry those needlessly. errno is only consulted as a fallback when
+    sqlstate isn't available at all.
+
+    This is still a broad match within the 08001 class, not a precise transient/persistent
+    classifier: a misconfigured account_id, a permanently invalid key pair, or a TLS/proxy
+    issue can also surface as 08001 and will be retried too. That's an accepted trade-off --
+    with only 3 attempts, the wasted retries on a persistent misconfiguration cost a few
+    seconds before the real error surfaces.
     """
     errno = getattr(e, "errno", None)
     sqlstate = getattr(e, "sqlstate", None)
-    if errno == 250001 or sqlstate == "08001":
+    if sqlstate is not None:
+        return sqlstate == "08001"
+    if errno == 250001:
         return True
     msg = str(e)
     return "250001" in msg and "Failed to connect" in msg

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_profiler.py
@@ -34,7 +34,9 @@ logger = logging.getLogger(__name__)
 
 PUBLIC_SCHEMA = "PUBLIC"
 
-# Matches the value used by the Fabric connector's SQLAlchemy engine.
+# Recycle pooled connections well within Snowflake's default idle session
+# timeout (4 hours) so a connection is never handed out after the server
+# has already dropped it.
 _POOL_RECYCLE_SECONDS = 3600
 
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_profiler.py
@@ -34,6 +34,9 @@ logger = logging.getLogger(__name__)
 
 PUBLIC_SCHEMA = "PUBLIC"
 
+# Matches the value used by the Fabric connector's SQLAlchemy engine.
+_POOL_RECYCLE_SECONDS = 3600
+
 
 class SnowflakeProfiler(GenericProfiler, SnowflakeCommonMixin):
     def __init__(
@@ -56,6 +59,13 @@ class SnowflakeProfiler(GenericProfiler, SnowflakeCommonMixin):
             self.config.options.setdefault(
                 "max_overflow", self.config.profiling.max_workers
             )
+            # pool_pre_ping validates a pooled connection is still alive before handing
+            # it out for reuse, and pool_recycle retires connections older than the
+            # interval below. Both guard against dropped/idle connections being reused --
+            # a different failure mode than the connect-time JWT rejection that
+            # get_native_connection()'s retry handles.
+            self.config.options.setdefault("pool_pre_ping", True)
+            self.config.options.setdefault("pool_recycle", _POOL_RECYCLE_SECONDS)
 
         if PUBLIC_SCHEMA not in db_tables:
             # If PUBLIC schema is absent, we use any one of schemas as default schema

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_connection_retry.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_connection_retry.py
@@ -297,6 +297,13 @@ class TestConnectionEstablishmentRetry:
                 False,
                 id="message_mentions_250001_without_failed_to_connect_not_retryable",
             ),
+            pytest.param(
+                250001,
+                "08004",
+                "Failed to get authentication by OKTA: 401: Unauthorized",
+                False,
+                id="okta_unauthorized_reuses_errno_250001_with_different_sqlstate_not_retryable",
+            ),
         ],
     )
     def test_is_retryable_connection_error(self, errno, sqlstate, message, expected):

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_connection_retry.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_connection_retry.py
@@ -5,15 +5,18 @@ Tests the retry behavior for ACCOUNT_USAGE intermittent unavailability.
 """
 
 import threading
-from typing import Callable
+from typing import Callable, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from datahub.ingestion.source.snowflake.snowflake_connection import (
+    _CONNECTION_RETRY_MAX_ATTEMPTS,
     SnowflakeConnection,
+    SnowflakeConnectionConfig,
     SnowflakePermissionError,
     _is_retryable_account_usage_error,
+    _is_retryable_connection_error,
 )
 
 
@@ -28,6 +31,20 @@ class MockSnowflakeError(Exception):
     """Mock Snowflake error for testing."""
 
     pass
+
+
+class MockConnectionError(Exception):
+    """Mock Snowflake connection error exposing errno/sqlstate for testing."""
+
+    def __init__(
+        self,
+        message: str,
+        errno: Optional[int] = None,
+        sqlstate: Optional[str] = None,
+    ):
+        super().__init__(message)
+        self.errno = errno
+        self.sqlstate = sqlstate
 
 
 @pytest.fixture
@@ -246,3 +263,111 @@ class TestConnectionRetry:
             assert len(errors) == 0, f"Expected no errors, got {len(errors)}: {errors}"
             assert call_counts["thread_1"] == 2
             assert call_counts["thread_2"] == 2
+
+
+class TestConnectionEstablishmentRetry:
+    """Unit tests for connect-time retry on transient 250001/08001 errors."""
+
+    @pytest.mark.parametrize(
+        "errno,sqlstate,message,expected",
+        [
+            pytest.param(250001, "08001", "", True, id="errno_and_sqlstate_match"),
+            pytest.param(None, "08001", "", True, id="sqlstate_only_match"),
+            pytest.param(
+                None,
+                None,
+                "250001 (08001): Failed to connect to DB: test_account.snowflakecomputing.com:443. JWT token is invalid.",
+                True,
+                id="message_fallback_match",
+            ),
+            pytest.param(
+                390100,
+                "08004",
+                "Incorrect username or password was specified.",
+                False,
+                id="non_transient_error_not_retryable",
+            ),
+        ],
+    )
+    def test_is_retryable_connection_error(self, errno, sqlstate, message, expected):
+        error = MockConnectionError(message, errno=errno, sqlstate=sqlstate)
+        assert _is_retryable_connection_error(error) is expected
+
+    def test_connect_retries_transient_failure_then_succeeds(self):
+        config = SnowflakeConnectionConfig(
+            account_id="test_account",
+            username="user",
+            password="pass",
+            authentication_type="DEFAULT_AUTHENTICATOR",
+        )
+
+        mock_native_conn = MagicMock()
+        call_count = 0
+
+        def connect_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise MockConnectionError(
+                    "250001 (08001): Failed to connect to DB: test_account.snowflakecomputing.com:443. JWT token is invalid.",
+                    errno=250001,
+                    sqlstate="08001",
+                )
+            return mock_native_conn
+
+        with patch(
+            "datahub.ingestion.source.snowflake.snowflake_connection.snowflake.connector.connect",
+            side_effect=connect_side_effect,
+        ) as mock_connect:
+            result = config.get_native_connection()
+
+        assert result is mock_native_conn
+        assert mock_connect.call_count == 2
+
+    def test_connect_gives_up_after_max_attempts(self):
+        config = SnowflakeConnectionConfig(
+            account_id="test_account",
+            username="user",
+            password="pass",
+            authentication_type="DEFAULT_AUTHENTICATOR",
+        )
+
+        def connect_side_effect(*args, **kwargs):
+            raise MockConnectionError(
+                "250001 (08001): Failed to connect to DB: test_account.snowflakecomputing.com:443. JWT token is invalid.",
+                errno=250001,
+                sqlstate="08001",
+            )
+
+        with patch(
+            "datahub.ingestion.source.snowflake.snowflake_connection.snowflake.connector.connect",
+            side_effect=connect_side_effect,
+        ) as mock_connect:
+            with pytest.raises(MockConnectionError):
+                config.get_native_connection()
+
+        assert mock_connect.call_count == _CONNECTION_RETRY_MAX_ATTEMPTS
+
+    def test_connect_does_not_retry_non_transient_error(self):
+        config = SnowflakeConnectionConfig(
+            account_id="test_account",
+            username="user",
+            password="pass",
+            authentication_type="DEFAULT_AUTHENTICATOR",
+        )
+
+        def connect_side_effect(*args, **kwargs):
+            raise MockConnectionError(
+                "Incorrect username or password was specified.",
+                errno=390100,
+                sqlstate="08004",
+            )
+
+        with patch(
+            "datahub.ingestion.source.snowflake.snowflake_connection.snowflake.connector.connect",
+            side_effect=connect_side_effect,
+        ) as mock_connect:
+            with pytest.raises(MockConnectionError):
+                config.get_native_connection()
+
+        assert mock_connect.call_count == 1

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_connection_retry.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_connection_retry.py
@@ -9,6 +9,8 @@ from typing import Callable, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from datahub.ingestion.source.snowflake.snowflake_connection import (
     _CONNECTION_RETRY_MAX_ATTEMPTS,
@@ -287,6 +289,14 @@ class TestConnectionEstablishmentRetry:
                 False,
                 id="non_transient_error_not_retryable",
             ),
+            pytest.param(
+                None,
+                None,
+                "Upstream error mentioned 250001 in its details but this is a"
+                " different failure.",
+                False,
+                id="message_mentions_250001_without_failed_to_connect_not_retryable",
+            ),
         ],
     )
     def test_is_retryable_connection_error(self, errno, sqlstate, message, expected):
@@ -347,6 +357,47 @@ class TestConnectionEstablishmentRetry:
                 config.get_native_connection()
 
         assert mock_connect.call_count == _CONNECTION_RETRY_MAX_ATTEMPTS
+
+    def test_connect_retries_transient_failure_under_key_pair_auth(self):
+        """The motivating scenario (JWT rejection) goes through the key-pair auth branch."""
+        private_key_pem = (
+            rsa.generate_private_key(public_exponent=65537, key_size=2048)
+            .private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+            .decode()
+        )
+        config = SnowflakeConnectionConfig(
+            account_id="test_account",
+            username="user",
+            private_key=private_key_pem,
+            authentication_type="KEY_PAIR_AUTHENTICATOR",
+        )
+
+        mock_native_conn = MagicMock()
+        call_count = 0
+
+        def connect_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise MockConnectionError(
+                    "250001 (08001): Failed to connect to DB: test_account.snowflakecomputing.com:443. JWT token is invalid.",
+                    errno=250001,
+                    sqlstate="08001",
+                )
+            return mock_native_conn
+
+        with patch(
+            "datahub.ingestion.source.snowflake.snowflake_connection.snowflake.connector.connect",
+            side_effect=connect_side_effect,
+        ) as mock_connect:
+            result = config.get_native_connection()
+
+        assert result is mock_native_conn
+        assert mock_connect.call_count == 2
 
     def test_connect_does_not_retry_non_transient_error(self):
         config = SnowflakeConnectionConfig(


### PR DESCRIPTION
- Snowflake connect attempts can fail with a transient `250001`/`SQLSTATE 08001` handshake error (e.g. a JWT rejected due to clock skew under key-pair auth). `get_native_connection()` had no retry, so one transient failure aborted the whole ingestion run.
- `get_native_connection()` now retries up to 3 times with exponential backoff on this error, regardless of authenticator. This also covers the profiler, which calls it directly as its connection pool's `creator`.
- Added `pool_pre_ping`/`pool_recycle` (1hr) to the profiler's SQLAlchemy engine as separate, cheap hygiene against reuse of dropped idle connections.


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
