### PR TITLE
fix(ingest/thoughtspot): Fix ThoughtSpot ingestion with Bigquery connection

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/thoughtspot/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/thoughtspot/client.py
@@ -159,7 +159,7 @@ def _extract_answer_chart_type(answer_tml: Dict[str, Any]) -> Optional[str]:
 _TS_TO_DATAHUB_PLATFORM: Dict[str, str] = {
     "DATABRICKS": "databricks",
     "SNOWFLAKE": "snowflake",
-    "BIGQUERY": "bigquery", # keep for backwards compatibility
+    "BIGQUERY": "bigquery",  # keep for backwards compatibility
     "GOOGLE_BIGQUERY": "bigquery",  # used in connections
     "GCP_BIGQUERY": "bigquery",  # used in tables
     "REDSHIFT": "redshift",
@@ -929,10 +929,12 @@ class ThoughtSpotClient:
                             flattened["stats"] = item["stats"]
 
                         if include_details:
-                            # in some rare cases, the metadata_detail field contains a string error message like 
+                            # in some rare cases, the metadata_detail field contains a string error message like
                             # 'Error fetching details for ...' instead of a dict. We handle that case to avoid breaking the ingestion.
                             if isinstance(item.get("metadata_detail"), str):
-                                logger.warning("Metadata detail invalid in item: %s", item)
+                                logger.warning(
+                                    "Metadata detail invalid in item: %s", item
+                                )
                                 item["metadata_detail"] = {}
                             detail = item.get("metadata_detail") or {}
                             if object_type == "LOGICAL_TABLE":

--- a/metadata-ingestion/src/datahub/ingestion/source/thoughtspot/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/thoughtspot/client.py
@@ -159,7 +159,9 @@ def _extract_answer_chart_type(answer_tml: Dict[str, Any]) -> Optional[str]:
 _TS_TO_DATAHUB_PLATFORM: Dict[str, str] = {
     "DATABRICKS": "databricks",
     "SNOWFLAKE": "snowflake",
-    "BIGQUERY": "bigquery",
+    "BIGQUERY": "bigquery", # keep for backwards compatibility
+    "GOOGLE_BIGQUERY": "bigquery",  # used in connections
+    "GCP_BIGQUERY": "bigquery",  # used in tables
     "REDSHIFT": "redshift",
     "SYNAPSE": "mssql",  # Synapse uses MSSQL URN conventions.
     "ORACLE": "oracle",
@@ -927,6 +929,11 @@ class ThoughtSpotClient:
                             flattened["stats"] = item["stats"]
 
                         if include_details:
+                            # in some rare cases, the metadata_detail field contains a string error message like 
+                            # 'Error fetching details for ...' instead of a dict. We handle that case to avoid breaking the ingestion.
+                            if isinstance(item.get("metadata_detail"), str):
+                                logger.warning("Metadata detail invalid in item: %s", item)
+                                item["metadata_detail"] = {}
                             detail = item.get("metadata_detail") or {}
                             if object_type == "LOGICAL_TABLE":
                                 flattened["columns"] = (

--- a/metadata-ingestion/src/datahub/ingestion/source/thoughtspot/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/thoughtspot/client.py
@@ -177,6 +177,25 @@ _TS_TO_DATAHUB_PLATFORM: Dict[str, str] = {
 }
 
 
+# TS prefixes a LogicalTable's ``dataSourceTypeEnum`` with the connection
+# category (``RDBMS_`` / ``NOSQL_`` / ``FILE_``) — e.g. ``RDBMS_SNOWFLAKE`` —
+# whereas ConnectionResponse reports the bare name (``SNOWFLAKE``). Note this
+# is orthogonal to vendor aliasing (``GCP_BIGQUERY`` on tables vs
+# ``GOOGLE_BIGQUERY`` on connections), which is handled by the map above.
+_TS_TABLE_TYPE_PREFIXES = ("RDBMS_", "NOSQL_", "FILE_")
+
+
+def normalize_ts_table_type(data_source_type: Optional[str]) -> str:
+    """Uppercase a table's ``data_source_type`` and strip the TS category
+    prefix so it resolves against ``_TS_TO_DATAHUB_PLATFORM`` (keyed by bare
+    warehouse names). Returns ``""`` when ``data_source_type`` is None/empty."""
+    ts_type = (data_source_type or "").upper()
+    for prefix in _TS_TABLE_TYPE_PREFIXES:
+        if ts_type.startswith(prefix):
+            return ts_type[len(prefix) :]
+    return ts_type
+
+
 # Each platform has its own canonical dataset-key shape; this table is
 # the single source of truth so adding a platform requires editing one
 # spot. Schema-less platforms (MySQL, Teradata, Athena) collapse the
@@ -782,6 +801,33 @@ class ThoughtSpotClient:
                     ids.append(tid)
         return ids
 
+    def _coerce_metadata_detail(
+        self,
+        raw_detail: Any,
+        *,
+        obj_id: Optional[str],
+        obj_name: Optional[str],
+    ) -> Dict[str, Any]:
+        """Coerce a raw ``metadata_detail`` value into a dict.
+
+        TS occasionally returns a string error message (e.g. 'Error fetching
+        details for ...') instead of the detail object. Surface it in the
+        report and fall back to ``{}`` so the object still ingests (without
+        columns/lineage) rather than crashing the run.
+        """
+        if isinstance(raw_detail, str):
+            self.report.warning(
+                title="Metadata Detail Unavailable",
+                message=(
+                    "ThoughtSpot returned an error instead of object details; "
+                    "the object is ingested without columns/lineage. Check "
+                    "ThoughtSpot-side permissions or object health."
+                ),
+                context=f"id={obj_id}, name={obj_name}, detail={raw_detail}",
+            )
+            return {}
+        return raw_detail or {}
+
     @staticmethod
     def _parse_columns_from_metadata_detail(
         detail: Dict[str, Any],
@@ -929,14 +975,12 @@ class ThoughtSpotClient:
                             flattened["stats"] = item["stats"]
 
                         if include_details:
-                            # in some rare cases, the metadata_detail field contains a string error message like
-                            # 'Error fetching details for ...' instead of a dict. We handle that case to avoid breaking the ingestion.
-                            if isinstance(item.get("metadata_detail"), str):
-                                logger.warning(
-                                    "Metadata detail invalid in item: %s", item
-                                )
-                                item["metadata_detail"] = {}
-                            detail = item.get("metadata_detail") or {}
+                            header = item.get("metadata_header") or {}
+                            detail = self._coerce_metadata_detail(
+                                item.get("metadata_detail"),
+                                obj_id=item.get("metadata_id") or header.get("id"),
+                                obj_name=header.get("name"),
+                            )
                             if object_type == "LOGICAL_TABLE":
                                 flattened["columns"] = (
                                     self._parse_columns_from_metadata_detail(detail)
@@ -1108,9 +1152,11 @@ class ThoughtSpotClient:
                     continue
 
                 header = item.get("metadata_header") or {}
-                detail = item.get("metadata_detail") or {}
                 obj_id = item.get("metadata_id") or header.get("id")
                 obj_name = header.get("name", "")
+                detail = self._coerce_metadata_detail(
+                    item.get("metadata_detail"), obj_id=obj_id, obj_name=obj_name
+                )
 
                 columns: List[Dict[str, str]] = []
                 for col in detail.get("columns") or []:

--- a/metadata-ingestion/src/datahub/ingestion/source/thoughtspot/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/thoughtspot/source.py
@@ -66,6 +66,7 @@ from datahub.ingestion.source.thoughtspot.client import (
     ThoughtSpotAuthenticationError,
     ThoughtSpotClient,
     ThoughtSpotPermissionError,
+    normalize_ts_table_type,
 )
 from datahub.ingestion.source.thoughtspot.config import (
     ExternalConnectionConfig,
@@ -2159,16 +2160,12 @@ class ThoughtSpotSource(StatefulIngestionSourceBase, TestableSource):
             )
 
         # Fallback: connection not in lookup. Read data_source_type
-        # off the table directly. Strip the ``RDBMS_`` / ``NOSQL_``
-        # prefix TS applies on the LogicalTableResponse so the map
-        # (keyed by bare warehouse names) resolves.
-        ts_type = (table.data_source_type or "").upper()
+        # off the table directly, normalizing the TS category prefix
+        # (``RDBMS_`` / ``NOSQL_`` / ``FILE_``) so the map (keyed by
+        # bare warehouse names) resolves.
+        ts_type = normalize_ts_table_type(table.data_source_type)
         if not ts_type:
             return None
-        for prefix in ("RDBMS_", "NOSQL_", "FILE_"):
-            if ts_type.startswith(prefix):
-                ts_type = ts_type[len(prefix) :]
-                break
         platform = _TS_TO_DATAHUB_PLATFORM.get(ts_type)
         if not platform:
             return None
@@ -2207,14 +2204,7 @@ class ThoughtSpotSource(StatefulIngestionSourceBase, TestableSource):
         # entry isn't a real failure to warn about. Without this guard,
         # every TS-internal table on a tenant triggers a false-positive
         # "External Lineage Resolution Failed" warning.
-        ts_type = (table.data_source_type or "").upper()
-        if not ts_type:
-            return None
-        for prefix in ("RDBMS_", "NOSQL_", "FILE_"):
-            if ts_type.startswith(prefix):
-                ts_type = ts_type[len(prefix) :]
-                break
-
+        ts_type = normalize_ts_table_type(table.data_source_type)
         if ts_type not in _TS_TO_DATAHUB_PLATFORM:
             return None
         conn = self._get_connection_lookup().get(table.data_source_id)

--- a/metadata-ingestion/src/datahub/ingestion/source/thoughtspot/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/thoughtspot/source.py
@@ -2208,6 +2208,13 @@ class ThoughtSpotSource(StatefulIngestionSourceBase, TestableSource):
         # every TS-internal table on a tenant triggers a false-positive
         # "External Lineage Resolution Failed" warning.
         ts_type = (table.data_source_type or "").upper()
+        if not ts_type:
+            return None
+        for prefix in ("RDBMS_", "NOSQL_", "FILE_"):
+            if ts_type.startswith(prefix):
+                ts_type = ts_type[len(prefix) :]
+                break
+
         if ts_type not in _TS_TO_DATAHUB_PLATFORM:
             return None
         conn = self._get_connection_lookup().get(table.data_source_id)

--- a/metadata-ingestion/tests/unit/test_thoughtspot_source.py
+++ b/metadata-ingestion/tests/unit/test_thoughtspot_source.py
@@ -15,6 +15,26 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 import yaml
+from datahub.metadata.schema_classes import (
+    AuditStampClass,
+    ChartInfoClass,
+    ChartUsageStatisticsClass,
+    ContainerClass,
+    DashboardInfoClass,
+    DashboardUsageStatisticsClass,
+    DatasetPropertiesClass,
+    FineGrainedLineageClass,
+    GlobalTagsClass,
+    InputFieldsClass,
+    OwnershipClass,
+    SchemaMetadataClass,
+    StatusClass,
+    SubTypesClass,
+    TimeTypeClass,
+    UpstreamClass,
+    UpstreamLineageClass,
+    ViewPropertiesClass,
+)
 from pydantic import ValidationError
 from requests.adapters import HTTPAdapter
 from requests.exceptions import HTTPError
@@ -78,26 +98,6 @@ from datahub.ingestion.source.thoughtspot.source import (
 )
 from datahub.ingestion.workunit_processors.auto_stale_entity_removal import (
     AutoStaleEntityRemovalProcessor,
-)
-from datahub.metadata.schema_classes import (
-    AuditStampClass,
-    ChartInfoClass,
-    ChartUsageStatisticsClass,
-    ContainerClass,
-    DashboardInfoClass,
-    DashboardUsageStatisticsClass,
-    DatasetPropertiesClass,
-    FineGrainedLineageClass,
-    GlobalTagsClass,
-    InputFieldsClass,
-    OwnershipClass,
-    SchemaMetadataClass,
-    StatusClass,
-    SubTypesClass,
-    TimeTypeClass,
-    UpstreamClass,
-    UpstreamLineageClass,
-    ViewPropertiesClass,
 )
 from datahub.sdk.dataset import Dataset
 
@@ -4014,6 +4014,40 @@ class TestThoughtSpotClientMetadataDetailParsing:
                 assert len(results) == 1
                 assert results[0]["columns"] == []
 
+    def test_metadata_search_handles_string_error_detail(self):
+        """In rare cases TS returns a string error message in
+        ``metadata_detail`` instead of a dict. The object must still ingest
+        (with empty columns) and the failure must surface in the report
+        rather than crashing the run."""
+        config = ThoughtSpotConnectionConfig(
+            base_url="https://test.thoughtspot.cloud",
+            auth=TrustedAuth(username="testuser", secret_key="test_token"),
+        )
+
+        with patch(
+            "datahub.ingestion.source.thoughtspot.client.ThoughtSpotClient._authenticate"
+        ):
+            client = ThoughtSpotClient(config)
+
+            with patch.object(client, "ts_client") as mock_ts_client:
+                mock_ts_client.metadata_search.return_value = [
+                    {
+                        "metadata_id": "table-789",
+                        "metadata_header": {"id": "table-789", "name": "broken_table"},
+                        "metadata_detail": "Error fetching details for table-789",
+                    }
+                ]
+
+                results = client.get_metadata_details(
+                    metadata_type="LOGICAL_TABLE",
+                    metadata_ids=["table-789"],
+                )
+
+                assert len(results) == 1
+                assert results[0]["columns"] == []
+                titles = [w.title for w in client.report.warnings]
+                assert "Metadata Detail Unavailable" in titles
+
     def test_metadata_search_batches_multiple_ids(self):
         """Multiple ids produce one metadata entry per id (API rejects list-valued identifier)."""
         config = ThoughtSpotConnectionConfig(
@@ -6066,6 +6100,8 @@ class TestExternalPlatformMapping:
             "DATABRICKS": "databricks",
             "SNOWFLAKE": "snowflake",
             "BIGQUERY": "bigquery",
+            "GOOGLE_BIGQUERY": "bigquery",
+            "GCP_BIGQUERY": "bigquery",
             "REDSHIFT": "redshift",
             "SYNAPSE": "mssql",
             "ORACLE": "oracle",
@@ -6355,6 +6391,72 @@ class TestResolveExternalUpstream:
         assert (
             ref.urn
             == "urn:li:dataset:(urn:li:dataPlatform:databricks,prod-dbx.warehouse.raw.events,PROD)"
+        )
+
+    def test_bigquery_vendor_aliases_resolve(self):
+        """TS labels BigQuery tables ``GCP_BIGQUERY`` but their connections
+        ``GOOGLE_BIGQUERY``. Both aliases must map to the ``bigquery``
+        platform so the physical upstream URN is emitted."""
+        source, mock_client = self._make_source()
+        mock_client.get_connections.return_value = [
+            ConnectionResponse(
+                id="c1",
+                name="Prod BQ",
+                data_source_type="GOOGLE_BIGQUERY",
+                default_database="my-project",
+                default_schema="analytics",
+            )
+        ]
+        table = LogicalTableResponse(
+            id="ts-table-1",
+            name="events",
+            type="LOGICAL_TABLE",
+            data_source_id="c1",
+            data_source_type="GCP_BIGQUERY",
+        )
+        table.physical_database_name = "my-project"
+        table.physical_schema_name = "raw"
+        table.physical_table_name = "events"
+
+        ref = source._resolve_external_upstream(table)
+        assert ref is not None
+        assert ref.platform == "bigquery"
+        assert (
+            ref.urn
+            == "urn:li:dataset:(urn:li:dataPlatform:bigquery,my-project.raw.events,PROD)"
+        )
+
+    def test_rdbms_prefixed_table_type_resolves(self):
+        """TS prefixes a table's ``data_source_type`` with ``RDBMS_`` while
+        the connection reports the bare name. The prefix must be stripped so
+        the early platform filter passes and the upstream resolves."""
+        source, mock_client = self._make_source()
+        mock_client.get_connections.return_value = [
+            ConnectionResponse(
+                id="c1",
+                name="Prod SF",
+                data_source_type="SNOWFLAKE",
+                default_database="db",
+                default_schema="public",
+            )
+        ]
+        table = LogicalTableResponse(
+            id="ts-table-1",
+            name="events",
+            type="LOGICAL_TABLE",
+            data_source_id="c1",
+            data_source_type="RDBMS_SNOWFLAKE",
+        )
+        table.physical_database_name = "db"
+        table.physical_schema_name = "public"
+        table.physical_table_name = "events"
+
+        ref = source._resolve_external_upstream(table)
+        assert ref is not None
+        assert ref.platform == "snowflake"
+        assert (
+            ref.urn
+            == "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.public.events,PROD)"
         )
 
     def test_in_memory_table_returns_none(self):

--- a/metadata-ingestion/tests/unit/test_thoughtspot_source.py
+++ b/metadata-ingestion/tests/unit/test_thoughtspot_source.py
@@ -15,26 +15,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 import yaml
-from datahub.metadata.schema_classes import (
-    AuditStampClass,
-    ChartInfoClass,
-    ChartUsageStatisticsClass,
-    ContainerClass,
-    DashboardInfoClass,
-    DashboardUsageStatisticsClass,
-    DatasetPropertiesClass,
-    FineGrainedLineageClass,
-    GlobalTagsClass,
-    InputFieldsClass,
-    OwnershipClass,
-    SchemaMetadataClass,
-    StatusClass,
-    SubTypesClass,
-    TimeTypeClass,
-    UpstreamClass,
-    UpstreamLineageClass,
-    ViewPropertiesClass,
-)
 from pydantic import ValidationError
 from requests.adapters import HTTPAdapter
 from requests.exceptions import HTTPError
@@ -98,6 +78,26 @@ from datahub.ingestion.source.thoughtspot.source import (
 )
 from datahub.ingestion.workunit_processors.auto_stale_entity_removal import (
     AutoStaleEntityRemovalProcessor,
+)
+from datahub.metadata.schema_classes import (
+    AuditStampClass,
+    ChartInfoClass,
+    ChartUsageStatisticsClass,
+    ContainerClass,
+    DashboardInfoClass,
+    DashboardUsageStatisticsClass,
+    DatasetPropertiesClass,
+    FineGrainedLineageClass,
+    GlobalTagsClass,
+    InputFieldsClass,
+    OwnershipClass,
+    SchemaMetadataClass,
+    StatusClass,
+    SubTypesClass,
+    TimeTypeClass,
+    UpstreamClass,
+    UpstreamLineageClass,
+    ViewPropertiesClass,
 )
 from datahub.sdk.dataset import Dataset
 


### PR DESCRIPTION
This fixes the ThoughtSpot ingestion source.

Currently the thoughtspot ingestion source contains 2 issues.

1. For BigQuery it contains the wrong data_source_type name
2. It only removes RDBMS for views, but not for tables

Both leads to not matching / invalid datahub platforms and therefore the lineage to the BigQuery objects is not available.

Furthermore, I had some rare case, where the "metadata_details" field contained an string error message, instead of the dictionary, which leads to a failed ingestion.
I fixed this edge case too.

