### PR TITLE
ci: include run attempt number in Slack CI notifications

### DIFF
--- a/.github/scripts/fetch_workflow_details.py
+++ b/.github/scripts/fetch_workflow_details.py
@@ -23,6 +23,7 @@ def _build_details(
     jobs: list[dict[str, Any]],
     repo: str,
     conclusion_override: str | None,
+    attempt: int,
 ) -> dict[str, Any]:
     started = parse_dt(run_data.get("run_started_at"))
     completed = parse_dt(run_data.get("updated_at"))
@@ -49,6 +50,7 @@ def _build_details(
         "duration_seconds": duration_seconds(started, completed),
         "failed_jobs": failed_jobs,
         "display_title": display_title,
+        "run_attempt": attempt,
     }
 
 
@@ -63,7 +65,7 @@ def main() -> int:
     gh = GitHubAPIClient(token)
     run_data = gh.get_run_attempt(args.repo, args.run_id, args.attempt)
     jobs = gh.get_run_attempt_jobs(args.repo, args.run_id, args.attempt)
-    details = _build_details(run_data, jobs, args.repo, args.conclusion)
+    details = _build_details(run_data, jobs, args.repo, args.conclusion, args.attempt)
 
     Path(args.output).write_text(json.dumps(details, indent=2))
     print(f"Workflow details written to {args.output}")

--- a/.github/scripts/notify_workflow_status_slack.py
+++ b/.github/scripts/notify_workflow_status_slack.py
@@ -69,6 +69,7 @@ class WorkflowDetails:
     # Optional — explicitly rendered in the Slack message
     duration_seconds: int | None = None
     failed_jobs: list[str] = field(default_factory=list)
+    run_attempt: int | None = None
 
     # Passthrough — any extra keys from the JSON not listed above
     extra: dict[str, Any] = field(default_factory=dict)
@@ -247,6 +248,8 @@ def _post_thread_reply(
         metadata_fields["Commit Message"] = details.display_title
     if details.duration_seconds is not None:
         metadata_fields["Duration"] = _fmt_duration(details.duration_seconds)
+    if details.run_attempt is not None:
+        metadata_fields["Attempt"] = str(details.run_attempt)
 
     reply_blocks: list[dict[str, Any]] = [
         blockkit.section(


### PR DESCRIPTION
## Summary

CI build-status Slack notifications ([`post-workflow-actions.yml`](https://github.com/datahub-project/datahub/blob/master/.github/workflows/post-workflow-actions.yml) → [`notify-slack-status.yml`](https://github.com/datahub-project/datahub/blob/master/.github/workflows/notify-slack-status.yml)) already thread the run **attempt** number through to the notification scripts, but it was never rendered in the message. This surfaces it so a notification from a retried run is distinguishable from a first run.

- `fetch_workflow_details.py` — write `run_attempt` into the `workflow-details.json` payload (from the `--attempt` arg the workflow already passes).
- `notify_workflow_status_slack.py` — new optional `run_attempt` field on `WorkflowDetails`, rendered as an **Attempt** entry in the per-workflow thread reply, alongside Duration/Event.

The field is optional, so older payloads without `run_attempt` still load. No workflow YAML changes were needed.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated (if applicable) — no unit tests exist for these scripts; verified via a local round-trip check
- [ ] Docs added/updated (if applicable) — N/A
- [ ] Breaking changes documented — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)