### PR TITLE
feat(agent-skills): add ml-drift-rca skill for model drift root-cause

### DIFF
--- a/.agent-skills/ml-drift-rca/SKILL.md
+++ b/.agent-skills/ml-drift-rca/SKILL.md
@@ -1,0 +1,83 @@
+# DataHub ML Drift Root-Cause
+
+You are an expert at diagnosing silent machine-learning model degradation using DataHub. Your role is to take a drift or performance signal for a production model, walk the model's lineage in DataHub to the specific upstream data change that caused it, identify the owning team, and record the finding durably back onto the catalog so the next engineer or agent inherits the diagnosis.
+
+The core insight: the person who detects a model degradation is rarely the person who caused it or has authority to fix it. The cause usually lives one or more hops upstream, in a table owned by a different team. DataHub's lineage graph is the bridge, and its metadata surfaces are where the answer should live.
+
+---
+
+## Multi-Agent Compatibility
+
+This skill is designed to work across multiple coding agents (Claude Code, Cursor, Codex, Copilot, Gemini CLI, Windsurf, and others).
+
+**What works everywhere:**
+
+- All procedures, standards references, and checklists in this document
+- Bash for running scripts (`trace-model-lineage.sh`, the `datahub` CLI, `curl` against GMS, `gh` CLI)
+- Reading files, calling the DataHub SDK, and generating the write-back
+
+**Claude Code-specific features** (other agents can safely ignore these):
+
+- `TaskCreate`/`TaskUpdate` for progress tracking. If unavailable, proceed through the steps sequentially.
+
+**Paths:** All standards, references, scripts, and templates are relative to `.agent-skills/ml-drift-rca/`.
+
+---
+
+## Quick Start
+
+1. Confirm the degradation is real, not just a distribution shift (see `standards/drift-root-cause.md`, Section 1).
+2. Walk upstream lineage from the model: `scripts/trace-model-lineage.sh <MODEL_URN> <GMS_URL>`.
+3. Localize the drifted feature and its source column, and read the owner from catalog metadata.
+4. Write the finding back: a structured property and a document on the model, and an incident on the upstream dataset (see Section 2 and `templates/drift-causation.md`).
+
+---
+
+## Scope
+
+### In Scope
+
+- Root-cause analysis for `mlModel` entities that have upstream lineage to `mlFeature`, `mlFeatureTable`, and `dataset` entities in DataHub.
+- Writing the diagnosis back onto the catalog via structured properties, documents, and incidents.
+
+### Out of Scope
+
+- Computing the drift signal itself. This skill consumes a signal (from NannyML, Evidently, Arize, a monitoring job, or labels) and assumes it exists. It does not train models or run detectors.
+- Proving causation. Lineage plus timing plus a data-quality change is strong correlation, not proof. Always say so.
+
+---
+
+## The Procedure
+
+### Step 1: Confirm real degradation
+
+A model can see a large input distribution shift with no performance loss (a tree model is invariant to a monotonic feature rescale, for example). Do not raise an incident for drift that does not degrade the model. Prefer a label-free performance estimate (NannyML CBPE for classification, DLE for regression) over raw input drift. See `standards/drift-root-cause.md` Section 1.
+
+### Step 2: Traverse lineage
+
+Walk upstream from the model URN through its features to the source tables. Use the Agent Context Kit `get_lineage` tool, the DataHub Python SDK (`DataHubGraph.get_aspect` for deterministic aspect reads), or the helper `scripts/trace-model-lineage.sh`. Deterministic aspect reads are more reliable than the async graph index immediately after ingestion.
+
+### Step 3: Localize the drifted column
+
+Rank per-feature drift with a comparable effect size (KS statistic for numeric, Cramer's V for categorical), correct for multiple testing (Benjamini-Hochberg FDR), and confirm with a data-quality fingerprint (null rate, cardinality, range). The feature with a large effect size plus a data-quality break (for example, a column that collapsed to a constant) is your prime suspect. Map it back to its source column via lineage.
+
+### Step 4: Identify the owner
+
+Read the ownership aspect on the upstream dataset. This is the team to notify. Do not guess. Use `get_entities` (Agent Context Kit) or the SDK ownership aspect.
+
+### Step 5: Write the finding back
+
+**A model cannot hold an incident in DataHub.** The incident metamodel allows incidents only on `dataset`, `chart`, `dashboard`, `dataFlow`, `dataJob`, and `schemaField`. So split the write-back:
+
+- On the **model**: a typed structured property (for example `drift_causation`) plus a context document with the full RCA. Optionally a `drift-degraded` tag.
+- On the **upstream dataset**: an incident (via the `raiseIncident` GraphQL mutation, since there is no typed Python SDK for incidents yet).
+
+See `standards/drift-root-cause.md` Section 2 for the exact rules, `references/datahub-apis.md` for the calls, and `templates/drift-causation.md` for the content templates.
+
+**Keep the LLM out of the write path.** Reason about the cause with the model, but execute every catalog write with deterministic code, and write-ahead each mutation so a failed write retries idempotently.
+
+---
+
+## Startup: Load Standards
+
+On activation, load `standards/drift-root-cause.md`. It contains the drift-versus-degradation rules, the write-back split, and the honesty requirement, with the reasoning behind each. After loading, confirm: "Loaded ML drift root-cause standards. Ready to diagnose."

--- a/.agent-skills/ml-drift-rca/references/datahub-apis.md
+++ b/.agent-skills/ml-drift-rca/references/datahub-apis.md
@@ -1,0 +1,81 @@
+# DataHub APIs for drift root-cause
+
+The exact reads and writes this skill uses. All examples assume a self-hosted DataHub Core with `DATAHUB_GMS_URL` set (and a token in `DATAHUB_GMS_TOKEN` if auth is on).
+
+## Reads
+
+### Walk lineage (Agent Context Kit)
+
+```python
+from datahub.sdk import DataHubClient
+from datahub_agent_context.langchain_tools import build_langchain_tools
+
+client = DataHubClient(server=GMS_URL, token=GMS_TOKEN)
+tools = {t.name: t for t in build_langchain_tools(client, include_mutations=False)}
+
+# upstream lineage from the model
+tools["get_lineage"].invoke({"urn": MODEL_URN, "upstream": True, "max_hops": 2})
+# model metadata and ownership
+tools["get_entities"].invoke({"urns": [MODEL_URN]})
+```
+
+### Deterministic aspect reads (SDK)
+
+Immediately after ingestion the async graph index can lag, so for reliable traversal read aspects directly:
+
+```python
+from datahub.ingestion.graph.client import DataHubGraph, DataHubGraphConfig
+
+graph = DataHubGraph(DataHubGraphConfig(server=GMS_URL, token=GMS_TOKEN))
+props = graph.get_aspect(MODEL_URN, aspect_type=MLModelPropertiesClass)  # upstreamFeatures, etc.
+owners = graph.get_aspect(DATASET_URN, aspect_type=OwnershipClass)
+```
+
+## Writes
+
+### Structured property on the model
+
+Define the property once (entity type `mlModel`), then set it:
+
+```python
+# via MCP tool add_structured_properties, or the SDK:
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+# emit a StructuredProperties aspect with your propertyUrn and value(s)
+```
+
+The MCP tool `add_structured_properties` is available on self-hosted DataHub Core when `TOOLS_IS_MUTATION_ENABLED=true` on `mcp-server-datahub` >= v0.5.0.
+
+### Document on the model
+
+```python
+# via MCP save_document, or the Document SDK:
+from datahub.sdk import DataHubClient
+# Document.create_document(...) attaching the RCA text and linking the model as a related asset
+```
+
+Do not use `update_description` in the open-source path; it is Cloud-only in recent MCP versions.
+
+### Incident on the upstream dataset (GraphQL)
+
+Incidents have no typed Python SDK yet. POST the mutation to `${GMS_URL}/api/graphql`:
+
+```graphql
+mutation raiseIncident($input: RaiseIncidentInput!) {
+  raiseIncident(input: $input)
+}
+```
+
+```json
+{
+  "input": {
+    "resourceUrn": "<UPSTREAM_DATASET_URN>",
+    "type": "FRESHNESS",
+    "title": "Upstream change degraded downstream model",
+    "description": "<one line naming the model, the feature, and the estimated impact>"
+  }
+}
+```
+
+## The metamodel constraint
+
+Incidents attach only to `dataset`, `chart`, `dashboard`, `dataFlow`, `dataJob`, and `schemaField`. Not `mlModel`. This is why the model gets a structured property and a document, and the upstream dataset gets the incident.

--- a/.agent-skills/ml-drift-rca/scripts/trace-model-lineage.sh
+++ b/.agent-skills/ml-drift-rca/scripts/trace-model-lineage.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Walk upstream lineage from an mlModel to its source datasets and their owners.
+#
+# This is the traversal step of ML drift root-cause: given a degrading model,
+# find the upstream tables (and owning teams) where the cause likely lives.
+#
+# Usage:
+#   ./trace-model-lineage.sh <MODEL_URN> <GMS_URL> [GMS_TOKEN]
+#
+# Example:
+#   ./trace-model-lineage.sh \
+#     'urn:li:mlModel:(urn:li:dataPlatform:mlflow,my_model,PROD)' \
+#     http://localhost:8080
+#
+# Output: one line per upstream entity, as "hop<N>  <type>  <urn>  owners=<...>".
+#
+# Requires: python3 (standard library only). Reads DATAHUB_GMS_TOKEN from the
+# env if a token is not passed as the third argument.
+#
+# Exit codes:
+#   0 = traversal ran
+#   1 = request or GraphQL error
+#   2 = missing arguments
+
+set -euo pipefail
+
+MODEL_URN="${1:-}"
+GMS_URL="${2:-${DATAHUB_GMS_URL:-}}"
+GMS_TOKEN="${3:-${DATAHUB_GMS_TOKEN:-}}"
+
+if [[ -z "$MODEL_URN" || -z "$GMS_URL" ]]; then
+  echo "usage: $0 <MODEL_URN> <GMS_URL> [GMS_TOKEN]" >&2
+  exit 2
+fi
+
+python3 - "$MODEL_URN" "$GMS_URL" "$GMS_TOKEN" <<'PY'
+import json, sys, urllib.request
+
+urn, gms, token = sys.argv[1], sys.argv[2].rstrip("/"), sys.argv[3]
+
+query = (
+    "query($urn: String!) {"
+    "  searchAcrossLineage(input: {urn: $urn, direction: UPSTREAM, query: \"*\", count: 100}) {"
+    "    searchResults {"
+    "      degree"
+    "      entity {"
+    "        urn type"
+    "        ... on Dataset { ownership { owners { owner {"
+    "          ... on CorpUser { urn } ... on CorpGroup { urn } } } } }"
+    "      }"
+    "    }"
+    "  }"
+    "}"
+)
+
+body = json.dumps({"query": query, "variables": {"urn": urn}}).encode()
+req = urllib.request.Request(f"{gms}/api/graphql", data=body,
+                            headers={"Content-Type": "application/json"})
+if token:
+    req.add_header("Authorization", f"Bearer {token}")
+
+try:
+    data = json.loads(urllib.request.urlopen(req, timeout=30).read())
+except Exception as e:  # noqa: BLE001
+    print(f"error: {e}", file=sys.stderr)
+    sys.exit(1)
+
+if data.get("errors"):
+    print("graphql errors:", [e.get("message") for e in data["errors"]][:3], file=sys.stderr)
+    sys.exit(1)
+
+results = (((data.get("data") or {}).get("searchAcrossLineage") or {}).get("searchResults")) or []
+if not results:
+    print(f"no upstream lineage found for {urn}")
+    sys.exit(0)
+
+for r in sorted(results, key=lambda x: x.get("degree", 99)):
+    e = r.get("entity") or {}
+    owners = [
+        (o.get("owner") or {}).get("urn")
+        for o in (((e.get("ownership") or {}).get("owners")) or [])
+        if (o.get("owner") or {}).get("urn")
+    ]
+    print(f"hop{r.get('degree', '?')}  {e.get('type', '')}  {e.get('urn', '')}  "
+          f"owners={','.join(owners) or '-'}")
+PY

--- a/.agent-skills/ml-drift-rca/standards/drift-root-cause.md
+++ b/.agent-skills/ml-drift-rca/standards/drift-root-cause.md
@@ -1,0 +1,64 @@
+# ML Drift Root-Cause Standards
+
+Rules for diagnosing silent model degradation with DataHub, and for writing the diagnosis back. Each rule states the reasoning so agents apply it in situations this document does not enumerate.
+
+---
+
+## 1. Drift is not degradation
+
+### 1.1 Only alarm on real performance loss
+
+An input distribution can shift a lot without the model getting worse, and it can shift a little while the model falls apart. Raw input drift (a KS test firing on a feature) is a diagnostic clue, not an incident on its own.
+
+- A monotonic rescale of a feature (for example, a unit change from dollars to cents) moves the distribution but leaves a tree model's predictions unchanged. This is benign. Do not raise an incident.
+- A feature that regresses to a constant default (for example, an upstream job coalescing nulls to 0) removes signal and degrades the model. This is harmful. Raise an incident.
+
+### 1.2 Prefer label-free performance estimation
+
+In production, ground-truth labels usually arrive late or never. Estimate performance without labels:
+
+- Classification: NannyML CBPE (Confidence-Based Performance Estimation). Valid under covariate shift with calibrated probabilities.
+- Regression: NannyML DLE (Direct Loss Estimation).
+
+Report the estimate as directional. CBPE is not valid under concept drift (when the relationship between features and target changes), so say "estimated" and note the assumption.
+
+### 1.3 Rank features with a comparable effect size
+
+Different tests produce non-comparable statistics (a KS statistic and a Chi-squared statistic are not on the same scale). To rank suspects, use a comparable effect size: the KS statistic for numeric features, Cramer's V for categorical features. Correct p-values for multiple testing with Benjamini-Hochberg FDR, since testing many features inflates false positives. Confirm the top suspect with a data-quality fingerprint (null rate, cardinality, min/max range) before acting.
+
+---
+
+## 2. The write-back split
+
+### 2.1 A model cannot hold an incident
+
+DataHub's incident metamodel allows incidents on `dataset`, `chart`, `dashboard`, `dataFlow`, `dataJob`, and `schemaField` only. It does not allow incidents on `mlModel`. Attempting to raise one on a model fails.
+
+Therefore split the write-back:
+
+| Target | What to write | Mechanism |
+| --- | --- | --- |
+| The model (`mlModel`) | A typed structured property (for example `drift_causation`) | `add_structured_properties` (MCP) or the SDK structured-property API |
+| The model (`mlModel`) | A context document with the full RCA | `save_document` (MCP) or the Document SDK |
+| The model (`mlModel`) | An optional `drift-degraded` tag | GlobalTags aspect |
+| The upstream `dataset` | An incident routed to the owner | `raiseIncident` GraphQL mutation |
+
+### 2.2 Use the open-source-available write surfaces
+
+On self-hosted DataHub Core with mutations enabled, `add_structured_properties` and `save_document` are available. Do not use `update_description` in the open-source path; it is Cloud-only in recent MCP versions. Incidents have no typed Python SDK yet, so call the `raiseIncident` GraphQL mutation directly.
+
+### 2.3 Write-ahead every mutation
+
+Before each catalog write, append the intended mutation to a local write-ahead log keyed by a deterministic id. On retry, skip anything already recorded as done. A partial failure mid-write must not double-write or corrupt the record.
+
+---
+
+## 3. Honesty
+
+### 3.1 Correlation, not causation
+
+Lineage plus timing plus a data-quality change is a strong correlation. It is not proof that the upstream change caused the degradation. State this in the RCA and recommend the human confirm the upstream commit history before rolling anything back.
+
+### 3.2 The model reasons, code writes
+
+Use the language model to synthesize the narrative and rank suspects. Execute every catalog mutation with deterministic code. This keeps the write path stable and auditable, and it means a demo or a production run behaves identically regardless of what the model says.

--- a/.agent-skills/ml-drift-rca/templates/drift-causation.md
+++ b/.agent-skills/ml-drift-rca/templates/drift-causation.md
@@ -1,0 +1,46 @@
+# Write-back templates
+
+Fill the placeholders and write these to the catalog. Keep them terse and factual.
+
+## 1. The `drift_causation` structured property (on the model)
+
+A single-line, machine-and-human readable value:
+
+```
+<CHANGE_TYPE> on feature <FEATURE> (upstream <UPSTREAM_TABLE>);
+<METRIC> <REFERENCE>-><CURRENT> (label-free), drop <DELTA>;
+notify <OWNER_URN>; detected <ISO8601_TIMESTAMP>
+```
+
+Example:
+
+```
+null_default_regression on feature PageValues (upstream ecommerce.web_sessions);
+roc_auc 0.808->0.7131 (label-free CBPE), drop 0.0949;
+notify urn:li:corpGroup:data-engineering; detected 2026-07-07T22:23:47+00:00
+```
+
+`CHANGE_TYPE` is one of: `null_default_regression`, `unit_rescale` (usually benign, do not alarm), `cardinality_collapse`, `range_shift`, `schema_change`, `freshness_gap`.
+
+## 2. The RCA document (on the model)
+
+Plain prose, five short parts. No marketing language, no em-dashes.
+
+```
+<METRIC> for <MODEL> dropped from <REFERENCE> to <CURRENT> (<DELTA>), label-free.
+The drift localizes to <FEATURE>, which shows <EVIDENCE: effect size, adjusted p-value,
+range/cardinality change>. This pattern is consistent with <CHANGE_TYPE>: <one-line mechanism>.
+Lineage traces <FEATURE> to <UPSTREAM_TABLE>, owned by <OWNER>, so the likely point of failure
+is a recent change to that table. Recommended fix: <concrete action for the owner>.
+This is a lineage-guided correlation, not a proven causal link, so confirm the upstream commit
+history before rolling back.
+```
+
+## 3. The incident (on the upstream dataset)
+
+```
+type:        FRESHNESS   (or DATA_QUALITY, OPERATIONAL, as fits)
+title:       Upstream change degraded <MODEL>
+description: <FEATURE> in this table <CHANGE_TYPE>; estimated impact on <MODEL>:
+             <METRIC> <REFERENCE>-><CURRENT>. Routed to <OWNER>.
+```


### PR DESCRIPTION
## What

Adds a new agent skill, `ml-drift-rca`, under `.agent-skills/`. It teaches an agent to root-cause silent ML model degradation using DataHub: confirm the degradation is real (not benign drift), walk the model's lineage to the upstream table that changed, identify the owning team from catalog metadata, and write the finding back onto the catalog.

## Why

The person who detects a model degradation is rarely the person who caused it or owns the upstream data. DataHub's lineage graph is the bridge between the two. This skill encodes that traversal and the write-back, including a constraint that is easy to miss: the incident metamodel does not allow incidents on `mlModel`, so the write-back is split (a structured property and a document on the model, an incident on the upstream dataset).

## Contents

Follows the same structure as the existing `test-review` skill:

- `SKILL.md`: the procedure, multi-agent compatible (Claude Code, Cursor, Codex, Copilot, Gemini CLI, Windsurf).
- `standards/drift-root-cause.md`: drift versus degradation, the write-back split, and honesty (lineage-guided correlation, not proven causation).
- `references/datahub-apis.md`: the exact Agent Context Kit reads and the structured-property, document, and `raiseIncident` writes, including the metamodel constraint.
- `scripts/trace-model-lineage.sh`: a standard-library Python-in-bash helper that walks upstream lineage to source datasets and their owners.
- `templates/drift-causation.md`: the structured-property, RCA-document, and incident content templates.

## Testing

The traversal script was run against a live self-hosted DataHub Core instance and correctly walked an `mlModel` through its `mlFeature` entities to the upstream `dataset` and its owning `corpGroup`.

## Notes

This skill was built while implementing an on-call drift-diagnosis agent on open-source DataHub Core (Agent Context Kit for reads, structured properties and documents plus `raiseIncident` for the write-back). Happy to adjust the structure, naming, or scope to match project conventions.
