### PR TITLE
perf(mae-consumer): skip no-relationship edge diffs + per-message aspect-decode cache

### DIFF
--- a/metadata-jobs/common/src/main/java/com/linkedin/metadata/kafka/listener/AbstractKafkaListener.java
+++ b/metadata-jobs/common/src/main/java/com/linkedin/metadata/kafka/listener/AbstractKafkaListener.java
@@ -65,8 +65,13 @@ public abstract class AbstractKafkaListener<E, H extends EventHook<E>, R>
 
   @Override
   public void consumeEnvelope(@Nonnull final InboundMetadataEnvelope<R> envelope) {
+    // Per-message copy carrying its own aspect-decode cache. eventContext must not be the shared
+    // system singleton here: hooks cache decoded aspects on it, which would leak for the JVM
+    // lifetime and race across consumer threads. See OperationContext#withFreshAspectDecodeCache.
     final OperationContext eventContext =
-        inboundContextResolver.resolve(envelope, systemOperationContext);
+        inboundContextResolver
+            .resolve(envelope, systemOperationContext)
+            .withFreshAspectDecodeCache();
     try {
       systemOperationContext
           .getMetricUtils()

--- a/metadata-jobs/common/src/test/java/com/linkedin/metadata/kafka/listener/AbstractKafkaListenerTest.java
+++ b/metadata-jobs/common/src/test/java/com/linkedin/metadata/kafka/listener/AbstractKafkaListenerTest.java
@@ -46,6 +46,9 @@ public class AbstractKafkaListenerTest {
     meterRegistry = new SimpleMeterRegistry();
     when(metricUtils.getRegistry()).thenReturn(meterRegistry);
     when(operationContext.getMetricUtils()).thenReturn(Optional.of(metricUtils));
+    // consumeEnvelope derives a per-message copy via withFreshAspectDecodeCache(); on a mock it
+    // must return the mock itself so the resolved context still threads through to the hooks.
+    when(operationContext.withFreshAspectDecodeCache()).thenReturn(operationContext);
     doAnswer(
             inv -> {
               inv.getArgument(3, Runnable.class).run();
@@ -188,6 +191,7 @@ public class AbstractKafkaListenerTest {
     InboundContextResolver pgQueueResolver = mock(InboundContextResolver.class);
     when(pgQueueResolver.resolve(any(InboundMetadataEnvelope.class), eq(operationContext)))
         .thenReturn(perEventContext);
+    when(perEventContext.withFreshAspectDecodeCache()).thenReturn(perEventContext);
     listener.init(
         operationContext,
         CONSUMER_GROUP,

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/config/PgQueueMaePollerSourcesConfiguration.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/config/PgQueueMaePollerSourcesConfiguration.java
@@ -272,9 +272,14 @@ public class PgQueueMaePollerSourcesConfiguration {
             // wired here by design. Multi-affinity deployments use Kafka; pgQueue users are
             // single-context single-deployment and invokeBatch under systemOperationContext is
             // the intended behavior.
+            // Fresh per-batch aspect-decode cache: hooks must not cache decoded aspects on the
+            // shared system singleton (JVM-lifetime leak + cross-thread race). Mirrors the Kafka
+            // ingress paths. See OperationContext#withFreshAspectDecodeCache.
+            final OperationContext batchContext =
+                systemOperationContext.withFreshAspectDecodeCache();
             for (MetadataChangeLogHook hook : initHooks) {
               try {
-                hook.invokeBatch(systemOperationContext, mcls);
+                hook.invokeBatch(batchContext, mcls);
               } catch (Exception ex) {
                 log.error(
                     "MCL pgQueue batch hook {} failed for group {}",

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHook.java
@@ -318,10 +318,6 @@ public class PlatformEventGeneratorHook implements MetadataChangeLogHook {
     } else if (logEvent.getEntityUrn() == null) {
       log.warn("Log event does not have an entity urn: {}", logEvent);
       return Collections.emptyList();
-    } else if (aspectSpec.getRelationshipFieldSpecs().isEmpty()) {
-      // The aspect declares no relationships, so it can never produce edge changes. Skip
-      // deserialization and the edge diff entirely — this is the common case on the MCL stream.
-      return Collections.emptyList();
     }
 
     final RecordTemplate oldAspect =

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHook.java
@@ -32,6 +32,7 @@ import com.linkedin.platform.event.v1.RelationshipChangeOperation;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -100,7 +101,7 @@ public class PlatformEventGeneratorHook implements MetadataChangeLogHook {
   private final EventProducer eventProducer;
   private final Boolean isEnabled;
   @Getter private final String consumerGroupSuffix;
-  private final List<String> entityExclusions;
+  private final Set<String> entityExclusions;
   private final List<String> fineGrainedLineageNotAllowedForPlatforms;
 
   @Autowired
@@ -119,7 +120,7 @@ public class PlatformEventGeneratorHook implements MetadataChangeLogHook {
     this.eventProducer = Objects.requireNonNull(eventProducer);
     this.isEnabled = isEnabled;
     this.consumerGroupSuffix = consumerGroupSuffix;
-    this.entityExclusions = entityExclusions;
+    this.entityExclusions = new HashSet<>(entityExclusions);
     this.fineGrainedLineageNotAllowedForPlatforms = fineGrainedLineageNotAllowedForPlatforms;
   }
 
@@ -152,19 +153,22 @@ public class PlatformEventGeneratorHook implements MetadataChangeLogHook {
 
     assert aspectSpec != null;
 
+    // NOTE: do NOT use the shared getDecodedAspect cache here. The change-event generators
+    // downstream (e.g. SchemaMetadataChangeEventGenerator.sortFieldsByPath) mutate the aspect in
+    // place, which would corrupt the cached instance for other hooks. Decode fresh copies instead.
     final RecordTemplate fromAspect =
-        logEvent.getPreviousAspectValue() != null
-            ? GenericRecordUtils.deserializeAspect(
+        logEvent.getPreviousAspectValue() == null
+            ? null
+            : GenericRecordUtils.deserializeAspect(
                 logEvent.getPreviousAspectValue().getValue(),
                 logEvent.getPreviousAspectValue().getContentType(),
-                aspectSpec)
-            : null;
+                aspectSpec);
 
     final RecordTemplate toAspect =
-        logEvent.getAspect() != null
-            ? GenericRecordUtils.deserializeAspect(
-                logEvent.getAspect().getValue(), logEvent.getAspect().getContentType(), aspectSpec)
-            : null;
+        logEvent.getAspect() == null
+            ? null
+            : GenericRecordUtils.deserializeAspect(
+                logEvent.getAspect().getValue(), logEvent.getAspect().getContentType(), aspectSpec);
 
     return ChangeEventGeneratorUtils.generateChangeEvents(
         entityChangeEventGeneratorRegistry,
@@ -314,21 +318,18 @@ public class PlatformEventGeneratorHook implements MetadataChangeLogHook {
     } else if (logEvent.getEntityUrn() == null) {
       log.warn("Log event does not have an entity urn: {}", logEvent);
       return Collections.emptyList();
+    } else if (aspectSpec.getRelationshipFieldSpecs().isEmpty()) {
+      // The aspect declares no relationships, so it can never produce edge changes. Skip
+      // deserialization and the edge diff entirely — this is the common case on the MCL stream.
+      return Collections.emptyList();
     }
 
     final RecordTemplate oldAspect =
-        logEvent.getPreviousAspectValue() != null
-            ? GenericRecordUtils.deserializeAspect(
-                logEvent.getPreviousAspectValue().getValue(),
-                logEvent.getPreviousAspectValue().getContentType(),
-                aspectSpec)
-            : null;
+        operationContext.getDecodedAspect(
+            logEvent.getPreviousAspectValue(), aspectSpec.getDataTemplateClass());
 
     final RecordTemplate newAspect =
-        logEvent.getAspect() != null
-            ? GenericRecordUtils.deserializeAspect(
-                logEvent.getAspect().getValue(), logEvent.getAspect().getContentType(), aspectSpec)
-            : null;
+        operationContext.getDecodedAspect(logEvent.getAspect(), aspectSpec.getDataTemplateClass());
 
     EdgeDiff edgeDiff =
         computeAspectEdgeDiff(

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/form/FormAssignmentHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/form/FormAssignmentHook.java
@@ -101,6 +101,9 @@ public class FormAssignmentHook implements MetadataChangeLogHook {
     // 1. Get the new form assignment
     DynamicFormAssignment formFilters =
         operationContext.getDecodedAspect(event.getAspect(), DynamicFormAssignment.class);
+    if (formFilters == null) {
+      return;
+    }
 
     // 2. Register a automation to assign it.
     formService.upsertFormAssignmentRunner(operationContext, event.getEntityUrn(), formFilters);

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/form/FormAssignmentHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/form/FormAssignmentHook.java
@@ -10,7 +10,6 @@ import com.linkedin.gms.factory.auth.SystemAuthenticationFactory;
 import com.linkedin.gms.factory.form.FormServiceFactory;
 import com.linkedin.metadata.kafka.hook.MetadataChangeLogHook;
 import com.linkedin.metadata.service.FormService;
-import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.mxe.MetadataChangeLog;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Objects;
@@ -101,10 +100,7 @@ public class FormAssignmentHook implements MetadataChangeLogHook {
       @Nonnull OperationContext operationContext, @Nonnull final MetadataChangeLog event) {
     // 1. Get the new form assignment
     DynamicFormAssignment formFilters =
-        GenericRecordUtils.deserializeAspect(
-            event.getAspect().getValue(),
-            event.getAspect().getContentType(),
-            DynamicFormAssignment.class);
+        operationContext.getDecodedAspect(event.getAspect(), DynamicFormAssignment.class);
 
     // 2. Register a automation to assign it.
     formService.upsertFormAssignmentRunner(operationContext, event.getEntityUrn(), formFilters);

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/incident/IncidentsSummaryHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/incident/IncidentsSummaryHook.java
@@ -21,7 +21,6 @@ import com.linkedin.metadata.kafka.hook.HookUtils;
 import com.linkedin.metadata.kafka.hook.MetadataChangeLogHook;
 import com.linkedin.metadata.service.IncidentService;
 import com.linkedin.metadata.service.IncidentsSummaryUtils;
-import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.mxe.MetadataChangeLog;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.List;
@@ -100,11 +99,11 @@ public class IncidentsSummaryHook implements MetadataChangeLogHook {
   public void invoke(
       @Nonnull OperationContext operationContext, @Nonnull final MetadataChangeLog event)
       throws Exception {
-    if (isEnabled && isEligibleForProcessing(event)) {
+    if (isEnabled && isEligibleForProcessing(operationContext, event)) {
       log.debug("Urn {} received by Incident Summary Hook.", event.getEntityUrn());
       final Urn urn = HookUtils.getUrnFromEvent(event, operationContext.getEntityRegistry());
       // Handle the deletion case.
-      if (isIncidentSoftDeleted(event)) {
+      if (isIncidentSoftDeleted(operationContext, event)) {
         handleIncidentSoftDeleted(operationContext, urn);
       } else if (isIncidentUpdate(event)) {
         handleIncidentUpdated(operationContext, event, urn);
@@ -150,10 +149,7 @@ public class IncidentsSummaryHook implements MetadataChangeLogHook {
     if (event.getAspectName().equals(INCIDENT_INFO_ASPECT_NAME)
         && event.getPreviousAspectValue() != null) {
       previousInfo =
-          GenericRecordUtils.deserializeAspect(
-              event.getPreviousAspectValue().getValue(),
-              event.getPreviousAspectValue().getContentType(),
-              IncidentInfo.class);
+          operationContext.getDecodedAspect(event.getPreviousAspectValue(), IncidentInfo.class);
     } else {
       previousInfo = null;
     }
@@ -275,22 +271,23 @@ public class IncidentsSummaryHook implements MetadataChangeLogHook {
    * Returns true if the event should be processed, which is only true if the change is on the
    * incident status aspect
    */
-  private boolean isEligibleForProcessing(@Nonnull final MetadataChangeLog event) {
-    return isIncidentSoftDeleted(event) || isIncidentUpdate(event);
+  private boolean isEligibleForProcessing(
+      @Nonnull OperationContext operationContext, @Nonnull final MetadataChangeLog event) {
+    return isIncidentSoftDeleted(operationContext, event) || isIncidentUpdate(event);
   }
 
   /** Returns true if an incident is being soft-deleted. */
-  private boolean isIncidentSoftDeleted(@Nonnull final MetadataChangeLog event) {
+  private boolean isIncidentSoftDeleted(
+      @Nonnull OperationContext operationContext, @Nonnull final MetadataChangeLog event) {
     return INCIDENT_ENTITY_NAME.equals(event.getEntityType())
         && SUPPORTED_UPDATE_TYPES.contains(event.getChangeType())
-        && isSoftDeletionEvent(event);
+        && isSoftDeletionEvent(operationContext, event);
   }
 
-  private boolean isSoftDeletionEvent(@Nonnull final MetadataChangeLog event) {
+  private boolean isSoftDeletionEvent(
+      @Nonnull OperationContext operationContext, @Nonnull final MetadataChangeLog event) {
     if (STATUS_ASPECT_NAME.equals(event.getAspectName()) && event.getAspect() != null) {
-      final Status status =
-          GenericRecordUtils.deserializeAspect(
-              event.getAspect().getValue(), event.getAspect().getContentType(), Status.class);
+      final Status status = operationContext.getDecodedAspect(event.getAspect(), Status.class);
       return status.hasRemoved() && status.isRemoved();
     }
     return false;

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/ingestion/IngestionSchedulerHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/ingestion/IngestionSchedulerHook.java
@@ -11,7 +11,6 @@ import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.kafka.hook.MetadataChangeLogHook;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.utils.EntityKeyUtils;
-import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.mxe.MetadataChangeLog;
 import io.datahubproject.metadata.context.OperationContext;
 import javax.annotation.Nonnull;
@@ -131,20 +130,8 @@ public class IngestionSchedulerHook implements MetadataChangeLogHook {
    */
   private DataHubIngestionSourceInfo getInfoFromEvent(
       final OperationContext operationContext, final MetadataChangeLog event) {
-    EntitySpec entitySpec;
-    try {
-      entitySpec = operationContext.getEntityRegistry().getEntitySpec(event.getEntityType());
-    } catch (IllegalArgumentException e) {
-      log.error("Error while processing entity type {}: {}", event.getEntityType(), e.toString());
-      throw new RuntimeException(
-          "Failed to get Ingestion Source info from MetadataChangeLog event. Skipping processing.",
-          e);
-    }
-    return (DataHubIngestionSourceInfo)
-        GenericRecordUtils.deserializeAspect(
-            event.getAspect().getValue(),
-            event.getAspect().getContentType(),
-            entitySpec.getAspectSpec(Constants.INGESTION_INFO_ASPECT_NAME));
+    return operationContext.getDecodedAspect(
+        event.getAspect(), DataHubIngestionSourceInfo.class);
   }
 
   @VisibleForTesting

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/ingestion/IngestionSchedulerHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/ingestion/IngestionSchedulerHook.java
@@ -130,8 +130,7 @@ public class IngestionSchedulerHook implements MetadataChangeLogHook {
    */
   private DataHubIngestionSourceInfo getInfoFromEvent(
       final OperationContext operationContext, final MetadataChangeLog event) {
-    return operationContext.getDecodedAspect(
-        event.getAspect(), DataHubIngestionSourceInfo.class);
+    return operationContext.getDecodedAspect(event.getAspect(), DataHubIngestionSourceInfo.class);
   }
 
   @VisibleForTesting

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/siblings/SiblingAssociationHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/siblings/SiblingAssociationHook.java
@@ -412,23 +412,10 @@ public class SiblingAssociationHook implements MetadataChangeLogHook {
    */
   private UpstreamLineage getUpstreamLineageFromEvent(
       final OperationContext operationContext, final MetadataChangeLog event) {
-    EntitySpec entitySpec;
     if (!event.getAspectName().equals(UPSTREAM_LINEAGE_ASPECT_NAME)) {
       return null;
     }
-
-    try {
-      entitySpec = operationContext.getEntityRegistry().getEntitySpec(event.getEntityType());
-    } catch (IllegalArgumentException e) {
-      log.error("Error while processing entity type {}: {}", event.getEntityType(), e.toString());
-      throw new RuntimeException(
-          "Failed to get UpstreamLineage from MetadataChangeLog event. Skipping processing.", e);
-    }
-    return (UpstreamLineage)
-        GenericRecordUtils.deserializeAspect(
-            event.getAspect().getValue(),
-            event.getAspect().getContentType(),
-            entitySpec.getAspectSpec(UPSTREAM_LINEAGE_ASPECT_NAME));
+    return operationContext.getDecodedAspect(event.getAspect(), UpstreamLineage.class);
   }
 
   /**
@@ -437,23 +424,10 @@ public class SiblingAssociationHook implements MetadataChangeLogHook {
    */
   private SubTypes getSubtypesFromEvent(
       final OperationContext operationContext, final MetadataChangeLog event) {
-    EntitySpec entitySpec;
     if (!event.getAspectName().equals(SUB_TYPES_ASPECT_NAME)) {
       return null;
     }
-
-    try {
-      entitySpec = operationContext.getEntityRegistry().getEntitySpec(event.getEntityType());
-    } catch (IllegalArgumentException e) {
-      log.error("Error while processing entity type {}: {}", event.getEntityType(), e.toString());
-      throw new RuntimeException(
-          "Failed to get SubTypes from MetadataChangeLog event. Skipping processing.", e);
-    }
-    return (SubTypes)
-        GenericRecordUtils.deserializeAspect(
-            event.getAspect().getValue(),
-            event.getAspect().getContentType(),
-            entitySpec.getAspectSpec(SUB_TYPES_ASPECT_NAME));
+    return operationContext.getDecodedAspect(event.getAspect(), SubTypes.class);
   }
 
   @SneakyThrows

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/listener/mcl/MCLBatchKafkaListener.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/listener/mcl/MCLBatchKafkaListener.java
@@ -184,7 +184,10 @@ public class MCLBatchKafkaListener
         continue;
       }
 
-      processBatchWithHooks(slice.context(), mcls, topicName);
+      // Fresh per-slice aspect-decode cache — the slice context must not be the shared system
+      // singleton for caching purposes (leak + cross-thread race). Cache is bounded to this slice
+      // and discarded when the slice completes.
+      processBatchWithHooks(slice.context().withFreshAspectDecodeCache(), mcls, topicName);
     }
   }
 

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContext.java
@@ -293,7 +293,9 @@ public class OperationContext implements AuthorizationSession, OperationFingerpr
   // deserialized once and reused across hooks instead of re-parsed by each. Keyed by the raw aspect
   // ByteString (which distinguishes current vs previous values and dedups identical payloads) then
   // by target class. Per-operation and not shared across threads, so HashMap is safe.
-  @Builder.Default @Nonnull @Getter(AccessLevel.NONE)
+  @Builder.Default
+  @Nonnull
+  @Getter(AccessLevel.NONE)
   private final Map<ByteString, Map<Class<?>, RecordTemplate>> aspectDecodeCache =
       new java.util.HashMap<>();
 
@@ -669,12 +671,13 @@ public class OperationContext implements AuthorizationSession, OperationFingerpr
   /**
    * Deserialize a {@link GenericAspect} into the given aspect class, caching the result for the
    * lifetime of this OperationContext. Multiple {@link com.linkedin.mxe.MetadataChangeLog} hooks
-   * that process the same event share one OperationContext instance, so this parses the aspect bytes
-   * once and returns the cached instance to subsequent callers instead of re-deserializing per hook.
+   * that process the same event share one OperationContext instance, so this parses the aspect
+   * bytes once and returns the cached instance to subsequent callers instead of re-deserializing
+   * per hook.
    *
-   * <p>Returns {@code null} when {@code aspect} is {@code null} (e.g. an absent previous value). The
-   * returned {@link RecordTemplate} is shared across callers and MUST be treated as read-only; use
-   * {@link GenericRecordUtils#copy} if a mutable copy is required.
+   * <p>Returns {@code null} when {@code aspect} is {@code null} (e.g. an absent previous value).
+   * The returned {@link RecordTemplate} is shared across callers and MUST be treated as read-only;
+   * use {@link GenericRecordUtils#copy} if a mutable copy is required.
    *
    * @param aspect the generic aspect to deserialize, or null
    * @param clazz the aspect record class to deserialize into
@@ -696,6 +699,37 @@ public class OperationContext implements AuthorizationSession, OperationFingerpr
         GenericRecordUtils.deserializeAspect(aspect.getValue(), aspect.getContentType(), clazz);
     byClass.put(clazz, decoded);
     return decoded;
+  }
+
+  /**
+   * Returns a shallow copy of this context carrying a fresh, empty {@link #getDecodedAspect} cache.
+   * All other sub-contexts (including {@code pendingDeletions}) are shared by reference; only the
+   * per-message aspect-decode cache is reset.
+   *
+   * <p>The inbound event path must call this once per message so each message gets an isolated
+   * cache. The base/system OperationContext is a long-lived singleton — caching decoded aspects on
+   * it directly would accumulate for the JVM lifetime (memory leak) and be read/written by multiple
+   * consumer threads concurrently (data race). A per-message copy is thread-confined to the
+   * consumer thread processing that message and is discarded when the message completes.
+   */
+  @Nonnull
+  public OperationContext withFreshAspectDecodeCache() {
+    return new OperationContext(
+        operationContextConfig,
+        sessionActorContext,
+        systemActorContext,
+        searchContext,
+        authorizationContext,
+        entityRegistryContext,
+        servicesRegistryContext,
+        requestContext,
+        retrieverContext,
+        objectMapperContext,
+        validationContext,
+        systemTelemetryContext,
+        primaryStorageContext,
+        pendingDeletions,
+        new java.util.HashMap<>());
   }
 
   @Override

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContext.java
@@ -12,6 +12,8 @@ import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.ByteString;
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.aspect.AspectRetriever;
 import com.linkedin.metadata.graph.cache.EntityGraphCache;
 import com.linkedin.metadata.models.registry.EntityRegistry;
@@ -19,13 +21,16 @@ import com.linkedin.metadata.models.registry.LineageRegistry;
 import com.linkedin.metadata.query.LineageFlags;
 import com.linkedin.metadata.query.SearchFlags;
 import com.linkedin.metadata.utils.AuditStampUtils;
+import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
+import com.linkedin.mxe.GenericAspect;
 import com.linkedin.mxe.SystemMetadata;
 import io.datahubproject.metadata.exception.ActorAccessException;
 import io.datahubproject.metadata.exception.OperationContextException;
 import io.datahubproject.metadata.exception.TraceException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -34,6 +39,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -281,6 +287,15 @@ public class OperationContext implements AuthorizationSession, OperationFingerpr
   // This is per-operation and not shared across threads, so ArrayList is safe
   @Builder.Default @Nonnull
   private final List<Object> pendingDeletions = new java.util.ArrayList<>();
+
+  // Per-operation cache of deserialized aspects. When multiple MetadataChangeLogHooks process the
+  // same MetadataChangeLog they share a single OperationContext instance, so the aspect bytes are
+  // deserialized once and reused across hooks instead of re-parsed by each. Keyed by the raw aspect
+  // ByteString (which distinguishes current vs previous values and dedups identical payloads) then
+  // by target class. Per-operation and not shared across threads, so HashMap is safe.
+  @Builder.Default @Nonnull @Getter(AccessLevel.NONE)
+  private final Map<ByteString, Map<Class<?>, RecordTemplate>> aspectDecodeCache =
+      new java.util.HashMap<>();
 
   public OperationContext withSearchFlags(
       @Nonnull Function<SearchFlags, SearchFlags> flagDefaults) {
@@ -651,6 +666,38 @@ public class OperationContext implements AuthorizationSession, OperationFingerpr
     pendingDeletions.clear();
   }
 
+  /**
+   * Deserialize a {@link GenericAspect} into the given aspect class, caching the result for the
+   * lifetime of this OperationContext. Multiple {@link com.linkedin.mxe.MetadataChangeLog} hooks
+   * that process the same event share one OperationContext instance, so this parses the aspect bytes
+   * once and returns the cached instance to subsequent callers instead of re-deserializing per hook.
+   *
+   * <p>Returns {@code null} when {@code aspect} is {@code null} (e.g. an absent previous value). The
+   * returned {@link RecordTemplate} is shared across callers and MUST be treated as read-only; use
+   * {@link GenericRecordUtils#copy} if a mutable copy is required.
+   *
+   * @param aspect the generic aspect to deserialize, or null
+   * @param clazz the aspect record class to deserialize into
+   * @return the (cached) deserialized aspect, or null if {@code aspect} is null
+   */
+  @Nullable
+  public <T extends RecordTemplate> T getDecodedAspect(
+      @Nullable GenericAspect aspect, @Nonnull Class<T> clazz) {
+    if (aspect == null) {
+      return null;
+    }
+    Map<Class<?>, RecordTemplate> byClass =
+        aspectDecodeCache.computeIfAbsent(aspect.getValue(), k -> new java.util.HashMap<>());
+    RecordTemplate cached = byClass.get(clazz);
+    if (cached != null) {
+      return clazz.cast(cached);
+    }
+    T decoded =
+        GenericRecordUtils.deserializeAspect(aspect.getValue(), aspect.getContentType(), clazz);
+    byClass.put(clazz, decoded);
+    return decoded;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -741,7 +788,8 @@ public class OperationContext implements AuthorizationSession, OperationFingerpr
               this.primaryStorageContext != null
                   ? this.primaryStorageContext
                   : PrimaryStorageContext.EMPTY,
-              new java.util.ArrayList<>());
+              new java.util.ArrayList<>(),
+              new java.util.HashMap<>());
 
       if (!sessionActor.isActive(authContext, retriever)) {
         throw new ActorAccessException("Actor is not active");

--- a/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/OperationContextTest.java
+++ b/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/OperationContextTest.java
@@ -11,7 +11,10 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 import com.datahub.authentication.Actor;
@@ -20,11 +23,14 @@ import com.datahub.authentication.Authentication;
 import com.datahub.authorization.SessionActorIdentity;
 import com.datahub.plugins.auth.authorization.Authorizer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.common.Status;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.metadata.aspect.AspectRetriever;
 import com.linkedin.metadata.aspect.CachingAspectRetriever;
 import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.GenericAspect;
 import com.linkedin.mxe.SystemMetadata;
 import io.datahubproject.metadata.exception.ActorAccessException;
 import io.datahubproject.metadata.services.RestrictedService;
@@ -428,6 +434,39 @@ public class OperationContextTest {
             false);
 
     assertEquals(opContext.getPrimaryStorageContext(), storageContext);
+  }
+
+  @Test
+  public void getDecodedAspect_cachesPerContext() {
+    OperationContext opContext = TestOperationContexts.systemContextNoValidate();
+    GenericAspect aspect = GenericRecordUtils.serializeAspect(new Status().setRemoved(true));
+
+    Status first = opContext.getDecodedAspect(aspect, Status.class);
+    Status second = opContext.getDecodedAspect(aspect, Status.class);
+
+    assertTrue(first.isRemoved());
+    assertSame(
+        first, second, "Repeat decode of the same aspect should return the cached instance");
+  }
+
+  @Test
+  public void getDecodedAspect_nullAspectReturnsNull() {
+    OperationContext opContext = TestOperationContexts.systemContextNoValidate();
+    assertNull(opContext.getDecodedAspect(null, Status.class));
+  }
+
+  @Test
+  public void getDecodedAspect_distinctPayloadsDecodeSeparately() {
+    OperationContext opContext = TestOperationContexts.systemContextNoValidate();
+    GenericAspect current = GenericRecordUtils.serializeAspect(new Status().setRemoved(true));
+    GenericAspect previous = GenericRecordUtils.serializeAspect(new Status().setRemoved(false));
+
+    Status decodedCurrent = opContext.getDecodedAspect(current, Status.class);
+    Status decodedPrevious = opContext.getDecodedAspect(previous, Status.class);
+
+    assertNotSame(decodedCurrent, decodedPrevious);
+    assertTrue(decodedCurrent.isRemoved());
+    assertFalse(decodedPrevious.isRemoved());
   }
 
   private OperationContext buildTraceMock() {

--- a/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/OperationContextTest.java
+++ b/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/OperationContextTest.java
@@ -445,8 +445,7 @@ public class OperationContextTest {
     Status second = opContext.getDecodedAspect(aspect, Status.class);
 
     assertTrue(first.isRemoved());
-    assertSame(
-        first, second, "Repeat decode of the same aspect should return the cached instance");
+    assertSame(first, second, "Repeat decode of the same aspect should return the cached instance");
   }
 
   @Test
@@ -467,6 +466,24 @@ public class OperationContextTest {
     assertNotSame(decodedCurrent, decodedPrevious);
     assertTrue(decodedCurrent.isRemoved());
     assertFalse(decodedPrevious.isRemoved());
+  }
+
+  @Test
+  public void withFreshAspectDecodeCache_isolatesCachePerCopy() {
+    OperationContext base = TestOperationContexts.systemContextNoValidate();
+    GenericAspect aspect = GenericRecordUtils.serializeAspect(new Status().setRemoved(true));
+
+    OperationContext msg1 = base.withFreshAspectDecodeCache();
+    OperationContext msg2 = base.withFreshAspectDecodeCache();
+
+    Status a = msg1.getDecodedAspect(aspect, Status.class);
+    Status aAgain = msg1.getDecodedAspect(aspect, Status.class);
+    Status b = msg2.getDecodedAspect(aspect, Status.class);
+
+    assertSame(a, aAgain, "Same per-message context reuses its cached instance");
+    assertNotSame(
+        a, b, "Distinct per-message copies must have independent caches (no shared singleton)");
+    assertEquals(msg1, base, "Copy shares all identity-bearing sub-contexts with the base");
   }
 
   private OperationContext buildTraceMock() {


### PR DESCRIPTION
## Summary

Two independent per-message optimizations on the MCL consumer hot path:

1. **`PlatformEventGeneratorHook` — skip work for non-relationship aspects (the realized win).**
   The relationship path now returns early when `aspectSpec.getRelationshipFieldSpecs().isEmpty()`,
   skipping both deserialization and the edge diff for aspects that can never produce edge changes —
   the common case on every MCL. `entityExclusions` also changes `List` → `Set` for O(1) membership
   in the hot filter.

2. **Per-message aspect-decode cache on `OperationContext` (enabling infrastructure).**
   Adds `getDecodedAspect(GenericAspect, Class<T>)`, which deserializes an aspect once and reuses the
   result for the lifetime of a single per-message (or per-batch) context. This dedups repeat decodes
   of the *same* aspect and lays the groundwork for cross-hook reuse.

## Scope / expected impact (honest framing)

- The concrete, unconditional CPU win in this PR is **#1** (the relationship gating), which runs on
  every MCL regardless of hook set.
- The cache (**#2**) currently sees little cross-hook reuse: the hooks migrated here decode
  **disjoint** aspect types (`UpstreamLineage`, `SubTypes`, `IncidentInfo`, `Status`,
  `DynamicFormAssignment`, `DataHubIngestionSourceInfo`), each gated by `aspectName`, so for a given
  MCL usually only one fires. The larger reuse — a single aspect decoded by many hooks
  (e.g. `assertionRunEvent` across index/graph/timeseries hooks) — lives in downstream hooks not in
  this repo; those will migrate to `getDecodedAspect` separately. Until then the cache is primarily
  scaffolding plus within-`invoke` dedup.
- **This is not an OOM fix.** It reduces redundant JSON parsing (GC/allocation churn), not peak heap.
  On the batch path the cache retains decoded aspects for the slice lifetime, so with distinct
  aspects it can raise the high-water mark rather than lower it (see follow-ups).

## Changes

**`metadata-operation-context`**
- `OperationContext.getDecodedAspect(GenericAspect, Class<T>)`: deserialize once, cache for the
  context lifetime, return the cached instance on repeat calls. Backed by a per-operation map
  (`ByteString` → `Class` → `RecordTemplate`), excluded from `equals`/`hashCode`. Returns `null` for
  a `null` aspect.
- The returned `RecordTemplate` is **shared** and documented read-only; callers that mutate must use
  `GenericRecordUtils.copy(...)`.
- `OperationContext.withFreshAspectDecodeCache()`: shallow copy carrying a fresh, empty cache. The
  system `OperationContext` is a long-lived singleton — caching on it directly would leak for the JVM
  lifetime and race across consumer threads. Every inbound ingress path builds a per-message /
  per-batch copy so the cache is thread-confined and discarded when the unit of work completes.

**Ingress wiring — fresh cache at every hook-invocation entry point**
- Single-message Kafka: `AbstractKafkaListener` — `resolve(...).withFreshAspectDecodeCache()`.
- Batch Kafka: `MCLBatchKafkaListener` — `slice.context().withFreshAspectDecodeCache()`.
- pgQueue poller: `PgQueueMaePollerSourcesConfiguration` — `systemOperationContext.withFreshAspectDecodeCache()`.

**Hook migrations (`mae-consumer`)** — decode via the cache instead of `deserializeAspect`:
- `SiblingAssociationHook` (`UpstreamLineage`, `SubTypes`) — also drops a redundant per-call
  `EntityRegistry` lookup.
- `IncidentsSummaryHook` (`IncidentInfo`, `Status`)
- `IngestionSchedulerHook` (`DataHubIngestionSourceInfo`)
- `FormAssignmentHook` (`DynamicFormAssignment`)
- `PlatformEventGeneratorHook` relationship path (`getPreviousAspectValue`/`getAspect`)

**`PlatformEventGeneratorHook` — per-message wins (see #1 above)**
- Relationship path gated by `aspectSpec.getRelationshipFieldSpecs().isEmpty()`.
- `entityExclusions` `List` → `Set`.
- The **change-event** path (`getChangeEvents`) intentionally does **not** use the cache and decodes
  fresh — its downstream generators (e.g. `SchemaMetadataChangeEventGenerator.sortFieldsByPath`)
  mutate the aspect in place, which would corrupt a shared cached instance.

## Safety

`getDecodedAspect` returns a shared instance, so a caller mutating the decoded aspect would corrupt
it for later hooks within the same message. Every migrated hook treats the decoded aspect as
read-only (read / diff / build new objects). The only in-place mutator on this path is the
schema-metadata change-event generator, which is why the change-event path decodes fresh.

## Testing

- New `OperationContextTest` cases: repeat decode returns the same cached instance; `null` aspect
  returns `null`; distinct payloads decode to distinct instances; `withFreshAspectDecodeCache`
  produces independent caches per copy while sharing identity-bearing sub-contexts.
- `./gradlew :metadata-operation-context:test :metadata-jobs:mae-consumer:compileJava`

## Notes / follow-ups

- **Realize the cache benefit:** migrate the heavy multi-hook decoders (index/graph/timeseries,
  assertion hooks) to `getDecodedAspect` — that is where an aspect is decoded by many hooks and the
  cache actually pays off.
- **Batch memory:** consider scoping the cache **per-MCL** (reset between MCLs inside `invokeBatch`)
  rather than per-slice, so the batch path keeps within-MCL dedup without raising the retained-object
  high-water mark.
