### PR TITLE
feat(ingestion): add S3-backed CLI version matrix source

### DIFF
--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -89,7 +89,10 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           // (e.g. "token ghp_xxx" for a private GitHub repo, "Bearer ey..." for OIDC). Property
           // name intentionally ends with "Token" so PropertiesCollector's keyword-based redaction
           // catches it without needing a new keyword in SENSITIVE_PATTERNS.
-          "ingestion.cliVersionMatrix.http.authToken");
+          "ingestion.cliVersionMatrix.http.authToken",
+          // S3 object key for the CLI version matrix JSON. Property name ends with "key" which
+          // triggers keyword-based redaction — classified SENSITIVE to match that behaviour.
+          "ingestion.cliVersionMatrix.s3.key");
 
   /**
    * Template patterns for sensitive properties that contain dynamic parts. Use [*] for numeric
@@ -794,6 +797,8 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "ingestion.maxSerializedStringLength",
           "ingestion.cliVersionMatrix.http.refreshSeconds",
           "ingestion.cliVersionMatrix.http.url",
+          "ingestion.cliVersionMatrix.s3.bucket",
+          "ingestion.cliVersionMatrix.s3.refreshSeconds",
           "ingestion.cliVersionMatrix.source",
           "ingestionMetrics.enabled",
           "ingestionScheduler.consumerGroupSuffix",

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/CliVersionMatrixConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/CliVersionMatrixConfiguration.java
@@ -19,6 +19,8 @@ public class CliVersionMatrixConfiguration {
    * <ul>
    *   <li>{@code "http"} (default) — fetch the matrix over HTTP using {@link #http}. When the URL
    *       in that block is empty, the factory wires a no-op source.
+   *   <li>{@code "s3"} — read the matrix from an S3 object using {@link #s3}. When the bucket is
+   *       empty or no S3 client is available, the factory wires a no-op source.
    *   <li>{@code "none"} — explicit kill-switch that wins even when an {@code http.url} is set.
    * </ul>
    */
@@ -26,4 +28,7 @@ public class CliVersionMatrixConfiguration {
 
   /** Configuration for the HTTP-fetched matrix backend. */
   private HttpMatrixSourceConfiguration http;
+
+  /** Configuration for the S3-fetched matrix backend. */
+  private S3MatrixSourceConfiguration s3;
 }

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/S3MatrixSourceConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/S3MatrixSourceConfiguration.java
@@ -1,0 +1,30 @@
+package com.linkedin.metadata.config;
+
+import lombok.Data;
+
+/**
+ * S3-fetched ingestion CLI version matrix configuration. Bound under {@code
+ * ingestion.cliVersionMatrix.s3} in application.yaml. Selected when {@code
+ * ingestion.cliVersionMatrix.source} is {@code "s3"}.
+ *
+ * <p>Reads the matrix object from a (typically private) S3 bucket using GMS's ambient AWS
+ * credentials — the pod's IAM role, resolved by the shared {@code s3Util} bean. Unlike the HTTP
+ * source, the bucket needs no public-read or static token: each request is SigV4-signed, so the
+ * bucket can stay private and be shared cross-account via bucket policy. Region/credentials are
+ * taken from the {@code s3Util} bean's configuration ({@code AWS_REGION} / {@code
+ * datahub.s3.roleArn}), so they are not repeated here.
+ */
+@Data
+public class S3MatrixSourceConfiguration {
+
+  /**
+   * S3 bucket holding the matrix JSON object. When empty, the factory wires a no-op matrix source.
+   */
+  private String bucket;
+
+  /** Object key of the matrix JSON within the bucket (e.g. {@code matrix.json}). */
+  private String key;
+
+  /** How often (in seconds) to re-fetch the matrix. Defaults to 600 (10 minutes). */
+  private int refreshSeconds;
+}

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/ingestion/HttpUrlIngestionCliVersionMatrixSource.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/ingestion/HttpUrlIngestionCliVersionMatrixSource.java
@@ -9,18 +9,11 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
@@ -62,47 +55,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class HttpUrlIngestionCliVersionMatrixSource implements IngestionCliVersionMatrixSource {
 
-  private static final String DEFAULT_FIELD = "_default";
-  private static final String COHORTS_FIELD = "cohorts";
-  private static final String VERSION_FIELD = "version";
-  private static final String DEPLOYMENTS_FIELD = "deployments";
   private static final int FETCH_TIMEOUT_MS = 10_000;
-
-  /**
-   * Permissive cleanliness check for version strings — NOT a PEP 440 validator. The regex accepts
-   * any non-empty string composed of alphanumerics, underscore, dot, plus, exclamation, and hyphen.
-   * We deliberately do not parse semantic version structure (release segments, pre / post / dev
-   * tags, local version identifier) because pip is the source of truth: any string that passes here
-   * but isn't a real PyPI release surfaces a clear "No matching distribution" error from pip at
-   * install time. This check exists so operator fat-fingering of the matrix file (pasting HTML,
-   * whitespace, JSON) produces a structured WARN at fetch time rather than a cryptic pip error
-   * minutes later on every execution.
-   *
-   * <p>Accepts every shape DataHub publishes to PyPI today:
-   *
-   * <ul>
-   *   <li>{@code 1.5.0.5}, {@code 1.4.0.3} — standard release
-   *   <li>{@code 1.5.0.6rc1} — release candidate
-   *   <li>{@code 1.5.0.13.post1} — post-release
-   *   <li>{@code 1!0.0.0.dev0} — PEP 440 epoch + dev tag
-   *   <li>{@code acryl-1.6.0+acryl.20251031} — internal build with local version identifier
-   * </ul>
-   *
-   * <p>Also accepts the special non-PyPI version sentinels the ingestion executor recognizes —
-   * these are not PEP 440 / PyPI versions and must <em>not</em> be rejected. This list is not
-   * exhaustive; the permissive character class is intentional so future sentinels keep working
-   * without a code change here. Known examples:
-   *
-   * <ul>
-   *   <li>{@code bundled} — run the CLI bundled in the executor image, skipping the pip install
-   *   <li>{@code no-acryl-datahub} — opt out of installing acryl-datahub (the recipe pulls it in
-   *       transitively)
-   * </ul>
-   *
-   * <p>Rejects: whitespace, embedded JSON like {@code {"version":"…"}}, HTML fragments, URLs,
-   * anything containing characters outside the allowed set.
-   */
-  private static final Pattern VALID_VERSION_PATTERN = Pattern.compile("^[\\w.+!-]+$");
 
   /** Seconds to wait for the refresh thread to drain on graceful shutdown. */
   private static final int SHUTDOWN_TIMEOUT_SECONDS = 5;
@@ -219,7 +172,7 @@ public class HttpUrlIngestionCliVersionMatrixSource implements IngestionCliVersi
         JsonNode root = objectMapper.readTree(is);
         IngestionCliVersionMatrix parsed;
         try {
-          parsed = parseMatrix(root);
+          parsed = IngestionCliVersionMatrixParser.parseMatrix(root);
         } catch (IllegalArgumentException schemaError) {
           // File-level schema violation (e.g. root not a JSON object). Refuse to swap the cache
           // — operator gets a fix-this-now WARN while in-flight resolutions continue to use the
@@ -251,194 +204,5 @@ public class HttpUrlIngestionCliVersionMatrixSource implements IngestionCliVersi
           url,
           e);
     }
-  }
-
-  /**
-   * Parses the nested schema into an {@link IngestionCliVersionMatrix} with two layers of
-   * validation:
-   *
-   * <ul>
-   *   <li><b>File-level (fail closed)</b>: if the root isn't a JSON object, throws {@link
-   *       IllegalArgumentException}. The caller refuses to swap the cache and the last-known-good
-   *       matrix continues to serve resolutions. Prevents a malformed file from blanking everyone.
-   *   <li><b>Entry-level (fail open + log)</b>: individual malformed connector entries / cohorts /
-   *       version strings are skipped with structured WARN logs that name the offending path
-   *       ({@code server='X' connector='Y' cohort[N]}). Good entries around the bad one are kept,
-   *       so a single typo doesn't take the whole matrix down.
-   * </ul>
-   *
-   * <p>Package-private so tests can drive it directly with arbitrary {@link JsonNode} input.
-   */
-  static IngestionCliVersionMatrix parseMatrix(JsonNode root) {
-    if (root == null || !root.isObject()) {
-      throw new IllegalArgumentException(
-          "matrix root must be a JSON object, got: "
-              + (root == null ? "null" : root.getNodeType().toString().toLowerCase()));
-    }
-
-    Map<String, ServerEntry> entries = new HashMap<>();
-    root.fields()
-        .forEachRemaining(
-            serverEntry -> {
-              String serverVersion = serverEntry.getKey();
-              JsonNode serverValue = serverEntry.getValue();
-              if (!serverValue.isObject()) {
-                log.warn(
-                    "Skipping malformed matrix entry: server='{}' value is not an object (got {})",
-                    serverVersion,
-                    serverValue.getNodeType().toString().toLowerCase());
-                return;
-              }
-              Map<String, ConnectorEntry> connectors = new HashMap<>();
-              serverValue
-                  .fields()
-                  .forEachRemaining(
-                      connectorEntry -> {
-                        String connector = connectorEntry.getKey();
-                        ConnectorEntry parsed =
-                            parseConnectorEntry(
-                                serverVersion, connector, connectorEntry.getValue());
-                        if (parsed != null) {
-                          connectors.put(connector, parsed);
-                        }
-                      });
-              entries.put(serverVersion, new ServerEntry(connectors));
-            });
-    return new IngestionCliVersionMatrix(entries);
-  }
-
-  /**
-   * Parses a single connector entry. Returns {@code null} if the entry's structure is wholly
-   * malformed (not a JSON object) — caller drops that connector. Bad sub-fields ({@code _default},
-   * {@code cohorts}) are logged and either ignored or skipped while keeping the rest of the entry.
-   */
-  @Nullable
-  private static ConnectorEntry parseConnectorEntry(
-      String serverVersion, String connector, JsonNode connectorNode) {
-    if (!connectorNode.isObject()) {
-      log.warn(
-          "Skipping malformed matrix entry: server='{}' connector='{}' value is not an object (got {})",
-          serverVersion,
-          connector,
-          connectorNode.getNodeType().toString().toLowerCase());
-      return null;
-    }
-
-    JsonNode defaultNode = connectorNode.path(DEFAULT_FIELD);
-    String defaultVersion = null;
-    if (!defaultNode.isMissingNode() && !defaultNode.isNull()) {
-      if (!defaultNode.isTextual()) {
-        log.warn(
-            "Ignoring non-textual '_default' value: server='{}' connector='{}' (got {})",
-            serverVersion,
-            connector,
-            defaultNode.getNodeType().toString().toLowerCase());
-      } else {
-        String candidate = defaultNode.asText();
-        if (isValidVersion(candidate)) {
-          defaultVersion = candidate;
-        } else {
-          log.warn(
-              "Ignoring invalid '_default' version: server='{}' connector='{}' version='{}'. "
-                  + "Cohort matches still apply; this connector will fall through to "
-                  + "APPLICATION_DEFAULT when no cohort matches.",
-              serverVersion,
-              connector,
-              candidate);
-        }
-      }
-    }
-
-    List<Cohort> cohorts = new ArrayList<>();
-    JsonNode cohortsNode = connectorNode.path(COHORTS_FIELD);
-    if (cohortsNode.isArray()) {
-      int index = 0;
-      for (JsonNode cohortNode : cohortsNode) {
-        Cohort cohort = parseCohort(serverVersion, connector, index, cohortNode);
-        if (cohort != null) {
-          cohorts.add(cohort);
-        }
-        index++;
-      }
-    } else if (!cohortsNode.isMissingNode() && !cohortsNode.isNull()) {
-      log.warn(
-          "Skipping malformed 'cohorts' field: server='{}' connector='{}' cohorts is not an array (got {})",
-          serverVersion,
-          connector,
-          cohortsNode.getNodeType().toString().toLowerCase());
-    }
-    return new ConnectorEntry(defaultVersion, cohorts);
-  }
-
-  /**
-   * Parses a single cohort entry. Returns {@code null} if the cohort is unusable (missing or
-   * invalid {@code version}). Other malformed sub-fields are logged but don't drop the cohort.
-   */
-  @Nullable
-  private static Cohort parseCohort(
-      String serverVersion, String connector, int cohortIndex, JsonNode cohortNode) {
-    if (!cohortNode.isObject()) {
-      log.warn(
-          "Skipping malformed cohort: server='{}' connector='{}' cohort[{}] is not an object",
-          serverVersion,
-          connector,
-          cohortIndex);
-      return null;
-    }
-
-    JsonNode versionNode = cohortNode.path(VERSION_FIELD);
-    if (versionNode.isMissingNode() || versionNode.isNull() || !versionNode.isTextual()) {
-      log.warn(
-          "Skipping malformed cohort: server='{}' connector='{}' cohort[{}] missing or non-textual 'version'",
-          serverVersion,
-          connector,
-          cohortIndex);
-      return null;
-    }
-    String version = versionNode.asText();
-    if (!isValidVersion(version)) {
-      log.warn(
-          "Skipping malformed cohort: server='{}' connector='{}' cohort[{}] has invalid version '{}'",
-          serverVersion,
-          connector,
-          cohortIndex,
-          version);
-      return null;
-    }
-
-    Set<String> deployments = new HashSet<>();
-    JsonNode deploymentsNode = cohortNode.path(DEPLOYMENTS_FIELD);
-    if (deploymentsNode.isArray()) {
-      for (JsonNode d : deploymentsNode) {
-        if (d.isTextual()) {
-          deployments.add(d.asText());
-        } else {
-          log.warn(
-              "Ignoring non-string deployment entry: server='{}' connector='{}' cohort[{}] (got {})",
-              serverVersion,
-              connector,
-              cohortIndex,
-              d.getNodeType().toString().toLowerCase());
-        }
-      }
-    } else if (!deploymentsNode.isMissingNode() && !deploymentsNode.isNull()) {
-      log.warn(
-          "Ignoring malformed 'deployments' field: server='{}' connector='{}' cohort[{}] is not an array (got {})",
-          serverVersion,
-          connector,
-          cohortIndex,
-          deploymentsNode.getNodeType().toString().toLowerCase());
-    }
-    return new Cohort(version, deployments);
-  }
-
-  /**
-   * Returns {@code true} if {@code s} is a non-empty string matching {@link
-   * #VALID_VERSION_PATTERN}. Permissive — allows weird-but-valid PyPI versions like {@code
-   * "1.5.0.6rc1"} or {@code "1!0.0.0.dev0"} — but rejects whitespace, embedded markup, and other
-   * shapes that obviously aren't versions.
-   */
-  private static boolean isValidVersion(String s) {
-    return s != null && !s.isEmpty() && VALID_VERSION_PATTERN.matcher(s).matches();
   }
 }

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/ingestion/IngestionCliVersionMatrixParser.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/ingestion/IngestionCliVersionMatrixParser.java
@@ -1,0 +1,257 @@
+package com.linkedin.metadata.ingestion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Parses the nested per-connector ingestion CLI version matrix JSON into an {@link
+ * IngestionCliVersionMatrix}.
+ *
+ * <p>Shared by every {@link IngestionCliVersionMatrixSource} implementation (HTTP, S3, …) so the
+ * schema, validation rules, and version sanity-checking live in exactly one place rather than being
+ * copied per backend.
+ *
+ * <p>Validation has two layers:
+ *
+ * <ul>
+ *   <li><b>File-level (fail closed)</b>: if the root isn't a JSON object, {@link #parseMatrix}
+ *       throws {@link IllegalArgumentException}. Callers refuse to swap their cache and the
+ *       last-known-good matrix continues to serve resolutions. Prevents a malformed file from
+ *       blanking everyone.
+ *   <li><b>Entry-level (fail open + log)</b>: individual malformed connector entries / cohorts /
+ *       version strings are skipped with structured WARN logs that name the offending path ({@code
+ *       server='X' connector='Y' cohort[N]}). Good entries around the bad one are kept, so a single
+ *       typo doesn't take the whole matrix down.
+ * </ul>
+ */
+@Slf4j
+public final class IngestionCliVersionMatrixParser {
+
+  private static final String DEFAULT_FIELD = "_default";
+  private static final String COHORTS_FIELD = "cohorts";
+  private static final String VERSION_FIELD = "version";
+  private static final String DEPLOYMENTS_FIELD = "deployments";
+
+  /**
+   * Permissive cleanliness check for version strings — NOT a PEP 440 validator. The regex accepts
+   * any non-empty string composed of alphanumerics, underscore, dot, plus, exclamation, and hyphen.
+   * We deliberately do not parse semantic version structure (release segments, pre / post / dev
+   * tags, local version identifier) because pip is the source of truth: any string that passes here
+   * but isn't a real PyPI release surfaces a clear "No matching distribution" error from pip at
+   * install time. This check exists so operator fat-fingering of the matrix file (pasting HTML,
+   * whitespace, JSON) produces a structured WARN at fetch time rather than a cryptic pip error
+   * minutes later on every execution.
+   *
+   * <p>Accepts every shape DataHub publishes to PyPI today:
+   *
+   * <ul>
+   *   <li>{@code 1.5.0.5}, {@code 1.4.0.3} — standard release
+   *   <li>{@code 1.5.0.6rc1} — release candidate
+   *   <li>{@code 1.5.0.13.post1} — post-release
+   *   <li>{@code 1!0.0.0.dev0} — PEP 440 epoch + dev tag
+   *   <li>{@code acryl-1.6.0+acryl.20251031} — internal build with local version identifier
+   * </ul>
+   *
+   * <p>Also accepts the special non-PyPI version sentinels the ingestion executor recognizes —
+   * these are not PEP 440 / PyPI versions and must <em>not</em> be rejected. This list is not
+   * exhaustive; the permissive character class is intentional so future sentinels keep working
+   * without a code change here. Known examples:
+   *
+   * <ul>
+   *   <li>{@code bundled} — run the CLI bundled in the executor image, skipping the pip install
+   *   <li>{@code no-acryl-datahub} — opt out of installing acryl-datahub (the recipe pulls it in
+   *       transitively)
+   * </ul>
+   *
+   * <p>Rejects: whitespace, embedded JSON like {@code {"version":"…"}}, HTML fragments, URLs,
+   * anything containing characters outside the allowed set.
+   */
+  private static final Pattern VALID_VERSION_PATTERN = Pattern.compile("^[\\w.+!-]+$");
+
+  private IngestionCliVersionMatrixParser() {}
+
+  /**
+   * Parses the nested schema into an {@link IngestionCliVersionMatrix}. See the class javadoc for
+   * the two-layer (file-level fail-closed, entry-level fail-open + log) validation strategy.
+   */
+  public static IngestionCliVersionMatrix parseMatrix(JsonNode root) {
+    if (root == null || !root.isObject()) {
+      throw new IllegalArgumentException(
+          "matrix root must be a JSON object, got: "
+              + (root == null ? "null" : root.getNodeType().toString().toLowerCase()));
+    }
+
+    Map<String, ServerEntry> entries = new HashMap<>();
+    root.fields()
+        .forEachRemaining(
+            serverEntry -> {
+              String serverVersion = serverEntry.getKey();
+              JsonNode serverValue = serverEntry.getValue();
+              if (!serverValue.isObject()) {
+                log.warn(
+                    "Skipping malformed matrix entry: server='{}' value is not an object (got {})",
+                    serverVersion,
+                    serverValue.getNodeType().toString().toLowerCase());
+                return;
+              }
+              Map<String, ConnectorEntry> connectors = new HashMap<>();
+              serverValue
+                  .fields()
+                  .forEachRemaining(
+                      connectorEntry -> {
+                        String connector = connectorEntry.getKey();
+                        ConnectorEntry parsed =
+                            parseConnectorEntry(
+                                serverVersion, connector, connectorEntry.getValue());
+                        if (parsed != null) {
+                          connectors.put(connector, parsed);
+                        }
+                      });
+              entries.put(serverVersion, new ServerEntry(connectors));
+            });
+    return new IngestionCliVersionMatrix(entries);
+  }
+
+  /**
+   * Parses a single connector entry. Returns {@code null} if the entry's structure is wholly
+   * malformed (not a JSON object) — caller drops that connector. Bad sub-fields ({@code _default},
+   * {@code cohorts}) are logged and either ignored or skipped while keeping the rest of the entry.
+   */
+  @Nullable
+  private static ConnectorEntry parseConnectorEntry(
+      String serverVersion, String connector, JsonNode connectorNode) {
+    if (!connectorNode.isObject()) {
+      log.warn(
+          "Skipping malformed matrix entry: server='{}' connector='{}' value is not an object (got {})",
+          serverVersion,
+          connector,
+          connectorNode.getNodeType().toString().toLowerCase());
+      return null;
+    }
+
+    JsonNode defaultNode = connectorNode.path(DEFAULT_FIELD);
+    String defaultVersion = null;
+    if (!defaultNode.isMissingNode() && !defaultNode.isNull()) {
+      if (!defaultNode.isTextual()) {
+        log.warn(
+            "Ignoring non-textual '_default' value: server='{}' connector='{}' (got {})",
+            serverVersion,
+            connector,
+            defaultNode.getNodeType().toString().toLowerCase());
+      } else {
+        String candidate = defaultNode.asText();
+        if (isValidVersion(candidate)) {
+          defaultVersion = candidate;
+        } else {
+          log.warn(
+              "Ignoring invalid '_default' version: server='{}' connector='{}' version='{}'. "
+                  + "Cohort matches still apply; this connector will fall through to "
+                  + "APPLICATION_DEFAULT when no cohort matches.",
+              serverVersion,
+              connector,
+              candidate);
+        }
+      }
+    }
+
+    List<Cohort> cohorts = new ArrayList<>();
+    JsonNode cohortsNode = connectorNode.path(COHORTS_FIELD);
+    if (cohortsNode.isArray()) {
+      int index = 0;
+      for (JsonNode cohortNode : cohortsNode) {
+        Cohort cohort = parseCohort(serverVersion, connector, index, cohortNode);
+        if (cohort != null) {
+          cohorts.add(cohort);
+        }
+        index++;
+      }
+    } else if (!cohortsNode.isMissingNode() && !cohortsNode.isNull()) {
+      log.warn(
+          "Skipping malformed 'cohorts' field: server='{}' connector='{}' cohorts is not an array (got {})",
+          serverVersion,
+          connector,
+          cohortsNode.getNodeType().toString().toLowerCase());
+    }
+    return new ConnectorEntry(defaultVersion, cohorts);
+  }
+
+  /**
+   * Parses a single cohort entry. Returns {@code null} if the cohort is unusable (missing or
+   * invalid {@code version}). Other malformed sub-fields are logged but don't drop the cohort.
+   */
+  @Nullable
+  private static Cohort parseCohort(
+      String serverVersion, String connector, int cohortIndex, JsonNode cohortNode) {
+    if (!cohortNode.isObject()) {
+      log.warn(
+          "Skipping malformed cohort: server='{}' connector='{}' cohort[{}] is not an object",
+          serverVersion,
+          connector,
+          cohortIndex);
+      return null;
+    }
+
+    JsonNode versionNode = cohortNode.path(VERSION_FIELD);
+    if (versionNode.isMissingNode() || versionNode.isNull() || !versionNode.isTextual()) {
+      log.warn(
+          "Skipping malformed cohort: server='{}' connector='{}' cohort[{}] missing or non-textual 'version'",
+          serverVersion,
+          connector,
+          cohortIndex);
+      return null;
+    }
+    String version = versionNode.asText();
+    if (!isValidVersion(version)) {
+      log.warn(
+          "Skipping malformed cohort: server='{}' connector='{}' cohort[{}] has invalid version '{}'",
+          serverVersion,
+          connector,
+          cohortIndex,
+          version);
+      return null;
+    }
+
+    Set<String> deployments = new HashSet<>();
+    JsonNode deploymentsNode = cohortNode.path(DEPLOYMENTS_FIELD);
+    if (deploymentsNode.isArray()) {
+      for (JsonNode d : deploymentsNode) {
+        if (d.isTextual()) {
+          deployments.add(d.asText());
+        } else {
+          log.warn(
+              "Ignoring non-string deployment entry: server='{}' connector='{}' cohort[{}] (got {})",
+              serverVersion,
+              connector,
+              cohortIndex,
+              d.getNodeType().toString().toLowerCase());
+        }
+      }
+    } else if (!deploymentsNode.isMissingNode() && !deploymentsNode.isNull()) {
+      log.warn(
+          "Ignoring malformed 'deployments' field: server='{}' connector='{}' cohort[{}] is not an array (got {})",
+          serverVersion,
+          connector,
+          cohortIndex,
+          deploymentsNode.getNodeType().toString().toLowerCase());
+    }
+    return new Cohort(version, deployments);
+  }
+
+  /**
+   * Returns {@code true} if {@code s} is a non-empty string matching {@link
+   * #VALID_VERSION_PATTERN}. Permissive — allows weird-but-valid PyPI versions like {@code
+   * "1.5.0.6rc1"} or {@code "1!0.0.0.dev0"} — but rejects whitespace, embedded markup, and other
+   * shapes that obviously aren't versions.
+   */
+  private static boolean isValidVersion(String s) {
+    return s != null && !s.isEmpty() && VALID_VERSION_PATTERN.matcher(s).matches();
+  }
+}

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -108,8 +108,8 @@ ingestion:
   # basis. Update the matrix file externally (S3/CDN/gist) without redeploying GMS to change
   # connector versions. Set source=none (or leave url empty) to disable.
   cliVersionMatrix:
-    # Source backend: "http" (default) or "none". Setting "none" is an explicit kill-switch even
-    # when an http.url is configured. With "http" but no url, the factory wires a no-op source.
+    # Source backend: "http" (default), "s3", or "none". Setting "none" is an explicit kill-switch
+    # even when an http.url is configured. With "http" but no url, the factory wires a no-op source.
     source: "${INGESTION_VERSION_MATRIX_SOURCE:http}"
     http:
       url: "${INGESTION_VERSION_MATRIX_URL:}"
@@ -122,6 +122,10 @@ ingestion:
       # Leave unset for public URLs. Property name ends with "Token" so it is auto-redacted in
       # system-info.
       authToken: "${INGESTION_VERSION_MATRIX_AUTH_TOKEN:}"
+    s3:
+      bucket: "${INGESTION_VERSION_MATRIX_S3_BUCKET:}"
+      key: "${INGESTION_VERSION_MATRIX_S3_KEY:matrix.json}"
+      refreshSeconds: ${INGESTION_VERSION_MATRIX_S3_REFRESH_SECONDS:600}
   # Identifier for this deployment, used for matching against `deployments` allowlists in the
   # version matrix. Sourced from DATAHUB_EXECUTOR_CUSTOMER_ID, which the Acryl Cloud Helm chart
   # injects from the K8s namespace. Empty in single-tenant / OSS deployments — cohort matching

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/ingestion/IngestionCliVersionMatrixParserTest.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/ingestion/IngestionCliVersionMatrixParserTest.java
@@ -1,0 +1,200 @@
+package com.linkedin.metadata.ingestion;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.Test;
+
+/**
+ * Direct unit tests for the JSON-schema validation rules in {@link
+ * IngestionCliVersionMatrixParser#parseMatrix}.
+ *
+ * <p>Two layers of validation are tested:
+ *
+ * <ul>
+ *   <li><b>File-level (fail closed)</b>: {@link IllegalArgumentException} for root structure
+ *       violations — caller refuses to swap the cache.
+ *   <li><b>Entry-level (fail open + log)</b>: bad sub-entries are skipped; good entries around them
+ *       are kept. We don't assert on the log lines themselves (brittle) — only on the resulting
+ *       {@link IngestionCliVersionMatrix} shape.
+ * </ul>
+ */
+public class IngestionCliVersionMatrixParserTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  // ---------------------------------------------------------------------------
+  // File-level (fail closed)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void rootNotObjectThrowsAndCallerRetainsCache() throws Exception {
+    // A JSON array at the root is the realistic operator-error case (e.g. they
+    // exported a list of versions instead of the keyed object). We refuse to swap.
+    // The thrown IllegalArgumentException is the signal the matrix sources'
+    // refresh() use to retain the last-known-good cache.
+    JsonNode root = MAPPER.readTree("[ {\"snowflake\": {} } ]");
+    assertThrows(
+        IllegalArgumentException.class, () -> IngestionCliVersionMatrixParser.parseMatrix(root));
+  }
+
+  @Test
+  public void rootNullThrows() {
+    assertThrows(
+        IllegalArgumentException.class, () -> IngestionCliVersionMatrixParser.parseMatrix(null));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Entry-level (fail open + log) — good entries survive bad neighbors
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void invalidDefaultVersionIgnoredButCohortsKept() throws Exception {
+    // The "_default" is unusable (has a space), but cohorts are well-formed and
+    // should still drive cohort matches. The connector falls through to
+    // APPLICATION_DEFAULT when no cohort matches.
+    JsonNode root =
+        MAPPER.readTree(
+            "{\"1.5.0\": {\"snowflake\": {"
+                + "\"_default\": \"not a version\","
+                + "\"cohorts\": [{\"version\": \"1.5.0.6\", \"deployments\": [\"acme\"]}]"
+                + "}}}");
+    IngestionCliVersionMatrix m = IngestionCliVersionMatrixParser.parseMatrix(root);
+    ConnectorEntry snowflake = m.getEntriesForServer("1.5.0").getConnectorEntry("snowflake");
+    assertNotNull(snowflake);
+    assertNull(
+        snowflake.getDefaultVersion(), "invalid _default should be dropped, not stored verbatim");
+    assertEquals(snowflake.getCohorts().size(), 1, "cohort should still be present");
+    assertEquals(snowflake.getCohorts().get(0).getVersion(), "1.5.0.6");
+  }
+
+  @Test
+  public void cohortMissingVersionIsSkippedOthersKept() throws Exception {
+    // First cohort has no version field — skipped. Second cohort is well-formed — kept.
+    JsonNode root =
+        MAPPER.readTree(
+            "{\"1.5.0\": {\"snowflake\": {\"cohorts\": ["
+                + "{\"deployments\": [\"acme\"]},"
+                + "{\"version\": \"1.5.0.6\", \"deployments\": [\"acme\"]}"
+                + "]}}}");
+    IngestionCliVersionMatrix m = IngestionCliVersionMatrixParser.parseMatrix(root);
+    ConnectorEntry snowflake = m.getEntriesForServer("1.5.0").getConnectorEntry("snowflake");
+    assertEquals(snowflake.getCohorts().size(), 1, "first cohort (no version) should be dropped");
+    assertEquals(snowflake.getCohorts().get(0).getVersion(), "1.5.0.6");
+  }
+
+  @Test
+  public void cohortWithGarbageVersionIsSkipped() throws Exception {
+    // Operator pasted a string with HTML — pattern rejects it.
+    JsonNode root =
+        MAPPER.readTree(
+            "{\"1.5.0\": {\"snowflake\": {\"cohorts\": ["
+                + "{\"version\": \"<script>alert(1)</script>\", \"deployments\": [\"acme\"]}"
+                + "]}}}");
+    IngestionCliVersionMatrix m = IngestionCliVersionMatrixParser.parseMatrix(root);
+    ConnectorEntry snowflake = m.getEntriesForServer("1.5.0").getConnectorEntry("snowflake");
+    assertTrue(
+        snowflake.getCohorts().isEmpty(), "cohort with invalid version pattern should be dropped");
+  }
+
+  @Test
+  public void permissiveVersionPatternAcceptsRealPyPiVersions() throws Exception {
+    // Make sure we don't over-reject. Each is a real shape that appears on PyPI for acryl-datahub
+    // or similar. Includes rc, post, dev, and PEP 440 epoch prefix.
+    String[] realVersions = {
+      "1.5.0.19", "1.5.0.6rc1", "1.5.0.13.post1", "1!0.0.0.dev0", "0.14.0.6rc3"
+    };
+    StringBuilder cohorts = new StringBuilder();
+    for (int i = 0; i < realVersions.length; i++) {
+      if (i > 0) cohorts.append(",");
+      cohorts
+          .append("{\"version\": \"")
+          .append(realVersions[i])
+          .append("\", \"deployments\": [\"d")
+          .append(i)
+          .append("\"]}");
+    }
+    JsonNode root =
+        MAPPER.readTree("{\"1.5.0\": {\"snowflake\": {\"cohorts\": [" + cohorts + "]}}}");
+    IngestionCliVersionMatrix m = IngestionCliVersionMatrixParser.parseMatrix(root);
+    assertEquals(
+        m.getEntriesForServer("1.5.0").getConnectorEntry("snowflake").getCohorts().size(),
+        realVersions.length,
+        "all real PyPI-style versions should pass the permissive pattern");
+  }
+
+  @Test
+  public void permissiveVersionPatternAcceptsSpecialSentinels() throws Exception {
+    // Ingestion supports special non-PyPI version sentinels (e.g. "bundled", "no-acryl-datahub").
+    // These are not PEP 440 versions and must not be rejected by the cleanliness check.
+    JsonNode root =
+        MAPPER.readTree(
+            "{\"1.5.0\": {\"snowflake\": {"
+                + "\"_default\": \"bundled\","
+                + "\"cohorts\": [{\"version\": \"no-acryl-datahub\", \"deployments\": [\"acme\"]}]"
+                + "}}}");
+    IngestionCliVersionMatrix m = IngestionCliVersionMatrixParser.parseMatrix(root);
+    ConnectorEntry snowflake = m.getEntriesForServer("1.5.0").getConnectorEntry("snowflake");
+    assertEquals(snowflake.getDefaultVersion(), "bundled", "'bundled' sentinel must be accepted");
+    assertEquals(snowflake.getCohorts().size(), 1);
+    assertEquals(
+        snowflake.getCohorts().get(0).getVersion(),
+        "no-acryl-datahub",
+        "'no-acryl-datahub' sentinel must be accepted");
+  }
+
+  @Test
+  public void connectorValueNotObjectIsSkippedOthersKept() throws Exception {
+    // "snowflake" got assigned an array by mistake — drop it. "bigquery" is fine — keep it.
+    JsonNode root =
+        MAPPER.readTree(
+            "{\"1.5.0\": {"
+                + "\"snowflake\": [\"oops\", \"this is wrong\"],"
+                + "\"bigquery\": {\"_default\": \"1.4.0.3\"}"
+                + "}}");
+    IngestionCliVersionMatrix m = IngestionCliVersionMatrixParser.parseMatrix(root);
+    assertNull(
+        m.getEntriesForServer("1.5.0").getConnectorEntry("snowflake"),
+        "malformed connector entry should be dropped");
+    assertNotNull(
+        m.getEntriesForServer("1.5.0").getConnectorEntry("bigquery"),
+        "well-formed sibling connector should survive");
+    assertEquals(
+        m.getEntriesForServer("1.5.0").getConnectorEntry("bigquery").getDefaultVersion(),
+        "1.4.0.3");
+  }
+
+  @Test
+  public void wellFormedMatrixParsesUnchanged() throws Exception {
+    // Regression test — the happy-path schema we documented in the class Javadoc still parses.
+    // Locks in the contract so future tightening of validation doesn't accidentally reject valid
+    // input.
+    JsonNode root =
+        MAPPER.readTree(
+            "{\"1.5.0\": {"
+                + "\"snowflake\": {"
+                + "  \"_default\": \"1.5.0.5\","
+                + "  \"cohorts\": [{\"version\": \"1.5.0.6\", \"deployments\": [\"acme\", \"beta\"]}]"
+                + "},"
+                + "\"bigquery\": {\"_default\": \"1.4.0.3\"}"
+                + "}}");
+    IngestionCliVersionMatrix m = IngestionCliVersionMatrixParser.parseMatrix(root);
+    ConnectorEntry snowflake = m.getEntriesForServer("1.5.0").getConnectorEntry("snowflake");
+    assertEquals(snowflake.getDefaultVersion(), "1.5.0.5");
+    assertEquals(snowflake.getCohorts().size(), 1);
+    Cohort cohort = snowflake.getCohorts().get(0);
+    assertEquals(cohort.getVersion(), "1.5.0.6");
+    assertEquals(cohort.getDeployments().size(), 2);
+    assertTrue(cohort.getDeployments().contains("acme"));
+    assertTrue(cohort.getDeployments().contains("beta"));
+
+    ConnectorEntry bigquery = m.getEntriesForServer("1.5.0").getConnectorEntry("bigquery");
+    assertEquals(bigquery.getDefaultVersion(), "1.4.0.3");
+    assertTrue(bigquery.getCohorts().isEmpty());
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/ingestion/IngestionCliVersionMatrixServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/ingestion/IngestionCliVersionMatrixServiceFactory.java
@@ -4,12 +4,16 @@ import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.config.CliVersionMatrixConfiguration;
 import com.linkedin.metadata.config.HttpMatrixSourceConfiguration;
 import com.linkedin.metadata.config.IngestionConfiguration;
+import com.linkedin.metadata.config.S3MatrixSourceConfiguration;
 import com.linkedin.metadata.ingestion.HttpUrlIngestionCliVersionMatrixSource;
 import com.linkedin.metadata.ingestion.IngestionCliVersionMatrixService;
 import com.linkedin.metadata.ingestion.IngestionCliVersionMatrixSource;
 import com.linkedin.metadata.ingestion.NoOpIngestionCliVersionMatrixSource;
+import com.linkedin.metadata.utils.aws.S3Util;
 import com.linkedin.metadata.version.GitVersion;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -24,9 +28,12 @@ import org.springframework.context.annotation.Configuration;
  *   <li>{@code ingestionCliVersionMatrixSource} — implements {@link
  *       IngestionCliVersionMatrixSource}. The implementation is selected from {@code
  *       ingestion.cliVersionMatrix.source}: {@code "none"} short-circuits to {@link
- *       NoOpIngestionCliVersionMatrixSource}; otherwise an HTTP source is wired when {@code
- *       http.url} is set and a no-op source is wired when the URL is empty. Future backends (GMS
- *       aspect, config server, …) add their own discriminator value handled here.
+ *       NoOpIngestionCliVersionMatrixSource}; {@code "s3"} wires an {@link
+ *       S3IngestionCliVersionMatrixSource} when usable (degrades to no-op if config is incomplete
+ *       or no S3 client is available, never a startup failure); otherwise {@code "http"} (the
+ *       default) wires an HTTP source when {@code http.url} is set and a no-op when the URL is
+ *       empty. Future backends (GMS aspect, config server, …) add their own discriminator value
+ *       handled here.
  *   <li>{@code ingestionCliVersionMatrixService} — consumes whichever {@link
  *       IngestionCliVersionMatrixSource} is bound and applies the resolution policy (cohort →
  *       connector default → application default).
@@ -38,10 +45,12 @@ import org.springframework.context.annotation.Configuration;
  * empty and cohort matching never fires — only the connector-level {@code _default} from the matrix
  * applies.
  */
+@Slf4j
 @Configuration
 public class IngestionCliVersionMatrixServiceFactory {
 
   private static final String SOURCE_NONE = "none";
+  private static final String SOURCE_S3 = "s3";
 
   @Autowired
   @Qualifier("configurationProvider")
@@ -51,10 +60,18 @@ public class IngestionCliVersionMatrixServiceFactory {
   @Qualifier("gitVersion")
   private GitVersion gitVersion;
 
+  // Optional: present only when AWS is configured (AWS_REGION / datahub.s3.roleArn); null
+  // otherwise, in which case source=s3 degrades to a no-op matrix source with a warning rather
+  // than failing.
+  @Autowired(required = false)
+  @Qualifier("s3Util")
+  private S3Util s3Util;
+
   /**
    * Picks the storage backend for the matrix from {@code ingestion.cliVersionMatrix.source}.
-   * Explicit {@code "none"} is a kill-switch that always wins. Otherwise the HTTP source is wired
-   * when {@code http.url} is non-empty, and a no-op source when the URL is empty.
+   * Explicit {@code "none"} is a kill-switch that always wins. {@code "s3"} selects the S3 source
+   * (degrades to no-op when config is incomplete or no S3 client is available). Otherwise the HTTP
+   * source is wired when {@code http.url} is non-empty, and a no-op source when the URL is empty.
    */
   @Bean(name = "ingestionCliVersionMatrixSource")
   @Nonnull
@@ -64,9 +81,15 @@ public class IngestionCliVersionMatrixServiceFactory {
     if (matrixConfig == null) {
       return new NoOpIngestionCliVersionMatrixSource();
     }
-    if (SOURCE_NONE.equalsIgnoreCase(trim(matrixConfig.getSource()))) {
+    String source = trim(matrixConfig.getSource());
+    if (SOURCE_NONE.equalsIgnoreCase(source)) {
       return new NoOpIngestionCliVersionMatrixSource();
     }
+    if (SOURCE_S3.equalsIgnoreCase(source)) {
+      IngestionCliVersionMatrixSource s3 = s3MatrixSourceOrNull(matrixConfig.getS3());
+      return s3 != null ? s3 : new NoOpIngestionCliVersionMatrixSource();
+    }
+    // Default: HTTP source (covers explicit "http" and any unrecognised value).
     HttpMatrixSourceConfiguration httpConfig = matrixConfig.getHttp();
     if (httpConfig == null || httpConfig.getUrl() == null || httpConfig.getUrl().isEmpty()) {
       return new NoOpIngestionCliVersionMatrixSource();
@@ -75,8 +98,42 @@ public class IngestionCliVersionMatrixServiceFactory {
         httpConfig.getUrl(), httpConfig.getRefreshSeconds(), httpConfig.getAuthToken());
   }
 
+  /**
+   * Builds the S3-backed matrix source, or {@code null} when the S3 config is incomplete or no S3
+   * client bean is available — so a misconfiguration degrades to a no-op (the application default)
+   * rather than failing GMS startup.
+   */
+  @Nullable
+  private IngestionCliVersionMatrixSource s3MatrixSourceOrNull(
+      @Nullable final S3MatrixSourceConfiguration s3Config) {
+    if (s3Config == null || isEmpty(s3Config.getBucket()) || isEmpty(s3Config.getKey())) {
+      log.warn("ingestion.cliVersionMatrix.source=s3 but bucket/key are not set.");
+      return null;
+    }
+    // A non-positive refresh interval would make scheduleAtFixedRate throw in the source
+    // constructor and fail GMS startup; degrade to the no-op (application default) instead.
+    if (s3Config.getRefreshSeconds() <= 0) {
+      log.warn(
+          "ingestion.cliVersionMatrix.source=s3 but refreshSeconds={} is not positive.",
+          s3Config.getRefreshSeconds());
+      return null;
+    }
+    if (s3Util == null) {
+      log.warn(
+          "ingestion.cliVersionMatrix.source=s3 but no s3Util bean is available "
+              + "(set AWS_REGION or datahub.s3.roleArn).");
+      return null;
+    }
+    return new S3IngestionCliVersionMatrixSource(
+        s3Util, s3Config.getBucket(), s3Config.getKey(), s3Config.getRefreshSeconds());
+  }
+
   private static String trim(String s) {
     return s == null ? null : s.trim();
+  }
+
+  private static boolean isEmpty(String s) {
+    return s == null || s.trim().isEmpty();
   }
 
   @Bean(name = "ingestionCliVersionMatrixService")

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/ingestion/S3IngestionCliVersionMatrixSource.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/ingestion/S3IngestionCliVersionMatrixSource.java
@@ -1,0 +1,132 @@
+package com.linkedin.gms.factory.ingestion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.metadata.ingestion.IngestionCliVersionMatrix;
+import com.linkedin.metadata.ingestion.IngestionCliVersionMatrixParser;
+import com.linkedin.metadata.ingestion.IngestionCliVersionMatrixSource;
+import com.linkedin.metadata.utils.aws.S3Util;
+import jakarta.annotation.PreDestroy;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@link IngestionCliVersionMatrixSource} backed by a (typically private) S3 object, read with
+ * GMS's ambient AWS credentials via the shared {@link S3Util} bean.
+ *
+ * <p>Each request is SigV4-signed, so the bucket can stay private and be shared cross-account via
+ * bucket policy. It is wired here in the factory module (rather than alongside the no-op source in
+ * {@code configuration}) because that is where the AWS SDK and the {@code s3Util} bean already
+ * live, keeping the lightweight {@code configuration} module free of an AWS dependency.
+ *
+ * <p>Runtime contract: background refresh on a fixed interval, atomic lock-free cache swap on
+ * {@link #getMatrix()}, and last-known-good retention on fetch/parse failure so in-flight
+ * executions never see a flapping view. Parsing + validation are delegated to the shared {@link
+ * IngestionCliVersionMatrixParser}.
+ */
+@Slf4j
+public class S3IngestionCliVersionMatrixSource implements IngestionCliVersionMatrixSource {
+
+  /** Thread name for the background refresh worker; stands out in thread dumps. */
+  private static final String REFRESH_THREAD_NAME = "ingestion-cli-version-matrix-s3-refresh";
+
+  /** Seconds to wait for the refresh thread to drain on graceful shutdown. */
+  private static final int SHUTDOWN_TIMEOUT_SECONDS = 5;
+
+  private final S3Util s3Util;
+  private final String bucket;
+  private final String key;
+  private final AtomicReference<IngestionCliVersionMatrix> cached;
+  private final AtomicLong lastFetchedAtMillis;
+  private final ObjectMapper objectMapper;
+
+  /** Background refresh scheduler, stopped by {@link #shutdown()} on Spring context teardown. */
+  private final ScheduledExecutorService executor;
+
+  public S3IngestionCliVersionMatrixSource(
+      final S3Util s3Util,
+      final String bucket,
+      final String key,
+      final int refreshIntervalSeconds) {
+    this.s3Util = s3Util;
+    this.bucket = bucket;
+    this.key = key;
+    this.cached = new AtomicReference<>(IngestionCliVersionMatrix.EMPTY);
+    this.lastFetchedAtMillis = new AtomicLong(0L);
+    this.objectMapper = new ObjectMapper();
+
+    this.executor =
+        Executors.newSingleThreadScheduledExecutor(
+            r -> {
+              Thread t = new Thread(r, REFRESH_THREAD_NAME);
+              // Daemon so the JVM can still exit cleanly if @PreDestroy somehow doesn't fire.
+              t.setDaemon(true);
+              return t;
+            });
+    // Fetch immediately on startup (delay=0), then repeat on the configured interval.
+    this.executor.scheduleAtFixedRate(this::refresh, 0, refreshIntervalSeconds, TimeUnit.SECONDS);
+  }
+
+  /** Gracefully stop the background refresh on Spring context teardown. */
+  @PreDestroy
+  public void shutdown() {
+    executor.shutdown();
+    try {
+      if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        executor.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      executor.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  @Override
+  public IngestionCliVersionMatrix getMatrix() {
+    return cached.get();
+  }
+
+  @Override
+  public long getLastFetchedAtMillis() {
+    return lastFetchedAtMillis.get();
+  }
+
+  /** Package-private so tests can force a refresh without waiting for the scheduled tick. */
+  void refresh() {
+    try {
+      final String body = s3Util.getObjectAsString(bucket, key);
+      final JsonNode root = objectMapper.readTree(body);
+      final IngestionCliVersionMatrix parsed;
+      try {
+        parsed = IngestionCliVersionMatrixParser.parseMatrix(root);
+      } catch (IllegalArgumentException schemaError) {
+        // File-level schema violation. Refuse to swap the cache; the last-known-good matrix keeps
+        // serving resolutions while the operator gets a fix-this-now WARN.
+        log.warn(
+            "Refusing to swap matrix cache from s3://{}/{}: {}. Retaining last known matrix.",
+            bucket,
+            key,
+            schemaError.getMessage());
+        return;
+      }
+      cached.set(parsed);
+      // Stamp the timestamp after the swap so readers never see a fresh stamp with a stale matrix.
+      lastFetchedAtMillis.set(System.currentTimeMillis());
+      log.info(
+          "Successfully refreshed ingestion version matrix from s3://{}/{}; {} server version entries loaded",
+          bucket,
+          key,
+          parsed.size());
+    } catch (Exception e) {
+      log.warn(
+          "Failed to refresh ingestion version matrix from s3://{}/{}. Retaining last known matrix.",
+          bucket,
+          key,
+          e);
+    }
+  }
+}

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/ingestion/IngestionCliVersionMatrixServiceFactoryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/ingestion/IngestionCliVersionMatrixServiceFactoryTest.java
@@ -7,10 +7,12 @@ import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.config.CliVersionMatrixConfiguration;
 import com.linkedin.metadata.config.HttpMatrixSourceConfiguration;
 import com.linkedin.metadata.config.IngestionConfiguration;
+import com.linkedin.metadata.config.S3MatrixSourceConfiguration;
 import com.linkedin.metadata.ingestion.HttpUrlIngestionCliVersionMatrixSource;
 import com.linkedin.metadata.ingestion.IngestionCliVersionMatrixService;
 import com.linkedin.metadata.ingestion.IngestionCliVersionMatrixSource;
 import com.linkedin.metadata.ingestion.NoOpIngestionCliVersionMatrixSource;
+import com.linkedin.metadata.utils.aws.S3Util;
 import com.linkedin.metadata.version.GitVersion;
 import java.lang.reflect.Field;
 import java.util.Map;
@@ -19,8 +21,9 @@ import org.testng.annotations.Test;
 
 /**
  * Direct unit tests for {@link IngestionCliVersionMatrixServiceFactory}. Covers the source
- * selection contract: explicit {@code source: "none"} is a kill-switch; otherwise the HTTP source
- * is wired when {@code http.url} is set and a no-op source is wired when the URL is empty.
+ * selection contract: explicit {@code source: "none"} is a kill-switch; {@code source: "s3"} wires
+ * the S3 source when usable; otherwise the HTTP source is wired when {@code http.url} is set and a
+ * no-op source is wired when the URL is empty.
  */
 public class IngestionCliVersionMatrixServiceFactoryTest {
 
@@ -48,7 +51,7 @@ public class IngestionCliVersionMatrixServiceFactoryTest {
   }
 
   // ---------------------------------------------------------------------------
-  // URL controls HTTP vs NoOp when source is not "none"
+  // URL controls HTTP vs NoOp when source is not "none" or "s3"
   // ---------------------------------------------------------------------------
 
   @Test
@@ -123,6 +126,63 @@ public class IngestionCliVersionMatrixServiceFactoryTest {
     assertTrue(
         source instanceof NoOpIngestionCliVersionMatrixSource,
         "Operators may set NONE or none — both must short-circuit to NoOp");
+  }
+
+  // ---------------------------------------------------------------------------
+  // source="s3" wiring
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testMatrixSource_whenSourceIsS3AndUsable_wiresS3Source() {
+    ingestionConfig.getCliVersionMatrix().setSource("s3");
+    ingestionConfig.getCliVersionMatrix().setS3(s3Config("cli-version-matrix", "matrix.json"));
+    setField(factory, "s3Util", mock(S3Util.class));
+
+    IngestionCliVersionMatrixSource source = factory.ingestionCliVersionMatrixSource();
+    assertTrue(
+        source instanceof S3IngestionCliVersionMatrixSource,
+        "source=s3 with a usable S3 client wires the S3 source");
+    ((S3IngestionCliVersionMatrixSource) source).shutdown();
+  }
+
+  @Test
+  public void testMatrixSource_whenSourceIsS3ButS3Unusable_wiresNoOp() {
+    // source=s3 but no s3Util bean (AWS not configured) → application default, not a startup
+    // failure.
+    ingestionConfig.getCliVersionMatrix().setSource("s3");
+    ingestionConfig.getCliVersionMatrix().setS3(s3Config("cli-version-matrix", "matrix.json"));
+    // s3Util intentionally left null.
+
+    IngestionCliVersionMatrixSource source = factory.ingestionCliVersionMatrixSource();
+
+    assertTrue(
+        source instanceof NoOpIngestionCliVersionMatrixSource,
+        "an unusable S3 (no client) wires a no-op source");
+  }
+
+  @Test
+  public void testMatrixSource_whenS3RefreshSecondsNotPositive_wiresNoOp() {
+    // A non-positive refresh interval would make scheduleAtFixedRate throw in the S3 source
+    // constructor and fail GMS startup; the factory must degrade to a no-op instead.
+    ingestionConfig.getCliVersionMatrix().setSource("s3");
+    S3MatrixSourceConfiguration s3 = s3Config("cli-version-matrix", "matrix.json");
+    s3.setRefreshSeconds(0);
+    ingestionConfig.getCliVersionMatrix().setS3(s3);
+    setField(factory, "s3Util", mock(S3Util.class));
+
+    IngestionCliVersionMatrixSource source = factory.ingestionCliVersionMatrixSource();
+
+    assertTrue(
+        source instanceof NoOpIngestionCliVersionMatrixSource,
+        "source=s3 with non-positive refreshSeconds must degrade to a no-op, not fail startup");
+  }
+
+  private static S3MatrixSourceConfiguration s3Config(String bucket, String key) {
+    S3MatrixSourceConfiguration s3 = new S3MatrixSourceConfiguration();
+    s3.setBucket(bucket);
+    s3.setKey(key);
+    s3.setRefreshSeconds(600);
+    return s3;
   }
 
   // ---------------------------------------------------------------------------

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/ingestion/S3IngestionCliVersionMatrixSourceTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/ingestion/S3IngestionCliVersionMatrixSourceTest.java
@@ -1,0 +1,97 @@
+package com.linkedin.gms.factory.ingestion;
+
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.metadata.ingestion.IngestionCliVersionMatrix;
+import com.linkedin.metadata.utils.aws.S3Util;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link S3IngestionCliVersionMatrixSource}. The S3 call is mocked via {@link
+ * S3Util}; JSON parsing/validation itself is covered by {@code
+ * IngestionCliVersionMatrixParserTest}, so these tests focus on the source's wiring (fetch → parse
+ * → cache → timestamp).
+ *
+ * <p>{@code refresh()} is driven directly rather than waiting for the background scheduler so the
+ * assertions are deterministic. The stub always returns the same body, so the immediate startup
+ * tick the constructor schedules can't race the explicit call to a different result.
+ */
+public class S3IngestionCliVersionMatrixSourceTest {
+
+  private static final String BUCKET = "cli-version-matrix";
+  private static final String KEY = "matrix.json";
+  private static final String MATRIX_JSON =
+      "{\"1.5.0\": {\"snowflake\": {\"_default\": \"1.5.0.5\"}}}";
+
+  @Test
+  public void refreshLoadsAndCachesMatrixFromS3() {
+    S3Util s3Util = mock(S3Util.class);
+    when(s3Util.getObjectAsString(BUCKET, KEY)).thenReturn(MATRIX_JSON);
+
+    S3IngestionCliVersionMatrixSource source =
+        new S3IngestionCliVersionMatrixSource(s3Util, BUCKET, KEY, 3600);
+    try {
+      source.refresh();
+
+      IngestionCliVersionMatrix matrix = source.getMatrix();
+      assertEquals(
+          matrix.getEntriesForServer("1.5.0").getConnectorEntry("snowflake").getDefaultVersion(),
+          "1.5.0.5");
+      assertTrue(
+          source.getLastFetchedAtMillis() > 0,
+          "successful fetch should stamp the last-fetched timestamp");
+    } finally {
+      source.shutdown();
+    }
+  }
+
+  @Test
+  public void getMatrixServesCachedInstanceBetweenRefreshes() {
+    S3Util s3Util = mock(S3Util.class);
+    when(s3Util.getObjectAsString(BUCKET, KEY)).thenReturn(MATRIX_JSON);
+
+    S3IngestionCliVersionMatrixSource source =
+        new S3IngestionCliVersionMatrixSource(s3Util, BUCKET, KEY, 3600);
+    // Stop the background scheduler up front so its startup tick can't race the reads below;
+    // refresh() is a plain method and still populates the cache deterministically.
+    source.shutdown();
+    source.refresh();
+    IngestionCliVersionMatrix cached = source.getMatrix();
+
+    // Between refreshes getMatrix() is a pure in-memory read: it returns the very same cached
+    // instance every time and never re-fetches from S3 / re-parses. clearInvocations() drops the
+    // refresh() read so we can assert the reads below touch S3 zero times.
+    clearInvocations(s3Util);
+    for (int i = 0; i < 5; i++) {
+      assertSame(
+          source.getMatrix(),
+          cached,
+          "getMatrix() must serve the cached instance between refreshes, not re-fetch");
+    }
+    verifyNoInteractions(s3Util);
+  }
+
+  @Test
+  public void getMatrixIsEmptyBeforeAnyFetch() {
+    // A source whose backing object errors on every read keeps serving the EMPTY matrix rather than
+    // throwing on the hot path — resolution falls through to the application default.
+    S3Util s3Util = mock(S3Util.class);
+    when(s3Util.getObjectAsString(BUCKET, KEY)).thenThrow(new RuntimeException("s3 unavailable"));
+
+    S3IngestionCliVersionMatrixSource source =
+        new S3IngestionCliVersionMatrixSource(s3Util, BUCKET, KEY, 3600);
+    try {
+      source.refresh(); // swallows the error, retains EMPTY
+      assertEquals(source.getMatrix().size(), 0, "no entries when the fetch never succeeds");
+      assertEquals(source.getLastFetchedAtMillis(), 0L, "no successful fetch means no timestamp");
+    } finally {
+      source.shutdown();
+    }
+  }
+}

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/aws/S3Util.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/aws/S3Util.java
@@ -185,6 +185,25 @@ public class S3Util {
   }
 
   /**
+   * Read an S3 object's full body as a UTF-8 string. Intended for small objects (config / metadata
+   * documents) fetched with the client's configured credentials — not for streaming large files.
+   *
+   * @param bucket The S3 bucket name
+   * @param key The S3 object key
+   * @return The object body decoded as UTF-8
+   */
+  public String getObjectAsString(@Nonnull String bucket, @Nonnull String key) {
+    try {
+      GetObjectRequest getObjectRequest =
+          GetObjectRequest.builder().bucket(bucket).key(key).build();
+      return s3Client.getObjectAsBytes(getObjectRequest).asUtf8String();
+    } catch (Exception e) {
+      log.error("Failed to read object from S3. Bucket: {}, Key: {}", bucket, key, e);
+      throw new RuntimeException("Failed to read object from S3: " + e.getMessage(), e);
+    }
+  }
+
+  /**
    * Delete an object from S3
    *
    * @param bucket The S3 bucket name


### PR DESCRIPTION
## Summary

- Extracts `IngestionCliVersionMatrixParser` from `HttpUrlIngestionCliVersionMatrixSource` as a shared parser used by both HTTP and S3 backends
- Adds `S3IngestionCliVersionMatrixSource` — fetches the version matrix from a private S3 bucket using GMS's ambient AWS credentials (SigV4 signed, no separate secret required)
- Keeps `HttpUrlIngestionCliVersionMatrixSource` as the existing default; S3 is opt-in via `INGESTION_VERSION_MATRIX_SOURCE=s3`
- Degrades gracefully to no-op (callers use `defaultCliVersion`) when bucket/key are unset or no AWS credentials are present — GMS startup is never blocked

## Configuration

Set `INGESTION_VERSION_MATRIX_SOURCE=s3` and the following env vars:

| Env var | Default | Description |
|---|---|---|
| `INGESTION_VERSION_MATRIX_S3_BUCKET` | _(required)_ | S3 bucket name |
| `INGESTION_VERSION_MATRIX_S3_KEY` | `matrix.json` | Object key within the bucket |
| `INGESTION_VERSION_MATRIX_S3_REFRESH_SECONDS` | `600` | Refresh interval in seconds |

The existing HTTP backend (`source=http`) and its env vars are unchanged.

## Checklist

- [x] PR conforms to Contributing Guidelines
- [x] Tests added/updated