### PR TITLE
fix(ece/structured-property): Refactor change event generation to always set parameters

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/StructuredPropertyChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/StructuredPropertyChangeEventGenerator.java
@@ -14,11 +14,14 @@ import com.linkedin.metadata.timeline.data.SemanticChangeType;
 import com.linkedin.metadata.timeline.data.entity.StructuredPropertyAssignmentChangeEvent;
 import com.linkedin.structured.StructuredProperties;
 import com.linkedin.structured.StructuredPropertyValueAssignment;
-import com.linkedin.structured.StructuredPropertyValueAssignmentArray;
 import jakarta.json.JsonPatch;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import javax.annotation.Nonnull;
 
 public class StructuredPropertyChangeEventGenerator
@@ -27,6 +30,10 @@ public class StructuredPropertyChangeEventGenerator
       "Structured property '%s' added to entity '%s'.";
   private static final String STRUCTURED_PROPERTY_REMOVED_FORMAT =
       "Structured property '%s' removed from entity '%s'.";
+  private static final String STRUCTURED_PROPERTY_CHANGED_FORMAT =
+      "Structured property '%s' changed on entity '%s'.";
+
+  private static final Comparator<Urn> URN_COMPARATOR = Comparator.comparing(Urn::toString);
 
   public List<ChangeEvent> getChangeEvents(
       @Nonnull Urn urn,
@@ -36,21 +43,6 @@ public class StructuredPropertyChangeEventGenerator
       @Nonnull Aspect<StructuredProperties> to,
       @Nonnull AuditStamp auditStamp) {
     return computeDiffs(from.getValue(), to.getValue(), urn.toString(), auditStamp);
-  }
-
-  private static void sortStructuredPropertiesByStructuredPropertyUrn(
-      StructuredProperties structuredProperties) {
-    if (structuredProperties == null) {
-      return;
-    }
-    List<StructuredPropertyValueAssignment> structuredPropertyValueAssignments =
-        new ArrayList<>(structuredProperties.getProperties());
-    structuredPropertyValueAssignments.sort(
-        Comparator.comparing(
-            StructuredPropertyValueAssignment::getPropertyUrn,
-            Comparator.comparing(Urn::toString)));
-    structuredProperties.setProperties(
-        new StructuredPropertyValueAssignmentArray(structuredPropertyValueAssignments));
   }
 
   private static StructuredProperties getStructuredPropertiesFromAspect(EntityAspect entityAspect) {
@@ -72,12 +64,15 @@ public class StructuredPropertyChangeEventGenerator
       throw new IllegalArgumentException("Aspect is not " + STRUCTURED_PROPERTIES_ASPECT_NAME);
     }
 
-    StructuredProperties baseGlobalTags = getStructuredPropertiesFromAspect(previousValue);
-    StructuredProperties targetGlobalTags = getStructuredPropertiesFromAspect(currentValue);
+    StructuredProperties baseStructuredProperties =
+        getStructuredPropertiesFromAspect(previousValue);
+    StructuredProperties targetStructuredProperties =
+        getStructuredPropertiesFromAspect(currentValue);
     List<ChangeEvent> changeEvents = new ArrayList<>();
     if (element == ChangeCategory.STRUCTURED_PROPERTY) {
       changeEvents.addAll(
-          computeDiffs(baseGlobalTags, targetGlobalTags, currentValue.getUrn(), null));
+          computeDiffs(
+              baseStructuredProperties, targetStructuredProperties, currentValue.getUrn(), null));
     }
 
     // Assess the highest change at the transaction(schema) level.
@@ -97,140 +92,84 @@ public class StructuredPropertyChangeEventGenerator
         .build();
   }
 
-  private List<ChangeEvent> computeDiffs(
+  private static List<ChangeEvent> computeDiffs(
       final StructuredProperties previousAspect,
       final StructuredProperties newAspect,
       final String entityUrn,
       final AuditStamp auditStamp) {
 
-    sortStructuredPropertiesByStructuredPropertyUrn(previousAspect);
-    sortStructuredPropertiesByStructuredPropertyUrn(newAspect);
+    Map<Urn, StructuredPropertyValueAssignment> baseAssignments =
+        buildAssignmentMap(previousAspect);
+    Map<Urn, StructuredPropertyValueAssignment> targetAssignments = buildAssignmentMap(newAspect);
+
+    // Sorted for deterministic event ordering.
+    Set<Urn> allPropertyUrns = new TreeSet<>(URN_COMPARATOR);
+    allPropertyUrns.addAll(baseAssignments.keySet());
+    allPropertyUrns.addAll(targetAssignments.keySet());
+
     List<ChangeEvent> changeEvents = new ArrayList<>();
-    StructuredPropertyValueAssignmentArray baseAssignments =
-        (previousAspect != null)
-            ? previousAspect.getProperties()
-            : new StructuredPropertyValueAssignmentArray();
-    StructuredPropertyValueAssignmentArray targetAssignments =
-        (newAspect != null)
-            ? newAspect.getProperties()
-            : new StructuredPropertyValueAssignmentArray();
-    int baseIdx = 0;
-    int targetIdx = 0;
+    for (Urn propertyUrn : allPropertyUrns) {
+      StructuredPropertyValueAssignment baseAssignment = baseAssignments.get(propertyUrn);
+      StructuredPropertyValueAssignment targetAssignment = targetAssignments.get(propertyUrn);
 
-    while (baseIdx < baseAssignments.size() && targetIdx < targetAssignments.size()) {
-      StructuredPropertyValueAssignment baseAssignment = baseAssignments.get(baseIdx);
-      StructuredPropertyValueAssignment targetAssignment = targetAssignments.get(targetIdx);
-      int comparison =
-          baseAssignment
-              .getPropertyUrn()
-              .toString()
-              .compareTo(targetAssignment.getPropertyUrn().toString());
-
-      if (comparison == 0) {
-        // No change to this property.
-        ++baseIdx;
-        ++targetIdx;
-        if (!baseAssignment.getValues().equals(targetAssignment.getValues())) {
-          changeEvents.add(
-              StructuredPropertyAssignmentChangeEvent
-                  .entityStructuredPropertyAssignmentChangeEventBuilder()
-                  .modifier(targetAssignment.getPropertyUrn().toString())
-                  .entityUrn(entityUrn)
-                  .category(ChangeCategory.STRUCTURED_PROPERTY)
-                  .operation(ChangeOperation.MODIFY)
-                  .semVerChange(SemanticChangeType.MINOR)
-                  .description(
-                      String.format(
-                          STRUCTURED_PROPERTY_ADDED_FORMAT,
-                          targetAssignment.getPropertyUrn().getId(),
-                          entityUrn))
-                  .auditStamp(auditStamp)
-                  .structuredPropertyValueAssignment(targetAssignment)
-                  .build());
-        }
-      } else if (comparison < 0) {
-        // Property got removed.
+      if (baseAssignment == null) {
         changeEvents.add(
-            StructuredPropertyAssignmentChangeEvent.builder()
-                .modifier(baseAssignment.getPropertyUrn().toString())
-                .entityUrn(entityUrn)
-                .category(ChangeCategory.STRUCTURED_PROPERTY)
-                .operation(ChangeOperation.REMOVE)
-                .semVerChange(SemanticChangeType.MINOR)
-                .description(
-                    String.format(
-                        STRUCTURED_PROPERTY_REMOVED_FORMAT,
-                        baseAssignment.getPropertyUrn().getId(),
-                        entityUrn))
-                .auditStamp(auditStamp)
-                .build());
-        ++baseIdx;
-      } else {
-        // Property got added.
+            buildChangeEvent(
+                ChangeOperation.ADD,
+                STRUCTURED_PROPERTY_ADDED_FORMAT,
+                targetAssignment,
+                entityUrn,
+                auditStamp));
+      } else if (targetAssignment == null) {
         changeEvents.add(
-            StructuredPropertyAssignmentChangeEvent
-                .entityStructuredPropertyAssignmentChangeEventBuilder()
-                .modifier(targetAssignment.getPropertyUrn().toString())
-                .entityUrn(entityUrn)
-                .category(ChangeCategory.STRUCTURED_PROPERTY)
-                .operation(ChangeOperation.ADD)
-                .semVerChange(SemanticChangeType.MINOR)
-                .description(
-                    String.format(
-                        STRUCTURED_PROPERTY_ADDED_FORMAT,
-                        targetAssignment.getPropertyUrn().getId(),
-                        entityUrn))
-                .auditStamp(auditStamp)
-                .structuredPropertyValueAssignment(targetAssignment)
-                .build());
-        ++targetIdx;
+            buildChangeEvent(
+                ChangeOperation.REMOVE,
+                STRUCTURED_PROPERTY_REMOVED_FORMAT,
+                baseAssignment,
+                entityUrn,
+                auditStamp));
+      } else if (!baseAssignment.getValues().equals(targetAssignment.getValues())) {
+        changeEvents.add(
+            buildChangeEvent(
+                ChangeOperation.MODIFY,
+                STRUCTURED_PROPERTY_CHANGED_FORMAT,
+                targetAssignment,
+                entityUrn,
+                auditStamp));
       }
     }
 
-    // Handle remaining properties in baseAssignments (removed properties)
-    while (baseIdx < baseAssignments.size()) {
-      StructuredPropertyValueAssignment baseAssignment = baseAssignments.get(baseIdx);
-      changeEvents.add(
-          StructuredPropertyAssignmentChangeEvent
-              .entityStructuredPropertyAssignmentChangeEventBuilder()
-              .modifier(baseAssignment.getPropertyUrn().toString())
-              .entityUrn(entityUrn)
-              .category(ChangeCategory.STRUCTURED_PROPERTY)
-              .operation(ChangeOperation.REMOVE)
-              .semVerChange(SemanticChangeType.MINOR)
-              .description(
-                  String.format(
-                      STRUCTURED_PROPERTY_REMOVED_FORMAT,
-                      baseAssignment.getPropertyUrn().getId(),
-                      entityUrn))
-              .auditStamp(auditStamp)
-              .structuredPropertyValueAssignment(baseAssignment)
-              .build());
-      ++baseIdx;
-    }
-
-    // Handle remaining properties in targetAssignments (added properties)
-    while (targetIdx < targetAssignments.size()) {
-      StructuredPropertyValueAssignment targetAssignment = targetAssignments.get(targetIdx);
-      changeEvents.add(
-          StructuredPropertyAssignmentChangeEvent
-              .entityStructuredPropertyAssignmentChangeEventBuilder()
-              .modifier(targetAssignment.getPropertyUrn().toString())
-              .entityUrn(entityUrn)
-              .category(ChangeCategory.STRUCTURED_PROPERTY)
-              .operation(ChangeOperation.ADD)
-              .semVerChange(SemanticChangeType.MINOR)
-              .description(
-                  String.format(
-                      STRUCTURED_PROPERTY_ADDED_FORMAT,
-                      targetAssignment.getPropertyUrn().getId(),
-                      entityUrn))
-              .auditStamp(auditStamp)
-              .structuredPropertyValueAssignment(targetAssignment)
-              .build());
-      ++targetIdx;
-    }
-
     return changeEvents;
+  }
+
+  private static Map<Urn, StructuredPropertyValueAssignment> buildAssignmentMap(
+      StructuredProperties structuredProperties) {
+    Map<Urn, StructuredPropertyValueAssignment> map = new TreeMap<>(URN_COMPARATOR);
+    if (structuredProperties != null) {
+      structuredProperties
+          .getProperties()
+          .forEach(assignment -> map.put(assignment.getPropertyUrn(), assignment));
+    }
+    return map;
+  }
+
+  private static ChangeEvent buildChangeEvent(
+      final ChangeOperation operation,
+      final String descriptionFormat,
+      final StructuredPropertyValueAssignment assignment,
+      final String entityUrn,
+      final AuditStamp auditStamp) {
+    return StructuredPropertyAssignmentChangeEvent
+        .entityStructuredPropertyAssignmentChangeEventBuilder()
+        .modifier(assignment.getPropertyUrn().toString())
+        .entityUrn(entityUrn)
+        .category(ChangeCategory.STRUCTURED_PROPERTY)
+        .operation(operation)
+        .semVerChange(SemanticChangeType.MINOR)
+        .description(
+            String.format(descriptionFormat, assignment.getPropertyUrn().getId(), entityUrn))
+        .auditStamp(auditStamp)
+        .structuredPropertyValueAssignment(assignment)
+        .build();
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/StructuredPropertiesChangeEventGeneratorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/StructuredPropertiesChangeEventGeneratorTest.java
@@ -11,11 +11,32 @@ import com.linkedin.structured.PrimitivePropertyValueArray;
 import com.linkedin.structured.StructuredProperties;
 import com.linkedin.structured.StructuredPropertyValueAssignment;
 import com.linkedin.structured.StructuredPropertyValueAssignmentArray;
+import java.util.Arrays;
 import java.util.List;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
 
 public class StructuredPropertiesChangeEventGeneratorTest extends AbstractTestNGSpringContextTests {
+
+  private static StructuredPropertyValueAssignment buildAssignment(
+      String propertyUrn, String... values) throws Exception {
+    StructuredPropertyValueAssignment assignment = new StructuredPropertyValueAssignment();
+    assignment.setPropertyUrn(new Urn(propertyUrn));
+    PrimitivePropertyValueArray valueArray = new PrimitivePropertyValueArray();
+    for (String value : values) {
+      valueArray.add(PrimitivePropertyValue.create(value));
+    }
+    assignment.setValues(valueArray);
+    return assignment;
+  }
+
+  private static StructuredProperties buildStructuredProperties(
+      StructuredPropertyValueAssignment... assignments) {
+    StructuredProperties properties = new StructuredProperties();
+    properties.setProperties(
+        new StructuredPropertyValueAssignmentArray(Arrays.asList(assignments)));
+    return properties;
+  }
 
   @Test
   public void testNoChange() throws Exception {
@@ -309,5 +330,151 @@ public class StructuredPropertiesChangeEventGeneratorTest extends AbstractTestNG
     String ea = (String) actual.get(0).getParameters().get("propertyValues");
     assertEquals("REMOVE", actual.get(0).getOperation().toString());
     assertEquals(expectedValue, ea);
+  }
+
+  @Test
+  public void testDeletePropertySortingBeforeRemainingProperty() throws Exception {
+    StructuredPropertyChangeEventGenerator test = new StructuredPropertyChangeEventGenerator();
+
+    Urn urn =
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hdfs,SampleHdfsDataset,PROD)");
+    String entity = "dataset";
+    String aspect = "structedProperties";
+    AuditStamp auditStamp =
+        new AuditStamp()
+            .setActor(Urn.createFromString("urn:li:corpuser:__datahub_system"))
+            .setTime(1683829509553L);
+
+    // Removed property sorts lexicographically BEFORE the property that remains.
+    StructuredPropertyValueAssignment removedProp = new StructuredPropertyValueAssignment();
+    removedProp.setPropertyUrn(new Urn("urn:li:structuredProperty:io.acryl.aRemovedProperty"));
+    PrimitivePropertyValueArray removedValues = new PrimitivePropertyValueArray();
+    removedValues.add(PrimitivePropertyValue.create("42"));
+    removedProp.setValues(removedValues);
+
+    StructuredPropertyValueAssignment remainingProp = new StructuredPropertyValueAssignment();
+    remainingProp.setPropertyUrn(
+        new Urn("urn:li:structuredProperty:io.acryl.privacy.retentionTime"));
+    PrimitivePropertyValueArray remainingValues = new PrimitivePropertyValueArray();
+    remainingValues.add(PrimitivePropertyValue.create("90"));
+    remainingProp.setValues(remainingValues);
+
+    StructuredProperties fromProperties = new StructuredProperties();
+    StructuredPropertyValueAssignmentArray fromAssignmentArray =
+        new StructuredPropertyValueAssignmentArray();
+    fromAssignmentArray.add(removedProp);
+    fromAssignmentArray.add(remainingProp);
+    fromProperties.setProperties(fromAssignmentArray);
+
+    StructuredProperties structuredPropertiesTo = new StructuredProperties();
+    StructuredPropertyValueAssignmentArray toAssignmentArray =
+        new StructuredPropertyValueAssignmentArray();
+    toAssignmentArray.add(remainingProp);
+    structuredPropertiesTo.setProperties(toAssignmentArray);
+
+    Aspect<StructuredProperties> from = new Aspect<>(fromProperties, new SystemMetadata());
+    Aspect<StructuredProperties> to = new Aspect<>(structuredPropertiesTo, new SystemMetadata());
+
+    List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, from, to, auditStamp);
+
+    assertEquals(1, actual.size());
+    assertEquals("REMOVE", actual.get(0).getOperation().toString());
+    assertNotNull(actual.get(0).getParameters());
+    assertEquals(
+        "urn:li:structuredProperty:io.acryl.aRemovedProperty",
+        actual.get(0).getParameters().get("propertyUrn").toString());
+    assertEquals("[\"42\"]", actual.get(0).getParameters().get("propertyValues"));
+  }
+
+  @Test
+  public void testAllPropertiesRemoved() throws Exception {
+    StructuredPropertyChangeEventGenerator test = new StructuredPropertyChangeEventGenerator();
+
+    Urn urn =
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hdfs,SampleHdfsDataset,PROD)");
+    String entity = "dataset";
+    String aspect = "structedProperties";
+    AuditStamp auditStamp =
+        new AuditStamp()
+            .setActor(Urn.createFromString("urn:li:corpuser:__datahub_system"))
+            .setTime(1683829509553L);
+
+    StructuredProperties fromProperties =
+        buildStructuredProperties(
+            buildAssignment("urn:li:structuredProperty:io.acryl.propertyA", "1"),
+            buildAssignment("urn:li:structuredProperty:io.acryl.propertyB", "2"));
+
+    // Aspect deletion: the new value is null.
+    Aspect<StructuredProperties> from = new Aspect<>(fromProperties, new SystemMetadata());
+    Aspect<StructuredProperties> to = new Aspect<>(null, new SystemMetadata());
+
+    List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, from, to, auditStamp);
+
+    assertEquals(2, actual.size());
+
+    assertEquals("REMOVE", actual.get(0).getOperation().toString());
+    assertNotNull(actual.get(0).getParameters());
+    assertEquals(
+        "urn:li:structuredProperty:io.acryl.propertyA",
+        actual.get(0).getParameters().get("propertyUrn").toString());
+    assertEquals("[\"1\"]", actual.get(0).getParameters().get("propertyValues"));
+
+    assertEquals("REMOVE", actual.get(1).getOperation().toString());
+    assertNotNull(actual.get(1).getParameters());
+    assertEquals(
+        "urn:li:structuredProperty:io.acryl.propertyB",
+        actual.get(1).getParameters().get("propertyUrn").toString());
+    assertEquals("[\"2\"]", actual.get(1).getParameters().get("propertyValues"));
+  }
+
+  @Test
+  public void testAddRemoveAndModifyInSingleChange() throws Exception {
+    StructuredPropertyChangeEventGenerator test = new StructuredPropertyChangeEventGenerator();
+
+    Urn urn =
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hdfs,SampleHdfsDataset,PROD)");
+    String entity = "dataset";
+    String aspect = "structedProperties";
+    AuditStamp auditStamp =
+        new AuditStamp()
+            .setActor(Urn.createFromString("urn:li:corpuser:__datahub_system"))
+            .setTime(1683829509553L);
+
+    StructuredProperties fromProperties =
+        buildStructuredProperties(
+            buildAssignment("urn:li:structuredProperty:io.acryl.propertyA", "1"),
+            buildAssignment("urn:li:structuredProperty:io.acryl.propertyC", "3"));
+
+    StructuredProperties toProperties =
+        buildStructuredProperties(
+            buildAssignment("urn:li:structuredProperty:io.acryl.propertyB", "2"),
+            buildAssignment("urn:li:structuredProperty:io.acryl.propertyC", "3", "4"));
+
+    Aspect<StructuredProperties> from = new Aspect<>(fromProperties, new SystemMetadata());
+    Aspect<StructuredProperties> to = new Aspect<>(toProperties, new SystemMetadata());
+
+    List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, from, to, auditStamp);
+
+    // Events are ordered by property urn: A removed, B added, C modified.
+    assertEquals(3, actual.size());
+
+    assertEquals("REMOVE", actual.get(0).getOperation().toString());
+    assertEquals(
+        "urn:li:structuredProperty:io.acryl.propertyA",
+        actual.get(0).getParameters().get("propertyUrn").toString());
+    assertEquals("[\"1\"]", actual.get(0).getParameters().get("propertyValues"));
+
+    assertEquals("ADD", actual.get(1).getOperation().toString());
+    assertEquals(
+        "urn:li:structuredProperty:io.acryl.propertyB",
+        actual.get(1).getParameters().get("propertyUrn").toString());
+    assertEquals("[\"2\"]", actual.get(1).getParameters().get("propertyValues"));
+
+    // MODIFY carries the new (multi-)values.
+    assertEquals("MODIFY", actual.get(2).getOperation().toString());
+    assertEquals(
+        "urn:li:structuredProperty:io.acryl.propertyC",
+        actual.get(2).getParameters().get("propertyUrn").toString());
+    assertEquals("[\"3\",\"4\"]", actual.get(2).getParameters().get("propertyValues"));
   }
 }


### PR DESCRIPTION
Structured property REMOVE entity change events were emitted with parameters: null whenever the removed property's URN sorted before a property still assigned to the entity. The removal branch inside the merge loop called StructuredPropertyAssignmentChangeEvent.builder(), which silently resolves to the inherited ChangeEvent.builder() and never populates parameters — so downstream consumers received REMOVE events with no propertyUrn/propertyValues.

This PR replaces the dual-pointer sorted-merge diff in StructuredPropertyChangeEventGenerator with a map-based set-difference approach (mirroring OwnershipChangeEventGenerator). All ADD/REMOVE/MODIFY events now go through a single builder helper that always sets the value assignment, so parameters can no longer be dropped. REMOVE events carry the removed property's previous values.

  Minor behavior changes:
  - MODIFY event descriptions now say "changed on entity" instead of incorrectly reusing the "added to entity" wording.
  - Inputs are no longer mutated (the old code sorted the aspects' property arrays in place).
  - Event ordering remains deterministic (sorted by property URN).


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
