### PR TITLE
docs: de-duplicate GitHub integration tile

### DIFF
--- a/metadata-ingestion/docs/sources/integrations_catalog.json
+++ b/metadata-ingestion/docs/sources/integrations_catalog.json
@@ -1021,13 +1021,9 @@
     "img_path": "img/logos/platforms/notion.svg"
   },
   "github": {
-    "description": "Import files and documentation from GitHub repositories into DataHub as Documents, keeping them discoverable and governed alongside the rest of your metadata. Ingested on a schedule through UI or CLI ingestion.",
-    "img_path": "img/logos/platforms/github.png"
-  },
-  "github-documents": {
     "platform_type": "Collaboration",
     "connection_type": "Pull",
-    "description": "Import files from a GitHub repository as DataHub Documents on a schedule.",
+    "description": "Import files and documentation from GitHub repositories into DataHub as Documents, keeping them discoverable and governed alongside the rest of your metadata. Ingested on a schedule through UI or CLI ingestion.",
     "img_path": "img/logos/platforms/github.png"
   },
   "excel": {


### PR DESCRIPTION
## Summary

Follow-up to #18143. The integrations page rendered **two** GitHub cards:

- the registry-derived `github` platform tile (canonical — real doc path, feature tags, support status), and
- a redundant `github-documents` catalog entry with an **empty doc path** (broken link).

Both describe the same `GitHubDocumentsSource` connector, so users saw a duplicate. This PR removes the `github-documents` catalog entry and keeps only the canonical `github` tile, categorizing it as `Collaboration` (matching Notion/Confluence) instead of falling back to the default `Metadata` type.

## Changes

- Remove the `github-documents` entry from `metadata-ingestion/docs/sources/integrations_catalog.json`.
- Add `platform_type: Collaboration` + `connection_type: Pull` to the `github` entry.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://docs.datahub.com/docs/contributing#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests added/updated (if applicable)
- [x] Docs added/updated (if applicable)

Made with [Cursor](https://cursor.com)