### PR TITLE
fix(ingest/snowflake): sample large tables in the SQLAlchemy profiler

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sqlalchemy_profiler/adapters/snowflake.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sqlalchemy_profiler/adapters/snowflake.py
@@ -1,6 +1,7 @@
 """Snowflake-specific profiling adapter."""
 
 import logging
+import uuid
 from typing import Any, List, Optional
 
 import sqlalchemy as sa
@@ -26,10 +27,8 @@ class SnowflakeAdapter(PlatformAdapter):
     Snowflake optimizations:
     1. APPROX_COUNT_DISTINCT for fast unique counts
     2. Native MEDIAN() function for median calculation
-
-    TODO: While Snowflake supports TABLESAMPLE SYSTEM for sampling large tables,
-    it's not implemented yet to maintain alignment with GE profiler behavior
-    (GE profiler only uses TABLESAMPLE for BigQuery, not Snowflake).
+    3. Sampling of large tables via a materialized temporary table (see
+       ``setup_profiling``), matching the legacy Great Expectations profiler.
     """
 
     def setup_profiling(
@@ -37,6 +36,16 @@ class SnowflakeAdapter(PlatformAdapter):
     ) -> ProfilingContext:
         """
         Snowflake setup - create SQL table object.
+
+        When the connector requested sampling for a large table,
+        ``SnowflakeProfiler.get_batch_kwargs`` supplies a ``TABLESAMPLE`` query
+        as ``context.custom_sql``. We materialize that sample into a
+        session-scoped temporary table and profile it instead of the base
+        table. This mirrors the legacy Great Expectations profiler, which
+        turned the same ``custom_sql`` into a ``CREATE TEMPORARY TABLE ... AS``.
+        Without it every column statistic (min/max/mean/median/distinct/…) would
+        scan every row of the base table, which is prohibitively slow on large
+        Snowflake tables.
 
         Args:
             context: Current profiling context
@@ -50,11 +59,28 @@ class SnowflakeAdapter(PlatformAdapter):
                 f"Cannot profile {context.pretty_name}: table name required"
             )
 
-        # Create SQLAlchemy table object
-        context.sql_table = self._create_sqlalchemy_table(
+        # Reflect the real (permanent) table to obtain its column names/types.
+        # This is safe on any pooled connection because the source table is a
+        # persistent object.
+        source_table = self._create_sqlalchemy_table(
             schema=context.schema,
             table=context.table,
         )
+
+        if context.custom_sql:
+            sampled_table = self._materialize_sample(context, source_table, conn)
+            if sampled_table is not None:
+                context.sql_table = sampled_table
+                context.is_sampled = True
+                logger.debug(
+                    f"Snowflake setup for {context.pretty_name}: "
+                    f"profiling sampled temp table {sampled_table.name}"
+                )
+                return context
+            # _materialize_sample already reported a warning; fall back to
+            # profiling the full table so the run does not fail outright.
+
+        context.sql_table = source_table
 
         logger.debug(
             f"Snowflake setup for {context.pretty_name}: "
@@ -63,14 +89,82 @@ class SnowflakeAdapter(PlatformAdapter):
 
         return context
 
+    def _materialize_sample(
+        self,
+        context: ProfilingContext,
+        source_table: "sa.Table",
+        conn: Connection,
+    ) -> Optional["sa.Table"]:
+        """
+        Materialize ``context.custom_sql`` (a ``TABLESAMPLE`` query) into a
+        session-scoped temporary table and return a Table object pointing at it.
+
+        The temporary table MUST be created on ``conn`` — the same connection
+        the ``QueryCombinerRunner`` uses to run the profiling queries — because
+        Snowflake ``TEMPORARY`` tables are visible only within the session that
+        created them. Using ``base_engine.raw_connection()`` (as the Athena /
+        Trino / BigQuery adapters do for their global views/cached tables) would
+        create the table in a different pooled session where the profiling
+        queries could not see it.
+
+        Returns None if the sample could not be created, signalling the caller
+        to fall back to full-table profiling.
+        """
+        # All-uppercase, unquoted-safe identifier. Snowflake stores unquoted
+        # identifiers upper-cased, so an all-caps name reflects/quotes
+        # consistently whether or not the dialect decides to quote it.
+        temp_name = f"GE_TMP_SAMPLE_{uuid.uuid4().hex[:12].upper()}"
+
+        # Created unqualified (in the session's current schema), matching the
+        # legacy GE profiler's behavior. The sample query itself references the
+        # fully-qualified source table, so no schema needs to be in scope for
+        # the SELECT.
+        ddl = f'CREATE OR REPLACE TEMPORARY TABLE "{temp_name}" AS {context.custom_sql}'
+        try:
+            conn.exec_driver_sql(ddl)
+        except SQLAlchemyError as e:
+            self.report.warning(
+                title="Profiling: falling back to full-table scan",
+                message=(
+                    "Failed to create a sampled temporary table for profiling; "
+                    "profiling will run against the full table, which may be slow "
+                    "on large tables."
+                ),
+                context=f"Asset: {context.pretty_name}",
+                exc=e,
+            )
+            return None
+
+        context.add_temp_resource("snowflake_temp_table", temp_name)
+
+        # Reuse the reflected columns of the source table (CREATE TABLE AS SELECT
+        # preserves exact column names/casing) rather than reflecting the temp
+        # table: Snowflake reflection is information-schema based and does not
+        # reliably surface session-scoped temporary tables.
+        try:
+            return source_table.to_metadata(sa.MetaData(), schema=None, name=temp_name)
+        except SQLAlchemyError as e:
+            self.report.warning(
+                title="Profiling: falling back to full-table scan",
+                message=(
+                    "Failed to build a table object for the sampled temporary "
+                    "table; profiling will run against the full table."
+                ),
+                context=f"Asset: {context.pretty_name}",
+                exc=e,
+            )
+            return None
+
     def cleanup(self, context: ProfilingContext) -> None:
         """
-        Snowflake cleanup - nothing to clean up.
+        Snowflake cleanup.
 
-        Args:
-            context: Profiling context
+        Any temporary sample table created in ``setup_profiling`` is
+        session-scoped and is dropped automatically when the underlying
+        connection is returned to the pool and closed, so no explicit DROP is
+        issued here (a DROP on a fresh pooled connection would target a
+        different session and be a no-op anyway).
         """
-        # No temp resources created in Snowflake setup
         pass
 
     # =========================================================================

--- a/metadata-ingestion/tests/unit/sqlalchemy_profiler/test_adapters.py
+++ b/metadata-ingestion/tests/unit/sqlalchemy_profiler/test_adapters.py
@@ -716,6 +716,88 @@ class TestSnowflakeAdapter:
         # Should quote both parts
         assert '"schema"."table"' in quoted or "schema.table" in quoted
 
+    def test_setup_profiling_without_custom_sql_profiles_full_table(self, adapter):
+        """Without a sampling custom_sql, profile the base table directly."""
+        context = ProfilingContext(
+            schema="MY_SCHEMA",
+            table="MY_TABLE",
+            custom_sql=None,
+            pretty_name="MY_DB.MY_SCHEMA.MY_TABLE",
+        )
+        source = sa.Table(
+            "MY_TABLE", sa.MetaData(), sa.Column("C1", sa.Integer), schema="MY_SCHEMA"
+        )
+        conn = MagicMock()
+        with patch.object(adapter, "_create_sqlalchemy_table", return_value=source):
+            result = adapter.setup_profiling(context, conn)
+
+        assert result.sql_table is source
+        assert result.is_sampled is False
+        conn.exec_driver_sql.assert_not_called()
+
+    def test_setup_profiling_with_custom_sql_materializes_sample(self, adapter):
+        """A sampling custom_sql is materialized into a session temp table."""
+        custom_sql = (
+            'select * from "MY_DB"."MY_SCHEMA"."MY_TABLE" TABLESAMPLE BERNOULLI (1.0)'
+        )
+        context = ProfilingContext(
+            schema="MY_SCHEMA",
+            table="MY_TABLE",
+            custom_sql=custom_sql,
+            pretty_name="MY_DB.MY_SCHEMA.MY_TABLE",
+        )
+        source = sa.Table(
+            "MY_TABLE",
+            sa.MetaData(),
+            sa.Column("C1", sa.Integer),
+            sa.Column("C2", sa.String),
+            schema="MY_SCHEMA",
+        )
+        conn = MagicMock()
+        with patch.object(adapter, "_create_sqlalchemy_table", return_value=source):
+            result = adapter.setup_profiling(context, conn)
+
+        # The temp table is created on the SAME connection used for profiling,
+        # since Snowflake TEMPORARY tables are session-scoped.
+        conn.exec_driver_sql.assert_called_once()
+        ddl = conn.exec_driver_sql.call_args[0][0]
+        assert ddl.startswith("CREATE OR REPLACE TEMPORARY TABLE")
+        assert custom_sql in ddl
+
+        # We profile the sample, not the base table, but keep its columns.
+        assert result.is_sampled is True
+        assert result.sql_table is not source
+        assert result.sql_table.name.startswith("GE_TMP_SAMPLE_")
+        assert result.sql_table.name in ddl
+        assert result.sql_table.schema is None
+        assert [c.name for c in result.sql_table.columns] == ["C1", "C2"]
+
+    def test_setup_profiling_falls_back_when_sample_creation_fails(self, adapter):
+        """If temp-table creation fails, fall back to full-table profiling."""
+        context = ProfilingContext(
+            schema="MY_SCHEMA",
+            table="MY_TABLE",
+            custom_sql=(
+                'select * from "MY_DB"."MY_SCHEMA"."MY_TABLE" '
+                "TABLESAMPLE BERNOULLI (1.0)"
+            ),
+            pretty_name="MY_DB.MY_SCHEMA.MY_TABLE",
+        )
+        source = sa.Table(
+            "MY_TABLE", sa.MetaData(), sa.Column("C1", sa.Integer), schema="MY_SCHEMA"
+        )
+        conn = MagicMock()
+        conn.exec_driver_sql.side_effect = sa.exc.SQLAlchemyError("temp table denied")
+        with (
+            patch.object(adapter, "_create_sqlalchemy_table", return_value=source),
+            patch.object(adapter.report, "warning") as mock_warning,
+        ):
+            result = adapter.setup_profiling(context, conn)
+
+        assert result.sql_table is source
+        assert result.is_sampled is False
+        mock_warning.assert_called_once()
+
 
 class TestBigQueryAdapter:
     """Test cases for BigQueryAdapter."""


### PR DESCRIPTION
## Summary

The SQLAlchemy profiler (the default profiling backend since 1.6.0) was ignoring the sampling that the Snowflake connector sets up for large tables, causing it to run every column statistic against the **full** table. This made Snowflake profiling slow to a crawl / time out after upgrading, with no recipe change.

`SnowflakeProfiler.get_batch_kwargs` builds a `TABLESAMPLE` query as `custom_sql` whenever `use_sampling=True` (default) and a table exceeds `sample_size` (default 10k rows). The legacy Great Expectations profiler materialized that `custom_sql` into a `CREATE TEMPORARY TABLE ... AS` and profiled the sample. The new `SnowflakeAdapter.setup_profiling`, however, never referenced `context.custom_sql` — it always reflected and profiled the base table (the class docstring even carried a `TODO: ... not implemented yet`). So `min`/`max`/`mean`/`MEDIAN`/`APPROX_COUNT_DISTINCT`/etc. scanned entire tables.

## What this changes

`SnowflakeAdapter.setup_profiling` now honors `context.custom_sql`: it materializes the sample into a session-scoped temporary table and profiles that instead of the base table, restoring the Great Expectations behavior.

Two Snowflake-specific details (why this differs from the Athena/Trino/BigQuery adapters):

1. **The temp table is created on the same `conn` the query runner uses.** Snowflake `TEMPORARY` tables are session-scoped, so creating one on a separate `base_engine.raw_connection()` (as the other adapters do for their globally-visible views/cached tables) would put it in a different pooled session that the profiling queries can't see.
2. **The sample Table reuses the reflected source columns** (via `Table.to_metadata(..., name=...)`) rather than reflecting the temp table. `CREATE TABLE AS SELECT` preserves exact column names/casing, and Snowflake reflection is information-schema based and doesn't reliably surface session temp tables.

If temp-table creation fails (e.g. missing `CREATE TABLE` privilege), it reports a warning and falls back to full-table profiling rather than failing the run.

### Workaround for affected users (no upgrade required)

Set `profiling.method: ge` in the recipe to use the legacy Great Expectations profiler, which already samples correctly.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added (`TestSnowflakeAdapter`: sample materialization, full-table when no `custom_sql`, graceful fallback)
- [ ] Docs — n/a (bug fix restoring prior behavior)
- [ ] Breaking change entry — n/a (restores pre-1.6.0 behavior)

## Testing

- 96/96 `sqlalchemy_profiler/test_adapters.py` unit tests pass, including 3 new ones.
- `./gradlew :metadata-ingestion:lintFix` passes; `mypy` clean on the changed source file.

> Note: the unit tests use a mocked connection. The end-to-end session-visibility behavior of the temporary table should be validated with a debug-mode ingestion run against a real large Snowflake table before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)