### PR TITLE
feat(sql-parsing): cgroup/CPU-aware worker sizing for parallel parsing

### DIFF
--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
@@ -4,7 +4,6 @@ import enum
 import functools
 import json
 import logging
-import os
 import pathlib
 import tempfile
 import threading
@@ -86,6 +85,7 @@ from datahub.sql_parsing.tool_meta_extractor import (
     ToolMetaExtractorReport,
 )
 from datahub.utilities.cooperative_timeout import CooperativeTimeoutError
+from datahub.utilities.cpu_detection import WorkerDecision, resolve_worker_count
 from datahub.utilities.dedup_list import deduplicate_list
 from datahub.utilities.file_backed_collections import (
     ConnectionWrapper,
@@ -129,8 +129,10 @@ class SqlParsingParallelismConfig(ConfigModel):
         default=False,
         description=(
             "Parse SQL queries across multiple processes to speed up lineage/usage "
-            "extraction. Off by default. Defaults to os.cpu_count() workers when "
-            "sql_parsing_workers is not set."
+            "extraction. Off by default. When sql_parsing_workers is not set, the "
+            "worker count is auto-detected from cgroup CPU quota, CPU affinity, and "
+            "os.cpu_count() (whichever is smallest), minus one core reserved for the "
+            "main process."
         ),
     )
     sql_parsing_workers: Optional[int] = Field(
@@ -138,7 +140,9 @@ class SqlParsingParallelismConfig(ConfigModel):
         ge=1,
         description=(
             "Number of worker processes for parallel SQL parsing. "
-            "Defaults to os.cpu_count() when not set."
+            "When not set, defaults to a cgroup/CPU-aware auto-detected safe value. "
+            "Explicit values are clamped to detected CPU capacity to prevent "
+            "over-subscription in containerized environments."
         ),
     )
 
@@ -384,6 +388,8 @@ class SqlAggregatorReport(Report):
     sql_parsing_parallelism: Optional[int] = None
     sql_parsing_fell_back_to_serial: bool = False
     num_queries_parsed_in_parallel: int = 0
+    sql_parsing_cpu_detected: Optional[int] = None
+    sql_parsing_workers_clamped: bool = False
 
     # Other lineage loading metrics.
     num_known_query_lineage: int = 0
@@ -662,18 +668,21 @@ class SqlParsingAggregator(Closeable):
         # parallel_sql_parsing_scope(). When disabled, everything runs inline
         # exactly as before.
         self._use_parallel_sql_parsing = use_parallel_sql_parsing
-        # Naive default; cgroup/CPU-aware sizing + clamping is added in a
-        # follow-up PR. We trust the user-provided worker count here.
         self._workers: Optional[int] = None
+        self._worker_decision: Optional[WorkerDecision] = None
         if use_parallel_sql_parsing:
-            self._workers = (
-                sql_parsing_workers
-                if sql_parsing_workers is not None
-                else (os.cpu_count() or 1)
-            )
+            decision = resolve_worker_count(sql_parsing_workers)
+            self._worker_decision = decision
             logger.info(
-                "Parallel SQL parsing requested with %d worker(s).", self._workers
+                "Parallel SQL parsing requested. %s",
+                decision.reason,
             )
+            if decision.fell_back_to_serial:
+                # Fewer than 2 CPUs detected — treat as if the feature is on but
+                # force the serial path inside parallel_sql_parsing_scope().
+                self._workers = None
+            else:
+                self._workers = decision.workers
         self._parallel_parser: Optional[ParallelSqlParser] = None
         self._partition_executor: Optional[PartitionExecutor] = None
         self._parallel_active: bool = False
@@ -708,7 +717,12 @@ class SqlParsingAggregator(Closeable):
         as it does today.
         """
         workers = self._workers
-        if not self._use_parallel_sql_parsing or workers is None:
+        if not self._use_parallel_sql_parsing:
+            yield
+            return
+        if workers is None:
+            # Detection fell back to serial (< 2 CPUs) — record it and run inline.
+            self._populate_parallel_report(workers=None, active=False)
             yield
             return
 
@@ -764,6 +778,9 @@ class SqlParsingAggregator(Closeable):
         self.report.sql_parsing_fell_back_to_serial = (
             not active and self._use_parallel_sql_parsing
         )
+        if self._worker_decision is not None:
+            self.report.sql_parsing_cpu_detected = self._worker_decision.detected_cpus
+            self.report.sql_parsing_workers_clamped = self._worker_decision.clamped
 
     def close(self) -> None:
         # Defensively tear down the parallel machinery in case a connector never

--- a/metadata-ingestion/src/datahub/utilities/cpu_detection.py
+++ b/metadata-ingestion/src/datahub/utilities/cpu_detection.py
@@ -1,0 +1,211 @@
+"""Cgroup-aware CPU detection for multiprocessing worker sizing.
+
+On virtualized EC2/K8s hosts, os.cpu_count() reports the host's physical core
+count (e.g. 64) rather than the container's CPU quota (e.g. 2). Spawning a
+process pool sized to os.cpu_count() on such a host causes severe CPU throttling
+and OOM. This module detects the actual usable CPU budget by consulting cgroup
+quotas and CPU affinity before falling back to os.cpu_count().
+"""
+
+import logging
+import math
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_cgroup_v2_cpu_max(content: str) -> Optional[float]:
+    """Parse /sys/fs/cgroup/cpu.max content.
+
+    Returns None for unlimited ("max <period>"), or quota/period as float.
+    Returns None on malformed input.
+    """
+    parts = content.strip().split()
+    if len(parts) != 2:
+        return None
+    quota_str, period_str = parts
+    if quota_str == "max":
+        return None
+    try:
+        quota = float(quota_str)
+        period = float(period_str)
+        if quota <= 0 or period <= 0:
+            return None
+        return quota / period
+    except ValueError:
+        return None
+
+
+def _parse_cgroup_v1_cpu_quota(quota_str: str, period_str: str) -> Optional[float]:
+    """Parse cgroup v1 cpu.cfs_quota_us and cpu.cfs_period_us values.
+
+    Returns None when quota is -1 (unlimited), or quota/period as float.
+    Returns None on malformed input.
+    """
+    try:
+        quota = int(quota_str.strip())
+        period = int(period_str.strip())
+    except ValueError:
+        return None
+    if quota <= 0:
+        return None
+    if period == 0:
+        return None
+    return quota / period
+
+
+def _cgroup_cpu_limit() -> Optional[float]:
+    """Read the container CPU limit from cgroup files.
+
+    Tries cgroup v2 first (/sys/fs/cgroup/cpu.max), then cgroup v1
+    (/sys/fs/cgroup/cpu/cpu.cfs_quota_us + cpu.cfs_period_us).
+    Returns None on any file/OS error or when no limit is set.
+    """
+    # cgroup v2
+    try:
+        with open("/sys/fs/cgroup/cpu.max") as f:
+            return _parse_cgroup_v2_cpu_max(f.read())
+    except OSError:
+        pass
+
+    # cgroup v1
+    try:
+        with open("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") as f:
+            quota_str = f.read()
+        with open("/sys/fs/cgroup/cpu/cpu.cfs_period_us") as f:
+            period_str = f.read()
+        return _parse_cgroup_v1_cpu_quota(quota_str, period_str)
+    except OSError:
+        pass
+
+    return None
+
+
+def _affinity_cpu_count() -> Optional[int]:
+    """Return the number of CPUs in this process's CPU affinity set.
+
+    Uses os.sched_getaffinity (Linux only; respects cpuset/taskset).
+    Returns None on platforms where affinity is not available.
+    """
+    if hasattr(os, "sched_getaffinity"):
+        return len(os.sched_getaffinity(0))
+    return None
+
+
+def _os_cpu_count() -> Optional[int]:
+    """Thin wrapper over os.cpu_count()."""
+    return os.cpu_count()
+
+
+def get_available_cpu_count() -> int:
+    """Return the number of CPUs actually usable by this process.
+
+    Takes the minimum of all available signals — cgroup quota (floored),
+    CPU affinity count, and os.cpu_count() — ignoring any that are None.
+    Always returns at least 1.
+    """
+    candidates = []
+
+    cgroup_limit = _cgroup_cpu_limit()
+    if cgroup_limit is not None:
+        candidates.append(math.floor(cgroup_limit))
+
+    affinity = _affinity_cpu_count()
+    if affinity is not None:
+        candidates.append(affinity)
+
+    os_count = _os_cpu_count()
+    if os_count is not None:
+        candidates.append(os_count)
+
+    return max(1, min(candidates)) if candidates else 1
+
+
+@dataclass
+class WorkerDecision:
+    """Outcome of resolve_worker_count, including diagnostics for logging/debugging."""
+
+    workers: int
+    detected_cpus: int
+    requested: Optional[int]
+    clamped: bool
+    fell_back_to_serial: bool
+    reason: str
+
+
+def resolve_worker_count(
+    requested: Optional[int],
+    *,
+    reserve: int = 1,
+    detected_cpus: Optional[int] = None,
+) -> WorkerDecision:
+    """Decide how many worker processes to spawn, respecting the container's CPU budget.
+
+    Args:
+        requested: Caller-requested worker count, or None for auto-detection.
+        reserve: Number of cores to hold back for the main/aggregation process.
+        detected_cpus: Override for testing; uses get_available_cpu_count() when None.
+
+    Returns:
+        WorkerDecision with the final worker count and diagnostic fields.
+    """
+    detected = detected_cpus if detected_cpus is not None else get_available_cpu_count()
+    usable = max(1, detected - reserve)
+
+    # Only fall back to serial when there is strictly fewer than 2 CPUs detected.
+    # With exactly 2 CPUs, usable=1 after reserving one core — callers treat
+    # workers=1 as a degenerate single-worker pool (not serial), which preserves
+    # the multiprocessing code path and avoids a special case in the caller.
+    if detected < 2:
+        return WorkerDecision(
+            workers=1,
+            detected_cpus=detected,
+            requested=requested,
+            clamped=False,
+            fell_back_to_serial=True,
+            reason=f"Only {detected} CPU(s) detected; falling back to serial execution.",
+        )
+
+    if requested is None:
+        return WorkerDecision(
+            workers=usable,
+            detected_cpus=detected,
+            requested=None,
+            clamped=False,
+            fell_back_to_serial=False,
+            reason=f"Auto-detected {detected} CPU(s); using {usable} worker(s) (reserving {reserve}).",
+        )
+
+    workers = min(requested, usable)
+    clamped = requested > usable
+    if clamped:
+        logger.warning(
+            "Requested %d workers but only %d are available after reserving %d core(s) "
+            "for the main process (detected %d CPU(s)). Clamping to %d workers. "
+            "This host may be a virtualized environment where os.cpu_count() over-reports.",
+            requested,
+            usable,
+            reserve,
+            detected,
+            workers,
+        )
+        reason = (
+            f"Requested {requested} workers clamped to {workers} "
+            f"(detected {detected} CPU(s), {reserve} reserved)."
+        )
+    else:
+        reason = (
+            f"Using {workers} of {requested} requested worker(s) "
+            f"(detected {detected} CPU(s), {reserve} reserved)."
+        )
+
+    return WorkerDecision(
+        workers=workers,
+        detected_cpus=detected,
+        requested=requested,
+        clamped=clamped,
+        fell_back_to_serial=False,
+        reason=reason,
+    )

--- a/metadata-ingestion/tests/unit/sql_parsing/test_parallel_aggregator.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_parallel_aggregator.py
@@ -8,7 +8,8 @@ normalizing ordering.
 """
 
 from datetime import datetime, timezone
-from typing import List, Union
+from typing import Iterator, List, Union
+from unittest.mock import patch
 
 import pytest
 import time_machine
@@ -26,6 +27,22 @@ from datahub.sql_parsing.sql_parsing_aggregator import (
 from datahub.sql_parsing.sql_parsing_common import QueryType
 
 _StreamItem = Union[ObservedQuery, PreparsedQuery]
+
+# Patch CPU detection to a high value so that explicitly-requested worker counts
+# (workers=2, workers=4) are never clamped in constrained CI environments.
+# Individual tests that exercise clamping/detection-fallback override this via
+# monkeypatch on ``datahub.utilities.cpu_detection.get_available_cpu_count``.
+_DETECTED_CPUS_DEFAULT = 32
+
+
+@pytest.fixture(autouse=True)
+def _pin_cpu_detection() -> Iterator[None]:
+    with patch(
+        "datahub.utilities.cpu_detection.get_available_cpu_count",
+        return_value=_DETECTED_CPUS_DEFAULT,
+    ):
+        yield
+
 
 # Freeze wall-clock so audit stamps that fall back to datetime.now() (for
 # downstream tables with no explicit timestamp) are identical across the serial
@@ -535,3 +552,125 @@ def test_feature_off_is_default() -> None:
     aggregator.close()
     assert len(mcps) > 0
     assert aggregator.report.sql_parsing_parallel_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# CPU-detection / clamping tests
+# ---------------------------------------------------------------------------
+
+_SIMPLE_ITEMS: List[_StreamItem] = [
+    ObservedQuery(
+        query="create table foo as select a, b from bar",
+        default_db="dev",
+        default_schema="public",
+        session_id="s1",
+        timestamp=datetime(2024, 2, 6, 1, 23, 45, tzinfo=timezone.utc),
+    ),
+    ObservedQuery(
+        query="insert into downstream (a, b) select a, b from upstream1",
+        default_db="dev",
+        default_schema="public",
+        session_id="s2",
+        timestamp=datetime(2024, 2, 6, 1, 23, 46, tzinfo=timezone.utc),
+    ),
+]
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def test_clamped_worker_count_report_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When sql_parsing_workers exceeds detected capacity the pool is built with
+    the clamped count, report.sql_parsing_workers_clamped is True, and
+    report.sql_parsing_cpu_detected reflects the detection result.
+
+    Output must still equal the serial run (correctness not affected by clamping).
+    """
+    detected = 2
+
+    monkeypatch.setattr(
+        "datahub.utilities.cpu_detection.get_available_cpu_count",
+        lambda: detected,
+    )
+
+    # Request far more workers than the detected capacity allows.
+    requested_workers = 16
+
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=True,
+        generate_usage_statistics=False,
+        generate_operations=False,
+        query_log=QueryLogSetting.DISABLED,
+        use_parallel_sql_parsing=True,
+        sql_parsing_workers=requested_workers,
+    )
+    aggregator._schema_resolver.add_raw_schema_info(
+        DatasetUrn("redshift", "dev.public.bar").urn(),
+        {"a": "int", "b": "int", "c": "int"},
+    )
+    aggregator._schema_resolver.add_raw_schema_info(
+        DatasetUrn("redshift", "dev.public.upstream1").urn(),
+        {"a": "int", "b": "int"},
+    )
+
+    with aggregator.parallel_sql_parsing_scope():
+        for item in _SIMPLE_ITEMS:
+            aggregator.add(item)
+
+    parallel_mcps = sorted(list(aggregator.gen_metadata()), key=_mcp_key)
+    report = aggregator.report
+    aggregator.close()
+
+    # Workers clamped: detected=2 → usable=1 (reserve 1) → workers=1 (clamped from 16).
+    assert report.sql_parsing_workers_clamped is True
+    assert report.sql_parsing_cpu_detected == detected
+
+    # Parallel path still produces correct output.
+    serial_mcps = _run_serial(_SIMPLE_ITEMS)
+    assert [_mcp_key(m) for m in parallel_mcps] == [_mcp_key(m) for m in serial_mcps]
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def test_detection_serial_fallback_one_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When fewer than 2 CPUs are detected the scope falls back to serial execution.
+
+    Asserts:
+    - output equals a plain serial run,
+    - report.sql_parsing_fell_back_to_serial is True,
+    - report.sql_parsing_cpu_detected reflects the single-CPU detection.
+    """
+    monkeypatch.setattr(
+        "datahub.utilities.cpu_detection.get_available_cpu_count",
+        lambda: 1,
+    )
+
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=True,
+        generate_usage_statistics=False,
+        generate_operations=False,
+        query_log=QueryLogSetting.DISABLED,
+        use_parallel_sql_parsing=True,
+        sql_parsing_workers=None,
+    )
+    aggregator._schema_resolver.add_raw_schema_info(
+        DatasetUrn("redshift", "dev.public.bar").urn(),
+        {"a": "int", "b": "int", "c": "int"},
+    )
+    aggregator._schema_resolver.add_raw_schema_info(
+        DatasetUrn("redshift", "dev.public.upstream1").urn(),
+        {"a": "int", "b": "int"},
+    )
+
+    with aggregator.parallel_sql_parsing_scope():
+        for item in _SIMPLE_ITEMS:
+            aggregator.add(item)
+
+    parallel_mcps = sorted(list(aggregator.gen_metadata()), key=_mcp_key)
+    report = aggregator.report
+    aggregator.close()
+
+    assert report.sql_parsing_fell_back_to_serial is True
+    assert report.sql_parsing_cpu_detected == 1
+
+    serial_mcps = _run_serial(_SIMPLE_ITEMS)
+    assert [_mcp_key(m) for m in parallel_mcps] == [_mcp_key(m) for m in serial_mcps]

--- a/metadata-ingestion/tests/unit/utilities/test_cpu_detection.py
+++ b/metadata-ingestion/tests/unit/utilities/test_cpu_detection.py
@@ -1,0 +1,98 @@
+import logging
+
+from datahub.utilities import cpu_detection
+from datahub.utilities.cpu_detection import (
+    WorkerDecision,
+    get_available_cpu_count,
+    resolve_worker_count,
+)
+
+
+class TestCgroupParsing:
+    def test_cgroup_v2_unlimited_returns_none(self):
+        assert cpu_detection._parse_cgroup_v2_cpu_max("max 100000\n") is None
+
+    def test_cgroup_v2_quota_returns_cpu_fraction(self):
+        # "<quota> <period>" — 200000/100000 == 2 CPUs.
+        assert cpu_detection._parse_cgroup_v2_cpu_max("200000 100000") == 2.0
+
+    def test_cgroup_v2_fractional(self):
+        assert cpu_detection._parse_cgroup_v2_cpu_max("150000 100000") == 1.5
+
+    def test_cgroup_v1_unlimited_quota_returns_none(self):
+        # quota of -1 means no limit.
+        assert cpu_detection._parse_cgroup_v1_cpu_quota("-1", "100000") is None
+
+    def test_cgroup_v1_quota_returns_cpu_fraction(self):
+        assert cpu_detection._parse_cgroup_v1_cpu_quota("250000", "100000") == 2.5
+
+    def test_malformed_input_returns_none(self):
+        assert cpu_detection._parse_cgroup_v2_cpu_max("garbage") is None
+        assert cpu_detection._parse_cgroup_v1_cpu_quota("x", "y") is None
+
+    def test_cgroup_v2_negative_quota_returns_none(self):
+        assert cpu_detection._parse_cgroup_v2_cpu_max("-100 100000") is None
+
+    def test_cgroup_v1_zero_quota_returns_none(self):
+        assert cpu_detection._parse_cgroup_v1_cpu_quota("0", "100000") is None
+
+    def test_cgroup_v1_zero_period_returns_none(self):
+        assert cpu_detection._parse_cgroup_v1_cpu_quota("200000", "0") is None
+
+
+class TestGetAvailableCpuCount:
+    def test_takes_minimum_of_all_signals(self, monkeypatch):
+        # A 2-CPU pod on a 64-core node: cgroup quota must win over cpu_count.
+        monkeypatch.setattr(cpu_detection, "_cgroup_cpu_limit", lambda: 2.0)
+        monkeypatch.setattr(cpu_detection, "_affinity_cpu_count", lambda: 8)
+        monkeypatch.setattr(cpu_detection, "_os_cpu_count", lambda: 64)
+        assert get_available_cpu_count() == 2
+
+    def test_fractional_cgroup_is_floored(self, monkeypatch):
+        monkeypatch.setattr(cpu_detection, "_cgroup_cpu_limit", lambda: 1.5)
+        monkeypatch.setattr(cpu_detection, "_affinity_cpu_count", lambda: 8)
+        monkeypatch.setattr(cpu_detection, "_os_cpu_count", lambda: 64)
+        assert get_available_cpu_count() == 1
+
+    def test_non_linux_fallback_to_cpu_count(self, monkeypatch):
+        # No cgroup, no affinity (e.g. macOS): fall back to os.cpu_count().
+        monkeypatch.setattr(cpu_detection, "_cgroup_cpu_limit", lambda: None)
+        monkeypatch.setattr(cpu_detection, "_affinity_cpu_count", lambda: None)
+        monkeypatch.setattr(cpu_detection, "_os_cpu_count", lambda: 8)
+        assert get_available_cpu_count() == 8
+
+    def test_always_at_least_one(self, monkeypatch):
+        monkeypatch.setattr(cpu_detection, "_cgroup_cpu_limit", lambda: None)
+        monkeypatch.setattr(cpu_detection, "_affinity_cpu_count", lambda: None)
+        monkeypatch.setattr(cpu_detection, "_os_cpu_count", lambda: None)
+        assert get_available_cpu_count() == 1
+
+
+class TestResolveWorkerCount:
+    def test_auto_detect_reserves_one_core(self):
+        decision = resolve_worker_count(None, detected_cpus=8)
+        assert isinstance(decision, WorkerDecision)
+        assert decision.workers == 7
+        assert not decision.clamped
+        assert not decision.fell_back_to_serial
+
+    def test_explicit_within_capacity_is_honored(self):
+        decision = resolve_worker_count(4, detected_cpus=8)
+        assert decision.workers == 4
+        assert not decision.clamped
+
+    def test_explicit_over_capacity_is_clamped(self):
+        # The virtualization footgun: user asks for 100 on an 8-core box.
+        decision = resolve_worker_count(100, detected_cpus=8)
+        assert decision.workers == 7  # 8 - 1 reserved
+        assert decision.clamped
+
+    def test_single_core_falls_back_to_serial(self):
+        decision = resolve_worker_count(4, detected_cpus=1)
+        assert decision.workers == 1
+        assert decision.fell_back_to_serial
+
+    def test_explicit_over_capacity_emits_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="datahub.utilities.cpu_detection"):
+            resolve_worker_count(100, detected_cpus=8)
+        assert "100" in caplog.text and "7" in caplog.text


### PR DESCRIPTION
## Summary
Add **cgroup/CPU-aware worker sizing** on top of the parallel-SQL-parsing core. Replaces the core's naive "trust the user value / default to `os.cpu_count()`" with a safe auto-detected worker count and clamping.

## Why separate
The core PR (#18146) intentionally trusts the user-provided `sql_parsing_workers` to keep its review small. This PR adds the safety layer needed for virtualized EC2/K8s hosts, where `os.cpu_count()` reports the host's cores (e.g. 64 on a node backing a 2-CPU pod) and would cause over-spawning / throttling / OOM.

## Changes
- `utilities/cpu_detection.py` — worker count = **minimum** of cgroup v2 (`cpu.max`) / v1 (`cfs_quota`) CPU quota, scheduling affinity, and `os.cpu_count()`; each signal guarded (malformed/unlimited → skipped); non-Linux falls back to `cpu_count`.
- `resolve_worker_count()` reserves a core for the main process, **clamps** an over-capacity explicit request down (with a warning), and **falls back to serial** under 2 usable cores.
- Aggregator now sizes the pool via `resolve_worker_count(sql_parsing_workers)` and re-adds report fields `sql_parsing_cpu_detected` and `sql_parsing_workers_clamped`; `sql_parsing_fell_back_to_serial` now also covers the <2-core case.

## Dependency
**Stacked on the core PR #18146** (base branch of this PR). Merge core first.

## Testing
Unit tests for cgroup v1/v2/unlimited/malformed/non-Linux + clamp + serial fallback; aggregator tests for clamped-count report fields and the detection serial-fallback path; existing equivalence/stress tests unaffected (detection pinned high in-test so explicit worker counts aren't clamped in low-CPU CI). ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
