### PR TITLE
fix(ingestion): poll GMS through the authenticated session

### DIFF
--- a/datahub-actions/src/datahub_actions/plugin/source/acryl/datahub_cloud_events_consumer.py
+++ b/datahub-actions/src/datahub_actions/plugin/source/acryl/datahub_cloud_events_consumer.py
@@ -2,7 +2,6 @@ import logging
 import time
 from typing import List, Optional
 
-import requests
 from pydantic import BaseModel, Field
 from requests.exceptions import (
     ChunkedEncodingError,
@@ -143,10 +142,14 @@ class DataHubEventsConsumer:
         # Remove keys where the value is None
         params = {k: v for k, v in params.items() if v is not None}
 
-        # Pass along the session headers from the graph for authentication.
-        headers = dict(self.graph._session.headers)
-
-        response = requests.get(endpoint, params=params, headers=headers)
+        # Poll through the graph's authenticated session: per-request auth (e.g.
+        # an OAuth token provider in session.auth) only applies to requests made
+        # through it. The read timeout must outlast the server-side long poll,
+        # and a timeout is required at all — sessions have no default, so a
+        # half-open connection would otherwise hang this consumer forever.
+        response = self.graph.session.get(
+            endpoint, params=params, timeout=(poll_timeout_seconds or 30) + 30
+        )
         response.raise_for_status()
 
         external_events_response = ExternalEventsResponse.model_validate(

--- a/datahub-actions/tests/unit/plugin/source/acryl/test_datahub_cloud_events_consumer.py
+++ b/datahub-actions/tests/unit/plugin/source/acryl/test_datahub_cloud_events_consumer.py
@@ -1,11 +1,13 @@
 # test_acryl_datahub_events_consumer.py
 
+import json
 import time
 from contextlib import contextmanager
-from typing import List, Optional, cast
+from typing import Any, List, Optional, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from requests.exceptions import (
     ChunkedEncodingError,
     ConnectionError,
@@ -672,3 +674,55 @@ def test_main_block_without_initial_offset(mock_graph: DataHubGraph) -> None:
         assert mock_poll_events.called
         assert mock_print.called
         assert mock_sleep.called
+
+
+class _RecordingAdapter(requests.adapters.HTTPAdapter):
+    """Captures fully prepared requests and returns a canned poll response."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.sent: List[requests.PreparedRequest] = []
+
+    def send(self, request: requests.PreparedRequest, **kwargs: Any) -> Response:  # type: ignore[override]
+        self.sent.append(request)
+        response = Response()
+        response.status_code = 200
+        response._content = json.dumps(
+            {"offsetId": "offset-after", "count": 0, "events": []}
+        ).encode()
+        response.request = request
+        return response
+
+
+def _oauth_style_auth(request: requests.PreparedRequest) -> requests.PreparedRequest:
+    # Mimics an OAuth token provider installed as session.auth: it attaches a
+    # fresh Authorization header to each request at send time, so auth that is
+    # not baked into session.headers is only present if the request actually
+    # goes through the session.
+    request.headers["Authorization"] = "Bearer fresh-oauth-token"
+    return request
+
+
+def test_poll_events_carries_session_auth_to_the_wire() -> None:
+    session = requests.Session()
+    session.auth = _oauth_style_auth
+    adapter = _RecordingAdapter()
+    session.mount("http://", adapter)
+
+    graph = MagicMock(spec=DataHubGraph)
+    graph.config = MagicMock()
+    graph.config.server = "http://gms.example"
+    graph.session = session
+
+    consumer = DataHubEventsConsumer(graph=cast(DataHubGraph, graph))
+    response = consumer.poll_events(topic="PlatformEvent_v1", limit=10)
+
+    assert len(adapter.sent) == 1
+    request = adapter.sent[0]
+    assert request.url is not None
+    assert request.url.startswith("http://gms.example/openapi/v1/events/poll?")
+    # The per-request credential from session.auth must reach the wire. A bare
+    # requests.get built from copied session.headers would drop it and poll
+    # unauthenticated.
+    assert request.headers["Authorization"] == "Bearer fresh-oauth-token"
+    assert response.offsetId == "offset-after"

--- a/datahub-actions/tests/unit/plugin/source/acryl/test_datahub_cloud_events_consumer.py
+++ b/datahub-actions/tests/unit/plugin/source/acryl/test_datahub_cloud_events_consumer.py
@@ -29,7 +29,7 @@ from datahub_actions.plugin.source.acryl.datahub_cloud_events_consumer_offsets_s
 @pytest.fixture
 def mock_graph() -> DataHubGraph:
     """
-    Provide a mock DataHubGraph instance, including a mock config and _session.
+    Provide a mock DataHubGraph instance, including a mock config and session.
     This prevents 'AttributeError: Mock object has no attribute "config"'.
     """
     mock_graph = MagicMock(spec=DataHubGraph)
@@ -42,7 +42,7 @@ def mock_graph() -> DataHubGraph:
     # Mock _session with headers
     mock_session = MagicMock()
     mock_session.headers = {"Authorization": "Bearer test-token"}
-    mock_graph._session = mock_session
+    mock_graph.session = mock_session
 
     return cast(DataHubGraph, mock_graph)
 
@@ -146,48 +146,48 @@ def test_poll_events_success(
         offset_id="initial-offset-456",
     )
 
-    with patch("requests.get") as mock_get:
-        mock_response = MagicMock()
-        # Simulate JSON decoding
-        mock_response.json.return_value = {
-            "offsetId": external_events_response.offsetId,
-            "count": external_events_response.count,
-            "events": [
-                {"contentType": evt.contentType, "value": evt.value}
-                for evt in external_events_response.events
-            ],
-        }
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+    mock_get = cast(MagicMock, mock_graph.session.get)
+    mock_response = MagicMock()
+    # Simulate JSON decoding
+    mock_response.json.return_value = {
+        "offsetId": external_events_response.offsetId,
+        "count": external_events_response.count,
+        "events": [
+            {"contentType": evt.contentType, "value": evt.value}
+            for evt in external_events_response.events
+        ],
+    }
+    mock_response.raise_for_status.return_value = None
+    mock_get.return_value = mock_response
 
-        polled_response = consumer.poll_events(
-            topic="TestTopic",
-            offset_id=given_offset_id,
-            limit=10,
-            poll_timeout_seconds=5,
-        )
+    polled_response = consumer.poll_events(
+        topic="TestTopic",
+        offset_id=given_offset_id,
+        limit=10,
+        poll_timeout_seconds=5,
+    )
 
-        # Verify the request params
-        expected_params = {
-            "topic": "TestTopic",
-            "offsetId": given_offset_id or "initial-offset-456",
-            "limit": 10,
-            "pollTimeoutSeconds": 5,
-        }
+    # Verify the request params
+    expected_params = {
+        "topic": "TestTopic",
+        "offsetId": given_offset_id or "initial-offset-456",
+        "limit": 10,
+        "pollTimeoutSeconds": 5,
+    }
 
-        # Check that requests.get was called once
-        mock_get.assert_called_once()
-        call_args, call_kwargs = mock_get.call_args
-        assert call_args[0] == f"{consumer.base_url}/v1/events/poll"
-        assert call_kwargs["params"] == expected_params
+    # Check that requests.get was called once
+    mock_get.assert_called_once()
+    call_args, call_kwargs = mock_get.call_args
+    assert call_args[0] == f"{consumer.base_url}/v1/events/poll"
+    assert call_kwargs["params"] == expected_params
 
-        # Verify returned response
-        assert polled_response.offsetId == external_events_response.offsetId
-        assert polled_response.count == external_events_response.count
-        assert len(polled_response.events) == len(external_events_response.events)
+    # Verify returned response
+    assert polled_response.offsetId == external_events_response.offsetId
+    assert polled_response.count == external_events_response.count
+    assert len(polled_response.events) == len(external_events_response.events)
 
-        # The consumer's offset_id should be updated
-        assert consumer.offset_id == external_events_response.offsetId
+    # The consumer's offset_id should be updated
+    assert consumer.offset_id == external_events_response.offsetId
 
 
 def test_poll_events_http_error(mock_graph: DataHubGraph) -> None:
@@ -208,8 +208,8 @@ def test_poll_events_http_error(mock_graph: DataHubGraph) -> None:
             if n == 15
             else stop_after_attempt(n),
         ),
-        patch(
-            "requests.get", side_effect=HTTPError(response=dummy_response)
+        patch.object(
+            mock_graph.session, "get", side_effect=HTTPError(response=dummy_response)
         ) as mock_get,
     ):
         with pytest.raises(HTTPError):
@@ -235,8 +235,8 @@ def test_poll_events_connection_error(mock_graph: DataHubGraph) -> None:
             "datahub_actions.plugin.source.acryl.datahub_cloud_events_consumer.stop_after_attempt",
             return_value=stop_after_attempt(3),
         ),
-        patch(
-            "requests.get", side_effect=ConnectionError("Connection Error")
+        patch.object(
+            mock_graph.session, "get", side_effect=ConnectionError("Connection Error")
         ) as mock_get,
     ):
         with pytest.raises(ConnectionError):
@@ -262,8 +262,10 @@ def test_poll_events_chunked_encoding_error(mock_graph: DataHubGraph) -> None:
             "datahub_actions.plugin.source.acryl.datahub_cloud_events_consumer.stop_after_attempt",
             return_value=stop_after_attempt(3),
         ),
-        patch(
-            "requests.get", side_effect=ChunkedEncodingError("Chunked Encoding Error")
+        patch.object(
+            mock_graph.session,
+            "get",
+            side_effect=ChunkedEncodingError("Chunked Encoding Error"),
         ) as mock_get,
     ):
         with pytest.raises(ChunkedEncodingError):
@@ -289,7 +291,9 @@ def test_poll_events_timeout(mock_graph: DataHubGraph) -> None:
             "datahub_actions.plugin.source.acryl.datahub_cloud_events_consumer.stop_after_attempt",
             return_value=stop_after_attempt(3),
         ),
-        patch("requests.get", side_effect=Timeout("Request Timeout")) as mock_get,
+        patch.object(
+            mock_graph.session, "get", side_effect=Timeout("Request Timeout")
+        ) as mock_get,
     ):
         with pytest.raises(Timeout):
             consumer.poll_events(topic="TestTopic")
@@ -390,7 +394,7 @@ def test_poll_events_infinite_retry_retries_more_than_default(
         mock_response.raise_for_status.return_value = None
         return mock_response
 
-    with patch("requests.get", side_effect=side_effect) as mock_get:
+    with patch.object(mock_graph.session, "get", side_effect=side_effect) as mock_get:
         result = consumer.poll_events(topic="TestTopic")
 
         # Should have been called 6 times (5 failures + 1 success)
@@ -418,8 +422,8 @@ def test_poll_events_infinite_retry_false_uses_default_retries(
             "datahub_actions.plugin.source.acryl.datahub_cloud_events_consumer.stop_after_attempt",
             return_value=stop_after_attempt(3),
         ),
-        patch(
-            "requests.get", side_effect=HTTPError(response=dummy_response)
+        patch.object(
+            mock_graph.session, "get", side_effect=HTTPError(response=dummy_response)
         ) as mock_get,
     ):
         with pytest.raises(HTTPError):
@@ -460,7 +464,7 @@ def test_poll_events_infinite_retry_connection_error(
         mock_response.raise_for_status.return_value = None
         return mock_response
 
-    with patch("requests.get", side_effect=side_effect) as mock_get:
+    with patch.object(mock_graph.session, "get", side_effect=side_effect) as mock_get:
         result = consumer.poll_events(topic="TestTopic")
 
         # Should have been called 5 times (4 failures + 1 success)
@@ -497,7 +501,7 @@ def test_poll_events_infinite_retry_timeout(mock_graph: DataHubGraph) -> None:
         mock_response.raise_for_status.return_value = None
         return mock_response
 
-    with patch("requests.get", side_effect=side_effect) as mock_get:
+    with patch.object(mock_graph.session, "get", side_effect=side_effect) as mock_get:
         result = consumer.poll_events(topic="TestTopic")
 
         # Should have been called 8 times (7 failures + 1 success)

--- a/datahub-actions/tests/unit/plugin/source/acryl/test_datahub_cloud_events_consumer.py
+++ b/datahub-actions/tests/unit/plugin/source/acryl/test_datahub_cloud_events_consumer.py
@@ -3,7 +3,7 @@
 import json
 import time
 from contextlib import contextmanager
-from typing import Any, List, Optional, cast
+from typing import List, Optional, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -683,7 +683,9 @@ class _RecordingAdapter(requests.adapters.HTTPAdapter):
         super().__init__()
         self.sent: List[requests.PreparedRequest] = []
 
-    def send(self, request: requests.PreparedRequest, **kwargs: Any) -> Response:  # type: ignore[override]
+    def send(
+        self, request: requests.PreparedRequest, *args: object, **kwargs: object
+    ) -> Response:
         self.sent.append(request)
         response = Response()
         response.status_code = 200

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -597,6 +597,17 @@ class DataHubRestEmitter(Closeable, Emitter):
             self._session.auth = auth
 
     @property
+    def session(self) -> requests.Session:
+        """The authenticated requests session used by this client.
+
+        Custom REST calls (e.g. polling an endpoint the SDK does not wrap) must
+        go through this session so per-request authentication applies — an OAuth
+        token provider lives in ``session.auth`` and is bypassed by requests
+        built from copied headers.
+        """
+        return self._session
+
+    @property
     def server_config(self) -> RestServiceConfig:
         return self.fetch_server_config()
 

--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/event_consumer.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/event_consumer.py
@@ -167,12 +167,10 @@ class DocumentEventConsumer:
         params = {k: v for k, v in params.items() if v is not None and v != ""}
 
         try:
-            import requests
-
-            headers = dict(self.graph._session.headers)
-            response = requests.get(
-                endpoint, params=params, headers=headers, timeout=30
-            )
+            # Poll through the graph's authenticated session: per-request auth
+            # (e.g. an OAuth token provider in session.auth) only applies to
+            # requests made through it.
+            response = self.graph.session.get(endpoint, params=params, timeout=30)
             response.raise_for_status()
 
             data = response.json()
@@ -225,12 +223,10 @@ class DocumentEventConsumer:
         }
 
         try:
-            import requests
-
-            headers = dict(self.graph._session.headers)
-            response = requests.get(
-                endpoint, params=params, headers=headers, timeout=30
-            )
+            # Poll through the graph's authenticated session: per-request auth
+            # (e.g. an OAuth token provider in session.auth) only applies to
+            # requests made through it.
+            response = self.graph.session.get(endpoint, params=params, timeout=30)
             response.raise_for_status()
 
             data = response.json()

--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/event_consumer.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/event_consumer.py
@@ -167,9 +167,6 @@ class DocumentEventConsumer:
         params = {k: v for k, v in params.items() if v is not None and v != ""}
 
         try:
-            # Poll through the graph's authenticated session: per-request auth
-            # (e.g. an OAuth token provider in session.auth) only applies to
-            # requests made through it.
             response = self.graph.session.get(endpoint, params=params, timeout=30)
             response.raise_for_status()
 
@@ -223,9 +220,6 @@ class DocumentEventConsumer:
         }
 
         try:
-            # Poll through the graph's authenticated session: per-request auth
-            # (e.g. an OAuth token provider in session.auth) only applies to
-            # requests made through it.
             response = self.graph.session.get(endpoint, params=params, timeout=30)
             response.raise_for_status()
 

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -422,7 +422,7 @@ class TestEventModeFallback:
         """Test fallback when Events API returns HTTP error."""
         import requests
 
-        with mock_graph:
+        with mock_graph as mock_graph_cls:
             source = DataHubDocumentsSource(ctx, config)
             # Mock state handler with valid offset
             mock_state_handler = patch.object(source, "state_handler").start()
@@ -430,7 +430,7 @@ class TestEventModeFallback:
             mock_state_handler.get_event_offset.return_value = "test-offset-123"
 
             # Mock requests.get to raise HTTP error
-            with patch("requests.get") as mock_get:
+            with patch.object(mock_graph_cls.return_value.session, "get") as mock_get:
                 # Simulate HTTP 500 error
                 mock_response = Mock()
                 mock_response.raise_for_status.side_effect = requests.HTTPError(
@@ -452,7 +452,7 @@ class TestEventModeFallback:
         """Test fallback when Events API connection fails."""
         import requests
 
-        with mock_graph:
+        with mock_graph as mock_graph_cls:
             source = DataHubDocumentsSource(ctx, config)
             # Mock state handler with valid offset
             mock_state_handler = patch.object(source, "state_handler").start()
@@ -460,7 +460,7 @@ class TestEventModeFallback:
             mock_state_handler.get_event_offset.return_value = "test-offset-123"
 
             # Mock requests.get to raise connection error
-            with patch("requests.get") as mock_get:
+            with patch.object(mock_graph_cls.return_value.session, "get") as mock_get:
                 mock_get.side_effect = requests.ConnectionError("Connection refused")
 
                 # Mock batch mode
@@ -477,7 +477,7 @@ class TestEventModeFallback:
         """Test fallback when Events API times out."""
         import requests
 
-        with mock_graph:
+        with mock_graph as mock_graph_cls:
             source = DataHubDocumentsSource(ctx, config)
             # Mock state handler with valid offset
             mock_state_handler = patch.object(source, "state_handler").start()
@@ -485,7 +485,7 @@ class TestEventModeFallback:
             mock_state_handler.get_event_offset.return_value = "test-offset-123"
 
             # Mock requests.get to raise timeout
-            with patch("requests.get") as mock_get:
+            with patch.object(mock_graph_cls.return_value.session, "get") as mock_get:
                 mock_get.side_effect = requests.Timeout("Request timed out")
 
                 # Mock batch mode
@@ -500,7 +500,7 @@ class TestEventModeFallback:
 
     def test_no_fallback_when_offsets_exist(self, ctx, config, mock_graph):
         """Test that fallback does NOT occur when offsets exist and events are processed."""
-        with mock_graph:
+        with mock_graph as mock_graph_cls:
             source = DataHubDocumentsSource(ctx, config)
             # Mock state handler with valid offset
             mock_state_handler = patch.object(source, "state_handler").start()
@@ -509,7 +509,7 @@ class TestEventModeFallback:
 
             # Mock successful event polling with events
 
-            with patch("requests.get") as mock_get:
+            with patch.object(mock_graph_cls.return_value.session, "get") as mock_get:
                 mock_response = Mock()
                 mock_response.status_code = 200
                 mock_response.json.return_value = {
@@ -559,7 +559,7 @@ class TestEventModeFallback:
 
     def test_fallback_when_no_events_and_no_lookback(self, ctx, config, mock_graph):
         """Test fallback when no events processed and no lookback window."""
-        with mock_graph:
+        with mock_graph as mock_graph_cls:
             source = DataHubDocumentsSource(ctx, config)
             # Mock state handler with valid offset
             mock_state_handler = patch.object(source, "state_handler").start()
@@ -568,7 +568,7 @@ class TestEventModeFallback:
 
             # Mock successful event polling but no events
 
-            with patch("requests.get") as mock_get:
+            with patch.object(mock_graph_cls.return_value.session, "get") as mock_get:
                 mock_response = Mock()
                 mock_response.status_code = 200
                 mock_response.json.return_value = {
@@ -779,7 +779,7 @@ class TestStateStorage:
     def test_event_mode_stores_offsets(self, ctx, config, mock_graph):
         """Test that event mode stores offsets in state."""
 
-        with mock_graph:
+        with mock_graph as mock_graph_cls:
             source = DataHubDocumentsSource(ctx, config)
             source.config.event_mode.enabled = True
 
@@ -790,7 +790,7 @@ class TestStateStorage:
             mock_state_handler.update_event_offset = Mock()
 
             # Mock successful event polling
-            with patch("requests.get") as mock_get:
+            with patch.object(mock_graph_cls.return_value.session, "get") as mock_get:
                 mock_response = Mock()
                 mock_response.status_code = 200
                 mock_response.json.return_value = {
@@ -1014,7 +1014,7 @@ class TestStateStorage:
         """Test that fallback to batch mode preserves existing event offsets."""
         import requests
 
-        with mock_graph:
+        with mock_graph as mock_graph_cls:
             source = DataHubDocumentsSource(ctx, config)
             source.config.event_mode.enabled = True
 
@@ -1023,52 +1023,50 @@ class TestStateStorage:
             mock_state_handler.is_checkpointing_enabled.return_value = True
             mock_state_handler.get_event_offset.return_value = "existing-offset-123"
 
-            # Mock event API to fail (triggers fallback)
-            with patch("requests.get") as mock_get:
-                mock_get.side_effect = requests.ConnectionError("Connection refused")
+            # Event polling goes through the graph's session; make it fail to
+            # trigger the fallback to batch mode.
+            mock_graph_cls.return_value.session.get.side_effect = (
+                requests.ConnectionError("Connection refused")
+            )
 
-                # Mock batch mode
-                mock_docs = [{"urn": "urn:li:document:1", "text": "Document 1"}]
-                with (
-                    patch.object(
-                        source, "_fetch_documents_graphql", return_value=mock_docs
-                    ),
-                    patch.object(
-                        source, "_process_single_document", return_value=iter([])
-                    ),
-                ):
-                    mock_state_handler.update_document_state = Mock()
-                    mock_state_handler.update_event_offset = Mock()
+            # Mock batch mode
+            mock_docs = [{"urn": "urn:li:document:1", "text": "Document 1"}]
+            with (
+                patch.object(
+                    source, "_fetch_documents_graphql", return_value=mock_docs
+                ),
+                patch.object(source, "_process_single_document", return_value=iter([])),
+            ):
+                mock_state_handler.update_document_state = Mock()
+                mock_state_handler.update_event_offset = Mock()
 
-                    # Process in event mode - should fallback
-                    list(source._process_event_mode())
+                # Process in event mode - should fallback
+                list(source._process_event_mode())
 
-                    # Verify document state was updated (fallback processed documents)
-                    mock_state_handler.update_document_state.assert_called_once()
+                # Verify document state was updated (fallback processed documents)
+                mock_state_handler.update_document_state.assert_called_once()
 
-                    # Note: update_event_offset may be called when event consumer closes
-                    # This is fine - it preserves the existing offset value
-                    # The important thing is that offsets are not cleared
+                # Note: update_event_offset may be called when event consumer closes
+                # This is fine - it preserves the existing offset value
+                # The important thing is that offsets are not cleared
 
-                    # Verify existing offset is still accessible (not cleared)
-                    assert (
-                        mock_state_handler.get_event_offset(
-                            "MetadataChangeLog_Versioned_v1"
-                        )
-                        == "existing-offset-123"
+                # Verify existing offset is still accessible (not cleared)
+                assert (
+                    mock_state_handler.get_event_offset(
+                        "MetadataChangeLog_Versioned_v1"
                     )
+                    == "existing-offset-123"
+                )
 
-                    # Verify offset was preserved (not changed to a different value)
-                    # If update_event_offset was called, it should be with the same offset
-                    if mock_state_handler.update_event_offset.called:
-                        offset_calls = (
-                            mock_state_handler.update_event_offset.call_args_list
-                        )
-                        # All calls should preserve the existing offset
-                        for call in offset_calls:
-                            assert (
-                                call[0][1] == "existing-offset-123"
-                            )  # Same offset preserved
+                # Verify offset was preserved (not changed to a different value)
+                # If update_event_offset was called, it should be with the same offset
+                if mock_state_handler.update_event_offset.called:
+                    offset_calls = mock_state_handler.update_event_offset.call_args_list
+                    # All calls should preserve the existing offset
+                    for call in offset_calls:
+                        assert (
+                            call[0][1] == "existing-offset-123"
+                        )  # Same offset preserved
 
     def test_incremental_mode_skips_unchanged_documents(self, ctx, config, mock_graph):
         """Test that incremental mode skips documents with unchanged hashes."""
@@ -2274,8 +2272,8 @@ class TestGetCurrentOffset:
         """Create a mock DataHubGraph."""
         graph = Mock()
         graph.config.server = "http://localhost:8080"
-        graph._session = Mock()
-        graph._session.headers = {"Authorization": "Bearer test-token"}
+        graph.session = Mock()
+        graph.session.headers = {"Authorization": "Bearer test-token"}
         return graph
 
     def test_get_current_offset_success(self, mock_graph):
@@ -2284,21 +2282,22 @@ class TestGetCurrentOffset:
             DocumentEventConsumer,
         )
 
-        # Mock the requests.get response
+        # The consumer polls through the graph's session (session.auth carries
+        # OAuth credentials), so mock the session, not module-level requests.
         mock_response = Mock()
         mock_response.json.return_value = {"offsetId": "test-offset-123"}
         mock_response.raise_for_status = Mock()
+        mock_graph.session.get.return_value = mock_response
 
-        with patch("requests.get", return_value=mock_response):
-            consumer = DocumentEventConsumer(
-                graph=mock_graph,
-                consumer_id="test-consumer",
-                topics=["MetadataChangeLog_Versioned_v1"],
-            )
+        consumer = DocumentEventConsumer(
+            graph=mock_graph,
+            consumer_id="test-consumer",
+            topics=["MetadataChangeLog_Versioned_v1"],
+        )
 
-            offset = consumer.get_current_offset("MetadataChangeLog_Versioned_v1")
+        offset = consumer.get_current_offset("MetadataChangeLog_Versioned_v1")
 
-            assert offset == "test-offset-123"
+        assert offset == "test-offset-123"
 
     def test_get_current_offset_no_offset_in_response(self, mock_graph):
         """Test when Events API returns no offsetId."""
@@ -2306,21 +2305,20 @@ class TestGetCurrentOffset:
             DocumentEventConsumer,
         )
 
-        # Mock the requests.get response with no offsetId
         mock_response = Mock()
         mock_response.json.return_value = {"events": []}  # No offsetId field
         mock_response.raise_for_status = Mock()
+        mock_graph.session.get.return_value = mock_response
 
-        with patch("requests.get", return_value=mock_response):
-            consumer = DocumentEventConsumer(
-                graph=mock_graph,
-                consumer_id="test-consumer",
-                topics=["MetadataChangeLog_Versioned_v1"],
-            )
+        consumer = DocumentEventConsumer(
+            graph=mock_graph,
+            consumer_id="test-consumer",
+            topics=["MetadataChangeLog_Versioned_v1"],
+        )
 
-            offset = consumer.get_current_offset("MetadataChangeLog_Versioned_v1")
+        offset = consumer.get_current_offset("MetadataChangeLog_Versioned_v1")
 
-            assert offset is None
+        assert offset is None
 
     def test_get_current_offset_http_error(self, mock_graph):
         """Test when Events API returns HTTP error."""
@@ -2330,23 +2328,22 @@ class TestGetCurrentOffset:
             DocumentEventConsumer,
         )
 
-        # Mock the requests.get to raise HTTPError
         mock_response = Mock()
         mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
             "401 Unauthorized"
         )
+        mock_graph.session.get.return_value = mock_response
 
-        with patch("requests.get", return_value=mock_response):
-            consumer = DocumentEventConsumer(
-                graph=mock_graph,
-                consumer_id="test-consumer",
-                topics=["MetadataChangeLog_Versioned_v1"],
-            )
+        consumer = DocumentEventConsumer(
+            graph=mock_graph,
+            consumer_id="test-consumer",
+            topics=["MetadataChangeLog_Versioned_v1"],
+        )
 
-            offset = consumer.get_current_offset("MetadataChangeLog_Versioned_v1")
+        offset = consumer.get_current_offset("MetadataChangeLog_Versioned_v1")
 
-            # Should return None on error, not raise
-            assert offset is None
+        # Should return None on error, not raise
+        assert offset is None
 
     def test_get_current_offset_connection_error(self, mock_graph):
         """Test when Events API connection fails."""
@@ -2356,21 +2353,20 @@ class TestGetCurrentOffset:
             DocumentEventConsumer,
         )
 
-        # Mock the requests.get to raise ConnectionError
-        with patch(
-            "requests.get",
-            side_effect=requests.exceptions.ConnectionError("Connection failed"),
-        ):
-            consumer = DocumentEventConsumer(
-                graph=mock_graph,
-                consumer_id="test-consumer",
-                topics=["MetadataChangeLog_Versioned_v1"],
-            )
+        mock_graph.session.get.side_effect = requests.exceptions.ConnectionError(
+            "Connection failed"
+        )
 
-            offset = consumer.get_current_offset("MetadataChangeLog_Versioned_v1")
+        consumer = DocumentEventConsumer(
+            graph=mock_graph,
+            consumer_id="test-consumer",
+            topics=["MetadataChangeLog_Versioned_v1"],
+        )
 
-            # Should return None on error, not raise
-            assert offset is None
+        offset = consumer.get_current_offset("MetadataChangeLog_Versioned_v1")
+
+        # Should return None on error, not raise
+        assert offset is None
 
     def test_get_current_offset_polls_with_no_offset_and_no_lookback(self, mock_graph):
         """Test that get_current_offset polls with no offsetId and no lookbackWindowDays."""
@@ -2381,25 +2377,26 @@ class TestGetCurrentOffset:
         mock_response = Mock()
         mock_response.json.return_value = {"offsetId": "test-offset-456"}
         mock_response.raise_for_status = Mock()
+        mock_get = mock_graph.session.get
+        mock_get.return_value = mock_response
 
-        with patch("requests.get", return_value=mock_response) as mock_get:
-            consumer = DocumentEventConsumer(
-                graph=mock_graph,
-                consumer_id="test-consumer",
-                topics=["MetadataChangeLog_Versioned_v1"],
-            )
+        consumer = DocumentEventConsumer(
+            graph=mock_graph,
+            consumer_id="test-consumer",
+            topics=["MetadataChangeLog_Versioned_v1"],
+        )
 
-            offset = consumer.get_current_offset("MetadataChangeLog_Versioned_v1")
+        offset = consumer.get_current_offset("MetadataChangeLog_Versioned_v1")
 
-            # Verify the request was made with correct parameters
-            assert mock_get.called
-            call_args = mock_get.call_args
-            assert call_args[1]["params"]["topic"] == "MetadataChangeLog_Versioned_v1"
-            assert call_args[1]["params"]["limit"] == 1
-            # Should NOT include offsetId or lookbackWindowDays
-            assert "offsetId" not in call_args[1]["params"]
-            assert "lookbackWindowDays" not in call_args[1]["params"]
-            assert offset == "test-offset-456"
+        # Verify the request was made with correct parameters
+        assert mock_get.called
+        call_args = mock_get.call_args
+        assert call_args[1]["params"]["topic"] == "MetadataChangeLog_Versioned_v1"
+        assert call_args[1]["params"]["limit"] == 1
+        # Should NOT include offsetId or lookbackWindowDays
+        assert "offsetId" not in call_args[1]["params"]
+        assert "lookbackWindowDays" not in call_args[1]["params"]
+        assert offset == "test-offset-456"
 
 
 class TestDataHubGraphInitialization:

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -3566,8 +3566,8 @@ class TestPollEventsSessionAuth:
             super().__init__()
             self.sent: list[requests.PreparedRequest] = []
 
-        def send(  # type: ignore[override]
-            self, request: requests.PreparedRequest, **kwargs: Any
+        def send(
+            self, request: requests.PreparedRequest, *args: object, **kwargs: object
         ) -> requests.Response:
             self.sent.append(request)
             response = requests.Response()

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -9,6 +9,11 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
+from datahub.ingestion.graph.client import DataHubGraph
+from datahub.ingestion.source.unstructured.event_consumer import (
+    DocumentEventConsumer,
+)
+
 # Skip entire module if unstructured is not installed (requires Python 3.10+)
 pytest.importorskip("unstructured")
 
@@ -3590,11 +3595,6 @@ class TestPollEventsSessionAuth:
         return request
 
     def test_poll_events_carries_session_auth_to_the_wire(self) -> None:
-        from datahub.ingestion.graph.client import DataHubGraph
-        from datahub.ingestion.source.unstructured.event_consumer import (
-            DocumentEventConsumer,
-        )
-
         session = requests.Session()
         session.auth = self._oauth_style_auth
         adapter = self._RecordingAdapter()

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 from unittest.mock import Mock, patch
 
 import pytest
+import requests
 
 # Skip entire module if unstructured is not installed (requires Python 3.10+)
 pytest.importorskip("unstructured")
@@ -3553,3 +3554,71 @@ class TestLockIntegrationWithSource:
             source = DataHubDocumentsSource(ctx, config)
             assert source.lock is not None
             assert str(source.lock.urn) == "urn:li:dataHubStepState:my-custom-lock"
+
+
+class TestPollEventsSessionAuth:
+    """The poll must go through the graph's session so session.auth applies."""
+
+    class _RecordingAdapter(requests.adapters.HTTPAdapter):
+        """Captures fully prepared requests and returns a canned poll response."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.sent: list[requests.PreparedRequest] = []
+
+        def send(  # type: ignore[override]
+            self, request: requests.PreparedRequest, **kwargs: Any
+        ) -> requests.Response:
+            self.sent.append(request)
+            response = requests.Response()
+            response.status_code = 200
+            response._content = json.dumps(
+                {"offsetId": "offset-after", "events": []}
+            ).encode()
+            response.request = request
+            return response
+
+    @staticmethod
+    def _oauth_style_auth(
+        request: requests.PreparedRequest,
+    ) -> requests.PreparedRequest:
+        # Mimics an OAuth token provider installed as session.auth: it attaches
+        # a fresh Authorization header to each request at send time, so auth
+        # that is not baked into session.headers is only present if the request
+        # actually goes through the session.
+        request.headers["Authorization"] = "Bearer fresh-oauth-token"
+        return request
+
+    def test_poll_events_carries_session_auth_to_the_wire(self) -> None:
+        from datahub.ingestion.graph.client import DataHubGraph
+        from datahub.ingestion.source.unstructured.event_consumer import (
+            DocumentEventConsumer,
+        )
+
+        session = requests.Session()
+        session.auth = self._oauth_style_auth
+        adapter = self._RecordingAdapter()
+        session.mount("http://", adapter)
+
+        graph = Mock(spec=DataHubGraph)
+        graph.config = Mock()
+        graph.config.server = "http://gms.example"
+        graph.session = session
+
+        consumer = DocumentEventConsumer(
+            graph=graph,
+            consumer_id="test-consumer",
+            topics=["MetadataChangeLog_Versioned_v1"],
+            reset_offsets=True,
+        )
+        events = consumer.poll_events("MetadataChangeLog_Versioned_v1")
+
+        assert len(adapter.sent) == 1
+        request = adapter.sent[0]
+        assert request.url is not None
+        assert request.url.startswith("http://gms.example/openapi/v1/events/poll?")
+        # The per-request credential from session.auth must reach the wire. A
+        # bare requests.get built from copied session.headers would drop it and
+        # poll unauthenticated.
+        assert request.headers["Authorization"] == "Bearer fresh-oauth-token"
+        assert events == []


### PR DESCRIPTION
## Summary

Two event pollers copied `session.headers` into bare `requests.get` calls. Copied headers only carry a **static** token — an OAuth token provider lives in `session.auth` and was silently bypassed (401s under OAuth):

- `DataHubRestEmitter` gains a public **`session` property** — the sanctioned way to make GMS REST calls the SDK doesn't wrap, with per-request authentication applied.
- The `datahub-actions` cloud-events consumer and the unstructured-events consumer now poll through that session, with explicit timeouts (the long-poll endpoint previously had none — a half-open connection would hang the consumer forever).

Split out of #18144 (see the stack there). Independent of the other PRs in the stack.

Note on urgency: the DataHub Cloud Remote Executor imports the `datahub-actions` events consumer for its work-poll loop, so its OAuth support only works end-to-end once this fix ships in an `acryl-datahub-actions` release — ideally the next one.

## Testing

Rewritten consumer tests in both modules assert the polls go through the graph's session and cover the retry/timeout behavior, plus wire-level tests: an OAuth-style credential installed as `session.auth` on a real `requests.Session` with a recording transport adapter, asserting the poll request actually carries the credential (fails on the previous implementation, which bypassed the session). ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## The stack

Split of the original #18144 per review feedback (one concern per PR):

| Order | PR | Base | Notes |
|---|---|---|---|
| 1 | #18187 token-provider hardening | `master` | merged |
| 2 | #18188 configured auth reaches the emitter | #18187 | merged |
| 3 | #18144 env-based OAuth (`DATAHUB_AUTH_TYPE`) | #18188 | merged |
| 4 | #18192 OAuth CI smoke harness | #18144 | open |
| 5 | this PR | `master` | independent |
