### PR TITLE
chore(ingestion): flag remaining static-token-only auth surfaces

### DIFF
--- a/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/airflow3/datahub_listener.py
+++ b/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/airflow3/datahub_listener.py
@@ -593,6 +593,9 @@ class DataHubListener:
                     )
                 )
 
+                # TODO(oauth): only a static token is supported here; accept a declarative
+                # AuthConfig (DatahubClientConfig.auth / datahub.ingestion.auth) so short-lived
+                # OAuth token providers work on this path too.
                 # Get token - check airflow.cfg first, then connection password
                 token = conf.get("datahub", "token", fallback=None)
                 if token is None:

--- a/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/hooks/datahub.py
+++ b/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/hooks/datahub.py
@@ -99,6 +99,9 @@ class DatahubRestHook(BaseHook):
         extra_args = conn.extra_dejson
         return (host, token, extra_args)
 
+    # TODO(oauth): only a static token is supported here; accept a declarative
+    # AuthConfig (DatahubClientConfig.auth / datahub.ingestion.auth) so short-lived
+    # OAuth token providers work on this path too.
     def make_emitter(self) -> "DataHubRestEmitter":
         import datahub.emitter.rest_emitter
         from datahub.ingestion.graph.config import ClientMode

--- a/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/operators/datahub_assertion_operator.py
+++ b/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/operators/datahub_assertion_operator.py
@@ -44,6 +44,9 @@ class DataHubAssertionOperator(BaseOperator):
 
         host, password, timeout_sec = hook._get_config()
         self.urn = urn
+        # TODO(oauth): only a static token is supported here; accept a declarative
+        # AuthConfig (DatahubClientConfig.auth / datahub.ingestion.auth) so short-lived
+        # OAuth token providers work on this path too.
         config: AssertionCircuitBreakerConfig = AssertionCircuitBreakerConfig(
             datahub_host=host,
             datahub_token=password,

--- a/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/operators/datahub_assertion_sensor.py
+++ b/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/operators/datahub_assertion_sensor.py
@@ -44,6 +44,9 @@ class DataHubAssertionSensor(BaseSensorOperator):
 
         host, password, timeout_sec = hook._get_config()
         self.urn = urn
+        # TODO(oauth): only a static token is supported here; accept a declarative
+        # AuthConfig (DatahubClientConfig.auth / datahub.ingestion.auth) so short-lived
+        # OAuth token providers work on this path too.
         config: AssertionCircuitBreakerConfig = AssertionCircuitBreakerConfig(
             datahub_host=host,
             datahub_token=password,

--- a/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/operators/datahub_operation_operator.py
+++ b/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/operators/datahub_operation_operator.py
@@ -59,6 +59,9 @@ class DataHubOperationCircuitBreakerOperator(BaseSensorOperator):
         self.operation_type = operation_type
         self.source_type = source_type
 
+        # TODO(oauth): only a static token is supported here; accept a declarative
+        # AuthConfig (DatahubClientConfig.auth / datahub.ingestion.auth) so short-lived
+        # OAuth token providers work on this path too.
         config: OperationCircuitBreakerConfig = OperationCircuitBreakerConfig(
             datahub_host=host,
             datahub_token=password,

--- a/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/operators/datahub_operation_sensor.py
+++ b/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/operators/datahub_operation_sensor.py
@@ -61,6 +61,9 @@ class DataHubOperationCircuitBreakerSensor(BaseSensorOperator):
         self.operation_type = operation_type
         self.source_type = source_type
 
+        # TODO(oauth): only a static token is supported here; accept a declarative
+        # AuthConfig (DatahubClientConfig.auth / datahub.ingestion.auth) so short-lived
+        # OAuth token providers work on this path too.
         config: OperationCircuitBreakerConfig = OperationCircuitBreakerConfig(
             datahub_host=host,
             datahub_token=password,

--- a/metadata-ingestion-modules/gx-plugin/src/datahub_gx_plugin/action.py
+++ b/metadata-ingestion-modules/gx-plugin/src/datahub_gx_plugin/action.py
@@ -111,6 +111,9 @@ class DataHubValidationAction(ValidationAction):
         platform_alias: Optional[str] = None,
         platform_instance_map: Optional[Dict[str, str]] = None,
         graceful_exceptions: bool = True,
+        # TODO(oauth): only a static token is supported here; accept a declarative
+        # AuthConfig (DatahubClientConfig.auth / datahub.ingestion.auth) so short-lived
+        # OAuth token providers work on this path too.
         token: Optional[str] = None,
         timeout_sec: Optional[float] = None,
         retry_status_codes: Optional[List[int]] = None,

--- a/metadata-ingestion-modules/prefect-plugin/src/prefect_datahub/datahub_emitter.py
+++ b/metadata-ingestion-modules/prefect-plugin/src/prefect_datahub/datahub_emitter.py
@@ -103,6 +103,9 @@ class DatahubEmitter(Block):
     datahub_rest_url: str = "http://localhost:8080"
     env: str = builder.DEFAULT_ENV
     platform_instance: Optional[str] = None
+    # TODO(oauth): only a static token is supported here; accept a declarative
+    # AuthConfig (DatahubClientConfig.auth / datahub.ingestion.auth) so short-lived
+    # OAuth token providers work on this path too.
     token: Optional[SecretStr] = None
     # Default to ASYNC so high-volume Prefect runs don't block GMS on a
     # synchronous commit per write. Set to SYNC_WAIT/SYNC_PRIMARY for

--- a/metadata-ingestion/src/datahub/api/circuit_breaker/circuit_breaker.py
+++ b/metadata-ingestion/src/datahub/api/circuit_breaker/circuit_breaker.py
@@ -22,6 +22,9 @@ class CircuitBreakerConfig(ConfigModel):
     )
 
 
+# TODO(oauth): only a static token is supported here; accept a declarative
+# AuthConfig (DatahubClientConfig.auth / datahub.ingestion.auth) so short-lived
+# OAuth token providers work on this path too (same gap as api/graphql/base.py).
 class AbstractCircuitBreaker:
     client: Client
 

--- a/metadata-ingestion/src/datahub/api/graphql/base.py
+++ b/metadata-ingestion/src/datahub/api/graphql/base.py
@@ -4,6 +4,9 @@ from gql import Client
 from gql.transport.requests import RequestsHTTPTransport
 
 
+# TODO(oauth): only a static token is supported here; accept a declarative
+# AuthConfig (DatahubClientConfig.auth / datahub.ingestion.auth) so short-lived
+# OAuth token providers work on this path too.
 class BaseApi:
     client: Client
 

--- a/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_source.py
@@ -1267,6 +1267,9 @@ class ConfluenceSource(StatefulIngestionSourceBase, TestableSource):
 
         try:
             # Create graph connection to query server (if datahub config provided)
+            # TODO(oauth): only a static token is supported here; accept a declarative
+            # AuthConfig (DatahubClientConfig.auth) so short-lived OAuth token
+            # providers work on this path too.
             graph = None
             if hasattr(config, "datahub") and config.datahub and config.datahub.server:
                 graph_config = DatahubClientConfig(

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -151,6 +151,9 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
         else:
             # Fallback: Create graph from config (for standalone usage)
             # Convert TransparentSecretStr to str for DatahubClientConfig
+            # TODO(oauth): only a static token is supported on this fallback path;
+            # accept a declarative AuthConfig (DatahubClientConfig.auth) so short-lived
+            # OAuth token providers work here too. The ctx.graph path above is OAuth-ready.
             token_str = (
                 self.config.datahub.token.get_secret_value()
                 if self.config.datahub.token

--- a/metadata-ingestion/src/datahub/ingestion/source/notion/notion_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/notion/notion_source.py
@@ -1189,6 +1189,9 @@ class NotionSource(StatefulIngestionSourceBase, TestableSource):
 
         try:
             # Create graph connection to query server (if datahub config provided)
+            # TODO(oauth): only a static token is supported here; accept a declarative
+            # AuthConfig (DatahubClientConfig.auth) so short-lived OAuth token
+            # providers work on this path too.
             graph = None
             if config.datahub and config.datahub.server:
                 graph_config = DatahubClientConfig(

--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_config.py
@@ -396,6 +396,9 @@ def _get_default_gms_token() -> Optional[TransparentSecretStr]:
     return None
 
 
+# TODO(oauth): only a static token is supported here; accept a declarative
+# AuthConfig (DatahubClientConfig.auth / datahub.ingestion.auth) so short-lived
+# OAuth token providers work on this path too.
 class DataHubConnectionConfig(ConfigModel):
     """DataHub connection configuration.
 

--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
@@ -133,6 +133,9 @@ class DocumentChunkingSource(Source):
         self.graph: Optional[DataHubGraph]
         if self.standalone:
             # Standalone mode: create our own graph client
+            # TODO(oauth): only a static token is supported here; accept a declarative
+            # AuthConfig (DatahubClientConfig.auth) so short-lived OAuth token
+            # providers work on this path too. Inline mode (parent graph) is OAuth-ready.
             graph_config = DatahubClientConfig(
                 server=self.config.datahub.server,
                 token=self.config.datahub.token.get_secret_value()


### PR DESCRIPTION
## Summary

**Comments only — no behavior change.** Greppable `TODO(oauth)` markers on every code path that still supports only a static token, so the residual map lives in the code:

- gql GraphQL stack (`api/graphql/base.py`, `api/circuit_breaker/`) + the four Airflow circuit-breaker operators/sensors
- Airflow REST hook + the Airflow 3 listener (the default lineage path — highest-priority future migration)
- GX and Prefect plugin emitters
- the shared doc-connector `DataHubConnectionConfig` and its standalone fallbacks (their primary `ctx.graph` paths are already OAuth-capable)

Draft on purpose: whether these markers land, or the map moves to a tracking issue, is a team call. Split out of #18144 (see the stack there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## The stack

Split of the original #18144 per review feedback (one concern per PR):

| Order | PR | Base | Notes |
|---|---|---|---|
| 1 | #18187 token-provider hardening | `master` | independent |
| 2 | #18188 configured auth reaches the emitter | #18187 | retarget to master when 1 merges |
| 3 | #18144 env-based OAuth (`DATAHUB_AUTH_TYPE`) | #18188 | the feature; retarget when 2 merges |
| 4 | #18192 OAuth CI canary | #18144 | draft until 3 merges |
| — | #18189 session-bypass fixes + lint | `master` | independent |
| — | #18190 metadata_change_sync + version check | `master` | independent |
| — | #18191 TODO(oauth) markers | `master` | draft, comments only |
