### PR TITLE
fix(ingestion/patch): revert: emit fieldPath add op for editableSchemaMetadata field patches (#18138)

### DIFF
--- a/metadata-ingestion/src/datahub/specific/dataset.py
+++ b/metadata-ingestion/src/datahub/specific/dataset.py
@@ -54,25 +54,8 @@ class FieldPatchHelper(Generic[_Parent]):
             else SchemaMetadataClass.ASPECT_NAME
         )
         self.aspect_field = "editableSchemaFieldInfo" if editable else "schemaFieldInfo"
-        self._field_path_op_added = False
-
-    def _ensure_field_path(self) -> None:
-        # The array element is keyed by fieldPath, but GMS's patch merge rebuilds the element
-        # from the map value and does not re-inject the key. Without an explicit fieldPath op,
-        # a newly created element fails server-side validation ("fieldPath is required").
-        # Emitted once per field; a repeated add of the same scalar is a harmless no-op.
-        if self._field_path_op_added:
-            return
-        self._parent._add_patch(
-            self.aspect_name,
-            "add",
-            path=(self.aspect_field, self.field_path, "fieldPath"),
-            value=self.field_path,
-        )
-        self._field_path_op_added = True
 
     def add_tag(self, tag: Tag) -> "FieldPatchHelper":
-        self._ensure_field_path()
         self._parent._add_patch(
             self.aspect_name,
             "add",
@@ -103,7 +86,6 @@ class FieldPatchHelper(Generic[_Parent]):
         return self
 
     def add_term(self, term: Term) -> "FieldPatchHelper":
-        self._ensure_field_path()
         self._parent._add_patch(
             self.aspect_name,
             "add",

--- a/metadata-ingestion/tests/unit/patch/complex_dataset_patch.json
+++ b/metadata-ingestion/tests/unit/patch/complex_dataset_patch.json
@@ -32,10 +32,7 @@
     "aspect": {
         "json": {
             "arrayPrimaryKeys": {
-                "tags": [
-                    "attribution\u241fsource",
-                    "tag"
-                ]
+                "tags": ["attribution\u241fsource", "tag"]
             },
             "patch": [
                 {
@@ -104,11 +101,6 @@
     "aspectName": "editableSchemaMetadata",
     "aspect": {
         "json": [
-            {
-                "op": "add",
-                "path": "/editableSchemaFieldInfo/field1/fieldPath",
-                "value": "field1"
-            },
             {
                 "op": "add",
                 "path": "/editableSchemaFieldInfo/field1/globalTags/tags/urn:li:tag:tag1",


### PR DESCRIPTION
This undoes a change that would add another patch (write) call for every schema field patched with `add_tag` or `add_term`. We should instead try to handle this on the backend.
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
