### PR TITLE
refactor(properties): use alchemy components in properties tab

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Properties/AddPropertyButton.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Properties/AddPropertyButton.tsx
@@ -1,7 +1,5 @@
-import { LoadingOutlined } from '@ant-design/icons';
 import { Tooltip } from '@components';
 import { Plus } from '@phosphor-icons/react/dist/csr/Plus';
-import { Dropdown } from 'antd';
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -9,7 +7,7 @@ import styled from 'styled-components';
 
 import { useEntityData } from '@app/entity/shared/EntityContext';
 import EditStructuredPropertyModal from '@app/entity/shared/tabs/Properties/Edit/EditStructuredPropertyModal';
-import { Icon, Input as InputComponent, Text } from '@src/alchemy-components';
+import { Button, Dropdown, Input as InputComponent, Loader, Text } from '@src/alchemy-components';
 import { useUserContext } from '@src/app/context/useUserContext';
 import {
     getStructuredPropertiesSearchInputs,
@@ -19,20 +17,6 @@ import { useEntityRegistry } from '@src/app/useEntityRegistry';
 import { PageRoutes } from '@src/conf/Global';
 import { useGetSearchResultsForMultipleQuery } from '@src/graphql/search.generated';
 import { DataPlatform, Maybe, StructuredProperties, StructuredPropertyEntity } from '@src/types.generated';
-
-const AddButton = styled.div<{ isV1Drawer?: boolean }>`
-    border-radius: 200px;
-    background-color: ${(props) => props.theme.colors.buttonFillBrand};
-    width: ${(props) => (props.isV1Drawer ? '24px' : '32px')};
-    height: ${(props) => (props.isV1Drawer ? '24px' : '32px')};
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    :hover {
-        cursor: pointer;
-    }
-`;
 
 const DropdownContainer = styled.div`
     border-radius: 12px;
@@ -177,7 +161,7 @@ const AddPropertyButton = ({ fieldUrn, refetch, fieldProperties, isV1Drawer }: P
                         </SearchContainer>
                         {loading ? (
                             <LoadingContainer>
-                                <LoadingOutlined />
+                                <Loader size="sm" />
                                 <Text size="sm">{tc('common.feedback:loading')}</Text>
                             </LoadingContainer>
                         ) : (
@@ -199,9 +183,15 @@ const AddPropertyButton = ({ fieldUrn, refetch, fieldProperties, isV1Drawer }: P
                 )}
             >
                 <Tooltip title={t('properties.addProperty.title')} placement="left" showArrow={false}>
-                    <AddButton isV1Drawer={isV1Drawer} data-testid="add-structured-prop-button">
-                        <Icon icon={Plus} size={isV1Drawer ? 'lg' : '2xl'} color="white" />
-                    </AddButton>
+                    <Button
+                        variant="text"
+                        size={isV1Drawer ? 'sm' : 'md'}
+                        icon={{ icon: Plus }}
+                        iconPosition="left"
+                        data-testid="add-structured-prop-button"
+                    >
+                        {tc('common.actions:add')}
+                    </Button>
                 </Tooltip>
             </Dropdown>
             {selectedProperty && (

--- a/datahub-web-react/src/app/entity/shared/tabs/Properties/Edit/EditColumn.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Properties/Edit/EditColumn.tsx
@@ -1,14 +1,14 @@
 import { DotsThreeVertical } from '@phosphor-icons/react/dist/csr/DotsThreeVertical';
-import { Dropdown } from 'antd';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
+import { ItemType } from '@components/components/Menu/types';
+
 import { useEntityContext, useEntityData, useMutationUrn } from '@app/entity/shared/EntityContext';
 import EditStructuredPropertyModal from '@app/entity/shared/tabs/Properties/Edit/EditStructuredPropertyModal';
-import { Icon, Text } from '@src/alchemy-components';
+import { Button, Menu } from '@src/alchemy-components';
 import analytics, { EventType } from '@src/app/analytics';
-import { MenuItem } from '@src/app/govern/structuredProperties/styledComponents';
 import { ConfirmationModal } from '@src/app/sharedV2/modals/ConfirmationModal';
 import { ToastType, showToastMessage } from '@src/app/sharedV2/toastMessageUtils';
 import { useRemoveStructuredPropertiesMutation } from '@src/graphql/structuredProperties.generated';
@@ -18,18 +18,6 @@ const MoreOptionsContainer = styled.div`
     display: flex;
     gap: 12px;
     justify-content: end;
-
-    div {
-        background-color: ${(props) => props.theme.colors.bgSurface};
-        border-radius: 20px;
-        width: 24px;
-        height: 24px;
-        padding: 3px;
-        color: ${(props) => props.theme.colors.icon};
-        :hover {
-            cursor: pointer;
-        }
-    }
 `;
 
 interface Props {
@@ -92,41 +80,36 @@ export function EditColumn({ structuredProperty, associatedUrn, values, refetch,
         setShowConfirmRemove(false);
     };
 
-    const items = [
+    const items: ItemType[] = [
         {
+            type: 'item',
             key: '0',
-            label: (
-                <MenuItem
-                    onClick={() => {
-                        setIsEditModalVisible(true);
-                    }}
-                >
-                    {isAddMode ? tc('common.actions:add') : tc('common.actions:edit')}
-                </MenuItem>
-            ),
+            title: isAddMode ? tc('common.actions:add') : tc('common.actions:edit'),
+            onClick: () => setIsEditModalVisible(true),
         },
     ];
     if (values && values?.length > 0) {
         items.push({
+            type: 'item',
             key: '1',
-            label: (
-                <MenuItem
-                    onClick={() => {
-                        setShowConfirmRemove(true);
-                    }}
-                >
-                    <Text color="red"> {tc('common.actions:remove')} </Text>
-                </MenuItem>
-            ),
+            title: tc('common.actions:remove'),
+            danger: true,
+            onClick: () => setShowConfirmRemove(true),
         });
     }
 
     return (
         <>
             <MoreOptionsContainer>
-                <Dropdown menu={{ items }} trigger={['click']}>
-                    <Icon icon={DotsThreeVertical} size="md" data-testid="structured-prop-entity-more-icon" />
-                </Dropdown>
+                <Menu items={items}>
+                    <Button
+                        variant="text"
+                        color="gray"
+                        isCircle
+                        icon={{ icon: DotsThreeVertical, size: 'xl', weight: 'bold' }}
+                        data-testid="structured-prop-entity-more-icon"
+                    />
+                </Menu>
             </MoreOptionsContainer>
             <EditStructuredPropertyModal
                 isOpen={isEditModalVisible}

--- a/datahub-web-react/src/app/entity/shared/tabs/Properties/TabHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Properties/TabHeader.tsx
@@ -1,6 +1,4 @@
-import { Icon } from '@components';
-import { MagnifyingGlass } from '@phosphor-icons/react/dist/csr/MagnifyingGlass';
-import { Input } from 'antd';
+import { SearchBar } from '@components';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
@@ -8,16 +6,13 @@ import styled from 'styled-components';
 import AddPropertyButton from '@app/entity/shared/tabs/Properties/AddPropertyButton';
 import { Maybe, StructuredProperties } from '@src/types.generated';
 
-const StyledInput = styled(Input)`
-    border-radius: 70px;
-    max-width: 300px;
-`;
-
 const TableHeader = styled.div`
     padding: 8px 16px;
     border-bottom: 1px solid ${(props) => props.theme.colors.border};
     display: flex;
     justify-content: space-between;
+    align-items: center;
+    gap: 8px;
 `;
 
 interface Props {
@@ -31,11 +26,10 @@ export default function TabHeader({ setFilterText, fieldUrn, fieldProperties, re
     const { t } = useTranslation('entity.profile.tabs');
     return (
         <TableHeader>
-            <StyledInput
+            <SearchBar
                 placeholder={t('properties.searchInProperties.placeholder')}
-                onChange={(e) => setFilterText(e.target.value)}
-                allowClear
-                prefix={<Icon icon={MagnifyingGlass} />}
+                onChange={(value) => setFilterText(value)}
+                width="300px"
             />
             <AddPropertyButton fieldUrn={fieldUrn} fieldProperties={fieldProperties} refetch={refetch} />
         </TableHeader>

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Properties/StructuredPropertyValue.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Properties/StructuredPropertyValue.tsx
@@ -13,7 +13,8 @@ import { useEntityRegistry } from '@app/useEntityRegistry';
 import { Tooltip } from '@src/alchemy-components';
 import { getSchemaFieldParentLink } from '@src/app/entityV2/schemaField/utils';
 import { CompactEntityNameComponent } from '@src/app/recommendations/renderer/component/CompactEntityNameComponent';
-import { Entity, EntityType, MetadataAttribution } from '@src/types.generated';
+import ActorPill from '@src/app/sharedV2/owners/ActorPill';
+import { Entity, EntityType, MetadataAttribution, OwnerType } from '@src/types.generated';
 
 import ExternalLink from '@images/link-out.svg?react';
 
@@ -141,7 +142,13 @@ export default function StructuredPropertyValue({
 
     let valueEntityRender = <></>;
     if (value.entity) {
-        if (hydratedEntityMap && hydratedEntityMap[value.entity.urn]) {
+        const entityToRender = hydratedEntityMap?.[value.entity.urn] || value.entity;
+        const isUserOrGroup =
+            entityToRender.type === EntityType.CorpUser || entityToRender.type === EntityType.CorpGroup;
+
+        if (isUserOrGroup) {
+            valueEntityRender = <ActorPill actor={entityToRender as OwnerType} />;
+        } else if (hydratedEntityMap && hydratedEntityMap[value.entity.urn]) {
             valueEntityRender = (
                 <CompactEntityNameComponent entity={hydratedEntityMap[value.entity.urn]} showFullTooltip />
             );


### PR DESCRIPTION
Before:
<img width="1840" height="1196" alt="Screenshot 2026-07-07 at 9 52 53 AM" src="https://github.com/user-attachments/assets/f63b82c9-22f9-4a92-ab09-40ee2ef65021" />

<img width="3456" height="1522" alt="image" src="https://github.com/user-attachments/assets/16175740-3af7-4109-8060-332a16f4bbba" />

After:
<img width="1840" height="1196" alt="Screenshot 2026-07-07 at 9 35 26 AM" src="https://github.com/user-attachments/assets/faf1fbf6-576c-4317-89f5-6188220ca1bd" />


Swap the properties tab UI over to alchemy primitives: the row edit/remove kebab menu now uses the alchemy Menu + Button, the search input uses the alchemy SearchBar, and the add-property control uses an alchemy Button. Owner values now render with the shared ActorPill so they match the entity sidebar owners section instead of a bare avatar pill.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
