### PR TITLE
ci(pre-commit): Add betterleaks secret scanning pre-commit hook

### DIFF
--- a/.betterleaks.toml
+++ b/.betterleaks.toml
@@ -1,0 +1,24 @@
+title = "DataHub betterleaks config"
+
+# Native betterleaks (Expr) config. `filter` is a global expression evaluated per
+# finding; when it returns true the finding is dropped. The patterns below match
+# specific known-safe fixtures, so any OTHER secret — even in the same files — is
+# still reported:
+#   MIIyourkey              -> dataplex docs placeholder private key
+#   MIIEvQIBADAN...HjpPX     -> archive.py documented public RSA test key (mocked replay tests)
+#   suppproject-id-1234567  -> dataplex docs sample GCP service account
+#
+# matchesAny (regex) is used rather than containsAny: containsAny misses multi-line
+# matches (e.g. the multi-line RSA key block in archive.py).
+filter = '''
+filter.matchesAny(finding["match"], [
+  "MIIyourkey",
+  "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDHjpPX",
+  "suppproject-id-1234567",
+])
+'''
+
+# Start from betterleaks' built-in ruleset. Without this, ZERO rules are loaded and
+# every scan reports "no leaks found" — a silent false-clean.
+[extend]
+useDefault = true

--- a/.github/scripts/pre-commit-override.yaml
+++ b/.github/scripts/pre-commit-override.yaml
@@ -69,3 +69,13 @@ repos:
         entry: python .github/scripts/bump_schema_versions.py
         language: python
         pass_filenames: false
+      - id: betterleaks
+        name: Detect hardcoded secrets
+        description: Detect hardcoded secrets using Betterleaks (system-installed binary)
+        entry: betterleaks git --staged --redact --verbose --config .betterleaks.toml
+        language: system
+        pass_filenames: false
+        # Scans only the staged diff. A native (non-docker) binary resolves git worktrees
+        # correctly — a docker_image hook cannot (it only mounts $PWD, not the external gitdir).
+        # Keep pass_filenames: false: betterleaks reads the staged diff itself; passing files
+        # would switch it to `dir` semantics (whole-file, and broken/slow on multiple file args).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -598,3 +598,10 @@ repos:
         entry: python .github/scripts/bump_schema_versions.py
         language: python
         pass_filenames: false
+      
+      - id: betterleaks
+        name: Detect hardcoded secrets
+        description: Detect hardcoded secrets using Betterleaks (system-installed binary)
+        entry: betterleaks git --staged --redact --verbose --config .betterleaks.toml
+        language: system
+        pass_filenames: false

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
 actionlint = "1.7.11"
+betterleaks = "1.6.1"
 java = "21"
 node = "22"
 python = "3.11"


### PR DESCRIPTION
# Summary

Adds a pre-commit hook that scans staged changes for hardcoded secrets using betterleaks (the actively-maintained gitleaks successor), to prevent accidental credential commits.

# Changes
- New .betterleaks.toml — extends betterleaks' default ruleset and adds a narrow native-Expr filter that allowlists known-safe documentation samples and test fixtures (a public RSA test key, sample service-account values). Any other secret, even in those same files, is still flagged.
- Registers a betterleaks hook in .github/scripts/pre-commit-override.yaml and .pre-commit-config.yaml.

# Key decisions
- language: system (native binary), not docker. A docker_image hook only mounts $PWD, so git --staged silently passes inside git worktrees (the external gitdir isn't visible) — a dangerous false-clean. The native binary resolves worktrees correctly.
- Scans the staged diff only (git --staged, pass_filenames: false) — fast and diff-scoped.
- Assumes betterleaks is available on PATH in dev/CI environments.

# Testing
- betterleaks config check → OK (325 rules loaded).
- Staged a planted key → hook blocks; allowlisted fixtures don't trigger; a new secret alongside them is still caught.