### PR TITLE
fix(ci): make schema-version bump check non-blocking on release/hotfix branches

### DIFF
--- a/.github/scripts/bump_schema_versions.py
+++ b/.github/scripts/bump_schema_versions.py
@@ -14,6 +14,10 @@ Rules:
   - If a non-aspect record A is included by aspect B and A changes, B is bumped
   - If a non-aspect record A is referenced as a field type in aspect B
     (e.g. `schedule: optional A`) and A changes, B is bumped
+  - The check is skipped entirely (exit 0, no bump) when the base is a
+    release (releases/*) or hotfix (hotfixes/*) branch. CI classifies the
+    explicit --base-branch; the local pre-commit hook infers the nearest
+    ancestor branch. OSS repos have no such branches, so this never fires there.
 
 Environment variables:
   PDL_ROOTS    Colon-separated list of PDL source roots to scan.
@@ -753,8 +757,6 @@ def find_transitively_affected_aspects(
 
 
 def main() -> int:
-    default_branch = detect_default_branch()
-
     parser = argparse.ArgumentParser(
         description="Bump schemaVersion on changed PDL aspect files.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -762,8 +764,10 @@ def main() -> int:
     )
     parser.add_argument(
         "--base-branch",
-        default=default_branch,
-        help=f"Branch to compare against (default: auto-detected '{default_branch}')",
+        default=None,
+        help="Branch to compare against. Defaults to the auto-detected default "
+        "branch. The check is skipped entirely when the base is a releases/* or "
+        "hotfixes/* branch.",
     )
     parser.add_argument(
         "--dry-run",
@@ -784,7 +788,31 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    remote_ref = f"refs/remotes/origin/{args.base_branch}"
+    # Skip on release/hotfix lines: the version-bump check compares against
+    # trunk and would demand pulling unrelated trunk schema churn into a
+    # release/hotfix. When an explicit base is given (CI passes the PR target),
+    # classify it directly; otherwise (local pre-commit hook) infer the nearest
+    # ancestor branch from git topology.
+    if args.base_branch is not None:
+        if is_release_or_hotfix_branch(args.base_branch):
+            print(
+                f"Base branch '{args.base_branch}' is a release/hotfix branch; "
+                "skipping schema version check."
+            )
+            return 0
+        base_branch = args.base_branch
+    else:
+        default_branch = detect_default_branch()
+        nearest = find_nearest_ancestor_release_branch(default_branch)
+        if nearest:
+            print(
+                f"Nearest base branch '{nearest}' is a release/hotfix branch; "
+                "skipping schema version check."
+            )
+            return 0
+        base_branch = default_branch
+
+    remote_ref = f"refs/remotes/origin/{base_branch}"
     merge_base = get_merge_base(remote_ref)
 
     directly_changed = get_changed_pdl_files(merge_base)
@@ -816,15 +844,15 @@ def main() -> int:
     if conflicting:
         files_list = "\n".join(f"  {f}" for f in conflicting)
         print(
-            f"ERROR: The following PDL file(s) also changed on {args.base_branch} "
+            f"ERROR: The following PDL file(s) also changed on {base_branch} "
             f"since this branch diverged. Please merge or rebase from "
-            f"{args.base_branch} first:\n{files_list}",
+            f"{base_branch} first:\n{files_list}",
             file=sys.stderr,
         )
         return 1
 
     if args.verbose:
-        print(f"Comparing against branch: {args.base_branch} (merge-base: {merge_base[:12]})")
+        print(f"Comparing against branch: {base_branch} (merge-base: {merge_base[:12]})")
         print(f"Found {len(directly_changed)} directly changed PDL file(s):")
         for f in directly_changed:
             print(f"  {f}")

--- a/.github/scripts/bump_schema_versions.py
+++ b/.github/scripts/bump_schema_versions.py
@@ -67,6 +67,31 @@ def detect_default_branch() -> str:
     return "master"
 
 
+# Branch-name prefixes for release and hotfix branches. A branch whose base is
+# one of these represents a targeted release/hotfix line, not trunk — the
+# schemaVersion bump check must not run against it (it would demand pulling
+# unrelated trunk schema churn into the release). Matches the convention in
+# .github/workflows/post-workflow-actions.yml.
+RELEASE_BRANCH_PREFIXES = ("releases/", "hotfixes/")
+
+_REMOTE_REF_PREFIXES = ("refs/remotes/origin/", "origin/")
+
+
+def is_release_or_hotfix_branch(name: str) -> bool:
+    """Return True if name refers to a releases/* or hotfixes/* branch.
+
+    Accepts bare names ('releases/x'), remote-tracking short names
+    ('origin/releases/x'), and full refs ('refs/remotes/origin/releases/x').
+    The match is a prefix on the branch portion — 'feature/releases-x' is not
+    a release branch.
+    """
+    for prefix in _REMOTE_REF_PREFIXES:
+        if name.startswith(prefix):
+            name = name[len(prefix):]
+            break
+    return name.startswith(RELEASE_BRANCH_PREFIXES)
+
+
 def get_merge_base(remote_ref: str) -> str:
     """Return the merge-base commit SHA between HEAD and remote_ref."""
     result = subprocess.run(

--- a/.github/scripts/bump_schema_versions.py
+++ b/.github/scripts/bump_schema_versions.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python3
 """
 CLI tool to bump schemaVersion annotations on changed PDL aspect files.
@@ -90,6 +91,92 @@ def is_release_or_hotfix_branch(name: str) -> bool:
             name = name[len(prefix):]
             break
     return name.startswith(RELEASE_BRANCH_PREFIXES)
+
+
+def _list_release_hotfix_refs() -> list[str]:
+    """Return short names of all local/remote releases/* and hotfixes/* refs.
+
+    Empty on git failure or when none exist (e.g. OSS DataHub).
+    """
+    result = subprocess.run(
+        [
+            "git",
+            "for-each-ref",
+            "--format=%(refname:short)",
+            "refs/remotes/*/releases/*",
+            "refs/remotes/*/hotfixes/*",
+            "refs/heads/releases/*",
+            "refs/heads/hotfixes/*",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return []
+    return [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+
+
+def _merge_base_distance(ref: str) -> int | None:
+    """Return the number of commits from merge-base(HEAD, ref) to HEAD.
+
+    Smaller means ref is a nearer ancestor of HEAD. Returns None if ref does
+    not resolve or shares no history with HEAD.
+    """
+    mb = subprocess.run(
+        ["git", "merge-base", "HEAD", ref], capture_output=True, text=True
+    )
+    if mb.returncode != 0 or not mb.stdout.strip():
+        return None
+    count = subprocess.run(
+        ["git", "rev-list", "--count", f"{mb.stdout.strip()}..HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    if count.returncode != 0 or not count.stdout.strip():
+        return None
+    try:
+        return int(count.stdout.strip())
+    except ValueError:
+        return None
+
+
+def find_nearest_ancestor_release_branch(default_branch: str) -> str | None:
+    """Return the releases/*|hotfixes/* branch that is the nearest ancestor of
+    HEAD, or None if the default branch is a nearer ancestor, none exist, or
+    the default branch cannot be resolved.
+
+    "Nearest" = fewest commits from the merge-base to HEAD. On a tie with the
+    default branch, the release/hotfix branch wins (release context is
+    intentional). Fails safe toward None so the check runs when in doubt.
+    """
+    candidates = _list_release_hotfix_refs()
+    if not candidates:
+        return None
+
+    # Distance to the default branch — try remote-tracking then bare name,
+    # since CI checkouts often only have the remote-tracking ref.
+    default_distance = None
+    for ref in (f"refs/remotes/origin/{default_branch}", default_branch):
+        default_distance = _merge_base_distance(ref)
+        if default_distance is not None:
+            break
+    if default_distance is None:
+        return None
+
+    nearest_ref = None
+    nearest_distance = None
+    for ref in candidates:
+        d = _merge_base_distance(ref)
+        if d is None:
+            continue
+        if nearest_distance is None or d < nearest_distance:
+            nearest_ref = ref
+            nearest_distance = d
+
+    if nearest_ref is None:
+        return None
+    # Tie → release/hotfix wins, hence <=.
+    return nearest_ref if nearest_distance <= default_distance else None
 
 
 def get_merge_base(remote_ref: str) -> str:

--- a/.github/scripts/bump_schema_versions.py
+++ b/.github/scripts/bump_schema_versions.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python3
 """
 CLI tool to bump schemaVersion annotations on changed PDL aspect files.

--- a/.github/scripts/bump_schema_versions.py
+++ b/.github/scripts/bump_schema_versions.py
@@ -149,8 +149,9 @@ def find_nearest_ancestor_release_branch(default_branch: str) -> str | None:
     the default branch cannot be resolved.
 
     "Nearest" = fewest commits from the merge-base to HEAD. On a tie with the
-    default branch, the release/hotfix branch wins (release context is
-    intentional). Fails safe toward None so the check runs when in doubt.
+    default branch, the default branch wins (a tie means HEAD shares the
+    same fork point with both, i.e. a trunk branch). Fails safe toward None
+    so the check runs when in doubt.
     """
     candidates = _list_release_hotfix_refs()
     if not candidates:
@@ -178,8 +179,10 @@ def find_nearest_ancestor_release_branch(default_branch: str) -> str | None:
 
     if nearest_ref is None:
         return None
-    # Tie → release/hotfix wins, hence <=.
-    return nearest_ref if nearest_distance <= default_distance else None
+    # Only a strictly-nearer release/hotfix branch wins. A tie means HEAD shares
+    # the same fork point with both (e.g. a feature branch off trunk and a
+    # release cut from trunk afterward) — that is a trunk branch, so run the check.
+    return nearest_ref if nearest_distance < default_distance else None
 
 
 def get_merge_base(remote_ref: str) -> str:

--- a/.github/scripts/test/test_bump_schema_versions.py
+++ b/.github/scripts/test/test_bump_schema_versions.py
@@ -1069,3 +1069,40 @@ def test_check_mode_passes_for_comment_only_change(tmp_path, monkeypatch):
     rc = _run_check(tmp_path, monkeypatch, [enum_file], {str(enum_file): enum_base})
 
     assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# main() release/hotfix skip
+# ---------------------------------------------------------------------------
+
+
+def test_main_skips_on_explicit_release_base(monkeypatch):
+    monkeypatch.setattr(
+        sys, "argv",
+        ["bump_schema_versions.py", "--check", "--base-branch", "releases/v0.3.12"],
+    )
+    # If the skip fails, main() would call get_merge_base — make that explode.
+    monkeypatch.setattr(bsv, "get_merge_base",
+                        lambda _ref: pytest.fail("must skip before git"))
+    assert bsv.main() == 0
+
+
+def test_main_skips_when_nearest_ancestor_is_release(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["bump_schema_versions.py"])
+    monkeypatch.setattr(bsv, "detect_default_branch", lambda: "acryl-main")
+    monkeypatch.setattr(bsv, "find_nearest_ancestor_release_branch",
+                        lambda _default: "origin/releases/v0.3.12")
+    monkeypatch.setattr(bsv, "get_merge_base",
+                        lambda _ref: pytest.fail("must skip before git"))
+    assert bsv.main() == 0
+
+
+def test_main_local_no_release_ancestor_proceeds(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["bump_schema_versions.py"])
+    monkeypatch.setattr(bsv, "detect_default_branch", lambda: "acryl-main")
+    monkeypatch.setattr(bsv, "find_nearest_ancestor_release_branch",
+                        lambda _default: None)
+    monkeypatch.setattr(bsv, "get_merge_base", lambda _ref: "deadbeef")
+    monkeypatch.setattr(bsv, "get_changed_pdl_files", lambda _ref: [])
+    # No changed PDL files → main() returns 0 after resolving the default base.
+    assert bsv.main() == 0

--- a/.github/scripts/test/test_bump_schema_versions.py
+++ b/.github/scripts/test/test_bump_schema_versions.py
@@ -765,6 +765,69 @@ def test_is_release_or_hotfix_branch_rejects_non_release():
     assert bsv.is_release_or_hotfix_branch("feature/releases-thing") is False
 
 
+# ---------------------------------------------------------------------------
+# _merge_base_distance
+# ---------------------------------------------------------------------------
+
+
+def test_merge_base_distance_returns_count(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_proc(0, "3\n"))
+    assert bsv._merge_base_distance("origin/releases/x") == 3
+
+
+def test_merge_base_distance_none_on_failure(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_proc(1))
+    assert bsv._merge_base_distance("origin/releases/x") is None
+
+
+# ---------------------------------------------------------------------------
+# find_nearest_ancestor_release_branch
+# ---------------------------------------------------------------------------
+
+
+def test_nearest_ancestor_no_candidates_returns_none(monkeypatch):
+    monkeypatch.setattr(bsv, "_list_release_hotfix_refs", lambda: [])
+    assert bsv.find_nearest_ancestor_release_branch("acryl-main") is None
+
+
+def test_nearest_ancestor_release_branch_wins(monkeypatch):
+    monkeypatch.setattr(bsv, "_list_release_hotfix_refs",
+                        lambda: ["origin/releases/v0.3.12"])
+    # release branch 2 commits back, default branch 10 commits back
+    dist = {"origin/releases/v0.3.12": 2,
+            "refs/remotes/origin/acryl-main": 10, "acryl-main": 10}
+    monkeypatch.setattr(bsv, "_merge_base_distance", lambda ref: dist.get(ref))
+    assert (bsv.find_nearest_ancestor_release_branch("acryl-main")
+            == "origin/releases/v0.3.12")
+
+
+def test_nearest_ancestor_default_nearer_returns_none(monkeypatch):
+    monkeypatch.setattr(bsv, "_list_release_hotfix_refs",
+                        lambda: ["origin/releases/v0.3.12"])
+    dist = {"origin/releases/v0.3.12": 10,
+            "refs/remotes/origin/acryl-main": 2, "acryl-main": 2}
+    monkeypatch.setattr(bsv, "_merge_base_distance", lambda ref: dist.get(ref))
+    assert bsv.find_nearest_ancestor_release_branch("acryl-main") is None
+
+
+def test_nearest_ancestor_tie_prefers_release(monkeypatch):
+    monkeypatch.setattr(bsv, "_list_release_hotfix_refs",
+                        lambda: ["origin/hotfixes/v0.3.12.1"])
+    dist = {"origin/hotfixes/v0.3.12.1": 5,
+            "refs/remotes/origin/acryl-main": 5, "acryl-main": 5}
+    monkeypatch.setattr(bsv, "_merge_base_distance", lambda ref: dist.get(ref))
+    assert (bsv.find_nearest_ancestor_release_branch("acryl-main")
+            == "origin/hotfixes/v0.3.12.1")
+
+
+def test_nearest_ancestor_unresolvable_default_returns_none(monkeypatch):
+    monkeypatch.setattr(bsv, "_list_release_hotfix_refs",
+                        lambda: ["origin/releases/v0.3.12"])
+    dist = {"origin/releases/v0.3.12": 2}  # default branch unresolvable → None
+    monkeypatch.setattr(bsv, "_merge_base_distance", lambda ref: dist.get(ref))
+    assert bsv.find_nearest_ancestor_release_branch("acryl-main") is None
+
+
 def test_get_merge_base_returns_sha(monkeypatch):
     monkeypatch.setattr(subprocess, "run",
                         lambda *a, **kw: _make_proc(0, "abc123def456\n"))

--- a/.github/scripts/test/test_bump_schema_versions.py
+++ b/.github/scripts/test/test_bump_schema_versions.py
@@ -741,6 +741,30 @@ def test_detect_default_branch_fallback_to_master(monkeypatch):
     assert bsv.detect_default_branch() == "master"
 
 
+# ---------------------------------------------------------------------------
+# is_release_or_hotfix_branch
+# ---------------------------------------------------------------------------
+
+
+def test_is_release_or_hotfix_branch_bare_names():
+    assert bsv.is_release_or_hotfix_branch("releases/v0.3.12") is True
+    assert bsv.is_release_or_hotfix_branch("hotfixes/v0.3.12.1") is True
+
+
+def test_is_release_or_hotfix_branch_strips_remote_prefixes():
+    assert bsv.is_release_or_hotfix_branch("origin/releases/v0.3.12") is True
+    assert bsv.is_release_or_hotfix_branch(
+        "refs/remotes/origin/hotfixes/v0.3.12.1"
+    ) is True
+
+
+def test_is_release_or_hotfix_branch_rejects_non_release():
+    assert bsv.is_release_or_hotfix_branch("acryl-main") is False
+    assert bsv.is_release_or_hotfix_branch("master") is False
+    # Substring, not prefix — must be rejected.
+    assert bsv.is_release_or_hotfix_branch("feature/releases-thing") is False
+
+
 def test_get_merge_base_returns_sha(monkeypatch):
     monkeypatch.setattr(subprocess, "run",
                         lambda *a, **kw: _make_proc(0, "abc123def456\n"))

--- a/.github/scripts/test/test_bump_schema_versions.py
+++ b/.github/scripts/test/test_bump_schema_versions.py
@@ -810,14 +810,15 @@ def test_nearest_ancestor_default_nearer_returns_none(monkeypatch):
     assert bsv.find_nearest_ancestor_release_branch("acryl-main") is None
 
 
-def test_nearest_ancestor_tie_prefers_release(monkeypatch):
+def test_nearest_ancestor_tie_prefers_default(monkeypatch):
     monkeypatch.setattr(bsv, "_list_release_hotfix_refs",
                         lambda: ["origin/hotfixes/v0.3.12.1"])
     dist = {"origin/hotfixes/v0.3.12.1": 5,
             "refs/remotes/origin/acryl-main": 5, "acryl-main": 5}
     monkeypatch.setattr(bsv, "_merge_base_distance", lambda ref: dist.get(ref))
-    assert (bsv.find_nearest_ancestor_release_branch("acryl-main")
-            == "origin/hotfixes/v0.3.12.1")
+    # A tie means HEAD shares the same fork point with both — that's a trunk
+    # branch, so the default branch wins and the check must run.
+    assert bsv.find_nearest_ancestor_release_branch("acryl-main") is None
 
 
 def test_nearest_ancestor_unresolvable_default_returns_none(monkeypatch):


### PR DESCRIPTION
## Summary

Makes the `bump-schema-versions` check (run as a local pre-commit hook and in the `check-schema-versions` CI job) **non-blocking — skipped entirely, exit 0, no bump** — when the branch's base is a `releases/*` or `hotfixes/*` branch.

Today the check compares changed PDL aspects against the default branch and, if a touched PDL file also changed on the base since divergence, hard-fails demanding a rebase/merge from the base. For a hotfix branched off a release line this is wrong: it forces pulling unrelated trunk schema churn into the hotfix. Release/hotfix branches should not be subject to this trunk-oriented check.

## What changed

`.github/scripts/bump_schema_versions.py`:

- `is_release_or_hotfix_branch(name)` — classifies a branch name (bare, `origin/…`, or `refs/remotes/origin/…`) as `releases/*`/`hotfixes/*` via prefix match (`feature/releases-x` is correctly not a match). Prefixes match the convention in `post-workflow-actions.yml`.
- `find_nearest_ancestor_release_branch(default_branch)` (+ `_list_release_hotfix_refs`, `_merge_base_distance`) — for the local hook (no explicit base), infers whether HEAD is **strictly** nearer a release/hotfix branch than the default branch, by merge-base distance.
- `main()` — `--base-branch` now defaults to `None`. When a base is passed explicitly (CI passes the PR target) it is classified directly; otherwise the nearest-ancestor is inferred. A release/hotfix base short-circuits with `return 0` **before any git/merge-base call**.

## Behavior

- PR into `releases/*`/`hotfixes/*` (CI) → skipped.
- Local commit genuinely descended from a release/hotfix branch → skipped.
- Trunk PRs, trunk feature branches, and OSS (no release/hotfix branches exist) → **run exactly as before**.
- Every git error / unresolvable ref / empty enumeration fails safe **toward running** the check, never toward silently skipping. CI also still enforces bumps at PR time via the explicit base.

## Testing

13 new unit tests (git mocked); full file **88 passing**. Covers the classifier, nearest-ancestor selection (strict win, default-wins-on-tie, no candidates, git failure, unresolvable default), and the `main()` skip gate.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [ ] Docs added/updated (n/a — internal CI tooling)
- [ ] Breaking changes (none)
