### PR TITLE
fix(ingest/kafka-connect): strip platform_instance prefix from schema resolver URNs

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
@@ -1155,10 +1155,23 @@ class BaseConnector:
             Extracted table name (e.g., "database.schema.table") or None if parsing fails
         """
         try:
-            return DatasetUrn.from_string(urn).name
+            name = DatasetUrn.from_string(urn).name
         except Exception as e:
             logger.debug(f"Failed to extract table name from URN {urn}: {e}")
             return None
+
+        # DataHub bakes the platform_instance into the URN name as a leading
+        # `{platform_instance}.` segment. Strip it so callers see the logical
+        # db.schema.table name; otherwise table discovery and pattern matching
+        # break for sources ingested with a platform_instance.
+        # platform_instance is not part of SchemaResolverInterface, so read it
+        # defensively for interface-only implementations that omit it.
+        platform_instance = getattr(self.schema_resolver, "platform_instance", None)
+        if platform_instance:
+            prefix = f"{platform_instance}."
+            if name.lower().startswith(prefix.lower()):
+                name = name[len(prefix) :]
+        return name
 
     def _extract_lineages_from_schema_resolver(
         self,

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
@@ -1164,9 +1164,9 @@ class BaseConnector:
         # `{platform_instance}.` segment. Strip it so callers see the logical
         # db.schema.table name; otherwise table discovery and pattern matching
         # break for sources ingested with a platform_instance.
-        # platform_instance is not part of SchemaResolverInterface, so read it
-        # defensively for interface-only implementations that omit it.
-        platform_instance = getattr(self.schema_resolver, "platform_instance", None)
+        platform_instance = (
+            self.schema_resolver.platform_instance if self.schema_resolver else None
+        )
         if platform_instance:
             prefix = f"{platform_instance}."
             if name.lower().startswith(prefix.lower()):

--- a/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
@@ -52,6 +52,11 @@ class SchemaResolverInterface(Protocol):
     @property
     def platform(self) -> str: ...
 
+    # Declared as a settable attribute (not a read-only property like `platform`)
+    # because implementers assign it in __init__; a Protocol property would
+    # install a read-only descriptor and break those assignments.
+    platform_instance: Optional[str]
+
     def includes_temp_tables(self) -> bool: ...
 
     def resolve_table(self, table: _TableName) -> Tuple[str, Optional[SchemaInfo]]: ...
@@ -370,6 +375,7 @@ class _SchemaResolverWithExtras(SchemaResolverInterface):
     ):
         self._base_resolver = base_resolver
         self._extra_schemas = extra_schemas
+        self.platform_instance = base_resolver.platform_instance
 
     @property
     def platform(self) -> str:

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py
@@ -44,6 +44,8 @@ class MockGraph:
 class MockSchemaResolver(SchemaResolverInterface):
     """Mock SchemaResolver for testing."""
 
+    platform_instance: Optional[str] = None
+
     def __init__(self, platform: str, mock_urns: Optional[List[str]] = None):
         self._platform = platform
         self._mock_urns = set(mock_urns or [])

--- a/metadata-ingestion/tests/unit/test_kafka_connect_platform_instance_prefix.py
+++ b/metadata-ingestion/tests/unit/test_kafka_connect_platform_instance_prefix.py
@@ -1,0 +1,98 @@
+"""Regression tests for kafka-connect Debezium table discovery when the source
+platform datasets were ingested with a `platform_instance`.
+
+DataHub encodes the platform_instance *inside* the dataset URN name, i.e.
+`urn:li:dataset:(urn:li:dataPlatform:postgres,<instance>.<db>.<schema>.<table>,PROD)`.
+When the Kafka Connect source builds a SchemaResolver for a platform that has a
+platform_instance configured, every cached URN carries that prefix.
+
+`_extract_table_name_from_urn` must strip that prefix so the rest of the
+Debezium logic sees the logical `db.schema.table` name. Otherwise:
+
+1. Table discovery filters on `db.` but the name starts with `instance.`, so
+   `_discover_tables_from_database` returns nothing.
+2. The resolver-derived `source_dataset` still carries the prefix and the
+   emitter re-applies the instance, producing a doubled `instance.instance.`
+   segment in the lineage URN.
+"""
+
+from unittest.mock import Mock
+
+from datahub.ingestion.source.kafka_connect.common import (
+    ConnectorManifest,
+    KafkaConnectSourceConfig,
+    KafkaConnectSourceReport,
+)
+from datahub.ingestion.source.kafka_connect.source_connectors import (
+    DebeziumSourceConnector,
+)
+
+PLATFORM_INSTANCE = "my_instance"
+DATABASE = "mydb"
+
+
+def _make_connector(platform_instance, urns):
+    manifest = ConnectorManifest(
+        name="test-postgres-cdc",
+        type="source",
+        config={
+            "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+            "database.dbname": DATABASE,
+            "topic.prefix": "server",
+        },
+        tasks=[],
+        topic_names=[],
+    )
+    config = Mock(spec=KafkaConnectSourceConfig)
+    config.use_schema_resolver = True
+    config.env = "PROD"
+
+    schema_resolver = Mock()
+    schema_resolver.platform = "postgres"
+    schema_resolver.platform_instance = platform_instance
+    schema_resolver.env = "PROD"
+    schema_resolver.get_urns.return_value = set(urns)
+
+    return DebeziumSourceConnector(
+        connector_manifest=manifest,
+        config=config,
+        report=Mock(spec=KafkaConnectSourceReport),
+        schema_resolver=schema_resolver,
+    )
+
+
+def test_extract_table_name_strips_platform_instance_prefix() -> None:
+    """The parsed name must be the logical db.schema.table, without the
+    platform_instance prefix that DataHub bakes into the URN."""
+    connector = _make_connector(PLATFORM_INSTANCE, urns=[])
+
+    urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:postgres,"
+        f"{PLATFORM_INSTANCE}.{DATABASE}.public.users,PROD)"
+    )
+    assert connector._extract_table_name_from_urn(urn) == f"{DATABASE}.public.users"
+
+
+def test_extract_table_name_without_platform_instance_unchanged() -> None:
+    """Sanity: with no platform_instance, the full URN name is returned as-is
+    (guards against stripping a legitimate leading component)."""
+    connector = _make_connector(None, urns=[])
+
+    urn = f"urn:li:dataset:(urn:li:dataPlatform:postgres,{DATABASE}.public.users,PROD)"
+    assert connector._extract_table_name_from_urn(urn) == f"{DATABASE}.public.users"
+
+
+def test_discover_tables_from_database_with_platform_instance() -> None:
+    """Discovery must find tables even when the SchemaResolver URNs carry a
+    platform_instance prefix, returning schema.table names."""
+    urns = [
+        "urn:li:dataset:(urn:li:dataPlatform:postgres,"
+        f"{PLATFORM_INSTANCE}.{DATABASE}.public.users,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:postgres,"
+        f"{PLATFORM_INSTANCE}.{DATABASE}.public.orders,PROD)",
+    ]
+    connector = _make_connector(PLATFORM_INSTANCE, urns=urns)
+
+    discovered = connector._discover_tables_from_database(DATABASE, "postgres")
+
+    assert sorted(discovered) == ["public.orders", "public.users"]


### PR DESCRIPTION
## Summary

DataHub encodes a dataset's `platform_instance` as a leading segment **inside** the URN name (`{platform_instance}.{db}.{schema}.{table}`), not as a separate URN field. `_extract_table_name_from_urn` returned the raw name, so for sources ingested **with a platform_instance** the recovered "table name" kept the instance prefix.

That one leak broke the Kafka Connect Debezium schema-resolver path in three ways, all funneling through that single method:

1. **Table discovery returned nothing** — `_discover_tables_from_database` filters on `{database}.` but the name starts with `{platform_instance}.`, so no tables were discovered and no lineage was emitted (the reported symptom).
2. **Doubled `instance.instance.` prefix** in resolver-derived lineage URNs, since the emitter re-applies the platform_instance to `source_dataset`.
3. **`table.include.list` regex matching failed** for the same reason.

Because there is no delimiter marking where the instance ends in the flattened name, the prefix cannot be recovered from the URN string alone — the authoritative value is the instance the `SchemaResolver` was constructed with. The fix strips exactly that prefix (case-insensitively, to account for URN lowercasing) at the single parse point, read defensively via `getattr` because `platform_instance` is not part of `SchemaResolverInterface`.

## Testing

- New unit tests: prefix stripping, the no-instance case (guards against stripping a legitimate leading segment), and table discovery through a resolver carrying a platform_instance.
- Full Kafka Connect unit suite passes (531 tests).
- Verified end-to-end against a live DataHub: with the fix reverted, discovery returns `[]` on instance-prefixed Postgres datasets; with the fix it returns the tables and derives the correct topics.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing/#commit-message-format))
- [x] Links to related issues (internal)
- [x] Tests added/updated
- [ ] Docs added/updated — n/a (bug fix, no behavior change for correctly-configured setups)