### PR TITLE
chore: Add .gitignore for Airbyte test artifacts

### DIFF
--- a/metadata-ingestion/tests/integration/airbyte/.gitignore
+++ b/metadata-ingestion/tests/integration/airbyte/.gitignore
@@ -1,0 +1,3 @@
+# abctl binary and archive downloaded by airbyte_test_setup.py at test time
+abctl
+abctl-*.tar.gz


### PR DESCRIPTION
## Description
Add a `.gitignore` file to the Airbyte integration tests directory to prevent committing dynamically downloaded test artifacts. This removes the previously committed `abctl` binary and ensures that the `abctl` binary and archive files downloaded by `airbyte_test_setup.py` at test time are not tracked by git.

## Changes
- Added `.gitignore` to `metadata-ingestion/tests/integration/airbyte/` to exclude:
  - `abctl` binary
  - `abctl-*.tar.gz` archives
- Removed the committed `abctl` binary from version control

## Motivation
The `abctl` binary is downloaded dynamically during test execution and should not be committed to the repository. This change keeps the repository clean and reduces unnecessary binary artifacts in version control.

## Test Plan
N/A - This is a configuration change with no functional impact on tests.

https://claude.ai/code/session_01Kc54Zgd5P2PpGqnKy36JGb