### PR TITLE
fix(scripts): reconcile schemaVersion debt by sha so no-PR catch-up bumps count

### DIFF
--- a/.github/scripts/report_aspect_changes.py
+++ b/.github/scripts/report_aspect_changes.py
@@ -537,6 +537,17 @@ def _shorten_change_line(line: str) -> str:
     return line
 
 
+def _slice_debt_key(entry: dict) -> Optional[str]:
+    """Stable identity for a per-PR slice when tracking schemaVersion debt.
+
+    Prefers the commit `sha` (always present in real audits, and unique even
+    for commits with no PR), falling back to the PR number. Keying on this
+    rather than the PR number alone lets a cumulative catch-up bump reconcile
+    debt introduced by a no-PR commit.
+    """
+    return entry.get("sha") or entry.get("pr")
+
+
 def _apply_catchup_reclassification(entries: list[dict]) -> list[dict]:
     """Reconcile schemaVersion debt across PRs chronologically.
 
@@ -548,35 +559,51 @@ def _apply_catchup_reclassification(entries: list[dict]) -> list[dict]:
     `bump_spurious`.
 
     Mutates entries in place; the new keys are `bump_status` (possibly
-    flipped from BUMP_SPURIOUS to BUMP_DONE) and `catch_up_for_prs` (list of
-    PRs whose unbumped changes this slice's bump covered). Returns the same
-    list for chaining.
+    flipped from BUMP_SPURIOUS to BUMP_DONE), `catch_up_shas` (the slice shas
+    whose unbumped changes this bump covered — the reconciliation unit), and
+    `catch_up_for_prs` (the PR-number subset of those, for display). Returns
+    the same list for chaining.
+
+    Debt is tracked by commit `sha`, not PR number: a change can arrive on a
+    commit with no PR (a direct push / release-catch-up commit), and a single
+    cumulative schemaVersion bump still covers it. Keying on PR number dropped
+    such no-PR debt entirely, so a later catch-up bump never reconciled it and
+    the file leaked a false `bump_needed` (e.g. AssertionRunEvent's transitive
+    BoundsValueSpace change, committed without a PR).
     """
     if not entries:
         return entries
     sorted_entries = sorted(
         entries,
-        key=lambda e: (e.get("date") or "", e.get("pr") or ""),
+        key=lambda e: (e.get("date") or "", e.get("pr") or "", e.get("sha") or ""),
     )
-    pending_prs: list[str] = []
+    # pending: list of (sha, pr) for unbumped changes awaiting a catch-up bump.
+    pending: list[tuple[str, Optional[str]]] = []
+
+    def _record_and_clear(e: dict) -> None:
+        e["catch_up_shas"] = [s for s, _ in pending]
+        # PR subset only — keeps the "catch-up for #N" display text clean and
+        # free of raw shas for no-PR debt.
+        e["catch_up_for_prs"] = [p for _, p in pending if p]
+
     for e in sorted_entries:
         status = e.get("bump_status")
         if status == BUMP_NEEDED:
-            pr = e.get("pr")
-            if pr and pr not in pending_prs:
-                pending_prs.append(pr)
+            key = _slice_debt_key(e)
+            if key and key not in [s for s, _ in pending]:
+                pending.append((key, e.get("pr")))
         elif status == BUMP_SPURIOUS:
-            if pending_prs:
+            if pending:
                 e["bump_status"] = BUMP_DONE
-                e["catch_up_for_prs"] = list(pending_prs)
-                pending_prs = []
+                _record_and_clear(e)
+                pending = []
             # else: stays BUMP_SPURIOUS — no debt to pay
         elif status == BUMP_DONE:
             # The slice's own change + own bump implicitly clears prior debt
             # (one bump covers all pending changes).
-            if pending_prs:
-                e["catch_up_for_prs"] = list(pending_prs)
-            pending_prs = []
+            if pending:
+                _record_and_clear(e)
+            pending = []
     return entries
 
 
@@ -1791,9 +1818,11 @@ def _aggregate_per_pr_verdict(entries: list[dict]) -> str:
     honoring catch-up reconciliation.
 
     Priority order (highest wins): bump_needed > bump_spurious > bump_done >
-    bump_not_needed. A BUMP_NEEDED entry is **ignored** when its PR appears
-    in any later slice's `catch_up_for_prs` — that NEEDED slice has already
-    been reconciled by a catch-up bump and is no longer an unpaid debt.
+    bump_not_needed. A BUMP_NEEDED entry is **ignored** when its sha appears
+    in any later slice's `catch_up_shas` — that NEEDED slice has already been
+    reconciled by a catch-up bump and is no longer an unpaid debt. Reconciling
+    by sha (not PR number) covers debt from no-PR commits, which a cumulative
+    bump still pays down.
 
     An *unreconciled* BUMP_NEEDED outranks BUMP_SPURIOUS: a needed bump is a
     release-blocking, silent-migration hazard, whereas a spurious bump is only
@@ -1808,13 +1837,21 @@ def _aggregate_per_pr_verdict(entries: list[dict]) -> str:
 
     The cumulative bucket therefore follows the per-PR truth.
     """
-    paid_prs: set[str] = set()
+    # Reconcile by commit sha (every slice has one), not PR number — a no-PR
+    # change still incurs debt that a later cumulative bump can pay down.
+    # Paid debt is keyed by `catch_up_shas` (sha-or-pr, the reconciliation unit);
+    # also union in `catch_up_for_prs` so a slice keyed only by PR number is still
+    # recognized as reconciled.
+    paid: set[str] = set()
     for e in entries:
-        for pr in e.get("catch_up_for_prs") or []:
-            paid_prs.add(pr)
+        for key in (e.get("catch_up_shas") or []):
+            paid.add(key)
+        for pr in (e.get("catch_up_for_prs") or []):
+            paid.add(pr)
     has_spurious = any(e["bump_status"] == BUMP_SPURIOUS for e in entries)
     has_unreconciled_needed = any(
-        e["bump_status"] == BUMP_NEEDED and e.get("pr") not in paid_prs for e in entries
+        e["bump_status"] == BUMP_NEEDED and _slice_debt_key(e) not in paid
+        for e in entries
     )
     has_done = any(e["bump_status"] == BUMP_DONE for e in entries)
     if has_unreconciled_needed:

--- a/.github/scripts/test/test_report_aspect_changes.py
+++ b/.github/scripts/test/test_report_aspect_changes.py
@@ -1660,6 +1660,45 @@ def test_catchup_sorts_by_date_not_input_order():
     assert statuses["9579"] == rac.BUMP_SPURIOUS
 
 
+def test_catchup_reconciles_no_pr_debt_by_sha():
+    """Regression (AssertionRunEvent): a real change committed with NO PR still
+    incurs schemaVersion debt, and a later cumulative catch-up bump must pay it
+    down. Reconciliation keyed on PR number alone dropped the no-PR debt, so the
+    file leaked a false bump_needed even though its version was genuinely bumped.
+
+    Slices mirror AssertionRunEvent: a no-PR transitive change, then a bump in
+    the same window. The bump must be recognized as a catch-up for the no-PR
+    change (keyed by sha), and the file aggregate must be bump_done, not
+    bump_needed.
+    """
+    entries = [
+        # no-PR transitive change, no bump → unbumped debt
+        {"sha": "aaaa111", "pr": None, "date": "2026-05-21", "bump_status": rac.BUMP_NEEDED},
+        # later bump with no change of its own → catch-up for the no-PR debt
+        {"sha": "bbbb222", "pr": "9658", "date": "2026-05-21", "bump_status": rac.BUMP_SPURIOUS},
+    ]
+    rac._apply_catchup_reclassification(entries)
+    by_sha = {e["sha"]: e for e in entries}
+
+    # The bump is reclassified as a catch-up that paid the no-PR debt (by sha).
+    assert by_sha["bbbb222"]["bump_status"] == rac.BUMP_DONE
+    assert "aaaa111" in (by_sha["bbbb222"].get("catch_up_shas") or [])
+
+    # The file aggregate is bump_done — the no-PR debt is reconciled, not leaked
+    # as a false bump_needed.
+    assert rac._aggregate_per_pr_verdict(entries) == rac.BUMP_DONE
+
+
+def test_aggregator_unreconciled_no_pr_needed_still_surfaces():
+    """Guard the other direction: a no-PR bump_needed that is NOT paid by any
+    later bump must still surface as bump_needed (we didn't just silence no-PR
+    debt)."""
+    entries = [
+        {"sha": "cccc333", "pr": None, "date": "2026-05-21", "bump_status": rac.BUMP_NEEDED},
+    ]
+    assert rac._aggregate_per_pr_verdict(entries) == rac.BUMP_NEEDED
+
+
 def test_describe_per_pr_slice_renders_catchup_annotation():
     """The 'What happened' prose names the PRs whose debt this slice cleared."""
     entry = {


### PR DESCRIPTION
## Summary

Fixes a false `bump_needed` in `.github/scripts/report_aspect_changes.py` caused by the per-PR catch-up reconciliation tracking schemaVersion debt **by PR number only**.

### Problem

`_apply_catchup_reclassification` recorded unbumped-change debt under each slice's PR number (`if pr:` guard). A change committed **without a PR** (a direct push / release catch-up commit) never entered the pending-debt set, so a later cumulative bump could never reconcile it. After reordering the aggregator (an unreconciled `bump_needed` outranks a coexisting `bump_spurious`), this latent gap surfaced as a false positive — e.g. `AssertionRunEvent` going `schemaVersion` 5 → 6 (a real cumulative bump) was still reported `bump_needed`.

### Fix

Key debt by commit **sha** (falling back to PR number) in both the reconciler and the aggregator, via a shared `_slice_debt_key` helper. A no-PR change now incurs trackable debt that a later catch-up bump pays down. `catch_up_for_prs` is retained (PR subset) for display; a new `catch_up_shas` carries the reconciliation keys.

### Validation

- Affected test suite (`.github/scripts/test/test_report_aspect_changes.py`): **128 passed**.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [ ] Docs — n/a (internal CI/reporting script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
