### PR TITLE
feat(sql-parsing): expose is_temp_table predicate on create_lineage_from_sql_statements

### DIFF
--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -2484,14 +2484,14 @@ def create_lineage_from_sql_statements(
         default_schema: Optional default schema for unqualified table references
         graph: Optional DataHub graph client for schema resolution
         schema_aware: Whether to use schema-aware parsing
-        is_temp_table: Optional predicate, given the table name (typically
-                       ``db.schema.table``, but the exact format is platform-
-                       dependent and differs when a platform_instance is set),
-                       returning whether it is an intermediate temp table. Use it
-                       when the dialect's own syntax does not mark them (e.g.
-                       Teradata ``CREATE VOLATILE TABLE`` parsed under another
-                       platform's dialect); such tables are then collapsed so
-                       lineage flows through to the real base tables.
+        is_temp_table: Optional predicate, given the table name in
+                ``db.schema.table`` form (the platform instance, if any,
+                is stripped before the predicate is called), returning
+                whether it is an intermediate temp table. Use it when the
+                dialect's own syntax does not mark them (e.g. Teradata
+                ``CREATE VOLATILE TABLE`` parsed under another platform's
+                dialect); such tables are then collapsed so lineage flows
+                through to the real base tables.
 
     Returns:
         SqlParsingResult containing merged lineage from all statements

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -2484,11 +2484,13 @@ def create_lineage_from_sql_statements(
         default_schema: Optional default schema for unqualified table references
         graph: Optional DataHub graph client for schema resolution
         schema_aware: Whether to use schema-aware parsing
-        is_temp_table: Optional predicate, given a table name, returning whether it
-                 is an intermediate temp table. Use it when the dialect's own
-                 syntax does not mark them (e.g. Teradata ``CREATE VOLATILE TABLE``
-                 parsed under another platform's dialect); such tables are then
-                 collapsed so lineage flows through to the real base tables.
+        is_temp_table: Optional predicate, given the fully qualified table name
+                       (``db.schema.table``), returning whether it is an
+                       intermediate temp table. Use it when the dialect's own
+                       syntax does not mark them (e.g. Teradata ``CREATE VOLATILE
+                       TABLE`` parsed under another platform's dialect); such
+                       tables are then collapsed so lineage flows through to the
+                       real base tables.
 
     Returns:
         SqlParsingResult containing merged lineage from all statements

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -2485,13 +2485,13 @@ def create_lineage_from_sql_statements(
         graph: Optional DataHub graph client for schema resolution
         schema_aware: Whether to use schema-aware parsing
         is_temp_table: Optional predicate, given the table name in
-                ``db.schema.table`` form (the platform instance, if any,
-                is stripped before the predicate is called), returning
-                whether it is an intermediate temp table. Use it when the
-                dialect's own syntax does not mark them (e.g. Teradata
-                ``CREATE VOLATILE TABLE`` parsed under another platform's
-                dialect); such tables are then collapsed so lineage flows
-                through to the real base tables.
+                       ``db.schema.table`` form (the platform instance, if any,
+                       is stripped before the predicate is called), returning
+                       whether it is an intermediate temp table. Use it when the
+                       dialect's own syntax does not mark them (e.g. Teradata
+                       ``CREATE VOLATILE TABLE`` parsed under another platform's
+                       dialect); such tables are then collapsed so lineage flows
+                       through to the real base tables.
 
     Returns:
         SqlParsingResult containing merged lineage from all statements

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from typing import (
     AbstractSet,
     Any,
+    Callable,
     Dict,
     Iterable,
     List,
@@ -2462,6 +2463,7 @@ def create_lineage_from_sql_statements(
     default_schema: Optional[str] = None,
     graph: Optional[DataHubGraph] = None,
     schema_aware: bool = True,
+    is_temp_table: Optional[Callable[[str], bool]] = None,
 ) -> SqlParsingResult:
     """Parse multiple SQL statements and return merged lineage with temp table resolution.
 
@@ -2482,6 +2484,11 @@ def create_lineage_from_sql_statements(
         default_schema: Optional default schema for unqualified table references
         graph: Optional DataHub graph client for schema resolution
         schema_aware: Whether to use schema-aware parsing
+        is_temp_table: Optional predicate, given a table name, returning whether it
+                 is an intermediate temp table. Use it when the dialect's own
+                 syntax does not mark them (e.g. Teradata ``CREATE VOLATILE TABLE``
+                 parsed under another platform's dialect); such tables are then
+                 collapsed so lineage flows through to the real base tables.
 
     Returns:
         SqlParsingResult containing merged lineage from all statements
@@ -2523,6 +2530,7 @@ def create_lineage_from_sql_statements(
             generate_operations=False,
             generate_query_subject_fields=False,
             generate_query_usage_statistics=False,
+            is_temp_table=is_temp_table,
         )
 
         try:

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -2484,13 +2484,14 @@ def create_lineage_from_sql_statements(
         default_schema: Optional default schema for unqualified table references
         graph: Optional DataHub graph client for schema resolution
         schema_aware: Whether to use schema-aware parsing
-        is_temp_table: Optional predicate, given the fully qualified table name
-                       (``db.schema.table``), returning whether it is an
-                       intermediate temp table. Use it when the dialect's own
-                       syntax does not mark them (e.g. Teradata ``CREATE VOLATILE
-                       TABLE`` parsed under another platform's dialect); such
-                       tables are then collapsed so lineage flows through to the
-                       real base tables.
+        is_temp_table: Optional predicate, given the table name (typically
+                       ``db.schema.table``, but the exact format is platform-
+                       dependent and differs when a platform_instance is set),
+                       returning whether it is an intermediate temp table. Use it
+                       when the dialect's own syntax does not mark them (e.g.
+                       Teradata ``CREATE VOLATILE TABLE`` parsed under another
+                       platform's dialect); such tables are then collapsed so
+                       lineage flows through to the real base tables.
 
     Returns:
         SqlParsingResult containing merged lineage from all statements

--- a/metadata-ingestion/tests/unit/sql_parsing/test_multi_statement_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_multi_statement_lineage.py
@@ -54,8 +54,8 @@ def _cll_map(result: SqlParsingResult) -> Dict[str, Dict[str, List[str]]]:
     return out
 
 
-def _leaf_in(*names: str) -> Callable[[str], bool]:
-    """Predicate matching a fully qualified name whose leaf (table) is in names."""
+def _table_name_in(*names: str) -> Callable[[str], bool]:
+    """Predicate matching a qualified name whose leaf (table) is in names."""
     wanted = set(names)
     return lambda name: name.split(".")[-1] in wanted
 
@@ -784,7 +784,7 @@ class TestIsTempTablePredicate:
                 "CREATE TABLE staging AS SELECT id, name FROM source",
                 "INSERT INTO target SELECT id, name FROM staging",
             ],
-            is_temp_table=_leaf_in("staging"),
+            is_temp_table=_table_name_in("staging"),
         )
         assert _table_short_names(result.in_tables) == {"source"}
         assert _table_short_names(result.out_tables) == {"target"}
@@ -795,7 +795,7 @@ class TestIsTempTablePredicate:
                 "CREATE TABLE staging AS SELECT id, 2 * val AS doubled FROM source",
                 "INSERT INTO target SELECT id, doubled FROM staging",
             ],
-            is_temp_table=_leaf_in("staging"),
+            is_temp_table=_table_name_in("staging"),
         )
         cll = _cll_map(result)
         assert set(cll["target"]["id"]) == {"source.id"}
@@ -812,7 +812,7 @@ class TestIsTempTablePredicate:
                 "INSERT INTO target SELECT staging.id, staging.amount, tmp.label "
                 "FROM staging JOIN tmp ON staging.id = tmp.id",
             ],
-            is_temp_table=_leaf_in("tmp"),
+            is_temp_table=_table_name_in("tmp"),
         )
         in_names = _table_short_names(result.in_tables)
         out_names = _table_short_names(result.out_tables)
@@ -846,5 +846,18 @@ class TestIsTempTablePredicate:
             is_temp_table=lambda name: False,
         )
         # Equivalent to passing no predicate: staging stays persistent.
+        assert "staging" in _table_short_names(result.in_tables)
+        assert "staging" in _table_short_names(result.out_tables)
+
+    def test_predicate_none_preserves_persistent_table(self) -> None:
+        # None takes the no-predicate fast path (distinct from a False-returning
+        # callable, even though the resulting lineage is identical).
+        result = _parse(
+            [
+                "CREATE TABLE staging AS SELECT id FROM source",
+                "INSERT INTO target SELECT id FROM staging",
+            ],
+            is_temp_table=None,
+        )
         assert "staging" in _table_short_names(result.in_tables)
         assert "staging" in _table_short_names(result.out_tables)

--- a/metadata-ingestion/tests/unit/sql_parsing/test_multi_statement_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_multi_statement_lineage.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Set
+from typing import Callable, Dict, List, Set
 
 import pytest
 
@@ -762,3 +762,88 @@ class TestEdgeCasePatterns:
         assert _table_short_names(result.out_tables) == {"target"}
         # source2 should be the upstream (latest definition)
         assert "source2" in {_urn_to_table_name(u) for u in result.in_tables}
+
+
+class TestIsTempTablePredicate:
+    """The is_temp_table predicate lets callers mark intermediates as temporary
+    even when the dialect's own syntax does not (e.g. Teradata CREATE VOLATILE
+    TABLE parsed under another dialect). Marked tables are collapsed so lineage
+    flows through to the real base tables, exactly like a native TEMP table.
+    Without the predicate the same plain CREATE TABLE stays persistent (see
+    TestPersistentTableLineage)."""
+
+    @staticmethod
+    def _leaf_in(*names: str) -> Callable[[str], bool]:
+        wanted = set(names)
+        return lambda name: name.split(".")[-1] in wanted
+
+    def test_predicate_collapses_plain_create_table(self) -> None:
+        result = _parse(
+            [
+                "CREATE TABLE staging AS SELECT id, name FROM source",
+                "INSERT INTO target SELECT id, name FROM staging",
+            ],
+            is_temp_table=self._leaf_in("staging"),
+        )
+        assert _table_short_names(result.in_tables) == {"source"}
+        assert _table_short_names(result.out_tables) == {"target"}
+
+    def test_predicate_collapses_column_lineage_through_marked_table(self) -> None:
+        result = _parse(
+            [
+                "CREATE TABLE staging AS SELECT id, 2 * val AS doubled FROM source",
+                "INSERT INTO target SELECT id, doubled FROM staging",
+            ],
+            is_temp_table=self._leaf_in("staging"),
+        )
+        cll = _cll_map(result)
+        assert set(cll["target"]["id"]) == {"source.id"}
+        assert set(cll["target"]["doubled"]) == {"source.val"}
+        # The collapsed table must not leak a phantom downstream CLL entry.
+        assert "staging" not in cll
+
+    def test_predicate_is_selective(self) -> None:
+        # Only 'tmp' is marked temp; 'staging' stays a persistent intermediate.
+        result = _parse(
+            [
+                "CREATE TABLE staging AS SELECT id, amount FROM source1",
+                "CREATE TABLE tmp AS SELECT id, label FROM source2",
+                "INSERT INTO target SELECT staging.id, staging.amount, tmp.label "
+                "FROM staging JOIN tmp ON staging.id = tmp.id",
+            ],
+            is_temp_table=self._leaf_in("tmp"),
+        )
+        in_names = _table_short_names(result.in_tables)
+        out_names = _table_short_names(result.out_tables)
+        assert "staging" in in_names and "staging" in out_names
+        assert "tmp" not in in_names and "tmp" not in out_names
+        assert "source2" in in_names
+
+    def test_predicate_receives_qualified_name(self) -> None:
+        seen: List[str] = []
+
+        def predicate(name: str) -> bool:
+            seen.append(name)
+            return name.split(".")[-1] == "staging"
+
+        _parse(
+            [
+                "CREATE TABLE staging AS SELECT id FROM source",
+                "INSERT INTO target SELECT id FROM staging",
+            ],
+            is_temp_table=predicate,
+        )
+        # The predicate is invoked with the fully qualified dataset name.
+        assert "dev.public.staging" in seen
+
+    def test_predicate_returning_false_preserves_persistent_table(self) -> None:
+        result = _parse(
+            [
+                "CREATE TABLE staging AS SELECT id FROM source",
+                "INSERT INTO target SELECT id FROM staging",
+            ],
+            is_temp_table=lambda name: False,
+        )
+        # Equivalent to passing no predicate: staging stays persistent.
+        assert "staging" in _table_short_names(result.in_tables)
+        assert "staging" in _table_short_names(result.out_tables)

--- a/metadata-ingestion/tests/unit/sql_parsing/test_multi_statement_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_multi_statement_lineage.py
@@ -54,6 +54,12 @@ def _cll_map(result: SqlParsingResult) -> Dict[str, Dict[str, List[str]]]:
     return out
 
 
+def _leaf_in(*names: str) -> Callable[[str], bool]:
+    """Predicate matching a fully qualified name whose leaf (table) is in names."""
+    wanted = set(names)
+    return lambda name: name.split(".")[-1] in wanted
+
+
 @pytest.fixture(scope="function", autouse=True)
 def _disable_cooperative_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     """Disable SQL lineage timeout to avoid flaky test failures."""
@@ -772,18 +778,13 @@ class TestIsTempTablePredicate:
     Without the predicate the same plain CREATE TABLE stays persistent (see
     TestPersistentTableLineage)."""
 
-    @staticmethod
-    def _leaf_in(*names: str) -> Callable[[str], bool]:
-        wanted = set(names)
-        return lambda name: name.split(".")[-1] in wanted
-
     def test_predicate_collapses_plain_create_table(self) -> None:
         result = _parse(
             [
                 "CREATE TABLE staging AS SELECT id, name FROM source",
                 "INSERT INTO target SELECT id, name FROM staging",
             ],
-            is_temp_table=self._leaf_in("staging"),
+            is_temp_table=_leaf_in("staging"),
         )
         assert _table_short_names(result.in_tables) == {"source"}
         assert _table_short_names(result.out_tables) == {"target"}
@@ -794,7 +795,7 @@ class TestIsTempTablePredicate:
                 "CREATE TABLE staging AS SELECT id, 2 * val AS doubled FROM source",
                 "INSERT INTO target SELECT id, doubled FROM staging",
             ],
-            is_temp_table=self._leaf_in("staging"),
+            is_temp_table=_leaf_in("staging"),
         )
         cll = _cll_map(result)
         assert set(cll["target"]["id"]) == {"source.id"}
@@ -811,7 +812,7 @@ class TestIsTempTablePredicate:
                 "INSERT INTO target SELECT staging.id, staging.amount, tmp.label "
                 "FROM staging JOIN tmp ON staging.id = tmp.id",
             ],
-            is_temp_table=self._leaf_in("tmp"),
+            is_temp_table=_leaf_in("tmp"),
         )
         in_names = _table_short_names(result.in_tables)
         out_names = _table_short_names(result.out_tables)

--- a/metadata-ingestion/tests/unit/sql_parsing/test_multi_statement_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_multi_statement_lineage.py
@@ -861,3 +861,26 @@ class TestIsTempTablePredicate:
         )
         assert "staging" in _table_short_names(result.in_tables)
         assert "staging" in _table_short_names(result.out_tables)
+
+    def test_predicate_receives_name_without_platform_instance(self) -> None:
+        # With a platform_instance set, the aggregator strips the instance prefix
+        # before calling the predicate, so it still sees db.schema.table (not
+        # my_instance.db.schema.table) and the marked table is still collapsed.
+        seen: List[str] = []
+
+        def predicate(name: str) -> bool:
+            seen.append(name)
+            return name.split(".")[-1] == "staging"
+
+        result = _parse(
+            [
+                "CREATE TABLE staging AS SELECT id FROM source",
+                "INSERT INTO target SELECT id FROM staging",
+            ],
+            platform_instance="my_instance",
+            is_temp_table=predicate,
+        )
+        assert "dev.public.staging" in seen
+        assert not any(name.startswith("my_instance") for name in seen)
+        assert _table_short_names(result.in_tables) == {"source"}
+        assert _table_short_names(result.out_tables) == {"target"}


### PR DESCRIPTION
## Summary

- Plumbs the `SqlParsingAggregator`'s existing `is_temp_table` predicate through the `create_lineage_from_sql_statements` convenience wrapper (defaults to `None`, so existing behavior is unchanged).
- Lets callers mark intermediate tables as temporary when the dialect's own syntax does not — e.g. Teradata `CREATE VOLATILE TABLE` parsed under another platform's dialect. Such tables are then collapsed so lineage flows through to the real base tables (table- and column-level).
- Adds focused unit tests in `test_multi_statement_lineage.py` (`TestIsTempTablePredicate`): predicate collapses a plain `CREATE TABLE`, collapses column lineage through the marked table without leaking phantom CLL, is selective (only marked tables collapse), receives the fully qualified dataset name, and a `False`-returning predicate preserves persistent-table behavior.

This is split out of the MicroStrategy connector work, where the SQL-view lineage extractor needs to treat MicroStrategy's multi-pass volatile/temp intermediates as temp tables even though they are parsed under the warehouse's dialect.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly Commit Message Format)
- [x] Tests added

Made with [Cursor](https://cursor.com)