### PR TITLE
feat(documents): scope document search to the active View

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -3162,6 +3162,7 @@ public class GmsGraphQLEngine {
             this.graphClient,
             entityRegistry,
             this.timelineService,
+            this.viewService,
             this.documentImportService)
         .configureResolvers(builder);
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentResolvers.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentResolvers.java
@@ -11,6 +11,7 @@ import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.ViewService;
 import com.linkedin.metadata.service.docimport.DocumentImportService;
 import com.linkedin.metadata.timeline.TimelineService;
 import graphql.schema.idl.RuntimeWiring;
@@ -33,6 +34,7 @@ public class DocumentResolvers {
   private final com.linkedin.metadata.graph.GraphClient graphClient;
   private final EntityRegistry entityRegistry;
   private final TimelineService timelineService;
+  private final ViewService viewService;
   @Nullable private final DocumentImportService documentImportService;
 
   public DocumentResolvers(
@@ -46,6 +48,7 @@ public class DocumentResolvers {
       @Nonnull com.linkedin.metadata.graph.GraphClient graphClient,
       @Nonnull EntityRegistry entityRegistry,
       @Nonnull TimelineService timelineService,
+      @Nonnull ViewService viewService,
       @Nullable DocumentImportService documentImportService) {
     this.documentService = documentService;
     this.entityTypes = entityTypes;
@@ -57,6 +60,7 @@ public class DocumentResolvers {
     this.graphClient = graphClient;
     this.entityRegistry = entityRegistry;
     this.timelineService = timelineService;
+    this.viewService = viewService;
     this.documentImportService = documentImportService;
   }
 
@@ -73,7 +77,7 @@ public class DocumentResolvers {
                 .dataFetcher(
                     "searchDocuments",
                     new com.linkedin.datahub.graphql.resolvers.knowledge.SearchDocumentsResolver(
-                        documentService, entityClient)));
+                        documentService, entityClient, viewService)));
 
     // Mutation resolvers
     builder.type(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/SearchDocumentsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/SearchDocumentsResolver.java
@@ -1,8 +1,11 @@
 package com.linkedin.datahub.graphql.resolvers.knowledge;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
+import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.combineFilters;
+import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.resolveView;
 
 import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.generated.Document;
@@ -19,7 +22,9 @@ import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchEntity;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.ViewService;
 import com.linkedin.metadata.utils.CriterionUtils;
+import com.linkedin.view.DataHubViewInfo;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.ArrayList;
@@ -50,6 +55,7 @@ public class SearchDocumentsResolver
 
   private final DocumentService _documentService;
   private final EntityClient _entityClient;
+  private final ViewService _viewService;
 
   @Override
   public CompletableFuture<SearchDocumentsResult> get(final DataFetchingEnvironment environment)
@@ -80,6 +86,23 @@ public class SearchDocumentsResolver
             List<Criterion> baseUserCriteria = buildBaseUserCriteria(input);
             Filter filter =
                 DocumentSearchFilterUtils.buildCombinedFilter(baseUserCriteria, userAndGroupUrns);
+
+            // Scope results to the active View, if one is provided. We combine the View's filter
+            // (domains, ownership, etc.) with the document filter so the Documents overview and
+            // sidebar respect the selected View, mirroring searchAcrossEntities. Entity-type
+            // intersection is intentionally omitted: this is a document-only search, so a View that
+            // does not list the "document" entity type should still scope by its field filter
+            // rather than return nothing.
+            if (input.getViewUrn() != null) {
+              final DataHubViewInfo resolvedView =
+                  resolveView(
+                      context.getOperationContext(),
+                      _viewService,
+                      UrnUtils.getUrn(input.getViewUrn()));
+              if (resolvedView != null) {
+                filter = combineFilters(filter, resolvedView.getDefinition().getFilter());
+              }
+            }
 
             // Step 1: Search using service to get URNs
             final SearchResult gmsResult;

--- a/datahub-graphql-core/src/main/resources/documents.graphql
+++ b/datahub-graphql-core/src/main/resources/documents.graphql
@@ -637,6 +637,13 @@ input SearchDocumentsInput {
   If not provided, searches all documents regardless of source.
   """
   sourceType: DocumentSourceType
+
+  """
+  Optional - the URN of a View to apply to the search. When provided, the View's
+  filter is combined with the document search filter so that document results are
+  scoped to the active View (mirrors searchAcrossEntities view scoping).
+  """
+  viewUrn: String
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentResolversTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentResolversTest.java
@@ -17,6 +17,7 @@ import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.graph.GraphClient;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.ViewService;
 import com.linkedin.metadata.service.docimport.DocumentImportService;
 import graphql.schema.idl.RuntimeWiring;
 import java.util.List;
@@ -34,6 +35,7 @@ public class DocumentResolversTest {
   private GraphClient mockGraphClient;
   private EntityRegistry mockEntityRegistry;
   private com.linkedin.metadata.timeline.TimelineService mockTimelineService;
+  private ViewService mockViewService;
   private DocumentResolvers resolvers;
 
   @BeforeMethod
@@ -47,6 +49,7 @@ public class DocumentResolversTest {
     mockGraphClient = mock(GraphClient.class);
     mockEntityRegistry = mock(EntityRegistry.class);
     mockTimelineService = mock(com.linkedin.metadata.timeline.TimelineService.class);
+    mockViewService = mock(ViewService.class);
 
     resolvers =
         new DocumentResolvers(
@@ -60,6 +63,7 @@ public class DocumentResolversTest {
             mockGraphClient,
             mockEntityRegistry,
             mockTimelineService,
+            mockViewService,
             mock(DocumentImportService.class));
   }
 
@@ -100,6 +104,7 @@ public class DocumentResolversTest {
             mockGraphClient,
             mockEntityRegistry,
             mockTimelineService,
+            mockViewService,
             null);
 
     RuntimeWiring.Builder mockBuilder = mock(RuntimeWiring.Builder.class);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/SearchDocumentsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/SearchDocumentsResolverTest.java
@@ -24,12 +24,20 @@ import com.linkedin.knowledge.DocumentInfo;
 import com.linkedin.knowledge.DocumentStatus;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.CriterionArray;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchEntity;
 import com.linkedin.metadata.search.SearchEntityArray;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.search.SearchResultMetadata;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.ViewService;
+import com.linkedin.metadata.utils.CriterionUtils;
+import com.linkedin.view.DataHubViewDefinition;
+import com.linkedin.view.DataHubViewInfo;
+import com.linkedin.view.DataHubViewType;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.HashMap;
@@ -46,8 +54,12 @@ public class SearchDocumentsResolverTest {
   private static final String TEST_GROUP_URN = "urn:li:corpGroup:testGroup";
   private static final String OTHER_USER_URN = "urn:li:corpuser:other";
 
+  private static final String TEST_VIEW_URN = "urn:li:dataHubView:testView";
+  private static final String TEST_DOMAIN_URN = "urn:li:domain:marketing";
+
   private DocumentService mockService;
   private EntityClient mockEntityClient;
+  private ViewService mockViewService;
   private SearchDocumentsResolver resolver;
   private DataFetchingEnvironment mockEnv;
   private SearchDocumentsInput input;
@@ -56,6 +68,7 @@ public class SearchDocumentsResolverTest {
   public void setupTest() throws Exception {
     mockService = mock(DocumentService.class);
     mockEntityClient = mock(EntityClient.class);
+    mockViewService = mock(ViewService.class);
     mockEnv = mock(DataFetchingEnvironment.class);
 
     // Setup default input
@@ -93,7 +106,36 @@ public class SearchDocumentsResolverTest {
         .thenReturn(entityResponseMap);
 
     // Session group membership is stubbed via TestUtils.withSessionGroupMembership when needed
-    resolver = new SearchDocumentsResolver(mockService, mockEntityClient);
+    resolver = new SearchDocumentsResolver(mockService, mockEntityClient, mockViewService);
+  }
+
+  /** Builds a minimal View whose filter scopes to a single domain. */
+  private DataHubViewInfo createViewWithDomainFilter(String domainUrn) {
+    Filter viewFilter =
+        new Filter()
+            .setOr(
+                new ConjunctiveCriterionArray(
+                    new ConjunctiveCriterion()
+                        .setAnd(
+                            new CriterionArray(
+                                CriterionUtils.buildCriterion(
+                                    "domains", Condition.EQUAL, domainUrn)))));
+    DataHubViewDefinition definition =
+        new DataHubViewDefinition()
+            .setEntityTypes(new com.linkedin.data.template.StringArray())
+            .setFilter(viewFilter);
+    return new DataHubViewInfo()
+        .setName("Test View")
+        .setType(DataHubViewType.GLOBAL)
+        .setDefinition(definition)
+        .setCreated(
+            new com.linkedin.common.AuditStamp()
+                .setTime(0L)
+                .setActor(UrnUtils.getUrn(TEST_USER_URN)))
+        .setLastModified(
+            new com.linkedin.common.AuditStamp()
+                .setTime(0L)
+                .setActor(UrnUtils.getUrn(TEST_USER_URN)));
   }
 
   private EntityResponse createPublishedDocumentResponse(String documentUrn, String ownerUrn) {
@@ -534,5 +576,56 @@ public class SearchDocumentsResolverTest {
         result.getDocuments().size(),
         1,
         "PUBLISHED document should be shown to all users regardless of ownership");
+  }
+
+  @Test
+  public void testSearchDocumentsAppliesViewFilter() throws Exception {
+    QueryContext mockContext = getMockAllowContext();
+    when(mockEnv.getContext()).thenReturn(mockContext);
+    when(mockEnv.getArgument(eq("input"))).thenReturn(input);
+
+    input.setViewUrn(TEST_VIEW_URN);
+    when(mockViewService.getViewInfo(
+            any(OperationContext.class), eq(UrnUtils.getUrn(TEST_VIEW_URN))))
+        .thenReturn(createViewWithDomainFilter(TEST_DOMAIN_URN));
+
+    resolver.get(mockEnv).get();
+
+    ArgumentCaptor<Filter> filterCaptor = ArgumentCaptor.forClass(Filter.class);
+    verify(mockService, times(1))
+        .searchDocuments(
+            any(OperationContext.class),
+            eq("test query"),
+            filterCaptor.capture(),
+            any(),
+            eq(0),
+            eq(10));
+
+    // The View's domain filter must be conjoined onto every OR clause of the base
+    // (published/unpublished) filter, so every disjunct should carry the domain criterion.
+    Filter filter = filterCaptor.getValue();
+    assertNotNull(filter.getOr(), "Filter OR clause should not be null");
+    boolean everyClauseHasDomain =
+        filter.getOr().stream()
+            .allMatch(
+                cc ->
+                    cc.getAnd().stream()
+                        .anyMatch(
+                            c ->
+                                "domains".equals(c.getField())
+                                    && c.getValues() != null
+                                    && c.getValues().contains(TEST_DOMAIN_URN)));
+    assertTrue(everyClauseHasDomain, "View domain filter should be applied to all filter clauses");
+  }
+
+  @Test
+  public void testSearchDocumentsWithoutViewUrnDoesNotResolveView() throws Exception {
+    QueryContext mockContext = getMockAllowContext();
+    when(mockEnv.getContext()).thenReturn(mockContext);
+    when(mockEnv.getArgument(eq("input"))).thenReturn(input);
+
+    resolver.get(mockEnv).get();
+
+    verify(mockViewService, never()).getViewInfo(any(OperationContext.class), any());
   }
 }

--- a/datahub-web-react/src/app/document/hooks/__tests__/useLoadDocumentTree.test.tsx
+++ b/datahub-web-react/src/app/document/hooks/__tests__/useLoadDocumentTree.test.tsx
@@ -4,6 +4,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { DEFAULT_STATE, UserContext } from '@app/context/userContext';
 import { DocumentTreeContext } from '@app/document/DocumentTreeContext';
 import { DOCUMENT_PAGE_SIZE, useLoadDocumentTree } from '@app/document/hooks/useLoadDocumentTree';
 
@@ -267,5 +268,40 @@ describe('useLoadDocumentTree', () => {
         const { result } = renderHook(() => useLoadDocumentTree(), { wrapper });
 
         expect(result.current.loading).toBe(true);
+    });
+
+    it('should scope tree queries to the active View', async () => {
+        const viewUrn = 'urn:li:dataHubView:test';
+        const viewWrapper = ({ children }: any) => (
+            <ApolloProvider client={mockClient}>
+                <UserContext.Provider
+                    value={{
+                        loaded: true,
+                        urn: 'urn:li:corpuser:test',
+                        localState: { selectedViewUrn: viewUrn },
+                        state: DEFAULT_STATE,
+                        updateLocalState: () => null,
+                        updateState: () => null,
+                        refetchUser: () => null,
+                    }}
+                >
+                    <DocumentTreeContext.Provider value={mockContextValue}>{children}</DocumentTreeContext.Provider>
+                </UserContext.Provider>
+            </ApolloProvider>
+        );
+
+        renderHook(() => useLoadDocumentTree(), { wrapper: viewWrapper });
+
+        await waitFor(() => {
+            expect(mockSearchDocumentsLazyQuery).toHaveBeenCalled();
+        });
+
+        expect(mockSearchDocumentsLazyQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                variables: expect.objectContaining({
+                    input: expect.objectContaining({ viewUrn }),
+                }),
+            }),
+        );
     });
 });

--- a/datahub-web-react/src/app/document/hooks/__tests__/useSearchDocuments.test.tsx
+++ b/datahub-web-react/src/app/document/hooks/__tests__/useSearchDocuments.test.tsx
@@ -4,10 +4,34 @@ import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
 import { describe, expect, it } from 'vitest';
 
+import { DEFAULT_STATE, UserContext } from '@app/context/userContext';
 import { SearchDocumentsInput, useSearchDocuments } from '@app/document/hooks/useSearchDocuments';
 
 import { SearchDocumentsDocument } from '@graphql/document.generated';
 import { DocumentSourceType, DocumentState } from '@types';
+
+const TEST_VIEW_URN = 'urn:li:dataHubView:test';
+
+/** Wrapper that provides a selected View in user context, wrapped around Apollo mocks. */
+function withSelectedView(viewUrn: string | undefined, mocks: any[]) {
+    return ({ children }: { children: React.ReactNode }) => (
+        <UserContext.Provider
+            value={{
+                loaded: true,
+                urn: 'urn:li:corpuser:test',
+                localState: { selectedViewUrn: viewUrn },
+                state: DEFAULT_STATE,
+                updateLocalState: () => null,
+                updateState: () => null,
+                refetchUser: () => null,
+            }}
+        >
+            <MockedProvider mocks={mocks} addTypename={false}>
+                {children}
+            </MockedProvider>
+        </UserContext.Provider>
+    );
+}
 
 describe('useSearchDocuments', () => {
     const mockDocuments = [
@@ -46,6 +70,7 @@ describe('useSearchDocuments', () => {
                             rootOnly: undefined,
                             types: undefined,
                             sourceType: 'NATIVE',
+                            viewUrn: undefined,
                         },
                         includeParentDocuments: false,
                     },
@@ -100,6 +125,7 @@ describe('useSearchDocuments', () => {
                             rootOnly: undefined,
                             types: undefined,
                             sourceType: 'NATIVE',
+                            viewUrn: undefined,
                         },
                         includeParentDocuments: false,
                     },
@@ -151,6 +177,7 @@ describe('useSearchDocuments', () => {
                             rootOnly: undefined,
                             types: undefined,
                             sourceType: 'NATIVE',
+                            viewUrn: undefined,
                         },
                         includeParentDocuments: false,
                     },
@@ -201,6 +228,7 @@ describe('useSearchDocuments', () => {
                             rootOnly: true,
                             types: undefined,
                             sourceType: 'NATIVE',
+                            viewUrn: undefined,
                         },
                         includeParentDocuments: false,
                     },
@@ -251,6 +279,7 @@ describe('useSearchDocuments', () => {
                             rootOnly: undefined,
                             types: ['guide', 'tutorial'],
                             sourceType: 'NATIVE',
+                            viewUrn: undefined,
                         },
                         includeParentDocuments: false,
                     },
@@ -301,6 +330,7 @@ describe('useSearchDocuments', () => {
                             rootOnly: undefined,
                             types: undefined,
                             sourceType: 'NATIVE',
+                            viewUrn: undefined,
                         },
                         includeParentDocuments: false,
                     },
@@ -350,6 +380,7 @@ describe('useSearchDocuments', () => {
                             rootOnly: undefined,
                             types: undefined,
                             sourceType: undefined,
+                            viewUrn: undefined,
                         },
                         includeParentDocuments: false,
                     },
@@ -401,6 +432,7 @@ describe('useSearchDocuments', () => {
                             rootOnly: undefined,
                             types: undefined,
                             sourceType: 'NATIVE',
+                            viewUrn: undefined,
                         },
                         includeParentDocuments: false,
                     },
@@ -452,6 +484,7 @@ describe('useSearchDocuments', () => {
                             rootOnly: undefined,
                             types: undefined,
                             sourceType: 'NATIVE',
+                            viewUrn: undefined,
                         },
                         includeParentDocuments: true,
                     },
@@ -501,6 +534,7 @@ describe('useSearchDocuments', () => {
                             rootOnly: undefined,
                             types: undefined,
                             sourceType: 'NATIVE',
+                            viewUrn: undefined,
                         },
                         includeParentDocuments: false,
                     },
@@ -551,6 +585,7 @@ describe('useSearchDocuments', () => {
                             rootOnly: undefined,
                             types: undefined,
                             sourceType: 'NATIVE',
+                            viewUrn: undefined,
                         },
                         includeParentDocuments: false,
                     },
@@ -601,6 +636,7 @@ describe('useSearchDocuments', () => {
                             rootOnly: undefined,
                             types: undefined,
                             sourceType: 'NATIVE',
+                            viewUrn: undefined,
                         },
                         includeParentDocuments: false,
                     },
@@ -644,6 +680,7 @@ describe('useSearchDocuments', () => {
                             rootOnly: undefined,
                             types: undefined,
                             sourceType: 'NATIVE',
+                            viewUrn: undefined,
                         },
                         includeParentDocuments: false,
                     },
@@ -694,6 +731,7 @@ describe('useSearchDocuments', () => {
                             rootOnly: undefined,
                             types: undefined,
                             sourceType: 'EXTERNAL',
+                            viewUrn: undefined,
                         },
                         includeParentDocuments: false,
                     },
@@ -723,5 +761,84 @@ describe('useSearchDocuments', () => {
 
         expect(result.current.documents).toEqual(mockDocuments);
         expect(result.current.total).toBe(2);
+    });
+
+    it('should scope search to the active View by default', async () => {
+        const input: SearchDocumentsInput = {
+            fetchPolicy: 'network-only',
+            sourceTypes: [DocumentSourceType.Native],
+        };
+
+        const mocks = [
+            {
+                request: {
+                    query: SearchDocumentsDocument,
+                    variables: {
+                        input: {
+                            start: 0,
+                            count: 100,
+                            query: '*',
+                            parentDocuments: undefined,
+                            rootOnly: undefined,
+                            types: undefined,
+                            sourceType: 'NATIVE',
+                            viewUrn: TEST_VIEW_URN,
+                        },
+                        includeParentDocuments: false,
+                    },
+                },
+                result: { data: { searchDocuments: { documents: mockDocuments, total: 2 } } },
+            },
+        ];
+
+        const { result } = renderHook(() => useSearchDocuments(input), {
+            wrapper: withSelectedView(TEST_VIEW_URN, mocks),
+        });
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.documents).toEqual(mockDocuments);
+    });
+
+    it('should bypass the active View when applyView is false', async () => {
+        const input: SearchDocumentsInput = {
+            fetchPolicy: 'network-only',
+            sourceTypes: [DocumentSourceType.Native],
+            applyView: false,
+        };
+
+        const mocks = [
+            {
+                request: {
+                    query: SearchDocumentsDocument,
+                    variables: {
+                        input: {
+                            start: 0,
+                            count: 100,
+                            query: '*',
+                            parentDocuments: undefined,
+                            rootOnly: undefined,
+                            types: undefined,
+                            sourceType: 'NATIVE',
+                            viewUrn: undefined,
+                        },
+                        includeParentDocuments: false,
+                    },
+                },
+                result: { data: { searchDocuments: { documents: mockDocuments, total: 2 } } },
+            },
+        ];
+
+        const { result } = renderHook(() => useSearchDocuments(input), {
+            wrapper: withSelectedView(TEST_VIEW_URN, mocks),
+        });
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.documents).toEqual(mockDocuments);
     });
 });

--- a/datahub-web-react/src/app/document/hooks/useLoadDocumentTree.ts
+++ b/datahub-web-react/src/app/document/hooks/useLoadDocumentTree.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from 'react';
 
 import { useInfiniteScroll } from '@components/components/InfiniteScrollList/useInfiniteScroll';
 
+import { useUserContext } from '@app/context/useUserContext';
 import { DocumentTreeNode, useDocumentTree } from '@app/document/DocumentTreeContext';
 import { documentToTreeNode, sortDocumentsByCreationTime } from '@app/document/utils/documentUtils';
 
@@ -20,6 +21,13 @@ export const DOCUMENT_PAGE_SIZE = 25;
 export function useLoadDocumentTree() {
     const { initializeTree, appendRootNodes, setNodeChildren, appendNodeChildren, getRootNodes } = useDocumentTree();
     const [searchDocumentsQuery] = useSearchDocumentsLazyQuery();
+
+    // Scope the document tree (overview page + sidebar) to the active View, mirroring
+    // how the rest of search respects the selected View. The picker popovers rely on
+    // useSearchDocuments' applyView opt-out for their search box, but the shared tree
+    // itself is always View-scoped.
+    const userContext = useUserContext();
+    const viewUrn = userContext.localState?.selectedViewUrn ?? undefined;
 
     // True until the first page of root documents finishes loading.
     // ContextDocumentsPage depends on this to show a spinner before redirecting.
@@ -53,6 +61,7 @@ export function useLoadDocumentTree() {
                             parentDocuments: urns,
                             start: 0,
                             count: urns.length * 100,
+                            viewUrn,
                         },
                     },
                     fetchPolicy: 'network-only',
@@ -78,7 +87,7 @@ export function useLoadDocumentTree() {
                 return {};
             }
         },
-        [searchDocumentsQuery],
+        [searchDocumentsQuery, viewUrn],
     );
 
     // fetchData for useInfiniteScroll — fetches root documents and pushes into tree context
@@ -94,6 +103,7 @@ export function useLoadDocumentTree() {
                             // Source filtering is applied client-side per platform via the sidebar filters.
                             start,
                             count: DOCUMENT_PAGE_SIZE,
+                            viewUrn,
                         },
                     },
                     fetchPolicy: start === 0 ? 'cache-and-network' : 'network-only',
@@ -123,7 +133,7 @@ export function useLoadDocumentTree() {
                 if (start === 0) setIsInitializing(false);
             }
         },
-        [searchDocumentsQuery, checkForChildren, initializeTree, appendRootNodes, getRootNodes],
+        [searchDocumentsQuery, checkForChildren, initializeTree, appendRootNodes, getRootNodes, viewUrn],
     );
 
     const {
@@ -149,6 +159,7 @@ export function useLoadDocumentTree() {
                             rootOnly: parentUrn === null ? true : undefined,
                             start: 0,
                             count: DOCUMENT_PAGE_SIZE,
+                            viewUrn,
                         },
                     },
                     fetchPolicy: 'network-only',
@@ -181,7 +192,7 @@ export function useLoadDocumentTree() {
                 return [];
             }
         },
-        [searchDocumentsQuery, checkForChildren, setNodeChildren],
+        [searchDocumentsQuery, checkForChildren, setNodeChildren, viewUrn],
     );
 
     // Load more children for a parent (subsequent pages)
@@ -198,6 +209,7 @@ export function useLoadDocumentTree() {
                             parentDocuments: [parentUrn],
                             start: state.offset,
                             count: DOCUMENT_PAGE_SIZE,
+                            viewUrn,
                         },
                     },
                     fetchPolicy: 'network-only',
@@ -220,7 +232,7 @@ export function useLoadDocumentTree() {
                 console.error('Failed to load more children:', error);
             }
         },
-        [searchDocumentsQuery, checkForChildren, appendNodeChildren],
+        [searchDocumentsQuery, checkForChildren, appendNodeChildren, viewUrn],
     );
 
     return {

--- a/datahub-web-react/src/app/document/hooks/useSearchDocuments.ts
+++ b/datahub-web-react/src/app/document/hooks/useSearchDocuments.ts
@@ -1,5 +1,7 @@
 import { useMemo } from 'react';
 
+import { useUserContext } from '@app/context/useUserContext';
+
 import { useSearchDocumentsQuery } from '@graphql/document.generated';
 import { Document, DocumentSourceType, DocumentState } from '@types';
 
@@ -24,6 +26,12 @@ export interface SearchDocumentsInput {
      * If true, skip the query execution.
      */
     skip?: boolean;
+    /**
+     * Whether to scope results to the currently active View (defaults to true).
+     * Set to false for pickers (e.g. move / link-document popovers) so users can
+     * still find any document they have access to, regardless of the active View.
+     */
+    applyView?: boolean;
 }
 
 /**
@@ -41,6 +49,9 @@ function getSourceTypeForQuery(sourceTypes: DocumentSourceType[]): DocumentSourc
 
 export function useSearchDocuments(input: SearchDocumentsInput) {
     const sourceType = getSourceTypeForQuery(input.sourceTypes);
+    const userContext = useUserContext();
+    const applyView = input.applyView ?? true;
+    const viewUrn = applyView ? (userContext.localState?.selectedViewUrn ?? undefined) : undefined;
 
     const { data, loading, error, refetch } = useSearchDocumentsQuery({
         variables: {
@@ -52,6 +63,7 @@ export function useSearchDocuments(input: SearchDocumentsInput) {
                 rootOnly: input.rootOnly,
                 types: input.types,
                 sourceType,
+                viewUrn,
             },
             includeParentDocuments: input.includeParentDocuments || false,
         },

--- a/datahub-web-react/src/app/homeV2/layout/sidebar/documents/MoveDocumentPopover.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/sidebar/documents/MoveDocumentPopover.tsx
@@ -119,7 +119,8 @@ export const MoveDocumentPopover: React.FC<MoveDocumentPopoverProps> = ({
         return () => clearTimeout(timer);
     }, [searchQuery]);
 
-    // Search for documents (only when searching)
+    // Search for documents (only when searching). Bypass the active View so a document
+    // can be re-parented under any destination the user can access, even outside the View.
     const { documents: searchResults, loading: searchLoading } = useSearchDocuments({
         query: debouncedSearchQuery || '*',
         states: [DocumentState.Published, DocumentState.Unpublished],
@@ -127,6 +128,7 @@ export const MoveDocumentPopover: React.FC<MoveDocumentPopoverProps> = ({
         fetchPolicy: 'network-only', // Always fetch fresh for search
         includeParentDocuments: true, // Fetch parent documents for breadcrumb display
         sourceTypes: [DocumentSourceType.Native],
+        applyView: false,
     });
 
     const isSearching = debouncedSearchQuery.trim().length > 0;

--- a/datahub-web-react/src/app/homeV2/layout/sidebar/documents/shared/DocumentPopoverBase.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/sidebar/documents/shared/DocumentPopoverBase.tsx
@@ -126,7 +126,8 @@ export const DocumentPopoverBase: React.FC<DocumentPopoverBaseProps> = ({
         return () => clearTimeout(timer);
     }, [searchQuery]);
 
-    // Search for documents
+    // Search for documents. Pickers bypass the active View so users can find and link
+    // any document they have access to, regardless of the current View scoping.
     const { documents: searchResults, loading: searchLoading } = useSearchDocuments({
         query: debouncedSearchQuery || '*',
         states: [DocumentState.Published, DocumentState.Unpublished],
@@ -134,6 +135,7 @@ export const DocumentPopoverBase: React.FC<DocumentPopoverBaseProps> = ({
         fetchPolicy: 'network-only',
         includeParentDocuments: true,
         sourceTypes,
+        applyView: false,
     });
 
     const isSearching = debouncedSearchQuery.trim().length > 0;


### PR DESCRIPTION
No View
<img width="1840" height="1196" alt="Screenshot 2026-07-06 at 7 58 24 AM" src="https://github.com/user-attachments/assets/54e7da42-3d7f-47f2-97d4-88cf0bdda30b" />
View with document + owner
<img width="1840" height="1196" alt="Screenshot 2026-07-06 at 7 58 14 AM" src="https://github.com/user-attachments/assets/ba887c44-391e-4843-b503-650a09514a33" />
<img width="1840" height="1196" alt="Screenshot 2026-07-06 at 7 59 01 AM" src="https://github.com/user-attachments/assets/8b289ac7-33b7-44eb-8add-564602143c67" />
<img width="1840" height="1196" alt="Screenshot 2026-07-06 at 7 59 08 AM" src="https://github.com/user-attachments/assets/3697fa97-ebbe-4aaf-8819-6f0e32662b51" />



…cat <<'EOF'

feat(documents): scope document search to the active View

searchDocuments had no notion of Views end-to-end, so the Documents overview/tree and sidebar ignored the active View (reported via Optiver feedback). This threads View scoping through document search, mirroring searchAcrossEntities.

Backend:
- Add viewUrn to SearchDocumentsInput
- Inject ViewService into SearchDocumentsResolver; when a viewUrn is provided, resolve the View and combine its filter with the existing published/ownership filter. Entity-type intersection is intentionally skipped since this is a document-only search (a View that omits the document type should still scope by its field filter, not return empty).
- Wire ViewService through DocumentResolvers and GmsGraphQLEngine

Frontend:
- useSearchDocuments and useLoadDocumentTree read the active selectedViewUrn and pass it to searchDocuments; the shared document tree (overview + sidebar) is now View-scoped
- Add an applyView opt-out on useSearchDocuments so the move/link document pickers bypass the View and can still reach any accessible doc

Out of scope: relatedDocuments (already asset-scoped) and the MCP tool (uses searchAcrossEntities, already View-aware).
EOF
)"

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
