### PR TITLE
docs(features): add multi-language support feature guide

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -545,6 +545,11 @@ module.exports = {
           id: "docs/features/feature-guides/mcp",
         },
         {
+          label: "Multi-Language Support",
+          type: "doc",
+          id: "docs/features/feature-guides/multi-language-support",
+        },
+        {
           label: "Ownership",
           type: "doc",
           id: "docs/ownership/ownership-types",

--- a/docs/features/feature-guides/multi-language-support.md
+++ b/docs/features/feature-guides/multi-language-support.md
@@ -1,0 +1,42 @@
+---
+title: Multi-Language Support
+description: "Display the DataHub UI in your preferred language, and contribute new translations to the open-source project."
+---
+
+import FeatureAvailability from '@site/src/components/FeatureAvailability';
+
+# Multi-Language Support
+
+<FeatureAvailability/>
+
+DataHub's UI can be displayed in multiple languages. Each user chooses their preferred language from
+their personal settings, so people on the same instance can use DataHub in whichever language they're
+most comfortable with.
+
+## Available Languages
+
+- English (default)
+- German (Deutsch)
+- Spanish (Español) — Beta
+- Portuguese, Brazil (Português) — Beta
+- French (Français) — Beta
+- Italian (Italiano) — Beta
+
+Languages marked _Beta_ are still being refined and may have untranslated strings.
+
+## Enabling Multi-Language Support
+
+Multi-language support is off by default. To turn it on, set the `I18N_ENABLED` environment variable
+to `true` on GMS and restart. Once enabled, each user can pick their language under
+**Settings → Preferences**.
+
+## Contributing a New Language
+
+DataHub is open source, and we welcome community contributions for new languages as well as
+improvements to existing translations. If a language you need isn't listed above — or you spot a
+translation that could be better — you can add or update it and open a pull request.
+
+Translation files live under `datahub-web-react/src/i18n/locales/<language>/` in the
+[DataHub repository](https://github.com/datahub-project/datahub). See the
+[Contributing Guide](../../CONTRIBUTING.md) to get started, and reach out on
+[Slack](https://datahubspace.slack.com) if you'd like to coordinate on a new language.


### PR DESCRIPTION
## Summary

Adds a short feature guide documenting DataHub's multi-language (i18n) UI support. There was previously no user-facing doc covering it.

The guide covers:
- **Available languages** — English (default), German, and Beta translations for Spanish, Portuguese (Brazil), French, and Italian.
- **Enabling it** — off by default; set `I18N_ENABLED=true` on GMS, then each user picks their language under **Settings → Preferences**.
- **Contributing a new language** — the project welcomes community submissions for new languages and translation improvements, pointing to where locale files live (`datahub-web-react/src/i18n/locales/<language>/`) and to the Contributing Guide.

New page: `docs/features/feature-guides/multi-language-support.md`, wired into the **Features** section of `docs-website/sidebars.js`.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Links to related issues (n/a)
- [ ] Tests added/updated (n/a — docs only)
- [x] Docs added/updated
- [ ] Breaking changes (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)