### PR TITLE
feat(models): add documentUsageStatistics timeseries aspect

### DIFF
--- a/metadata-models/src/main/pegasus/com/linkedin/knowledge/DocumentUsageStatistics.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/knowledge/DocumentUsageStatistics.pdl
@@ -1,0 +1,49 @@
+namespace com.linkedin.knowledge
+
+import com.linkedin.timeseries.TimeseriesAspectBase
+import com.linkedin.dataset.DatasetUserUsageCounts
+
+/**
+ * Experimental (Subject to breaking change) -- Stats corresponding to a document's usage.
+ *
+ * If this aspect represents the latest snapshot of the statistics about a Document, the eventGranularity field should be null.
+ * If this aspect represents a bucketed window of usage statistics (e.g. over a day), then the eventGranularity field should be set accordingly.
+ */
+@Aspect = {
+  "name": "documentUsageStatistics",
+  "type": "timeseries",
+}
+record DocumentUsageStatistics includes TimeseriesAspectBase {
+  /**
+   * The total number of times this document has been read by a human in this bucket (e.g. UI views).
+   * Follows the dataset/chart convention that a view count is a human view; agent reads are tracked separately in agentViewsCount.
+   */
+  @TimeseriesField = {}
+  viewsCount: optional int
+
+  /**
+   * The total number of times this document has been read by an AI agent in this bucket,
+   * counted when an MCP tool returns the document. Disjoint from viewsCount (the two never
+   * overlap). Agent identity is intentionally not tracked, so agents never appear in userCounts.
+   */
+  @TimeseriesField = {}
+  agentViewsCount: optional int
+
+  /**
+   * Number of distinct human users that read this document in this bucket
+   */
+  @TimeseriesField = {}
+  uniqueUserCount: optional int
+
+  /**
+   * Timestamp (epoch millis) the document was last read, by either a human or an agent
+   */
+  @TimeseriesField = {}
+  lastViewedAt: optional long
+
+  /**
+   * Human users within this bucket, with frequency counts. Agent reads are excluded.
+   */
+  @TimeseriesFieldCollection = {"key":"user"}
+  userCounts: optional array[DatasetUserUsageCounts]
+}

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -359,6 +359,7 @@ entities:
       - semanticContent
       - institutionalMemory
       - documentation
+      - documentUsageStatistics
   - name: dataHubIngestionSource
     category: internal
     keyAspect: dataHubIngestionSourceKey


### PR DESCRIPTION
## Summary

Adds a `documentUsageStatistics` timeseries aspect for the **Document** entity, capturing how documents (knowledge articles) are read.

Fields:
- `viewsCount` — human reads in the bucket (e.g. UI views)
- `agentViewsCount` — AI-agent reads (e.g. via MCP tools); disjoint from `viewsCount`, no user identity tracked
- `uniqueUserCount` — distinct human users in the bucket
- `userCounts` — per-user human read counts (reuses `DatasetUserUsageCounts`)
- `lastViewedAt` — last read timestamp (human or agent)

This mirrors the existing `datasetUsageStatistics` / `chartUsageStatistics` / `dashboardUsageStatistics` / `queryUsageStatistics` aspects (same `TimeseriesAspectBase` shape, same per-user struct reuse), extending the same usage-tracking pattern to the Document entity.

## Notes
- Aspect-definition only. Registering it on the `document` entity and the code that populates/rolls it up are handled separately by downstream consumers.
- Marked `Experimental (Subject to breaking change)` in the doc comment, consistent with the other usage-statistics aspects.

## Checklist
- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable) — N/A, schema-only addition validated by `metadata-models` build
