### PR TITLE
fix(slack): failed to update connection settings when configuring Slack

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/connection/ConnectionMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/connection/ConnectionMapper.java
@@ -91,6 +91,9 @@ public class ConnectionMapper {
     if (opContext != null
         && opContext.getRequestContext() != null
         && opContext.getRequestContext().getAgentClass().isHuman()) {
+      // Return an empty (non-null) blob: the GraphQL schema declares blob as String! (non-null),
+      // so leaving it null surfaces as a GraphQL error even though the underlying write succeeded.
+      result.setBlob("");
       return result;
     }
     result.setBlob(secretService.decrypt(opContext, gmsJsonConnection.getEncryptedBlob()));

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/connection/UpsertConnectionResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/connection/UpsertConnectionResolverTest.java
@@ -2,6 +2,9 @@ package com.linkedin.datahub.graphql.resolvers.connection;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertThrows;
 
@@ -24,7 +27,9 @@ import com.linkedin.entity.EnvelopedAspectMap;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.connection.ConnectionService;
 import graphql.schema.DataFetchingEnvironment;
+import io.datahubproject.metadata.context.AgentClass;
 import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.RequestContext;
 import io.datahubproject.metadata.services.SecretService;
 import java.util.concurrent.CompletionException;
 import org.mockito.Mockito;
@@ -106,6 +111,75 @@ public class UpsertConnectionResolverTest {
     Assert.assertEquals(actual.getPlatform().getUrn(), platformUrn.toString());
     Assert.assertEquals(actual.getDetails().getType(), input.getType());
     Assert.assertEquals(actual.getDetails().getJson().getBlob(), input.getJson().getBlob());
+  }
+
+  @Test
+  public void testGetHumanCallerReceivesEmptyBlob() throws Exception {
+    // Browsers must never receive decrypted credentials, but the GraphQL schema declares
+    // DataHubJsonConnection.blob as String! — so the human path must still return a non-null
+    // (empty) blob, otherwise GraphQL raises a non-null error and the UI reports a failed write.
+    Urn connectionUrn = UrnUtils.getUrn("urn:li:dataHubConnection:test-id");
+    Urn platformUrn = UrnUtils.getUrn("urn:li:dataPlatform:slack");
+
+    final UpsertDataHubConnectionInput input = new UpsertDataHubConnectionInput();
+    input.setId(connectionUrn.getId());
+    input.setPlatformUrn(platformUrn.toString());
+    input.setType(DataHubConnectionDetailsType.JSON);
+    input.setName("test-name");
+    input.setJson(new DataHubJsonConnectionInput("{}"));
+
+    QueryContext mockContext = getMockAllowContext();
+    // Force the caller to be classified as a human (browser) agent.
+    OperationContext humanOpContext = spy(mockContext.getOperationContext());
+    RequestContext browserRequest = Mockito.mock(RequestContext.class);
+    when(browserRequest.getAgentClass()).thenReturn(AgentClass.BROWSER);
+    when(humanOpContext.getRequestContext()).thenReturn(browserRequest);
+    when(mockContext.getOperationContext()).thenReturn(humanOpContext);
+
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    final DataHubConnectionDetails details =
+        new DataHubConnectionDetails()
+            .setType(com.linkedin.connection.DataHubConnectionDetailsType.JSON)
+            .setJson(new DataHubJsonConnection().setEncryptedBlob("encrypted"));
+
+    final DataPlatformInstance platformInstance =
+        new DataPlatformInstance().setPlatform(platformUrn);
+
+    when(connectionService.upsertConnection(
+            any(OperationContext.class),
+            Mockito.eq(input.getId()),
+            Mockito.eq(platformUrn),
+            Mockito.eq(details.getType()),
+            Mockito.eq(details.getJson()),
+            Mockito.any(String.class)))
+        .thenReturn(connectionUrn);
+    when(connectionService.getConnectionEntityResponse(
+            any(OperationContext.class), Mockito.eq(connectionUrn)))
+        .thenReturn(
+            new EntityResponse()
+                .setUrn(connectionUrn)
+                .setEntityName(Constants.DATAHUB_CONNECTION_ENTITY_NAME)
+                .setAspects(
+                    new EnvelopedAspectMap(
+                        ImmutableMap.of(
+                            Constants.DATAHUB_CONNECTION_DETAILS_ASPECT_NAME,
+                            new EnvelopedAspect()
+                                .setName(Constants.DATAHUB_CONNECTION_DETAILS_ASPECT_NAME)
+                                .setValue(new Aspect(details.data())),
+                            Constants.DATA_PLATFORM_INSTANCE_ASPECT_NAME,
+                            new EnvelopedAspect()
+                                .setName(Constants.DATA_PLATFORM_INSTANCE_ASPECT_NAME)
+                                .setValue(new Aspect(platformInstance.data()))))));
+
+    DataHubConnection actual = resolver.get(mockEnv).get();
+
+    // Non-null empty blob satisfies the schema's String! contract...
+    Assert.assertEquals(actual.getDetails().getJson().getBlob(), "");
+    // ...and the credential is never decrypted for a human caller.
+    verify(secretService, never()).decrypt(any(), any());
   }
 
   @Test


### PR DESCRIPTION
  The mapJsonConnectionDetails method returns a DataHubJsonConnection with blob = null when the caller is a human browser (to avoid leaking credentials). However, the GraphQL schema declares blob: String! (non-nullable), so GraphQL propagates this as an error and the UI shows "Failed to update connection settings." even though the write succeeded.

  The fix: When returning early for human callers, set blob to an empty string instead of leaving it null.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
