### PR TITLE
fix(ingest/unity-catalog): honor include_views and view_pattern

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -228,6 +228,16 @@ class UnityCatalogSourceConfig(
         ),
     )
 
+    view_pattern: AllowDenyPattern = Field(
+        default=AllowDenyPattern.allow_all(),
+        description=(
+            "Regex patterns for views to filter in ingestion."
+            " Specify regex to match the entire view name in `catalog.schema.view` format."
+            " Defaults to `table_pattern` if not specified."
+            " Only applies when `include_views` is True; set `include_views: false` to skip all views."
+        ),
+    )
+
     metric_view_pattern: AllowDenyPattern = Field(
         default=AllowDenyPattern.allow_all(),
         description=(

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -228,15 +228,8 @@ class UnityCatalogSourceConfig(
         ),
     )
 
-    view_pattern: AllowDenyPattern = Field(
-        default=AllowDenyPattern.allow_all(),
-        description=(
-            "Regex patterns for views to filter in ingestion."
-            " Specify regex to match the entire view name in `catalog.schema.view` format."
-            " Defaults to `table_pattern` if not specified."
-            " Only applies when `include_views` is True; set `include_views: false` to skip all views."
-        ),
-    )
+    # view_pattern and include_views are inherited from SQLCommonConfig and applied
+    # in process_tables; not redeclared here to avoid drift from the base defaults.
 
     metric_view_pattern: AllowDenyPattern = Field(
         default=AllowDenyPattern.allow_all(),

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
@@ -726,6 +726,16 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                 self.report.tables.dropped(table.id, f"table ({table.table_type})")
                 continue
 
+            # Views (VIEW / MATERIALIZED_VIEW / HIVE_VIEW) are honored via
+            # include_views + view_pattern, mirroring SQL-based sources. Metric
+            # views are not is_view and keep their dedicated filtering below.
+            if table.is_view and (
+                not self.config.include_views
+                or not self.config.view_pattern.allowed(table.ref.qualified_table_name)
+            ):
+                self.report.tables.dropped(table.id, f"view ({table.table_type})")
+                continue
+
             if (
                 table.is_metric_view
                 and self.config.include_metric_views

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
@@ -747,6 +747,16 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                 self.report.metric_views.dropped(table.id)
                 continue
 
+            # Regular tables (neither view nor metric view) are honored via
+            # include_tables; views and metric views keep their own toggles above.
+            if (
+                not table.is_view
+                and not table.is_metric_view
+                and not self.config.include_tables
+            ):
+                self.report.tables.dropped(table.id, f"table ({table.table_type})")
+                continue
+
             if (
                 self.config.is_profiling_enabled()
                 and self.config.uses_table_level_profiler()

--- a/metadata-ingestion/tests/integration/unity/test_unity_catalog_ingest.py
+++ b/metadata-ingestion/tests/integration/unity/test_unity_catalog_ingest.py
@@ -1660,3 +1660,9 @@ def test_view_pattern_deny_skips_views(pytestconfig, tmp_path, requests_mock):
     )
     assert any("my_table" in urn for urn in urns)
     assert not any("my_view" in urn for urn in urns)
+
+
+def test_include_tables_false_skips_tables(pytestconfig, tmp_path, requests_mock):
+    urns = _run_view_filter_pipeline(tmp_path, requests_mock, {"include_tables": False})
+    assert not any("my_table" in urn for urn in urns)
+    assert any("my_view" in urn for urn in urns)

--- a/metadata-ingestion/tests/integration/unity/test_unity_catalog_ingest.py
+++ b/metadata-ingestion/tests/integration/unity/test_unity_catalog_ingest.py
@@ -1547,3 +1547,116 @@ def test_unity_catalog_usage_via_aggregator(pytestconfig, tmp_path, requests_moc
             output_path=f"/{tmp_path}/{output_file_name}",
             golden_path=f"{test_resources_dir}/unity_catalog_usage_aggregator_mces_golden.json",
         )
+
+
+def _view_filter_tables():
+    """One managed table and one view in quickstart_catalog.quickstart_schema."""
+    columns = [
+        {
+            "name": "columnA",
+            "type_text": "int",
+            "type_json": '{"name":"columnA","type":"integer","nullable":true,"metadata":{}}',
+            "type_name": "INT",
+            "type_precision": 0,
+            "type_scale": 0,
+            "position": 0,
+            "nullable": True,
+        }
+    ]
+    return [
+        databricks.sdk.service.catalog.TableInfo.from_dict(
+            {
+                "name": "my_table",
+                "catalog_name": "quickstart_catalog",
+                "schema_name": "quickstart_schema",
+                "table_type": "MANAGED",
+                "data_source_format": "DELTA",
+                "columns": columns,
+                "full_name": "quickstart_catalog.quickstart_schema.my_table",
+                "table_id": "aaaaaaaa-0000-0000-0000-000000000001",
+            }
+        ),
+        databricks.sdk.service.catalog.TableInfo.from_dict(
+            {
+                "name": "my_view",
+                "catalog_name": "quickstart_catalog",
+                "schema_name": "quickstart_schema",
+                "table_type": "VIEW",
+                "view_definition": "SELECT columnA FROM quickstart_catalog.quickstart_schema.my_table",
+                "columns": columns,
+                "full_name": "quickstart_catalog.quickstart_schema.my_view",
+                "table_id": "aaaaaaaa-0000-0000-0000-000000000002",
+            }
+        ),
+    ]
+
+
+def _run_view_filter_pipeline(tmp_path, requests_mock, source_extra):
+    """Run a minimal UC ingestion over one table + one view; return emitted dataset URNs."""
+    register_mock_api(request_mock=requests_mock)
+    output_file_name = "unity_catalog_view_filter_mcps.json"
+
+    with patch(
+        "datahub.ingestion.source.unity.connection.WorkspaceClient"
+    ) as mock_client:
+        workspace_client: mock.MagicMock = mock.MagicMock()
+        mock_client.return_value = workspace_client
+        register_mock_data(workspace_client)
+        # Override the schema's objects with exactly one table and one view.
+        workspace_client.tables.list = lambda *args, **kwargs: _view_filter_tables()
+
+        config_dict: dict = {
+            "run_id": "unity-catalog-view-filter-test",
+            "source": {
+                "type": "unity-catalog",
+                "config": {
+                    "workspace_url": "https://dummy.cloud.databricks.com",
+                    "token": "fake",
+                    "include_hive_metastore": False,
+                    "include_ownership": False,
+                    "include_table_lineage": False,
+                    "include_column_lineage": False,
+                    "include_usage_statistics": False,
+                    "include_table_constraints": False,
+                    "include_partition_keys": False,
+                    **source_extra,
+                },
+            },
+            "sink": {
+                "type": "file",
+                "config": {"filename": f"/{tmp_path}/{output_file_name}"},
+            },
+        }
+        pipeline = Pipeline.create(config_dict)
+        pipeline.run()
+        pipeline.raise_from_status()
+
+    import json
+
+    with open(f"/{tmp_path}/{output_file_name}") as f:
+        mcps = json.load(f)
+    return {
+        mcp["entityUrn"]
+        for mcp in mcps
+        if mcp.get("entityUrn", "").startswith("urn:li:dataset:")
+    }
+
+
+def test_views_ingested_by_default(pytestconfig, tmp_path, requests_mock):
+    urns = _run_view_filter_pipeline(tmp_path, requests_mock, {})
+    assert any("my_table" in urn for urn in urns)
+    assert any("my_view" in urn for urn in urns)
+
+
+def test_include_views_false_skips_views(pytestconfig, tmp_path, requests_mock):
+    urns = _run_view_filter_pipeline(tmp_path, requests_mock, {"include_views": False})
+    assert any("my_table" in urn for urn in urns)
+    assert not any("my_view" in urn for urn in urns)
+
+
+def test_view_pattern_deny_skips_views(pytestconfig, tmp_path, requests_mock):
+    urns = _run_view_filter_pipeline(
+        tmp_path, requests_mock, {"view_pattern": {"deny": [".*"]}}
+    )
+    assert any("my_table" in urn for urn in urns)
+    assert not any("my_view" in urn for urn in urns)

--- a/metadata-ingestion/tests/unit/test_unity_catalog_source.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_source.py
@@ -2834,3 +2834,23 @@ class TestUnityCatalogViewFiltering:
         process_table.assert_called_once()
         assert table.id not in list(source.report.tables.dropped_entities)
         assert table.ref in source.table_refs
+
+    def test_include_tables_false_drops_only_regular_tables(self):
+        """include_tables gates regular tables only; views and metric views keep their own toggles."""
+        if not hasattr(TableType, "METRIC_VIEW"):
+            pytest.skip("Installed databricks-sdk lacks TableType.METRIC_VIEW")
+        source = self._build_source(include_tables=False, include_metric_views=True)
+        table, schema = self._build_table("my_table", TableType.MANAGED)
+        view, _ = self._build_table("my_view", TableType.VIEW)
+        metric_view, _ = self._build_table("my_metric", TableType.METRIC_VIEW)
+
+        def _stub_tables(schema, _objs=(table, view, metric_view)):
+            return iter(_objs)
+
+        source.unity_catalog_api_proxy.tables = _stub_tables  # type: ignore[assignment]
+        with patch.object(source, "process_table", return_value=iter([])):
+            list(source.process_tables(schema))
+        dropped = list(source.report.tables.dropped_entities)
+        assert dropped == [table.id]
+        assert view.ref in source.view_refs
+        assert metric_view.ref in source.table_refs

--- a/metadata-ingestion/tests/unit/test_unity_catalog_source.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_source.py
@@ -1,11 +1,12 @@
 from unittest.mock import ANY, patch
 
 import pytest
+from databricks.sdk.service.catalog import TableType
 
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.report import EntityFilterReport
 from datahub.ingestion.source.unity.config import UnityCatalogSourceConfig
-from datahub.ingestion.source.unity.proxy_types import Column
+from datahub.ingestion.source.unity.proxy_types import Column, Schema, Table
 from datahub.ingestion.source.unity.source import UnityCatalogSource
 
 
@@ -2715,3 +2716,121 @@ class TestUnityCatalogMetricViews:
         assert any("orders" in u for u in upstream_urns)
         assert any("customer" in u for u in upstream_urns)
         assert any("nation" in u for u in upstream_urns)
+
+
+class TestUnityCatalogViewFiltering:
+    @pytest.fixture(autouse=True)
+    def _mock_workspace_client(self):
+        with patch("datahub.ingestion.source.unity.source.create_workspace_client"):
+            yield
+
+    @staticmethod
+    def _build_source(**extra: object) -> UnityCatalogSource:
+        config = UnityCatalogSourceConfig.model_validate(
+            {
+                "token": "test_token",
+                "workspace_url": "https://test.databricks.com",
+                "warehouse_id": "test_warehouse",
+                "include_hive_metastore": False,
+                **extra,
+            }
+        )
+        ctx = PipelineContext(run_id="test_run")
+        return UnityCatalogSource.create(config, ctx)
+
+    @staticmethod
+    def _build_table(name: str, table_type: TableType) -> tuple:
+        from datahub.ingestion.source.unity.proxy_types import (
+            Catalog,
+            Metastore,
+        )
+
+        metastore = Metastore(
+            id="metastore",
+            name="metastore",
+            comment=None,
+            global_metastore_id=None,
+            metastore_id=None,
+            owner=None,
+            region=None,
+            cloud=None,
+        )
+        catalog = Catalog(
+            id="c",
+            name="c",
+            metastore=metastore,
+            comment=None,
+            owner=None,
+            type=None,
+        )
+        schema = Schema(
+            id="c.s",
+            name="s",
+            catalog=catalog,
+            comment=None,
+            owner=None,
+        )
+        table = Table(
+            id=f"c.s.{name}",
+            name=name,
+            comment=None,
+            schema=schema,
+            columns=[],
+            storage_location=None,
+            data_source_format=None,
+            table_type=table_type,
+            owner=None,
+            generation=None,
+            created_at=None,
+            created_by=None,
+            updated_at=None,
+            updated_by=None,
+            table_id=None,
+            view_definition="SELECT 1" if "view" in name else None,
+            properties={},
+        )
+        return table, schema
+
+    def _run(self, source: UnityCatalogSource, table: Table, schema: Schema) -> list:
+        def _stub_tables(schema, _table=table):
+            return iter([_table])
+
+        source.unity_catalog_api_proxy.tables = _stub_tables  # type: ignore[assignment]
+        return list(source.process_tables(schema))
+
+    def test_include_views_false_drops_view(self):
+        source = self._build_source(include_views=False)
+        view, schema = self._build_table("my_view", TableType.VIEW)
+        assert self._run(source, view, schema) == []
+        assert view.id in list(source.report.tables.dropped_entities)
+        assert view.ref not in source.view_refs
+
+    def test_view_pattern_deny_drops_view(self):
+        source = self._build_source(view_pattern={"deny": [".*"]})
+        view, schema = self._build_table("my_view", TableType.VIEW)
+        assert self._run(source, view, schema) == []
+        assert view.id in list(source.report.tables.dropped_entities)
+        assert view.ref not in source.view_refs
+
+    def test_view_ingested_by_default(self):
+        source = self._build_source()
+        view, schema = self._build_table("my_view", TableType.VIEW)
+        with patch.object(
+            source, "process_table", return_value=iter([])
+        ) as process_table:
+            self._run(source, view, schema)
+        process_table.assert_called_once()
+        assert view.id not in list(source.report.tables.dropped_entities)
+        assert view.ref in source.view_refs
+
+    def test_table_not_affected_by_view_filters(self):
+        """Denying views must not drop ordinary tables."""
+        source = self._build_source(include_views=False, view_pattern={"deny": [".*"]})
+        table, schema = self._build_table("my_table", TableType.MANAGED)
+        with patch.object(
+            source, "process_table", return_value=iter([])
+        ) as process_table:
+            self._run(source, table, schema)
+        process_table.assert_called_once()
+        assert table.id not in list(source.report.tables.dropped_entities)
+        assert table.ref in source.table_refs


### PR DESCRIPTION
## Summary

The Unity Catalog (Databricks) source inherits several filter fields from `SQLCommonConfig`, so recipes can set them without a validation error — but the source **never applied them**, silently ignoring:

- `include_views: false` → views still ingested
- `view_pattern` → ignored
- `include_tables: false` → tables still ingested

This wires all three into `process_tables`, gating on the already-computed `table.is_view` / `table.is_metric_view`, mirroring how the SQLAlchemy base and the Snowflake/BigQuery sources filter these.

## Changes

- `unity/source.py` (`process_tables`):
  - **Views** (VIEW / MATERIALIZED_VIEW / HIVE_VIEW): dropped when `include_views` is false or `view_pattern` denies them.
  - **Regular tables** (neither view nor metric view): dropped when `include_tables` is false.
  - Dropped entities are not added to `view_refs` / `table_refs`, so stateful ingestion soft-deletes anything previously ingested.
- `view_pattern` and `include_views` are applied from the values **inherited from `SQLCommonConfig`** — not redeclared on the Unity config, to avoid drift from the base defaults.
- **Metric views** keep their dedicated `include_metric_views` / `metric_view_pattern` handling and are unaffected by either toggle.

## Backward compatibility

Fully compatible. `view_pattern` defaults to `table_pattern` (via the existing `SQLCommonConfig` validator); `include_views` and `include_tables` default to `true`. Existing recipes behave exactly as before.

## Tests

- **Unit** (`TestUnityCatalogViewFiltering`): views dropped via `include_views` / `view_pattern`; ordinary tables unaffected by view filters; `include_tables: false` drops only regular tables (views and metric views exempt via their own toggles).
- **Integration** (`test_unity_catalog_ingest.py`): full-pipeline assertions that views ingest by default and are skipped under `include_views: false` / `view_pattern` deny, and that `include_tables: false` skips tables while keeping views.
- Verified end-to-end against a live Unity Catalog workspace for all three toggles.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added
- [ ] Docs (config field docs auto-generate from field descriptions)
- [x] No breaking changes (defaults preserve prior behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)