### PR TITLE
docs(agent-context): add Coding Assistants category and generated-ind…

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -134,10 +134,39 @@ module.exports = {
               id: "docs/dev-guides/agent-context/skills",
             },
             {
+              label: "AI Coding Assistants",
+              type: "category",
+              collapsible: true,
+              collapsed: true,
+              link: {
+                type: "generated-index",
+                title: "AI Coding Assistants",
+                description: "Connect DataHub to AI coding assistants.",
+              },
+              items: [
+                {
+                  label: "Cursor",
+                  type: "doc",
+                  id: "docs/dev-guides/agent-context/cursor",
+                },
+                {
+                  label: "Claude",
+                  type: "doc",
+                  id: "docs/dev-guides/agent-context/claude",
+                },
+              ],
+            },
+            {
               label: "Snowflake",
               type: "category",
               collapsible: true,
               collapsed: true,
+              link: {
+                type: "generated-index",
+                title: "Snowflake",
+                description:
+                  "Connect DataHub to Snowflake Cortex agents and Cortex Code.",
+              },
               items: [
                 {
                   label: "Cortex Agents",
@@ -156,6 +185,12 @@ module.exports = {
               type: "category",
               collapsible: true,
               collapsed: true,
+              link: {
+                type: "generated-index",
+                title: "Google",
+                description:
+                  "Connect DataHub to Google Gemini CLI, Agent Development Kit, and Vertex AI.",
+              },
               items: [
                 {
                   label: "Gemini CLI",
@@ -179,6 +214,12 @@ module.exports = {
               type: "category",
               collapsible: true,
               collapsed: true,
+              link: {
+                type: "generated-index",
+                title: "Databricks",
+                description:
+                  "Connect DataHub to Databricks Genie Code and Agent Bricks.",
+              },
               items: [
                 {
                   label: "Genie Code",
@@ -196,16 +237,6 @@ module.exports = {
               label: "LangChain",
               type: "doc",
               id: "docs/dev-guides/agent-context/langchain",
-            },
-            {
-              label: "Cursor",
-              type: "doc",
-              id: "docs/dev-guides/agent-context/cursor",
-            },
-            {
-              label: "Claude",
-              type: "doc",
-              id: "docs/dev-guides/agent-context/claude",
             },
             {
               label: "Microsoft Copilot Studio",


### PR DESCRIPTION
Groups the loose Cursor and Claude entries under a new " AI Coding Assistants" category, and adds generated-index landing pages to the Snowflake / Google / Databricks sub-categories so clicking them opens a card page instead of only expanding.

Sidebar-only: no files moved, no content changed.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in Updating DataHub