### PR TITLE
fix(kafka-connect): handle platform_instance prefix in Debezium table discovery

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
@@ -783,6 +783,10 @@ class BaseConnector:
                 if not table_name:
                     continue
 
+                # When platform_instance is configured, DatasetUrn embeds it as
+                # "{platform_instance}.{table_name}". Strip it before filtering.
+                table_name = self._strip_platform_instance_prefix(table_name)
+
                 # Filter by database - check if table_name starts with database prefix
                 if database_name:
                     if table_name.lower().startswith(f"{database_name.lower()}."):
@@ -1160,6 +1164,24 @@ class BaseConnector:
             logger.debug(f"Failed to extract table name from URN {urn}: {e}")
             return None
 
+    def _strip_platform_instance_prefix(self, table_name: str) -> str:
+        """Strip platform_instance prefix from URN table name if present.
+
+        DatasetUrn.create_from_ids embeds platform_instance in the name field
+        as "{platform_instance}.{table_name}". This reverses that embedding so
+        that filter and pattern-matching logic operates on the bare table name.
+        When no platform_instance is configured this is a no-op.
+        """
+        if not self.schema_resolver:
+            return table_name
+        platform_instance = getattr(self.schema_resolver, "platform_instance", None)
+        if not platform_instance:
+            return table_name
+        prefix = f"{platform_instance}."
+        if table_name.startswith(prefix):
+            return table_name[len(prefix) :]
+        return table_name
+
     def _extract_lineages_from_schema_resolver(
         self,
         source_platform: str,
@@ -1228,6 +1250,10 @@ class BaseConnector:
                 table_name = self._extract_table_name_from_urn(urn)
                 if not table_name:
                     continue
+
+                # When platform_instance is configured, DatasetUrn embeds it as
+                # "{platform_instance}.{table_name}". Strip it before topic naming.
+                table_name = self._strip_platform_instance_prefix(table_name)
 
                 # Generate base topic name using connector-specific naming logic
                 expected_topic = topic_namer(table_name)

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
@@ -1880,6 +1880,10 @@ class SnowflakeSourceConnector(BaseConnector):
                 if f"dataplatform:{platform.lower()}" not in urn.lower():
                     continue
 
+                # When platform_instance is configured, DatasetUrn embeds it as
+                # "{platform_instance}.{table_name}". Strip it before pattern matching.
+                table_name = self._strip_platform_instance_prefix(table_name)
+
                 # Try pattern match (table_name from DataHub is already lowercase)
                 if regex.fullmatch(table_name):
                     matched_tables.append(table_name)
@@ -3392,6 +3396,10 @@ class DebeziumSourceConnector(BaseConnector):
                 table_name = self._extract_table_name_from_urn(urn)
                 if not table_name:
                     continue
+
+                # When platform_instance is configured, DatasetUrn embeds it as
+                # "{platform_instance}.{table_name}". Strip it before pattern matching.
+                table_name = self._strip_platform_instance_prefix(table_name)
 
                 # Try direct match first (handles patterns like "mydb.schema.*")
                 full_name_matches = (

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_debezium_table_discovery.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_debezium_table_discovery.py
@@ -14,6 +14,7 @@ from datahub.ingestion.source.kafka_connect.common import (
 )
 from datahub.ingestion.source.kafka_connect.source_connectors import (
     DebeziumSourceConnector,
+    SnowflakeSourceConnector,
 )
 from datahub.sql_parsing.schema_resolver import SchemaResolver
 
@@ -48,6 +49,32 @@ def create_debezium_connector(
     report = Mock(spec=KafkaConnectSourceReport)
 
     connector = DebeziumSourceConnector(manifest, config, report)
+    connector.schema_resolver = schema_resolver
+
+    return connector
+
+
+def create_snowflake_connector(
+    connector_config: dict,
+    schema_resolver: Optional[SchemaResolver] = None,
+) -> SnowflakeSourceConnector:
+    """Helper to create a SnowflakeSourceConnector instance for testing."""
+    manifest = ConnectorManifest(
+        name="test-snowflake-connector",
+        type="source",
+        config=connector_config,
+        tasks=[],
+        topic_names=[],
+    )
+
+    config = Mock(spec=KafkaConnectSourceConfig)
+    config.use_schema_resolver = True
+    config.schema_resolver_expand_patterns = True
+    config.env = "PROD"
+
+    report = Mock(spec=KafkaConnectSourceReport)
+
+    connector = SnowflakeSourceConnector(manifest, config, report)
     connector.schema_resolver = schema_resolver
 
     return connector
@@ -659,3 +686,139 @@ class TestGetTopicsFromConfigIntegration:
 
         # Should return empty list instead of crashing
         assert result == []
+
+
+class TestDiscoverTablesWithPlatformInstance:
+    """Tests for platform_instance prefix stripping in table discovery.
+
+    When platform_instance_map is configured, DatasetUrn.create_from_ids embeds
+    the platform_instance in the URN name field as "{platform_instance}.{table_name}".
+    These tests verify that the PI prefix is correctly stripped before filtering and
+    pattern matching, so discovery returns the expected tables.
+    """
+
+    def test_strip_platform_instance_prefix_strips_when_present(self) -> None:
+        """_strip_platform_instance_prefix removes the PI prefix."""
+        connector_config = {
+            "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+            "database.server.name": "myserver",
+            "database.dbname": "my_db",
+        }
+        schema_resolver = Mock(spec=SchemaResolver)
+        schema_resolver.platform_instance = "my_instance"
+        connector = create_debezium_connector(
+            connector_config, schema_resolver=schema_resolver, use_schema_resolver=True
+        )
+
+        result = connector._strip_platform_instance_prefix(
+            "my_instance.my_db.public.orders"
+        )
+        assert result == "my_db.public.orders"
+
+    def test_strip_platform_instance_prefix_noop_when_no_pi(self) -> None:
+        """_strip_platform_instance_prefix is a no-op when no platform_instance is set."""
+        connector_config = {
+            "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+            "database.server.name": "myserver",
+            "database.dbname": "testdb",
+        }
+        schema_resolver = Mock(spec=SchemaResolver)
+        schema_resolver.platform_instance = None
+        connector = create_debezium_connector(
+            connector_config, schema_resolver=schema_resolver, use_schema_resolver=True
+        )
+
+        result = connector._strip_platform_instance_prefix("testdb.public.users")
+        assert result == "testdb.public.users"
+
+    def test_discover_tables_from_database_strips_pi_prefix(self) -> None:
+        """_discover_tables_from_database returns tables when URNs have a PI prefix.
+
+        Reproduces the reported platform_instance scenario: platform_instance=my_instance,
+        database=my_db. Without the fix, zero tables are discovered
+        because the PI-prefixed name never starts with the database prefix.
+        """
+        connector_config = {
+            "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+            "database.server.name": "myserver",
+            "database.dbname": "my_db",
+        }
+        schema_resolver = Mock(spec=SchemaResolver)
+        schema_resolver.platform_instance = "my_instance"
+        schema_resolver.env = "PROD"
+        # Simulate URNs as stored in the SchemaResolver cache when PI is configured
+        schema_resolver.get_urns.return_value = {
+            "urn:li:dataset:(urn:li:dataPlatform:postgres,my_instance.my_db.public.orders,PROD)",
+            "urn:li:dataset:(urn:li:dataPlatform:postgres,my_instance.my_db.public.products,PROD)",
+        }
+        connector = create_debezium_connector(
+            connector_config, schema_resolver=schema_resolver, use_schema_resolver=True
+        )
+
+        result = connector._discover_tables_from_database(
+            platform="postgres",
+            database_name="my_db",
+        )
+
+        # After PI stripping, both tables should match the database prefix
+        assert sorted(result) == ["public.orders", "public.products"]
+
+    def test_query_tables_from_datahub_strips_pi_prefix(self) -> None:
+        """_query_tables_from_datahub pattern matching works when URNs have a PI prefix."""
+        connector_config = {
+            "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+            "database.server.name": "myserver",
+            "database.dbname": "my_db",
+            "table.include.list": "public.*",
+        }
+        schema_resolver = Mock(spec=SchemaResolver)
+        schema_resolver.platform_instance = "my_instance"
+        schema_resolver.env = "PROD"
+        schema_resolver.get_urns.return_value = {
+            "urn:li:dataset:(urn:li:dataPlatform:postgres,my_instance.my_db.public.orders,PROD)",
+            "urn:li:dataset:(urn:li:dataPlatform:postgres,my_instance.my_db.public.products,PROD)",
+            "urn:li:dataset:(urn:li:dataPlatform:postgres,my_instance.my_db.internal.audit,PROD)",
+        }
+        connector = create_debezium_connector(
+            connector_config, schema_resolver=schema_resolver, use_schema_resolver=True
+        )
+
+        result = connector._query_tables_from_datahub(
+            platform="postgres",
+            pattern="my_db.public.*",
+            database="my_db",
+        )
+
+        # Only tables matching "my_db.public.*" should be returned
+        assert sorted(result) == [
+            "my_db.public.orders",
+            "my_db.public.products",
+        ]
+
+    def test_snowflake_query_tables_from_datahub_strips_pi_prefix(self) -> None:
+        """Snowflake _query_tables_from_datahub matches patterns after PI stripping."""
+        connector_config = {
+            "connector.class": "com.snowflake.kafka.connector.SnowflakeSinkConnector",
+            "topic.prefix": "sf_",
+        }
+        schema_resolver = Mock(spec=SchemaResolver)
+        schema_resolver.platform_instance = "my_instance"
+        schema_resolver.env = "PROD"
+        schema_resolver.graph = Mock()
+        schema_resolver.graph.get_urns_by_filter.return_value = [
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.public.orders,PROD)",
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.public.products,PROD)",
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.internal.audit,PROD)",
+        ]
+        connector = create_snowflake_connector(
+            connector_config, schema_resolver=schema_resolver
+        )
+
+        result = connector._query_tables_from_datahub(
+            pattern="my_db.public.*",
+            platform="snowflake",
+            database="my_db",
+        )
+
+        # PI prefix stripped before matching; only public-schema tables match
+        assert sorted(result) == ["my_db.public.orders", "my_db.public.products"]


### PR DESCRIPTION
## Summary

When `platform_instance_map` is configured (e.g. `{postgres: my_instance}`), `DatasetUrn.create_from_ids` embeds the platform instance in the URN name field as `"{platform_instance}.{table_name}"` (e.g. `my_instance.my_db.public.orders`). This caused the Kafka Connect table-discovery paths to silently return 0 results, because the PI-prefixed name never matched the database prefix or the pattern filter.

**Root cause:** `_discover_tables_from_database` filters by `table_name.startswith(f"{database_name}.")`, but the `table_name` read from the SchemaResolver cache is `my_instance.my_db.public.orders` — it starts with `my_instance.`, not `my_db.`, so zero tables are discovered. The same mismatch affects the shared lineage path and the Debezium/Snowflake pattern-matching paths.

**Fix:** Adds `_strip_platform_instance_prefix()` to `BaseConnector` and calls it at every table-name extraction site across all discovery paths:

- `_discover_tables_from_database` (common.py) — used by Debezium when `table.include.list` is omitted
- `_extract_lineages_from_schema_resolver` (common.py) — shared lineage path for all connectors
- Debezium `_query_tables_from_datahub` (source_connectors.py) — pattern-matching path
- Snowflake `_query_tables_from_datahub` (source_connectors.py) — same fix for consistency

When no `platform_instance` is configured the method is a strict no-op, preserving full backwards compatibility. It uses `getattr()` for safe access to `platform_instance`, so existing callers/mocks without the attribute continue to work.

## Files Changed

- `metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py` — adds the `_strip_platform_instance_prefix()` helper and applies it in `_discover_tables_from_database` and `_extract_lineages_from_schema_resolver`
- `metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py` — applies PI stripping in both the Debezium and Snowflake `_query_tables_from_datahub` paths
- `metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_debezium_table_discovery.py` — adds `TestDiscoverTablesWithPlatformInstance` with focused regression tests for the PI-prefix scenario

## Test Plan

- [x] `./gradlew :metadata-ingestion:lintFix` — all checks pass
- [x] `test_kafka_connect_debezium_table_discovery.py` — 36/36 pass with the fix
- [x] Confirmed genuine regression coverage: reverting only the source-file changes (keeping the tests) turns the platform-instance tests red — `_discover_tables_from_database` returns `[]` instead of the expected tables, reproducing the "silently 0 results" bug
- [x] Reachable extraction sites are covered directly: `_discover_tables_from_database`, the Debezium `_query_tables_from_datahub`, and the Snowflake `_query_tables_from_datahub` override
- [x] The no-`platform_instance` path is covered and stays a no-op (backwards compatibility)

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (PR Title Format)
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated
- [ ] Docs related to the changes have been added/updated (not applicable — internal fix, no user-facing surface change)
- [ ] For any breaking change an entry has been made in Updating DataHub (not applicable — no breaking change)
