### PR TITLE
docs(website): update announcement banner to promote Agent Hackathon

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -100,7 +100,7 @@ module.exports = {
     announcementBar: {
       id: "announcement-4",
       content:
-        '<div class="shimmer-banner"><span>New: Open Source Analytics Agent</span><a href="https://datahub.com/blog/datahub-analytics-agent/?utm_term=docs" target="_blank" class="button"><div>Read the Blog<span> →</span></div></a></div>',
+        '<div class="shimmer-banner"><span>Build with DataHub: The Agent Hackathon is live</span><a href="https://datahub.devpost.com/" target="_blank" class="button"><div>Learn More<span> →</span></div></a></div>',
       backgroundColor: "transparent",
       textColor: "#ffffff",
       isCloseable: false,


### PR DESCRIPTION
## Summary
- Updates the docs site announcement banner (`docusaurus.config.js`) to promote the DataHub Agent Hackathon
- Text: "Build with DataHub: The Agent Hackathon is live", button: "Learn More" linking to https://datahub.devpost.com/