### PR TITLE
fix(ingestion/dremio): restore chunking on the array-typed jobs query

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_sql_queries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_sql_queries.py
@@ -321,6 +321,7 @@ class DremioSQLQueries:
             AND submitted_ts >= TIMESTAMP '{start_timestamp_millis}'
             AND submitted_ts <= TIMESTAMP '{end_timestamp_millis}'
         ORDER BY submitted_ts ASC
+        {{limit_clause}}
         """
 
     @staticmethod

--- a/metadata-ingestion/tests/unit/dremio/test_dremio_jobs_array.py
+++ b/metadata-ingestion/tests/unit/dremio/test_dremio_jobs_array.py
@@ -40,6 +40,17 @@ class TestQueriedDatasetsArrayQuery:
         assert "LENGTH(queried_datasets)>0" in query
         assert "ARRAY_SIZE(queried_datasets)" not in query
 
+    def test_all_jobs_queries_support_chunking(self):
+        # Every jobs query is run through _get_queries_chunked, which formats in a
+        # LIMIT/OFFSET via {limit_clause}. Without the placeholder the LIMIT is
+        # dropped and the chunk loop re-runs the same unbounded query forever.
+        for query in (
+            DremioSQLQueries.get_query_all_jobs(),
+            DremioSQLQueries.get_query_all_jobs_array(),
+            DremioSQLQueries.get_query_all_jobs_cloud(),
+        ):
+            assert "{limit_clause}" in query
+
 
 class TestSupportsArrayQueriedDatasetsProbe:
     @pytest.fixture


### PR DESCRIPTION
## Summary

`DremioSQLQueries.get_query_all_jobs_array()` — the jobs/usage query used on **Dremio Software 26.1.0+**, where `sys.jobs_recent.queried_datasets` is `ARRAY<VARCHAR>` — was missing the `{{limit_clause}}` placeholder that its two sibling builders (`get_query_all_jobs`, `get_query_all_jobs_cloud`) have.

`_get_queries_chunked` drives all three via `base_query.format(limit_clause="LIMIT ... OFFSET ...")`. With no placeholder, `str.format` silently drops the `LIMIT/OFFSET` and returns the query unchanged. Because the chunk loop only stops when a chunk returns fewer than `chunk_size` rows and otherwise just advances `offset`, an instance with at least `chunk_size` matching jobs re-runs the **same unbounded query every iteration**, re-yielding all rows and never terminating.

Net effect on affected on-prem instances: unbounded jobs query, duplicated query rows, and a non-terminating extraction loop.

### Fix

- Add the missing `{{limit_clause}}` to `get_query_all_jobs_array()` so it chunks like the other two.
- Add a regression test asserting all three jobs-query builders carry the `{limit_clause}` placeholder.

This is a small, self-contained fix, independent of the view-definition work in #18207.

## Test plan

- [x] `pytest tests/unit/dremio/test_dremio_jobs_array.py` — 15 passed
- [x] `ruff` + `mypy` clean

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [x] No breaking changes

Made with [Cursor](https://cursor.com)