### PR TITLE
refactor(auth): move TokenType to auth-api

### DIFF
--- a/metadata-auth/auth-api/src/main/java/com/datahub/authentication/token/TokenClaimNames.java
+++ b/metadata-auth/auth-api/src/main/java/com/datahub/authentication/token/TokenClaimNames.java
@@ -1,0 +1,9 @@
+package com.datahub.authentication.token;
+
+/** Standard JWT claim names used in DataHub-issued access tokens. */
+public final class TokenClaimNames {
+
+  public static final String TOKEN_TYPE = "type";
+
+  private TokenClaimNames() {}
+}

--- a/metadata-auth/auth-api/src/main/java/com/datahub/authentication/token/TokenType.java
+++ b/metadata-auth/auth-api/src/main/java/com/datahub/authentication/token/TokenType.java
@@ -1,6 +1,6 @@
 package com.datahub.authentication.token;
 
-/** Represents a type of JWT access token granted by the {@link StatelessTokenService}. */
+/** Represents a type of JWT access token granted by the DataHub token service. */
 public enum TokenType {
 
   /** A UI-initiated session token */

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/TokenClaims.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/TokenClaims.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 public class TokenClaims {
 
   public static final String TOKEN_VERSION_CLAIM_NAME = "version";
-  public static final String TOKEN_TYPE_CLAIM_NAME = "type";
+  public static final String TOKEN_TYPE_CLAIM_NAME = TokenClaimNames.TOKEN_TYPE;
   public static final String ACTOR_TYPE_CLAIM_NAME = "actorType";
   public static final String ACTOR_ID_CLAIM_NAME = "actorId";
   public static final String EXPIRATION_CLAIM = "exp";


### PR DESCRIPTION
## Summary

- Move `TokenType` from `auth-impl` to `auth-api` so it can be shared across modules
- Add `TokenClaimNames` with standard JWT claim name constants
- Update `TokenClaims` to reference the shared claim name

Part 1 of 6 in the OSS usage aggregation stack.

## Test plan

- [x] `./gradlew spotlessApply`
- [ ] CI spotlessJavaCheck

Made with [Cursor](https://cursor.com)