### PR TITLE
fix(ingest/powerbi): resolve M-query parameters under admin_apis_only from scan expressions

### DIFF
--- a/metadata-ingestion/docs/sources/powerbi/powerbi_pre.md
+++ b/metadata-ingestion/docs/sources/powerbi/powerbi_pre.md
@@ -43,7 +43,7 @@ If you have granted your Entra application permissions to the public APIs and ad
 If you don't want to add an Entra application as a member in your workspace, then you can enable `admin_apis_only: true` in your recipe to use the Power BI Admin API only. Caveats of setting `admin_apis_only` to `true`:
 
 - Report Pages will not get ingested as the page API is not available in the Power BI Admin API
-- [Power BI Parameters](https://learn.microsoft.com/en-us/power-query/power-query-query-parameters) will not get resolved to actual values while processing M-Query for table lineage
+- [Power BI Parameters](https://learn.microsoft.com/en-us/power-query/power-query-query-parameters) referenced in M-Queries are resolved from the dataset's mashup expressions returned by the Admin scan. This requires the **"Enhance admin APIs responses with DAX and mashup expressions"** tenant setting to be enabled for your Entra application (see [Admin APIs ingestion](#admin-apis-ingestion) below). Without that setting — or for parameters whose values are not present in the mashup expressions — M-Query table lineage may be incomplete.
 - Dataset profiling is unavailable, as it requires access to the non-admin workspace API
 
 #### Admin APIs ingestion

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/config.py
@@ -123,6 +123,7 @@ class Constant:
     ENDORSEMENT_DETAIL = "endorsementDetails"
     TABLES = "tables"
     EXPRESSION = "expression"
+    EXPRESSIONS = "expressions"
     SOURCE = "source"
     SCHEMA_METADATA = "schemaMetadata"
     PLATFORM_NAME = "powerbi"

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/rest_api_wrapper/data_classes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/rest_api_wrapper/data_classes.py
@@ -1,5 +1,6 @@
 import dataclasses
 import logging
+import re
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
@@ -440,6 +441,36 @@ class Dashboard:
 
     def __hash__(self):
         return hash(self.__members())
+
+
+def parse_dataset_parameters_from_expressions(
+    expressions: Optional[List[Dict[str, str]]],
+) -> Dict[str, str]:
+    """Extract Power BI query parameter name->value pairs from a scan result's
+    dataset-level ``expressions`` array (returned when the scan is created with
+    ``datasetExpressions=true``).
+
+    A parameter is an M expression of the form ``<literal> meta [IsParameterQuery=true, ...]``,
+    e.g. ``"adb-....azuredatabricks.net" meta [IsParameterQuery=true, Type="Text"]``.
+    Shared (non-parameter) query expressions are skipped. This lets ``admin_apis_only``
+    ingestions resolve M-query parameters that would otherwise only come from the
+    regular ``/datasets/{id}/parameters`` endpoint (unavailable via the Admin API).
+    """
+    parameters: Dict[str, str] = {}
+    for expression in expressions or []:
+        name = expression.get(Constant.NAME)
+        raw = expression.get(Constant.EXPRESSION)
+        # Only literal parameter queries carry a resolvable value; skip shared
+        # query expressions (which are full ``let ... in ...`` M programs).
+        if not name or not raw or "IsParameterQuery=true" not in raw.replace(" ", ""):
+            continue
+        # Drop the trailing ``meta [ ... ]`` annotation to leave just the literal.
+        value = re.sub(r"\s*meta\s*\[.*\]\s*$", "", raw, flags=re.DOTALL).strip()
+        # Unwrap an M text literal; leave numeric/other literals untouched.
+        if len(value) >= 2 and value.startswith('"') and value.endswith('"'):
+            value = value[1:-1]
+        parameters[name] = value
+    return parameters
 
 
 def new_powerbi_dataset(workspace: Workspace, raw_instance: dict) -> PowerBIDataset:

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/rest_api_wrapper/powerbi_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/rest_api_wrapper/powerbi_api.py
@@ -29,6 +29,7 @@ from datahub.ingestion.source.powerbi.rest_api_wrapper.data_classes import (
     new_powerbi_dashboards,
     new_powerbi_dataset,
     new_powerbi_reports,
+    parse_dataset_parameters_from_expressions,
 )
 from datahub.ingestion.source.powerbi.rest_api_wrapper.data_resolver import (
     AdminAPIResolver,
@@ -612,14 +613,24 @@ class PowerBiAPI:
             dataset_instance = new_powerbi_dataset(workspace, dataset_dict)
 
             # fetch + set dataset parameters
+            regular_parameters: Dict[str, str] = {}
             try:
-                dataset_parameters = self._get_resolver().get_dataset_parameters(
+                regular_parameters = self._get_resolver().get_dataset_parameters(
                     workspace_id=workspace.id,
                     dataset_id=dataset_id,
                 )
-                dataset_instance.parameters = dataset_parameters
             except Exception as e:
                 logger.info(f"Unable to fetch dataset parameters for {dataset_id}: {e}")
+
+            # The admin scan (datasetExpressions=true) carries parameter values in
+            # the dataset-level `expressions` array. Use them as a base so
+            # admin_apis_only ingestions — where the regular /parameters endpoint is
+            # unavailable — can still resolve M-query parameters for lineage. Values
+            # from the regular API win when both are present.
+            scan_parameters = parse_dataset_parameters_from_expressions(
+                dataset_dict.get(Constant.EXPRESSIONS)
+            )
+            dataset_instance.parameters = {**scan_parameters, **regular_parameters}
 
             if self.__config.extract_endorsements_to_tags:
                 dataset_instance.tags = self._parse_endorsement(

--- a/metadata-ingestion/tests/unit/powerbi/test_scan_expression_parameters.py
+++ b/metadata-ingestion/tests/unit/powerbi/test_scan_expression_parameters.py
@@ -1,0 +1,48 @@
+from datahub.ingestion.source.powerbi.rest_api_wrapper.data_classes import (
+    parse_dataset_parameters_from_expressions,
+)
+
+
+def test_extracts_text_parameter_value():
+    expressions = [
+        {
+            "name": "ServerHostName",
+            "expression": '"adb-574989277074981.1.azuredatabricks.net" meta [IsParameterQuery=true, Type="Text", IsParameterQueryRequired=true]',
+        }
+    ]
+    assert parse_dataset_parameters_from_expressions(expressions) == {
+        "ServerHostName": "adb-574989277074981.1.azuredatabricks.net"
+    }
+
+
+def test_ignores_shared_query_expressions():
+    """Non-parameter shared queries (IsParameterQuery absent) must not be
+    treated as parameter values."""
+    expressions = [
+        {
+            "name": "Revenues",
+            "expression": 'let\n    Source = Sql.Database("host", "DB"),\n    T = Source{[Schema="s",Item="t"]}[Data]\nin\n    T',
+        },
+        {
+            "name": "Catalog",
+            "expression": '"prod00_bonsai" meta [IsParameterQuery=true, Type="Text"]',
+        },
+    ]
+    assert parse_dataset_parameters_from_expressions(expressions) == {
+        "Catalog": "prod00_bonsai"
+    }
+
+
+def test_extracts_non_text_parameter_value():
+    expressions = [
+        {
+            "name": "Port",
+            "expression": '443 meta [IsParameterQuery=true, Type="Number"]',
+        }
+    ]
+    assert parse_dataset_parameters_from_expressions(expressions) == {"Port": "443"}
+
+
+def test_empty_or_none_expressions():
+    assert parse_dataset_parameters_from_expressions([]) == {}
+    assert parse_dataset_parameters_from_expressions(None) == {}

--- a/metadata-ingestion/tests/unit/test_powerbi_fill_metadata_from_scan.py
+++ b/metadata-ingestion/tests/unit/test_powerbi_fill_metadata_from_scan.py
@@ -1794,3 +1794,38 @@ def test_fill_dashboards_wires_tile_dataset_via_registry_and_report_via_workspac
     info_titles = [i.title for i in api.reporter.infos]
     assert "Missing Dataset Lineage For Tile" in info_titles
     assert "Missing Report Lineage For Tile" in info_titles
+
+
+def test_get_workspace_datasets_recovers_parameters_from_scan_expressions():
+    """Under admin_apis_only the regular /parameters endpoint is unavailable, so
+    dataset parameters must be recovered from the scan result's dataset-level
+    `expressions` array to keep M-query lineage resolvable."""
+    api = _make_api(admin_apis_only=True)
+    workspace = _make_workspace("ws-1")
+    workspace.scan_result = _scan_workspace_payload(
+        "ws-1",
+        datasets=[
+            {
+                Constant.ID: "ds-1",
+                Constant.NAME: "ds",
+                "tables": [],
+                "expressions": [
+                    {
+                        "name": "Revenues",
+                        "expression": "let\n    Source = Sql.Database(SrvName, DbName)\nin\n    Source",
+                    },
+                    {
+                        "name": "SrvName",
+                        "expression": '"adb-574989277074981.1.azuredatabricks.net" meta [IsParameterQuery=true, Type="Text", IsParameterQueryRequired=true]',
+                    },
+                ],
+            }
+        ],
+    )
+
+    datasets = api._get_workspace_datasets(workspace)
+
+    # Only the parameter is recovered; the shared query expression is skipped.
+    assert datasets["ds-1"].parameters == {
+        "SrvName": "adb-574989277074981.1.azuredatabricks.net"
+    }


### PR DESCRIPTION
## Summary

With `admin_apis_only: true`, the PowerBI connector could not resolve Power BI query parameters referenced in M-queries (server host, catalog, schema, table names), so table lineage extraction produced no upstreams (high `m_query_resolver_no_lineage` / `m_query_resolver_errors`). This is because the regular `/datasets/{id}/parameters` endpoint is unavailable in admin-only mode — `AdminAPIResolver.get_dataset_parameters` returns `{}`.

However, the admin scan is already created with `datasetExpressions=true`, and the scan result's dataset-level `expressions` array carries parameter values as M literals, e.g.:

```json
{ "name": "ServerHostName", "expression": "\"host.example.com\" meta [IsParameterQuery=true, Type=\"Text\"]" }
```

The connector ignored this array and only read table-level `source[].expression`. This PR parses parameter values out of the dataset-level `expressions`, enabling parameterized PowerBI table lineage under `admin_apis_only` — needing only the *"Enhance admin APIs responses with DAX and mashup expressions"* tenant setting, not workspace membership.

## Changes

- New helper `parse_dataset_parameters_from_expressions` (`rest_api_wrapper/data_classes.py`): extracts `name → value` for expression entries marked `IsParameterQuery=true`, stripping the trailing ` meta [...]` annotation and unwrapping M text literals. Shared (non-parameter) query expressions are skipped.
- `rest_api_wrapper/powerbi_api.py` (`_get_workspace_datasets`): populate `dataset.parameters` from the scan expressions as a base; regular-API values still take precedence when present, so the non-admin path is unchanged.
- `config.py`: add `Constant.EXPRESSIONS`.
- Docs: update the `admin_apis_only` caveat in `powerbi_pre.md` to reflect that parameters now resolve from mashup expressions when the corresponding tenant setting is enabled.

## Tests

- `tests/unit/powerbi/test_scan_expression_parameters.py` — parser unit tests (text/number parameters, shared-query exclusion, empty/None input).
- `tests/unit/test_powerbi_fill_metadata_from_scan.py` — wire-in test asserting parameters are recovered from scan expressions under `admin_apis_only`.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Links to related issues (if applicable)
- [x] Tests added
- [x] Docs updated
- [ ] Breaking changes (not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
