### PR TITLE
fix(documents): Skip writing auto status aspect on datahub-documents source

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
@@ -863,7 +863,12 @@ class DocumentChunkingSource(Source):
             aspect=semantic_content,
         )
 
-        workunit = MetadataWorkUnit(id=f"{document_urn}-semanticContent", mcp=mcp)
+        # Mark as non-primary so AutoStatusAspectProcessor does not emit a
+        # StatusClass UPSERT for these document URNs — that would overwrite
+        # lifecycleStage / lifecycleState set by other sources or users.
+        workunit = MetadataWorkUnit(
+            id=f"{document_urn}-semanticContent", mcp=mcp, is_primary_source=False
+        )
 
         logger.info(
             f"Emitting SemanticContent for {document_urn} with {len(chunks)} chunks"


### PR DESCRIPTION
We don't need the datahub-documents source, which emits semantic content on documents, to auto-produce status or browse path aspects so we can safely pass in `is_primary_source=False` to skip these side effects.

The sources that actually produce these documents (Notion, Confluence, etc.) produce their own workunits on docs, and then call this secondary source to emit semantic content. So the primary sources should be controlled by stateful ingestion and these other side effects. Not datahub-documents.


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
