### PR TITLE
feat(glossary): surface deprecation badge on glossary term tree

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/EntityDropdown/EntityDropdown.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/EntityDropdown/EntityDropdown.tsx
@@ -1,7 +1,7 @@
-import { Menu } from '@components';
-import MoreVertOutlinedIcon from '@mui/icons-material/MoreVertOutlined';
+import { Menu, toast } from '@components';
 import { ClockCounterClockwise } from '@phosphor-icons/react/dist/csr/ClockCounterClockwise';
 import { Copy } from '@phosphor-icons/react/dist/csr/Copy';
+import { DotsThreeVertical } from '@phosphor-icons/react/dist/csr/DotsThreeVertical';
 import { Envelope } from '@phosphor-icons/react/dist/csr/Envelope';
 import { FolderOpen } from '@phosphor-icons/react/dist/csr/FolderOpen';
 import { FolderPlus } from '@phosphor-icons/react/dist/csr/FolderPlus';
@@ -15,12 +15,11 @@ import { Plus } from '@phosphor-icons/react/dist/csr/Plus';
 import { Share } from '@phosphor-icons/react/dist/csr/Share';
 import { Trash } from '@phosphor-icons/react/dist/csr/Trash';
 import { Warning } from '@phosphor-icons/react/dist/csr/Warning';
-import { message } from 'antd';
 import qs from 'query-string';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Redirect, useHistory } from 'react-router';
-import styled, { useTheme } from 'styled-components';
+import { useTheme } from 'styled-components';
 
 import { EventType } from '@app/analytics';
 import analytics from '@app/analytics/analytics';
@@ -60,18 +59,6 @@ import DeprecatedIcon from '@images/deprecated-status.svg?react';
 
 // Tab path segment passed to getEntityPath — a route identifier, not user-visible copy.
 const INCIDENTS_TAB_NAME = 'Incidents';
-
-const StyledMoreIcon = styled(MoreVertOutlinedIcon)`
-    &&& {
-        display: flex;
-        font-size: 20px;
-        padding: 2px;
-
-        :hover {
-            color: ${(p) => p.theme.colors.textBrand};
-        }
-    }
-`;
 
 interface Options {
     hideDeleteMessage?: boolean;
@@ -144,7 +131,7 @@ const EntityDropdown = (props: Props) => {
     const [isChangeHistoryOpen, setIsChangeHistoryOpen] = useState(false);
 
     const handleUpdateDeprecation = async (deprecatedStatus: boolean) => {
-        message.loading({ content: tcf('updating') });
+        toast.loading(tcf('updating'));
         try {
             await updateDeprecation({
                 variables: {
@@ -156,20 +143,17 @@ const EntityDropdown = (props: Props) => {
                     },
                 },
             });
-            message.destroy();
-            message.success({ content: t('deprecation.updated'), duration: 2 });
+            toast.destroy();
+            toast.success(t('deprecation.updated'), { duration: 2 });
             analytics.event({
                 type: EventType.SetDeprecation,
                 entityUrns: [urn],
                 deprecated: deprecatedStatus,
             });
         } catch (e: unknown) {
-            message.destroy();
+            toast.destroy();
             if (e instanceof Error) {
-                message.error({
-                    content: t('deprecation.updateError', { errorMessage: e.message || '' }),
-                    duration: 2,
-                });
+                toast.error(t('deprecation.updateError', { errorMessage: e.message || '' }), { duration: 2 });
             }
         }
         refetchForEntity?.();
@@ -197,7 +181,7 @@ const EntityDropdown = (props: Props) => {
             icon: Link,
             onClick: () => {
                 navigator.clipboard.writeText(pageUrl);
-                message.info(t('menuItem.copiedUrl'), 1.2);
+                toast.info(t('menuItem.copiedUrl'), { duration: 1.2 });
             },
         });
     }
@@ -516,7 +500,7 @@ const EntityDropdown = (props: Props) => {
     return (
         <>
             <Menu items={menuItemsList} trigger={triggerType} overlayStyle={{ minWidth: 150 }}>
-                <StyledMoreIcon />
+                <DotsThreeVertical size={20} weight="bold" />
             </Menu>
             {isCreateTermModalVisible && (
                 <CreateGlossaryEntityModal

--- a/datahub-web-react/src/app/entityV2/shared/EntityDropdown/EntityDropdown.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/EntityDropdown/EntityDropdown.tsx
@@ -500,7 +500,7 @@ const EntityDropdown = (props: Props) => {
     return (
         <>
             <Menu items={menuItemsList} trigger={triggerType} overlayStyle={{ minWidth: 150 }}>
-                <DotsThreeVertical size={20} weight="bold" />
+                <DotsThreeVertical data-testid="MoreVertOutlinedIcon" size={20} weight="bold" />
             </Menu>
             {isCreateTermModalVisible && (
                 <CreateGlossaryEntityModal

--- a/datahub-web-react/src/app/entityV2/shared/EntityDropdown/UpdateDeprecationMenuAction.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/EntityDropdown/UpdateDeprecationMenuAction.tsx
@@ -1,16 +1,24 @@
-import { ExclamationCircleOutlined } from '@ant-design/icons';
-import { Tooltip } from '@components';
-import { message } from 'antd';
+import { Button, Tooltip, toast } from '@components';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
 
 import analytics, { EventType } from '@app/analytics';
 import { useEntityData, useRefetch } from '@app/entity/shared/EntityContext';
 import { UpdateDeprecationModal } from '@app/entityV2/shared/EntityDropdown/UpdateDeprecationModal';
-import { ActionMenuItem } from '@app/entityV2/shared/EntityDropdown/styledComponents';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { useUpdateDeprecationMutation } from '@graphql/mutations.generated';
+
+import DeprecatedIcon from '@images/deprecated-status.svg?react';
+
+const DeprecationActionButton = styled(Button)`
+    flex-shrink: 0;
+    width: 28px;
+    height: 28px;
+    min-width: 28px;
+    padding: 0;
+`;
 
 export default function UpdateDeprecationMenuAction() {
     const { t } = useTranslation('entity.shared.entityDropdown');
@@ -22,7 +30,7 @@ export default function UpdateDeprecationMenuAction() {
     const [updateDeprecation] = useUpdateDeprecationMutation();
 
     const handleUpdateDeprecation = async (deprecatedStatus: boolean) => {
-        message.loading({ content: tcf('updating') });
+        toast.loading(tcf('updating'));
         try {
             await updateDeprecation({
                 variables: {
@@ -34,20 +42,17 @@ export default function UpdateDeprecationMenuAction() {
                     },
                 },
             });
-            message.destroy();
-            message.success({ content: t('deprecation.updated'), duration: 2 });
+            toast.destroy();
+            toast.success(t('deprecation.updated'), { duration: 2 });
             analytics.event({
                 type: EventType.SetDeprecation,
                 entityUrns: [urn],
                 deprecated: deprecatedStatus,
             });
         } catch (e: unknown) {
-            message.destroy();
+            toast.destroy();
             if (e instanceof Error) {
-                message.error({
-                    content: t('deprecation.updateError', { errorMessage: e.message || '' }),
-                    duration: 2,
-                });
+                toast.error(t('deprecation.updateError', { errorMessage: e.message || '' }), { duration: 2 });
             }
         }
         refetchForEntity?.();
@@ -62,8 +67,12 @@ export default function UpdateDeprecationMenuAction() {
                     : t('deprecation.markUnTooltip', { entityName: entityRegistry.getEntityName(entityType) })
             }
         >
-            <ActionMenuItem
+            <DeprecationActionButton
                 key="deprecation"
+                variant="outline"
+                color="gray"
+                size="sm"
+                isCircle
                 onClick={() =>
                     !entityData?.deprecation?.deprecated
                         ? setIsDeprecationModalVisible(true)
@@ -71,8 +80,8 @@ export default function UpdateDeprecationMenuAction() {
                 }
                 data-testid="entity-menu-deprecate-button"
             >
-                <ExclamationCircleOutlined style={{ display: 'flex' }} />
-            </ActionMenuItem>
+                <DeprecatedIcon style={{ width: 16, height: 16 }} />
+            </DeprecationActionButton>
             {isDeprecationModalVisible && (
                 <UpdateDeprecationModal
                     urns={[urn]}

--- a/datahub-web-react/src/app/entityV2/shared/EntityDropdown/UpdateDeprecationModal.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/EntityDropdown/UpdateDeprecationModal.tsx
@@ -1,7 +1,7 @@
-import { Form, Select, Skeleton, message } from 'antd';
-import TextArea from 'antd/lib/input/TextArea';
-import React from 'react';
+import { Button, DatePicker, Loader, Modal, SimpleSelect, TextArea, toast } from '@components';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
 
 import analytics, { EventType } from '@app/analytics';
 import { EntityCapabilityType } from '@app/entityV2/Entity';
@@ -13,24 +13,38 @@ import { handleBatchError } from '@app/entityV2/shared/utils';
 import { EntityLink } from '@app/homeV2/reference/sections/EntityLink';
 import { getV1FieldPathFromSchemaFieldUrn } from '@app/lineageV2/lineageUtils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
-import { Button, Modal } from '@src/alchemy-components';
-import DatePicker from '@utils/DayjsDatePicker';
-import dayjs from '@utils/dayjs';
+import type { Dayjs } from '@utils/dayjs';
 
 import { useGetEntitiesQuery } from '@graphql/entity.generated';
 import { useBatchUpdateDeprecationMutation } from '@graphql/mutations.generated';
-import { ResourceRefInput, SubResourceType } from '@types';
+import { Entity, ResourceRefInput, SubResourceType } from '@types';
+
+type DeprecationModalResult = {
+    note?: string | null;
+    decommissionTime?: number | null;
+    replacement?: Entity | null;
+};
 
 type Props = {
     urns: string[];
     // if you need to provide context for subresources, resourceRefs should be provided and will take precedence over urns
     resourceRefs?: ResourceRefInput[];
     onClose: () => void;
-    refetch?: () => void;
+    refetch?: (result?: DeprecationModalResult) => void;
     zIndexOverride?: number;
 };
 
 const SCHEMA_FIELD_PREFIX = 'urn:li:schemaField:';
+
+const FieldGroup = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+`;
+
+const ReplacementControls = styled.div`
+    align-self: flex-start;
+`;
 
 export const UpdateDeprecationModal = ({ urns, resourceRefs, onClose, refetch, zIndexOverride }: Props) => {
     const { t } = useTranslation('entity.shared.entityDropdown');
@@ -38,11 +52,13 @@ export const UpdateDeprecationModal = ({ urns, resourceRefs, onClose, refetch, z
     const { t: tcf } = useTranslation('common.feedback');
     const { entityWithSchema } = useGetEntityWithSchema();
     const schemaMetadata: any = entityWithSchema?.schemaMetadata || undefined;
+    const entityRegistry = useEntityRegistry();
 
     const [batchUpdateDeprecation] = useBatchUpdateDeprecationMutation();
-    const [isReplacementModalVisible, setIsReplacementModalVisible] = React.useState(false);
-    const [replacementUrn, setReplacementUrn] = React.useState<string | null>(null);
-    const entityRegistry = useEntityRegistry();
+    const [isReplacementModalVisible, setIsReplacementModalVisible] = useState(false);
+    const [replacementUrn, setReplacementUrn] = useState<string | null>(null);
+    const [note, setNote] = useState<string>('');
+    const [decommissionTime, setDecommissionTime] = useState<Dayjs | null | undefined>(undefined);
 
     const isDeprecatingFields =
         !!resourceRefs && resourceRefs.length > 0 && resourceRefs[0].subResourceType === SubResourceType.DatasetField;
@@ -55,23 +71,16 @@ export const UpdateDeprecationModal = ({ urns, resourceRefs, onClose, refetch, z
         skip: !replacementUrn || replacementUrn?.startsWith(SCHEMA_FIELD_PREFIX),
     });
 
-    const [form] = Form.useForm();
-
-    const handleClose = () => {
-        form.resetFields();
-        onClose();
-    };
-
-    const handleOk = async (formData: any) => {
-        message.loading({ content: tcf('updating') });
+    const handleSubmit = async () => {
+        toast.loading(tcf('updating'));
         try {
             await batchUpdateDeprecation({
                 variables: {
                     input: {
                         resources: resourceRefs || urns.map((resourceUrn) => ({ resourceUrn })),
                         deprecated: true,
-                        note: formData.note,
-                        decommissionTime: formData.decommissionTime && formData.decommissionTime.unix() * 1000,
+                        note,
+                        decommissionTime: decommissionTime ? decommissionTime.unix() * 1000 : null,
                         replacement: replacementUrn,
                     },
                 },
@@ -82,136 +91,132 @@ export const UpdateDeprecationModal = ({ urns, resourceRefs, onClose, refetch, z
                 deprecated: true,
                 resources: isDeprecatingFields ? resourceRefs : undefined,
             });
-            message.destroy();
-            message.success({ content: t('deprecation.updated'), duration: 2 });
+            toast.destroy();
+            toast.success(t('deprecation.updated'), { duration: 2 });
         } catch (e: unknown) {
-            message.destroy();
+            toast.destroy();
             if (e instanceof Error) {
-                message.error(
-                    handleBatchError(urns, e, {
-                        content: t('deprecation.updateError', { errorMessage: e.message || '' }),
-                        duration: 2,
-                    }),
-                );
+                const fallback = {
+                    content: t('deprecation.updateError', { errorMessage: e.message || '' }),
+                    duration: 2,
+                };
+                const { content, duration } = handleBatchError(urns, e, fallback);
+                toast.error(content, { duration });
             }
         }
-        refetch?.();
-        handleClose();
+        refetch?.({
+            note: note || null,
+            decommissionTime: decommissionTime ? decommissionTime.unix() * 1000 : null,
+            replacement: replacementData?.entities?.[0] ?? null,
+        });
+        onClose();
     };
 
     return (
         <Modal
             title={t('deprecation.modalTitle')}
             zIndex={zIndexOverride ?? 1000}
-            onCancel={handleClose}
-            keyboard
+            onCancel={onClose}
             buttons={[
                 {
                     text: tc('cancel'),
                     variant: 'text',
-                    onClick: handleClose,
+                    onClick: onClose,
                 },
                 {
-                    buttonDataTestId: 'add',
-                    text: tc('save'),
-                    onClick: form.submit,
+                    buttonDataTestId: 'add-deprecation-submit',
+                    text: t('deprecation.ok'),
+                    onClick: handleSubmit,
                 },
             ]}
         >
-            <Form form={form} name="addDeprecationForm" onFinish={handleOk} layout="vertical">
-                <Form.Item
-                    name="note"
+            <FieldGroup>
+                <TextArea
                     label={t('deprecation.reasonLabel')}
-                    rules={[{ whitespace: true }, { min: 0, max: 1000 }]}
-                >
-                    <TextArea placeholder={t('deprecation.reasonPlaceholder')} autoFocus rows={4} />
-                </Form.Item>
-                <Form.Item
-                    name="decommissionTime"
-                    label={t('deprecation.decommissionDateLabel')}
-                    initialValue={dayjs()}
-                >
-                    <DatePicker style={{ width: '100%' }} defaultValue={dayjs()} />
-                </Form.Item>
-                <Form.Item name="replacement" label={t('deprecation.replacementLabel')}>
-                    {isReplacementModalVisible && !isDeprecatingFields && (
-                        <SearchSelectModal
-                            limit={1}
-                            titleText={t('deprecation.replacementSearchTitle')}
-                            continueText={t('deprecation.setReplacement')}
-                            onContinue={(entityUrns) => {
-                                if (entityUrns.length > 0) {
-                                    setReplacementUrn(entityUrns[0]);
-                                }
-                                setIsReplacementModalVisible(false);
-                            }}
-                            onCancel={() => setIsReplacementModalVisible(false)}
-                            fixedEntityTypes={Array.from(
-                                entityRegistry.getTypesWithSupportedCapabilities(EntityCapabilityType.DEPRECATION),
-                            )}
-                        />
-                    )}
-                    {isReplacementModalVisible && isDeprecatingFields && (
-                        <Modal
-                            open
-                            title={t('deprecation.selectReplacement')}
-                            onCancel={() => setIsReplacementModalVisible(false)}
-                            onOk={() => setIsReplacementModalVisible(false)}
-                            buttons={[]}
-                        >
-                            <Select
-                                style={{ width: 250 }}
-                                dropdownMatchSelectWidth
-                                placeholder={t('deprecation.selectReplacement')}
-                                onChange={(value) =>
+                    placeholder={t('deprecation.reasonPlaceholder')}
+                    value={note}
+                    onChange={(e) => setNote(e.target.value)}
+                    rows={4}
+                    autoFocus
+                />
+                <DatePicker
+                    placeholder={t('deprecation.decommissionDateLabel')}
+                    value={decommissionTime}
+                    onChange={(v) => setDecommissionTime(v)}
+                />
+
+                {isReplacementModalVisible && !isDeprecatingFields && (
+                    <SearchSelectModal
+                        limit={1}
+                        titleText={t('deprecation.replacementSearchTitle')}
+                        continueText={t('deprecation.setReplacement')}
+                        onContinue={(entityUrns) => {
+                            if (entityUrns.length > 0) {
+                                setReplacementUrn(entityUrns[0]);
+                            }
+                            setIsReplacementModalVisible(false);
+                        }}
+                        onCancel={() => setIsReplacementModalVisible(false)}
+                        fixedEntityTypes={Array.from(
+                            entityRegistry.getTypesWithSupportedCapabilities(EntityCapabilityType.DEPRECATION),
+                        )}
+                    />
+                )}
+                {isReplacementModalVisible && isDeprecatingFields && (
+                    <Modal
+                        title={t('deprecation.selectReplacement')}
+                        onCancel={() => setIsReplacementModalVisible(false)}
+                        buttons={[
+                            {
+                                text: tc('cancel'),
+                                variant: 'text',
+                                onClick: () => setIsReplacementModalVisible(false),
+                            },
+                            {
+                                text: tc('save'),
+                                onClick: () => setIsReplacementModalVisible(false),
+                            },
+                        ]}
+                    >
+                        <SimpleSelect
+                            placeholder={t('deprecation.selectReplacement')}
+                            options={
+                                schemaMetadata?.fields?.map((field: any) => ({
+                                    value: field.fieldPath,
+                                    label: downgradeV2FieldPath(field.fieldPath),
+                                })) || []
+                            }
+                            onUpdate={(vals) => {
+                                if (vals.length > 0) {
                                     setReplacementUrn(
-                                        generateSchemaFieldUrn(value, resourceFromWhichReplacementIsSelected || ''),
-                                    )
+                                        generateSchemaFieldUrn(vals[0], resourceFromWhichReplacementIsSelected || ''),
+                                    );
                                 }
-                            >
-                                {schemaMetadata?.fields?.map((field: any) => (
-                                    <Select.Option key={field.fieldPath} value={field.fieldPath}>
-                                        {downgradeV2FieldPath(field.fieldPath)}
-                                    </Select.Option>
-                                ))}
-                            </Select>
-                        </Modal>
-                    )}
-                    {replacementUrn && replacementLoading && <Skeleton />}
+                            }}
+                        />
+                    </Modal>
+                )}
+
+                <ReplacementControls>
+                    {replacementUrn && replacementLoading && <Loader size="sm" />}
                     {replacementUrn && !replacementLoading && !!replacementData?.entities?.[0] && (
                         <EntityLink
-                            onClick={() => {
-                                setIsReplacementModalVisible(true);
-                            }}
+                            onClick={() => setIsReplacementModalVisible(true)}
                             entity={replacementData?.entities?.[0] as any}
                         />
                     )}
                     {replacementUrn && isDeprecatingFields && (
-                        <Button
-                            variant="text"
-                            style={{
-                                padding: 5,
-                                marginLeft: -5,
-                            }}
-                            onClick={() => {
-                                setIsReplacementModalVisible(true);
-                            }}
-                        >
+                        <Button variant="text" onClick={() => setIsReplacementModalVisible(true)}>
                             {getV1FieldPathFromSchemaFieldUrn(replacementUrn)}
                         </Button>
                     )}
                     {!replacementUrn && (
-                        <Button
-                            variant="outline"
-                            type="button"
-                            size="sm"
-                            onClick={() => setIsReplacementModalVisible(true)}
-                        >
+                        <Button variant="secondary" size="sm" onClick={() => setIsReplacementModalVisible(true)}>
                             {t('deprecation.selectReplacement')}
                         </Button>
                     )}
-                </Form.Item>
-            </Form>
+                </ReplacementControls>
+            </FieldGroup>
         </Modal>
     );
 };

--- a/datahub-web-react/src/app/glossaryV2/GlossaryBrowser/TermItem.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryBrowser/TermItem.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
+import styled from 'styled-components/macro';
 
+import { DeprecationIcon } from '@app/entityV2/shared/components/styled/DeprecationIcon';
 import { useGlossaryEntityData } from '@app/entityV2/shared/GlossaryEntityContext';
 import { EDITING_DOCUMENTATION_URL_PARAM } from '@app/entityV2/shared/constants';
 import { useGlossaryActiveTabPath } from '@app/entityV2/shared/containers/profile/utils';
@@ -21,6 +23,16 @@ import { EntityType } from '@types';
 
 // Row chrome (RowContainer/LeftContent/IconSlot/Title) lives in `treeRow.styles.ts`
 // — shared with `NodeItem` so the two leaf-row types stay visually identical.
+
+const DeprecationSlot = styled.span`
+    display: inline-flex;
+    align-items: center;
+    margin-left: 6px;
+    & svg {
+        width: 12px;
+        height: 12px;
+    }
+`;
 
 interface Props {
     term: ChildGlossaryTermFragment;
@@ -75,6 +87,17 @@ function TermItem(props: Props) {
 
     const displayName = entityRegistry.getDisplayName(term.type, isOnEntityPage ? entityData : term);
 
+    // Prefer the profile page's live (post-mutation) deprecation state over the sidebar's own
+    // fetch when this row is the currently-open entity, mirroring the same isOnEntityPage
+    // pattern already used above for the display name.
+    const deprecation = isOnEntityPage ? entityData?.deprecation : term.deprecation;
+
+    const deprecationBadge = deprecation?.deprecated && (
+        <DeprecationSlot>
+            <DeprecationIcon urn={term.urn} deprecation={deprecation} showUndeprecate={false} showText={false} />
+        </DeprecationSlot>
+    );
+
     return (
         <TreeRowContainer
             $level={depth}
@@ -86,7 +109,10 @@ function TermItem(props: Props) {
                 <TreeRowIconSlot>
                     <GlossaryColoredIcon color={resolvedIconColor} icon={TermIcon} size={20} iconSize={12} />
                 </TreeRowIconSlot>
-                <TreeRowTitle $isSelected={isRowSelected}>{displayName}</TreeRowTitle>
+                <TreeRowTitle $isSelected={isRowSelected}>
+                    {displayName}
+                    {deprecationBadge}
+                </TreeRowTitle>
             </TreeRowLeftContent>
             {isMultiSelected && <SelectedMark />}
         </TreeRowContainer>

--- a/datahub-web-react/src/app/glossaryV2/GlossaryBrowser/TermItem.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryBrowser/TermItem.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components/macro';
 
-import { DeprecationIcon } from '@app/entityV2/shared/components/styled/DeprecationIcon';
 import { useGlossaryEntityData } from '@app/entityV2/shared/GlossaryEntityContext';
+import { DeprecationIcon } from '@app/entityV2/shared/components/styled/DeprecationIcon';
 import { EDITING_DOCUMENTATION_URL_PARAM } from '@app/entityV2/shared/constants';
 import { useGlossaryActiveTabPath } from '@app/entityV2/shared/containers/profile/utils';
 import { SelectedMark } from '@app/glossaryV2/GlossaryBrowser/SelectedMark';
@@ -24,10 +24,21 @@ import { EntityType } from '@types';
 // Row chrome (RowContainer/LeftContent/IconSlot/Title) lives in `treeRow.styles.ts`
 // — shared with `NodeItem` so the two leaf-row types stay visually identical.
 
+const TitleContent = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    flex: 1;
+    overflow: hidden;
+`;
+
 const DeprecationSlot = styled.span`
     display: inline-flex;
     align-items: center;
-    margin-left: 6px;
+    flex-shrink: 0;
+    line-height: 0;
+
     & svg {
         width: 12px;
         height: 12px;
@@ -109,10 +120,10 @@ function TermItem(props: Props) {
                 <TreeRowIconSlot>
                     <GlossaryColoredIcon color={resolvedIconColor} icon={TermIcon} size={20} iconSize={12} />
                 </TreeRowIconSlot>
-                <TreeRowTitle $isSelected={isRowSelected}>
-                    {displayName}
+                <TitleContent>
+                    <TreeRowTitle $isSelected={isRowSelected}>{displayName}</TreeRowTitle>
                     {deprecationBadge}
-                </TreeRowTitle>
+                </TitleContent>
             </TreeRowLeftContent>
             {isMultiSelected && <SelectedMark />}
         </TreeRowContainer>

--- a/datahub-web-react/src/app/glossaryV2/GlossaryBrowser/__tests__/TermItem.test.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryBrowser/__tests__/TermItem.test.tsx
@@ -75,7 +75,10 @@ describe('TermItem — live deprecation state when this row is the open entity',
         vi.mocked(useGlossaryEntityData).mockReturnValueOnce({
             entityData: { urn: baseTerm.urn, deprecation: { deprecated: true, note: '', decommissionTime: null } },
         } as any);
-        renderTermItem({ ...baseTerm, deprecation: { deprecated: false, note: null, actor: null, decommissionTime: null } });
+        renderTermItem({
+            ...baseTerm,
+            deprecation: { deprecated: false, note: null, actor: null, decommissionTime: null },
+        });
         expect(screen.getByTestId('deprecation-icon')).toBeInTheDocument();
     });
 
@@ -83,7 +86,10 @@ describe('TermItem — live deprecation state when this row is the open entity',
         vi.mocked(useGlossaryEntityData).mockReturnValueOnce({
             entityData: { urn: baseTerm.urn, deprecation: { deprecated: false, note: null, decommissionTime: null } },
         } as any);
-        renderTermItem({ ...baseTerm, deprecation: { deprecated: true, note: 'stale', actor: null, decommissionTime: null } });
+        renderTermItem({
+            ...baseTerm,
+            deprecation: { deprecated: true, note: 'stale', actor: null, decommissionTime: null },
+        });
         expect(screen.queryByTestId('deprecation-icon')).not.toBeInTheDocument();
     });
 
@@ -94,7 +100,10 @@ describe('TermItem — live deprecation state when this row is the open entity',
                 deprecation: { deprecated: false, note: null, decommissionTime: null },
             },
         } as any);
-        renderTermItem({ ...baseTerm, deprecation: { deprecated: true, note: null, actor: null, decommissionTime: null } });
+        renderTermItem({
+            ...baseTerm,
+            deprecation: { deprecated: true, note: null, actor: null, decommissionTime: null },
+        });
         expect(screen.getByTestId('deprecation-icon')).toBeInTheDocument();
     });
 });

--- a/datahub-web-react/src/app/glossaryV2/GlossaryBrowser/__tests__/TermItem.test.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryBrowser/__tests__/TermItem.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
+
+import { useGlossaryEntityData } from '@app/entityV2/shared/GlossaryEntityContext';
+import TermItem from '@app/glossaryV2/GlossaryBrowser/TermItem';
+import themeV2 from '@conf/theme/themeV2';
+
+import { EntityType } from '@types';
+
+vi.mock('@app/useEntityRegistry', () => ({
+    useEntityRegistry: () => ({
+        getDisplayName: vi.fn(() => 'Adoptions'),
+        getEntityUrl: vi.fn(() => '/glossaryTerm/test'),
+    }),
+}));
+
+vi.mock('@app/entityV2/shared/components/styled/DeprecationIcon', () => ({
+    DeprecationIcon: () => <div data-testid="deprecation-icon" />,
+}));
+
+vi.mock('@app/entityV2/shared/GlossaryEntityContext', () => ({
+    useGlossaryEntityData: vi.fn(() => ({ entityData: null })),
+}));
+
+const baseTerm = {
+    urn: 'urn:li:glossaryTerm:test',
+    type: EntityType.GlossaryTerm,
+    name: 'Adoptions',
+    hierarchicalName: 'Adoptions.Adoptions',
+    properties: { name: 'Adoptions', description: null },
+    domain: null,
+} as any;
+
+const renderTermItem = (term: any) =>
+    render(
+        <ThemeProvider theme={themeV2}>
+            <BrowserRouter>
+                <TermItem term={term} depth={0} />
+            </BrowserRouter>
+        </ThemeProvider>,
+    );
+
+describe('TermItem — deprecation badge', () => {
+    it('renders deprecation icon when term is deprecated', () => {
+        renderTermItem({
+            ...baseTerm,
+            deprecation: { deprecated: true, note: 'Replaced', actor: null, decommissionTime: null },
+        });
+        expect(screen.getByTestId('deprecation-icon')).toBeInTheDocument();
+    });
+
+    it('does not render deprecation icon when deprecated is false', () => {
+        renderTermItem({
+            ...baseTerm,
+            deprecation: { deprecated: false, note: null, actor: null, decommissionTime: null },
+        });
+        expect(screen.queryByTestId('deprecation-icon')).not.toBeInTheDocument();
+    });
+
+    it('does not render deprecation icon when deprecation is null', () => {
+        renderTermItem({ ...baseTerm, deprecation: null });
+        expect(screen.queryByTestId('deprecation-icon')).not.toBeInTheDocument();
+    });
+
+    it('does not render deprecation icon when deprecation is absent', () => {
+        renderTermItem({ ...baseTerm });
+        expect(screen.queryByTestId('deprecation-icon')).not.toBeInTheDocument();
+    });
+});
+
+describe('TermItem — live deprecation state when this row is the open entity', () => {
+    it('shows the badge from entityData even when the sidebar-fetched term is not deprecated', () => {
+        vi.mocked(useGlossaryEntityData).mockReturnValueOnce({
+            entityData: { urn: baseTerm.urn, deprecation: { deprecated: true, note: '', decommissionTime: null } },
+        } as any);
+        renderTermItem({ ...baseTerm, deprecation: { deprecated: false, note: null, actor: null, decommissionTime: null } });
+        expect(screen.getByTestId('deprecation-icon')).toBeInTheDocument();
+    });
+
+    it('clears a stale badge when entityData shows un-deprecated but the sidebar fetch is still deprecated', () => {
+        vi.mocked(useGlossaryEntityData).mockReturnValueOnce({
+            entityData: { urn: baseTerm.urn, deprecation: { deprecated: false, note: null, decommissionTime: null } },
+        } as any);
+        renderTermItem({ ...baseTerm, deprecation: { deprecated: true, note: 'stale', actor: null, decommissionTime: null } });
+        expect(screen.queryByTestId('deprecation-icon')).not.toBeInTheDocument();
+    });
+
+    it('falls back to the term prop when entityData belongs to a different entity', () => {
+        vi.mocked(useGlossaryEntityData).mockReturnValueOnce({
+            entityData: {
+                urn: 'urn:li:glossaryTerm:someOtherTerm',
+                deprecation: { deprecated: false, note: null, decommissionTime: null },
+            },
+        } as any);
+        renderTermItem({ ...baseTerm, deprecation: { deprecated: true, note: null, actor: null, decommissionTime: null } });
+        expect(screen.getByTestId('deprecation-icon')).toBeInTheDocument();
+    });
+});

--- a/datahub-web-react/src/graphql/glossaryNode.graphql
+++ b/datahub-web-react/src/graphql/glossaryNode.graphql
@@ -13,6 +13,9 @@ fragment childGlossaryTerm on GlossaryTerm {
     domain {
         ...entityDomain
     }
+    deprecation {
+        ...deprecationFields
+    }
 }
 
 fragment glossaryNodeFields on GlossaryNode {


### PR DESCRIPTION
## Summary
- Adds `deprecation { ...deprecationFields }` to the `childGlossaryTerm` fragment in `glossaryNode.graphql` so the glossary sidebar tree query fetches a term's deprecation status
- Renders the existing `DeprecationIcon` next to a term's name in `TermItem.tsx` when `deprecation.deprecated` is true, following the same pattern already used for tags, domains, and data products
- Reuses the `isOnEntityPage ? entityData : term` fallback already in place for `getDisplayName`, so the badge reflects live state immediately after deprecating/un-deprecating from the term's own profile page, and falls back to the sidebar-fetched value otherwise

<img width="1507" height="408" alt="Screenshot 2026-07-05 at 5 13 27 PM" src="https://github.com/user-attachments/assets/04c31183-9f46-49d7-b425-313683fd7b1a" />

## Test plan
- [x] `TermItem.test.tsx` (new): 7 cases covering deprecated / not-deprecated / null / absent deprecation, plus the live `entityData` override behavior (shows live state, clears a stale badge, falls back correctly when `entityData` belongs to a different entity)
- [x] `yarn vitest run` on the new test file: all passing
- [x] `eslint` on changed files: clean
- [x] `tsc --noEmit`: no errors
- [x] `GlossaryTerm.deprecation` already exists on the backend schema, so no server-side change was needed

Note: `glossaryNode.generated.ts` is gitignored and not part of this diff; run `yarn generate` after pulling this branch to pick up the updated fragment types.