### PR TITLE
fix(graphql): expose custom properties on domains

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/domain/DomainMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/domain/DomainMapper.java
@@ -17,6 +17,7 @@ import com.linkedin.datahub.graphql.generated.Domain;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.ResolvedAuditStamp;
 import com.linkedin.datahub.graphql.types.common.mappers.AssetSettingsMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.CustomPropertiesMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.DisplayPropertiesMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.InstitutionalMemoryMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.OwnershipMapper;
@@ -62,6 +63,7 @@ public class DomainMapper {
       result.setProperties(
           mapDomainProperties(
               new DomainProperties(envelopedDomainProperties.getValue().data()),
+              entityUrn,
               createdAuditStampFromKeyAspect));
     }
 
@@ -121,11 +123,14 @@ public class DomainMapper {
 
   private static com.linkedin.datahub.graphql.generated.DomainProperties mapDomainProperties(
       final DomainProperties gmsProperties,
+      final Urn entityUrn,
       final ResolvedAuditStamp createdAuditStampFromKeyAspect) {
     final com.linkedin.datahub.graphql.generated.DomainProperties propertiesResult =
         new com.linkedin.datahub.graphql.generated.DomainProperties();
     propertiesResult.setName(gmsProperties.getName());
     propertiesResult.setDescription(gmsProperties.getDescription());
+    propertiesResult.setCustomProperties(
+        CustomPropertiesMapper.map(gmsProperties.getCustomProperties(), entityUrn));
 
     // Map created audit stamp
     if (gmsProperties.getCreated() != null) {

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -11940,6 +11940,11 @@ type DomainProperties {
   A Resolved Audit Stamp corresponding to the creation of this resource
   """
   createdOn: ResolvedAuditStamp
+
+  """
+  Custom properties of the Domain
+  """
+  customProperties: [CustomPropertiesEntry!]
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/domain/DomainMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/domain/DomainMapperTest.java
@@ -10,8 +10,10 @@ import com.linkedin.common.Forms;
 import com.linkedin.common.InstitutionalMemory;
 import com.linkedin.common.Ownership;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.StringMap;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
+import com.linkedin.datahub.graphql.generated.CustomPropertiesEntry;
 import com.linkedin.datahub.graphql.generated.Domain;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.domain.DomainProperties;
@@ -23,7 +25,9 @@ import com.linkedin.metadata.key.DomainKey;
 import com.linkedin.structured.StructuredProperties;
 import java.net.URISyntaxException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.mockito.MockedStatic;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -124,6 +128,35 @@ public class DomainMapperTest {
       assertNotNull(result.getStructuredProperties());
       assertNotNull(result.getForms());
       assertNotNull(result.getDisplayProperties());
+    }
+  }
+
+  @Test
+  public void testMapDomainCustomProperties() throws URISyntaxException {
+    EntityResponse entityResponse = createBasicEntityResponse();
+
+    DomainProperties domainProperties = new DomainProperties();
+    domainProperties.setName(TEST_DOMAIN_NAME);
+    StringMap customProperties = new StringMap();
+    customProperties.put("tier", "gold");
+    customProperties.put("team", "growth");
+    domainProperties.setCustomProperties(customProperties);
+    addAspectToResponse(entityResponse, DOMAIN_PROPERTIES_ASPECT_NAME, domainProperties);
+
+    try (MockedStatic<AuthorizationUtils> authUtilsMock = mockStatic(AuthorizationUtils.class)) {
+      authUtilsMock.when(() -> AuthorizationUtils.canView(any(), eq(domainUrn))).thenReturn(true);
+
+      Domain result = DomainMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result.getProperties());
+      List<CustomPropertiesEntry> mappedProperties = result.getProperties().getCustomProperties();
+      assertNotNull(mappedProperties);
+      Map<String, String> asMap =
+          mappedProperties.stream()
+              .collect(
+                  Collectors.toMap(CustomPropertiesEntry::getKey, CustomPropertiesEntry::getValue));
+      assertEquals(asMap.get("tier"), "gold");
+      assertEquals(asMap.get("team"), "growth");
     }
   }
 

--- a/datahub-web-react/src/graphql/domain.graphql
+++ b/datahub-web-react/src/graphql/domain.graphql
@@ -9,6 +9,9 @@ query getDomain($urn: String!) {
             createdOn {
                 time
             }
+            customProperties {
+                ...customPropertiesFields
+            }
         }
         parentDomains {
             ...parentDomainsFields
@@ -48,6 +51,9 @@ fragment ListDomain on Domain {
     properties {
         name
         description
+        customProperties {
+            ...customPropertiesFields
+        }
     }
     parentDomains {
         ...parentDomainsFields


### PR DESCRIPTION
## Summary

Domain was the **only** entity with a user-facing **Properties** tab whose `DomainProperties` GraphQL type omitted `customProperties`.

<img width="2892" height="1082" alt="CleanShot 2026-07-07 at 10 47 14@2x" src="https://github.com/user-attachments/assets/edab2372-3337-46cc-8e7f-de96bcc5b765" />


- The `domainProperties` aspect includes the `CustomProperties` mixin (`DomainProperties.pdl` → `record DomainProperties includes CustomProperties`), so custom properties **are persisted in GMS**.
- But `type DomainProperties` in `entity.graphql` exposed only `name` / `description` / `createdOn`, and `DomainMapper` never mapped them — so they were **silently unreadable** in the UI.
- ~27 other Properties/Info types (Dataset, Container, Dashboard, DataProduct, …) expose and render `customProperties`. The frontend Properties tab reads `properties.customProperties` (`getDataForEntityType`), which was always `undefined` for domains.

This change brings Domains to parity: custom properties are now surfaced **read-only** in the Properties tab, alongside Structured Properties — exactly how every other entity behaves.

## Changes

- **`entity.graphql`** — add `customProperties: [CustomPropertiesEntry!]` to `type DomainProperties`.
- **`DomainMapper.java`** — map it via the shared `CustomPropertiesMapper` (same pattern as `DataProductMapper`), passing the domain URN.
- **`domain.graphql`** (frontend) — select `customProperties` in the `getDomain` query and `ListDomain` fragment so the data flows into the Properties tab.
- **`DomainMapperTest.java`** — add a focused unit test asserting custom properties are mapped.

## Testing

Verified end-to-end on a local quickstart built from this branch:

1. Created a domain with custom properties (`tier=gold`, `owner_team=growth`, `cost_center=CC-1042`) via the API.
2. Queried GraphQL against the running (patched) GMS:

```graphql
{ domain(urn:"urn:li:domain:custom-props-demo"){ properties { name customProperties { key value } } } }
```

returns all three key/value pairs (previously the field did not exist on the type).

3. Frontend GraphQL codegen validates the updated `getDomain`/`ListDomain` queries against the schema and generates types including `customProperties`, wiring them into the Properties tab data path.
4. `DomainMapperTest` passes (12 tests in the suite).

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests for the changes have been added/updated
- [ ] Docs — n/a (additive, no behavior change beyond surfacing existing data)
- [ ] Breaking changes — none (additive, nullable field)
