### PR TITLE
fix(search): stabilize noisy reindex ETA estimate

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
@@ -933,7 +933,8 @@ public class ESIndexBuilder {
     Pair<Long, Long> documentCounts =
         getDocumentCounts(opContext, expectedCountSupplier, destIndex);
     long documentCountsLastUpdated = System.currentTimeMillis();
-    long previousDocCount = documentCounts.getSecond();
+    final long pollStartTimeMillis = documentCountsLastUpdated;
+    final long pollStartDocCount = documentCounts.getSecond();
     long estimatedMinutesRemaining = 0;
 
     while (System.currentTimeMillis() < timeoutAt) {
@@ -942,22 +943,19 @@ public class ESIndexBuilder {
 
       Pair<Long, Long> latestCounts =
           getDocumentCounts(opContext, expectedCountSupplier, destIndex);
+      long currentTime = System.currentTimeMillis();
 
       if (!latestCounts.equals(documentCounts)) {
-        long currentTime = System.currentTimeMillis();
-        long timeElapsed = currentTime - documentCountsLastUpdated;
-        long docsIndexed = latestCounts.getSecond() - previousDocCount;
-
-        double indexingRate = timeElapsed > 0 ? (double) docsIndexed / timeElapsed : 0;
-        long remainingDocs = latestCounts.getFirst() - latestCounts.getSecond();
-        long estimatedMillisRemaining =
-            indexingRate > 0 ? (long) (remainingDocs / indexingRate) : 0;
-        estimatedMinutesRemaining = estimatedMillisRemaining / (1000 * 60);
-
+        // Stall-detection bookkeeping only; the ETA below is computed unconditionally.
         documentCountsLastUpdated = currentTime;
         documentCounts = latestCounts;
-        previousDocCount = documentCounts.getSecond();
       }
+
+      estimatedMinutesRemaining =
+          estimateMinutesRemaining(
+              latestCounts.getSecond() - pollStartDocCount,
+              currentTime - pollStartTimeMillis,
+              latestCounts.getFirst() - latestCounts.getSecond());
 
       if (documentCounts.getFirst().equals(documentCounts.getSecond())) {
         log.info(
@@ -1081,6 +1079,20 @@ public class ESIndexBuilder {
     return indexConfig.getMaxReindexHours() > 0
         ? System.currentTimeMillis() + (1000L * 60 * 60 * indexConfig.getMaxReindexHours())
         : Long.MAX_VALUE;
+  }
+
+  /**
+   * Computes estimated minutes remaining for a reindex based on the cumulative average indexing
+   * rate since the start of the current polling loop (not the most recent poll-to-poll delta). A
+   * cumulative average smooths out bursty ES bulk-indexing throughput and the polling loop's own
+   * growing sleep interval, both of which make a single-sample rate estimate very noisy.
+   */
+  public static long estimateMinutesRemaining(
+      long docsIndexedSinceStart, long elapsedMillisSinceStart, long remainingDocs) {
+    double indexingRate =
+        elapsedMillisSinceStart > 0 ? (double) docsIndexedSinceStart / elapsedMillisSinceStart : 0;
+    long estimatedMillisRemaining = indexingRate > 0 ? (long) (remainingDocs / indexingRate) : 0;
+    return estimatedMillisRemaining / (1000 * 60);
   }
 
   private ReindexResult reindex(@Nonnull OperationContext opContext, ReindexConfig indexState)

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ESIndexBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ESIndexBuilderTest.java
@@ -1883,6 +1883,30 @@ public class ESIndexBuilderTest {
     ESIndexBuilder.extractTargetShards(config);
   }
 
+  @Test(dataProvider = "estimateMinutesRemainingData")
+  void testEstimateMinutesRemaining(
+      long docsIndexedSinceStart,
+      long elapsedMillisSinceStart,
+      long remainingDocs,
+      long expectedMinutes) {
+    assertEquals(
+        ESIndexBuilder.estimateMinutesRemaining(
+            docsIndexedSinceStart, elapsedMillisSinceStart, remainingDocs),
+        expectedMinutes);
+  }
+
+  @DataProvider(name = "estimateMinutesRemainingData")
+  public Object[][] provideEstimateMinutesRemainingData() {
+    return new Object[][] {
+      // docsIndexedSinceStart, elapsedMillisSinceStart, remainingDocs, expectedMinutes
+      {1000L, 60_000L, 9000L, 9L}, // steady cumulative rate
+      {100L, 0L, 500L, 0L}, // zero elapsed time guards divide-by-zero
+      {0L, 30_000L, 1000L, 0L}, // no progress yet
+      {1000L, 60_000L, 0L, 0L}, // already complete
+      {10_000L, 60_000L, 100L, 0L}, // sub-minute ETA truncates to 0
+    };
+  }
+
   @Test
   void testGetIncrementalNextIndexNameSanitizesVersion() {
     String result = ESIndexBuilder.getIncrementalNextIndexName("datasetindex_v2", "1.2.3-4", 1000L);


### PR DESCRIPTION
## Summary

- **Compute reindex ETA from a cumulative average, not the last delta** — `pollReindexCompletion`'s "Estimated time remaining" log previously derived the indexing rate from docs indexed since the *last observed count change*. Elasticsearch bulk-indexing is bursty and the poll interval itself grows over time, so this rate swung wildly between consecutive polls (e.g. 500 → 2800 minutes on the same steadily-progressing reindex). It now uses the average rate since the polling loop started, which is far more stable while still trending toward the correct estimate.
- **Extract `estimateMinutesRemaining` as a standalone method** — the rate/ETA arithmetic is now a small, pure `public static` helper on `ESIndexBuilder`, independently unit tested rather than buried inline in the polling loop.

Stall detection and reindex-retry-resubmission behavior are unchanged — this only affects the logged ETA on non-terminal poll iterations.

## Test plan

- [x] `ESIndexBuilderTest` — added `testEstimateMinutesRemaining` (steady rate, zero elapsed time, zero progress, already complete, sub-minute truncation); full suite passes (56 tests)
- [x] `IndexBuilderElasticSearchTest` — existing integration test exercising `pollReindexCompletion` end-to-end against real Elasticsearch still passes (42 tests, 2 pre-existing unrelated skips)
- [x] `BuildIndicesIncrementalStepTest` — existing mocks of `pollReindexCompletion` still pass unchanged (signature untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)