### PR TITLE
feat(fabrictype): add CERT fabric type for certification environments

### DIFF
--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -3162,6 +3162,11 @@ enum FabricType {
   Alternative spelling for sandbox
   """
   SBX
+
+  """
+  Designates certification fabrics
+  """
+  CERT
 }
 
 """

--- a/docs/lineage/openlineage.md
+++ b/docs/lineage/openlineage.md
@@ -105,7 +105,7 @@ The DataHub OpenLineage integration can be configured using environment variable
 | `DATAHUB_OPENLINEAGE_USE_PATCH`                        | `datahub.openlineage.use-patch`                        | Boolean | `false` | Whether to use patch operations for lineage/incremental lineage                                                   |
 | `DATAHUB_OPENLINEAGE_FILE_PARTITION_REGEXP_PATTERN`    | `datahub.openlineage.file-partition-regexp-pattern`    | String  | `null`  | Regular expression pattern for file partition detection                                                           |
 
-> **Valid `env` values**: `PROD`, `DEV`, `TEST`, `QA`, `UAT`, `EI`, `PRE`, `STG`, `NON_PROD`, `CORP`, `RVW`, `PRD`, `TST`, `SIT`, `SBX`, `SANDBOX`
+> **Valid `env` values**: `PROD`, `DEV`, `TEST`, `QA`, `UAT`, `EI`, `PRE`, `STG`, `NON_PROD`, `CORP`, `RVW`, `PRD`, `TST`, `SIT`, `SBX`, `SANDBOX`, `CERT`
 >
 > **How `env` works**:
 >

--- a/li-utils/src/main/pegasus/com/linkedin/common/FabricType.pdl
+++ b/li-utils/src/main/pegasus/com/linkedin/common/FabricType.pdl
@@ -84,4 +84,9 @@ enum FabricType {
    * Designates sandbox fabrics
    */
   SANDBOX
+
+  /**
+   * Designates certification fabrics
+   */
+  CERT
 }

--- a/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/MLModel.java
+++ b/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/MLModel.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -1079,7 +1080,10 @@ public class MLModel extends Entity
         throw new IllegalArgumentException(
             "Invalid environment: "
                 + env
-                + ". Must be one of: PROD, DEV, STAGING, TEST, QA, UAT, EI, PRE, STG, NON_PROD, CORP",
+                + ". Must be one of: "
+                + Arrays.stream(FabricType.values())
+                    .map(Enum::name)
+                    .collect(Collectors.joining(", ")),
             e);
       }
     }

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/openlineage/config/OpenLineageServletConfig.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/openlineage/config/OpenLineageServletConfig.java
@@ -32,7 +32,7 @@ public class OpenLineageServletConfig {
         fabricType = FabricType.valueOf(envValue.toUpperCase());
       } catch (IllegalArgumentException e) {
         log.warn(
-            "Invalid env value '{}'. Using default PROD. Valid values: PROD, DEV, TEST, QA, UAT, EI, PRE, STG, NON_PROD, CORP, RVW, PRD, TST, SIT, SBX, SANDBOX",
+            "Invalid env value '{}'. Using default PROD. Valid values: PROD, DEV, TEST, QA, UAT, EI, PRE, STG, NON_PROD, CORP, RVW, PRD, TST, SIT, SBX, SANDBOX, CERT",
             envValue);
       }
     }

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -872,8 +872,9 @@
     "name" : "FabricType",
     "namespace" : "com.linkedin.common",
     "doc" : "Fabric group type",
-    "symbols" : [ "DEV", "TEST", "QA", "UAT", "EI", "PRE", "STG", "NON_PROD", "PROD", "CORP", "RVW", "PRD", "TST", "SIT", "SBX", "SANDBOX" ],
+    "symbols" : [ "DEV", "TEST", "QA", "UAT", "EI", "PRE", "STG", "NON_PROD", "PROD", "CORP", "RVW", "PRD", "TST", "SIT", "SBX", "SANDBOX", "CERT" ],
     "symbolDocs" : {
+      "CERT" : "Designates certification fabrics",
       "CORP" : "Designates corporation fabrics",
       "DEV" : "Designates development fabrics",
       "EI" : "Designates early-integration fabrics",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -855,8 +855,9 @@
     "name" : "FabricType",
     "namespace" : "com.linkedin.common",
     "doc" : "Fabric group type",
-    "symbols" : [ "DEV", "TEST", "QA", "UAT", "EI", "PRE", "STG", "NON_PROD", "PROD", "CORP", "RVW", "PRD", "TST", "SIT", "SBX", "SANDBOX" ],
+    "symbols" : [ "DEV", "TEST", "QA", "UAT", "EI", "PRE", "STG", "NON_PROD", "PROD", "CORP", "RVW", "PRD", "TST", "SIT", "SBX", "SANDBOX", "CERT" ],
     "symbolDocs" : {
+      "CERT" : "Designates certification fabrics",
       "CORP" : "Designates corporation fabrics",
       "DEV" : "Designates development fabrics",
       "EI" : "Designates early-integration fabrics",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
@@ -590,8 +590,9 @@
     "name" : "FabricType",
     "namespace" : "com.linkedin.common",
     "doc" : "Fabric group type",
-    "symbols" : [ "DEV", "TEST", "QA", "UAT", "EI", "PRE", "STG", "NON_PROD", "PROD", "CORP", "RVW", "PRD", "TST", "SIT", "SBX", "SANDBOX" ],
+    "symbols" : [ "DEV", "TEST", "QA", "UAT", "EI", "PRE", "STG", "NON_PROD", "PROD", "CORP", "RVW", "PRD", "TST", "SIT", "SBX", "SANDBOX", "CERT" ],
     "symbolDocs" : {
+      "CERT" : "Designates certification fabrics",
       "CORP" : "Designates corporation fabrics",
       "DEV" : "Designates development fabrics",
       "EI" : "Designates early-integration fabrics",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.operations.operations.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.operations.operations.snapshot.json
@@ -590,8 +590,9 @@
     "name" : "FabricType",
     "namespace" : "com.linkedin.common",
     "doc" : "Fabric group type",
-    "symbols" : [ "DEV", "TEST", "QA", "UAT", "EI", "PRE", "STG", "NON_PROD", "PROD", "CORP", "RVW", "PRD", "TST", "SIT", "SBX", "SANDBOX" ],
+    "symbols" : [ "DEV", "TEST", "QA", "UAT", "EI", "PRE", "STG", "NON_PROD", "PROD", "CORP", "RVW", "PRD", "TST", "SIT", "SBX", "SANDBOX", "CERT" ],
     "symbolDocs" : {
+      "CERT" : "Designates certification fabrics",
       "CORP" : "Designates corporation fabrics",
       "DEV" : "Designates development fabrics",
       "EI" : "Designates early-integration fabrics",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
@@ -855,8 +855,9 @@
     "name" : "FabricType",
     "namespace" : "com.linkedin.common",
     "doc" : "Fabric group type",
-    "symbols" : [ "DEV", "TEST", "QA", "UAT", "EI", "PRE", "STG", "NON_PROD", "PROD", "CORP", "RVW", "PRD", "TST", "SIT", "SBX", "SANDBOX" ],
+    "symbols" : [ "DEV", "TEST", "QA", "UAT", "EI", "PRE", "STG", "NON_PROD", "PROD", "CORP", "RVW", "PRD", "TST", "SIT", "SBX", "SANDBOX", "CERT" ],
     "symbolDocs" : {
+      "CERT" : "Designates certification fabrics",
       "CORP" : "Designates corporation fabrics",
       "DEV" : "Designates development fabrics",
       "EI" : "Designates early-integration fabrics",


### PR DESCRIPTION
## Summary

Adds a new `CERT` `FabricType` enum value for **certification** fabrics, keeping every source-of-truth definition in sync.

Changes:
- **`FabricType.pdl`** (source of truth) + **GraphQL enum** (`entity.graphql`)
- The five **restli-api snapshot JSONs** (`symbols` + `symbolDocs`)
- **OpenLineage servlet** valid-values log message

Also fixes the **`MLModel` builder's invalid-environment error message**, which hardcoded a stale list (missing `RVW/PRD/TST/SIT/SBX/SANDBOX` and listing a non-existent `STAGING`). It now derives valid values from `FabricType.values()` so it can never drift again.

Auto-generated artifacts (`_internal_schema_classes.py`, frontend `types.generated.ts`) regenerate on build. The legacy frozen `v1/avro/*.avsc` schemas were intentionally left untouched — they predate `SBX`/`SIT`/`PRD`/`TST` and are not kept in sync with `FabricType`.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Links to related issues (if applicable)
- [x] Tests added/updated (if applicable) — existing `MLModelTest.testMLModelBuilderInvalidEnvironment` covers the changed branch; it asserts on exception type, not message, so it remains valid. No new enum-value test added per the project's "quality over coverage" testing guidance.
- [x] Docs added/updated — `docs/lineage/openlineage.md` valid-`env` list
- [x] Breaking changes documented in `docs/how/updating-datahub.md` — N/A (additive enum value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)