### PR TITLE
fix(ingest/powerbi): remove duplicate test helpers breaking mypy on master

### DIFF
--- a/metadata-ingestion/tests/unit/powerbi/test_pattern_handler.py
+++ b/metadata-ingestion/tests/unit/powerbi/test_pattern_handler.py
@@ -800,30 +800,8 @@ def test_remap_column_lineage_multi_table_shared_column_name():
 
 # ---------------------------------------------------------------------------
 # OdbcLineage — view leaves and dialect-aware SQL detection
+# (reuses the _build_odbc_lineage / _nav_accessor helpers defined above)
 # ---------------------------------------------------------------------------
-
-
-def _build_odbc_lineage() -> OdbcLineage:
-    table = Table(columns=None, measures=[], expression="", name="t", full_name="ds.t")
-    resolver = MagicMock(spec=AbstractDataPlatformInstanceResolver)
-    resolver.get_platform_instance.return_value = PlatformDetail()
-    return OdbcLineage(
-        ctx=MagicMock(spec=PipelineContext),
-        table=table,
-        config=_build_config(),
-        reporter=PowerBiDashboardSourceReport(),
-        platform_instance_resolver=resolver,
-    )
-
-
-def _nav_accessor(*levels: tuple) -> IdentifierAccessor:
-    head: Optional[IdentifierAccessor] = None
-    for kind, name in reversed(levels):
-        head = IdentifierAccessor(
-            identifier=name, items={"Kind": kind, "Name": name}, next=head
-        )
-    assert head is not None
-    return head
 
 
 def test_odbc_view_leaf_resolves_like_table():


### PR DESCRIPTION
## Summary

Master's `metadata-ingestion` lint is currently failing repo-wide:

```
tests/unit/powerbi/test_pattern_handler.py:806: error: Name "_build_odbc_lineage" already defined on line 624  [no-redef]
tests/unit/powerbi/test_pattern_handler.py:819: error: Name "_nav_accessor" already defined on line 639  [no-redef]
```

#18017 (merged Jul 2) and #18098 (merged Jul 3) each independently added `_build_odbc_lineage` / `_nav_accessor` to this file. Both PRs were green in isolation — #18098's CI last ran on Jun 30, before #18017 merged — and the two helper blocks live in different regions of the file, so the merge combined cleanly textually while leaving two definitions of each helper. Since the lint check runs on every PR's merge ref, this now fails `mypy` for **every open PR**.

The two copies are functionally identical (the second is the first minus docstrings). This PR drops the duplicates from the #18098 section and points it at the originals.

## Testing

- `pytest tests/unit/powerbi/test_pattern_handler.py`: 26 passed (covers both PRs' tests, incl. the ODBC view-leaf/native-query tests that used the removed copies).
- `mypy tests/unit/powerbi/test_pattern_handler.py`: clean.
- ruff format/check: clean.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly Contribution Message Format)
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)