### PR TITLE
fix(structured-properties): escape allowed values in JSON Pointer path

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/builder/AbstractMultiFieldPatchBuilder.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/builder/AbstractMultiFieldPatchBuilder.java
@@ -105,7 +105,8 @@ public abstract class AbstractMultiFieldPatchBuilder<T extends AbstractMultiFiel
   }
 
   protected static String encodeValue(@Nonnull String value) {
-    return value.replace("~ ", "~0").replace("/", "~1");
+    // RFC 6901 JSON Pointer escaping: '~' -> '~0' first, then '/' -> '~1'.
+    return value.replace("~", "~0").replace("/", "~1");
   }
 
   protected static String encodeValueUrn(@Nonnull Urn urn) {

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/builder/StructuredPropertyDefinitionPatchBuilder.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/builder/StructuredPropertyDefinitionPatchBuilder.java
@@ -88,7 +88,14 @@ public class StructuredPropertyDefinitionPatchBuilder
       this.pathValues.add(
           ImmutableTriple.of(
               PatchOperationType.ADD.getValue(),
-              PATH_DELIM + ALLOWED_VALUES_FIELD + PATH_DELIM + propertyValue.getValue(),
+              // The allowed value becomes a JSON Pointer path segment, so it must
+              // be RFC 6901 escaped - otherwise a value containing '/' (e.g.
+              // "SITS/eVision") is split into extra path segments and the patched
+              // allowedValues element loses its required "value" field.
+              PATH_DELIM
+                  + ALLOWED_VALUES_FIELD
+                  + PATH_DELIM
+                  + encodeValue(String.valueOf(propertyValue.getValue())),
               valueNode));
       return this;
     } catch (JsonProcessingException e) {

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/builder/StructuredPropertyDefinitionPatchBuilderTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/builder/StructuredPropertyDefinitionPatchBuilderTest.java
@@ -100,7 +100,10 @@ public class StructuredPropertyDefinitionPatchBuilderTest {
     propertyValue.setValue(primitive);
     builder.addAllowedValue(propertyValue);
 
-    ImmutableTriple<String, String, JsonNode> op = builder.getTestPathValues().get(0);
+    List<ImmutableTriple<String, String, JsonNode>> pathValues = builder.getTestPathValues();
+    assertEquals(pathValues.size(), 1);
+
+    ImmutableTriple<String, String, JsonNode> op = pathValues.get(0);
     String prefix = "/allowedValues/";
     assertTrue(op.getMiddle().startsWith(prefix));
     String segment = op.getMiddle().substring(prefix.length());

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/builder/StructuredPropertyDefinitionPatchBuilderTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/builder/StructuredPropertyDefinitionPatchBuilderTest.java
@@ -1,11 +1,14 @@
 package com.linkedin.metadata.aspect.patch.builder;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.structured.PrimitivePropertyValue;
+import com.linkedin.structured.PropertyValue;
 import java.net.URISyntaxException;
 import java.util.List;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
@@ -61,5 +64,48 @@ public class StructuredPropertyDefinitionPatchBuilderTest {
     List<String> paths = pathValues.stream().map(ImmutableTriple::getMiddle).toList();
     assertTrue(paths.stream().anyMatch(p -> p.contains("bigquery")));
     assertTrue(paths.stream().anyMatch(p -> p.contains("snowflake")));
+  }
+
+  @Test
+  public void testAddAllowedValueEscapesSlash() {
+    PrimitivePropertyValue primitive = new PrimitivePropertyValue();
+    primitive.setString("SITS/eVision");
+    PropertyValue propertyValue = new PropertyValue();
+    propertyValue.setValue(primitive);
+    builder.addAllowedValue(propertyValue);
+
+    List<ImmutableTriple<String, String, JsonNode>> pathValues = builder.getTestPathValues();
+    assertEquals(pathValues.size(), 1);
+
+    ImmutableTriple<String, String, JsonNode> op = pathValues.get(0);
+    assertEquals(op.getLeft(), "add");
+
+    String prefix = "/allowedValues/";
+    assertTrue(op.getMiddle().startsWith(prefix), "Path should be under /allowedValues/");
+    String segment = op.getMiddle().substring(prefix.length());
+    // The allowed value must be a single JSON Pointer segment - no raw '/' may leak
+    // through, or it would be tokenised into extra path segments on apply.
+    assertFalse(segment.contains("/"), "Slash in the allowed value must be escaped, not left raw");
+    assertTrue(segment.contains("~1"), "Slash should be encoded as ~1 per RFC 6901");
+    // Decoding (~1 -> /, ~0 -> ~) round-trips back to the original value.
+    String decoded = segment.replace("~1", "/").replace("~0", "~");
+    assertEquals(decoded, String.valueOf(propertyValue.getValue()));
+  }
+
+  @Test
+  public void testAddAllowedValueEscapesTilde() {
+    PrimitivePropertyValue primitive = new PrimitivePropertyValue();
+    primitive.setString("grade~level");
+    PropertyValue propertyValue = new PropertyValue();
+    propertyValue.setValue(primitive);
+    builder.addAllowedValue(propertyValue);
+
+    ImmutableTriple<String, String, JsonNode> op = builder.getTestPathValues().get(0);
+    String prefix = "/allowedValues/";
+    assertTrue(op.getMiddle().startsWith(prefix));
+    String segment = op.getMiddle().substring(prefix.length());
+    assertTrue(segment.contains("~0"), "Tilde should be encoded as ~0 per RFC 6901");
+    String decoded = segment.replace("~1", "/").replace("~0", "~");
+    assertEquals(decoded, String.valueOf(propertyValue.getValue()));
   }
 }

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/template/StructuredPropertyDefinitionTemplateTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/template/StructuredPropertyDefinitionTemplateTest.java
@@ -1,0 +1,78 @@
+package com.linkedin.metadata.aspect.patch.template;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.aspect.patch.GenericJsonPatch;
+import com.linkedin.metadata.aspect.patch.builder.StructuredPropertyDefinitionPatchBuilder;
+import com.linkedin.metadata.aspect.patch.template.structuredproperty.StructuredPropertyDefinitionTemplate;
+import com.linkedin.structured.PrimitivePropertyValue;
+import com.linkedin.structured.PropertyValue;
+import com.linkedin.structured.PropertyValueArray;
+import com.linkedin.structured.StructuredPropertyDefinition;
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonPatch;
+import jakarta.json.JsonValue;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class StructuredPropertyDefinitionTemplateTest {
+
+  private static final StructuredPropertyDefinitionTemplate TEMPLATE =
+      new StructuredPropertyDefinitionTemplate();
+  private static final String TEST_PROPERTY_URN =
+      "urn:li:structuredProperty:io.acryl.classification";
+
+  private static PropertyValue stringValue(String value) {
+    PrimitivePropertyValue primitive = new PrimitivePropertyValue();
+    primitive.setString(value);
+    return new PropertyValue().setValue(primitive);
+  }
+
+  /**
+   * Bridges the patch produced by the builder into a jakarta {@link JsonPatch} the template
+   * applies, so the round-trip exercises {@code addAllowedValue}'s escaping and the template's
+   * decode together rather than a hand-written path.
+   */
+  private static JsonPatch toJsonPatch(GenericJsonPatch genericJsonPatch) {
+    JsonArrayBuilder ops = Json.createArrayBuilder();
+    for (GenericJsonPatch.PatchOp op : genericJsonPatch.getPatch()) {
+      JsonObjectBuilder node =
+          Json.createObjectBuilder().add("op", op.getOp()).add("path", op.getPath());
+      if (op.getValue() != null) {
+        node.add("value", (JsonValue) op.getValue());
+      }
+      ops.add(node);
+    }
+    return Json.createPatch(ops.build());
+  }
+
+  /**
+   * End-to-end: an allowed value containing a "/" produced by the builder must survive the full
+   * applyPatch stack as a single, correctly-decoded entry. Before the RFC 6901 escaping fix the
+   * unescaped slash split the JSON Pointer path and the entry was dropped/malformed.
+   */
+  @Test
+  public void testAddAllowedValueWithSlashRoundTrips() throws Exception {
+    StructuredPropertyDefinition initial = TEMPLATE.getDefault();
+    // An existing allowed value so the template's array->map transform is active.
+    initial.setAllowedValues(new PropertyValueArray(stringValue("Public")));
+
+    StructuredPropertyDefinitionPatchBuilder builder =
+        new StructuredPropertyDefinitionPatchBuilder();
+    builder.urn(Urn.createFromString(TEST_PROPERTY_URN));
+    builder.addAllowedValue(stringValue("SITS/eVision"));
+
+    StructuredPropertyDefinition result =
+        TEMPLATE.applyPatch(initial, toJsonPatch(builder.getJsonPatch()));
+
+    Assert.assertNotNull(result.getAllowedValues());
+    List<String> values =
+        result.getAllowedValues().stream().map(v -> v.getValue().getString()).toList();
+    Assert.assertTrue(
+        values.contains("SITS/eVision"), "slash-bearing allowed value should survive applyPatch");
+    Assert.assertTrue(values.contains("Public"), "existing allowed value should be retained");
+    Assert.assertEquals(result.getAllowedValues().size(), 2, "no split or duplicate entries");
+  }
+}


### PR DESCRIPTION
## Summary

Creating or updating a structured property whose allowed **string** value contains a `/` (or `~`) fails with HTTP 500:

```
Invalid format for aspect: structuredProperty
 Cause: ERROR :: /allowedValues/0/value :: field is required but not found and has no default value
```

Minimal repro: an allowed value of `SITS/eVision` fails; `SITS_eVision` succeeds, everything else identical. A single offending value breaks the whole `allowedValues` write (the server reports from index 0 regardless of which value holds the slash).

## Root cause

`StructuredPropertyDefinitionPatchBuilder.addAllowedValue` embeds the allowed value directly into the JSON Pointer path without RFC 6901 escaping:

```java
PATH_DELIM + ALLOWED_VALUES_FIELD + PATH_DELIM + propertyValue.getValue()
// "/allowedValues/" + "SITS/eVision"  ->  "/allowedValues/SITS/eVision"
```

On apply, `TemplateUtil` splits the pointer on `/`, so `SITS/eVision` is parsed as nested segments (`allowedValues` -> `SITS` -> `eVision`). The reconstructed `/allowedValues/0` element is then missing its required `value` field and aspect validation rejects it.

## Fix

Escape the value with the existing `encodeValue` helper before using it as a path segment. `TemplateUtil.decodeValue` already reverses `~1`/`~0` on apply, so the round-trip map key is unchanged for values that contain no `/` or `~` (i.e. no behaviour change for existing properties).

This also fixes `encodeValue` itself, which had a typo (`"~ "` with a space instead of `"~"`) that left `~` unescaped. It now follows RFC 6901 - `~` -> `~0`, then `/` -> `~1` - which is the exact inverse of `decodeValue` and matches the escaping the existing patch-builder tests already compute (for example `GlobalTagsPatchBuilderTest`).

## Testing

Added unit tests to `StructuredPropertyDefinitionPatchBuilderTest` covering `/` and `~` in allowed values: the value is emitted as a single escaped path segment and decodes back to the original.

```
./gradlew :entity-registry:test --tests "*StructuredPropertyDefinitionPatchBuilderTest"
```

The same builder backs both `createStructuredProperty` and `updateStructuredProperty`, so both paths are fixed.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing/#commit-message-format))
- [x] Links to related issues (if applicable) - describes the bug and repro above
- [x] Tests for the changes have been added/updated (if applicable)
