### PR TITLE
fix(ingestion/clickhouse): strip NUL bytes from column comments

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/clickhouse.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/clickhouse.py
@@ -438,6 +438,11 @@ def _get_column_info(self, name, format_type, comment):
         col_type = col_type.nested_type
         nullable = True
 
+    # Strip NUL bytes that may appear in column comments due to encoding
+    # issues when reading from ClickHouse system.columns via HTTP interface.
+    if comment:
+        comment = comment.replace("\x00", "")
+
     result = {
         "name": name,
         "type": col_type,

--- a/metadata-ingestion/tests/unit/test_clickhouse_source.py
+++ b/metadata-ingestion/tests/unit/test_clickhouse_source.py
@@ -172,3 +172,41 @@ def test_is_temp_table_custom_patterns():
     assert config.is_temp_table("test_table")
     # Default patterns no longer match with custom patterns
     assert not config.is_temp_table("_temp_table")
+
+
+def test_column_info_strips_nul_bytes():
+    """Column comments from ClickHouse may contain NUL bytes due to encoding
+    issues when reading multibyte characters via the HTTP interface."""
+    from unittest.mock import MagicMock
+
+    from datahub.ingestion.source.sql.clickhouse import _get_column_info
+
+    mock_dialect = MagicMock()
+    mock_dialect._get_column_type.return_value = "String"
+
+    result = _get_column_info(
+        mock_dialect,
+        name="vat_ratio",
+        format_type="String",
+        comment="부가\ufffd\x00치세비율",
+    )
+    assert result["comment"] == "부가\ufffd치세비율"
+    assert "\x00" not in result["comment"]
+
+
+def test_column_info_preserves_normal_comment():
+    """Normal column comments should be preserved as-is."""
+    from unittest.mock import MagicMock
+
+    from datahub.ingestion.source.sql.clickhouse import _get_column_info
+
+    mock_dialect = MagicMock()
+    mock_dialect._get_column_type.return_value = "String"
+
+    result = _get_column_info(
+        mock_dialect,
+        name="vat_ratio",
+        format_type="String",
+        comment="부가가치세비율",
+    )
+    assert result["comment"] == "부가가치세비율"


### PR DESCRIPTION
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

## Summary

When ingesting schema metadata from ClickHouse via the HTTP interface, column comments containing certain multibyte characters (e.g. Korean) can be corrupted, resulting in NUL bytes (`\x00`) embedded in the comment string. This causes downstream failures when attempting to store the metadata in PostgreSQL-based systems, which reject NUL bytes in text fields:

```
psycopg.DataError: PostgreSQL text fields cannot contain NUL (0x00) bytes
```

## Root Cause

ClickHouse stores the column comment correctly (e.g. `부가가치세비율`), but when DataHub reads it from `system.columns` via `clickhouse-connect`'s HTTP interface, certain multibyte character sequences are corrupted — for example, the Korean character `가` (U+AC00) becomes `\ufffd\x00`. The exact cause of this encoding corruption is unclear and may reside in `clickhouse-connect`'s HTTP response parsing rather than in DataHub's code.

## Fix

This PR is a **defensive fix** that prevents crashes caused by NUL bytes in column comments. It strips NUL bytes in `_get_column_info` before returning the column metadata:

```python
# Strip NUL bytes that may appear in column comments due to encoding
# issues when reading from ClickHouse system.columns via HTTP interface.
if comment:
    comment = comment.replace("\x00", "")
```

> **Note**: This fix prevents the crash but does not fully restore the original comment. For example, `부가가치세비율` (correct) may still be stored as `부가\ufffd치세비율` due to the upstream encoding corruption. Fully fixing the display would require identifying and resolving the root encoding bug in `clickhouse-connect`'s HTTP response parsing.

## Testing

Added two unit tests:
- `test_column_info_strips_nul_bytes`: verifies NUL bytes are removed from comments
- `test_column_info_preserves_normal_comment`: verifies normal comments are unaffected