### PR TITLE
feat(context-sidebar): folder tap-target expand + per-section expand/…

### DIFF
--- a/datahub-web-react/src/app/context/ContextSidebar.tsx
+++ b/datahub-web-react/src/app/context/ContextSidebar.tsx
@@ -181,7 +181,11 @@ const TreeContainer = styled.div`
     flex: 1;
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 8px;
+    /* Trimmed right padding: scrollbar-gutter already reserves space on the right,
+       so the rows/labels can sit closer to the edge without shifting. */
+    padding: 8px 2px 8px 8px;
+    /* Reserve the scrollbar's space so rows don't shift left when it appears. */
+    scrollbar-gutter: stable;
 
     /* Custom scrollbar styling */
     &::-webkit-scrollbar {
@@ -189,20 +193,20 @@ const TreeContainer = styled.div`
     }
 
     &::-webkit-scrollbar-track {
-        background: transparent;
+        background: ${(props) => props.theme.colors.scrollbarTrack};
     }
 
     &::-webkit-scrollbar-thumb {
-        background: ${(props) => props.theme.colors.textTertiary};
+        background: ${(props) => props.theme.colors.scrollbarThumb};
         border-radius: 3px;
     }
 
     &::-webkit-scrollbar-thumb:hover {
-        background: ${(props) => props.theme.colors.textTertiary};
+        background: ${(props) => props.theme.colors.scrollbarThumbHover};
     }
 
     scrollbar-width: thin;
-    scrollbar-color: ${(props) => props.theme.colors.textTertiary} transparent;
+    scrollbar-color: ${(props) => props.theme.colors.scrollbarThumb} ${(props) => props.theme.colors.scrollbarTrack};
 `;
 
 type Props = {

--- a/datahub-web-react/src/app/document/hooks/__tests__/useDocumentNavigation.test.ts
+++ b/datahub-web-react/src/app/document/hooks/__tests__/useDocumentNavigation.test.ts
@@ -1,0 +1,55 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useDocumentNavigation } from '@app/document/hooks/useDocumentNavigation';
+
+const mockPush = vi.fn();
+let mockPathname = '/';
+
+vi.mock('react-router-dom', () => ({
+    useHistory: () => ({ push: mockPush }),
+    useLocation: () => ({ pathname: mockPathname }),
+}));
+
+vi.mock('@app/useEntityRegistry', () => ({
+    useEntityRegistry: () => ({
+        getEntityUrl: (_type: unknown, urn: string) => `/document/${urn}`,
+    }),
+}));
+
+describe('useDocumentNavigation', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockPathname = '/';
+    });
+
+    describe('getCurrentDocumentUrn', () => {
+        it('decodes the document urn from the current route', () => {
+            mockPathname = `/document/${encodeURIComponent('urn:li:document:abc')}`;
+            const { result } = renderHook(() => useDocumentNavigation());
+            expect(result.current.getCurrentDocumentUrn()).toBe('urn:li:document:abc');
+        });
+
+        it('returns null when the route is not a document page', () => {
+            mockPathname = '/search';
+            const { result } = renderHook(() => useDocumentNavigation());
+            expect(result.current.getCurrentDocumentUrn()).toBe(null);
+        });
+    });
+
+    describe('handleDocumentClick', () => {
+        it('navigates to the entity url when not in selection mode', () => {
+            const { result } = renderHook(() => useDocumentNavigation());
+            result.current.handleDocumentClick('urn:li:document:x');
+            expect(mockPush).toHaveBeenCalledWith('/document/urn:li:document:x');
+        });
+
+        it('selects rather than navigates when onSelectDocument is provided', () => {
+            const onSelectDocument = vi.fn();
+            const { result } = renderHook(() => useDocumentNavigation(onSelectDocument));
+            result.current.handleDocumentClick('urn:li:document:y');
+            expect(onSelectDocument).toHaveBeenCalledWith('urn:li:document:y');
+            expect(mockPush).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/datahub-web-react/src/app/document/hooks/__tests__/useNodeChildrenLoading.test.tsx
+++ b/datahub-web-react/src/app/document/hooks/__tests__/useNodeChildrenLoading.test.tsx
@@ -1,0 +1,84 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DocumentTreeNode, DocumentTreeProvider, useDocumentTree } from '@app/document/DocumentTreeContext';
+import { useNodeChildrenLoading } from '@app/document/hooks/useNodeChildrenLoading';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <DocumentTreeProvider>{children}</DocumentTreeProvider>
+);
+
+function makeNode(overrides: Partial<DocumentTreeNode> = {}): DocumentTreeNode {
+    return { urn: 'urn:li:document:test', title: 'Test', parentUrn: null, hasChildren: false, ...overrides };
+}
+
+describe('useNodeChildrenLoading', () => {
+    let loadChildren: ReturnType<typeof vi.fn>;
+    let loadMoreChildren: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        loadChildren = vi.fn().mockResolvedValue([]);
+        loadMoreChildren = vi.fn().mockResolvedValue(undefined);
+    });
+
+    const render = () =>
+        renderHook(
+            () => ({
+                loading: useNodeChildrenLoading({ loadChildren, loadMoreChildren }),
+                tree: useDocumentTree(),
+            }),
+            { wrapper },
+        );
+
+    it('expands a collapsed folder and fetches its children', async () => {
+        const { result } = render();
+        act(() => {
+            result.current.tree.addNode(makeNode({ urn: 'f', hasChildren: true }));
+        });
+
+        await act(async () => {
+            await result.current.loading.handleToggleExpand('f');
+        });
+
+        expect(result.current.tree.expandedUrns.has('f')).toBe(true);
+        expect(loadChildren).toHaveBeenCalledWith('f');
+        // The in-flight marker is cleared once the fetch settles.
+        expect(result.current.loading.loadingUrns.has('f')).toBe(false);
+    });
+
+    it('collapses an already-expanded folder without refetching', async () => {
+        const { result } = render();
+        act(() => {
+            result.current.tree.addNode(makeNode({ urn: 'f', hasChildren: true }));
+            result.current.tree.expandNode('f');
+        });
+
+        await act(async () => {
+            await result.current.loading.handleToggleExpand('f');
+        });
+
+        expect(result.current.tree.expandedUrns.has('f')).toBe(false);
+        expect(loadChildren).not.toHaveBeenCalled();
+    });
+
+    it('does nothing for an unknown urn', async () => {
+        const { result } = render();
+        await act(async () => {
+            await result.current.loading.handleToggleExpand('missing');
+        });
+
+        expect(loadChildren).not.toHaveBeenCalled();
+        expect(result.current.tree.expandedUrns.size).toBe(0);
+    });
+
+    it('loads the next page of children via handleLoadMoreChildren', async () => {
+        const { result } = render();
+        await act(async () => {
+            await result.current.loading.handleLoadMoreChildren('p');
+        });
+
+        expect(loadMoreChildren).toHaveBeenCalledWith('p');
+        expect(result.current.loading.loadingChildrenUrns.has('p')).toBe(false);
+    });
+});

--- a/datahub-web-react/src/app/document/hooks/__tests__/useSectionExpansion.test.tsx
+++ b/datahub-web-react/src/app/document/hooks/__tests__/useSectionExpansion.test.tsx
@@ -1,0 +1,114 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DocumentTreeNode, DocumentTreeProvider, useDocumentTree } from '@app/document/DocumentTreeContext';
+import { useSectionExpansion } from '@app/document/hooks/useSectionExpansion';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <DocumentTreeProvider>{children}</DocumentTreeProvider>
+);
+
+function makeNode(overrides: Partial<DocumentTreeNode> = {}): DocumentTreeNode {
+    return { urn: 'urn:li:document:test', title: 'Test', parentUrn: null, hasChildren: false, ...overrides };
+}
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+        resolve = res;
+    });
+    return { promise, resolve };
+}
+
+describe('useSectionExpansion', () => {
+    let loadChildren: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        loadChildren = vi.fn().mockResolvedValue([]);
+    });
+
+    const render = () =>
+        renderHook(
+            () => ({
+                section: useSectionExpansion(loadChildren),
+                tree: useDocumentTree(),
+            }),
+            { wrapper },
+        );
+
+    describe('isSectionExpanded', () => {
+        it('reflects whether any folder in the section is expanded', () => {
+            const roots = [makeNode({ urn: 'f', hasChildren: true })];
+            const { result } = render();
+
+            expect(result.current.section.isSectionExpanded(roots)).toBe(false);
+
+            act(() => {
+                result.current.tree.expandNode('f');
+            });
+
+            expect(result.current.section.isSectionExpanded(roots)).toBe(true);
+        });
+    });
+
+    describe('toggleSectionExpandAll', () => {
+        it('expands every folder, discovering deeper levels from loadChildren', async () => {
+            const g = makeNode({ urn: 'g', hasChildren: true });
+            loadChildren = vi.fn(async (urn: string) => (urn === 'f' ? [g] : []));
+            const roots = [makeNode({ urn: 'f', hasChildren: true })];
+            const { result } = render();
+
+            await act(async () => {
+                await result.current.section.toggleSectionExpandAll('sec', roots);
+            });
+
+            expect(result.current.tree.expandedUrns.has('f')).toBe(true);
+            expect(result.current.tree.expandedUrns.has('g')).toBe(true);
+            expect(loadChildren).toHaveBeenCalledWith('f');
+            expect(loadChildren).toHaveBeenCalledWith('g');
+        });
+
+        it('collapses the whole section when something is already expanded', async () => {
+            const roots = [
+                makeNode({ urn: 'f', hasChildren: true, children: [makeNode({ urn: 'g', hasChildren: true })] }),
+            ];
+            const { result } = render();
+
+            act(() => {
+                result.current.tree.expandNode('f');
+                result.current.tree.expandNode('g');
+            });
+            expect(result.current.tree.expandedUrns.size).toBe(2);
+
+            await act(async () => {
+                await result.current.section.toggleSectionExpandAll('sec', roots);
+            });
+
+            expect(result.current.tree.expandedUrns.has('f')).toBe(false);
+            expect(result.current.tree.expandedUrns.has('g')).toBe(false);
+            expect(loadChildren).not.toHaveBeenCalled();
+        });
+
+        it('marks the section in-flight while expanding and clears it when done', async () => {
+            const d = deferred<DocumentTreeNode[]>();
+            loadChildren = vi.fn(() => d.promise);
+            const roots = [makeNode({ urn: 'f', hasChildren: true })];
+            const { result } = render();
+
+            let pending: Promise<void>;
+            act(() => {
+                pending = result.current.section.toggleSectionExpandAll('sec', roots);
+            });
+
+            expect(result.current.section.isSectionExpanding('sec')).toBe(true);
+
+            await act(async () => {
+                d.resolve([]);
+                await pending;
+            });
+
+            expect(result.current.section.isSectionExpanding('sec')).toBe(false);
+        });
+    });
+});

--- a/datahub-web-react/src/app/document/hooks/useDocumentNavigation.ts
+++ b/datahub-web-react/src/app/document/hooks/useDocumentNavigation.ts
@@ -1,0 +1,47 @@
+import { useCallback } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+
+import { useEntityRegistry } from '@app/useEntityRegistry';
+
+import { EntityType } from '@types';
+
+interface DocumentNavigation {
+    /** The document urn in the current route, or null when none is open. */
+    getCurrentDocumentUrn: () => string | null;
+    /**
+     * Handle a click on a document row: select it in selection mode (e.g. the
+     * move dialog), otherwise navigate to its entity page.
+     */
+    handleDocumentClick: (urn: string) => void;
+}
+
+/**
+ * Routing/selection glue for the document sidebar tree. Kept out of the tree
+ * component so the render code stays focused on layout, and so selection vs
+ * navigation is decided in one place.
+ *
+ * @param onSelectDocument - When provided, clicks select rather than navigate.
+ */
+export function useDocumentNavigation(onSelectDocument?: (urn: string) => void): DocumentNavigation {
+    const history = useHistory();
+    const location = useLocation();
+    const entityRegistry = useEntityRegistry();
+
+    const getCurrentDocumentUrn = useCallback(() => {
+        const match = location.pathname.match(/\/document\/([^/]+)/);
+        return match ? decodeURIComponent(match[1]) : null;
+    }, [location.pathname]);
+
+    const handleDocumentClick = useCallback(
+        (urn: string) => {
+            if (onSelectDocument) {
+                onSelectDocument(urn);
+            } else {
+                history.push(entityRegistry.getEntityUrl(EntityType.Document, urn));
+            }
+        },
+        [onSelectDocument, entityRegistry, history],
+    );
+
+    return { getCurrentDocumentUrn, handleDocumentClick };
+}

--- a/datahub-web-react/src/app/document/hooks/useNodeChildrenLoading.ts
+++ b/datahub-web-react/src/app/document/hooks/useNodeChildrenLoading.ts
@@ -1,0 +1,77 @@
+import { useCallback, useState } from 'react';
+
+import { DocumentTreeNode, useDocumentTree } from '@app/document/DocumentTreeContext';
+
+interface NodeLoaders {
+    /** Loads (and returns) the first page of a node's children. */
+    loadChildren: (parentUrn: string | null) => Promise<DocumentTreeNode[]>;
+    /** Loads the next page of an already-expanded node's children. */
+    loadMoreChildren: (parentUrn: string) => Promise<void>;
+}
+
+interface NodeChildrenLoading {
+    /** Nodes whose first page of children is being fetched (drives the row spinner). */
+    loadingUrns: Set<string>;
+    /** Nodes whose next page of children is being fetched (drives the load-more spinner). */
+    loadingChildrenUrns: Set<string>;
+    /** Toggle a single node: collapse if open, otherwise expand and fetch its children. */
+    handleToggleExpand: (urn: string) => Promise<void>;
+    /** Fetch the next page of children for an already-expanded parent. */
+    handleLoadMoreChildren: (parentUrn: string) => Promise<void>;
+}
+
+/**
+ * Per-node expand + lazy child-loading for the document sidebar tree.
+ *
+ * Owns the two "in flight" sets (first-page vs next-page) and the toggle/load-more
+ * handlers, keeping that async bookkeeping out of the render-heavy tree component.
+ * The loaders are passed in rather than pulled from `useLoadDocumentTree` here so
+ * we don't spin up a second root-loading instance — the tree owns the single
+ * loader and hands us the child fetches it already has.
+ */
+export function useNodeChildrenLoading({ loadChildren, loadMoreChildren }: NodeLoaders): NodeChildrenLoading {
+    const { getNode, expandedUrns, expandNode, collapseNode } = useDocumentTree();
+    const [loadingUrns, setLoadingUrns] = useState<Set<string>>(new Set());
+    const [loadingChildrenUrns, setLoadingChildrenUrns] = useState<Set<string>>(new Set());
+
+    const handleToggleExpand = useCallback(
+        async (urn: string) => {
+            const node = getNode(urn);
+            if (!node) return;
+
+            if (expandedUrns.has(urn)) {
+                collapseNode(urn);
+                return;
+            }
+
+            expandNode(urn);
+            // Always refetch on expand; the context merges server data with any
+            // optimistic local children rather than clobbering them.
+            if (node.hasChildren) {
+                setLoadingUrns((prev) => new Set(prev).add(urn));
+                await loadChildren(urn);
+                setLoadingUrns((prev) => {
+                    const next = new Set(prev);
+                    next.delete(urn);
+                    return next;
+                });
+            }
+        },
+        [getNode, expandedUrns, expandNode, collapseNode, loadChildren],
+    );
+
+    const handleLoadMoreChildren = useCallback(
+        async (parentUrn: string) => {
+            setLoadingChildrenUrns((prev) => new Set(prev).add(parentUrn));
+            await loadMoreChildren(parentUrn);
+            setLoadingChildrenUrns((prev) => {
+                const next = new Set(prev);
+                next.delete(parentUrn);
+                return next;
+            });
+        },
+        [loadMoreChildren],
+    );
+
+    return { loadingUrns, loadingChildrenUrns, handleToggleExpand, handleLoadMoreChildren };
+}

--- a/datahub-web-react/src/app/document/hooks/useSectionExpansion.ts
+++ b/datahub-web-react/src/app/document/hooks/useSectionExpansion.ts
@@ -1,0 +1,85 @@
+import { useCallback, useState } from 'react';
+
+import { DocumentTreeNode, useDocumentTree } from '@app/document/DocumentTreeContext';
+import {
+    collectExpandableUrns,
+    expandAllFolders,
+    hasExpandedDescendant,
+} from '@app/document/utils/documentTreeExpansion';
+
+interface SectionExpansion {
+    /** True when any folder within the section is currently expanded. */
+    isSectionExpanded: (roots: DocumentTreeNode[]) => boolean;
+    /** True while a section's expand-all traversal is in flight (drives disabled state). */
+    isSectionExpanding: (sectionId: string) => boolean;
+    /**
+     * Expand every folder in the section if none are open, otherwise collapse them
+     * all. `sectionId` is any stable key (a platform urn, or a sentinel for the
+     * native group) used only to track the in-flight/disabled state.
+     */
+    toggleSectionExpandAll: (sectionId: string, roots: DocumentTreeNode[]) => Promise<void>;
+}
+
+/**
+ * Section-scoped expand-all / collapse-all for the document sidebar tree.
+ *
+ * Each tree "section" (the DataHub group and each per-platform group) exposes a
+ * bulk toggle. This hook owns the async expand-all traversal, the collapse-all
+ * reset, and a per-section "in flight" set that drives the toggle's disabled
+ * state, keeping that orchestration out of the already-large `DocumentTree`.
+ *
+ * `loadChildren` is passed in (rather than pulled from `useLoadDocumentTree`
+ * here) so we don't spin up a second root-loading instance — the tree owns the
+ * single loader and hands us just the child-fetch it already has.
+ */
+export function useSectionExpansion(loadChildren: (urn: string) => Promise<DocumentTreeNode[]>): SectionExpansion {
+    const { expandedUrns, setExpandedUrns } = useDocumentTree();
+    const [expandingSectionIds, setExpandingSectionIds] = useState<Set<string>>(new Set());
+
+    const isSectionExpanded = useCallback(
+        (roots: DocumentTreeNode[]) => hasExpandedDescendant(roots, expandedUrns),
+        [expandedUrns],
+    );
+
+    const isSectionExpanding = useCallback(
+        (sectionId: string) => expandingSectionIds.has(sectionId),
+        [expandingSectionIds],
+    );
+
+    const toggleSectionExpandAll = useCallback(
+        async (sectionId: string, roots: DocumentTreeNode[]) => {
+            if (hasExpandedDescendant(roots, expandedUrns)) {
+                const urns = collectExpandableUrns(roots);
+                setExpandedUrns((prev) => {
+                    const next = new Set(prev);
+                    urns.forEach((urn) => next.delete(urn));
+                    return next;
+                });
+                return;
+            }
+
+            setExpandingSectionIds((prev) => new Set(prev).add(sectionId));
+            try {
+                await expandAllFolders({
+                    roots,
+                    loadChildren,
+                    onExpandLevel: (urns) =>
+                        setExpandedUrns((prev) => {
+                            const next = new Set(prev);
+                            urns.forEach((urn) => next.add(urn));
+                            return next;
+                        }),
+                });
+            } finally {
+                setExpandingSectionIds((prev) => {
+                    const next = new Set(prev);
+                    next.delete(sectionId);
+                    return next;
+                });
+            }
+        },
+        [expandedUrns, setExpandedUrns, loadChildren],
+    );
+
+    return { isSectionExpanded, isSectionExpanding, toggleSectionExpandAll };
+}

--- a/datahub-web-react/src/app/document/utils/__tests__/documentTreeExpansion.test.ts
+++ b/datahub-web-react/src/app/document/utils/__tests__/documentTreeExpansion.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DocumentTreeNode } from '@app/document/DocumentTreeContext';
+import {
+    collectExpandableUrns,
+    expandAllFolders,
+    hasExpandedDescendant,
+} from '@app/document/utils/documentTreeExpansion';
+
+function makeNode(overrides: Partial<DocumentTreeNode> = {}): DocumentTreeNode {
+    return {
+        urn: 'urn:li:document:test',
+        title: 'Test Document',
+        parentUrn: null,
+        hasChildren: false,
+        children: undefined,
+        isUnpublished: false,
+        isExternal: false,
+        platform: null,
+        creator: null,
+        ...overrides,
+    };
+}
+
+describe('documentTreeExpansion', () => {
+    describe('collectExpandableUrns', () => {
+        it('returns only nodes that have children, depth-first, including nested folders', () => {
+            const roots = [
+                makeNode({
+                    urn: 'folder-a',
+                    hasChildren: true,
+                    children: [
+                        makeNode({ urn: 'leaf-a1' }),
+                        makeNode({ urn: 'folder-a2', hasChildren: true, children: [makeNode({ urn: 'leaf-a2a' })] }),
+                    ],
+                }),
+                makeNode({ urn: 'leaf-b' }),
+            ];
+
+            expect(collectExpandableUrns(roots)).toEqual(['folder-a', 'folder-a2']);
+        });
+
+        it('includes an expandable node whose children have not loaded yet', () => {
+            const roots = [makeNode({ urn: 'folder', hasChildren: true, children: undefined })];
+            expect(collectExpandableUrns(roots)).toEqual(['folder']);
+        });
+
+        it('returns an empty array when there are no folders', () => {
+            expect(collectExpandableUrns([makeNode({ urn: 'leaf' })])).toEqual([]);
+        });
+    });
+
+    describe('hasExpandedDescendant', () => {
+        const roots = [makeNode({ urn: 'folder', hasChildren: true, children: [makeNode({ urn: 'leaf' })] })];
+
+        it('is true when an expandable node is in the expanded set', () => {
+            expect(hasExpandedDescendant(roots, new Set(['folder']))).toBe(true);
+        });
+
+        it('is false when no expandable node is expanded', () => {
+            expect(hasExpandedDescendant(roots, new Set(['leaf']))).toBe(false);
+            expect(hasExpandedDescendant(roots, new Set())).toBe(false);
+        });
+    });
+
+    describe('expandAllFolders', () => {
+        it('expands folders level-by-level, discovering deeper folders from loadChildren', async () => {
+            // Tree: root-folder -> child-folder -> grandchild-leaf
+            const childrenByUrn: Record<string, DocumentTreeNode[]> = {
+                'root-folder': [makeNode({ urn: 'child-folder', hasChildren: true })],
+                'child-folder': [makeNode({ urn: 'grandchild-leaf' })],
+            };
+            const loadChildren = vi.fn(async (urn: string) => childrenByUrn[urn] ?? []);
+            const levels: string[][] = [];
+
+            await expandAllFolders({
+                roots: [makeNode({ urn: 'root-folder', hasChildren: true })],
+                loadChildren,
+                onExpandLevel: (urns) => levels.push(urns),
+            });
+
+            expect(levels).toEqual([['root-folder'], ['child-folder']]);
+            expect(loadChildren).toHaveBeenCalledWith('root-folder');
+            expect(loadChildren).toHaveBeenCalledWith('child-folder');
+            expect(loadChildren).toHaveBeenCalledTimes(2);
+        });
+
+        it('does not revisit a folder reachable by more than one path', async () => {
+            // Two roots both report the same shared folder as a child.
+            const loadChildren = vi.fn(async (urn: string) => {
+                if (urn === 'root-a' || urn === 'root-b') {
+                    return [makeNode({ urn: 'shared-folder', hasChildren: true })];
+                }
+                return [];
+            });
+            const expanded: string[] = [];
+
+            await expandAllFolders({
+                roots: [makeNode({ urn: 'root-a', hasChildren: true }), makeNode({ urn: 'root-b', hasChildren: true })],
+                loadChildren,
+                onExpandLevel: (urns) => expanded.push(...urns),
+            });
+
+            expect(expanded).toEqual(['root-a', 'root-b', 'shared-folder']);
+            expect(loadChildren).toHaveBeenCalledTimes(3);
+        });
+
+        it('does nothing when there are no folders to expand', async () => {
+            const loadChildren = vi.fn(async () => []);
+            const onExpandLevel = vi.fn();
+
+            await expandAllFolders({ roots: [makeNode({ urn: 'leaf' })], loadChildren, onExpandLevel });
+
+            expect(onExpandLevel).not.toHaveBeenCalled();
+            expect(loadChildren).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/datahub-web-react/src/app/document/utils/documentTreeExpansion.ts
+++ b/datahub-web-react/src/app/document/utils/documentTreeExpansion.ts
@@ -1,0 +1,89 @@
+import { DocumentTreeNode } from '@app/document/DocumentTreeContext';
+
+/**
+ * Collect the urns of every expandable node (a node that `hasChildren`) reachable
+ * from `roots` through the already-loaded tree, including the roots themselves.
+ *
+ * Walks the loaded `children` of each node depth-first; nodes whose children have
+ * not been fetched yet still contribute their own urn (they are expandable), we
+ * just can't see below them until they load. Drives section-level collapse-all
+ * (which urns to clear) and the expand-state check below.
+ *
+ * @param roots - The section's root nodes to walk
+ * @returns Urns of expandable nodes in depth-first order
+ */
+export function collectExpandableUrns(roots: DocumentTreeNode[]): string[] {
+    const urns: string[] = [];
+    const walk = (node: DocumentTreeNode) => {
+        if (node.hasChildren) urns.push(node.urn);
+        (node.children || []).forEach(walk);
+    };
+    roots.forEach(walk);
+    return urns;
+}
+
+/**
+ * True when any expandable node under `roots` is currently expanded. Drives the
+ * section toggle glyph: collapse-all when something is open, expand-all otherwise.
+ *
+ * @param roots - The section's root nodes to walk
+ * @param expandedUrns - The set of currently-expanded node urns
+ */
+export function hasExpandedDescendant(roots: DocumentTreeNode[], expandedUrns: Set<string>): boolean {
+    return collectExpandableUrns(roots).some((urn) => expandedUrns.has(urn));
+}
+
+interface ExpandAllFoldersArgs {
+    /** The section's root nodes to expand from. */
+    roots: DocumentTreeNode[];
+    /** Loads (and returns) the freshly-fetched children of a parent urn. */
+    loadChildren: (urn: string) => Promise<DocumentTreeNode[]>;
+    /** Invoked with each breadth-first level's urns so the caller can expand them. */
+    onExpandLevel: (urns: string[]) => void;
+}
+
+/**
+ * Breadth-first expand of every folder under `roots`, loading children one level
+ * at a time.
+ *
+ * `loadChildren` returns the nodes it just loaded, so we discover the next level
+ * of folders from its return value rather than reading back potentially-stale
+ * tree state. `onExpandLevel` fires per level so expansion state updates as the
+ * walk progresses (rather than in one batch at the end). A `seen` set makes the
+ * walk resilient to repeats/cycles and prevents redundant fetches.
+ *
+ * @returns Resolves once the whole reachable folder subtree has been expanded.
+ */
+export async function expandAllFolders({ roots, loadChildren, onExpandLevel }: ExpandAllFoldersArgs): Promise<void> {
+    const seen = new Set<string>();
+
+    // Keep only urns we haven't queued before, marking them seen as we go. This
+    // dedupes both within a level (two parents sharing a child) and across levels
+    // (a folder reachable by more than one path), so each folder loads/expands once.
+    const enqueue = (urns: string[]): string[] => {
+        const fresh: string[] = [];
+        urns.forEach((urn) => {
+            if (!seen.has(urn)) {
+                seen.add(urn);
+                fresh.push(urn);
+            }
+        });
+        return fresh;
+    };
+
+    let current = enqueue(roots.filter((node) => node.hasChildren).map((node) => node.urn));
+
+    while (current.length > 0) {
+        onExpandLevel(current);
+
+        // eslint-disable-next-line no-await-in-loop
+        const results = await Promise.all(current.map((urn) => loadChildren(urn)));
+        const candidates: string[] = [];
+        results.forEach((children) => {
+            children.forEach((child) => {
+                if (child.hasChildren) candidates.push(child.urn);
+            });
+        });
+        current = enqueue(candidates);
+    }
+}

--- a/datahub-web-react/src/app/homeV2/layout/sidebar/documents/ChildLoadMoreTrigger.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/sidebar/documents/ChildLoadMoreTrigger.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
+import styled from 'styled-components';
+
+import Loading from '@app/shared/Loading';
+
+const ObserverContainer = styled.div`
+    height: 1px;
+    margin-top: 1px;
+`;
+
+const LoadMoreContainer = styled.div<{ $level: number }>`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px 8px 4px ${(props) => 8 + props.$level * 16}px;
+    min-height: 28px;
+`;
+
+interface ChildLoadMoreTriggerProps {
+    parentUrn: string;
+    level: number;
+    loading: boolean;
+    onLoad: (parentUrn: string) => void;
+}
+
+/**
+ * Invisible trigger that auto-loads the next page of a parent's children when
+ * scrolled into view. Renders a spinner in place while the page is loading.
+ */
+export function ChildLoadMoreTrigger({ parentUrn, level, loading: isLoading, onLoad }: ChildLoadMoreTriggerProps) {
+    const [ref, inView] = useInView();
+
+    useEffect(() => {
+        if (inView && !isLoading) {
+            onLoad(parentUrn);
+        }
+    }, [inView, isLoading, parentUrn, onLoad]);
+
+    if (isLoading) {
+        return (
+            <LoadMoreContainer $level={level}>
+                <Loading height={12} />
+            </LoadMoreContainer>
+        );
+    }
+
+    return <ObserverContainer ref={ref} />;
+}

--- a/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTree.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTree.tsx
@@ -1,13 +1,12 @@
-import { CaretDown } from '@phosphor-icons/react/dist/csr/CaretDown';
-import { CaretRight } from '@phosphor-icons/react/dist/csr/CaretRight';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useInView } from 'react-intersection-observer';
-import { useHistory, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { useDocumentTree } from '@app/document/DocumentTreeContext';
+import { useDocumentNavigation } from '@app/document/hooks/useDocumentNavigation';
 import { useLoadDocumentTree } from '@app/document/hooks/useLoadDocumentTree';
+import { useNodeChildrenLoading } from '@app/document/hooks/useNodeChildrenLoading';
+import { useSectionExpansion } from '@app/document/hooks/useSectionExpansion';
 import {
     DocumentTreeFilterSelection,
     NO_FILTER_SELECTION,
@@ -18,126 +17,26 @@ import {
     formatPlatformLabel,
     partitionRootNodesByLayer,
 } from '@app/document/utils/documentTreeGrouping';
+import { ChildLoadMoreTrigger } from '@app/homeV2/layout/sidebar/documents/ChildLoadMoreTrigger';
 import { DocumentTreeItem } from '@app/homeV2/layout/sidebar/documents/DocumentTreeItem';
+import { TreeSectionHeader } from '@app/homeV2/layout/sidebar/documents/TreeSectionHeader';
 import Loading from '@app/shared/Loading';
-import { useEntityRegistry } from '@app/useEntityRegistry';
 
-import { EntityType } from '@types';
+// Section id for the built-in "DataHub" (native docs) group. Platform groups use
+// their platform urn as the id; this sentinel keeps the native group distinct.
+const NATIVE_SECTION_ID = '__native__';
 
 const TreeContainer = styled.div`
     display: flex;
     flex-direction: column;
 `;
 
-const ObserverContainer = styled.div`
+// Sentinel row for the root-level infinite scroll — mirrors the child trigger's
+// observer, but for the top-level document list.
+const RootObserver = styled.div`
     height: 1px;
     margin-top: 1px;
 `;
-
-const LoadMoreContainer = styled.div<{ $level: number }>`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 4px 8px 4px ${(props) => 8 + props.$level * 16}px;
-    min-height: 28px;
-`;
-
-// Section header for the DataHub / per-platform group rows. Indent mirrors
-// DocumentTreeItem (8 + level*16) so a level-1 platform header lines up with a
-// level-1 doc row. The chevron sits on the right (vs. left on tree items) to
-// signal that this row is a structural group, not an interactive doc.
-// No hover background — it's a tree label, not a nav row; the pointer
-// cursor alone is enough affordance for the toggle.
-const SectionHeader = styled.button<{ $level: number }>`
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-    width: 100%;
-    padding: 6px 8px 6px ${(props) => 8 + props.$level * 16}px;
-    min-height: 32px;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    text-align: left;
-    color: ${(props) => props.theme.colors.textTertiary};
-    font-family: Mulish;
-    font-size: 14px;
-    font-weight: 700;
-`;
-
-const SectionHeaderLabel = styled.span`
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-`;
-
-/**
- * Collapsible header row for a tree section (DataHub or a per-platform
- * sub-section). Pure presentation — owns no expansion state of its own.
- */
-function TreeSectionHeader({
-    level,
-    label,
-    icon,
-    isExpanded,
-    onToggle,
-    testId,
-}: {
-    level: number;
-    label: string;
-    icon?: React.ReactNode;
-    isExpanded: boolean;
-    onToggle: () => void;
-    testId?: string;
-}) {
-    const Chevron = isExpanded ? CaretDown : CaretRight;
-    return (
-        <SectionHeader type="button" $level={level} onClick={onToggle} aria-expanded={isExpanded} data-testid={testId}>
-            <SectionHeaderLabel>
-                {icon}
-                {label}
-            </SectionHeaderLabel>
-            <Chevron size={14} weight="regular" />
-        </SectionHeader>
-    );
-}
-
-/**
- * Invisible trigger that auto-loads more children when scrolled into view.
- */
-function ChildLoadMoreTrigger({
-    parentUrn,
-    level,
-    loading: isLoading,
-    onLoad,
-}: {
-    parentUrn: string;
-    level: number;
-    loading: boolean;
-    onLoad: (parentUrn: string) => void;
-}) {
-    const [ref, inView] = useInView();
-
-    useEffect(() => {
-        if (inView && !isLoading) {
-            onLoad(parentUrn);
-        }
-    }, [inView, isLoading, parentUrn, onLoad]);
-
-    if (isLoading) {
-        return (
-            <LoadMoreContainer $level={level}>
-                <Loading height={12} />
-            </LoadMoreContainer>
-        );
-    }
-
-    return <ObserverContainer ref={ref} />;
-}
 
 interface DocumentTreeProps {
     onCreateChild: (parentUrn: string | null) => void;
@@ -165,13 +64,10 @@ export const DocumentTree: React.FC<DocumentTreeProps> = ({
     filterSelection = NO_FILTER_SELECTION,
 }) => {
     const { t } = useTranslation('misc');
-    const history = useHistory();
-    const location = useLocation();
-    const entityRegistry = useEntityRegistry();
 
     // Tree state (single source of truth!)
     // Note: expandedUrns is now in context to persist across component remounts
-    const { getRootNodes, getNode, expandedUrns, expandNode, collapseNode } = useDocumentTree();
+    const { getRootNodes, getNode, expandedUrns } = useDocumentTree();
     const {
         loadChildren,
         loadMoreChildren,
@@ -182,24 +78,17 @@ export const DocumentTree: React.FC<DocumentTreeProps> = ({
         rootObserverRef,
     } = useLoadDocumentTree();
 
-    // Local UI state for loading indicators only
-    const [loadingUrns, setLoadingUrns] = useState<Set<string>>(new Set());
+    // Per-node expand + lazy child loading, and routing/selection glue.
+    const { loadingUrns, loadingChildrenUrns, handleToggleExpand, handleLoadMoreChildren } = useNodeChildrenLoading({
+        loadChildren,
+        loadMoreChildren,
+    });
+    const { getCurrentDocumentUrn, handleDocumentClick } = useDocumentNavigation(onSelectDocument);
 
-    // Child infinite scroll loading state
-    const [loadingChildrenUrns, setLoadingChildrenUrns] = useState<Set<string>>(new Set());
-
-    const handleLoadMoreChildren = useCallback(
-        async (parentUrn: string) => {
-            setLoadingChildrenUrns((prev) => new Set(prev).add(parentUrn));
-            await loadMoreChildren(parentUrn);
-            setLoadingChildrenUrns((prev) => {
-                const next = new Set(prev);
-                next.delete(parentUrn);
-                return next;
-            });
-        },
-        [loadMoreChildren],
-    );
+    // Section-scoped expand-all / collapse-all (per DataHub + per-platform group).
+    const { isSectionExpanded, isSectionExpanding, toggleSectionExpandAll } = useSectionExpansion(loadChildren);
+    const expandAllLabel = t('context.tree.expandAll');
+    const collapseAllLabel = t('context.tree.collapseAll');
 
     const rootNodes = getRootNodes();
     const visibleRootNodes = useMemo(
@@ -228,55 +117,6 @@ export const DocumentTree: React.FC<DocumentTreeProps> = ({
             return next;
         });
     }, []);
-
-    const getCurrentDocumentUrn = useCallback(() => {
-        const match = location.pathname.match(/\/document\/([^/]+)/);
-        return match ? decodeURIComponent(match[1]) : null;
-    }, [location.pathname]);
-
-    const handleToggleExpand = useCallback(
-        async (urn: string) => {
-            const node = getNode(urn);
-            if (!node) return;
-
-            const isExpanded = expandedUrns.has(urn);
-
-            if (isExpanded) {
-                // Collapse
-                collapseNode(urn);
-            } else {
-                // Expand
-                expandNode(urn);
-
-                // Always fetch from server when expanding (if has children)
-                // The merge logic will combine server data with any optimistic updates
-                if (node.hasChildren) {
-                    setLoadingUrns((prev) => new Set(prev).add(urn));
-                    await loadChildren(urn);
-                    setLoadingUrns((prev) => {
-                        const next = new Set(prev);
-                        next.delete(urn);
-                        return next;
-                    });
-                }
-            }
-        },
-        [getNode, expandedUrns, expandNode, collapseNode, loadChildren],
-    );
-
-    const handleDocumentClick = useCallback(
-        (urn: string) => {
-            if (onSelectDocument) {
-                // Selection mode (e.g., in move dialog)
-                onSelectDocument(urn);
-            } else {
-                // Navigation mode
-                const url = entityRegistry.getEntityUrl(EntityType.Document, urn);
-                history.push(url);
-            }
-        },
-        [onSelectDocument, entityRegistry, history],
-    );
 
     const renderTreeNode = useCallback(
         (urn: string, level: number): React.ReactNode => {
@@ -356,6 +196,7 @@ export const DocumentTree: React.FC<DocumentTreeProps> = ({
         (group: DocumentSourceGroup) => {
             const { platform } = group;
             const isExpanded = !collapsedPlatformUrns.has(platform.urn);
+            const allExpanded = isSectionExpanded(group.nodes);
 
             return (
                 <React.Fragment key={platform.urn}>
@@ -365,12 +206,32 @@ export const DocumentTree: React.FC<DocumentTreeProps> = ({
                         isExpanded={isExpanded}
                         onToggle={() => togglePlatformGroup(platform.urn)}
                         testId={`document-tree-platform-${platform.urn}`}
+                        onToggleExpandAll={() => {
+                            // Opening the folders is useless if the section itself is collapsed.
+                            if (!allExpanded && collapsedPlatformUrns.has(platform.urn)) {
+                                togglePlatformGroup(platform.urn);
+                            }
+                            toggleSectionExpandAll(platform.urn, group.nodes);
+                        }}
+                        isAllExpanded={allExpanded}
+                        expandAllLoading={isSectionExpanding(platform.urn)}
+                        expandAllLabel={expandAllLabel}
+                        collapseAllLabel={collapseAllLabel}
                     />
                     {isExpanded && group.nodes.map((node) => renderTreeNode(node.urn, 0))}
                 </React.Fragment>
             );
         },
-        [collapsedPlatformUrns, renderTreeNode, togglePlatformGroup],
+        [
+            collapsedPlatformUrns,
+            renderTreeNode,
+            togglePlatformGroup,
+            isSectionExpanded,
+            isSectionExpanding,
+            toggleSectionExpandAll,
+            expandAllLabel,
+            collapseAllLabel,
+        ],
     );
 
     if (loading) {
@@ -387,12 +248,20 @@ export const DocumentTree: React.FC<DocumentTreeProps> = ({
                         isExpanded={isNativeExpanded}
                         onToggle={() => setIsNativeExpanded((v) => !v)}
                         testId="document-tree-datahub-section"
+                        onToggleExpandAll={() => {
+                            if (!isSectionExpanded(nativeRootNodes)) setIsNativeExpanded(true);
+                            toggleSectionExpandAll(NATIVE_SECTION_ID, nativeRootNodes);
+                        }}
+                        isAllExpanded={isSectionExpanded(nativeRootNodes)}
+                        expandAllLoading={isSectionExpanding(NATIVE_SECTION_ID)}
+                        expandAllLabel={expandAllLabel}
+                        collapseAllLabel={collapseAllLabel}
                     />
                     {isNativeExpanded && nativeRootNodes.map((node) => renderTreeNode(node.urn, 0))}
                 </>
             )}
             {sourcesByPlatform.map(renderPlatformGroup)}
-            {hasMoreRoots && <ObserverContainer ref={rootObserverRef} />}
+            {hasMoreRoots && <RootObserver ref={rootObserverRef} />}
             {loadingMoreRoots && <Loading height={12} />}
         </TreeContainer>
     );

--- a/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTreeItem.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTreeItem.tsx
@@ -16,20 +16,21 @@ import { Button, Tooltip } from '@src/alchemy-components';
 
 import { DataPlatform } from '@types';
 
-const TreeItemContainer = styled.div<{ $level: number; $isSelected: boolean }>`
+const TreeItemContainer = styled.div<{ $isSelected: boolean }>`
     position: relative;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 4px 8px 4px ${(props) => 8 + props.$level * 16}px;
+    /* No vertical padding: the row's full height is a hit area so the ExpandZone
+       (which stretches edge-to-edge) catches clicks in the space above/below the
+       folder icon instead of the row's navigate handler. */
+    padding: 0 2px 0 0;
     min-height: 38px;
     height: 38px;
     cursor: pointer;
     border-radius: 6px;
     transition: background-color 0.15s ease;
     margin-bottom: 2px;
-    margin-left: 2px;
-    margin-right: 2px;
 
     ${(props) =>
         props.$isSelected &&
@@ -51,17 +52,31 @@ background: ${props.theme.colors.bgHover};
 const LeftContent = styled.div`
     display: flex;
     align-items: center;
+    align-self: stretch;
     flex: 1;
     min-width: 0;
     overflow: hidden;
+`;
+
+// The whole left region — the indentation plus the icon/arrow — is the
+// expand/collapse tap target for folders. It carries the level indentation (moved
+// off the row container) and stretches to full row height so the hit area is
+// generous, while the title beyond it stays a navigation target.
+const ExpandZone = styled.div<{ $level: number; $expandable: boolean }>`
+    display: flex;
+    align-items: center;
+    align-self: stretch;
+    padding-left: ${(props) => 8 + props.$level * 16}px;
+    flex-shrink: 0;
+    cursor: ${(props) => (props.$expandable ? 'pointer' : 'inherit')};
 `;
 
 const IconSlot = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
+    align-self: stretch;
     width: 24px;
-    height: 20px;
     margin-right: 8px;
     flex-shrink: 0;
 `;
@@ -205,6 +220,15 @@ export const DocumentTreeItem: React.FC<DocumentTreeItemProps> = ({
         onClick();
     };
 
+    // The left zone (indent + icon/arrow) expands folders in place. Leaf rows have
+    // nothing to expand, so we let the click bubble up to the row and open the
+    // document instead.
+    const handleExpandZoneClick = (e: React.MouseEvent) => {
+        if (!hasChildren) return;
+        e.stopPropagation();
+        onToggleExpand();
+    };
+
     const showExpandButton = hasChildren && (isExpanded || isHovered);
 
     const renderIcon = () => {
@@ -260,14 +284,15 @@ export const DocumentTreeItem: React.FC<DocumentTreeItemProps> = ({
         <TreeItemContainer
             className="tree-item-container"
             data-testid={`document-tree-item-${urn}`}
-            $level={level}
             $isSelected={isSelected}
             onClick={handleItemClick}
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
         >
             <LeftContent>
-                <IconSlot>{renderIcon()}</IconSlot>
+                <ExpandZone $level={level} $expandable={hasChildren} onClick={handleExpandZoneClick}>
+                    <IconSlot>{renderIcon()}</IconSlot>
+                </ExpandZone>
 
                 <Title $isSelected={isSelected} title={title}>
                     {title}

--- a/datahub-web-react/src/app/homeV2/layout/sidebar/documents/TreeSectionHeader.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/sidebar/documents/TreeSectionHeader.tsx
@@ -1,0 +1,150 @@
+import { ArrowsInLineVertical } from '@phosphor-icons/react/dist/csr/ArrowsInLineVertical';
+import { ArrowsOutLineVertical } from '@phosphor-icons/react/dist/csr/ArrowsOutLineVertical';
+import { CaretDown } from '@phosphor-icons/react/dist/csr/CaretDown';
+import { CaretRight } from '@phosphor-icons/react/dist/csr/CaretRight';
+import React from 'react';
+import styled from 'styled-components';
+
+import { Tooltip } from '@src/alchemy-components';
+
+// Section header for the DataHub / per-platform group rows. Indent mirrors
+// DocumentTreeItem (8 + level*16) so a level-1 platform header lines up with a
+// level-1 doc row. The controls (expand-all + chevron) sit on the right to
+// signal that this row is a structural group, not an interactive doc.
+// No hover background — it's a tree label, not a nav row.
+const SectionHeaderRow = styled.div<{ $level: number }>`
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    width: 100%;
+    padding: 6px 2px 6px ${(props) => 8 + props.$level * 16}px;
+    min-height: 32px;
+    color: ${(props) => props.theme.colors.textTertiary};
+    font-family: Mulish;
+    font-size: 14px;
+    font-weight: 700;
+`;
+
+// Fills the row up to the trailing controls so the whole label area toggles the
+// section. Transparent, borderless — it reads as a label, not a button.
+const SectionToggleButton = styled.button`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    min-width: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    text-align: left;
+    color: inherit;
+    font: inherit;
+`;
+
+const SectionHeaderLabel = styled.span`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+`;
+
+const SectionIconButton = styled.button`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: ${(props) => props.theme.colors.icon};
+    flex-shrink: 0;
+
+    &:hover {
+        opacity: 0.7;
+    }
+
+    &:disabled {
+        cursor: default;
+        opacity: 0.5;
+    }
+`;
+
+interface TreeSectionHeaderProps {
+    level: number;
+    label: string;
+    icon?: React.ReactNode;
+    isExpanded: boolean;
+    onToggle: () => void;
+    testId?: string;
+    onToggleExpandAll?: () => void;
+    isAllExpanded?: boolean;
+    expandAllLoading?: boolean;
+    expandAllLabel?: string;
+    collapseAllLabel?: string;
+}
+
+/**
+ * Collapsible header row for a tree section (DataHub or a per-platform
+ * sub-section). Pure presentation — owns no expansion state of its own.
+ *
+ * When `onToggleExpandAll` is provided, a bulk expand/collapse control renders
+ * next to the section chevron. `isAllExpanded` picks the glyph (arrows-in =
+ * collapse everything in this section, arrows-out = expand everything).
+ */
+export function TreeSectionHeader({
+    level,
+    label,
+    icon,
+    isExpanded,
+    onToggle,
+    testId,
+    onToggleExpandAll,
+    isAllExpanded = false,
+    expandAllLoading = false,
+    expandAllLabel,
+    collapseAllLabel,
+}: TreeSectionHeaderProps) {
+    const Caret = isExpanded ? CaretDown : CaretRight;
+    const bulkLabel = isAllExpanded ? collapseAllLabel : expandAllLabel;
+    return (
+        <SectionHeaderRow $level={level} data-testid={testId}>
+            <SectionToggleButton type="button" onClick={onToggle} aria-expanded={isExpanded}>
+                <SectionHeaderLabel>
+                    {icon}
+                    {label}
+                </SectionHeaderLabel>
+            </SectionToggleButton>
+            {onToggleExpandAll && (
+                <Tooltip title={bulkLabel} placement="bottom" showArrow={false}>
+                    <SectionIconButton
+                        type="button"
+                        onClick={onToggleExpandAll}
+                        disabled={expandAllLoading}
+                        aria-label={bulkLabel}
+                        data-testid={testId ? `${testId}-expand-all` : undefined}
+                    >
+                        {isAllExpanded ? (
+                            <ArrowsInLineVertical size={16} weight="regular" />
+                        ) : (
+                            <ArrowsOutLineVertical size={16} weight="regular" />
+                        )}
+                    </SectionIconButton>
+                </Tooltip>
+            )}
+            <SectionIconButton
+                type="button"
+                onClick={onToggle}
+                aria-expanded={isExpanded}
+                aria-label={label}
+                tabIndex={-1}
+            >
+                <Caret size={16} weight="regular" />
+            </SectionIconButton>
+        </SectionHeaderRow>
+    );
+}

--- a/datahub-web-react/src/i18n/locales/en/misc.json
+++ b/datahub-web-react/src/i18n/locales/en/misc.json
@@ -64,6 +64,8 @@
     "context.sourceFilter.label": "Source",
     "context.sourceFilter.placeholder": "Filter sources",
     "context.tree.dataHubSection": "DataHub",
+    "context.tree.expandAll": "Expand all",
+    "context.tree.collapseAll": "Collapse all",
     "context.statusFilter.all": "All",
     "context.statusFilter.placeholder": "All",
     "context.statusFilter.published": "Published",


### PR DESCRIPTION


https://github.com/user-attachments/assets/f3cd3bd8-3aa6-4769-bc46-15613e2db8b6



Fixes the clunky document browse where trying to expand a folder often navigated into it instead.

- Expand/collapse: the whole left region of a folder row (indent + icon, full row height) is now the toggle target, while the title onward still navigates/opens the document.
- Per-section expand-all / collapse-all controls on the DataHub and each per-platform group header (Phosphor arrows-out/arrows-in), lazily loading children level-by-level.
- Scrollbar uses semantic color tokens and reserves its gutter so rows no longer shift when it appears.

Refactor (behavior-preserving) to keep the tree maintainable and match the codebase's util/hook conventions:
- Extract pure, unit-tested logic into document/utils/documentTreeExpansion.ts.
- Extract hooks: useSectionExpansion, useNodeChildrenLoading, useDocumentNavigation.
- Split TreeSectionHeader and ChildLoadMoreTrigger into their own files, slimming DocumentTree.tsx from 518 to 262 lines.
- Add colocated unit tests for the new util and hooks.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
