### PR TITLE
fix(ingest/kafka-connect): use sink-direction CLL helper for ClickHouse

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/sink_connectors.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/sink_connectors.py
@@ -466,9 +466,8 @@ class ClickHouseSinkConnector(BaseConnector):
             for topic, table in parser.topics_to_tables.items():
                 target_dataset: str = f"{parser.database}.{table}"
 
-                fine_grained = self._extract_fine_grained_lineage(
-                    source_dataset=topic,
-                    source_platform=KAFKA,
+                fine_grained = self._extract_sink_fine_grained_lineage(
+                    source_topic=topic,
                     target_dataset=target_dataset,
                     target_platform="clickhouse",
                 )

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect.py
@@ -703,6 +703,42 @@ class TestClickHouseSinkConnector:
         assert "user_updates" in source_datasets
         assert "deprecated_topic" not in source_datasets
 
+    def test_clickhouse_sink_uses_sink_direction_fine_grained_lineage(self) -> None:
+        """ClickHouse sink CLL must use the sink-direction helper (Kafka topic → table).
+
+        Regression test: the connector previously called the source-direction
+        ``_extract_fine_grained_lineage`` helper, which hard-returns ``None`` for a
+        Kafka ``source_platform``, so column-level lineage was silently never emitted.
+        It must call ``_extract_sink_fine_grained_lineage`` instead, like the other
+        sink connectors (Snowflake, BigQuery, JDBC).
+        """
+        connector_config: Dict[str, str] = {
+            "connector.class": "com.clickhouse.kafka.connect.ClickHouseSinkConnector",
+            "database": "analytics",
+            "topics": "events",
+        }
+        manifest = self.create_mock_manifest(connector_config)
+        config: Mock = create_mock_kafka_connect_config()
+        report: Mock = Mock(spec=KafkaConnectSourceReport)
+
+        connector = ClickHouseSinkConnector(manifest, config, report)
+
+        sentinel_cll: List = [Mock()]
+        with patch.object(
+            connector,
+            "_extract_sink_fine_grained_lineage",
+            return_value=sentinel_cll,
+        ) as mock_sink_cll:
+            lineages: List = connector.extract_lineages()
+
+        mock_sink_cll.assert_called_once_with(
+            source_topic="events",
+            target_dataset="analytics.events",
+            target_platform="clickhouse",
+        )
+        assert len(lineages) == 1
+        assert lineages[0].fine_grained_lineages is sentinel_cll
+
 
 class TestJDBCSourceConnector:
     """Test JDBC source connector with RegexRouter support."""


### PR DESCRIPTION
## Summary

`ClickHouseSinkConnector.extract_lineages` computed column-level lineage with the **source-direction** helper `_extract_fine_grained_lineage(source_platform=KAFKA, …)`, which hard-returns `None` whenever the source platform is Kafka (`common.py`). As a result, **column-level lineage was silently never emitted for the ClickHouse sink** — only asset-level lineage was produced.

This switches to the **sink-direction** helper `_extract_sink_fine_grained_lineage(source_topic, target_dataset, target_platform)` (Kafka topic → DB table), which is already used correctly by the Snowflake, BigQuery, and JDBC sink connectors in the same file.

## Changes

- `sink_connectors.py`: `ClickHouseSinkConnector.extract_lineages` now calls `_extract_sink_fine_grained_lineage`.
- Added `test_clickhouse_sink_uses_sink_direction_fine_grained_lineage` — asserts the sink-direction helper is invoked with the expected arguments and its output is threaded into `fine_grained_lineages`. Verified it fails on the old code and passes with the fix.

## Testing

- `pytest tests/unit/kafka_connect/test_kafka_connect.py` — 161 passed
- `ruff` (lintFix) clean; `mypy` clean for the touched files

## Notes

The Iceberg Sink Connector (#18002) has the identical bug; it is flagged in that PR's review to be fixed there.
