### PR TITLE
fix(upgrade): bound incremental reindex catch-up window to alias-swap time

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStep.java
@@ -202,6 +202,7 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
               return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.FAILED);
             }
             log.info("Alias swapped: {} -> {}", config.name(), existingNextIndex.get());
+            upgradeState = recordAliasSwap(context, upgradeState, config.name());
             continue;
           }
 
@@ -248,6 +249,7 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
             }
             log.info(
                 "Index {} had 0 docs, next index created as empty, alias swapped", config.name());
+            upgradeState = recordAliasSwap(context, upgradeState, config.name());
             continue;
           }
 
@@ -287,6 +289,7 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
             return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.FAILED);
           }
           log.info("Alias swapped: {} -> {}", config.name(), result.nextIndexName());
+          upgradeState = recordAliasSwap(context, upgradeState, config.name());
         }
 
         // Also handle indices that don't need reindex but need mapping/settings updates, note that
@@ -350,6 +353,20 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
             e.getMessage());
       }
     }
+    return upgradeState;
+  }
+
+  /**
+   * Records the alias-swap time for an index and checkpoints it. This is the exact end of the T0
+   * catch-up window (the moment the next index began serving live writes), consumed by Phase 2 as
+   * the preferred upper bound for the catch-up query.
+   */
+  private Map<String, String> recordAliasSwap(
+      UpgradeContext context, Map<String, String> upgradeState, String indexName) {
+    upgradeState =
+        IncrementalReindexState.setAliasSwapTime(
+            upgradeState, indexName, System.currentTimeMillis());
+    checkpoint(context, upgradeState, DataHubUpgradeState.IN_PROGRESS);
     return upgradeState;
   }
 

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/IncrementalReindexCatchUpStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/IncrementalReindexCatchUpStep.java
@@ -47,13 +47,17 @@ import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.tasks.TaskInfo;
 
 /**
- * Phase 2 non-blocking upgrade step that closes the T0 gap created during Phase 1. Queries aspects
- * modified between {@code reindexStartTime} and {@code dualWriteStartTime} and emits MCLs via
- * Kafka. The dual-write strategy (already active in the MAE consumer) handles writing these MCLs to
- * both current and next indices.
+ * Phase 2 non-blocking upgrade step that closes the T0 gap created during Phase 1. For each
+ * reindexed index it queries aspects modified in the window {@code [reindexStartTime,
+ * catchUpEndTime)} and emits MCLs via Kafka, so both the current and next indices receive the
+ * writes that landed on the old backing index during the reindex but were absent from the frozen
+ * _reindex snapshot. Applies to every reindexed index (including settings-only reindexes): the T0
+ * gap is a set of missing <em>documents</em> written during the reindex window, independent of
+ * whether any field mapping changed.
  *
- * <p>Only processes indices where {@code requiresDataBackfill=true} — settings-only changes don't
- * need this since the ES _reindex already copied all docs correctly.
+ * <p>The window's upper bound is resolved by {@link #resolveCatchUpEndTime} with a
+ * most-precise-first fallback (aliasSwapTime → dualWriteStartTime → reindexCompleteTime + buffer →
+ * now), always erring late so no T0-window write is missed.
  *
  * <p>Uses {@link ChangeType#RESTATE} so the consumer re-processes the full aspect state regardless
  * of diff mode optimizations.
@@ -220,12 +224,9 @@ public class IncrementalReindexCatchUpStep implements UpgradeStep {
     }
 
     long reindexStartTime = Long.parseLong(reindexStartTimeStr);
-    long dualWriteStartTime =
-        dualWriteStartTimeStr != null
-            ? Long.parseLong(dualWriteStartTimeStr)
-            : System.currentTimeMillis();
+    long catchUpEndTime = resolveCatchUpEndTime(indexName, indexState, dualWriteStartTimeStr);
 
-    if (reindexStartTime >= dualWriteStartTime) {
+    if (reindexStartTime >= catchUpEndTime) {
       return CatchUpStatus.SKIPPED;
     }
 
@@ -240,9 +241,9 @@ public class IncrementalReindexCatchUpStep implements UpgradeStep {
           indexName,
           entityName,
           reindexStartTime,
-          dualWriteStartTime);
+          catchUpEndTime);
       emitMCLsForTimeRange(
-          context, indexName, "urn:li:" + entityName + ":%", reindexStartTime, dualWriteStartTime);
+          context, indexName, "urn:li:" + entityName + ":%", reindexStartTime, catchUpEndTime);
       return CatchUpStatus.COMPLETED;
     }
 
@@ -257,9 +258,9 @@ public class IncrementalReindexCatchUpStep implements UpgradeStep {
           indexName,
           oldBackingIndexName,
           reindexStartTime,
-          dualWriteStartTime);
+          catchUpEndTime);
       return reindexTimeseriesGap(
-          indexName, oldBackingIndexName, nextIndexName, reindexStartTime, dualWriteStartTime);
+          indexName, oldBackingIndexName, nextIndexName, reindexStartTime, catchUpEndTime);
     }
 
     if (isGlobalIndex(indexName)) {
@@ -267,13 +268,58 @@ public class IncrementalReindexCatchUpStep implements UpgradeStep {
           "Catch-up for global index {}: window [{}, {}]",
           indexName,
           reindexStartTime,
-          dualWriteStartTime);
-      emitMCLsForTimeRange(context, indexName, "%", reindexStartTime, dualWriteStartTime);
+          catchUpEndTime);
+      emitMCLsForTimeRange(context, indexName, "%", reindexStartTime, catchUpEndTime);
       return CatchUpStatus.COMPLETED;
     }
 
     log.warn("Could not resolve index '{}' as entity, timeseries, or global, skipping", indexName);
     return CatchUpStatus.SKIPPED;
+  }
+
+  /**
+   * Resolves the exclusive upper bound of the T0 catch-up window, most-precise source first:
+   *
+   * <ol>
+   *   <li>{@code aliasSwapTime} — the exact moment Phase 1 swapped the alias to the next index
+   *       (only present on records written by the aliasSwapTime-aware Phase 1).
+   *   <li>{@code dualWriteStartTime} — when the MAE consumer first dual-wrote; recorded at/after
+   *       the swap, so a safe (never-early) over-estimate.
+   *   <li>{@code reindexCompleteTime + buffer} — for legacy records lacking both timestamps above.
+   *       The swap happens shortly after reindex completion, gated by up to two blocking {@code
+   *       getCount} refreshes each bounded by {@code slowOperationTimeoutSeconds}; a buffer of
+   *       {@code 2 × slowOperationTimeoutSeconds} guarantees the bound is at/after the real swap.
+   *   <li>{@code now} — last resort if reindex completion was never recorded.
+   * </ol>
+   *
+   * <p>Every fallback deliberately errs late: over-estimating only replays already-present writes
+   * (RESTATE is idempotent), whereas under-estimating would leave T0-window writes missing from the
+   * next index.
+   */
+  private long resolveCatchUpEndTime(
+      String indexName, Map<String, String> indexState, @Nullable String dualWriteStartTimeStr) {
+    String aliasSwapTimeStr = indexState.get(IncrementalReindexState.ALIAS_SWAP_TIME);
+    if (aliasSwapTimeStr != null) {
+      return Long.parseLong(aliasSwapTimeStr);
+    }
+    if (dualWriteStartTimeStr != null) {
+      return Long.parseLong(dualWriteStartTimeStr);
+    }
+    String reindexCompleteTimeStr = indexState.get(IncrementalReindexState.REINDEX_COMPLETE_TIME);
+    if (reindexCompleteTimeStr != null) {
+      long bufferMs = 2L * buildIndicesConfig.getSlowOperationTimeoutSeconds() * 1000L;
+      long end = Long.parseLong(reindexCompleteTimeStr) + bufferMs;
+      log.info(
+          "Index {} has no aliasSwapTime/dualWriteStartTime; using reindexCompleteTime + {}ms buffer as catch-up end ({})",
+          indexName,
+          bufferMs,
+          end);
+      return end;
+    }
+    log.warn(
+        "Index {} has no aliasSwapTime/dualWriteStartTime/reindexCompleteTime; falling back to now for catch-up end",
+        indexName);
+    return System.currentTimeMillis();
   }
 
   private void persistCatchUpCheckpoint(

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/IncrementalReindexCatchUpStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/IncrementalReindexCatchUpStepTest.java
@@ -189,6 +189,78 @@ public class IncrementalReindexCatchUpStepTest {
   }
 
   @Test
+  public void testAliasSwapTimePreferredOverDualWriteStartTime() {
+    // aliasSwapTime is the exact end of the T0 window and takes precedence over dualWriteStartTime
+    Map<String, String> phase1State =
+        IncrementalReindexState.setPhase1State(
+            null,
+            INDEX_NAME,
+            "datasetindex_v2_0_14_0-0_100",
+            null,
+            1000L,
+            0L,
+            null,
+            true,
+            IncrementalReindexState.Status.COMPLETED);
+    phase1State = IncrementalReindexState.setDualWriteStartTime(phase1State, INDEX_NAME, 2000L);
+    phase1State = IncrementalReindexState.setAliasSwapTime(phase1State, INDEX_NAME, 3000L);
+    setupPhase1Result(phase1State);
+
+    when(aspectDao.streamAspectBatches(any(OperationContext.class), any()))
+        .thenReturn(
+            PartitionedStream.<EbeanAspectV2>builder().delegateStream(Stream.empty()).build());
+
+    UpgradeStepResult result = step.executable().apply(upgradeContext);
+    assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
+
+    ArgumentCaptor<RestoreIndicesArgs> argsCaptor =
+        ArgumentCaptor.forClass(RestoreIndicesArgs.class);
+    verify(aspectDao).streamAspectBatches(any(OperationContext.class), argsCaptor.capture());
+    RestoreIndicesArgs capturedArgs = argsCaptor.getValue();
+    assertEquals(capturedArgs.gePitEpochMs, 1000L);
+    assertEquals(capturedArgs.lePitEpochMs, 3000L);
+  }
+
+  @Test
+  public void testFallsBackToReindexCompleteTimePlusBufferWhenNoSwapOrDualWriteTime() {
+    // Legacy records lack aliasSwapTime and dualWriteStartTime: the window upper bound falls back
+    // to
+    // reindexCompleteTime + (2 x slowOperationTimeoutSeconds) so it stays bounded near the real
+    // swap
+    // instead of running to now.
+    Map<String, String> phase1State =
+        IncrementalReindexState.setPhase1State(
+            null,
+            INDEX_NAME,
+            "datasetindex_v2_0_14_0-0_100",
+            null,
+            1000L,
+            0L,
+            null,
+            true,
+            IncrementalReindexState.Status.COMPLETED);
+    phase1State = IncrementalReindexState.setReindexCompleteTime(phase1State, INDEX_NAME, 5000L);
+    setupPhase1Result(phase1State);
+
+    when(aspectDao.streamAspectBatches(any(OperationContext.class), any()))
+        .thenReturn(
+            PartitionedStream.<EbeanAspectV2>builder().delegateStream(Stream.empty()).build());
+
+    UpgradeStepResult result = step.executable().apply(upgradeContext);
+    assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
+
+    long expectedBufferMs =
+        2L * new BuildIndicesConfiguration().getSlowOperationTimeoutSeconds() * 1000L;
+
+    ArgumentCaptor<RestoreIndicesArgs> argsCaptor =
+        ArgumentCaptor.forClass(RestoreIndicesArgs.class);
+    verify(aspectDao).streamAspectBatches(any(OperationContext.class), argsCaptor.capture());
+    RestoreIndicesArgs capturedArgs = argsCaptor.getValue();
+    assertEquals(capturedArgs.gePitEpochMs, 1000L);
+    assertEquals(capturedArgs.lePitEpochMs, 5000L + expectedBufferMs);
+  }
+
+  @Test
   public void testShouldFlushTriggersOnRowOrByteThreshold() {
     assertTrue(IncrementalReindexCatchUpStep.shouldFlush(500, 0, 500, 0));
     assertFalse(IncrementalReindexCatchUpStep.shouldFlush(499, 0, 500, 0));

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/IncrementalReindexState.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/IncrementalReindexState.java
@@ -45,6 +45,14 @@ public final class IncrementalReindexState {
   public static final String STATUS = "status";
 
   /**
+   * Epoch millis when the alias was atomically swapped to the next index during Phase 1 — the exact
+   * moment the next index began serving live writes, and therefore the precise upper bound of the
+   * T0 catch-up window. Writes before this went to the old backing index and may be missing from
+   * next; writes after it already land in next.
+   */
+  public static final String ALIAS_SWAP_TIME = "aliasSwapTime";
+
+  /**
    * Epoch millis when the MAE consumer first performed a dual-write to the next index. Set at
    * runtime by the upgrade strategy, not during Phase 1.
    */
@@ -252,6 +260,16 @@ public final class IncrementalReindexState {
     return result;
   }
 
+  /**
+   * Record when the alias was swapped to the next index — the exact end of the T0 catch-up window.
+   */
+  public static Map<String, String> setAliasSwapTime(
+      @Nonnull Map<String, String> existing, @Nonnull String indexName, long swapTime) {
+    Map<String, String> result = new HashMap<>(existing);
+    result.put(key(indexName, ALIAS_SWAP_TIME), String.valueOf(swapTime));
+    return result;
+  }
+
   /** Record when dual-write started for this index. */
   public static Map<String, String> setDualWriteStartTime(
       @Nonnull Map<String, String> existing, @Nonnull String indexName, long startTime) {
@@ -305,6 +323,7 @@ public final class IncrementalReindexState {
               OLD_BACKING_INDEX_NAME,
               REINDEX_START_TIME,
               REINDEX_COMPLETE_TIME,
+              ALIAS_SWAP_TIME,
               STATUS,
               DUAL_WRITE_START_TIME,
               REQUIRES_DATA_BACKFILL,

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/IncrementalReindexStateTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/IncrementalReindexStateTest.java
@@ -34,6 +34,26 @@ public class IncrementalReindexStateTest {
   }
 
   @Test
+  public void testAliasSwapTimeRoundTripsThroughGetAllIndexStates() {
+    Map<String, String> state =
+        IncrementalReindexState.setPhase1State(
+            null,
+            ENTITY_INDEX,
+            NEXT_INDEX,
+            OLD_BACKING,
+            1000L,
+            0L,
+            null,
+            true,
+            IncrementalReindexState.Status.COMPLETED);
+    state = IncrementalReindexState.setAliasSwapTime(state, ENTITY_INDEX, 4242L);
+
+    Map<String, String> indexState =
+        IncrementalReindexState.getAllIndexStates(state).get(ENTITY_INDEX);
+    assertEquals(indexState.get(IncrementalReindexState.ALIAS_SWAP_TIME), "4242");
+  }
+
+  @Test
   public void testCatchUpStatusTerminal() {
     assertTrue(IncrementalReindexState.CatchUpStatus.COMPLETED.isTerminal());
     assertTrue(IncrementalReindexState.CatchUpStatus.SKIPPED.isTerminal());


### PR DESCRIPTION
The Phase 2 catch-up window upper bound was `dualWriteStartTime`, falling back to `System.currentTimeMillis()` when absent.

Two problems compound:

1. `reindexStartTime` is stamped once by Phase 1, is version-scoped, and is sticky: a same-version re-run finds the index already COMPLETED and skips the reindex (no-op), reusing the `reindexStartTime` persisted by the earlier run (potentially days old). If the catch-up step fails (e.g. an error mid-stream), its status stays non-terminal and it re-runs, each time reusing that stale `reindexStartTime`.

2. `dualWriteStartTime` is never written for the system metadata (or graph) index: the MAE consumer records it only for its dual-write targets, which are keyed by entity name, and global indices have none. So for those indices the upper bound always falls back to `now` — producing an all-entity (urnLike="%") catch-up window from the stale `reindexStartTime` to now, potentially days wide, on every re-run.

Persist the exact alias-swap time in Phase 1 and resolve the catch-up window upper bound with a most-precise-first fallback that always errs late (over-replay is idempotent; under-replay would drop T0-window docs):

  aliasSwapTime -> dualWriteStartTime -> reindexCompleteTime + buffer -> now

reindexCompleteTime is persisted for every COMPLETED index, so this bounds indices lacking aliasSwapTime and dualWriteStartTime (notably the global system metadata index) to ~the real reindex duration instead of days.

Also correct the stale class Javadoc claiming only requiresDataBackfill=true indices are processed: the T0 gap is a set of missing documents written during the reindex window, independent of any field-mapping change, so all reindexed indices (including settings-only) need catch-up.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
