### PR TITLE
ci: delete Vercel preview deployments on PR close

### DIFF
--- a/.github/workflows/post-workflow-actions.yml
+++ b/.github/workflows/post-workflow-actions.yml
@@ -37,6 +37,7 @@ on:
       - "Release Tests"
       - "Release Validation"
       - "spark smoke test"
+      - "Vercel Preview Cleanup"
       - "Verify Quickstart Compose"
     types:
       - completed

--- a/.github/workflows/vercel-preview-cleanup.yml
+++ b/.github/workflows/vercel-preview-cleanup.yml
@@ -2,8 +2,6 @@ name: Vercel Preview Cleanup
 
 # Deletes the Vercel preview deployments tied to a PR's head branch when the PR
 # is closed or merged, so stale previews (and their aliases/DNS) don't linger.
-# See SEC-884. Vercel's own "delete on branch deletion" setting is the primary
-# safeguard; this gives immediate, deterministic teardown on PR close.
 
 on:
   pull_request:

--- a/.github/workflows/vercel-preview-cleanup.yml
+++ b/.github/workflows/vercel-preview-cleanup.yml
@@ -1,0 +1,71 @@
+name: Vercel Preview Cleanup
+
+# Deletes the Vercel preview deployments tied to a PR's head branch when the PR
+# is closed or merged, so stale previews (and their aliases/DNS) don't linger.
+# See SEC-884. Vercel's own "delete on branch deletion" setting is the primary
+# safeguard; this gives immediate, deterministic teardown on PR close.
+
+on:
+  pull_request:
+    types: [closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  cleanup:
+    name: Delete Vercel previews for branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Fork PRs are not given repo secrets and Vercel does not build previews for
+    # them, so there is nothing to clean up.
+    if: ${{ github.event.pull_request.head.repo.fork == false }}
+    steps:
+      - name: Delete preview deployments
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_DOCS }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${VERCEL_TOKEN}" ] || [ -z "${VERCEL_PROJECT_ID}" ]; then
+            echo "VERCEL_TOKEN / VERCEL_PROJECT_ID not configured; skipping cleanup."
+            exit 0
+          fi
+
+          list_args=(
+            --data-urlencode "projectId=${VERCEL_PROJECT_ID}"
+            --data-urlencode "branch=${BRANCH}"
+            --data-urlencode "limit=100"
+          )
+          team_qs=""
+          if [ -n "${VERCEL_ORG_ID}" ]; then
+            list_args+=(--data-urlencode "teamId=${VERCEL_ORG_ID}")
+            team_qs="?teamId=${VERCEL_ORG_ID}"
+          fi
+
+          echo "Listing preview deployments for branch: ${BRANCH}"
+          # Guard against ever touching production even though a PR branch filter
+          # already excludes it (production == default branch only).
+          ids="$(curl -fsS -G "https://api.vercel.com/v6/deployments" \
+            -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+            "${list_args[@]}" \
+            | jq -r '.deployments[] | select(.target != "production") | .uid')"
+
+          if [ -z "${ids}" ]; then
+            echo "No preview deployments found for ${BRANCH}."
+            exit 0
+          fi
+
+          for id in ${ids}; do
+            echo "Deleting deployment ${id}"
+            # No -f: a 404 (already deleted) is our desired end state, not a failure.
+            curl -sS -X DELETE "https://api.vercel.com/v13/deployments/${id}${team_qs}" \
+              -H "Authorization: Bearer ${VERCEL_TOKEN}" | jq -c '.'
+          done
+          echo "Cleanup complete."


### PR DESCRIPTION
## Summary

Adds a workflow that deletes the Vercel preview deployments tied to a PR's head branch when the PR is closed or merged, so stale previews (and their aliases/DNS) don't linger. This gives immediate, deterministic teardown on PR close instead of waiting on Vercel's own cleanup cycle.

On `pull_request: closed` (non-fork only), it lists the project's deployments filtered server-side by the head branch and deletes each via the Vercel REST API (`GET /v6/deployments` → `DELETE /v13/deployments/{id}`). No checkout, no marketplace action — just `curl` + `jq`, which are preinstalled on the runner. `permissions: {}` since it never touches the GitHub API. Production is guarded twice: the branch filter already excludes it, plus an explicit `target != "production"` check.

Also registers the workflow with `post-workflow-actions.yml` so failures surface through the existing notification path.

## Required repo secrets

The workflow no-ops safely until these are configured:

- `VERCEL_TOKEN` — API token
- `VERCEL_PROJECT_ID_DOCS` — the docs-website project ID
- `VERCEL_ORG_ID` — team/org ID (optional; omit only for a personal-scoped project)

## Notes

- Uses `pull_request` (not `pull_request_target`) with a fork guard, mirroring the existing `react-cloudflare-pages.yml` preview workflow — fork PRs get no secrets and no Vercel previews anyway.
- No `paths:` filter: runs on every non-fork PR close and is a fast no-op when the branch has no previews.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Links to related issues (tracked internally)
- [ ] Tests — the jq extraction logic was covered by a local check; the workflow body itself isn't unit-testable in CI
- [ ] Docs — n/a
- [ ] Breaking changes — none

Test merging this PR should delete the PR deployment linked to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
