### PR TITLE
ci(smoke): enable pytest-xdist and improve matrix batch balancing

### DIFF
--- a/.github/scripts/compare_test_weights.py
+++ b/.github/scripts/compare_test_weights.py
@@ -13,7 +13,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional
 
 
 def load_weights(file_path: str, test_id_key: str) -> Dict[str, float]:
@@ -24,13 +24,12 @@ def load_weights(file_path: str, test_id_key: str) -> Dict[str, float]:
     with open(file_path) as f:
         data = json.load(f)
 
-    return {
-        item[test_id_key]: float(item['duration'].rstrip('s'))
-        for item in data
-    }
+    return {item[test_id_key]: float(item["duration"].rstrip("s")) for item in data}
 
 
-def calculate_changes(old_weights: Dict[str, float], new_weights: Dict[str, float]) -> Dict:
+def calculate_changes(
+    old_weights: Dict[str, float], new_weights: Dict[str, float]
+) -> Dict:
     """Calculate comprehensive change statistics."""
 
     # New and removed tests (calculate first to exclude from significant changes)
@@ -43,7 +42,9 @@ def calculate_changes(old_weights: Dict[str, float], new_weights: Dict[str, floa
     # Overall stats
     old_total = sum(old_weights.values())
     new_total = sum(new_weights.values())
-    total_change_pct = ((new_total - old_total) / old_total * 100) if old_total > 0 else 0
+    total_change_pct = (
+        ((new_total - old_total) / old_total * 100) if old_total > 0 else 0
+    )
 
     # Individual test changes (ONLY for tests that exist in both old and new)
     significant_changes = []
@@ -56,39 +57,47 @@ def calculate_changes(old_weights: Dict[str, float], new_weights: Dict[str, floa
 
             # Only report significant changes for tests with meaningful durations (>5s)
             # This filters out noise from very fast tests
-            if (abs(pct_change) > 10 or abs(diff) > 10) and (old_time >= 5.0 or new_time >= 5.0):
-                significant_changes.append({
-                    'test': test_id,
-                    'old': old_time,
-                    'new': new_time,
-                    'diff': diff,
-                    'pct': pct_change
-                })
+            if (abs(pct_change) > 10 or abs(diff) > 10) and (
+                old_time >= 5.0 or new_time >= 5.0
+            ):
+                significant_changes.append(
+                    {
+                        "test": test_id,
+                        "old": old_time,
+                        "new": new_time,
+                        "diff": diff,
+                        "pct": pct_change,
+                    }
+                )
 
     # Sort by absolute percentage change
-    significant_changes.sort(key=lambda x: abs(x['pct']), reverse=True)
+    significant_changes.sort(key=lambda x: abs(x["pct"]), reverse=True)
 
     return {
-        'old_total': old_total,
-        'new_total': new_total,
-        'total_change_pct': total_change_pct,
-        'old_count': len(old_weights),
-        'new_count': len(new_weights),
-        'significant_changes': significant_changes,
-        'new_tests': new_tests,
-        'removed_tests': removed_tests,
-        'new_tests_total': sum(new_tests.values()),
-        'removed_tests_total': sum(removed_tests.values())
+        "old_total": old_total,
+        "new_total": new_total,
+        "total_change_pct": total_change_pct,
+        "old_count": len(old_weights),
+        "new_count": len(new_weights),
+        "significant_changes": significant_changes,
+        "new_tests": new_tests,
+        "removed_tests": removed_tests,
+        "new_tests_total": sum(new_tests.values()),
+        "removed_tests_total": sum(removed_tests.values()),
     }
 
 
-def generate_pr_body(cypress_changes: Dict, pytest_changes: Dict) -> str:
+def generate_pr_body(
+    pytest_changes: Dict, cypress_changes: Optional[Dict] = None
+) -> str:
     """Generate markdown PR body with change analysis."""
 
     lines = []
     lines.append("## 🤖 Automated Test Weight Update")
     lines.append("")
-    lines.append("This PR updates test weights based on recent CI runs to improve batch balancing.")
+    lines.append(
+        "This PR updates test weights based on recent CI runs to improve batch balancing."
+    )
     lines.append("")
 
     # Overall summary
@@ -97,10 +106,14 @@ def generate_pr_body(cypress_changes: Dict, pytest_changes: Dict) -> str:
     lines.append("| Test Type | Old Total | New Total | Change | # Tests |")
     lines.append("|-----------|-----------|-----------|--------|---------|")
 
-    for name, changes in [("Cypress", cypress_changes), ("Pytest", pytest_changes)]:
-        old_min = changes['old_total'] / 60
-        new_min = changes['new_total'] / 60
-        change_sign = "+" if changes['total_change_pct'] > 0 else ""
+    summary_rows: List[tuple[str, Dict]] = [("Pytest", pytest_changes)]
+    if cypress_changes is not None:
+        summary_rows.insert(0, ("Cypress", cypress_changes))
+
+    for name, changes in summary_rows:
+        old_min = changes["old_total"] / 60
+        new_min = changes["new_total"] / 60
+        change_sign = "+" if changes["total_change_pct"] > 0 else ""
         lines.append(
             f"| {name} | {old_min:.1f} min | {new_min:.1f} min | "
             f"{change_sign}{changes['total_change_pct']:.1f}% | "
@@ -111,8 +124,8 @@ def generate_pr_body(cypress_changes: Dict, pytest_changes: Dict) -> str:
 
     # Warnings for large changes
     warnings = []
-    for name, changes in [("Cypress", cypress_changes), ("Pytest", pytest_changes)]:
-        if abs(changes['total_change_pct']) > 20:
+    for name, changes in summary_rows:
+        if abs(changes["total_change_pct"]) > 20:
             warnings.append(
                 f"⚠️ **{name} total time changed by {changes['total_change_pct']:+.1f}%** - "
                 f"Consider reviewing batch count configuration!"
@@ -128,11 +141,16 @@ def generate_pr_body(cypress_changes: Dict, pytest_changes: Dict) -> str:
         lines.append("<summary>Batch count recommendations</summary>")
         lines.append("")
         lines.append("Current configuration:")
-        lines.append("- Cypress: 11 batches (Depot) / 5 batches (GitHub runners)")
-        lines.append("- Pytest: 6 batches (Depot) / 3 batches (GitHub runners)")
+        if cypress_changes is not None:
+            lines.append("- Cypress: 11 batches (Depot) / 5 batches (GitHub runners)")
+        lines.append("- Pytest: 7 batches (GitHub runners)")
         lines.append("")
-        lines.append("If total time increased >20%, consider increasing batch count to maintain CI speed.")
-        lines.append("If total time decreased >20%, consider decreasing batch count to save runner costs.")
+        lines.append(
+            "If total time increased >20%, consider increasing batch count to maintain CI speed."
+        )
+        lines.append(
+            "If total time decreased >20%, consider decreasing batch count to save runner costs."
+        )
         lines.append("")
         lines.append("Update batch counts in `.github/workflows/docker-unified.yml`")
         lines.append("</details>")
@@ -140,40 +158,46 @@ def generate_pr_body(cypress_changes: Dict, pytest_changes: Dict) -> str:
 
     # Significant changes
     def format_significant_changes(changes: Dict, name: str, max_display: int = 15):
-        if not changes['significant_changes']:
+        if not changes["significant_changes"]:
             return []
 
         section = []
         section.append(f"## 🔍 {name} - Significant Changes (>10% or >10s)")
         section.append("")
         section.append("<details>")
-        section.append(f"<summary>{len(changes['significant_changes'])} tests with significant duration changes</summary>")
+        section.append(
+            f"<summary>{len(changes['significant_changes'])} tests with significant duration changes</summary>"
+        )
         section.append("")
 
-        for item in changes['significant_changes'][:max_display]:
-            sign = "+" if item['diff'] > 0 else ""
-            emoji = "🔴" if item['diff'] > 0 else "🟢"
+        for item in changes["significant_changes"][:max_display]:
+            sign = "+" if item["diff"] > 0 else ""
+            emoji = "🔴" if item["diff"] > 0 else "🟢"
             section.append(f"**{emoji} `{item['test']}`**")
-            section.append(f"- Old: {item['old']:.1f}s → New: {item['new']:.1f}s ({sign}{item['diff']:.1f}s, {sign}{item['pct']:.1f}%)")
+            section.append(
+                f"- Old: {item['old']:.1f}s → New: {item['new']:.1f}s ({sign}{item['diff']:.1f}s, {sign}{item['pct']:.1f}%)"
+            )
             section.append("")
 
-        if len(changes['significant_changes']) > max_display:
-            section.append(f"*... and {len(changes['significant_changes']) - max_display} more*")
+        if len(changes["significant_changes"]) > max_display:
+            section.append(
+                f"*... and {len(changes['significant_changes']) - max_display} more*"
+            )
             section.append("")
 
         section.append("</details>")
         section.append("")
         return section
 
-    lines.extend(format_significant_changes(cypress_changes, "Cypress"))
-    lines.extend(format_significant_changes(pytest_changes, "Pytest"))
+    for name, changes in summary_rows:
+        lines.extend(format_significant_changes(changes, name))
 
     # New and removed tests - show summary instead of listing all
     def format_test_changes(changes: Dict, name: str):
-        new_tests = changes['new_tests']
-        removed_tests = changes['removed_tests']
-        new_tests_total = changes['new_tests_total']
-        removed_tests_total = changes['removed_tests_total']
+        new_tests = changes["new_tests"]
+        removed_tests = changes["removed_tests"]
+        new_tests_total = changes["new_tests_total"]
+        removed_tests_total = changes["removed_tests_total"]
 
         if not new_tests and not removed_tests:
             return []
@@ -183,7 +207,9 @@ def generate_pr_body(cypress_changes: Dict, pytest_changes: Dict) -> str:
         section.append("")
 
         if new_tests:
-            section.append(f"**➕ Added: {len(new_tests)} tests** ({new_tests_total/60:.1f} min total)")
+            section.append(
+                f"**➕ Added: {len(new_tests)} tests** ({new_tests_total / 60:.1f} min total)"
+            )
             section.append("<details>")
             section.append("<summary>View new tests</summary>")
             section.append("")
@@ -196,7 +222,9 @@ def generate_pr_body(cypress_changes: Dict, pytest_changes: Dict) -> str:
             section.append("")
 
         if removed_tests:
-            section.append(f"**➖ Removed: {len(removed_tests)} tests** ({removed_tests_total/60:.1f} min total)")
+            section.append(
+                f"**➖ Removed: {len(removed_tests)} tests** ({removed_tests_total / 60:.1f} min total)"
+            )
             section.append("<details>")
             section.append("<summary>View removed tests</summary>")
             section.append("")
@@ -210,8 +238,8 @@ def generate_pr_body(cypress_changes: Dict, pytest_changes: Dict) -> str:
 
         return section
 
-    lines.extend(format_test_changes(cypress_changes, "Cypress"))
-    lines.extend(format_test_changes(pytest_changes, "Pytest"))
+    for name, changes in summary_rows:
+        lines.extend(format_test_changes(changes, name))
 
     # Footer
     lines.append("---")
@@ -223,52 +251,84 @@ def generate_pr_body(cypress_changes: Dict, pytest_changes: Dict) -> str:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Compare test weights and generate PR description")
-    parser.add_argument("--old-cypress", required=True, help="Path to old Cypress weights JSON")
-    parser.add_argument("--new-cypress", required=True, help="Path to new Cypress weights JSON")
-    parser.add_argument("--old-pytest", required=True, help="Path to old Pytest weights JSON")
-    parser.add_argument("--new-pytest", required=True, help="Path to new Pytest weights JSON")
-    parser.add_argument("--output", required=True, help="Output file for PR body markdown")
-    parser.add_argument("--threshold", type=float, default=5.0,
-                       help="Minimum total change percentage to trigger PR (default: 5.0)")
+    parser = argparse.ArgumentParser(
+        description="Compare test weights and generate PR description"
+    )
+    parser.add_argument(
+        "--old-cypress",
+        required=False,
+        help="Path to old Cypress weights JSON",
+    )
+    parser.add_argument(
+        "--new-cypress",
+        required=False,
+        help="Path to new Cypress weights JSON",
+    )
+    parser.add_argument(
+        "--old-pytest", required=True, help="Path to old Pytest weights JSON"
+    )
+    parser.add_argument(
+        "--new-pytest", required=True, help="Path to new Pytest weights JSON"
+    )
+    parser.add_argument(
+        "--output", required=True, help="Output file for PR body markdown"
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=5.0,
+        help="Minimum total change percentage to trigger PR (default: 5.0)",
+    )
 
     args = parser.parse_args()
 
-    # Load weights
-    old_cypress = load_weights(args.old_cypress, 'filePath')
-    new_cypress = load_weights(args.new_cypress, 'filePath')
-    old_pytest = load_weights(args.old_pytest, 'testId')
-    new_pytest = load_weights(args.new_pytest, 'testId')
+    if (args.old_cypress is None) != (args.new_cypress is None):
+        print("Error: --old-cypress and --new-cypress must be provided together")
+        sys.exit(1)
 
-    # Calculate changes
-    cypress_changes = calculate_changes(old_cypress, new_cypress)
+    old_pytest = load_weights(args.old_pytest, "testId")
+    new_pytest = load_weights(args.new_pytest, "testId")
     pytest_changes = calculate_changes(old_pytest, new_pytest)
 
-    # Check if changes exceed threshold
-    max_change = max(abs(cypress_changes['total_change_pct']), abs(pytest_changes['total_change_pct']))
+    cypress_changes = None
+    change_pcts = [abs(pytest_changes["total_change_pct"])]
+    if args.old_cypress and args.new_cypress:
+        old_cypress = load_weights(args.old_cypress, "filePath")
+        new_cypress = load_weights(args.new_cypress, "filePath")
+        cypress_changes = calculate_changes(old_cypress, new_cypress)
+        change_pcts.append(abs(cypress_changes["total_change_pct"]))
+        print(f"Cypress total change: {cypress_changes['total_change_pct']:+.2f}%")
 
-    print(f"Cypress total change: {cypress_changes['total_change_pct']:+.2f}%")
+    max_change = max(change_pcts)
+
     print(f"Pytest total change: {pytest_changes['total_change_pct']:+.2f}%")
     print(f"Max change: {max_change:.2f}%")
     print(f"Threshold: {args.threshold}%")
 
     if max_change < args.threshold:
         print(f"\n✓ Changes below threshold ({args.threshold}%). No PR needed.")
-        with open(args.output, 'w') as f:
+        with open(args.output, "w") as f:
             f.write("")
         sys.exit(0)
 
-    print(f"\n✓ Changes exceed threshold. Generating PR body...")
+    print("\n✓ Changes exceed threshold. Generating PR body...")
 
-    # Generate PR body
-    pr_body = generate_pr_body(cypress_changes, pytest_changes)
+    pr_body = generate_pr_body(pytest_changes, cypress_changes)
 
-    # Write to output file
-    with open(args.output, 'w') as f:
+    with open(args.output, "w") as f:
         f.write(pr_body)
 
     print(f"✓ PR body written to {args.output}")
-    print(f"✓ Significant changes: Cypress={len(cypress_changes['significant_changes'])}, Pytest={len(pytest_changes['significant_changes'])}")
+    if cypress_changes is not None:
+        print(
+            "✓ Significant changes: "
+            f"Cypress={len(cypress_changes['significant_changes'])}, "
+            f"Pytest={len(pytest_changes['significant_changes'])}"
+        )
+    else:
+        print(
+            f"✓ Significant changes: Pytest={len(pytest_changes['significant_changes'])}"
+        )
 
     sys.exit(0)
 

--- a/.github/scripts/generate_test_weights.py
+++ b/.github/scripts/generate_test_weights.py
@@ -39,26 +39,26 @@ def parse_cypress_results(artifact_dir: Path) -> Dict[str, List[float]]:
             root = tree.getroot()
 
             # Find the root suite with file attribute
-            root_suite = root.find('.//testsuite[@file]')
+            root_suite = root.find(".//testsuite[@file]")
             if root_suite is None:
                 continue
 
-            file_path = root_suite.get('file')
+            file_path = root_suite.get("file")
 
             # Strip "cypress/e2e/" prefix to get relative path
-            if file_path.startswith('cypress/e2e/'):
-                relative_path = file_path.replace('cypress/e2e/', '')
+            if file_path.startswith("cypress/e2e/"):
+                relative_path = file_path.replace("cypress/e2e/", "")
             else:
                 relative_path = file_path
 
             # Find all other testsuites (not the root suite) to get actual test durations
-            all_testsuites = root.findall('.//testsuite')
+            all_testsuites = root.findall(".//testsuite")
             for testsuite in all_testsuites:
                 # Skip if this is the root suite with file attribute
-                if testsuite.get('file'):
+                if testsuite.get("file"):
                     continue
 
-                time_str = testsuite.get('time', '0')
+                time_str = testsuite.get("time", "0")
                 try:
                     duration = float(time_str)
 
@@ -108,10 +108,10 @@ def parse_pytest_results(artifact_dir: Path) -> Dict[str, List[float]]:
             root = tree.getroot()
 
             # Find all testcase elements
-            for testcase in root.findall('.//testcase'):
-                classname = testcase.get('classname', '')
-                name = testcase.get('name', '')
-                time_str = testcase.get('time', '0')
+            for testcase in root.findall(".//testcase"):
+                classname = testcase.get("classname", "")
+                name = testcase.get("name", "")
+                time_str = testcase.get("time", "0")
 
                 # Build test ID
                 if classname and name:
@@ -141,8 +141,7 @@ def parse_pytest_results(artifact_dir: Path) -> Dict[str, List[float]]:
 
 
 def calculate_median_weights(
-    test_durations: Dict[str, List[float]],
-    key_name: str = "filePath"
+    test_durations: Dict[str, List[float]], key_name: str = "filePath"
 ) -> List[Dict]:
     """
     Calculate median duration for each test.
@@ -162,10 +161,7 @@ def calculate_median_weights(
             continue
 
         median = statistics.median(durations)
-        results.append({
-            key_name: test_id,
-            "duration": f"{median:.3f}s"
-        })
+        results.append({key_name: test_id, "duration": f"{median:.3f}s"})
 
     # Sort by duration descending
     results.sort(key=lambda x: float(x["duration"][:-1]), reverse=True)
@@ -181,19 +177,19 @@ def main():
         "--input-dir",
         type=Path,
         required=True,
-        help="Directory containing test artifacts (organized by run ID)"
+        help="Directory containing test artifacts (organized by run ID)",
     )
     parser.add_argument(
         "--cypress-output",
         type=Path,
-        required=True,
-        help="Output path for Cypress test weights JSON"
+        required=False,
+        help="Output path for Cypress test weights JSON",
     )
     parser.add_argument(
         "--pytest-output",
         type=Path,
         required=True,
-        help="Output path for Pytest test weights JSON"
+        help="Output path for Pytest test weights JSON",
     )
 
     args = parser.parse_args()
@@ -202,11 +198,13 @@ def main():
         print(f"Error: Input directory does not exist: {args.input_dir}")
         sys.exit(1)
 
-    print("=" * 60)
-    print("Parsing Cypress test results...")
-    print("=" * 60)
-    cypress_durations = parse_cypress_results(args.input_dir)
-    print(f"Found {len(cypress_durations)} unique Cypress tests")
+    cypress_durations = {}
+    if args.cypress_output:
+        print("=" * 60)
+        print("Parsing Cypress test results...")
+        print("=" * 60)
+        cypress_durations = parse_cypress_results(args.input_dir)
+        print(f"Found {len(cypress_durations)} unique Cypress tests")
 
     print("\n" + "=" * 60)
     print("Parsing Pytest test results...")
@@ -218,14 +216,20 @@ def main():
     print("Calculating median weights...")
     print("=" * 60)
 
-    cypress_weights = calculate_median_weights(cypress_durations, key_name="filePath")
+    cypress_weights = (
+        calculate_median_weights(cypress_durations, key_name="filePath")
+        if args.cypress_output
+        else []
+    )
     pytest_weights = calculate_median_weights(pytest_durations, key_name="testId")
 
-    print(f"Generated {len(cypress_weights)} Cypress weights")
+    if args.cypress_output:
+        print(f"Generated {len(cypress_weights)} Cypress weights")
     print(f"Generated {len(pytest_weights)} Pytest weights")
 
     # Create output directories if they don't exist
-    args.cypress_output.parent.mkdir(parents=True, exist_ok=True)
+    if args.cypress_output:
+        args.cypress_output.parent.mkdir(parents=True, exist_ok=True)
     args.pytest_output.parent.mkdir(parents=True, exist_ok=True)
 
     # Write output files
@@ -233,14 +237,15 @@ def main():
     print("Writing output files...")
     print("=" * 60)
 
-    with open(args.cypress_output, 'w') as f:
-        json.dump(cypress_weights, f, indent=2)
-        f.write('\n')
-    print(f"Wrote Cypress weights to: {args.cypress_output}")
+    if args.cypress_output:
+        with open(args.cypress_output, "w") as f:
+            json.dump(cypress_weights, f, indent=2)
+            f.write("\n")
+        print(f"Wrote Cypress weights to: {args.cypress_output}")
 
-    with open(args.pytest_output, 'w') as f:
+    with open(args.pytest_output, "w") as f:
         json.dump(pytest_weights, f, indent=2)
-        f.write('\n')
+        f.write("\n")
     print(f"Wrote Pytest weights to: {args.pytest_output}")
 
     # Print top 5 longest tests for each type

--- a/.github/scripts/send_failed_tests_to_posthog.py
+++ b/.github/scripts/send_failed_tests_to_posthog.py
@@ -460,6 +460,8 @@ def build_workflow_metadata(args: argparse.Namespace) -> Dict[str, Any]:
     # docker-unified matrix context
     if args.batch is not None:
         metadata["batch"] = args.batch
+    if args.batch_label:
+        metadata["batch_label"] = args.batch_label
     if args.batch_count is not None:
         metadata["batch_count"] = args.batch_count
     if args.test_strategy:
@@ -556,6 +558,10 @@ Examples:
         help='Batch number (for docker-unified matrix)'
     )
     parser.add_argument(
+        '--batch-label',
+        help='Human-readable batch identifier (e.g. profile-architecture)'
+    )
+    parser.add_argument(
         '--batch-count',
         type=int,
         help='Total batch count (for docker-unified matrix)'
@@ -599,7 +605,12 @@ Examples:
         print(f"Branch: {args.branch}")
         print(f"Run ID: {args.run_id}")
         if args.batch is not None:
-            print(f"Batch: {args.batch}/{args.batch_count} ({args.test_strategy})")
+            batch_desc = (
+                f"{args.batch_label} ({args.batch}/{args.batch_count})"
+                if args.batch_label
+                else f"{args.batch}/{args.batch_count}"
+            )
+            print(f"Batch: {batch_desc} ({args.test_strategy})")
         print()
 
         # Process and send failures

--- a/.github/workflows/docker-unified-nightly.yml
+++ b/.github/workflows/docker-unified-nightly.yml
@@ -3,6 +3,16 @@ name: Nightly Docker Test
 # and if tests pass, tags them as nightly and daily for publishing
 on:
   workflow_dispatch:
+    inputs:
+      force_full_run:
+        description: >
+          Bypass retry optimizations (re-run skip / failed-module filtering) and
+          always pull images, run quickstart, and execute the full smoke suite.
+          Use this when validating a branch change or when a prior attempt failed
+          before writing useful JUnit results (e.g. collection errors).
+        required: false
+        default: false
+        type: boolean
   schedule:
     - cron: "0 8 * * *" # Run at midnight Pacific time (8 AM UTC) every day
 
@@ -180,15 +190,24 @@ jobs:
       - name: Detect workflow retry
         id: retry-detection
         run: |
+          # Boolean dispatch inputs are strings in github.event.inputs; schedule has no inputs.
+          FORCE_FULL_RUN="${{ github.event.inputs.force_full_run == 'true' }}"
           RUN_ATTEMPT="${{ github.run_attempt }}"
-          if [[ "$RUN_ATTEMPT" -gt 1 ]]; then
+
+          if [[ "$FORCE_FULL_RUN" == "true" ]]; then
+            echo "force_full_run=true — bypassing retry optimizations; running full suite"
+            echo "is_retry=false" >> "$GITHUB_OUTPUT"
+            echo "force_full_run=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$RUN_ATTEMPT" -gt 1 ]]; then
             echo "This is retry attempt $RUN_ATTEMPT"
             echo "is_retry=true" >> "$GITHUB_OUTPUT"
+            echo "force_full_run=false" >> "$GITHUB_OUTPUT"
             PREVIOUS_ATTEMPT=$((RUN_ATTEMPT - 1))
             echo "previous_attempt=${PREVIOUS_ATTEMPT}" >> "$GITHUB_OUTPUT"
           else
             echo "This is the first attempt"
             echo "is_retry=false" >> "$GITHUB_OUTPUT"
+            echo "force_full_run=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Download previous test results
@@ -395,8 +414,9 @@ jobs:
           DATAHUB_VERSION: ${{ needs.setup.outputs.tag }}
           CLEANUP_DATA: "false"
           TEST_STRATEGY: ${{ matrix.test_strategy }}
-          BATCH_COUNT: "1" # since this workflow runs only on schedule trigger, batching isn't really needed.
+          BATCH_COUNT: "1"
           BATCH_NUMBER: "0"
+          PYTEST_XDIST_WORKERS: "3"
           FILTERED_TESTS: ${{ steps.parse-pytest-failures.outputs.filtered_tests_file || '' }}
           DATAHUB_SMOKETEST_EXECUTOR_ID: "${{ github.sha }}-${{ matrix.test_strategy }}-${{ matrix.architecture }}"
           PROFILE_NAME: ${{ matrix.profile }}
@@ -476,7 +496,8 @@ jobs:
             --branch "${GH_HEAD_REF}" \
             --run-id "${{ github.run_id }}" \
             --run-attempt "${{ github.run_attempt }}" \
-            --batch "${{ matrix.profile }}-${{ matrix.architecture }}" \
+            --batch "${{ strategy.job-index }}" \
+            --batch-label "${{ matrix.profile }}-${{ matrix.architecture }}" \
             --batch-count "${{ strategy.job-total }}" \
             --test-strategy "${{ matrix.test_strategy }}"
 

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -786,6 +786,7 @@ jobs:
           TEST_STRATEGY: pytests
           BATCH_COUNT: ${{ matrix.batch_count }}
           BATCH_NUMBER: ${{ matrix.batch }}
+          PYTEST_XDIST_WORKERS: "3"
           FILTERED_TESTS: ${{ steps.retry-check.outputs.filtered_tests_file || '' }}
         run: |
           if [[ -n "$FILTERED_TESTS" && -f "$FILTERED_TESTS" ]]; then

--- a/smoke-test/conftest.py
+++ b/smoke-test/conftest.py
@@ -20,10 +20,13 @@ from tests.test_result_msg import send_message
 from tests.utilities import env_vars
 from tests.utils import (
     TestSessionWrapper,
+    assert_admin_corpuser_info_preserved,
     delete_urns,
     delete_urns_from_file,
+    fetch_admin_corpuser_info,
     get_frontend_session,
     ingest_file_via_rest,
+    wait_for_admin_corpuser_system_bootstrap,
     wait_for_healthcheck_util,
     wait_for_writes_to_sync,
 )
@@ -52,10 +55,12 @@ def build_auth_session():
         return TestSessionWrapper(requests.Session(), prebuilt_token=prebuilt_token)
 
     wait_for_healthcheck_util(requests)
-    return TestSessionWrapper(get_frontend_session())
+    auth_session = TestSessionWrapper(get_frontend_session())
+    wait_for_admin_corpuser_system_bootstrap(auth_session)
+    return auth_session
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="session", autouse=True)
 def auth_session():
     auth_session = build_auth_session()
     os.environ["DATAHUB_GMS_TOKEN"] = auth_session.gms_token()
@@ -94,6 +99,29 @@ def clear_graph_cache():
     """
     get_default_graph.cache_clear()
     yield
+
+
+@pytest.fixture(scope="session")
+def admin_corpuser_info_baseline(auth_session):
+    """Snapshot privileged admin corpUserInfo flags after session bootstrap."""
+    if os.environ.get("DATAHUB_GMS_TOKEN"):
+        return None
+    return fetch_admin_corpuser_info(auth_session)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def verify_admin_corpuser_info_unchanged(
+    auth_session, admin_corpuser_info_baseline, request
+):
+    """Detect tests that overwrite admin corpUserInfo and clear system/support flags."""
+    yield
+    if admin_corpuser_info_baseline is None:
+        return
+    assert_admin_corpuser_info_preserved(
+        auth_session,
+        admin_corpuser_info_baseline,
+        context=request.node.nodeid,
+    )
 
 
 def _ingest_cleanup_data_impl(
@@ -203,6 +231,23 @@ def load_pytest_test_weights() -> Dict[str, float]:
         return {}
 
 
+def get_pytest_test_weight(item: Item, test_weights: Dict[str, float]) -> float:
+    nodeid = item.nodeid
+    test_id = nodeid.replace("/", ".").replace(".py::", "::")
+    weight = test_weights.get(test_id)
+    if weight is not None:
+        return weight
+
+    nodeid_parts = nodeid.split("::")
+    if len(nodeid_parts) > 2:
+        module_id = nodeid_parts[0].replace("/", ".").removesuffix(".py")
+        weight = test_weights.get(f"{module_id}::{nodeid_parts[-1]}")
+        if weight is not None:
+            return weight
+
+    return 1.0
+
+
 def aggregate_module_weights(
     items: List[Item], test_weights: Dict[str, float]
 ) -> List[Tuple[str, List[Item], float]]:
@@ -229,21 +274,40 @@ def aggregate_module_weights(
     for module_path, module_items in modules.items():
         total_weight = 0.0
         for item in module_items:
-            # Build test ID from nodeid
-            # nodeid format: "tests/database/test_database.py::test_method"
-            # weights format: "tests.database.test_database::test_method"
-            nodeid = item.nodeid
-
-            # Convert path separators to dots and remove .py extension
-            # tests/database/test_database.py::test_method -> tests.database.test_database::test_method
-            test_id = nodeid.replace("/", ".").replace(".py::", "::")
-
-            weight = test_weights.get(test_id, 1.0)  # Default to 1.0 if not found
-            total_weight += weight
+            total_weight += get_pytest_test_weight(item, test_weights)
 
         module_data.append((module_path, module_items, total_weight))
 
     return module_data
+
+
+def _is_global_policy_mutator(item: Item) -> bool:
+    return item.get_closest_marker("global_policy_mutator") is not None
+
+
+def _apply_smoke_policy_phase_filter(items: List[Item]) -> None:
+    """Keep batch assignment stable across smoke.sh's two pytest invocations.
+
+    Batching runs on the full module set first; this filter then selects
+    non-mutators (phase 1) or mutators (phase 2). Unset means run everything
+    (ad-hoc local pytest without smoke.sh).
+    """
+    phase = env_vars.get_smoke_policy_phase()
+    if phase is None:
+        return
+    if phase == "1":
+        items[:] = [item for item in items if not _is_global_policy_mutator(item)]
+        logger.info(
+            "SMOKE_POLICY_PHASE=1: running %s non-mutator test(s)", len(items)
+        )
+        return
+    if phase == "2":
+        items[:] = [item for item in items if _is_global_policy_mutator(item)]
+        logger.info("SMOKE_POLICY_PHASE=2: running %s mutator test(s)", len(items))
+        return
+    logger.warning(
+        "Unknown SMOKE_POLICY_PHASE=%r; running all collected tests", phase
+    )
 
 
 def pytest_collection_modifyitems(
@@ -285,6 +349,7 @@ def pytest_collection_modifyitems(
                 f"RETRY MODE: Running {len(filtered_items)} tests from {len(filtered_modules)} failed module(s)"
             )
             items[:] = filtered_items
+            _apply_smoke_policy_phase_filter(items)
             return
         except Exception as e:
             logger.warning(
@@ -299,7 +364,7 @@ def pytest_collection_modifyitems(
     batch_number = int(batch_number_env)
 
     if batch_count <= 1:
-        # No batching needed
+        _apply_smoke_policy_phase_filter(items)
         return
 
     # Load test weights
@@ -340,5 +405,6 @@ def pytest_collection_modifyitems(
         f"Batch {batch_number}: Running {len(selected_items)} tests from {len(selected_modules)} modules"
     )
 
-    # Replace items with the filtered list
+    # Replace items with the filtered list, then apply smoke.sh phase filter
     items[:] = selected_items
+    _apply_smoke_policy_phase_filter(items)

--- a/smoke-test/pyproject.toml
+++ b/smoke-test/pyproject.toml
@@ -86,6 +86,7 @@ markers = [
     "no_cypress_suite1: main smoke tests, suite 1",
     "test_run_cypress: run cypress tests",
     "integration: marks tests as integration tests requiring a running DataHub stack",
+    "global_policy_mutator: module mutates shared platform policy state (disables All Users defaults and/or heavy policy-cache tests); smoke.sh runs these serially in a second pytest invocation after non-mutators",
 ]
 filterwarnings = [
     # Ignore some warnings that come from dependencies.

--- a/smoke-test/pytest_test_weights.json
+++ b/smoke-test/pytest_test_weights.json
@@ -1,1578 +1,1894 @@
 [
   {
-    "testId": "tests.cypress.integration_test::test_run_cypress",
-    "duration": "409.288s"
-  },
-  {
     "testId": "tests.status.test_lifecycle_state.TestLifecycleStageAPIs::test_hidden_stage_excludes_from_search",
-    "duration": "160.355s"
+    "duration": "329.753s"
   },
   {
-    "testId": "tests.datapack.test_datapack_smoke.TestShowcaseData::test_showcase_has_datasets",
-    "duration": "90.774s"
+    "testId": "tests.metrics.test_metrics::test_usage_aggregation_micrometer_export",
+    "duration": "151.062s"
   },
   {
-    "testId": "tests.knowledge.document_search_filter_test::test_search_across_entities_filters_documents",
-    "duration": "90.209s"
-  },
-  {
-    "testId": "tests.knowledge.document_test::test_search_documents_with_filters",
-    "duration": "89.688s"
-  },
-  {
-    "testId": "tests.actions.doc_propagation.test_propagation::test_col_col_propagation_large_fanout",
-    "duration": "87.831s"
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationActiveIdentities::test_usage_aggregation_regular_user_active_identities",
+    "duration": "138.164s"
   },
   {
     "testId": "tests.openapi.test_openapi::test_openapi",
-    "duration": "81.938s"
+    "duration": "110.039s"
   },
   {
-    "testId": "tests.knowledge.document_test::test_parent_documents_hierarchy",
-    "duration": "80.562s"
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_session_user_dual_group_types_labeled_correctly",
+    "duration": "104.383s"
   },
   {
-    "testId": "tests.knowledge.document_test::test_update_related_entities",
-    "duration": "79.717s"
+    "testId": "tests.timeseries.test_dataset_profiles_graphql::test_dataset_profiles_graphql",
+    "duration": "97.036s"
   },
   {
-    "testId": "tests.knowledge.document_search_filter_test::test_search_documents_filters_hidden_context_documents",
-    "duration": "70.897s"
+    "testId": "tests.knowledge.document_search_filter_test::test_search_across_entities_filters_documents",
+    "duration": "89.511s"
   },
   {
-    "testId": "tests.knowledge.document_test::test_change_history",
-    "duration": "70.362s"
+    "testId": "tests.knowledge.document_test.TestDocumentSearchAndHistory::test_search_documents_with_filters",
+    "duration": "89.416s"
   },
   {
-    "testId": "tests.tags_and_terms.tags_and_terms_test::test_update_schemafield",
-    "duration": "70.278s"
-  },
-  {
-    "testId": "tests.knowledge.document_test::test_search_ownership_filtering",
-    "duration": "70.186s"
-  },
-  {
-    "testId": "tests.knowledge.document_test::test_document_settings",
-    "duration": "70.151s"
-  },
-  {
-    "testId": "test_e2e::test_gms_get_user",
-    "duration": "66.310s"
-  },
-  {
-    "testId": "tests.privileges.test_privileges::test_privilege_from_group_role_can_create_and_manage_secret",
-    "duration": "60.466s"
-  },
-  {
-    "testId": "tests.knowledge.document_test::test_move_document",
-    "duration": "60.441s"
-  },
-  {
-    "testId": "tests.openapi.v2.test_timeseries_scroll::test_timeseries_scroll_pagination_no_duplicates",
-    "duration": "60.270s"
-  },
-  {
-    "testId": "tests.openapi.v2.test_timeseries_scroll::test_timeseries_scroll_no_scrollid_on_last_page",
-    "duration": "60.056s"
-  },
-  {
-    "testId": "tests.knowledge.document_change_history_test::test_document_change_history",
-    "duration": "59.910s"
-  },
-  {
-    "testId": "tests.openapi.v2.test_timeseries_scroll::test_timeseries_scroll_returns_scrollid",
-    "duration": "55.135s"
-  },
-  {
-    "testId": "tests.containers.containers_test::test_update_container",
-    "duration": "55.055s"
-  },
-  {
-    "testId": "tests.datapack.test_datapack_smoke.TestShowcaseData::test_showcase_has_dashboards",
-    "duration": "52.340s"
-  },
-  {
-    "testId": "tests.datapack.test_datapack_smoke.TestShowcaseData::test_showcase_has_glossary_terms",
-    "duration": "50.927s"
-  },
-  {
-    "testId": "tests.trace.test_api_trace::test_noop_with_fmcp_async_write",
-    "duration": "50.263s"
-  },
-  {
-    "testId": "tests.cli.delete_cmd.test_timeseries_delete::test_timeseries_delete",
-    "duration": "50.155s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_patch",
-    "duration": "50.125s"
-  },
-  {
-    "testId": "tests.knowledge.document_search_filter_test::test_related_documents_shows_context_only_documents",
-    "duration": "49.964s"
-  },
-  {
-    "testId": "tests.status.test_lifecycle_state.TestLifecycleStageAPIs::test_visible_stage_remains_in_search",
-    "duration": "49.856s"
-  },
-  {
-    "testId": "tests.knowledge.document_test::test_context_documents_for_dataset",
-    "duration": "49.808s"
-  },
-  {
-    "testId": "tests.status.test_lifecycle_state.TestLifecycleStageAPIs::test_set_lifecycle_stage_mutation",
-    "duration": "45.743s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_string",
-    "duration": "45.390s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_delete",
-    "duration": "45.126s"
-  },
-  {
-    "testId": "tests.policies.test_policies::test_frontend_policy_operations",
-    "duration": "44.723s"
-  },
-  {
-    "testId": "tests.service_accounts.test_service_accounts::test_create_list_get_delete_service_account",
-    "duration": "43.800s"
-  },
-  {
-    "testId": "tests.trace.test_api_trace::test_overwritten_async_write",
-    "duration": "42.947s"
-  },
-  {
-    "testId": "tests.domains.domains_test::test_create_list_get_domain",
-    "duration": "42.676s"
-  },
-  {
-    "testId": "tests.audit_events.audit_events_test::test_audit_token_events",
-    "duration": "41.887s"
-  },
-  {
-    "testId": "tests.dataproduct.test_dataproduct::test_create_data_product",
-    "duration": "40.683s"
-  },
-  {
-    "testId": "tests.audit_events.audit_events_test::test_failed_login_events",
-    "duration": "40.316s"
+    "testId": "tests.actions.doc_propagation.test_propagation::test_col_col_propagation_large_fanout",
+    "duration": "88.131s"
   },
   {
     "testId": "tests.tokens.revokable_access_token_test::test_admin_can_create_list_and_revoke_tokens",
-    "duration": "40.213s"
-  },
-  {
-    "testId": "tests.actions.doc_propagation.test_propagation::test_col_col_propagation_depth_6",
-    "duration": "40.175s"
-  },
-  {
-    "testId": "tests.knowledge.document_test::test_update_document_contents",
-    "duration": "40.104s"
-  },
-  {
-    "testId": "tests.tokens.revokable_access_token_test::test_admin_can_manage_tokens_generated_by_other_user",
-    "duration": "40.103s"
-  },
-  {
-    "testId": "tests.tokens.revokable_access_token_test::test_admin_can_create_and_revoke_tokens_for_other_user",
-    "duration": "40.080s"
-  },
-  {
-    "testId": "tests.actions.doc_propagation.test_propagation::test_col_col_propagation_cycles",
-    "duration": "40.052s"
-  },
-  {
-    "testId": "tests.tokens.revokable_access_token_test::test_non_admin_can_create_list_revoke_tokens",
-    "duration": "40.049s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_search",
-    "duration": "40.042s"
-  },
-  {
-    "testId": "tests.tokens.session_access_token_test::test_01_soft_delete",
-    "duration": "40.018s"
-  },
-  {
-    "testId": "tests.audit_events.audit_events_test::test_policy_create_delete",
-    "duration": "39.986s"
-  },
-  {
-    "testId": "tests.tokens.session_access_token_test::test_02_suspend",
-    "duration": "39.932s"
-  },
-  {
-    "testId": "tests.knowledge.document_test::test_update_document_status",
-    "duration": "39.883s"
-  },
-  {
-    "testId": "tests.knowledge.document_test::test_update_document_subtype",
-    "duration": "39.875s"
-  },
-  {
-    "testId": "tests.audit_events.audit_events_test::test_policy_events",
-    "duration": "39.800s"
-  },
-  {
-    "testId": "tests.trace.test_api_trace::test_noop_async_write",
-    "duration": "39.744s"
-  },
-  {
-    "testId": "tests.privileges.test_privileges::test_privilege_to_create_and_manage_secrets",
-    "duration": "38.244s"
-  },
-  {
-    "testId": "tests.service_accounts.test_service_accounts::test_create_access_token_for_service_account",
-    "duration": "36.641s"
-  },
-  {
-    "testId": "tests.trace.test_api_trace::test_successful_async_write",
-    "duration": "35.908s"
-  },
-  {
-    "testId": "tests.managed_ingestion.managed_ingestion_test::test_create_list_get_ingestion_execution_request",
-    "duration": "35.758s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_ownership_changes",
-    "duration": "34.820s"
-  },
-  {
-    "testId": "tests.tags_and_terms.tags_and_terms_test::test_add_tag",
-    "duration": "34.062s"
-  },
-  {
-    "testId": "tests.domains.domains_test::test_set_unset_domain",
-    "duration": "34.013s"
-  },
-  {
-    "testId": "tests.managed_ingestion.managed_ingestion_test::test_create_list_get_remove_ingestion_source",
-    "duration": "33.686s"
+    "duration": "85.875s"
   },
   {
     "testId": "tests.managed_ingestion.managed_ingestion_test::test_create_list_get_remove_secret",
-    "duration": "33.645s"
+    "duration": "83.676s"
   },
   {
-    "testId": "tests.timeline.timeline_test::test_all",
-    "duration": "33.335s"
+    "testId": "tests.audit_events.audit_events_test::test_audit_token_events",
+    "duration": "83.373s"
   },
   {
-    "testId": "tests.delete.delete_test::test_delete_reference",
-    "duration": "31.954s"
+    "testId": "tests.knowledge.document_test.TestDocumentHierarchyAndSettings::test_parent_documents_hierarchy",
+    "duration": "80.416s"
   },
   {
-    "testId": "tests.service_accounts.test_service_accounts::test_list_service_accounts_with_query",
-    "duration": "31.558s"
+    "testId": "tests.knowledge.document_test.TestDocumentCrudAndMutations::test_update_related_entities",
+    "duration": "80.313s"
   },
   {
-    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_soft_delete_read_mutation",
-    "duration": "30.634s"
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationByteMetrics::test_usage_aggregation_graphql_output_bytes_not_double_counted",
+    "duration": "78.182s"
   },
   {
-    "testId": "tests.tags_and_terms.tags_and_terms_test::test_add_tag_to_chart",
-    "duration": "30.563s"
+    "testId": "tests.metrics.test_queue_ingest_usage::test_queue_ingest_metadata_ingest_metric_on_mce",
+    "duration": "74.370s"
   },
   {
-    "testId": "tests.knowledge.document_search_filter_test::test_search_documents_shows_owned_unpublished",
-    "duration": "30.543s"
+    "testId": "tests.knowledge.document_search_filter_test::test_search_documents_filters_hidden_context_documents",
+    "duration": "72.107s"
   },
   {
-    "testId": "tests.views.views_test::test_create_list_delete_global_view",
-    "duration": "30.517s"
+    "testId": "tests.knowledge.document_test.TestDocumentCrudAndMutations::test_move_document",
+    "duration": "70.212s"
   },
   {
-    "testId": "tests.incidents.incidents_test::test_raise_resolve_incident",
-    "duration": "30.513s"
+    "testId": "tests.tags_and_terms.tags_and_terms_test::test_update_schemafield",
+    "duration": "70.194s"
   },
   {
-    "testId": "tests.knowledge.document_change_history_test::test_document_change_history_empty",
-    "duration": "30.474s"
+    "testId": "tests.knowledge.document_test.TestDocumentSearchAndHistory::test_change_history",
+    "duration": "70.084s"
   },
   {
-    "testId": "tests.audit_events.audit_events_test::test_ingestion_source_events",
-    "duration": "30.074s"
+    "testId": "tests.policies.test_policy_eval_perf::test_domains_page_perf_with_domain_scoped_policies[100-50]",
+    "duration": "70.034s"
   },
   {
-    "testId": "tests.audit_events.audit_events_test::test_user_events",
-    "duration": "29.937s"
+    "testId": "tests.knowledge.document_test.TestDocumentHierarchyAndSettings::test_document_settings",
+    "duration": "70.017s"
   },
   {
-    "testId": "tests.audit_events.audit_events_test::test_login_events",
-    "duration": "29.880s"
+    "testId": "tests.knowledge.document_test.TestDocumentHierarchyAndSettings::test_search_ownership_filtering",
+    "duration": "70.003s"
+  },
+  {
+    "testId": "tests.datapack.test_datapack_smoke.TestShowcaseData::test_showcase_has_datasets",
+    "duration": "69.078s"
+  },
+  {
+    "testId": "test_e2e::test_gms_get_user",
+    "duration": "68.646s"
+  },
+  {
+    "testId": "tests.policies.test_policy_eval_perf::test_domains_page_perf_with_domain_scoped_policies[10-20]",
+    "duration": "66.053s"
+  },
+  {
+    "testId": "tests.tokens.session_access_token_test::test_01_soft_delete",
+    "duration": "62.345s"
+  },
+  {
+    "testId": "tests.service_accounts.test_service_accounts::test_service_account_default_view",
+    "duration": "61.845s"
+  },
+  {
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationAdminSessions::test_usage_aggregation_admin_actor_class_and_tags",
+    "duration": "61.452s"
+  },
+  {
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationAdminSessions::test_usage_aggregation_fresh_admin_session_login",
+    "duration": "60.567s"
+  },
+  {
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationAdminSessions::test_usage_aggregation_pat_authenticated_traffic",
+    "duration": "60.363s"
+  },
+  {
+    "testId": "tests.openapi.v2.test_timeseries_scroll::test_timeseries_scroll_pagination_no_duplicates",
+    "duration": "60.325s"
+  },
+  {
+    "testId": "tests.openapi.v2.test_timeseries_scroll::test_timeseries_scroll_no_scrollid_on_last_page",
+    "duration": "60.299s"
+  },
+  {
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationByteMetrics::test_usage_aggregation_graphql_output_bytes",
+    "duration": "60.278s"
+  },
+  {
+    "testId": "tests.privileges.test_privileges::test_privilege_from_group_role_can_create_and_manage_secret",
+    "duration": "60.274s"
+  },
+  {
+    "testId": "tests.audit_events.audit_events_test::test_policy_create_delete",
+    "duration": "59.910s"
+  },
+  {
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationByteMetrics::test_usage_aggregation_openapi_read_and_search",
+    "duration": "59.253s"
+  },
+  {
+    "testId": "tests.privileges.test_privileges::test_privilege_to_create_and_manage_secrets",
+    "duration": "58.137s"
+  },
+  {
+    "testId": "tests.managed_ingestion.managed_ingestion_test::test_create_list_get_ingestion_execution_request",
+    "duration": "56.947s"
+  },
+  {
+    "testId": "tests.containers.containers_test::test_update_container",
+    "duration": "56.546s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_corp_group_incoming_members_after_native_add",
+    "duration": "55.905s"
+  },
+  {
+    "testId": "tests.openapi.v2.test_timeseries_scroll::test_timeseries_scroll_returns_scrollid",
+    "duration": "54.281s"
   },
   {
     "testId": "tests.privileges.test_privileges::test_privilege_to_create_and_revoke_personal_access_tokens",
-    "duration": "29.849s"
+    "duration": "50.775s"
   },
   {
-    "testId": "tests.timeline.timeline_test::test_glossary",
-    "duration": "29.744s"
+    "testId": "tests.audit_events.audit_events_test::test_policy_events",
+    "duration": "50.449s"
   },
   {
-    "testId": "tests.timeline.timeline_test::test_tags",
-    "duration": "29.710s"
+    "testId": "tests.knowledge.document_search_filter_test::test_related_documents_shows_context_only_documents",
+    "duration": "50.055s"
   },
   {
-    "testId": "tests.institutional_memory.institutional_memory_test::test_upsert_institutional_memory",
-    "duration": "29.704s"
+    "testId": "tests.tokens.session_access_token_test::test_02_suspend",
+    "duration": "49.949s"
   },
   {
-    "testId": "tests.knowledge.document_test::test_search_documents",
-    "duration": "29.671s"
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_domain_sync_move_reflects_in_parent_domains",
+    "duration": "49.855s"
   },
   {
-    "testId": "tests.timeline.timeline_test::test_ownership",
-    "duration": "29.666s"
+    "testId": "tests.status.test_lifecycle_state.TestLifecycleStageAPIs::test_visible_stage_remains_in_search",
+    "duration": "49.842s"
   },
   {
-    "testId": "test_e2e::test_add_remove_members_from_group",
-    "duration": "29.652s"
+    "testId": "tests.knowledge.document_change_history_test::test_document_change_history",
+    "duration": "49.829s"
   },
   {
-    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_soft_delete_search_filter_validation",
-    "duration": "29.633s"
+    "testId": "tests.knowledge.document_test.TestDocumentHierarchyAndSettings::test_context_documents_for_dataset",
+    "duration": "49.620s"
   },
   {
-    "testId": "tests.timeline.timeline_test::test_documentation",
-    "duration": "29.614s"
+    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_patch",
+    "duration": "49.225s"
   },
   {
-    "testId": "tests.tags_and_terms.tags_and_terms_test::test_add_term",
-    "duration": "29.613s"
+    "testId": "tests.trace.test_api_trace::test_noop_with_fmcp_async_write",
+    "duration": "48.626s"
   },
   {
-    "testId": "tests.views.views_test::test_create_list_delete_personal_view",
-    "duration": "29.547s"
+    "testId": "tests.status.test_lifecycle_state.TestLifecycleStageAPIs::test_set_lifecycle_stage_mutation",
+    "duration": "46.794s"
   },
   {
-    "testId": "tests.managed_ingestion.managed_ingestion_test::test_secret_roundtrip_preserves_json_credentials_with_newlines_and_slashes",
-    "duration": "29.520s"
+    "testId": "tests.cli.delete_cmd.test_timeseries_delete::test_timeseries_delete",
+    "duration": "45.857s"
   },
   {
-    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_structured_property_changes",
-    "duration": "29.506s"
+    "testId": "tests.dataproduct.test_dataproduct::test_create_data_product",
+    "duration": "45.068s"
   },
   {
-    "testId": "tests.knowledge.document_change_history_test::test_document_change_history_with_time_range",
-    "duration": "29.455s"
+    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_delete",
+    "duration": "44.093s"
   },
   {
-    "testId": "tests.actions.doc_propagation.test_propagation::test_col_col_propagation_depth_1",
-    "duration": "29.174s"
+    "testId": "tests.tokens.revokable_access_token_test::test_admin_can_manage_tokens_generated_by_other_user",
+    "duration": "43.975s"
   },
   {
-    "testId": "tests.trace.test_api_trace::test_missing_elasticsearch_async_write",
-    "duration": "28.937s"
+    "testId": "tests.service_accounts.test_service_accounts::test_create_list_get_delete_service_account",
+    "duration": "43.177s"
   },
   {
-    "testId": "tests.timeline.timeline_test::test_schema",
-    "duration": "28.656s"
+    "testId": "tests.tags_and_terms.tags_and_terms_test::test_add_tag",
+    "duration": "43.161s"
   },
   {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[role_query.py]",
-    "duration": "28.308s"
+    "testId": "tests.audit_events.audit_events_test::test_ingestion_source_events",
+    "duration": "43.015s"
   },
   {
-    "testId": "tests.views.views_test::test_update_global_view",
-    "duration": "26.553s"
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_domain_parent_domains_hierarchy",
+    "duration": "42.774s"
   },
   {
-    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_ownership_changes",
-    "duration": "26.542s"
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationByteMetrics::test_usage_aggregation_openapi_search_output_bytes",
+    "duration": "42.198s"
   },
   {
-    "testId": "tests.timeline.timeline_change_history_test.TestDomainTimeline::test_domain_ownership_changes",
-    "duration": "26.447s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_ownership_changes",
-    "duration": "26.436s"
-  },
-  {
-    "testId": "tests.managed_ingestion.managed_ingestion_test::test_secret_roundtrip_preserves_passwords_and_connection_strings_with_special_chars",
-    "duration": "26.428s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_structured_properties_list",
-    "duration": "25.827s"
-  },
-  {
-    "testId": "tests.database.test_database::test_mysql_deadlock_gap_locking",
-    "duration": "25.823s"
-  },
-  {
-    "testId": "tests.cli.dataset_cmd.test_dataset_command::test_dataset_sync_bidirectional",
-    "duration": "25.695s"
-  },
-  {
-    "testId": "test_system_info::test_system_info_authenticated_non_admin_user_returns_403",
-    "duration": "25.676s"
-  },
-  {
-    "testId": "tests.assertions.assertions_test::test_assertion_info_patch_preserves_note",
-    "duration": "25.527s"
-  },
-  {
-    "testId": "test_rapid::test_ingestion_via_rest_rapid",
-    "duration": "25.515s"
-  },
-  {
-    "testId": "tests.tokens.session_access_token_test::test_03_hard_delete",
-    "duration": "24.565s"
-  },
-  {
-    "testId": "tests.deprecation.deprecation_test::test_update_deprecation_all_fields",
-    "duration": "23.614s"
-  },
-  {
-    "testId": "tests.browse.browse_test::test_get_browse_paths",
-    "duration": "22.484s"
-  },
-  {
-    "testId": "tests.cli.ingest_cmd.test_timeseries_rollback::test_timeseries_rollback",
-    "duration": "20.803s"
-  },
-  {
-    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_without_role",
-    "duration": "20.720s"
+    "testId": "tests.trace.test_api_trace::test_overwritten_async_write",
+    "duration": "42.109s"
   },
   {
     "testId": "tests.tokens.revokable_access_token_test::test_non_admin_can_not_generate_tokens_for_others",
-    "duration": "20.560s"
+    "duration": "41.696s"
   },
   {
-    "testId": "tests.trace.test_api_trace::test_mcp_fail_aspect_async_write",
-    "duration": "20.537s"
+    "testId": "tests.authorization.test_aspect_write_auth::test_update_data_product_name_allowed_with_edit_entity_on_data_product",
+    "duration": "41.081s"
   },
   {
-    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_double_multiple",
-    "duration": "20.536s"
+    "testId": "tests.domains.domains_test::test_create_list_get_domain",
+    "duration": "40.853s"
   },
   {
-    "testId": "tests.institutional_memory.institutional_memory_test::test_add_institutional_memory",
-    "duration": "20.524s"
+    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_allowed_with_edit_entity_on_target_and_parent",
+    "duration": "40.797s"
   },
   {
-    "testId": "tests.knowledge.document_test::test_create_document_with_owners",
-    "duration": "20.481s"
+    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_schema_field_allowed_with_mixed_dataset_and_field_grants",
+    "duration": "40.755s"
   },
   {
-    "testId": "tests.institutional_memory.institutional_memory_test::test_remove_institutional_memory",
-    "duration": "20.447s"
+    "testId": "tests.actions.doc_propagation.test_propagation::test_col_col_propagation_depth_6",
+    "duration": "40.643s"
   },
   {
-    "testId": "test_e2e::test_update_corp_group_description",
-    "duration": "20.432s"
+    "testId": "tests.knowledge.document_test.TestDocumentCrudAndMutations::test_update_document_status",
+    "duration": "40.564s"
   },
   {
-    "testId": "tests.lineage.test_lineage::test_lineage_via_node[3-LineageStyle.DATASET_JOB_DATASET]",
-    "duration": "20.420s"
+    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_search",
+    "duration": "40.308s"
   },
   {
-    "testId": "test_authentication_e2e::test_session_vs_token_authentication",
-    "duration": "20.395s"
+    "testId": "tests.assertions.assertions_test::test_assertion_info_patch_preserves_note",
+    "duration": "40.005s"
   },
   {
-    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_glossary_term_changes",
-    "duration": "20.366s"
+    "testId": "tests.trace.test_api_trace::test_noop_async_write",
+    "duration": "39.970s"
   },
   {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_domain_changes",
-    "duration": "20.363s"
+    "testId": "tests.views.views_test::test_create_list_delete_personal_view",
+    "duration": "39.880s"
   },
   {
-    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_structured_property_changes",
-    "duration": "20.360s"
+    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_schema_field_allowed_via_dataset_policies_only",
+    "duration": "39.739s"
   },
   {
-    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_application_changes",
-    "duration": "20.339s"
+    "testId": "tests.tokens.revokable_access_token_test::test_admin_can_create_and_revoke_tokens_for_other_user",
+    "duration": "39.728s"
   },
   {
-    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_domain_changes",
-    "duration": "20.332s"
+    "testId": "tests.knowledge.document_test.TestDocumentCrudAndMutations::test_update_document_contents",
+    "duration": "39.661s"
   },
   {
-    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_domain_changes",
-    "duration": "20.332s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_application_changes",
-    "duration": "20.330s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_documentation_changes",
-    "duration": "20.319s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_glossary_term_changes",
-    "duration": "20.312s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDomainTimeline::test_domain_structured_property_changes",
-    "duration": "20.297s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_application_changes",
-    "duration": "20.297s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_tag_changes",
-    "duration": "20.296s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_structured_property_changes",
-    "duration": "20.289s"
-  },
-  {
-    "testId": "tests.datapack.test_datapack_smoke.TestDemoDataBootstrap::test_load_bootstrap_via_cli",
-    "duration": "20.136s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_api_token_authentication",
-    "duration": "20.027s"
-  },
-  {
-    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_admin_role",
-    "duration": "19.800s"
-  },
-  {
-    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_editor_role",
-    "duration": "19.716s"
-  },
-  {
-    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_reader_role",
-    "duration": "19.702s"
-  },
-  {
-    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_duplicate_user",
-    "duration": "19.658s"
-  },
-  {
-    "testId": "tests.privileges.test_privileges::test_privilege_to_create_and_manage_ingestion_source",
-    "duration": "19.649s"
+    "testId": "tests.knowledge.document_test.TestDocumentCrudAndMutations::test_update_document_subtype",
+    "duration": "39.627s"
   },
   {
     "testId": "tests.privileges.test_privileges::test_privilege_to_create_and_manage_policies",
-    "duration": "19.614s"
+    "duration": "39.602s"
   },
   {
-    "testId": "tests.knowledge.document_test::test_get_document",
-    "duration": "19.608s"
+    "testId": "tests.privileges.test_privileges::test_privilege_to_create_and_manage_ingestion_source",
+    "duration": "39.505s"
   },
   {
-    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_double",
-    "duration": "19.581s"
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_corp_group_incoming_members_immediately_after_add_second_member",
+    "duration": "39.494s"
   },
   {
-    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_string_allowed_values",
-    "duration": "19.528s"
+    "testId": "tests.actions.doc_propagation.test_propagation::test_col_col_propagation_cycles",
+    "duration": "39.489s"
   },
   {
-    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_schema_field",
-    "duration": "19.512s"
+    "testId": "tests.datapack.test_datapack_smoke.TestShowcaseData::test_showcase_has_structured_properties",
+    "duration": "38.795s"
   },
   {
-    "testId": "tests.graph.test_graph_client::test_graph_relationships",
-    "duration": "19.510s"
+    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_string",
+    "duration": "38.314s"
   },
   {
-    "testId": "tests.institutional_memory.institutional_memory_test::test_update_institutional_memory",
-    "duration": "19.457s"
+    "testId": "tests.policies.test_policies::test_frontend_policy_operations",
+    "duration": "37.587s"
   },
   {
-    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_tag_changes",
-    "duration": "19.337s"
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationAdminSessions::test_usage_aggregation_configured_admin_actor_class",
+    "duration": "37.314s"
   },
   {
-    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_related_terms_changes",
-    "duration": "19.327s"
+    "testId": "tests.trace.test_api_trace::test_missing_elasticsearch_async_write",
+    "duration": "36.254s"
   },
   {
-    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_schema_changes",
-    "duration": "19.323s"
+    "testId": "tests.views.views_test::test_update_global_view",
+    "duration": "35.812s"
   },
   {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_asset_membership_changes",
-    "duration": "19.281s"
+    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_denied_without_edit_entity_on_target",
+    "duration": "35.256s"
   },
   {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_wildcard_returns_json",
-    "duration": "17.978s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_admin_endpoints_require_privileges",
-    "duration": "17.503s"
-  },
-  {
-    "testId": "tests.trace.test_api_trace::test_timeseries_async_write",
-    "duration": "17.312s"
-  },
-  {
-    "testId": "tests.read_only.test_lineage_apis::test_search_across_lineage_api",
-    "duration": "16.472s"
-  },
-  {
-    "testId": "test_e2e::test_update_corp_group_properties",
-    "duration": "16.331s"
+    "testId": "tests.service_accounts.test_service_accounts::test_create_access_token_for_service_account",
+    "duration": "35.128s"
   },
   {
     "testId": "tests.read_only.test_search::test_search_works",
-    "duration": "16.326s"
+    "duration": "34.569s"
   },
   {
-    "testId": "tests.knowledge.document_test::test_create_document",
-    "duration": "16.225s"
+    "testId": "tests.tokens.session_access_token_test::test_03_hard_delete",
+    "duration": "34.551s"
   },
   {
-    "testId": "tests.read_only.test_search::test_openapi_v3_entity",
-    "duration": "16.213s"
+    "testId": "tests.actions.doc_propagation.test_propagation::test_col_col_propagation_depth_1",
+    "duration": "34.378s"
+  },
+  {
+    "testId": "tests.domains.domains_test::test_set_unset_domain",
+    "duration": "34.049s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_ownership_changes",
+    "duration": "33.750s"
+  },
+  {
+    "testId": "tests.managed_ingestion.managed_ingestion_test::test_create_list_get_remove_ingestion_source",
+    "duration": "33.596s"
+  },
+  {
+    "testId": "tests.timeline.timeline_test::test_all",
+    "duration": "32.659s"
+  },
+  {
+    "testId": "tests.incidents.incidents_test::test_raise_resolve_incident",
+    "duration": "32.569s"
+  },
+  {
+    "testId": "tests.service_accounts.test_service_accounts::test_list_service_accounts_with_query",
+    "duration": "30.818s"
+  },
+  {
+    "testId": "tests.timeline.timeline_test::test_ownership",
+    "duration": "30.746s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_soft_delete_search_filter_validation",
+    "duration": "30.701s"
+  },
+  {
+    "testId": "tests.managed_ingestion.managed_ingestion_test::test_secret_roundtrip_preserves_passwords_and_connection_strings_with_special_chars",
+    "duration": "30.649s"
+  },
+  {
+    "testId": "tests.tags_and_terms.tags_and_terms_test::test_add_term",
+    "duration": "30.611s"
+  },
+  {
+    "testId": "tests.knowledge.document_search_filter_test::test_search_documents_shows_owned_unpublished",
+    "duration": "30.610s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_batch_unset_data_product_allowed_with_asset_side_privilege_only",
+    "duration": "30.544s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_structured_property_changes",
+    "duration": "30.529s"
+  },
+  {
+    "testId": "tests.knowledge.document_test.TestDocumentCrudAndMutations::test_search_documents",
+    "duration": "30.432s"
+  },
+  {
+    "testId": "tests.database.test_database::test_mysql_deadlock_gap_locking",
+    "duration": "30.013s"
+  },
+  {
+    "testId": "tests.timeline.timeline_test::test_glossary",
+    "duration": "29.901s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_soft_delete_read_mutation",
+    "duration": "29.738s"
+  },
+  {
+    "testId": "test_e2e::test_add_remove_members_from_group",
+    "duration": "29.725s"
+  },
+  {
+    "testId": "tests.domains.domains_test::test_delete_parent_domain_immediately_after_child_deletion",
+    "duration": "29.721s"
+  },
+  {
+    "testId": "tests.timeline.timeline_test::test_tags",
+    "duration": "29.700s"
+  },
+  {
+    "testId": "tests.timeline.timeline_test::test_documentation",
+    "duration": "29.698s"
+  },
+  {
+    "testId": "tests.institutional_memory.institutional_memory_test::test_upsert_institutional_memory",
+    "duration": "29.631s"
+  },
+  {
+    "testId": "tests.knowledge.document_change_history_test::test_document_change_history_empty",
+    "duration": "29.610s"
+  },
+  {
+    "testId": "tests.views.views_test::test_create_list_delete_global_view",
+    "duration": "29.605s"
+  },
+  {
+    "testId": "tests.tags_and_terms.tags_and_terms_test::test_add_tag_to_chart",
+    "duration": "29.579s"
+  },
+  {
+    "testId": "tests.knowledge.document_change_history_test::test_document_change_history_with_time_range",
+    "duration": "29.534s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_batch_remove_from_data_products_allowed_with_asset_side_privilege_only",
+    "duration": "29.500s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[role_query.py]",
+    "duration": "28.278s"
+  },
+  {
+    "testId": "tests.timeline.timeline_test::test_schema",
+    "duration": "27.819s"
+  },
+  {
+    "testId": "tests.institutional_memory.institutional_memory_test::test_add_institutional_memory",
+    "duration": "27.634s"
+  },
+  {
+    "testId": "tests.audit_events.audit_events_test::test_failed_login_events",
+    "duration": "27.306s"
+  },
+  {
+    "testId": "tests.trace.test_api_trace::test_successful_async_write",
+    "duration": "26.735s"
+  },
+  {
+    "testId": "tests.delete.delete_test::test_delete_reference",
+    "duration": "26.069s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_structured_properties_list",
+    "duration": "25.829s"
+  },
+  {
+    "testId": "tests.cli.dataset_cmd.test_dataset_command::test_dataset_sync_bidirectional",
+    "duration": "25.796s"
+  },
+  {
+    "testId": "tests.managed_ingestion.managed_ingestion_test::test_secret_roundtrip_preserves_json_credentials_with_newlines_and_slashes",
+    "duration": "25.538s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDomainTimeline::test_domain_ownership_changes",
+    "duration": "25.438s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_ownership_changes",
+    "duration": "25.429s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_ownership_changes",
+    "duration": "25.425s"
+  },
+  {
+    "testId": "tests.audit_events.audit_events_test::test_user_events",
+    "duration": "25.361s"
   },
   {
     "testId": "tests.assertions.custom_assertions_test::test_create_update_delete_dataset_custom_assertion",
-    "duration": "15.545s"
+    "duration": "24.697s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_auth_test::test_get_timeline_unauthorized_user_is_denied[Dataset]",
+    "duration": "24.624s"
+  },
+  {
+    "testId": "tests.deprecation.deprecation_test::test_update_deprecation_all_fields",
+    "duration": "24.446s"
+  },
+  {
+    "testId": "tests.browse.browse_test::test_get_browse_paths",
+    "duration": "24.388s"
   },
   {
     "testId": "tests.assertions.assertions_test::test_gms_get_latest_assertions_results_by_partition",
-    "duration": "14.699s"
+    "duration": "23.809s"
   },
   {
-    "testId": "tests.openapi.v1.test_tracking::test_tracking_api_elasticsearch",
-    "duration": "14.577s"
+    "testId": "test_rapid::test_ingestion_via_rest_rapid",
+    "duration": "21.948s"
   },
   {
-    "testId": "tests.containers.containers_test::test_get_full_container",
-    "duration": "14.533s"
+    "testId": "tests.trace.test_api_trace::test_mcp_fail_aspect_async_write",
+    "duration": "21.655s"
   },
   {
-    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_explicit_id",
-    "duration": "14.387s"
+    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_double",
+    "duration": "20.702s"
   },
   {
-    "testId": "tests.search.test_lineage_search_index_fields::test_lineage_search_index_fields_with_lineage",
-    "duration": "14.386s"
+    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_string_allowed_values",
+    "duration": "20.617s"
   },
   {
-    "testId": "test_e2e::test_remove_user",
-    "duration": "14.320s"
+    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_schema_field",
+    "duration": "20.603s"
   },
   {
-    "testId": "tests.cli.dataset_cmd.test_dataset_command::test_dataset_sync_from_datahub",
-    "duration": "14.293s"
+    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_reader_role",
+    "duration": "20.585s"
   },
   {
-    "testId": "tests.incidents.incidents_test::test_list_dataset_incidents",
-    "duration": "13.414s"
-  },
-  {
-    "testId": "tests.data_process_instance.test_data_process_instance::test_search_dpi",
-    "duration": "12.379s"
-  },
-  {
-    "testId": "tests.ml_models.test_ml_models::test_create_ml_models",
-    "duration": "11.315s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_authentication_behavior_summary",
-    "duration": "11.242s"
+    "testId": "tests.trace.test_api_trace::test_timeseries_async_write",
+    "duration": "20.547s"
   },
   {
     "testId": "tests.lineage.test_lineage::test_lineage_via_node[3-LineageStyle.DATASET_QUERY_DATASET]",
-    "duration": "10.964s"
+    "duration": "20.495s"
   },
   {
-    "testId": "tests.lineage.test_lineage::test_lineage_via_node[2-LineageStyle.DATASET_QUERY_DATASET]",
-    "duration": "10.938s"
+    "testId": "test_authentication_e2e::test_session_vs_token_authentication",
+    "duration": "20.478s"
   },
   {
-    "testId": "tests.structured_properties.test_structured_properties::test_dataset_yaml_loader",
-    "duration": "10.711s"
+    "testId": "test_e2e::test_update_corp_group_description",
+    "duration": "20.465s"
   },
   {
-    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_listing_by_resource_type",
-    "duration": "10.352s"
+    "testId": "tests.institutional_memory.institutional_memory_test::test_remove_institutional_memory",
+    "duration": "20.433s"
   },
   {
-    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_search",
-    "duration": "10.302s"
+    "testId": "tests.authorization.test_aspect_write_auth::test_batch_set_data_product_allowed_with_manage_data_products_on_domain",
+    "duration": "20.389s"
   },
   {
-    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_urn_secondary_key",
-    "duration": "10.296s"
+    "testId": "tests.authorization.test_aspect_write_auth::test_batch_add_to_data_products_allowed_with_asset_side_privilege_only",
+    "duration": "20.358s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_schema_field_denied_without_edit_entity_on_physical_dataset",
+    "duration": "20.352s"
+  },
+  {
+    "testId": "tests.knowledge.document_test.TestDocumentCrudAndMutations::test_get_document",
+    "duration": "20.340s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_glossary_term_changes",
+    "duration": "20.332s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_domain_changes",
+    "duration": "20.331s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_tag_changes",
+    "duration": "20.326s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_schema_changes",
+    "duration": "20.326s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_tag_changes",
+    "duration": "20.316s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDomainTimeline::test_domain_structured_property_changes",
+    "duration": "20.315s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_structured_property_changes",
+    "duration": "20.314s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_application_changes",
+    "duration": "20.314s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_documentation_changes",
+    "duration": "20.308s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_related_terms_changes",
+    "duration": "20.295s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_domain_changes",
+    "duration": "20.292s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_application_changes",
+    "duration": "20.288s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_api_token_authentication",
+    "duration": "20.115s"
+  },
+  {
+    "testId": "tests.cli.ingest_cmd.test_timeseries_rollback::test_timeseries_rollback",
+    "duration": "20.004s"
+  },
+  {
+    "testId": "tests.lineage.test_lineage::test_lineage_via_node[3-LineageStyle.DATASET_JOB_DATASET]",
+    "duration": "19.904s"
+  },
+  {
+    "testId": "test_system_info::test_system_info_authenticated_non_admin_user_returns_403",
+    "duration": "19.632s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_double_multiple",
+    "duration": "19.619s"
+  },
+  {
+    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_admin_role",
+    "duration": "19.595s"
+  },
+  {
+    "testId": "tests.graph.test_graph_client::test_graph_relationships",
+    "duration": "19.592s"
+  },
+  {
+    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_editor_role",
+    "duration": "19.558s"
+  },
+  {
+    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_duplicate_user",
+    "duration": "19.539s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_glossary_sync_reparent_reflects_in_parent_nodes",
+    "duration": "19.515s"
+  },
+  {
+    "testId": "tests.institutional_memory.institutional_memory_test::test_update_institutional_memory",
+    "duration": "19.465s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_denied_without_edit_entity_on_parent",
+    "duration": "19.356s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_batch_set_data_product_allowed_cross_domain_with_manage_on_product_domain",
+    "duration": "19.348s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_update_data_product_name_allowed_with_manage_data_products_on_domain",
+    "duration": "19.336s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_batch_set_data_product_denied_with_asset_side_privilege_only",
+    "duration": "19.331s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_schema_field_denied_without_edit_entity_on_logical_dataset",
+    "duration": "19.329s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_glossary_term_changes",
+    "duration": "19.313s"
+  },
+  {
+    "testId": "tests.knowledge.document_test.TestDocumentCrudAndMutations::test_create_document_with_owners",
+    "duration": "19.309s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_application_changes",
+    "duration": "19.303s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_domain_changes",
+    "duration": "19.301s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_asset_membership_changes",
+    "duration": "19.289s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_structured_property_changes",
+    "duration": "19.281s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_admin_endpoints_require_privileges",
+    "duration": "18.659s"
+  },
+  {
+    "testId": "tests.audit_events.audit_events_test::test_login_events",
+    "duration": "17.281s"
+  },
+  {
+    "testId": "tests.timeseries.test_stats_summary_graphql::test_dashboard_stats_summary",
+    "duration": "16.920s"
+  },
+  {
+    "testId": "tests.data_process_instance.test_data_process_instance::test_search_dpi",
+    "duration": "16.461s"
+  },
+  {
+    "testId": "tests.tokens.revokable_access_token_test::test_non_admin_can_create_list_revoke_tokens",
+    "duration": "16.447s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_auth_test::test_get_timeline_rest_v2_unauthorized_user_is_denied",
+    "duration": "16.425s"
+  },
+  {
+    "testId": "tests.read_only.test_search::test_openapi_v3_entity",
+    "duration": "16.358s"
+  },
+  {
+    "testId": "tests.knowledge.document_test.TestDocumentCrudAndMutations::test_create_document",
+    "duration": "16.303s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_update_data_product_name_denied_with_asset_side_privilege_only",
+    "duration": "16.238s"
+  },
+  {
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationActiveIdentities::test_usage_aggregation_admin_active_identities",
+    "duration": "16.206s"
+  },
+  {
+    "testId": "tests.lineage.test_lineage::test_lineage_via_node[1-LineageStyle.DATASET_QUERY_DATASET]",
+    "duration": "15.701s"
+  },
+  {
+    "testId": "tests.incidents.incidents_test::test_list_dataset_incidents",
+    "duration": "15.481s"
+  },
+  {
+    "testId": "test_e2e::test_update_corp_group_properties",
+    "duration": "15.338s"
+  },
+  {
+    "testId": "tests.cli.user_groups_cmd.test_group_cmd::test_group_upsert",
+    "duration": "15.181s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_wildcard_returns_json",
+    "duration": "14.981s"
+  },
+  {
+    "testId": "tests.openapi.v1.test_tracking::test_tracking_api_elasticsearch",
+    "duration": "14.796s"
+  },
+  {
+    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_without_role",
+    "duration": "14.639s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_glossary_parent_nodes_hierarchy",
+    "duration": "14.365s"
+  },
+  {
+    "testId": "tests.cli.dataset_cmd.test_dataset_command::test_dataset_sync_from_datahub",
+    "duration": "14.352s"
+  },
+  {
+    "testId": "test_e2e::test_remove_user",
+    "duration": "14.339s"
+  },
+  {
+    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_explicit_id",
+    "duration": "14.336s"
+  },
+  {
+    "testId": "tests.containers.containers_test::test_get_full_container",
+    "duration": "13.581s"
+  },
+  {
+    "testId": "test_e2e::test_ingest_with_system_metadata",
+    "duration": "13.434s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_basic",
+    "duration": "13.410s"
+  },
+  {
+    "testId": "tests.search.test_lineage_search_index_fields::test_lineage_search_index_fields_with_lineage",
+    "duration": "13.349s"
+  },
+  {
+    "testId": "tests.status.test_lifecycle_state.TestLifecycleStageAPIs::test_list_lifecycle_stages_includes_ingested",
+    "duration": "13.248s"
+  },
+  {
+    "testId": "tests.ml_models.test_ml_models::test_create_ml_models",
+    "duration": "12.396s"
   },
   {
     "testId": "tests.institutional_memory.institutional_memory_test::test_get_institutional_memory",
-    "duration": "10.281s"
+    "duration": "12.359s"
   },
   {
-    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_definition_evolution",
-    "duration": "10.270s"
+    "testId": "tests.cli.user_groups_cmd.test_user_cmd::test_user_upsert",
+    "duration": "12.307s"
   },
   {
-    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_soft_delete_validation",
-    "duration": "10.260s"
+    "testId": "tests.read_only.test_lineage_apis::test_search_across_lineage_api",
+    "duration": "12.200s"
+  },
+  {
+    "testId": "tests.read_only.test_lineage_apis::test_scroll_across_lineage_api",
+    "duration": "12.186s"
+  },
+  {
+    "testId": "tests.datapack.test_datapack_smoke.TestDemoDataBootstrap::test_load_bootstrap_via_cli",
+    "duration": "11.864s"
+  },
+  {
+    "testId": "tests.schema_fields.test_schemafields::test_schema_field_gql_mapper_for_charts",
+    "duration": "11.521s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_authentication_behavior_summary",
+    "duration": "11.328s"
+  },
+  {
+    "testId": "tests.lineage.test_lineage::test_lineage_via_node[2-LineageStyle.DATASET_QUERY_DATASET]",
+    "duration": "11.247s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_glossary_deep_hierarchy_within_bundled_max_depth",
+    "duration": "10.488s"
+  },
+  {
+    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_listing_complex_queries",
+    "duration": "10.393s"
+  },
+  {
+    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_listing_by_resource_type",
+    "duration": "10.374s"
   },
   {
     "testId": "tests.graph.test_graph_client::test_get_aspect_v2",
-    "duration": "10.257s"
+    "duration": "10.349s"
+  },
+  {
+    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_search",
+    "duration": "10.337s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_container_parent_containers_hierarchy",
+    "duration": "10.311s"
+  },
+  {
+    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_read_write",
+    "duration": "10.310s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_soft_delete_validation",
+    "duration": "10.275s"
   },
   {
     "testId": "tests.cli.user_cmd.test_user_add::test_user_add_id_different_from_email",
-    "duration": "10.257s"
+    "duration": "10.233s"
   },
   {
-    "testId": "tests.read_only.test_policies::test_policies_are_accessible",
-    "duration": "10.236s"
-  },
-  {
-    "testId": "test_e2e::test_remove_group",
-    "duration": "10.191s"
-  },
-  {
-    "testId": "tests.cli.dataset_cmd.test_dataset_command::test_dataset_sync_validation",
-    "duration": "10.186s"
+    "testId": "tests.lineage.test_lineage::test_lineage_via_node[2-LineageStyle.DATASET_JOB_DATASET]",
+    "duration": "10.230s"
   },
   {
     "testId": "test_e2e::test_create_group",
-    "duration": "10.185s"
-  },
-  {
-    "testId": "tests.read_only.test_dataproduct::test_dataproduct_search_works",
-    "duration": "10.180s"
-  },
-  {
-    "testId": "tests.lineage.test_lineage::test_lineage_via_node[1-LineageStyle.DATASET_JOB_DATASET]",
-    "duration": "10.179s"
+    "duration": "10.201s"
   },
   {
     "testId": "tests.deprecation.deprecation_test::test_update_deprecation_partial_fields",
-    "duration": "10.170s"
+    "duration": "10.157s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_membership_relationships_idempotent_for_session_user",
+    "duration": "10.151s"
   },
   {
     "testId": "tests.timeline.timeline_change_history_test.TestDomainTimeline::test_domain_documentation_changes",
-    "duration": "10.147s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_documentation_changes",
     "duration": "10.135s"
   },
   {
     "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_documentation_changes",
-    "duration": "10.126s"
+    "duration": "10.131s"
   },
   {
-    "testId": "tests.lineage.test_lineage::test_lineage_via_node[2-LineageStyle.DATASET_JOB_DATASET]",
-    "duration": "10.033s"
+    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_documentation_changes",
+    "duration": "10.123s"
   },
   {
-    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_listing_complex_queries",
-    "duration": "9.327s"
+    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_all_edges_around_urn",
+    "duration": "10.085s"
   },
   {
-    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_read_write",
-    "duration": "9.276s"
-  },
-  {
-    "testId": "test_e2e::test_ingest_with_system_metadata",
-    "duration": "9.255s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_entities_basic",
-    "duration": "9.250s"
-  },
-  {
-    "testId": "tests.openapi.v1.test_tracking::test_tracking_api_kafka",
-    "duration": "9.247s"
-  },
-  {
-    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_many_versions",
-    "duration": "9.236s"
-  },
-  {
-    "testId": "tests.lineage.test_lineage::test_lineage_via_node[1-LineageStyle.DATASET_QUERY_DATASET]",
-    "duration": "9.182s"
-  },
-  {
-    "testId": "tests.status.test_lifecycle_state.TestLifecycleStageAPIs::test_list_lifecycle_stages_includes_ingested",
-    "duration": "9.128s"
-  },
-  {
-    "testId": "tests.cli.user_groups_cmd.test_group_cmd::test_group_upsert",
-    "duration": "9.059s"
-  },
-  {
-    "testId": "tests.schema_fields.test_schemafields::test_schema_field_gql_mapper_for_charts",
-    "duration": "8.369s"
+    "testId": "tests.structured_properties.test_structured_properties::test_dataset_yaml_loader",
+    "duration": "9.803s"
   },
   {
     "testId": "tests.cli.dataset_cmd.test_dataset_command::test_dataset_sync_to_datahub",
-    "duration": "8.284s"
+    "duration": "9.448s"
   },
   {
-    "testId": "tests.read_only.test_lineage_apis::test_scroll_across_lineage_api",
-    "duration": "8.181s"
+    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_urn_secondary_key",
+    "duration": "9.298s"
   },
   {
-    "testId": "test_e2e::test_generate_personal_access_token",
-    "duration": "8.104s"
+    "testId": "tests.lineage.test_lineage::test_lineage_via_node[1-LineageStyle.DATASET_JOB_DATASET]",
+    "duration": "9.272s"
   },
   {
-    "testId": "test_authentication_e2e::test_cross_service_authentication_consistency",
-    "duration": "8.086s"
+    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_definition_evolution",
+    "duration": "9.260s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_container_relationships_direct_children",
+    "duration": "9.259s"
+  },
+  {
+    "testId": "tests.cli.dataset_cmd.test_dataset_command::test_dataset_sync_validation",
+    "duration": "9.193s"
+  },
+  {
+    "testId": "test_e2e::test_remove_group",
+    "duration": "9.157s"
   },
   {
     "testId": "tests.lineage.test_lineage_sdk::test_table_level_lineage",
-    "duration": "7.456s"
+    "duration": "8.623s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_cross_service_authentication_consistency",
+    "duration": "8.112s"
+  },
+  {
+    "testId": "test_e2e::test_generate_personal_access_token",
+    "duration": "8.110s"
+  },
+  {
+    "testId": "tests.read_only.test_dataproduct::test_dataproduct_search_works",
+    "duration": "8.094s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_basic",
+    "duration": "7.242s"
   },
   {
     "testId": "tests.restli.test_restli_batch_ingestion::test_restli_batch_ingestion_async",
-    "duration": "7.149s"
+    "duration": "7.144s"
   },
   {
-    "testId": "tests.cli.user_groups_cmd.test_user_cmd::test_user_upsert",
-    "duration": "6.286s"
+    "testId": "tests.openapi.v1.test_tracking::test_tracking_api_kafka",
+    "duration": "6.197s"
   },
   {
-    "testId": "test_e2e::test_home_page_recommendations",
-    "duration": "5.017s"
-  },
-  {
-    "testId": "tests.read_only.test_analytics::test_highlights_is_accessible",
-    "duration": "4.953s"
+    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_many_versions",
+    "duration": "5.976s"
   },
   {
     "testId": "tests.analytics.test_analytics::test_analytics_charts_have_data",
-    "duration": "4.921s"
+    "duration": "5.100s"
+  },
+  {
+    "testId": "test_e2e::test_home_page_recommendations",
+    "duration": "4.592s"
   },
   {
     "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_timeline_structure",
-    "duration": "4.503s"
+    "duration": "4.474s"
+  },
+  {
+    "testId": "tests.read_only.test_analytics::test_highlights_is_accessible",
+    "duration": "4.340s"
   },
   {
     "testId": "test_e2e::test_gms_search_across_entities[covid-1]",
-    "duration": "4.244s"
+    "duration": "4.297s"
   },
   {
-    "testId": "tests.read_only.test_analytics::test_analytics_chart_is_accessible",
-    "duration": "4.142s"
+    "testId": "tests.timeseries.test_stats_summary_graphql::test_dataset_stats_summary",
+    "duration": "4.226s"
   },
   {
     "testId": "test_e2e::test_gms_search_dataset[covid-1]",
-    "duration": "4.139s"
+    "duration": "4.155s"
   },
   {
-    "testId": "test_e2e::test_frontend_search_across_entities[sample-3]",
-    "duration": "4.139s"
+    "testId": "tests.read_only.test_analytics::test_analytics_chart_is_accessible",
+    "duration": "4.130s"
   },
   {
-    "testId": "tests.read_only.test_analytics::test_metadata_analytics_chart_is_accessible",
-    "duration": "4.135s"
-  },
-  {
-    "testId": "test_e2e::test_frontend_search_datasets[covid-1]",
+    "testId": "tests.analytics.test_analytics::test_top_searches_chart",
     "duration": "4.128s"
   },
   {
-    "testId": "test_e2e::test_gms_usage_fetch",
-    "duration": "4.124s"
+    "testId": "tests.analytics.test_analytics::test_weekly_active_users_chart",
+    "duration": "4.126s"
   },
   {
-    "testId": "test_e2e::test_frontend_browse_datasets",
+    "testId": "test_e2e::test_frontend_search_datasets[covid-1]",
+    "duration": "4.122s"
+  },
+  {
+    "testId": "tests.read_only.test_analytics::test_metadata_analytics_chart_is_accessible",
     "duration": "4.122s"
   },
   {
     "testId": "test_e2e::test_frontend_search_across_entities[covid-1]",
-    "duration": "4.117s"
+    "duration": "4.121s"
   },
   {
-    "testId": "test_e2e::test_frontend_search_across_entities[-1]",
-    "duration": "4.115s"
-  },
-  {
-    "testId": "tests.analytics.test_analytics::test_weekly_active_users_chart",
-    "duration": "4.111s"
+    "testId": "tests.authorization.test_aspect_write_auth::test_update_data_product_name_denied_without_privilege",
+    "duration": "4.121s"
   },
   {
     "testId": "test_e2e::test_gms_search_across_entities[sample-3]",
-    "duration": "4.108s"
+    "duration": "4.120s"
   },
   {
-    "testId": "tests.analytics.test_analytics::test_top_searches_chart",
-    "duration": "4.094s"
+    "testId": "test_e2e::test_frontend_search_across_entities[sample-3]",
+    "duration": "4.120s"
   },
   {
-    "testId": "test_e2e::test_frontend_search_datasets[sample-3]",
-    "duration": "4.091s"
-  },
-  {
-    "testId": "test_e2e::test_frontend_app_config",
-    "duration": "4.090s"
+    "testId": "test_e2e::test_frontend_browse_datasets",
+    "duration": "4.117s"
   },
   {
     "testId": "tests.analytics.test_analytics::test_top_viewed_datasets_chart",
-    "duration": "4.088s"
-  },
-  {
-    "testId": "tests.analytics.test_analytics::test_tab_views_by_entity_type_chart",
-    "duration": "4.086s"
-  },
-  {
-    "testId": "test_e2e::test_frontend_search_datasets[-1]",
-    "duration": "4.084s"
+    "duration": "4.112s"
   },
   {
     "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDiagnose::test_diagnose_semantic_section_has_expected_keys",
-    "duration": "4.083s"
-  },
-  {
-    "testId": "test_e2e::test_list_groups",
-    "duration": "4.083s"
+    "duration": "4.110s"
   },
   {
     "testId": "test_e2e::test_gms_search_dataset[sample-3]",
-    "duration": "4.072s"
+    "duration": "4.108s"
   },
   {
-    "testId": "test_e2e::test_search_results_recommendations",
-    "duration": "4.071s"
+    "testId": "test_e2e::test_gms_usage_fetch",
+    "duration": "4.105s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_search_datasets[sample-3]",
+    "duration": "4.099s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_search_across_entities[-1]",
+    "duration": "4.097s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_app_config",
+    "duration": "4.094s"
+  },
+  {
+    "testId": "tests.analytics.test_analytics::test_tab_views_by_entity_type_chart",
+    "duration": "4.092s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_search_datasets[-1]",
+    "duration": "4.091s"
+  },
+  {
+    "testId": "test_e2e::test_list_groups",
+    "duration": "4.081s"
+  },
+  {
+    "testId": "tests.read_only.test_ingestion_list::test_policies_are_accessible",
+    "duration": "4.079s"
+  },
+  {
+    "testId": "tests.service_accounts.test_service_accounts::test_get_nonexistent_service_account",
+    "duration": "4.078s"
+  },
+  {
+    "testId": "tests.read_only.test_policies::test_policies_are_accessible",
+    "duration": "4.078s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_restli_endpoints_with_valid_auth",
+    "duration": "4.076s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_me_query",
+    "duration": "4.075s"
   },
   {
     "testId": "test_e2e::test_list_users",
-    "duration": "4.068s"
+    "duration": "4.074s"
   },
   {
-    "testId": "test_e2e::test_frontend_datasets[urn:li:dataPlatform:kafka-SampleKafkaDataset-PROD]",
-    "duration": "4.063s"
-  },
-  {
-    "testId": "test_e2e::test_frontend_user_info",
-    "duration": "4.062s"
+    "testId": "test_e2e::test_search_results_recommendations",
+    "duration": "4.074s"
   },
   {
     "testId": "test_e2e::test_frontend_datasets[urn:li:dataPlatform:bigquery-bigquery-public-data.covid19_geotab_mobility_impact.us_border_wait_times-PROD]",
-    "duration": "4.060s"
+    "duration": "4.072s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_datasets[urn:li:dataPlatform:kafka-SampleKafkaDataset-PROD]",
+    "duration": "4.067s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_user_info",
+    "duration": "4.065s"
+  },
+  {
+    "testId": "tests.service_accounts.test_service_accounts::test_delete_nonexistent_service_account",
+    "duration": "4.063s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_graphql_endpoint_valid_token",
+    "duration": "4.062s"
   },
   {
     "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_all_categories",
     "duration": "4.059s"
   },
   {
-    "testId": "test_e2e::test_frontend_me_query",
+    "testId": "test_authentication_e2e::test_graphql_endpoint_via_frontend_uses_gzip",
+    "duration": "4.059s"
+  },
+  {
+    "testId": "tests.containers.containers_test::test_get_parent_container",
+    "duration": "4.059s"
+  },
+  {
+    "testId": "tests.datapack.test_datapack_smoke.TestShowcaseData::test_showcase_has_dashboards",
     "duration": "4.058s"
   },
   {
-    "testId": "tests.read_only.test_ingestion_list::test_policies_are_accessible",
-    "duration": "4.056s"
+    "testId": "test_e2e::test_ingest_with_blank_system_metadata",
+    "duration": "4.055s"
   },
   {
-    "testId": "test_authentication_e2e::test_restli_endpoints_with_valid_auth",
-    "duration": "4.054s"
-  },
-  {
-    "testId": "tests.service_accounts.test_service_accounts::test_get_nonexistent_service_account",
+    "testId": "tests.datapack.test_datapack_smoke.TestShowcaseData::test_showcase_has_glossary_terms",
     "duration": "4.052s"
   },
   {
-    "testId": "test_e2e::test_ingest_with_blank_system_metadata",
-    "duration": "4.051s"
+    "testId": "tests.timeline.timeline_change_history_test.TestDomainTimeline::test_domain_all_categories",
+    "duration": "4.050s"
   },
   {
     "testId": "test_e2e::test_ingest_without_system_metadata",
     "duration": "4.048s"
   },
   {
-    "testId": "tests.timeline.timeline_change_history_test.TestDomainTimeline::test_domain_all_categories",
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_all_categories",
     "duration": "4.046s"
   },
   {
     "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_all_categories",
-    "duration": "4.045s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_all_categories",
-    "duration": "4.045s"
-  },
-  {
-    "testId": "tests.containers.containers_test::test_get_parent_container",
-    "duration": "4.045s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_graphql_endpoint_via_frontend_uses_gzip",
-    "duration": "4.045s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_graphql_endpoint_valid_token",
     "duration": "4.044s"
   },
   {
-    "testId": "tests.service_accounts.test_service_accounts::test_delete_nonexistent_service_account",
-    "duration": "4.043s"
+    "testId": "tests.search.test_lineage_search_index_fields::test_lineage_search_index_fields_without_lineage",
+    "duration": "4.034s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_auth_test::test_get_timeline_authorized_user_succeeds",
+    "duration": "4.034s"
   },
   {
     "testId": "tests.search.test_lineage_search_index_fields::test_upstream_dataset_search_index_fields",
-    "duration": "4.041s"
-  },
-  {
-    "testId": "tests.search.test_lineage_search_index_fields::test_lineage_search_index_fields_without_lineage",
-    "duration": "4.033s"
+    "duration": "4.032s"
   },
   {
     "testId": "tests.semantic.test_current_offset_api::test_poll_with_retrieved_offset",
-    "duration": "4.012s"
+    "duration": "4.013s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestRollingRestartPhaseHappyPath::test_dual_write_timeout_does_not_hang_on_quiet_log_stream",
+    "duration": "3.002s"
   },
   {
     "testId": "tests.datapack.test_datapack_smoke.TestDemoDataBootstrap::test_unload_bootstrap_via_cli",
-    "duration": "2.826s"
+    "duration": "2.852s"
   },
   {
     "testId": "tests.library_examples.test_library_examples::test_library_example[data_process_instance_create_simple.py]",
-    "duration": "2.658s"
+    "duration": "2.712s"
   },
   {
     "testId": "tests.semantic.test_current_offset_api::test_offset_behavior_without_lookback",
-    "duration": "2.514s"
+    "duration": "2.513s"
   },
   {
     "testId": "tests.semantic.test_current_offset_api::test_get_current_offset_no_params",
-    "duration": "2.010s"
+    "duration": "2.011s"
   },
   {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_simple_query_passes_through",
-    "duration": "0.680s"
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseTimeout::test_watchdog_terminates_silent_child_and_marks_timeout",
+    "duration": "1.002s"
   },
   {
     "testId": "tests.test_stateful_ingestion::test_stateful_ingestion",
-    "duration": "0.562s"
+    "duration": "0.777s"
   },
   {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFilterCombinations::test_comma_or_logic_returns_union",
-    "duration": "0.485s"
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_limit_respected",
+    "duration": "0.439s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchWhereFilter::test_where_in_list",
+    "duration": "0.429s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[application_create.py]",
+    "duration": "0.427s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFilterCombinations::test_multiple_filters_are_anded",
+    "duration": "0.424s"
   },
   {
     "testId": "tests.library_examples.test_library_examples::test_library_example[dataproduct_create.py]",
-    "duration": "0.465s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[ermodelrelationship_create_basic.py]",
-    "duration": "0.425s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[container_create_schema.py]",
-    "duration": "0.423s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchPagination::test_total_is_consistent_across_pages",
-    "duration": "0.414s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchWhereFilter::test_where_and_narrows_results",
-    "duration": "0.409s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[dataset_create_with_structured_properties.py]",
-    "duration": "0.409s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[chart_create_simple.py]",
-    "duration": "0.401s"
+    "duration": "0.410s"
   },
   {
     "testId": "tests.restli.test_restli_batch_ingestion::test_restli_batch_ingestion_exception_async",
-    "duration": "0.400s"
+    "duration": "0.398s"
   },
   {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[mlmodel_group_create.py]",
-    "duration": "0.389s"
+    "testId": "tests.library_examples.test_library_examples::test_library_example[chart_create_simple.py]",
+    "duration": "0.392s"
   },
   {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[mlmodel_create.py]",
-    "duration": "0.386s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[dashboard_create_simple.py]",
-    "duration": "0.384s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[datajob_create_basic.py]",
-    "duration": "0.380s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByPlatform::test_filter_snowflake_returns_snowflake_datasets",
-    "duration": "0.379s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[dataflow_create.py]",
+    "testId": "tests.library_examples.test_library_examples::test_library_example[ermodelrelationship_create_basic.py]",
     "duration": "0.377s"
   },
   {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[corpgroup_create.py]",
-    "duration": "0.374s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_facets_only",
-    "duration": "0.369s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[container_create.py]",
+    "testId": "tests.library_examples.test_library_examples::test_library_example[container_create_schema.py]",
     "duration": "0.367s"
   },
   {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[corpuser_create_basic.py]",
-    "duration": "0.367s"
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_table_format",
+    "duration": "0.366s"
   },
   {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[tag_create_basic.py]",
-    "duration": "0.365s"
-  },
-  {
-    "testId": "test_e2e::test_native_user_endpoints",
+    "testId": "tests.query_projection.test_query_projection_smoke::test_simple_query_passes_through",
     "duration": "0.359s"
   },
   {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_filter_dashboard_returns_only_dashboards",
-    "duration": "0.356s"
+    "testId": "tests.library_examples.test_library_examples::test_library_example[dataset_create_with_structured_properties.py]",
+    "duration": "0.351s"
   },
   {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[incident_create.py]",
-    "duration": "0.356s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_json_result_structure",
-    "duration": "0.355s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[container_create_database.py]",
+    "testId": "tests.library_examples.test_library_examples::test_library_example[glossary_node_create.py]",
     "duration": "0.342s"
   },
   {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[structured_property_create_basic.py]",
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByPlatform::test_filter_snowflake_returns_snowflake_datasets",
     "duration": "0.342s"
   },
   {
     "testId": "tests.library_examples.test_library_examples::test_library_example[search_filter_by_domain.py]",
-    "duration": "0.340s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[incident_query_rest_api.py]",
-    "duration": "0.338s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[glossary_node_create.py]",
     "duration": "0.337s"
   },
   {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[datacontract_create_basic.py]",
-    "duration": "0.335s"
+    "testId": "tests.library_examples.test_library_examples::test_library_example[tag_create_basic.py]",
+    "duration": "0.337s"
   },
   {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[domain_create.py]",
-    "duration": "0.324s"
+    "testId": "tests.library_examples.test_library_examples::test_library_example[corpuser_create_basic.py]",
+    "duration": "0.336s"
   },
   {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[ownership_type_create_custom.py]",
-    "duration": "0.323s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[mlprimarykey_create.py]",
-    "duration": "0.321s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[domain_create_nested.py]",
-    "duration": "0.318s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[query_create.py]",
-    "duration": "0.314s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[notebook_create.py]",
-    "duration": "0.308s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[mlfeature_table_create.py]",
-    "duration": "0.307s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[glossary_term_create_simple.py]",
-    "duration": "0.306s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[data_platform_create.py]",
-    "duration": "0.304s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_volume_rows.py]",
-    "duration": "0.301s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_sql_metric.py]",
-    "duration": "0.301s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[platform_instance_create.py]",
-    "duration": "0.300s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_freshness.py]",
-    "duration": "0.296s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[mlmodel_deployment_create.py]",
-    "duration": "0.294s"
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_filter_dashboard_returns_only_dashboards",
+    "duration": "0.336s"
   },
   {
     "testId": "tests.library_examples.test_library_examples::test_library_example[glossary_term_create.py]",
-    "duration": "0.293s"
+    "duration": "0.330s"
   },
   {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[role_create.py]",
-    "duration": "0.293s"
+    "testId": "tests.library_examples.test_library_examples::test_library_example[mlmodel_create.py]",
+    "duration": "0.329s"
   },
   {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[mlfeature_create.py]",
-    "duration": "0.292s"
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFilterCombinations::test_complex_filters_json_and",
+    "duration": "0.329s"
   },
   {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_field_uniqueness.py]",
+    "testId": "tests.library_examples.test_library_examples::test_library_example[container_create.py]",
+    "duration": "0.325s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[dashboard_create_simple.py]",
+    "duration": "0.325s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[datajob_create_basic.py]",
+    "duration": "0.324s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchWhereFilter::test_where_platform_eq",
+    "duration": "0.324s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[dataflow_create.py]",
+    "duration": "0.319s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchProjectionLive::test_minimal_projection_urn_only",
+    "duration": "0.319s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[structured_property_create_basic.py]",
+    "duration": "0.318s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[container_create_database.py]",
+    "duration": "0.316s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[mlmodel_group_create.py]",
+    "duration": "0.314s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[glossary_term_create_simple.py]",
+    "duration": "0.309s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[corpgroup_create.py]",
+    "duration": "0.307s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[datacontract_create_basic.py]",
+    "duration": "0.305s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[incident_create.py]",
+    "duration": "0.298s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[query_create.py]",
     "duration": "0.290s"
   },
   {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_schema.py]",
+    "testId": "test_e2e::test_native_user_endpoints",
     "duration": "0.289s"
   },
   {
     "testId": "tests.library_examples.test_library_examples::test_library_example[business_attribute_create.py]",
-    "duration": "0.286s"
+    "duration": "0.283s"
   },
   {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[application_create.py]",
-    "duration": "0.285s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_field_tags_patch[graph_client]",
-    "duration": "0.238s"
-  },
-  {
-    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_version_properties_version_set_new_latest",
-    "duration": "0.210s"
-  },
-  {
-    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_version_properties",
-    "duration": "0.201s"
-  },
-  {
-    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_version_properties_alphanumeric",
-    "duration": "0.199s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_limit_respected",
-    "duration": "0.194s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchWhereFilter::test_where_in_list",
-    "duration": "0.193s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_custom_properties_patch[openapi_graph_client]",
-    "duration": "0.191s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_ownership_multi_type_urn_patch[openapi_graph_client]",
-    "duration": "0.179s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_field_tags_patch[openapi_graph_client]",
-    "duration": "0.169s"
-  },
-  {
-    "testId": "tests.lineage.test_lineage_sdk::test_column_level_lineage_from_schema_field",
-    "duration": "0.169s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_attributed_duplicates_survive_unrelated_tag_patch[graph_client]",
-    "duration": "0.167s"
+    "testId": "tests.library_examples.test_library_examples::test_library_example[ownership_type_create_custom.py]",
+    "duration": "0.279s"
   },
   {
     "testId": "tests.patch.test_dataset_patches::test_custom_properties_patch[graph_client]",
-    "duration": "0.166s"
+    "duration": "0.278s"
   },
   {
-    "testId": "tests.patch.test_dataset_patches::test_unattributed_and_attributed_tag_coexist[graph_client]",
-    "duration": "0.166s"
+    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_freshness.py]",
+    "duration": "0.273s"
   },
   {
-    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_version_properties_version_set_not_latest",
-    "duration": "0.164s"
+    "testId": "tests.library_examples.test_library_examples::test_library_example[incident_query_rest_api.py]",
+    "duration": "0.272s"
   },
   {
-    "testId": "tests.patch.test_dataset_patches::test_field_terms_patch[openapi_graph_client]",
-    "duration": "0.164s"
+    "testId": "tests.library_examples.test_library_examples::test_library_example[domain_create.py]",
+    "duration": "0.271s"
   },
   {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_ownership_patch[openapi_graph_client]",
-    "duration": "0.160s"
+    "testId": "tests.library_examples.test_library_examples::test_library_example[mlfeature_table_create.py]",
+    "duration": "0.271s"
   },
   {
-    "testId": "tests.patch.test_dataset_patches::test_unattributed_and_attributed_tag_coexist[openapi_graph_client]",
-    "duration": "0.158s"
+    "testId": "tests.library_examples.test_library_examples::test_library_example[mlmodel_deployment_create.py]",
+    "duration": "0.271s"
   },
   {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_entity_type_filter_narrows_results",
-    "duration": "0.157s"
+    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_sql_metric.py]",
+    "duration": "0.270s"
   },
   {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_tags_patch[graph_client]",
-    "duration": "0.156s"
+    "testId": "tests.library_examples.test_library_examples::test_library_example[notebook_create.py]",
+    "duration": "0.269s"
   },
   {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_ownership_patch[graph_client]",
-    "duration": "0.155s"
+    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_schema.py]",
+    "duration": "0.268s"
   },
   {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchPagination::test_offset_returns_different_results",
-    "duration": "0.150s"
+    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_volume_rows.py]",
+    "duration": "0.267s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[data_platform_create.py]",
+    "duration": "0.267s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[role_create.py]",
+    "duration": "0.266s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[mlfeature_create.py]",
+    "duration": "0.265s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_field_uniqueness.py]",
+    "duration": "0.264s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[platform_instance_create.py]",
+    "duration": "0.264s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[domain_create_nested.py]",
+    "duration": "0.261s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[mlprimarykey_create.py]",
+    "duration": "0.261s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_custom_properties_patch[openapi_graph_client]",
+    "duration": "0.228s"
+  },
+  {
+    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_version_properties",
+    "duration": "0.225s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFilterCombinations::test_comma_or_logic_returns_union",
+    "duration": "0.217s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domain_associations_patch_updates_domains[graph_client]",
+    "duration": "0.214s"
   },
   {
     "testId": "tests.patch.test_dataset_patches::test_dataset_terms_patch[graph_client]",
-    "duration": "0.149s"
+    "duration": "0.214s"
   },
   {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_terms_patch[openapi_graph_client]",
-    "duration": "0.149s"
+    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domains_updates_domain_associations[graph_client]",
+    "duration": "0.213s"
   },
   {
-    "testId": "tests.patch.test_dataset_patches::test_attribution_based_tag_patch[openapi_graph_client]",
-    "duration": "0.145s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_upstream_lineage_patch[graph_client]",
-    "duration": "0.141s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_tags_patch[openapi_graph_client]",
-    "duration": "0.138s"
+    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domains_updates_domain_associations[openapi_graph_client]",
+    "duration": "0.206s"
   },
   {
     "testId": "tests.patch.test_dataset_patches::test_ownership_multi_type_urn_patch[graph_client]",
-    "duration": "0.137s"
+    "duration": "0.205s"
   },
   {
-    "testId": "tests.restli.restli_test::test_gms_delete_mcp",
-    "duration": "0.134s"
+    "testId": "tests.patch.test_dataset_patches::test_dataset_tags_patch[openapi_graph_client]",
+    "duration": "0.199s"
   },
   {
-    "testId": "tests.patch.test_dataset_patches::test_field_terms_patch[graph_client]",
-    "duration": "0.134s"
+    "testId": "tests.patch.test_dataset_patches::test_field_tags_patch[graph_client]",
+    "duration": "0.197s"
+  },
+  {
+    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_version_properties_alphanumeric",
+    "duration": "0.193s"
+  },
+  {
+    "testId": "tests.lineage.test_lineage_sdk::test_column_level_lineage_from_schema_field",
+    "duration": "0.192s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_dataset_ownership_patch[graph_client]",
+    "duration": "0.183s"
   },
   {
     "testId": "tests.patch.test_dataset_patches::test_attributed_duplicates_survive_unrelated_tag_patch[openapi_graph_client]",
-    "duration": "0.130s"
+    "duration": "0.183s"
   },
   {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFilterCombinations::test_multiple_filters_are_anded",
-    "duration": "0.129s"
+    "testId": "tests.patch.test_dataset_patches::test_dataset_ownership_patch[openapi_graph_client]",
+    "duration": "0.181s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domain_associations_upsert_updates_domains[openapi_graph_client]",
+    "duration": "0.179s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_produces_source_is_upstream",
+    "duration": "0.178s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_dataset_upstream_lineage_patch[graph_client]",
+    "duration": "0.178s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_field_tags_patch[openapi_graph_client]",
+    "duration": "0.175s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_read_modify_write_associations_updates_domains[openapi_graph_client]",
+    "duration": "0.171s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_entity_type_filter_narrows_results",
+    "duration": "0.170s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_read_modify_write_associations_updates_domains[graph_client]",
+    "duration": "0.168s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_ownership_multi_type_urn_patch[openapi_graph_client]",
+    "duration": "0.167s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domain_associations_patch_updates_domains[openapi_graph_client]",
+    "duration": "0.165s"
+  },
+  {
+    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_version_properties_version_set_new_latest",
+    "duration": "0.164s"
   },
   {
     "testId": "tests.patch.test_dataset_patches::test_dataset_upstream_lineage_patch[openapi_graph_client]",
-    "duration": "0.128s"
+    "duration": "0.164s"
   },
   {
-    "testId": "tests.patch.test_dataset_patches::test_documentation_patch[openapi_graph_client]",
-    "duration": "0.118s"
+    "testId": "tests.patch.test_dataset_patches::test_attributed_duplicates_survive_unrelated_tag_patch[graph_client]",
+    "duration": "0.163s"
   },
   {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_list_operations",
-    "duration": "0.117s"
+    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_downstream_of_upstream_node",
+    "duration": "0.162s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domain_associations_upsert_updates_domains[graph_client]",
+    "duration": "0.161s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_field_terms_patch[graph_client]",
+    "duration": "0.161s"
+  },
+  {
+    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_version_properties_version_set_not_latest",
+    "duration": "0.158s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchPagination::test_offset_returns_different_results",
+    "duration": "0.158s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchPagination::test_total_is_consistent_across_pages",
+    "duration": "0.158s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchWhereFilter::test_where_and_narrows_results",
+    "duration": "0.158s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_pagination",
+    "duration": "0.152s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_unattributed_and_attributed_tag_coexist[graph_client]",
+    "duration": "0.152s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_field_terms_patch[openapi_graph_client]",
+    "duration": "0.151s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_dataset_tags_patch[graph_client]",
+    "duration": "0.148s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_unattributed_and_attributed_tag_coexist[openapi_graph_client]",
+    "duration": "0.148s"
   },
   {
     "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchProjectionLive::test_projection_reduces_payload",
-    "duration": "0.113s"
+    "duration": "0.147s"
   },
   {
-    "testId": "tests.patch.test_dataset_patches::test_remove_without_attribution_deletes_all_entries[openapi_graph_client]",
-    "duration": "0.109s"
+    "testId": "tests.graph.test_graph_client::test_get_entity_aspect_specs",
+    "duration": "0.146s"
   },
   {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByPlatform::test_filter_bigquery_returns_bigquery_datasets",
-    "duration": "0.108s"
+    "testId": "tests.patch.test_dataset_patches::test_attribution_based_tag_patch[openapi_graph_client]",
+    "duration": "0.143s"
   },
   {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_add_fine_grained_lineage[graph_client]",
-    "duration": "0.108s"
+    "testId": "tests.patch.test_datajob_patches::test_dataset_terms_patch[openapi_graph_client]",
+    "duration": "0.142s"
   },
   {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_table_format",
-    "duration": "0.106s"
+    "testId": "tests.restli.restli_test::test_gms_delete_mcp",
+    "duration": "0.140s"
   },
   {
-    "testId": "tests.patch.test_datajob_patches::test_custom_properties_patch[openapi_graph_client]",
-    "duration": "0.106s"
+    "testId": "tests.patch.test_dataset_patches::test_add_attributed_tag_is_idempotent[graph_client]",
+    "duration": "0.138s"
   },
   {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_tags_patch[graph_client]",
-    "duration": "0.104s"
+    "testId": "tests.patch.test_dataset_patches::test_dataset_terms_patch[openapi_graph_client]",
+    "duration": "0.137s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_dataset_terms_patch[graph_client]",
+    "duration": "0.135s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_filter_dataset_returns_only_datasets",
+    "duration": "0.133s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_custom_properties_patch[graph_client]",
+    "duration": "0.133s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_read_modify_write_domains_updates_associations[openapi_graph_client]",
+    "duration": "0.130s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_remove_all_documentation[openapi_graph_client]",
+    "duration": "0.129s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_datajob_tags_patch[openapi_graph_client]",
+    "duration": "0.127s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_attribution_based_tag_patch[graph_client]",
+    "duration": "0.126s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_add_attributed_tag_is_idempotent[openapi_graph_client]",
+    "duration": "0.125s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_facets_only",
+    "duration": "0.123s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_documentation_patch[graph_client]",
+    "duration": "0.122s"
+  },
+  {
+    "testId": "test_system_info::test_system_info_endpoint_separation",
+    "duration": "0.121s"
   },
   {
     "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_urns_only_format",
+    "duration": "0.119s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_datajob_directions",
+    "duration": "0.119s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_propagated_domains_ordered_after_manual[graph_client]",
+    "duration": "0.118s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_json_result_structure",
+    "duration": "0.116s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_remove_all_documentation[graph_client]",
+    "duration": "0.116s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_filter_corpuser_returns_only_corpusers",
+    "duration": "0.114s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_remove_without_attribution_deletes_all_entries[graph_client]",
+    "duration": "0.114s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_custom_properties_patch[openapi_graph_client]",
+    "duration": "0.112s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_filter_chart_returns_only_charts",
+    "duration": "0.110s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByPlatform::test_filter_bigquery_returns_bigquery_datasets",
+    "duration": "0.110s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_list_operations",
+    "duration": "0.109s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_dataset_set_fine_grained_lineages[openapi_graph_client]",
+    "duration": "0.108s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_read_modify_write_domains_updates_associations[graph_client]",
+    "duration": "0.106s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_dataset_set_fine_grained_lineages[graph_client]",
+    "duration": "0.106s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByPlatform::test_filter_snowflake_excludes_bigquery",
+    "duration": "0.105s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_datajob_ownership_patch[graph_client]",
+    "duration": "0.103s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_remove_without_attribution_deletes_all_entries[openapi_graph_client]",
+    "duration": "0.103s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_documentation_patch[openapi_graph_client]",
+    "duration": "0.103s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_propagated_domains_ordered_after_manual[openapi_graph_client]",
     "duration": "0.102s"
   },
   {
     "testId": "tests.restli.test_restli_batch_ingestion::test_restli_batch_ingestion_sync",
-    "duration": "0.102s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_tags_patch[openapi_graph_client]",
-    "duration": "0.102s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_set_fine_grained_lineages[graph_client]",
-    "duration": "0.102s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByPlatform::test_filter_snowflake_excludes_bigquery",
-    "duration": "0.101s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_attribution_based_tag_patch[graph_client]",
-    "duration": "0.101s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_remove_all_documentation[openapi_graph_client]",
-    "duration": "0.101s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_add_attributed_tag_is_idempotent[openapi_graph_client]",
     "duration": "0.100s"
   },
   {
     "testId": "tests.patch.test_datajob_patches::test_datajob_ownership_patch[openapi_graph_client]",
+    "duration": "0.099s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_datajob_tags_patch[graph_client]",
     "duration": "0.098s"
   },
   {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_filter_dataset_returns_only_datasets",
-    "duration": "0.097s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_filter_corpuser_returns_only_corpusers",
-    "duration": "0.097s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_documentation_patch[graph_client]",
-    "duration": "0.096s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_remove_all_documentation[graph_client]",
-    "duration": "0.096s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[corpgroup_query_rest_api.py]",
-    "duration": "0.095s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_filter_chart_returns_only_charts",
-    "duration": "0.094s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFilterCombinations::test_complex_filters_json_and",
-    "duration": "0.094s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_custom_properties_patch[graph_client]",
-    "duration": "0.094s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_set_fine_grained_lineages[openapi_graph_client]",
-    "duration": "0.094s"
+    "testId": "tests.patch.test_dataset_patches::test_dataset_add_fine_grained_lineage[graph_client]",
+    "duration": "0.098s"
   },
   {
     "testId": "tests.patch.test_dataset_patches::test_dataset_add_fine_grained_lineage[openapi_graph_client]",
+    "duration": "0.095s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_updating_both_domains_and_domain_associations_errors[graph_client]",
     "duration": "0.093s"
   },
   {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchWhereFilter::test_where_platform_eq",
+    "testId": "tests.patch.test_domain_patches::test_updating_both_domains_and_domain_associations_errors[openapi_graph_client]",
+    "duration": "0.093s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDiagnose::test_diagnose_keyword_connected",
     "duration": "0.092s"
   },
   {
-    "testId": "test_system_info::test_system_info_endpoint_separation",
-    "duration": "0.089s"
+    "testId": "tests.library_examples.test_library_examples::test_library_example[corpgroup_query_rest_api.py]",
+    "duration": "0.085s"
   },
   {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[application_query_rest_api.py]",
-    "duration": "0.088s"
+    "testId": "tests.authorization.test_query_entity_read_auth::test_query_entity_hidden_without_subject_view",
+    "duration": "0.084s"
   },
   {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_ownership_patch[graph_client]",
-    "duration": "0.088s"
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_aspects_empty_returns_all_aspects",
+    "duration": "0.083s"
   },
   {
-    "testId": "tests.patch.test_dataset_patches::test_add_attributed_tag_is_idempotent[graph_client]",
-    "duration": "0.087s"
+    "testId": "tests.restli.restli_test::test_gms_ignore_unknown_dashboard_info",
+    "duration": "0.081s"
   },
   {
-    "testId": "tests.patch.test_dataset_patches::test_remove_without_attribution_deletes_all_entries[graph_client]",
-    "duration": "0.087s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDiagnose::test_diagnose_json_structure",
-    "duration": "0.079s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_dataset_terms_patch[openapi_graph_client]",
-    "duration": "0.077s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[business_attribute_query.py]",
-    "duration": "0.076s"
+    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_feature_directions",
+    "duration": "0.078s"
   },
   {
     "testId": "tests.patch.test_datajob_patches::test_datajob_inputoutput_dataset_patch[graph_client]",
     "duration": "0.076s"
   },
   {
-    "testId": "tests.metrics.test_metrics::test_usage_aggregation_micrometer_export",
-    "duration": "12.000s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchProjectionLive::test_minimal_projection_urn_only",
-    "duration": "0.075s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDiagnose::test_diagnose_keyword_connected",
-    "duration": "0.075s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIStandalone::test_graphql_schema_discovery",
-    "duration": "0.075s"
-  },
-  {
     "testId": "tests.patch.test_datajob_patches::test_datajob_inputoutput_dataset_patch[openapi_graph_client]",
+    "duration": "0.074s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDiagnose::test_diagnose_json_structure",
     "duration": "0.073s"
   },
   {
-    "testId": "tests.patch.test_datajob_patches::test_dataset_terms_patch[graph_client]",
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_describe_me_returns_operation_details",
+    "duration": "0.073s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[application_query_rest_api.py]",
     "duration": "0.072s"
   },
   {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_multiple_inputoutput_dataset_patch[graph_client]",
-    "duration": "0.071s"
+    "testId": "tests.library_examples.test_library_examples::test_library_example[business_attribute_query.py]",
+    "duration": "0.072s"
   },
   {
     "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDiagnose::test_diagnose_text_exits_cleanly",
-    "duration": "0.066s"
+    "duration": "0.072s"
   },
   {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_schema_introspection",
-    "duration": "0.063s"
+    "testId": "test_system_info::test_system_info_main_endpoint",
+    "duration": "0.070s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_datajob_multiple_inputoutput_dataset_patch[graph_client]",
+    "duration": "0.069s"
+  },
+  {
+    "testId": "tests.search.test_search_projection.TestSearchProjection::test_projection_reduces_payload",
+    "duration": "0.068s"
+  },
+  {
+    "testId": "tests.query_projection.test_query_projection_smoke::test_query_with_variables_and_operation_name",
+    "duration": "0.064s"
   },
   {
     "testId": "tests.patch.test_datajob_patches::test_datajob_multiple_inputoutput_dataset_patch[openapi_graph_client]",
     "duration": "0.063s"
   },
   {
-    "testId": "tests.datapack.test_datapack_smoke.TestDatapackCLI::test_datapack_list",
+    "testId": "tests.patch.test_datajob_patches::test_datajob_set_fine_grained_lineages[openapi_graph_client]",
+    "duration": "0.063s"
+  },
+  {
+    "testId": "tests.lineage.test_lineage_sdk::test_column_level_lineage",
     "duration": "0.062s"
   },
   {
@@ -1580,255 +1896,251 @@
     "duration": "0.062s"
   },
   {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_add_fine_grained_lineage[openapi_graph_client]",
-    "duration": "0.062s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_entities_parallel_slicing",
-    "duration": "0.062s"
-  },
-  {
     "testId": "tests.patch.test_datajob_patches::test_datajob_set_fine_grained_lineages[graph_client]",
-    "duration": "0.061s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_set_fine_grained_lineages[openapi_graph_client]",
-    "duration": "0.061s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_describe_me_returns_operation_details",
     "duration": "0.060s"
   },
   {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_list_operations_returns_real_schema",
-    "duration": "0.055s"
+    "testId": "test_authentication_e2e::test_config_progressive_disclosure",
+    "duration": "0.057s"
+  },
+  {
+    "testId": "tests.query_projection.test_query_projection_smoke::test_unknown_field_on_known_type_stripped",
+    "duration": "0.054s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIStandalone::test_graphql_relative_path_handling",
+    "duration": "0.054s"
+  },
+  {
+    "testId": "tests.lineage.test_lineage_sdk::test_filtered_column_level_lineage",
+    "duration": "0.054s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_datajob_add_fine_grained_lineage[openapi_graph_client]",
+    "duration": "0.054s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIStandalone::test_graphql_schema_discovery",
+    "duration": "0.053s"
   },
   {
     "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_dry_run_with_operation_resolves_via_introspection",
     "duration": "0.053s"
   },
   {
-    "testId": "tests.lineage.test_lineage_sdk::test_column_level_lineage",
-    "duration": "0.053s"
-  },
-  {
-    "testId": "tests.search.test_search_projection.TestSearchProjection::test_projection_reduces_payload",
-    "duration": "0.052s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_actuator_prometheus_no_auth",
-    "duration": "0.046s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_config_progressive_disclosure",
-    "duration": "0.046s"
-  },
-  {
-    "testId": "tests.lineage.test_lineage_sdk::test_filtered_column_level_lineage",
-    "duration": "0.043s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_simple_query_execution",
-    "duration": "0.040s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_execute_me_query_returns_current_user",
-    "duration": "0.040s"
-  },
-  {
-    "testId": "test_system_info::test_system_info_main_endpoint",
-    "duration": "0.039s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_json_output_format",
-    "duration": "0.039s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_query_from_file",
-    "duration": "0.038s"
-  },
-  {
     "testId": "test_system_info::test_system_info_properties_structure",
-    "duration": "0.037s"
+    "duration": "0.051s"
   },
   {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_search_query_with_known_entity_types",
-    "duration": "0.037s"
-  },
-  {
-    "testId": "tests.restli.restli_test::test_gms_ignore_unknown_dashboard_info",
-    "duration": "0.036s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_entities_pagination",
-    "duration": "0.035s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIFileHandling::test_relative_path_resolution",
-    "duration": "0.034s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIStandalone::test_graphql_file_path_handling",
-    "duration": "0.033s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIStandalone::test_graphql_relative_path_handling",
-    "duration": "0.033s"
-  },
-  {
-    "testId": "tests.read_only.test_services_up::test_gms_config_accessible",
-    "duration": "0.033s"
-  },
-  {
-    "testId": "test_system_info::test_system_info_properties_endpoint",
-    "duration": "0.032s"
-  },
-  {
-    "testId": "test_system_info::test_system_info_simple_properties_endpoint",
-    "duration": "0.032s"
-  },
-  {
-    "testId": "test_system_info::test_system_info_spring_components_structure",
-    "duration": "0.031s"
-  },
-  {
-    "testId": "test_system_info::test_system_info_spring_components_endpoint",
-    "duration": "0.031s"
-  },
-  {
-    "testId": "tests.semantic.test_config_fingerprint.TestConfigFingerprint::test_chunking_max_characters_change_triggers_reprocessing",
-    "duration": "0.031s"
-  },
-  {
-    "testId": "test_system_info::test_system_info_sensitive_data_redaction",
-    "duration": "0.030s"
+    "testId": "tests.datapack.test_datapack_smoke.TestDatapackCLI::test_datapack_list",
+    "duration": "0.051s"
   },
   {
     "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_dry_run_with_raw_query_returns_json",
-    "duration": "0.029s"
+    "duration": "0.051s"
   },
   {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_entities_by_entity_type",
-    "duration": "0.027s"
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_schema_introspection",
+    "duration": "0.050s"
   },
   {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_entities_by_multiple_entity_types",
-    "duration": "0.026s"
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_execute_me_query_returns_current_user",
+    "duration": "0.050s"
   },
   {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_error_handling",
-    "duration": "0.025s"
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_query_from_file",
+    "duration": "0.047s"
   },
   {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_agent_context_flag_exits_zero",
-    "duration": "0.025s"
+    "testId": "test_system_info::test_system_info_spring_components_structure",
+    "duration": "0.044s"
   },
   {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_relationships_source_urns_and_filter_equivalent",
-    "duration": "0.025s"
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_simple_query_execution",
+    "duration": "0.044s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_json_output_format",
+    "duration": "0.044s"
+  },
+  {
+    "testId": "test_system_info::test_system_info_properties_endpoint",
+    "duration": "0.043s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_relationship_types_filter",
+    "duration": "0.043s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_parallel_slicing",
+    "duration": "0.043s"
+  },
+  {
+    "testId": "test_system_info::test_system_info_spring_components_endpoint",
+    "duration": "0.042s"
+  },
+  {
+    "testId": "test_system_info::test_system_info_simple_properties_endpoint",
+    "duration": "0.042s"
+  },
+  {
+    "testId": "tests.query_projection.test_query_projection_smoke::test_nonexistent_type_fragment_stripped",
+    "duration": "0.042s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_list_operations_returns_real_schema",
+    "duration": "0.042s"
+  },
+  {
+    "testId": "test_system_info::test_system_info_sensitive_data_redaction",
+    "duration": "0.041s"
+  },
+  {
+    "testId": "tests.telemetry.telemetry_test::test_no_telemetry_client_id",
+    "duration": "0.040s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIFileHandling::test_relative_path_resolution",
+    "duration": "0.039s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_no_urns_returns_lineage_edges",
+    "duration": "0.039s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_pagination",
+    "duration": "0.039s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIStandalone::test_graphql_file_path_handling",
+    "duration": "0.037s"
+  },
+  {
+    "testId": "tests.query_projection.test_query_projection_smoke::test_multiple_unknown_fragments_and_fields",
+    "duration": "0.032s"
+  },
+  {
+    "testId": "tests.search.test_search_projection.TestSearchProjection::test_dataset_properties_projection",
+    "duration": "0.032s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_by_entity_type",
+    "duration": "0.032s"
+  },
+  {
+    "testId": "tests.query_projection.test_query_projection_smoke::test_schema_cached_across_calls",
+    "duration": "0.030s"
+  },
+  {
+    "testId": "tests.search.test_search_projection.TestSearchProjection::test_minimal_projection",
+    "duration": "0.030s"
+  },
+  {
+    "testId": "tests.authorization.test_query_entity_read_auth::test_query_entity_visible_with_edit_queries_on_subject",
+    "duration": "0.030s"
   },
   {
     "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDryRun::test_dry_run_shows_compiled_filter",
-    "duration": "0.024s"
+    "duration": "0.029s"
   },
   {
-    "testId": "tests.assertions.assertions_test::test_gms_get_assertions_on_dataset",
-    "duration": "0.024s"
+    "testId": "tests.restli.test_restli_batch_ingestion::test_restli_batch_ingestion_exception_sync",
+    "duration": "0.028s"
   },
   {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_relationships_destination_urns_and_filter_equivalent",
-    "duration": "0.024s"
+    "testId": "tests.search.test_search_projection.TestSearchProjection::test_platform_fields_fragment_projection",
+    "duration": "0.028s"
+  },
+  {
+    "testId": "tests.query_projection.test_query_projection_smoke::test_search_query_with_known_entity_types",
+    "duration": "0.027s"
+  },
+  {
+    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flags_accessible_without_auth",
+    "duration": "0.027s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_with_query",
+    "duration": "0.027s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_auth_test::test_get_timeline_unauthorized_user_is_denied[Domain]",
+    "duration": "0.026s"
+  },
+  {
+    "testId": "tests.search.test_search_projection.TestSearchProjection::test_facets_always_present",
+    "duration": "0.026s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_pagination",
+    "duration": "0.025s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_by_multiple_entity_types",
+    "duration": "0.025s"
   },
   {
     "testId": "tests.graph.test_graph_client::test_get_entities_v3",
+    "duration": "0.024s"
+  },
+  {
+    "testId": "tests.query_projection.test_query_projection_smoke::test_strip_false_with_bad_field_fails",
     "duration": "0.023s"
   },
   {
     "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDryRun::test_dry_run_offline",
-    "duration": "0.022s"
+    "duration": "0.023s"
   },
   {
-    "testId": "tests.semantic.test_semantic_search.TestSemanticSearchWithIngestion::test_end_to_end_ingestion_and_semantic_search",
+    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_non_existent",
     "duration": "0.022s"
   },
   {
     "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDryRun::test_dry_run_with_projection_shows_query",
+    "duration": "0.022s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_error_handling",
+    "duration": "0.022s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_actuator_prometheus_no_auth",
     "duration": "0.021s"
-  },
-  {
-    "testId": "tests.search.test_search_projection.TestSearchProjection::test_minimal_projection",
-    "duration": "0.021s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_entities_with_query",
-    "duration": "0.021s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_relationships_pagination",
-    "duration": "0.021s"
-  },
-  {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_multiple_unknown_fragments_and_fields",
-    "duration": "0.021s"
-  },
-  {
-    "testId": "tests.search.test_search_projection.TestSearchProjection::test_dataset_properties_projection",
-    "duration": "0.020s"
-  },
-  {
-    "testId": "tests.restli.test_restli_batch_ingestion::test_restli_batch_ingestion_exception_sync",
-    "duration": "0.020s"
-  },
-  {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_unknown_field_on_known_type_stripped",
-    "duration": "0.020s"
-  },
-  {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_query_with_variables_and_operation_name",
-    "duration": "0.020s"
-  },
-  {
-    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_non_existent",
-    "duration": "0.020s"
-  },
-  {
-    "testId": "tests.search.test_search_projection.TestSearchProjection::test_platform_fields_fragment_projection",
-    "duration": "0.019s"
-  },
-  {
-    "testId": "tests.search.test_search_projection.TestSearchProjection::test_facets_always_present",
-    "duration": "0.019s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIFileHandling::test_json_file_detection",
-    "duration": "0.019s"
-  },
-  {
-    "testId": "tests.assertions.assertions_test::test_gms_get_assertion_info",
-    "duration": "0.019s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_relationships_basic",
-    "duration": "0.019s"
-  },
-  {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_nonexistent_type_fragment_stripped",
-    "duration": "0.019s"
   },
   {
     "testId": "test_e2e::test_gms_get_dataset[urn:li:dataPlatform:kafka-SampleKafkaDataset-PROD]",
+    "duration": "0.020s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_destination_urns_and_filter_equivalent",
+    "duration": "0.020s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIFileHandling::test_json_file_detection",
+    "duration": "0.020s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_source_urns_and_filter_equivalent",
+    "duration": "0.019s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_with_system_metadata",
+    "duration": "0.019s"
+  },
+  {
+    "testId": "tests.query_projection.test_query_projection_smoke::test_strip_false_still_works",
     "duration": "0.018s"
   },
   {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_entities_with_system_metadata",
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_aspects_single_returns_only_that_aspect",
+    "duration": "0.018s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_aspects_none_returns_urns_only",
     "duration": "0.017s"
   },
   {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_relationships_by_type_downstream",
-    "duration": "0.017s"
-  },
-  {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_strip_false_with_bad_field_fails",
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_with_sort_criteria",
     "duration": "0.017s"
   },
   {
@@ -1836,119 +2148,143 @@
     "duration": "0.015s"
   },
   {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_entities_with_sort_criteria",
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_agent_context_flag_exits_zero",
     "duration": "0.015s"
   },
   {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_schema_cached_across_calls",
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_filter_is_applied",
     "duration": "0.015s"
   },
   {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_relationships_by_type_consumes",
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_by_type_downstream",
     "duration": "0.014s"
   },
   {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_entities_filter_is_applied",
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_edge_filter",
+    "duration": "0.014s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_destination_types",
     "duration": "0.013s"
   },
   {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_relationships_with_source_urns",
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_direction_outgoing",
     "duration": "0.013s"
   },
   {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_relationships_with_destination_urns",
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_direction_incoming",
     "duration": "0.013s"
   },
   {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_relationships_by_type_derived_from",
-    "duration": "0.012s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_relationships_with_source_types",
-    "duration": "0.011s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_relationships_with_destination_types",
-    "duration": "0.011s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_relationships_with_direction_outgoing",
-    "duration": "0.011s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_relationships_with_direction_incoming",
-    "duration": "0.011s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll::test_scroll_relationships_with_edge_filter",
-    "duration": "0.010s"
+    "testId": "tests.assertions.assertions_test::test_gms_get_assertions_on_dataset",
+    "duration": "0.013s"
   },
   {
     "testId": "test_e2e::test_gms_batch_get_v2",
+    "duration": "0.012s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_by_type_derived_from",
+    "duration": "0.012s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_by_type_consumes",
+    "duration": "0.012s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_source_urns",
+    "duration": "0.011s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_source_types",
+    "duration": "0.011s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestWaitForESDrain::test_partial_drain_resolves_on_retry",
+    "duration": "0.011s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_authentication_priority_and_fallback",
+    "duration": "0.011s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_destination_urns",
     "duration": "0.010s"
   },
   {
     "testId": "tests.assertions.assertions_test::test_gms_get_assertions_on_dataset_field",
-    "duration": "0.009s"
+    "duration": "0.010s"
   },
   {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_strip_false_still_works",
-    "duration": "0.008s"
+    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flags_endpoint_is_active",
+    "duration": "0.010s"
   },
   {
     "testId": "test_e2e::test_gms_get_dataset[urn:li:dataPlatform:bigquery-bigquery-public-data.covid19_geotab_mobility_impact.us_border_wait_times-PROD]",
-    "duration": "0.008s"
+    "duration": "0.009s"
   },
   {
-    "testId": "test_authentication_e2e::test_authentication_priority_and_fallback",
-    "duration": "0.008s"
+    "testId": "test_authentication_e2e::test_excluded_paths_no_auth[/public-iceberg/health]",
+    "duration": "0.009s"
+  },
+  {
+    "testId": "tests.assertions.assertions_test::test_gms_get_assertion_info",
+    "duration": "0.007s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_graphql_endpoint_no_auth",
+    "duration": "0.007s"
+  },
+  {
+    "testId": "tests.read_only.test_services_up::test_gms_config_accessible",
+    "duration": "0.007s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_graphql_endpoint_invalid_token",
+    "duration": "0.006s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_malformed_auth_headers[Bearer]",
+    "duration": "0.006s"
   },
   {
     "testId": "tests.datapack.test_datapack_smoke.TestDatapackCLI::test_datapack_info",
     "duration": "0.006s"
   },
   {
-    "testId": "tests.telemetry.telemetry_test::test_no_client_id",
-    "duration": "0.006s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_health_endpoint_with_invalid_token",
-    "duration": "0.006s"
-  },
-  {
     "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_no_args_exits_with_usage_code",
-    "duration": "0.005s"
+    "duration": "0.006s"
   },
   {
-    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flags_endpoint_is_active",
-    "duration": "0.005s"
+    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_reader_writer_events_dump_observations_and_writes",
+    "duration": "0.006s"
   },
   {
-    "testId": "tests.telemetry.telemetry_test::test_no_telemetry_client_id",
+    "testId": "tests.pgqueue.test_messaging_operations::test_messaging_transport_reports_pgqueue",
     "duration": "0.005s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_graphql_endpoint_no_auth",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_malformed_auth_headers[Bearer]",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flags_contain_stable_keys",
-    "duration": "0.004s"
   },
   {
     "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flag_single_lookup",
+    "duration": "0.005s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_writes_bundle_on_phase_failure",
+    "duration": "0.005s"
+  },
+  {
+    "testId": "tests.telemetry.telemetry_test::test_no_client_id",
+    "duration": "0.005s"
+  },
+  {
+    "testId": "tests.pgqueue.test_messaging_operations::test_mcp_consumer_lag_detailed",
     "duration": "0.004s"
   },
   {
-    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flag_unknown_name_returns_404",
+    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseDefensiveErrors::test_es_failure_marks_phase_failed_but_does_not_crash",
     "duration": "0.004s"
   },
   {
-    "testId": "test_authentication_e2e::test_excluded_paths_no_auth[/public-iceberg/health]",
+    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseFailures::test_ingest_failure_fails_phase_with_partial_dual_write_urns",
     "duration": "0.004s"
   },
   {
@@ -1956,15 +2292,55 @@
     "duration": "0.004s"
   },
   {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIStandalone::test_graphql_help",
+    "testId": "test_authentication_e2e::test_protected_endpoints_invalid_token[/entities?action=search-POST]",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_malformed_auth_headers[bearer invalid-token]",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_malformed_auth_headers[Basic dXNlcjpwYXNz]",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_malformed_auth_headers[InvalidPrefix token]",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_malformed_auth_headers[Bearer ]",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flags_contain_stable_keys",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flag_unknown_name_returns_404",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "tests.openapi.v1.test_tracking::test_tracking_api_pgqueue",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "tests.pgqueue.test_messaging_operations::test_mcl_versioned_consumer_lag_detailed",
     "duration": "0.003s"
   },
   {
-    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flags_accessible_without_auth",
+    "testId": "tests.pgqueue.test_messaging_operations::test_mcl_timeseries_consumer_lag_detailed",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestSeedIOPoolViaRest::test_seeds_io_pool_via_rest_not_mysql",
     "duration": "0.003s"
   },
   {
     "testId": "test_authentication_e2e::test_health_endpoint_no_auth",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_health_endpoint_with_invalid_token",
     "duration": "0.003s"
   },
   {
@@ -1976,7 +2352,7 @@
     "duration": "0.003s"
   },
   {
-    "testId": "test_authentication_e2e::test_graphql_endpoint_invalid_token",
+    "testId": "test_authentication_e2e::test_protected_endpoints_no_auth[/entities?action=search-POST]",
     "duration": "0.003s"
   },
   {
@@ -1984,31 +2360,71 @@
     "duration": "0.003s"
   },
   {
-    "testId": "test_authentication_e2e::test_malformed_auth_headers[bearer invalid-token]",
+    "testId": "tests.zdu.framework.test_inject_traffic_pre.TestInjectTrafficPrePhaseFailures::test_ingest_failure_fails_phase",
     "duration": "0.003s"
   },
   {
-    "testId": "test_authentication_e2e::test_malformed_auth_headers[Basic dXNlcjpwYXNz]",
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseTimeout::test_deadline_hits_mid_stream_kills_process",
     "duration": "0.003s"
   },
   {
-    "testId": "test_authentication_e2e::test_malformed_auth_headers[InvalidPrefix token]",
+    "testId": "tests.zdu.framework.test_upgrade_nonblocking.TestUpgradeNonBlockingPhase::test_passes_explicit_nonblocking_extra_args_to_run_upgrade_job",
     "duration": "0.003s"
   },
   {
-    "testId": "test_authentication_e2e::test_malformed_auth_headers[Bearer ]",
+    "testId": "tests.zdu.framework.test_upgrade_nonblocking.TestUpgradeNonBlockingPhase::test_captures_upgrade_nonblocking_result_on_completion",
     "duration": "0.003s"
   },
   {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_conflicting_filters_exit_code_2",
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestFailurePropagation::test_build_failure_propagates",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_skips_when_no_failures",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_upgrade_result_includes_blocking_and_nonblocking",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_continues_on_per_artifact_failure",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.pgqueue.test_messaging_operations::test_list_registered_consumers",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.pgqueue.test_messaging_operations::test_reset_stuck_ahead_consumer_offsets",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.pgqueue.test_messaging_operations::test_consumer_registration_lifecycle",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseHappyPath::test_captures_aliases_doc_counts_and_aspects",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseDefensiveErrors::test_one_aspect_query_failure_does_not_drop_other_aspects",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseHappyPath::test_no_upgrade_blocking_state_skips_index_checks_entirely",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_cleanup.TestHealthCheckLogging::test_success_logs_health_confirmation",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_runtime_migration.TestRuntimeMigrationPhase::test_read_probe_records_mismatch_without_failing_phase",
     "duration": "0.002s"
   },
   {
     "testId": "test_authentication_e2e::test_excluded_paths_no_auth[/config/search/export]",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_protected_endpoints_no_auth[/entities?action=search-POST]",
     "duration": "0.002s"
   },
   {
@@ -2024,10 +2440,6 @@
     "duration": "0.002s"
   },
   {
-    "testId": "test_authentication_e2e::test_protected_endpoints_invalid_token[/entities?action=search-POST]",
-    "duration": "0.002s"
-  },
-  {
     "testId": "test_authentication_e2e::test_protected_endpoints_invalid_token[/aspects?action=getAspect-GET]",
     "duration": "0.002s"
   },
@@ -2036,39 +2448,651 @@
     "duration": "0.002s"
   },
   {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_invalid_limit_exit_code_2",
-    "duration": "0.001s"
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestHappyPath::test_captures_secrets_wipes_redeploys_and_waits_for_health",
+    "duration": "0.002s"
   },
   {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_invalid_offset_exit_code_2",
-    "duration": "0.001s"
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestPartialSecretCapture::test_partial_capture_filled_from_secrets_file",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_pre.TestInjectTrafficPrePhaseHappyPath::test_writes_n_entities_and_records_gap_urns",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_invalid_limit_exit_code_2",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_conflicting_filters_exit_code_2",
+    "duration": "0.002s"
   },
   {
     "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_invalid_projection_exit_code_2",
-    "duration": "0.001s"
+    "duration": "0.002s"
   },
   {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_list_filters_subcommand",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_describe_filter_subcommand",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.search.test_search_projection.TestSearchProjection::test_default_query_no_projection",
-    "duration": "0.001s"
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIStandalone::test_graphql_help",
+    "duration": "0.002s"
   },
   {
     "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_non_tty_help_includes_agent_context",
-    "duration": "0.001s"
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestSkipsWhenDisabled::test_skips_when_build_images_false",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestCacheHit::test_cache_hit_skips_build_and_returns_passed",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestCacheMissBuildsBothSides::test_cache_miss_builds_both_sides",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestCacheMissLogIsDiagnostic::test_cache_miss_log_names_missing_image",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestWorktreeLifecycle::test_build_old_does_not_remove_worktree",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseHappyPath::test_records_alias_swaps_and_indices_state",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseHappyPath::test_no_reindex_needed_still_passes",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseFailures::test_nonzero_exit_marks_failed",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseFailures::test_alias_swap_failure_in_log_marks_failed",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseTimeout::test_timeout_kills_process_and_returns_failed",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseImageTag::test_passes_new_image_tag_via_compose_env",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestTokenServiceSecretsInComposeEnv::test_compose_env_includes_token_service_keys",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_nonblocking.TestUpgradeNonBlockingPhase::test_compose_env_includes_token_service_keys",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_nonblocking.TestUpgradeNonBlockingPhase::test_capture_result_skipped_when_mysql_returns_none",
+    "duration": "0.002s"
   },
   {
     "testId": "tests.structured_properties.test_structured_properties::test_structured_properties_yaml_load_with_bad_entity_type",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_int_when_present",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_none_when_field_absent",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestCountAspectsBySchemaVersion::test_returns_empty_when_no_rows",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestFindUpgradeResultWithField::test_skips_malformed_metadata",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestDumpZduAspectsCsv::test_returns_csv_with_header_and_rows",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestDumpZduAspectsCsv::test_returns_only_header_when_no_rows",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestAllChecksPass::test_passes_when_stack_up_token_set_and_env_correct",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestAuthzBypassEnvUnset::test_fails_when_local_common_env_set_to_empty_env",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestFailurePropagation::test_nuke_failure_propagates",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestRefreshTokenSubprocess::test_writes_refreshed_token_to_config",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestRefreshTokenSubprocess::test_fails_when_subprocess_returns_nonzero",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestRefreshTokenSubprocess::test_fails_when_datahubenv_has_no_token_after_init",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_writes_bundle_on_scenario_failure",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestRollingRestartPhaseHappyPath::test_recreates_services_in_order",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestDualWriteTailG20d::test_collapsed_debug_profile_tails_gms_when_mae_absent",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestRollingRestartPhaseFailures::test_recreate_service_failure_aborts_phase",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestRollingRestartPhaseFailures::test_health_timeout_propagates",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_auth",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.openapi.v1.test_tracking::test_tracking_api_mixpanel",
+    "testId": "tests.zdu.framework.test_suite.TestSuiteEnum::test_lowercase_string_values",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[101-Suite.B]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[109-Suite.B]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[201-Suite.D]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[206-Suite.D]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[323-Suite.N]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_live_traffic_executor.TestTC501WritesPersistAtTarget::test_skips_when_snapshot_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseDefensiveErrors::test_one_index_doc_count_failure_does_not_drop_other_indices",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseUpgradeResultCheck::test_no_upgrade_id_means_no_check",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseUpgradeResultCheck::test_upgrade_id_present_sets_flag_true",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseUpgradeResultCheck::test_upgrade_id_absent_sets_flag_false",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestListIndices::test_filters_by_prefix",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestListIndices::test_empty_when_no_match",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetAliasTargets::test_returns_index_keys",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetAliasTargets::test_404_returns_empty",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetDocCount::test_returns_count",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetDocCount::test_404_returns_zero",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetDoc::test_returns_source",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetDoc::test_404_returns_none",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetDoc::test_doc_id_with_special_chars_is_double_encoded",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestSearchForEntity::test_finds_urn_in_results",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestSearchForEntity::test_missing_urn_returns_false",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetMappings::test_returns_mappings_inner_dict",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetMappings::test_404_returns_empty",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestCatEndpoints::test_cat_indices_returns_text_body",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestCatEndpoints::test_cat_aliases_returns_text_body",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestCatEndpoints::test_cat_returns_empty_string_on_error",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestListTasks::test_flattens_nodes_and_attaches_task_id",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_domain_cache_metrics_when_isolated",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_glossary_cache_metrics_when_isolated",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestSeedIOPoolViaRest::test_io_pool_seed_aspect_is_embed",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestRegisterReferencedPlatforms::test_registers_test_platform_via_ingest_mcp",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestRegisterReferencedPlatforms::test_swallows_ingest_failure",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestWaitForESDrain::test_returns_empty_when_no_es_client",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestWaitForESDrain::test_returns_empty_when_no_scenarios_have_known_alias",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestWaitForESDrain::test_returns_empty_when_all_urns_present_immediately",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestWaitForESDrain::test_returns_pending_urns_on_timeout",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseHappyPath::test_writes_n_entities_and_records_dual_write_urns",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseHappyPath::test_old_index_missing_doc_emits_warning",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseHappyPath::test_new_index_missing_doc_emits_warning",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseHappyPath::test_degenerate_single_image_case_skips_index_distinction",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseFailures::test_mysql_missing_one_urn_fails_phase",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_scenario_executor::test_register_and_dispatch",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_scenario_executor::test_double_register_raises",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_started",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_completed",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestOutputPathsAreRepoRootRelative::test_report_path_default_is_absolute",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestOutputPathsAreRepoRootRelative::test_paths_are_invariant_to_cwd",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_env_var_wins_over_datahubenv",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_falls_back_to_datahubenv_when_env_unset",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_returns_none_when_neither_source_present",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_returns_none_when_datahubenv_has_no_token_line",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_returns_none_when_token_value_is_empty",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_strips_whitespace_from_token",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_from_env_picks_up_datahubenv_token",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestUrnSyncEnabledEnvBinding::test_default_is_enabled",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestUrnSyncEnabledEnvBinding::test_explicit_zero_disables",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestUrnSyncEnabledEnvBinding::test_unrecognized_value_keeps_default",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_cleanup.TestSkipsWhenNoSnapshot::test_skips_when_prepare_old_stack_is_none",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_cleanup.TestDigestFallsBackToRestTag::test_digest_pre_test_image_uses_rest_tag",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_cleanup.TestZduArtifactFallsBackToRestTag::test_pretest_zdu_new_artifact_falls_back_to_rest_tag",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_cleanup.TestZduArtifactFallsBackToRestTag::test_pretest_zdu_old_artifact_also_falls_back",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_cleanup.TestZduArtifactFallsBackToRestTag::test_custom_rest_tag_via_constructor",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_cleanup.TestNoOpWhenAlreadyOnOriginal::test_passes_without_recreate_when_gms_already_on_original_tag",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_cleanup.TestRestoresWhenMismatched::test_recreates_with_original_tag_and_full_passthrough",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_cleanup.TestHealthCheckTimeout::test_fails_when_gms_does_not_come_back_healthy",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_cleanup.TestHealthCheckLogging::test_timeout_logs_failure",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_cleanup.TestZduSkipCleanupEnvVar::test_skip_cleanup_env_var_appends_to_skip_phases",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_cleanup.TestZduSkipCleanupEnvVar::test_no_env_var_means_cleanup_not_skipped",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestSkipsWhenDisabled::test_skips_when_prepare_old_stack_false",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestSkipsWhenTagIsDefault::test_skips_when_old_image_tag_is_debug",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestNoRestartWhenAlreadyOnOld::test_passes_without_restart_when_image_matches",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestRecreatesWhenMismatched::test_recreates_all_services_when_running_debug",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestPartialMismatch::test_recreates_only_mismatched_services",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestHealthCheckTimeout::test_returns_failed_when_health_check_times_out",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestPassthroughEnvForwarded::test_recreate_calls_include_token_service_secrets",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestSkipsAbsentServices::test_only_recreates_present_services",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestFailFastOnMissingPassthrough::test_fails_when_signing_key_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestFailFastOnMissingPassthrough::test_fails_when_both_keys_empty_string",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_invokes_gradle_bootjar_when_repo_root_found",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_opt_out_via_env_var_skips_gradle",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_idempotent_within_process",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_raises_runtime_error_on_gradle_failure",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_skips_when_repo_root_not_found",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_runs_gradle_from_repo_root_cwd",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestFindRepoRoot::test_finds_root_with_settings_gradle_and_gradlew",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestFindRepoRoot::test_returns_none_when_no_root_found",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_runtime_migration.TestRuntimeMigrationPhase::test_reads_n_seeded_entities_and_records_probes",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_runtime_migration.TestRuntimeMigrationPhase::test_writes_n_fresh_entities_and_verifies_persisted_version",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_runtime_migration.TestRuntimeMigrationPhase::test_write_probe_records_error_when_ingest_fails",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_runtime_migration.TestRuntimeMigrationPhase::test_no_seeded_entities_skips_read_probes",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_scenario_loader.TestLoadScenarios::test_load_returns_full_suite_a",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_scenario_loader.TestExecutorValidateTakesCtxAndFiltersByTc::test_validates_only_tc_specific_urns",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_scenario_loader.TestAllSuites::test_load_scenarios_returns_combined_list",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_no_opted_in_scenarios_returns_no_failures",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_all_fields_present_returns_no_failures",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_missing_field_emits_fail",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_doc_not_found_emits_fail",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_dataset_entity_type_uses_dataset_alias",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_unknown_entity_type_emits_fail",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_es_client_exception_emits_fail",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestSkipsWhenCleanBuildDisabled::test_skipped_when_clean_build_false",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestSkipsWhenOldTagIsDebug::test_skipped_when_old_tag_is_debug",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestMissingLocalCommonEnv::test_skips_authz_env_when_not_set",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestHealthCheckFailure::test_fails_when_gms_does_not_come_back",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestCleanBuildEnvVars::test_default_is_on",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_pre.TestInjectTrafficPrePhaseHappyPath::test_degenerate_single_image_case_skips_index_distinction",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_pre.TestInjectTrafficPrePhaseHappyPath::test_no_upgrade_blocking_state_skips_index_checks_entirely",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_pre.TestInjectTrafficPrePhaseFailures::test_mysql_missing_one_urn_fails_phase",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_pre.TestInjectTrafficPrePhaseFailures::test_index_distinction_failure_logs_but_does_not_fail_phase",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_pre.TestInjectTrafficPrePhaseFailures::test_partial_ingest_records_partial_gap_urns_on_failure",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_pre.TestInjectTrafficPrePhaseFailures::test_mysql_missing_records_full_ingested_list_on_failure",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_host_mounts.TestWorktreeMountEnv::test_returns_env_dict_when_all_dirs_present",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_host_mounts.TestWorktreeMountEnv::test_returns_none_when_worktree_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_host_mounts.TestWorktreeMountEnv::test_returns_none_when_any_mount_source_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_host_mounts.TestWorktreeMountEnv::test_rejects_invalid_side",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_host_mounts.TestWorktreeMountEnv::test_paths_have_trailing_slash",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_shared.TestReadTokenPassthrough::test_returns_env_when_all_keys_present",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_shared.TestReadTokenPassthrough::test_returns_empty_dict_when_get_service_env_returns_empty",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_shared.TestReadTokenPassthrough::test_warns_on_partial_keys_but_still_returns_what_was_captured",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_shared.TestReadTokenPassthrough::test_passes_purpose_into_log_message",
     "duration": "0.001s"
   },
   {
@@ -2084,7 +3108,331 @@
     "duration": "0.001s"
   },
   {
-    "testId": "tests.patch.test_dataset_patches::test_field_tags_attribution_patch[openapi_graph_client]",
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_invalid_offset_exit_code_2",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_list_filters_subcommand",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_describe_filter_subcommand",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.openapi.v1.test_tracking::test_tracking_api_mixpanel",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestShaResolution::test_resolves_short_sha_from_git_ref",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestCacheMissLogIsDiagnostic::test_first_missing_image_returns_first_missing_ref",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestMutatesConfigTags::test_run_sets_config_image_tags",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestWorktreeLifecycle::test_build_old_uses_persistent_worktree",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestRaisesOnGradleFailure::test_gradle_nonzero_returncode_raises",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestEnsureWorktree::test_existing_worktree_synced_to_ref",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestEnsureWorktree::test_dirty_worktree_refuses_to_clobber",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestEnsureWorktree::test_clean_worktree_proceeds_to_reset",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestEnsureWorktree::test_new_worktree_uses_resolved_sha_not_head_string",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestGradleTagPropertyName::test_build_old_passes_ptag_flag",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestGradleTagPropertyName::test_build_new_passes_ptag_flag",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestPostBuildImageVerification::test_raises_when_image_not_in_daemon_after_build",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestPostBuildImageVerification::test_passes_when_image_present_after_build",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestParseIndicesState::test_non_dict_alias_value_skipped",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseImageTag::test_default_new_image_tag_is_debug",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestTokenServiceSecretsInComposeEnv::test_env_overrides_includes_g20a_reindex_flags",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestTokenServiceSecretsInComposeEnv::test_env_overrides_still_includes_token_keys",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.search.test_search_projection.TestSearchProjection::test_default_query_no_projection",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestSeedIsNoop::test_seed_returns_empty",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC105MultiIndexAllReindex::test_passes_at_boundary",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_none_when_metadata_is_null",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_none_when_no_row",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_none_on_malformed_json",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_none_when_systemmetadata_is_json_null",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetAspectRaw::test_returns_dataclass",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetAspectRaw::test_returns_none_when_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestCountAspectsBySchemaVersion::test_groups_by_schema_version_with_pymysql_string_keys",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestCountAspectsBySchemaVersion::test_unparseable_string_falls_through_to_none",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetUpgradeResult::test_returns_parsed_json",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetUpgradeResult::test_returns_none_when_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetUpgradeResult::test_returns_none_on_malformed_json",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetUpgradeResult::test_returns_none_when_metadata_is_non_dict_json",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestFromEnvCredentials::test_mysql_credentials_from_env",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestFindUpgradeResultWithField::test_returns_first_match",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestFindUpgradeResultWithField::test_returns_none_when_no_match",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestFindUpgradeResultWithField::test_skips_non_dict_payload",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestUpsertAspectRaw::test_inserts_row_with_default_systemmetadata",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestUpsertAspectRaw::test_explicit_systemmetadata_passed_through",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestUpsertAspectRaw::test_commits_after_execute",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestGmsUnreachable::test_fails_when_health_endpoint_unreachable",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestTokenMissing::test_fails_when_token_none",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestTokenMissing::test_fails_when_token_empty_string",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestAuthzBypassEnvUnset::test_fails_when_local_common_env_unset",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestAuthzBypassEnvFileBroken::test_fails_when_env_file_does_not_exist",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestAuthzBypassEnvFileBroken::test_fails_when_env_file_missing_bypass_keys",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestMultipleFailuresReportedTogether::test_all_failures_collected_in_single_run",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestConditionalSkipping::test_gms_check_skipped_when_clean_build_on",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestConditionalSkipping::test_token_check_skipped_when_refresh_on",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestConditionalSkipping::test_both_defaults_on_only_authz_env_checked",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestDefaultAllSubStepsRun::test_all_three_sub_steps_called",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestCleanBuildOptOut::test_nuke_skipped_when_clean_build_false",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestRefreshTokenOptOut::test_token_refresh_skipped_when_disabled",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestFailurePropagation::test_token_refresh_failure_is_best_effort",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestRefreshTokenSubprocess::test_fails_when_cli_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_sweep_executor.TestXfailDispatch::test_expected_to_fail_returns_xfail_with_skip_reason",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_sweep_executor.TestHonestSkipDispatch::test_returns_skip_with_scenario_reason[328]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRunUpgradeJob::test_env_overrides_become_dash_e_flags",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRunUpgradeJob::test_extra_args_appended_after_service",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRunUpgradeJob::test_compose_env_sets_subprocess_env",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRunUpgradeJob::test_compose_env_does_not_become_dash_e_flag",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRunUpgradeJob::test_compose_env_none_does_not_override_parent_env",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRecreateService::test_runs_compose_up_d_with_compose_env",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRecreateService::test_no_compose_env_does_not_pass_env_kwarg",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRecreateService::test_logs_recreate_duration_before_wait_healthy",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRecreateService::test_wait_healthy_logs_duration_on_success",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRecreateService::test_failed_up_d_raises",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestGetServiceLogs::test_returns_stdout_from_docker_compose_logs",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestGetServiceLogs::test_returns_empty_string_on_failure",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestGetProjectName::test_returns_name_from_compose_config_json",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestGetProjectName::test_raises_when_compose_config_fails",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestGetProjectName::test_raises_when_output_is_not_json",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestGetProjectName::test_raises_when_name_field_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestDownAndWipeVolumeQualification::test_prepends_live_project_prefix_to_short_volume_names",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestDownAndWipeVolumeQualification::test_underscore_in_short_name_is_NOT_treated_as_qualified",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestRollingRestartPhaseHappyPath::test_no_dual_write_log_lines_yields_empty_dict",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestDualWriteTailG20d::test_both_services_present_first_timestamp_wins",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestDualWriteTailG20d::test_no_mae_no_gms_present_logs_warning_and_returns_empty",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_catchup_executor.TestSeedIsNoop::test_seed_returns_empty_list",
     "duration": "0.001s"
   }
 ]

--- a/smoke-test/smoke.sh
+++ b/smoke-test/smoke.sh
@@ -37,6 +37,66 @@ source ./set-test-env-vars.sh
 
 echo "TEST_STRATEGY: $TEST_STRATEGY, BATCH_COUNT: $BATCH_COUNT, BATCH_NUMBER: $BATCH_NUMBER"
 
+# PYTEST_XDIST_WORKERS: optional pytest-xdist worker count (nightly sets this to 3).
+# Independent of BATCH_COUNT/BATCH_NUMBER — matrix batching and xdist are orthogonal knobs.
+# --dist=loadscope groups by class (or whole module for module-level tests).
+# Policy mutators run in a second serial pytest invocation after non-mutators finish.
+xdist_args=()
+if [[ "${PYTEST_XDIST_WORKERS:-0}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "PYTEST_XDIST_WORKERS=${PYTEST_XDIST_WORKERS}: enabling pytest-xdist -n ${PYTEST_XDIST_WORKERS} --dist=loadscope"
+  xdist_args=(-n "${PYTEST_XDIST_WORKERS}" --dist=loadscope)
+fi
+
+# pytest exit 5 = no tests collected (empty phase for this batch is OK).
+_pytest_ok() {
+  local rc=$1
+  [[ "$rc" -eq 0 || "$rc" -eq 5 ]]
+}
+
+# Run non-mutator tests (optional xdist), then mutators serially.
+# Batching in conftest always sees the full module set before the phase filter,
+# so both invocations keep identical BATCH_NUMBER assignment.
+run_pytest_policy_phases() {
+  local junit_prefix=$1
+  shift
+  local extra_args=("$@")
+  local rc1=0
+  local rc2=0
+
+  echo "=========================================="
+  echo "SMOKE POLICY PHASE 1: non-mutator tests"
+  echo "=========================================="
+  set +e
+  SMOKE_POLICY_PHASE=1 pytest -rP --durations=20 -vv --continue-on-collection-errors \
+    ${xdist_args[@]+"${xdist_args[@]}"} \
+    --junit-xml="${junit_prefix}-phase1.xml" \
+    ${extra_args[@]+"${extra_args[@]}"}
+  rc1=$?
+  set -e
+  if ! _pytest_ok "$rc1"; then
+    echo "Phase 1 failed with exit code $rc1"
+  fi
+
+  echo "=========================================="
+  echo "SMOKE POLICY PHASE 2: global_policy_mutator tests (serial)"
+  echo "=========================================="
+  set +e
+  # No xdist: mutators must not run concurrently against shared policy state.
+  SMOKE_POLICY_PHASE=2 pytest -rP --durations=20 -vv --continue-on-collection-errors \
+    --reruns 1 --reruns-delay 1 \
+    --junit-xml="${junit_prefix}-phase2.xml" \
+    ${extra_args[@]+"${extra_args[@]}"}
+  rc2=$?
+  set -e
+  if ! _pytest_ok "$rc2"; then
+    echo "Phase 2 failed with exit code $rc2"
+  fi
+
+  _pytest_ok "$rc1" || return "$rc1"
+  _pytest_ok "$rc2" || return "$rc2"
+  return 0
+}
+
 # TEST_STRATEGY:
 #   if set to pytests, runs all pytests, skips cypress tests(though cypress test launch is via  a pytest).
 #   if set tp cypress, runs all cypress tests
@@ -46,13 +106,14 @@ echo "TEST_STRATEGY: $TEST_STRATEGY, BATCH_COUNT: $BATCH_COUNT, BATCH_NUMBER: $B
 # increase, the batch_count config (in docker-unified.yml) may need adjustment.
 if [[ "${TEST_STRATEGY}" == "pytests" ]]; then
   #pytests only - github test matrix runs pytests in one of the runners when applicable.
-  pytest -ra -vv --reruns 1 --reruns-delay 1 --junit-xml=junit.smoke-pytests.xml -k 'not test_run_cypress'
+  run_pytest_policy_phases junit.smoke-pytests -k 'not test_run_cypress'
 elif [[ "${TEST_STRATEGY}" == "cypress" ]]; then
   # run only cypress tests. The test inspects BATCH_COUNT and BATCH_NUMBER and runs only a subset of tests in that batch.
   # github workflow test matrix will invoke this in multiple runners for each batch.
   # Skipping the junit at the pytest level since cypress itself generates junits on a per-test basis. The pytest is a single test for all cypress
   # tests and isnt very helpful.
+  # Cypress is launched from a single pytest module; xdist is not useful here.
   pytest -rP --durations=20 -vvs --continue-on-collection-errors tests/cypress/integration_test.py
 else
-  pytest -rP --durations=20 -vvs --continue-on-collection-errors --junit-xml=junit.smoke-all.xml
+  run_pytest_policy_phases junit.smoke-all
 fi

--- a/smoke-test/test_authentication_e2e.py
+++ b/smoke-test/test_authentication_e2e.py
@@ -33,6 +33,7 @@ import pytest
 import requests
 
 from tests.privileges.utils import create_user, remove_user
+from tests.tokens.token_utils import assert_graphql_mutation_succeeded
 from tests.utils import (
     TestSessionWrapper,
     get_admin_credentials,
@@ -45,6 +46,7 @@ from tests.utils import (
 logger = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.no_cypress_suite1
+
 
 # Test constants
 restli_default_headers = {
@@ -90,7 +92,9 @@ def extract_api_token_from_session(session: TestSessionWrapper) -> Tuple[str, st
     response = session.post(f"{get_frontend_url()}/api/v2/graphql", json=json_payload)
     response.raise_for_status()
 
-    token_data = response.json()["data"]["createAccessToken"]
+    res_data = response.json()
+    assert_graphql_mutation_succeeded(res_data)
+    token_data = res_data["data"]["createAccessToken"]
     return token_data["accessToken"], token_data["metadata"]["id"]
 
 
@@ -355,10 +359,11 @@ def test_admin_endpoints_require_privileges(auth_session) -> None:
     limited_auth_email = "limited.auth.test@smoke.datahub.test"
     test_user_urn = f"urn:li:corpuser:{limited_auth_email}"
     token_id = None
+    limited_session = None
 
     try:
-        # Create limited user
-        create_user(admin_session, limited_auth_email, "testpass123")
+        # Create limited user (returns a fresh admin session after /signUp)
+        admin_session = create_user(admin_session, limited_auth_email, "testpass123")
 
         # Login as limited user and get API token
         limited_session = login_as(limited_auth_email, "testpass123")
@@ -383,7 +388,7 @@ def test_admin_endpoints_require_privileges(auth_session) -> None:
     finally:
         # Cleanup
         try:
-            if token_id:
+            if token_id and limited_session is not None:
                 revoke_api_token(limited_session, token_id)
             # Remove test user
             admin_cleanup_session = login_as(admin_user, admin_pass)

--- a/smoke-test/test_e2e.py
+++ b/smoke-test/test_e2e.py
@@ -538,6 +538,7 @@ def test_ingest_with_system_metadata(auth_session, test_run_ingestion):
                                     "email": "datahub@linkedin.com",
                                     "title": "CEO",
                                     "fullName": "DataHub",
+                                    "system": True,
                                 }
                             }
                         ],
@@ -570,6 +571,7 @@ def test_ingest_with_blank_system_metadata(auth_session):
                                     "email": "datahub@linkedin.com",
                                     "title": "CEO",
                                     "fullName": "DataHub",
+                                    "system": True,
                                 }
                             }
                         ],
@@ -599,6 +601,7 @@ def test_ingest_without_system_metadata(auth_session):
                                     "email": "datahub@linkedin.com",
                                     "title": "CEO",
                                     "fullName": "DataHub",
+                                    "system": True,
                                 }
                             }
                         ],

--- a/smoke-test/test_system_info.py
+++ b/smoke-test/test_system_info.py
@@ -4,11 +4,13 @@ import pytest
 import requests
 
 from tests.privileges.utils import create_user, remove_user
+from tests.tokens.token_utils import assert_graphql_mutation_succeeded
 from tests.utils import get_admin_credentials, get_frontend_url, get_gms_url, login_as
 
 logger = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.no_cypress_suite1
+
 
 # ==============================================
 # SYSTEM INFO API TESTS
@@ -260,7 +262,9 @@ def extract_api_token_from_session(session):
     response = session.post(f"{get_frontend_url()}/api/v2/graphql", json=json_payload)
     response.raise_for_status()
 
-    token_data = response.json()["data"]["createAccessToken"]
+    res_data = response.json()
+    assert_graphql_mutation_succeeded(res_data)
+    token_data = res_data["data"]["createAccessToken"]
     return token_data["accessToken"], token_data["metadata"]["id"]
 
 
@@ -278,10 +282,11 @@ def test_system_info_authenticated_non_admin_user_returns_403(auth_session):
     limited_test_email = "limited.test.user@smoke.datahub.test"
     test_user_urn = f"urn:li:corpuser:{limited_test_email}"
     token_id = None
+    limited_user_session = None
 
     try:
         # Create a limited-privilege user (no special privileges by default)
-        create_user(admin_session, limited_test_email, "testpass123")
+        admin_session = create_user(admin_session, limited_test_email, "testpass123")
 
         # Login as the limited user
         limited_user_session = login_as(limited_test_email, "testpass123")
@@ -325,7 +330,7 @@ def test_system_info_authenticated_non_admin_user_returns_403(auth_session):
     finally:
         # Clean up: revoke the API token and remove the test user
         try:
-            if token_id:
+            if token_id and limited_user_session is not None:
                 # Revoke the API token
                 revoke_json = {
                     "query": """mutation revokeAccessToken($tokenId: String!) {

--- a/smoke-test/tests/audit_events/audit_events_test.py
+++ b/smoke-test/tests/audit_events/audit_events_test.py
@@ -5,8 +5,15 @@ from typing import Dict, List, Set
 
 import pytest
 
-from tests.tokens.token_utils import removeUser, wait_for_user_in_list
+from tests.tokens.token_utils import (
+    assert_graphql_mutation_succeeded,
+    removeUser,
+    revoke_tokens_matching,
+    token_name_filter,
+    wait_for_no_tokens_matching,
+)
 from tests.utils import (
+    TestSessionWrapper,
     get_admin_credentials,
     get_frontend_url,
     login_as,
@@ -20,222 +27,195 @@ pytestmark = pytest.mark.no_cypress_suite1
 # Disable telemetry
 os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"
 
-(admin_user, admin_pass) = get_admin_credentials()
-# Valid email for auth.native.signUp.enforceValidEmail (Play EmailValidator).
-AUDIT_SUITE_USER_EMAIL = "audit.events.user@smoke.datahub.test"
-AUDIT_SUITE_USER_URN = f"urn:li:corpuser:{AUDIT_SUITE_USER_EMAIL}"
+DEFAULT_AUDIT_USER_PASSWORD = "user"
+
+# Valid emails for auth.native.signUp.enforceValidEmail (Play EmailValidator).
+TOKEN_AUDIT_USER_EMAIL = "audit.events.token@smoke.datahub.test"
+TOKEN_AUDIT_USER_URN = f"urn:li:corpuser:{TOKEN_AUDIT_USER_EMAIL}"
+TOKEN_AUDIT_TOKEN_NAME = "audit-token-test-token"
+
+LOGIN_AUDIT_USER_EMAIL = "audit.events.login@smoke.datahub.test"
+LOGIN_AUDIT_USER_URN = f"urn:li:corpuser:{LOGIN_AUDIT_USER_EMAIL}"
+
+SIGNUP_AUDIT_USER_EMAIL = "audit.events.signup@smoke.datahub.test"
+SIGNUP_AUDIT_USER_URN = f"urn:li:corpuser:{SIGNUP_AUDIT_USER_EMAIL}"
+
+FAILED_LOGIN_USER_EMAIL = "audit.events.failed-login@smoke.datahub.test"
+FAILED_LOGIN_USER_URN = f"urn:li:corpuser:{FAILED_LOGIN_USER_EMAIL}"
+
+AUDIT_EVENT_SEARCH_SIZE = 25
+
+
+def audit_action_started_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _provision_audit_user(
+    email: str, password: str = DEFAULT_AUDIT_USER_PASSWORD
+) -> TestSessionWrapper:
+    from tests.privileges.utils import create_user
+
+    admin_user, admin_pass = get_admin_credentials()
+    return TestSessionWrapper(
+        create_user(login_as(admin_user, admin_pass), email, password)
+    )
+
+
+def _teardown_audit_user(admin_session: TestSessionWrapper, user_urn: str) -> None:
+    res_data = removeUser(admin_session, user_urn)
+    assert res_data
+    assert "error" not in res_data
+    wait_for_writes_to_sync(auth_session=admin_session)
+    admin_session.destroy()
 
 
 @pytest.fixture()
-def auth_exclude_filter():
-    return {
-        "field": "name",
-        "condition": "EQUAL",
-        "negated": True,
-        "values": ["Test Session Token"],
-    }
-
-
-@pytest.fixture(scope="class", autouse=True)
-def custom_user_setup():
-    admin_session = login_as(admin_user, admin_pass)
+def token_audit_user(auth_session):
+    token_filter = [token_name_filter(TOKEN_AUDIT_TOKEN_NAME)]
+    wait_for_no_tokens_matching(auth_session, token_filter)
+    admin_session = _provision_audit_user(TOKEN_AUDIT_USER_EMAIL)
     try:
-        """Fixture to execute setup before and tear down after all tests are run"""
-        res_data = removeUser(admin_session, AUDIT_SUITE_USER_URN)
-        assert res_data
-        assert "error" not in res_data
-        wait_for_writes_to_sync()
-        wait_for_user_in_list(admin_session, AUDIT_SUITE_USER_EMAIL, present=False)
-
-        # Regenerate invite token (createInviteToken) so sign-up gets a fresh token.
-        get_invite_token_json = {
-            "query": """mutation createInviteToken($input: CreateInviteTokenInput!) {
-                createInviteToken(input: $input){
-                  inviteToken
-                }
-            }""",
-            "variables": {"input": {}},
-        }
-
-        get_invite_token_response = admin_session.post(
-            f"{get_frontend_url()}/api/v2/graphql", json=get_invite_token_json
-        )
-        get_invite_token_response.raise_for_status()
-        get_invite_token_res_data = get_invite_token_response.json()
-
-        assert get_invite_token_res_data
-        assert get_invite_token_res_data["data"]
-        invite_token = get_invite_token_res_data["data"]["createInviteToken"][
-            "inviteToken"
-        ]
-        assert invite_token is not None
-
-        # Pass the invite token when creating the user
-        sign_up_json = {
-            "fullName": "Test User",
-            "email": AUDIT_SUITE_USER_EMAIL,
-            "password": "user",
-            "title": "Data Engineer",
-            "inviteToken": invite_token,
-        }
-
-        sign_up_response = admin_session.post(
-            f"{get_frontend_url()}/signUp", json=sign_up_json
-        )
-        sign_up_response.raise_for_status()
-        # signUp will override the session cookie to the new user to be signed up.
-        admin_session.cookies.clear()
-        admin_session = login_as(admin_user, admin_pass)
-
-        wait_for_writes_to_sync()
-        wait_for_user_in_list(admin_session, AUDIT_SUITE_USER_EMAIL, present=True)
-        admin_session.cookies.clear()
-
-        yield
-
+        yield admin_session
     finally:
-        # Delete created user
-        admin_session = login_as(admin_user, admin_pass)
-        res_data = removeUser(admin_session, AUDIT_SUITE_USER_URN)
-        assert res_data
-        assert res_data["data"]
-        assert res_data["data"]["removeUser"] is True
-        wait_for_writes_to_sync()
-        wait_for_user_in_list(admin_session, AUDIT_SUITE_USER_EMAIL, present=False)
+        revoke_tokens_matching(auth_session, token_filter)
+        _teardown_audit_user(admin_session, TOKEN_AUDIT_USER_URN)
 
 
-@pytest.fixture(autouse=True)
-def access_token_setup(auth_session, auth_exclude_filter):
-    """Fixture to execute asserts before and after a test is run"""
-    admin_session = login_as(admin_user, admin_pass)
-
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
-    assert res_data
-    assert res_data["data"]
-
-    if res_data["data"]["listAccessTokens"]["tokens"]:
-        for metadata in res_data["data"]["listAccessTokens"]["tokens"]:
-            revokeAccessToken(admin_session, metadata["id"])
-        wait_for_writes_to_sync()
-
-    # Verify clean state after cleanup
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
-    assert res_data["data"]["listAccessTokens"]["total"] == 0
-    assert not res_data["data"]["listAccessTokens"]["tokens"]
-
-    yield
-
-    # Clean up after the test
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
-    for metadata in res_data["data"]["listAccessTokens"]["tokens"]:
-        revokeAccessToken(admin_session, metadata["id"])
-    wait_for_writes_to_sync()
+@pytest.fixture()
+def login_audit_user():
+    admin_session = _provision_audit_user(LOGIN_AUDIT_USER_EMAIL)
+    try:
+        yield admin_session
+    finally:
+        _teardown_audit_user(admin_session, LOGIN_AUDIT_USER_URN)
 
 
-def test_audit_token_events(auth_exclude_filter):
-    user_session = login_as(AUDIT_SUITE_USER_EMAIL, "user")
+@pytest.fixture()
+def signup_audit_user():
+    provision_started_ms = audit_action_started_ms()
+    admin_session = _provision_audit_user(SIGNUP_AUDIT_USER_EMAIL)
+    try:
+        wait_for_writes_to_sync(
+            consumer_group="datahub-usage-event-consumer-job-client",
+            auth_session=admin_session,
+        )
+        yield admin_session, provision_started_ms
+    finally:
+        _teardown_audit_user(admin_session, SIGNUP_AUDIT_USER_URN)
 
-    # Normal user should be able to generate token for himself.
-    res_data = generateAccessToken_v2(user_session, AUDIT_SUITE_USER_URN)
-    assert res_data
-    assert res_data["data"]
+
+@pytest.fixture()
+def failed_login_audit_user():
+    """Dedicated user so failed-login audit events are not mixed with suite logins."""
+    admin_session = _provision_audit_user(
+        FAILED_LOGIN_USER_EMAIL, DEFAULT_AUDIT_USER_PASSWORD
+    )
+    try:
+        yield admin_session
+    finally:
+        _teardown_audit_user(admin_session, FAILED_LOGIN_USER_URN)
+
+
+def test_audit_token_events(auth_session, token_audit_user):
+    user_session = login_as(TOKEN_AUDIT_USER_EMAIL, DEFAULT_AUDIT_USER_PASSWORD)
+
+    create_started_ms = audit_action_started_ms()
+    res_data = generateAccessToken_v2(
+        user_session, TOKEN_AUDIT_USER_URN, TOKEN_AUDIT_TOKEN_NAME
+    )
+    assert_graphql_mutation_succeeded(res_data)
     assert res_data["data"]["createAccessToken"]
     assert res_data["data"]["createAccessToken"]["accessToken"]
     assert (
         res_data["data"]["createAccessToken"]["metadata"]["actorUrn"]
-        == AUDIT_SUITE_USER_URN
+        == TOKEN_AUDIT_USER_URN
     )
     user_token_id = res_data["data"]["createAccessToken"]["metadata"]["id"]
-    # Sleep for eventual consistency
-    wait_for_writes_to_sync(consumer_group="datahub-usage-event-consumer-job-client")
+    token_entity_urn = f"urn:li:dataHubAccessToken:{user_token_id}"
+    wait_for_writes_to_sync(
+        consumer_group="datahub-usage-event-consumer-job-client",
+        auth_session=auth_session,
+    )
 
-    # User should be able to revoke his own token
+    revoke_started_ms = audit_action_started_ms()
     res_data = revokeAccessToken(user_session, user_token_id)
     assert res_data
     assert res_data["data"]
     assert res_data["data"]["revokeAccessToken"]
     assert res_data["data"]["revokeAccessToken"] is True
-    wait_for_writes_to_sync(consumer_group="datahub-usage-event-consumer-job-client")
+    wait_for_writes_to_sync(
+        consumer_group="datahub-usage-event-consumer-job-client",
+        auth_session=auth_session,
+    )
 
-    # Audit events for create & revoke should show
-    res_data = searchForAuditEvents(
+    create_event = wait_for_audit_event(
         user_session,
-        2,
-        [
-            "CreateAccessTokenEvent",
-            "RevokeAccessTokenEvent",
-        ],
-        [AUDIT_SUITE_USER_URN],
-        [],
+        actor_urn=TOKEN_AUDIT_USER_URN,
+        event_types=["CreateAccessTokenEvent", "RevokeAccessTokenEvent"],
+        event_type="CreateAccessTokenEvent",
+        entity_urn=token_entity_urn,
+        after_timestamp_ms=create_started_ms,
     )
-    logger.info(res_data)
-    assert res_data
-    assert res_data["usageEvents"]
-    assert len(res_data["usageEvents"]) == 2
-    assert res_data["usageEvents"][0]["eventType"] == "RevokeAccessTokenEvent"
-    assert (
-        res_data["usageEvents"][0]["entityUrn"]
-        == f"urn:li:dataHubAccessToken:{user_token_id}"
-    )
-    assert res_data["usageEvents"][1]["eventType"] == "CreateAccessTokenEvent"
-    assert (
-        res_data["usageEvents"][1]["entityUrn"]
-        == f"urn:li:dataHubAccessToken:{user_token_id}"
-    )
-
-
-def test_login_events(auth_exclude_filter):
-    user_session = login_as(AUDIT_SUITE_USER_EMAIL, "user")
-    time.sleep(10)
-
-    # Audit events for create & revoke should show
-    res_data = searchForAuditEvents(
+    revoke_event = wait_for_audit_event(
         user_session,
-        1,
-        [
-            "LogInEvent",
-        ],
-        [AUDIT_SUITE_USER_URN],
-        [],
+        actor_urn=TOKEN_AUDIT_USER_URN,
+        event_types=["CreateAccessTokenEvent", "RevokeAccessTokenEvent"],
+        event_type="RevokeAccessTokenEvent",
+        entity_urn=token_entity_urn,
+        after_timestamp_ms=revoke_started_ms,
     )
-    logger.info(res_data)
-    assert res_data
-    assert res_data["usageEvents"]
-    assert len(res_data["usageEvents"]) == 1
-    assert res_data["usageEvents"][0]["eventType"] == "LogInEvent"
-    assert res_data["usageEvents"][0]["loginSource"] == "PASSWORD_LOGIN"
+    logger.info(
+        {"createAccessTokenEvent": create_event, "revokeAccessTokenEvent": revoke_event}
+    )
+    assert revoke_event["timestamp"] > create_event["timestamp"]
+
+
+def test_login_events(auth_session, login_audit_user):
+    login_started_ms = audit_action_started_ms()
+    user_session = login_as(LOGIN_AUDIT_USER_EMAIL, DEFAULT_AUDIT_USER_PASSWORD)
+    wait_for_writes_to_sync(
+        consumer_group="datahub-usage-event-consumer-job-client",
+        auth_session=auth_session,
+    )
+
+    login_event = wait_for_audit_event(
+        user_session,
+        actor_urn=LOGIN_AUDIT_USER_URN,
+        event_types=["LogInEvent"],
+        event_type="LogInEvent",
+        login_source="PASSWORD_LOGIN",
+        after_timestamp_ms=login_started_ms,
+    )
+    logger.info({"passwordLoginEvent": login_event})
     user_session.cookies.clear()
 
 
-def test_failed_login_events(auth_exclude_filter):
+def test_failed_login_events(failed_login_audit_user):
+    admin_session = failed_login_audit_user
+    failed_login_started_ms = audit_action_started_ms()
     try:
-        user_session = login_as(AUDIT_SUITE_USER_EMAIL, "NOTMYPASSWORD")
+        login_as(FAILED_LOGIN_USER_EMAIL, "NOTMYPASSWORD")
     except Exception:
         pass
 
-    time.sleep(10)
-    user_session = login_as(admin_user, admin_pass)
-    wait_for_writes_to_sync(consumer_group="datahub-usage-event-consumer-job-client")
-
-    # Audit events for failed login should show, search for both to rule out any previous failures from any other tests
-    res_data = searchForAuditEvents(
-        user_session,
-        1,
-        ["FailedLogInEvent", "LogInEvent"],
-        [AUDIT_SUITE_USER_URN],
-        [],
+    wait_for_writes_to_sync(
+        consumer_group="datahub-usage-event-consumer-job-client",
+        auth_session=admin_session,
     )
-    logger.info(res_data)
-    assert res_data
-    assert res_data["usageEvents"]
-    assert len(res_data["usageEvents"]) == 1
-    assert res_data["usageEvents"][0]["eventType"] == "FailedLogInEvent"
-    assert res_data["usageEvents"][0]["loginSource"] == "PASSWORD_LOGIN"
-    user_session.cookies.clear()
+
+    failed_login_event = wait_for_audit_event(
+        admin_session,
+        actor_urn=FAILED_LOGIN_USER_URN,
+        event_types=["FailedLogInEvent"],
+        event_type="FailedLogInEvent",
+        login_source="PASSWORD_LOGIN",
+        after_timestamp_ms=failed_login_started_ms,
+    )
+    logger.info({"failedLoginEvent": failed_login_event})
 
 
-def test_policy_events(auth_exclude_filter):
-    user_session = login_as(admin_user, admin_pass)
+def test_policy_events(auth_session):
+    user_session = auth_session
     json = {
         "query": """mutation createPolicy($input: PolicyUpdateInput!) {\n
             createPolicy(input: $input) }""",
@@ -265,7 +245,10 @@ def test_policy_events(auth_exclude_filter):
     assert res_data["data"]
     assert res_data["data"]["createPolicy"]
 
-    wait_for_writes_to_sync(consumer_group="datahub-usage-event-consumer-job-client")
+    wait_for_writes_to_sync(
+        consumer_group="datahub-usage-event-consumer-job-client",
+        auth_session=auth_session,
+    )
 
     new_urn = res_data["data"]["createPolicy"]
 
@@ -301,7 +284,10 @@ def test_policy_events(auth_exclude_filter):
     assert res_data["data"]["updatePolicy"]
     assert res_data["data"]["updatePolicy"] == new_urn
 
-    wait_for_writes_to_sync(consumer_group="datahub-usage-event-consumer-job-client")
+    wait_for_writes_to_sync(
+        consumer_group="datahub-usage-event-consumer-job-client",
+        auth_session=auth_session,
+    )
     wait_for_audit_event_types_for_entity(
         user_session,
         new_urn,
@@ -309,11 +295,10 @@ def test_policy_events(auth_exclude_filter):
         ["CreatePolicyEvent", "UpdatePolicyEvent"],
         ["urn:li:corpuser:datahub", "urn:li:corpuser:admin"],
     )
-    user_session.cookies.clear()
 
 
-def test_ingestion_source_events(auth_exclude_filter):
-    user_session = login_as(admin_user, admin_pass)
+def test_ingestion_source_events(auth_session):
+    user_session = auth_session
     json = {
         "query": """mutation createIngestionSource($input: UpdateIngestionSourceInput!) {\n
             createIngestionSource(input: $input)\n}""",
@@ -371,7 +356,10 @@ def test_ingestion_source_events(auth_exclude_filter):
     response.raise_for_status()
     res_data = response.json()
     assert res_data["data"]["updateIngestionSource"]
-    wait_for_writes_to_sync(consumer_group="datahub-usage-event-consumer-job-client")
+    wait_for_writes_to_sync(
+        consumer_group="datahub-usage-event-consumer-job-client",
+        auth_session=auth_session,
+    )
 
     wait_for_audit_event_types_for_entity(
         user_session,
@@ -380,58 +368,55 @@ def test_ingestion_source_events(auth_exclude_filter):
         ["CreateIngestionSourceEvent", "UpdateIngestionSourceEvent"],
         ["urn:li:corpuser:datahub", "urn:li:corpuser:admin"],
     )
-    user_session.cookies.clear()
 
 
-def test_user_events(auth_exclude_filter):
-    user_session = login_as(admin_user, admin_pass)
-    wait_for_writes_to_sync(consumer_group="datahub-usage-event-consumer-job-client")
+def test_user_events(auth_session, signup_audit_user):
+    user_session = auth_session
+    _, provision_started_ms = signup_audit_user
 
-    # TODO: This feels wrong, sign up link should have the user who created the sign up link as the actor, but this
-    #       requires a fairly significant refactor that's not in scope right now
+    # TODO: sign-up link actor should be the admin who created the invite, not __datahub_system.
+    event_types = ["CreateUserEvent", "UpdateUserEvent"]
+    actor_urns = ["urn:li:corpuser:__datahub_system"]
+    aspect_names = [
+        "corpUserKey",
+        "corpUserInfo",
+        "corpUserStatus",
+        "corpUserCredentials",
+    ]
+
+    wait_for_audit_event_types_for_entity(
+        user_session,
+        SIGNUP_AUDIT_USER_URN,
+        {"CreateUserEvent", "UpdateUserEvent"},
+        event_types,
+        actor_urns,
+        aspect_names,
+        after_timestamp_ms=provision_started_ms,
+    )
+
     res_data = searchForAuditEvents(
         user_session,
-        4,
-        ["CreateUserEvent", "UpdateUserEvent"],
-        ["urn:li:corpuser:__datahub_system"],
-        ["corpUserKey", "corpUserInfo", "corpUserStatus", "corpUserCredentials"],
+        AUDIT_EVENT_SEARCH_SIZE,
+        event_types,
+        actor_urns,
+        aspect_names,
     )
-    logger.info(res_data)
-    assert len(res_data["usageEvents"]) == 4
-    assert res_data["usageEvents"][0]["eventType"] == "UpdateUserEvent"
-    assert res_data["usageEvents"][0]["entityUrn"] == AUDIT_SUITE_USER_URN
-    # Credentials and settings are in random order due to async
-    assert res_data["usageEvents"][0]["aspectName"] == "corpUserCredentials"
+    entity_events = audit_events_for_entity(
+        res_data.get("usageEvents", []),
+        SIGNUP_AUDIT_USER_URN,
+        after_timestamp_ms=provision_started_ms,
+    )
+    logger.info({"signupAuditUserEvents": entity_events})
 
-    assert res_data["usageEvents"][1]["eventType"] == "UpdateUserEvent"
-    assert res_data["usageEvents"][1]["entityUrn"] == AUDIT_SUITE_USER_URN
-    assert res_data["usageEvents"][1]["aspectName"] == "corpUserStatus"
-
-    # These get created at the same time
-    assert (
-        res_data["usageEvents"][2]["eventType"] == "UpdateUserEvent"
-        or res_data["usageEvents"][2]["eventType"] == "CreateUserEvent"
-    )
-    assert res_data["usageEvents"][2]["entityUrn"] == AUDIT_SUITE_USER_URN
-    assert (
-        res_data["usageEvents"][2]["aspectName"] == "corpUserInfo"
-        or res_data["usageEvents"][2]["aspectName"] == "corpUserKey"
-    )
-
-    assert (
-        res_data["usageEvents"][3]["eventType"] == "UpdateUserEvent"
-        or res_data["usageEvents"][3]["eventType"] == "CreateUserEvent"
-    )
-    assert res_data["usageEvents"][3]["entityUrn"] == AUDIT_SUITE_USER_URN
-    assert (
-        res_data["usageEvents"][3]["aspectName"] == "corpUserInfo"
-        or res_data["usageEvents"][3]["aspectName"] == "corpUserKey"
-    )
-    user_session.cookies.clear()
+    assert len(entity_events) >= 4
+    assert {event["aspectName"] for event in entity_events} == set(aspect_names)
+    found_types = {event["eventType"] for event in entity_events}
+    assert "CreateUserEvent" in found_types
+    assert "UpdateUserEvent" in found_types
 
 
-def test_policy_create_delete(auth_exclude_filter):
-    user_session = login_as(admin_user, admin_pass)
+def test_policy_create_delete(auth_session):
+    user_session = auth_session
     json = {
         "query": """mutation createPolicy($input: PolicyUpdateInput!) {\n
             createPolicy(input: $input) }""",
@@ -461,7 +446,10 @@ def test_policy_create_delete(auth_exclude_filter):
     assert res_data["data"]
     assert res_data["data"]["createPolicy"]
 
-    wait_for_writes_to_sync(consumer_group="datahub-usage-event-consumer-job-client")
+    wait_for_writes_to_sync(
+        consumer_group="datahub-usage-event-consumer-job-client",
+        auth_session=auth_session,
+    )
 
     new_urn = res_data["data"]["createPolicy"]
 
@@ -485,7 +473,10 @@ def test_policy_create_delete(auth_exclude_filter):
     assert res_data["data"]["deletePolicy"]
     assert res_data["data"]["deletePolicy"] == new_urn
 
-    wait_for_writes_to_sync(consumer_group="datahub-usage-event-consumer-job-client")
+    wait_for_writes_to_sync(
+        consumer_group="datahub-usage-event-consumer-job-client",
+        auth_session=auth_session,
+    )
     wait_for_audit_event_types_for_entity(
         user_session,
         new_urn,
@@ -493,10 +484,9 @@ def test_policy_create_delete(auth_exclude_filter):
         ["CreatePolicyEvent", "DeletePolicyEvent"],
         ["urn:li:corpuser:datahub", "urn:li:corpuser:admin"],
     )
-    user_session.cookies.clear()
 
 
-def generateAccessToken_v2(session, actorUrn):
+def generateAccessToken_v2(session, actorUrn, token_name: str):
     # Create new token
     json = {
         "query": """mutation createAccessToken($input: CreateAccessTokenInput!) {
@@ -516,7 +506,7 @@ def generateAccessToken_v2(session, actorUrn):
                 "type": "PERSONAL",
                 "actorUrn": actorUrn,
                 "duration": "ONE_HOUR",
-                "name": "my token",
+                "name": token_name,
             }
         },
     }
@@ -588,8 +578,92 @@ def searchForAuditEvents(
     return response.json()
 
 
-def audit_events_for_entity(events: List[Dict], entity_urn: str) -> List[Dict]:
-    return [event for event in events if event.get("entityUrn") == entity_urn]
+def filter_audit_events(
+    events: List[Dict],
+    *,
+    actor_urn: str | None = None,
+    event_type: str | None = None,
+    entity_urn: str | None = None,
+    login_source: str | None = None,
+    after_timestamp_ms: int | None = None,
+) -> List[Dict]:
+    matched: List[Dict] = []
+    for event in events:
+        if actor_urn is not None and event.get("actorUrn") != actor_urn:
+            continue
+        if event_type is not None and event.get("eventType") != event_type:
+            continue
+        if entity_urn is not None and event.get("entityUrn") != entity_urn:
+            continue
+        if login_source is not None and event.get("loginSource") != login_source:
+            continue
+        if (
+            after_timestamp_ms is not None
+            and event.get("timestamp", 0) <= after_timestamp_ms
+        ):
+            continue
+        matched.append(event)
+    return matched
+
+
+def wait_for_audit_event(
+    session,
+    *,
+    actor_urn: str,
+    event_types: List[str],
+    event_type: str,
+    entity_urn: str | None = None,
+    login_source: str | None = None,
+    after_timestamp_ms: int | None = None,
+    aspect_names: List | None = None,
+    search_size: int = AUDIT_EVENT_SEARCH_SIZE,
+    timeout_sec: int = 60,
+) -> Dict:
+    """Poll audit search for a specific actor/event after an action timestamp.
+
+    Audit search returns a recent page sorted by timestamp DESC. Under xdist the
+    newest event for an actor may still be from fixture setup, and indexing can lag
+    behind consumer lag reaching zero. Filter by actor URN plus
+    ``timestamp > after_timestamp_ms`` to target events from the current test action.
+    """
+    deadline = time.time() + timeout_sec
+    last_events: List[Dict] = []
+    last_page: List[Dict] = []
+    while time.time() < deadline:
+        res_data = searchForAuditEvents(
+            session, search_size, event_types, [actor_urn], aspect_names or []
+        )
+        last_page = res_data.get("usageEvents", [])
+        last_events = filter_audit_events(
+            last_page,
+            actor_urn=actor_urn,
+            event_type=event_type,
+            entity_urn=entity_urn,
+            login_source=login_source,
+            after_timestamp_ms=after_timestamp_ms,
+        )
+        if last_events:
+            return last_events[0]
+        time.sleep(2)
+
+    raise AssertionError(
+        f"Timed out waiting for {event_type} actor={actor_urn} "
+        f"entity={entity_urn} login_source={login_source} "
+        f"after_timestamp_ms={after_timestamp_ms}; last page: {last_page}"
+    )
+
+
+def audit_events_for_entity(
+    events: List[Dict],
+    entity_urn: str,
+    *,
+    after_timestamp_ms: int | None = None,
+) -> List[Dict]:
+    return filter_audit_events(
+        events,
+        entity_urn=entity_urn,
+        after_timestamp_ms=after_timestamp_ms,
+    )
 
 
 def assert_audit_event_types_for_entity(
@@ -608,7 +682,8 @@ def wait_for_audit_event_types_for_entity(
     actor_urns: List[str],
     aspect_names: List | None = None,
     *,
-    search_size: int = 10,
+    after_timestamp_ms: int | None = None,
+    search_size: int = AUDIT_EVENT_SEARCH_SIZE,
     timeout_sec: int = 60,
 ) -> None:
     """Poll audit search until each expected event type is indexed for entity_urn.
@@ -628,7 +703,9 @@ def wait_for_audit_event_types_for_entity(
             session, search_size, event_types, actor_urns, aspect_names or []
         )
         last_entity_events = audit_events_for_entity(
-            res_data.get("usageEvents", []), entity_urn
+            res_data.get("usageEvents", []),
+            entity_urn,
+            after_timestamp_ms=after_timestamp_ms,
         )
         found_types = {event["eventType"] for event in last_entity_events}
         if expected_types <= found_types:

--- a/smoke-test/tests/authorization/test_aspect_write_auth.py
+++ b/smoke-test/tests/authorization/test_aspect_write_auth.py
@@ -42,7 +42,7 @@ from tests.utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.global_policy_mutator]
 
 _UNIQUE = uuid.uuid4().hex[:8]
 TEST_USER_EMAIL = f"aspect.auth.test.{_UNIQUE}@smoke.datahub.test"
@@ -141,8 +141,15 @@ def _schema_metadata_with_field(field_path: str = "col1") -> SchemaMetadataClass
     )
 
 
+ASPECT_WRITE_POLICY_PREFIXES = ["Test EDIT_ENTITY", "Test MANAGE_DATA_PRODUCTS"]
+
+
 @pytest.fixture(scope="module", autouse=True)
 def auth_test_setup(graph_client, auth_session):
+    yield from _auth_test_setup_impl(graph_client, auth_session)
+
+
+def _auth_test_setup_impl(graph_client, auth_session):
     global DATA_PRODUCT_URN
     graph_client.emit_mcp(
         MetadataChangeProposalWrapper(
@@ -260,7 +267,7 @@ def auth_test_setup(graph_client, auth_session):
     wait_for_writes_to_sync()
 
     admin_session = get_frontend_session()
-    clear_polices(admin_session)
+    clear_polices(admin_session, name_prefixes=ASPECT_WRITE_POLICY_PREFIXES)
     set_base_platform_privileges_policy_status("INACTIVE", admin_session)
     set_view_dataset_sensitive_info_policy_status("INACTIVE", admin_session)
     set_view_entity_profile_privileges_policy_status("INACTIVE", admin_session)
@@ -270,7 +277,7 @@ def auth_test_setup(graph_client, auth_session):
     yield
 
     remove_user(admin_session, TEST_USER_URN)
-    clear_polices(admin_session)
+    clear_polices(admin_session, name_prefixes=ASPECT_WRITE_POLICY_PREFIXES)
     set_base_platform_privileges_policy_status("ACTIVE", admin_session)
     set_view_dataset_sensitive_info_policy_status("ACTIVE", admin_session)
     set_view_entity_profile_privileges_policy_status("ACTIVE", admin_session)
@@ -328,10 +335,39 @@ def _wait_until_data_product_rename_denied() -> None:
     )
 
 
+def _schema_field_logical_parent_payload() -> dict:
+    return {
+        "query": SET_LOGICAL_PARENT_MUTATION,
+        "variables": {
+            "input": {
+                "resourceUrn": PHYSICAL_SCHEMA_FIELD_URN,
+                "parentUrn": LOGICAL_SCHEMA_FIELD_URN,
+            }
+        },
+    }
+
+
+def _wait_until_schema_field_logical_parent_denied() -> None:
+    wait_until_graphql_auth_denied(
+        lambda: _post_graphql_as_user(
+            TEST_USER_EMAIL,
+            TEST_USER_PASSWORD,
+            _schema_field_logical_parent_payload(),
+        ),
+        description="schema field setLogicalParent denial for test user",
+    )
+
+
 def _prepare_denied_data_product_rename_tests(admin_session) -> None:
-    clear_polices(admin_session)
+    clear_polices(admin_session, name_prefixes=ASPECT_WRITE_POLICY_PREFIXES)
     wait_for_writes_to_sync()
     _wait_until_data_product_rename_denied()
+
+
+def _prepare_schema_field_denied_tests(admin_session) -> None:
+    clear_polices(admin_session, name_prefixes=ASPECT_WRITE_POLICY_PREFIXES)
+    wait_for_writes_to_sync()
+    _wait_until_schema_field_logical_parent_denied()
 
 
 def test_set_logical_parent_denied_without_edit_entity_on_target():
@@ -412,11 +448,13 @@ def test_set_logical_parent_allowed_with_edit_entity_on_target_and_parent(auth_s
 
     remove_policy(target_policy_urn, admin_session)
     remove_policy(parent_policy_urn, admin_session)
+    wait_for_writes_to_sync()
 
 
 def test_set_logical_parent_schema_field_denied_without_edit_entity_on_logical_dataset():
     """Schema field logicalParent denied when only the physical dataset is authorized."""
     admin_session = get_frontend_session()
+    _prepare_schema_field_denied_tests(admin_session)
     policy_urn = create_metadata_policy(
         admin_session,
         name=f"Test EDIT_ENTITY physical dataset only {_UNIQUE}",
@@ -427,16 +465,11 @@ def test_set_logical_parent_schema_field_denied_without_edit_entity_on_logical_d
     )
     wait_for_writes_to_sync()
 
-    payload = {
-        "query": SET_LOGICAL_PARENT_MUTATION,
-        "variables": {
-            "input": {
-                "resourceUrn": PHYSICAL_SCHEMA_FIELD_URN,
-                "parentUrn": LOGICAL_SCHEMA_FIELD_URN,
-            }
-        },
-    }
-    res = _post_graphql_as_user(TEST_USER_EMAIL, TEST_USER_PASSWORD, payload)
+    res = _post_graphql_as_user(
+        TEST_USER_EMAIL,
+        TEST_USER_PASSWORD,
+        _schema_field_logical_parent_payload(),
+    )
     _assert_graphql_auth_denied(res)
 
     remove_policy(policy_urn, admin_session)
@@ -445,6 +478,7 @@ def test_set_logical_parent_schema_field_denied_without_edit_entity_on_logical_d
 def test_set_logical_parent_schema_field_denied_without_edit_entity_on_physical_dataset():
     """Schema field logicalParent denied when only the logical dataset is authorized."""
     admin_session = get_frontend_session()
+    _prepare_schema_field_denied_tests(admin_session)
     policy_urn = create_metadata_policy(
         admin_session,
         name=f"Test EDIT_ENTITY logical dataset only {_UNIQUE}",
@@ -455,16 +489,11 @@ def test_set_logical_parent_schema_field_denied_without_edit_entity_on_physical_
     )
     wait_for_writes_to_sync()
 
-    payload = {
-        "query": SET_LOGICAL_PARENT_MUTATION,
-        "variables": {
-            "input": {
-                "resourceUrn": PHYSICAL_SCHEMA_FIELD_URN,
-                "parentUrn": LOGICAL_SCHEMA_FIELD_URN,
-            }
-        },
-    }
-    res = _post_graphql_as_user(TEST_USER_EMAIL, TEST_USER_PASSWORD, payload)
+    res = _post_graphql_as_user(
+        TEST_USER_EMAIL,
+        TEST_USER_PASSWORD,
+        _schema_field_logical_parent_payload(),
+    )
     _assert_graphql_auth_denied(res)
 
     remove_policy(policy_urn, admin_session)

--- a/smoke-test/tests/authorization/test_query_entity_read_auth.py
+++ b/smoke-test/tests/authorization/test_query_entity_read_auth.py
@@ -43,7 +43,7 @@ from tests.utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.global_policy_mutator]
 
 _UNIQUE = uuid.uuid4().hex[:8]
 TEST_USER_EMAIL = f"query.auth.test.{_UNIQUE}@smoke.datahub.test"
@@ -71,8 +71,15 @@ query entity($urn: String!) {
 """
 
 
+QUERY_AUTH_POLICY_PREFIXES = ["Test VIEW", "Test EDIT_ENTITY_QUERIES"]
+
+
 @pytest.fixture(scope="module", autouse=True)
 def query_auth_setup(graph_client, auth_session):
+    yield from _query_auth_setup_impl(graph_client, auth_session)
+
+
+def _query_auth_setup_impl(graph_client, auth_session):
     if not is_view_authorization_enabled(auth_session):
         pytest.skip(
             "VIEW_AUTHORIZATION_ENABLED is false; "
@@ -116,7 +123,7 @@ def query_auth_setup(graph_client, auth_session):
     wait_for_writes_to_sync()
 
     admin_session = get_frontend_session()
-    clear_polices(admin_session)
+    clear_polices(admin_session, name_prefixes=QUERY_AUTH_POLICY_PREFIXES)
     set_base_platform_privileges_policy_status("INACTIVE", admin_session)
     set_view_dataset_sensitive_info_policy_status("INACTIVE", admin_session)
     set_view_entity_profile_privileges_policy_status("INACTIVE", admin_session)
@@ -126,7 +133,7 @@ def query_auth_setup(graph_client, auth_session):
     yield
 
     remove_user(admin_session, TEST_USER_URN)
-    clear_polices(admin_session)
+    clear_polices(admin_session, name_prefixes=QUERY_AUTH_POLICY_PREFIXES)
     set_base_platform_privileges_policy_status("ACTIVE", admin_session)
     set_view_dataset_sensitive_info_policy_status("ACTIVE", admin_session)
     set_view_entity_profile_privileges_policy_status("ACTIVE", admin_session)

--- a/smoke-test/tests/consistency_utils.py
+++ b/smoke-test/tests/consistency_utils.py
@@ -1,7 +1,7 @@
 import logging
 import subprocess
 import time
-from typing import List, Optional
+from typing import List, Optional, Protocol
 
 import requests
 
@@ -24,6 +24,10 @@ _MESSAGING_LAG_ENDPOINTS = {
 }
 
 
+class _AuthenticatedSession(Protocol):
+    def get(self, url: str, **kwargs: object) -> requests.Response: ...
+
+
 def _get_gms_url() -> str:
     return env_vars.get_gms_url() or "http://localhost:8080"
 
@@ -40,10 +44,17 @@ def _request_headers() -> dict:
     return headers
 
 
-def _fetch_lag_envelope(gms_url: str, endpoint: str) -> Optional[dict]:
+def _fetch_lag_envelope(
+    gms_url: str,
+    endpoint: str,
+    auth_session: Optional[_AuthenticatedSession] = None,
+) -> Optional[dict]:
     url = f"{gms_url}{endpoint}?skipCache=true"
     try:
-        resp = requests.get(url, headers=_request_headers(), timeout=5)
+        if auth_session is not None:
+            resp = auth_session.get(url, timeout=5)
+        else:
+            resp = requests.get(url, headers=_request_headers(), timeout=5)
         resp.raise_for_status()
         return resp.json()
     except Exception as e:
@@ -82,10 +93,13 @@ def _sum_lag_from_envelope(
 
 
 def _get_total_lag(
-    gms_url: str, endpoint: str, consumer_group: Optional[str] = None
+    gms_url: str,
+    endpoint: str,
+    consumer_group: Optional[str] = None,
+    auth_session: Optional[_AuthenticatedSession] = None,
 ) -> Optional[int]:
     """Fetch total lag from a GMS messaging consumer lag endpoint."""
-    data = _fetch_lag_envelope(gms_url, endpoint)
+    data = _fetch_lag_envelope(gms_url, endpoint, auth_session)
     if data is None:
         return None
     lag, _group_found = _sum_lag_from_envelope(data, consumer_group)
@@ -104,13 +118,15 @@ def _endpoints_for_consumer_group(consumer_group: str) -> List[str]:
     return ["mcp", "mcl", "mcl_timeseries", "usage_events"]
 
 
-def _get_messaging_transport(gms_url: str) -> Optional[str]:
+def _get_messaging_transport(
+    gms_url: str, auth_session: Optional[_AuthenticatedSession] = None
+) -> Optional[str]:
     try:
-        resp = requests.get(
-            f"{gms_url}/openapi/operations/messaging/transport",
-            headers=_request_headers(),
-            timeout=5,
-        )
+        url = f"{gms_url}/openapi/operations/messaging/transport"
+        if auth_session is not None:
+            resp = auth_session.get(url, timeout=5)
+        else:
+            resp = requests.get(url, headers=_request_headers(), timeout=5)
         resp.raise_for_status()
         return resp.json().get("transport")
     except Exception as e:
@@ -119,7 +135,10 @@ def _get_messaging_transport(gms_url: str) -> Optional[str]:
 
 
 def _get_consumer_lag(
-    gms_url: str, consumers: List[str], consumer_group: Optional[str] = None
+    gms_url: str,
+    consumers: List[str],
+    consumer_group: Optional[str] = None,
+    auth_session: Optional[_AuthenticatedSession] = None,
 ) -> tuple[Optional[int], bool, bool]:
     """Get combined lag across endpoints.
 
@@ -132,7 +151,7 @@ def _get_consumer_lag(
         endpoint = _MESSAGING_LAG_ENDPOINTS.get(consumer)
         if not endpoint:
             continue
-        data = _fetch_lag_envelope(gms_url, endpoint)
+        data = _fetch_lag_envelope(gms_url, endpoint, auth_session)
         if data is None:
             continue
         api_available = True
@@ -165,7 +184,9 @@ def _infer_kafka_broker_container() -> str:
 
 
 def _wait_for_kafka_consumer_group_lag(
-    consumer_group: str, max_timeout_in_sec: int
+    consumer_group: str,
+    max_timeout_in_sec: int,
+    topic: Optional[str] = None,
 ) -> bool:
     """Poll kafka-consumer-groups for a single consumer group (Kafka transport fallback)."""
     kafka_bootstrap = env_vars.get_kafka_bootstrap_server()
@@ -177,27 +198,43 @@ def _wait_for_kafka_consumer_group_lag(
 
     while (time.time() - start_time) < max_timeout_in_sec:
         time.sleep(1)
-        cmd = (
-            f"docker exec {broker_container} /bin/kafka-consumer-groups "
-            f"--bootstrap-server {kafka_bootstrap} --group '{consumer_group}' --describe "
-            "| grep -v LAG | awk '{print $6}'"
-        )
+        cmd = [
+            "docker",
+            "exec",
+            broker_container,
+            "/bin/kafka-consumer-groups",
+            "--bootstrap-server",
+            kafka_bootstrap,
+            "--group",
+            consumer_group,
+            "--describe",
+        ]
         try:
             completed_process = subprocess.run(
                 cmd,
                 capture_output=True,
-                shell=True,
                 text=True,
                 check=False,
             )
-            lines = [
-                int(line)
-                for line in str(completed_process.stdout).splitlines()
-                if line.strip() != ""
-            ]
-            if not lines:
+            if completed_process.returncode != 0:
+                logger.warning(
+                    "Kafka lag command failed for consumer group %s: %s",
+                    consumer_group,
+                    completed_process.stderr.strip(),
+                )
+                return False
+
+            lag_values = []
+            for line in completed_process.stdout.splitlines():
+                columns = line.split()
+                if (
+                    len(columns) >= 6
+                    and columns[0] != "GROUP"
+                    and (topic is None or columns[1] == topic)
+                ):
+                    lag_values.append(int(columns[5]))
+            if not lag_values:
                 continue
-            lag_values = lines
             if max(lag_values) == 0:
                 logger.info(
                     "Kafka consumer group %s lag reached zero via broker CLI",
@@ -206,7 +243,9 @@ def _wait_for_kafka_consumer_group_lag(
                 return True
         except ValueError:
             logger.warning(
-                "Error reading kafka lag using command: %s", cmd, exc_info=True
+                "Error reading Kafka lag for consumer group %s",
+                consumer_group,
+                exc_info=True,
             )
 
     logger.warning(
@@ -223,6 +262,7 @@ def wait_for_writes_to_sync(
     mae_only: bool = False,
     cdc_only: bool = False,
     consumer_group: str | None = None,
+    auth_session: Optional[_AuthenticatedSession] = None,
 ) -> None:
     """Wait for consumer lag to reach zero using the GMS messaging operations API.
 
@@ -240,6 +280,7 @@ def wait_for_writes_to_sync(
             ``datahub-usage-event-consumer-job-client`` for audit-event indexing).
             Falls back to ``kafka-consumer-groups`` when the group is not exposed
             via the messaging lag API (Kafka usage-event consumer).
+        auth_session: Base authenticated test session used for GMS operations.
     """
     if env_vars.get_use_static_sleep():
         time.sleep(ELASTICSEARCH_REFRESH_INTERVAL_SECONDS)
@@ -258,9 +299,13 @@ def wait_for_writes_to_sync(
 
     # Usage events on Kafka are not exposed via trace readers; use broker CLI lag.
     if consumer_group == _USAGE_EVENT_CONSUMER_GROUP:
-        transport = _get_messaging_transport(gms_url)
+        transport = _get_messaging_transport(gms_url, auth_session)
         if transport == "kafka":
-            _wait_for_kafka_consumer_group_lag(consumer_group, max_timeout_in_sec)
+            _wait_for_kafka_consumer_group_lag(
+                consumer_group,
+                max_timeout_in_sec,
+                topic=env_vars.get_datahub_usage_event_topic(),
+            )
             time.sleep(ELASTICSEARCH_REFRESH_INTERVAL_SECONDS)
             return
 
@@ -273,7 +318,7 @@ def wait_for_writes_to_sync(
         time.sleep(1)
 
         lag, group_found, api_available = _get_consumer_lag(
-            gms_url, consumers, consumer_group
+            gms_url, consumers, consumer_group, auth_session
         )
         if (
             consumer_group
@@ -282,6 +327,11 @@ def wait_for_writes_to_sync(
             and _wait_for_kafka_consumer_group_lag(
                 consumer_group,
                 max(1, int(max_timeout_in_sec - (time.time() - start_time))),
+                topic=(
+                    env_vars.get_datahub_usage_event_topic()
+                    if consumer_group == _USAGE_EVENT_CONSUMER_GROUP
+                    else None
+                ),
             )
         ):
             used_kafka_fallback = True

--- a/smoke-test/tests/knowledge/document_test.py
+++ b/smoke-test/tests/knowledge/document_test.py
@@ -43,1442 +43,1441 @@ def _unique_id(prefix: str) -> str:
     return f"{prefix}-{uuid.uuid4().hex[:8]}"
 
 
-@pytest.mark.dependency()
-def test_create_document(auth_session):
-    document_id = _unique_id("smoke-doc-create")
+class TestDocumentCrudAndMutations:
+    def test_create_document(self, auth_session):
+        document_id = _unique_id("smoke-doc-create")
 
-    create_mutation = """
-        mutation CreateKA($input: CreateDocumentInput!) {
-          createDocument(input: $input)
-        }
-    """
-
-    variables = {
-        "input": {
-            "id": document_id,
-            "subType": "how-to",
-            "title": f"Smoke Create {document_id}",
-            "contents": {"text": "Initial content"},
-        }
-    }
-
-    result = execute_graphql(auth_session, create_mutation, variables)
-    assert "errors" not in result, f"GraphQL errors: {result.get('errors')}"
-    urn = result["data"]["createDocument"]
-    assert urn.startswith("urn:li:document:"), f"Unexpected URN: {urn}"
-
-    # Cleanup
-    delete_mutation = """
-        mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
-    """
-    del_res = execute_graphql(auth_session, delete_mutation, {"urn": urn})
-    assert del_res["data"]["deleteDocument"] is True
-
-
-@pytest.mark.dependency()
-def test_get_document(auth_session):
-    document_id = _unique_id("smoke-doc-get")
-
-    # Create
-    create_mutation = """
-        mutation CreateKA($input: CreateDocumentInput!) {
-          createDocument(input: $input)
-        }
-    """
-    variables = {
-        "input": {
-            "id": document_id,
-            "subType": "reference",
-            "title": f"Smoke Get {document_id}",
-            "contents": {"text": "Get content"},
-        }
-    }
-    create_res = execute_graphql(auth_session, create_mutation, variables)
-    urn = create_res["data"]["createDocument"]
-
-    get_query = """
-        query GetKA($urn: String!) {
-          document(urn: $urn) {
-            urn
-            type
-            subType
-            info {
-              title
-              source {
-                sourceType
-              }
-              status { state }
-              contents { text }
-              created { time actor { urn } }
-              lastModified { time actor { urn } }
-              relatedAssets { asset { urn } }
-              relatedDocuments { document { urn } }
-              parentDocument { document { urn } }
+        create_mutation = """
+            mutation CreateKA($input: CreateDocumentInput!) {
+              createDocument(input: $input)
             }
-          }
-        }
-    """
-    get_res = execute_graphql(auth_session, get_query, {"urn": urn})
-    assert "errors" not in get_res, f"GraphQL errors: {get_res.get('errors')}"
-    ka = get_res["data"]["document"]
-    assert ka and ka["urn"] == urn
-    assert ka["subType"] == "reference"
-    assert ka["info"]["title"].startswith("Smoke Get ")
-    # Verify source is automatically set to NATIVE (users can't set this via API)
-    # Note: This requires the backend to be restarted with the updated code
-    if ka["info"]["source"] is not None:
-        assert ka["info"]["source"]["sourceType"] == "NATIVE"
-    assert ka["info"]["contents"]["text"] == "Get content"
-    assert ka["info"]["status"]["state"] == "UNPUBLISHED"  # Default state
-    assert ka["info"]["created"]["time"] > 0
-    assert ka["info"]["lastModified"]["time"] > 0
+        """
 
-    # Cleanup
-    delete_mutation = """
-        mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
-    """
-    del_res = execute_graphql(auth_session, delete_mutation, {"urn": urn})
-    assert del_res["data"]["deleteDocument"] is True
-
-
-@pytest.mark.dependency()
-def test_update_document_contents(auth_session):
-    document_id = _unique_id("smoke-doc-update")
-
-    # Create
-    create_mutation = """
-        mutation CreateKA($input: CreateDocumentInput!) {
-          createDocument(input: $input)
-        }
-    """
-    variables = {
-        "input": {
-            "id": document_id,
-            "subType": "guide",
-            "title": f"Smoke Update {document_id}",
-            "contents": {"text": "Old content"},
-        }
-    }
-    create_res = execute_graphql(auth_session, create_mutation, variables)
-    urn = create_res["data"]["createDocument"]
-
-    # Update contents
-    update_mutation = """
-        mutation UpdateKA($input: UpdateDocumentContentsInput!) {
-          updateDocumentContents(input: $input)
-        }
-    """
-    update_vars = {
-        "input": {
-            "urn": urn,
-            "title": f"Smoke Updated {document_id}",
-            "contents": {"text": "New content"},
-        }
-    }
-    update_res = execute_graphql(auth_session, update_mutation, update_vars)
-    assert update_res["data"]["updateDocumentContents"] is True
-
-    wait_for_writes_to_sync()
-
-    # Verify update and that lastModified changed
-    get_query = """
-        query GetKA($urn: String!) {
-          document(urn: $urn) {
-            urn
-            info {
-              title
-              contents { text }
-              created { time }
-              lastModified { time actor { urn } }
+        variables = {
+            "input": {
+                "id": document_id,
+                "subType": "how-to",
+                "title": f"Smoke Create {document_id}",
+                "contents": {"text": "Initial content"},
             }
-          }
         }
-    """
-    get_res = execute_graphql(auth_session, get_query, {"urn": urn})
-    info = get_res["data"]["document"]["info"]
-    assert info["title"].startswith("Smoke Updated ")
-    assert info["contents"]["text"] == "New content"
-    # lastModified should be >= created (and typically later after an update)
-    assert info["lastModified"]["time"] >= info["created"]["time"]
 
-    # Cleanup
-    delete_mutation = """
-        mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
-    """
-    del_res = execute_graphql(auth_session, delete_mutation, {"urn": urn})
-    assert del_res["data"]["deleteDocument"] is True
+        result = execute_graphql(auth_session, create_mutation, variables)
+        assert "errors" not in result, f"GraphQL errors: {result.get('errors')}"
+        urn = result["data"]["createDocument"]
+        assert urn.startswith("urn:li:document:"), f"Unexpected URN: {urn}"
 
+        # Cleanup
+        delete_mutation = """
+            mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
+        """
+        del_res = execute_graphql(auth_session, delete_mutation, {"urn": urn})
+        assert del_res["data"]["deleteDocument"] is True
 
-@pytest.mark.dependency()
-def test_update_document_status(auth_session):
-    """
-    Test updating document status.
-    1. Create an document (defaults to UNPUBLISHED).
-    2. Update status to PUBLISHED.
-    3. Verify the status changed and lastModified was updated.
-    4. Clean up.
-    """
-    document_id = _unique_id("smoke-doc-status")
+    def test_get_document(self, auth_session):
+        document_id = _unique_id("smoke-doc-get")
 
-    # Create document
-    create_mutation = """
-        mutation CreateKA($input: CreateDocumentInput!) {
-          createDocument(input: $input)
-        }
-    """
-    variables = {
-        "input": {
-            "id": document_id,
-            "subType": "guide",
-            "title": f"Smoke Status {document_id}",
-            "contents": {"text": "Status test content"},
-        }
-    }
-    create_res = execute_graphql(auth_session, create_mutation, variables)
-    urn = create_res["data"]["createDocument"]
-
-    # Get initial state
-    get_query = """
-        query GetKA($urn: String!) {
-          document(urn: $urn) {
-            info {
-              status { state }
-              created { time }
-              lastModified { time }
+        # Create
+        create_mutation = """
+            mutation CreateKA($input: CreateDocumentInput!) {
+              createDocument(input: $input)
             }
-          }
+        """
+        variables = {
+            "input": {
+                "id": document_id,
+                "subType": "reference",
+                "title": f"Smoke Get {document_id}",
+                "contents": {"text": "Get content"},
+            }
         }
-    """
-    initial_res = execute_graphql(auth_session, get_query, {"urn": urn})
-    initial_info = initial_res["data"]["document"]["info"]
-    assert initial_info["status"]["state"] == "UNPUBLISHED"
-    initial_modified_time = initial_info["lastModified"]["time"]
+        create_res = execute_graphql(auth_session, create_mutation, variables)
+        urn = create_res["data"]["createDocument"]
 
-    # Small delay to ensure timestamp difference
-    time.sleep(1)
-
-    # Update status to PUBLISHED
-    update_status_mutation = """
-        mutation UpdateStatus($input: UpdateDocumentStatusInput!) {
-          updateDocumentStatus(input: $input)
-        }
-    """
-    status_vars = {"input": {"urn": urn, "state": "PUBLISHED"}}
-    status_res = execute_graphql(auth_session, update_status_mutation, status_vars)
-    assert "errors" not in status_res, f"GraphQL errors: {status_res.get('errors')}"
-    assert status_res["data"]["updateDocumentStatus"] is True
-
-    wait_for_writes_to_sync()
-
-    # Verify status changed and lastModified was updated
-    final_res = execute_graphql(auth_session, get_query, {"urn": urn})
-    final_info = final_res["data"]["document"]["info"]
-    assert final_info["status"]["state"] == "PUBLISHED"
-    # lastModified should have been updated (newer timestamp)
-    assert final_info["lastModified"]["time"] >= initial_modified_time
-
-    # Cleanup
-    delete_mutation = """
-        mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
-    """
-    del_res = execute_graphql(auth_session, delete_mutation, {"urn": urn})
-    assert del_res["data"]["deleteDocument"] is True
-
-
-@pytest.mark.dependency()
-def test_create_document_with_owners(auth_session):
-    """
-    Test creating document with custom owners.
-    1. Create an document with two owners.
-    2. Verify the document was created successfully.
-    3. Retrieve the document and verify ownership.
-    4. Clean up.
-    """
-    document_id = _unique_id("smoke-doc-owners")
-
-    # Create document with custom owners
-    create_mutation = """
-        mutation CreateKA($input: CreateDocumentInput!) {
-          createDocument(input: $input)
-        }
-    """
-    variables = {
-        "input": {
-            "id": document_id,
-            "subType": "guide",
-            "title": f"Smoke Owners {document_id}",
-            "contents": {"text": "Ownership test content"},
-            "owners": [
-                {
-                    "ownerUrn": "urn:li:corpuser:datahub",
-                    "ownerEntityType": "CORP_USER",
-                    "type": "TECHNICAL_OWNER",
+        get_query = """
+            query GetKA($urn: String!) {
+              document(urn: $urn) {
+                urn
+                type
+                subType
+                info {
+                  title
+                  source {
+                    sourceType
+                  }
+                  status { state }
+                  contents { text }
+                  created { time actor { urn } }
+                  lastModified { time actor { urn } }
+                  relatedAssets { asset { urn } }
+                  relatedDocuments { document { urn } }
+                  parentDocument { document { urn } }
                 }
-            ],
-        }
-    }
-    create_res = execute_graphql(auth_session, create_mutation, variables)
-    assert "errors" not in create_res, f"GraphQL errors: {create_res.get('errors')}"
-    urn = create_res["data"]["createDocument"]
-    assert urn.startswith("urn:li:document:")
+              }
+            }
+        """
+        get_res = execute_graphql(auth_session, get_query, {"urn": urn})
+        assert "errors" not in get_res, f"GraphQL errors: {get_res.get('errors')}"
+        ka = get_res["data"]["document"]
+        assert ka and ka["urn"] == urn
+        assert ka["subType"] == "reference"
+        assert ka["info"]["title"].startswith("Smoke Get ")
+        # Verify source is automatically set to NATIVE (users can't set this via API)
+        # Note: This requires the backend to be restarted with the updated code
+        if ka["info"]["source"] is not None:
+            assert ka["info"]["source"]["sourceType"] == "NATIVE"
+        assert ka["info"]["contents"]["text"] == "Get content"
+        assert ka["info"]["status"]["state"] == "UNPUBLISHED"  # Default state
+        assert ka["info"]["created"]["time"] > 0
+        assert ka["info"]["lastModified"]["time"] > 0
 
-    # Verify ownership was set
-    get_query = """
-        query GetKA($urn: String!) {
-          document(urn: $urn) {
-            urn
-            ownership {
-              owners {
-                owner {
-                  ... on CorpUser {
-                    urn
+        # Cleanup
+        delete_mutation = """
+            mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
+        """
+        del_res = execute_graphql(auth_session, delete_mutation, {"urn": urn})
+        assert del_res["data"]["deleteDocument"] is True
+
+    def test_update_document_contents(self, auth_session):
+        document_id = _unique_id("smoke-doc-update")
+
+        # Create
+        create_mutation = """
+            mutation CreateKA($input: CreateDocumentInput!) {
+              createDocument(input: $input)
+            }
+        """
+        variables = {
+            "input": {
+                "id": document_id,
+                "subType": "guide",
+                "title": f"Smoke Update {document_id}",
+                "contents": {"text": "Old content"},
+            }
+        }
+        create_res = execute_graphql(auth_session, create_mutation, variables)
+        urn = create_res["data"]["createDocument"]
+
+        # Update contents
+        update_mutation = """
+            mutation UpdateKA($input: UpdateDocumentContentsInput!) {
+              updateDocumentContents(input: $input)
+            }
+        """
+        update_vars = {
+            "input": {
+                "urn": urn,
+                "title": f"Smoke Updated {document_id}",
+                "contents": {"text": "New content"},
+            }
+        }
+        update_res = execute_graphql(auth_session, update_mutation, update_vars)
+        assert update_res["data"]["updateDocumentContents"] is True
+
+        wait_for_writes_to_sync()
+
+        # Verify update and that lastModified changed
+        get_query = """
+            query GetKA($urn: String!) {
+              document(urn: $urn) {
+                urn
+                info {
+                  title
+                  contents { text }
+                  created { time }
+                  lastModified { time actor { urn } }
+                }
+              }
+            }
+        """
+        get_res = execute_graphql(auth_session, get_query, {"urn": urn})
+        info = get_res["data"]["document"]["info"]
+        assert info["title"].startswith("Smoke Updated ")
+        assert info["contents"]["text"] == "New content"
+        # lastModified should be >= created (and typically later after an update)
+        assert info["lastModified"]["time"] >= info["created"]["time"]
+
+        # Cleanup
+        delete_mutation = """
+            mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
+        """
+        del_res = execute_graphql(auth_session, delete_mutation, {"urn": urn})
+        assert del_res["data"]["deleteDocument"] is True
+
+    def test_update_document_status(self, auth_session):
+        """
+        Test updating document status.
+        1. Create an document (defaults to UNPUBLISHED).
+        2. Update status to PUBLISHED.
+        3. Verify the status changed and lastModified was updated.
+        4. Clean up.
+        """
+        document_id = _unique_id("smoke-doc-status")
+
+        # Create document
+        create_mutation = """
+            mutation CreateKA($input: CreateDocumentInput!) {
+              createDocument(input: $input)
+            }
+        """
+        variables = {
+            "input": {
+                "id": document_id,
+                "subType": "guide",
+                "title": f"Smoke Status {document_id}",
+                "contents": {"text": "Status test content"},
+            }
+        }
+        create_res = execute_graphql(auth_session, create_mutation, variables)
+        urn = create_res["data"]["createDocument"]
+
+        # Get initial state
+        get_query = """
+            query GetKA($urn: String!) {
+              document(urn: $urn) {
+                info {
+                  status { state }
+                  created { time }
+                  lastModified { time }
+                }
+              }
+            }
+        """
+        initial_res = execute_graphql(auth_session, get_query, {"urn": urn})
+        initial_info = initial_res["data"]["document"]["info"]
+        assert initial_info["status"]["state"] == "UNPUBLISHED"
+        initial_modified_time = initial_info["lastModified"]["time"]
+
+        # Small delay to ensure timestamp difference
+        time.sleep(1)
+
+        # Update status to PUBLISHED
+        update_status_mutation = """
+            mutation UpdateStatus($input: UpdateDocumentStatusInput!) {
+              updateDocumentStatus(input: $input)
+            }
+        """
+        status_vars = {"input": {"urn": urn, "state": "PUBLISHED"}}
+        status_res = execute_graphql(auth_session, update_status_mutation, status_vars)
+        assert "errors" not in status_res, f"GraphQL errors: {status_res.get('errors')}"
+        assert status_res["data"]["updateDocumentStatus"] is True
+
+        wait_for_writes_to_sync()
+
+        # Verify status changed and lastModified was updated
+        final_res = execute_graphql(auth_session, get_query, {"urn": urn})
+        final_info = final_res["data"]["document"]["info"]
+        assert final_info["status"]["state"] == "PUBLISHED"
+        # lastModified should have been updated (newer timestamp)
+        assert final_info["lastModified"]["time"] >= initial_modified_time
+
+        # Cleanup
+        delete_mutation = """
+            mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
+        """
+        del_res = execute_graphql(auth_session, delete_mutation, {"urn": urn})
+        assert del_res["data"]["deleteDocument"] is True
+
+    def test_create_document_with_owners(self, auth_session):
+        """
+        Test creating document with custom owners.
+        1. Create an document with two owners.
+        2. Verify the document was created successfully.
+        3. Retrieve the document and verify ownership.
+        4. Clean up.
+        """
+        document_id = _unique_id("smoke-doc-owners")
+
+        # Create document with custom owners
+        create_mutation = """
+            mutation CreateKA($input: CreateDocumentInput!) {
+              createDocument(input: $input)
+            }
+        """
+        variables = {
+            "input": {
+                "id": document_id,
+                "subType": "guide",
+                "title": f"Smoke Owners {document_id}",
+                "contents": {"text": "Ownership test content"},
+                "owners": [
+                    {
+                        "ownerUrn": "urn:li:corpuser:datahub",
+                        "ownerEntityType": "CORP_USER",
+                        "type": "TECHNICAL_OWNER",
+                    }
+                ],
+            }
+        }
+        create_res = execute_graphql(auth_session, create_mutation, variables)
+        assert "errors" not in create_res, f"GraphQL errors: {create_res.get('errors')}"
+        urn = create_res["data"]["createDocument"]
+        assert urn.startswith("urn:li:document:")
+
+        # Verify ownership was set
+        get_query = """
+            query GetKA($urn: String!) {
+              document(urn: $urn) {
+                urn
+                ownership {
+                  owners {
+                    owner {
+                      ... on CorpUser {
+                        urn
+                      }
+                    }
+                    type
                   }
                 }
-                type
               }
             }
-          }
+        """
+        get_res = execute_graphql(auth_session, get_query, {"urn": urn})
+        assert "errors" not in get_res, f"GraphQL errors: {get_res.get('errors')}"
+        ka = get_res["data"]["document"]
+        assert ka["ownership"] is not None
+        assert len(ka["ownership"]["owners"]) >= 1
+        owner_urns = [o["owner"]["urn"] for o in ka["ownership"]["owners"]]
+        assert "urn:li:corpuser:datahub" in owner_urns
+
+        # Cleanup
+        delete_mutation = """
+            mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
+        """
+        del_res = execute_graphql(auth_session, delete_mutation, {"urn": urn})
+        assert del_res["data"]["deleteDocument"] is True
+
+    def test_search_documents(self, auth_session):
+        document_id = _unique_id("smoke-doc-search")
+        title = f"Smoke Search {document_id}"
+
+        # Create
+        create_mutation = """
+            mutation CreateKA($input: CreateDocumentInput!) {
+              createDocument(input: $input)
+            }
+        """
+        variables = {
+            "input": {
+                "id": document_id,
+                "subType": "tutorial",
+                "title": title,
+                "contents": {"text": "Searchable content"},
+            }
         }
-    """
-    get_res = execute_graphql(auth_session, get_query, {"urn": urn})
-    assert "errors" not in get_res, f"GraphQL errors: {get_res.get('errors')}"
-    ka = get_res["data"]["document"]
-    assert ka["ownership"] is not None
-    assert len(ka["ownership"]["owners"]) >= 1
-    owner_urns = [o["owner"]["urn"] for o in ka["ownership"]["owners"]]
-    assert "urn:li:corpuser:datahub" in owner_urns
+        create_res = execute_graphql(auth_session, create_mutation, variables)
+        urn = create_res["data"]["createDocument"]
 
-    # Cleanup
-    delete_mutation = """
-        mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
-    """
-    del_res = execute_graphql(auth_session, delete_mutation, {"urn": urn})
-    assert del_res["data"]["deleteDocument"] is True
+        search_query = """
+            query SearchKA($input: SearchDocumentsInput!) {
+              searchDocuments(input: $input) {
+                start
+                count
+                total
+                documents { urn info { title } }
+              }
+            }
+        """
+        # Wait for search indexing to catch up
+        time.sleep(5)
 
+        # No need to specify states - ownership filtering handles showing UNPUBLISHED docs we own
+        search_vars = {"input": {"start": 0, "count": 100}}
+        search_res = execute_graphql(auth_session, search_query, search_vars)
 
-@pytest.mark.dependency()
-def test_search_documents(auth_session):
-    document_id = _unique_id("smoke-doc-search")
-    title = f"Smoke Search {document_id}"
-
-    # Create
-    create_mutation = """
-        mutation CreateKA($input: CreateDocumentInput!) {
-          createDocument(input: $input)
-        }
-    """
-    variables = {
-        "input": {
-            "id": document_id,
-            "subType": "tutorial",
-            "title": title,
-            "contents": {"text": "Searchable content"},
-        }
-    }
-    create_res = execute_graphql(auth_session, create_mutation, variables)
-    urn = create_res["data"]["createDocument"]
-
-    search_query = """
-        query SearchKA($input: SearchDocumentsInput!) {
-          searchDocuments(input: $input) {
-            start
-            count
-            total
-            documents { urn info { title } }
-          }
-        }
-    """
-    # Wait for search indexing to catch up
-    time.sleep(5)
-
-    # No need to specify states - ownership filtering handles showing UNPUBLISHED docs we own
-    search_vars = {"input": {"start": 0, "count": 100}}
-    search_res = execute_graphql(auth_session, search_query, search_vars)
-
-    # Search can fail if index is not ready - log and skip assertion if it fails
-    if "errors" in search_res:
-        logger.info(
-            f"WARNING: Search failed (index may not be ready): {search_res.get('errors')}"
+        # Search can fail if index is not ready - log and skip assertion if it fails
+        if "errors" in search_res:
+            logger.info(
+                f"WARNING: Search failed (index may not be ready): {search_res.get('errors')}"
+            )
+            # Cleanup and return early
+            delete_mutation = """
+                mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
+            """
+            execute_graphql(auth_session, delete_mutation, {"urn": urn})
+            pytest.skip("Search index not available")
+            return
+        result = search_res["data"]["searchDocuments"]
+        assert result["total"] >= 1, (
+            f"Expected at least 1 document, got {result['total']}"
         )
-        # Cleanup and return early
+        urns = [a["urn"] for a in result["documents"]]
+        assert urn in urns, (
+            f"Expected created document {urn} in search results. Found {len(urns)} documents."
+        )
+
+        # Cleanup
+        delete_mutation = """
+            mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
+        """
+        del_res = execute_graphql(auth_session, delete_mutation, {"urn": urn})
+        assert del_res["data"]["deleteDocument"] is True
+
+    def test_move_document(self, auth_session):
+        """
+        Test moving document to a parent and then to root.
+        1. Create two documents (parent and child).
+        2. Move child to parent.
+        3. Verify parent relationship.
+        4. Move child to root (no parent).
+        5. Verify parent relationship is removed.
+        6. Clean up.
+        """
+        parent_id = _unique_id("smoke-doc-parent")
+        child_id = _unique_id("smoke-doc-child")
+
+        # Create parent document
+        create_mutation = """
+            mutation CreateKA($input: CreateDocumentInput!) {
+              createDocument(input: $input)
+            }
+        """
+        parent_vars = {
+            "input": {
+                "id": parent_id,
+                "subType": "guide",
+                "title": f"Parent {parent_id}",
+                "contents": {"text": "Parent content"},
+            }
+        }
+        parent_res = execute_graphql(auth_session, create_mutation, parent_vars)
+        parent_urn = parent_res["data"]["createDocument"]
+
+        # Create child document
+        child_vars = {
+            "input": {
+                "id": child_id,
+                "subType": "guide",
+                "title": f"Child {child_id}",
+                "contents": {"text": "Child content"},
+            }
+        }
+        child_res = execute_graphql(auth_session, create_mutation, child_vars)
+        child_urn = child_res["data"]["createDocument"]
+
+        # Move child to parent
+        move_mutation = """
+            mutation MoveDoc($input: MoveDocumentInput!) {
+              moveDocument(input: $input)
+            }
+        """
+        move_vars = {"input": {"urn": child_urn, "parentDocument": parent_urn}}
+        move_res = execute_graphql(auth_session, move_mutation, move_vars)
+        assert move_res["data"]["moveDocument"] is True
+
+        # Verify parent relationship
+        get_query = """
+            query GetDoc($urn: String!) {
+              document(urn: $urn) {
+                info {
+                  parentDocument {
+                    document {
+                      urn
+                      info { title }
+                    }
+                  }
+                }
+              }
+            }
+        """
+        get_res = execute_graphql(auth_session, get_query, {"urn": child_urn})
+        parent_doc = get_res["data"]["document"]["info"]["parentDocument"]
+        assert parent_doc is not None
+        assert parent_doc["document"]["urn"] == parent_urn
+        assert parent_doc["document"]["info"]["title"].startswith("Parent ")
+
+        # Move child to root (null parent)
+        move_to_root_vars = {"input": {"urn": child_urn, "parentDocument": None}}
+        move_root_res = execute_graphql(auth_session, move_mutation, move_to_root_vars)
+        assert move_root_res["data"]["moveDocument"] is True
+
+        # Verify parent is removed
+        get_res2 = execute_graphql(auth_session, get_query, {"urn": child_urn})
+        parent_doc2 = get_res2["data"]["document"]["info"]["parentDocument"]
+        assert parent_doc2 is None
+
+        # Cleanup
+        delete_mutation = """
+            mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
+        """
+        execute_graphql(auth_session, delete_mutation, {"urn": child_urn})
+        execute_graphql(auth_session, delete_mutation, {"urn": parent_urn})
+
+    def test_update_document_subtype(self, auth_session):
+        """
+        Test updating document sub-type.
+        1. Create a document with subType "guide".
+        2. Update sub-type to "tutorial".
+        3. Verify the change.
+        4. Clean up.
+        """
+        document_id = _unique_id("smoke-doc-subtype")
+
+        # Create document
+        create_mutation = """
+            mutation CreateKA($input: CreateDocumentInput!) {
+              createDocument(input: $input)
+            }
+        """
+        variables = {
+            "input": {
+                "id": document_id,
+                "subType": "guide",
+                "title": f"SubType Test {document_id}",
+                "contents": {"text": "SubType content"},
+            }
+        }
+        create_res = execute_graphql(auth_session, create_mutation, variables)
+        urn = create_res["data"]["createDocument"]
+
+        # Update sub-type
+        update_mutation = """
+            mutation UpdateSubType($input: UpdateDocumentSubTypeInput!) {
+              updateDocumentSubType(input: $input)
+            }
+        """
+        update_vars = {"input": {"urn": urn, "subType": "tutorial"}}
+        update_res = execute_graphql(auth_session, update_mutation, update_vars)
+        assert update_res["data"]["updateDocumentSubType"] is True
+
+        wait_for_writes_to_sync()
+
+        # Verify update
+        get_query = """
+            query GetDoc($urn: String!) {
+              document(urn: $urn) {
+                subType
+              }
+            }
+        """
+        get_res = execute_graphql(auth_session, get_query, {"urn": urn})
+        assert get_res["data"]["document"]["subType"] == "tutorial"
+
+        # Cleanup
         delete_mutation = """
             mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
         """
         execute_graphql(auth_session, delete_mutation, {"urn": urn})
-        pytest.skip("Search index not available")
-        return
-    result = search_res["data"]["searchDocuments"]
-    assert result["total"] >= 1, f"Expected at least 1 document, got {result['total']}"
-    urns = [a["urn"] for a in result["documents"]]
-    assert urn in urns, (
-        f"Expected created document {urn} in search results. Found {len(urns)} documents."
-    )
 
-    # Cleanup
-    delete_mutation = """
-        mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
-    """
-    del_res = execute_graphql(auth_session, delete_mutation, {"urn": urn})
-    assert del_res["data"]["deleteDocument"] is True
+    def test_update_related_entities(self, auth_session):
+        """
+        Test updating related entities (related assets and related documents).
+        1. Create three documents (main, related1, related2).
+        2. Update main document's related documents.
+        3. Verify the relationships via GraphQL walk.
+        4. Clean up.
+        """
+        main_id = _unique_id("smoke-doc-main")
+        related1_id = _unique_id("smoke-doc-related1")
+        related2_id = _unique_id("smoke-doc-related2")
 
+        # Create documents
+        create_mutation = """
+            mutation CreateKA($input: CreateDocumentInput!) {
+              createDocument(input: $input)
+            }
+        """
 
-@pytest.mark.dependency()
-def test_move_document(auth_session):
-    """
-    Test moving document to a parent and then to root.
-    1. Create two documents (parent and child).
-    2. Move child to parent.
-    3. Verify parent relationship.
-    4. Move child to root (no parent).
-    5. Verify parent relationship is removed.
-    6. Clean up.
-    """
-    parent_id = _unique_id("smoke-doc-parent")
-    child_id = _unique_id("smoke-doc-child")
-
-    # Create parent document
-    create_mutation = """
-        mutation CreateKA($input: CreateDocumentInput!) {
-          createDocument(input: $input)
+        main_vars = {
+            "input": {
+                "id": main_id,
+                "subType": "guide",
+                "title": f"Main {main_id}",
+                "contents": {"text": "Main content"},
+            }
         }
-    """
-    parent_vars = {
-        "input": {
-            "id": parent_id,
-            "subType": "guide",
-            "title": f"Parent {parent_id}",
-            "contents": {"text": "Parent content"},
-        }
-    }
-    parent_res = execute_graphql(auth_session, create_mutation, parent_vars)
-    parent_urn = parent_res["data"]["createDocument"]
+        main_res = execute_graphql(auth_session, create_mutation, main_vars)
+        main_urn = main_res["data"]["createDocument"]
 
-    # Create child document
-    child_vars = {
-        "input": {
-            "id": child_id,
-            "subType": "guide",
-            "title": f"Child {child_id}",
-            "contents": {"text": "Child content"},
+        related1_vars = {
+            "input": {
+                "id": related1_id,
+                "subType": "reference",
+                "title": f"Related1 {related1_id}",
+                "contents": {"text": "Related1 content"},
+            }
         }
-    }
-    child_res = execute_graphql(auth_session, create_mutation, child_vars)
-    child_urn = child_res["data"]["createDocument"]
+        related1_res = execute_graphql(auth_session, create_mutation, related1_vars)
+        related1_urn = related1_res["data"]["createDocument"]
 
-    # Move child to parent
-    move_mutation = """
-        mutation MoveDoc($input: MoveDocumentInput!) {
-          moveDocument(input: $input)
+        related2_vars = {
+            "input": {
+                "id": related2_id,
+                "subType": "reference",
+                "title": f"Related2 {related2_id}",
+                "contents": {"text": "Related2 content"},
+            }
         }
-    """
-    move_vars = {"input": {"urn": child_urn, "parentDocument": parent_urn}}
-    move_res = execute_graphql(auth_session, move_mutation, move_vars)
-    assert move_res["data"]["moveDocument"] is True
+        related2_res = execute_graphql(auth_session, create_mutation, related2_vars)
+        related2_urn = related2_res["data"]["createDocument"]
 
-    # Verify parent relationship
-    get_query = """
-        query GetDoc($urn: String!) {
-          document(urn: $urn) {
-            info {
-              parentDocument {
-                document {
+        # Update related entities
+        update_mutation = """
+            mutation UpdateRelated($input: UpdateDocumentRelatedEntitiesInput!) {
+              updateDocumentRelatedEntities(input: $input)
+            }
+        """
+        update_vars = {
+            "input": {
+                "urn": main_urn,
+                "relatedDocuments": [related1_urn, related2_urn],
+            }
+        }
+        update_res = execute_graphql(auth_session, update_mutation, update_vars)
+        assert update_res["data"]["updateDocumentRelatedEntities"] is True
+
+        wait_for_writes_to_sync()
+
+        # Verify related documents via GraphQL walk
+        get_query = """
+            query GetDoc($urn: String!) {
+              document(urn: $urn) {
+                info {
+                  relatedDocuments {
+                    document {
+                      urn
+                      info {
+                        title
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        """
+        get_res = execute_graphql(auth_session, get_query, {"urn": main_urn})
+        related_docs = get_res["data"]["document"]["info"]["relatedDocuments"]
+        assert related_docs is not None
+        assert len(related_docs) == 2
+
+        related_urns = [doc["document"]["urn"] for doc in related_docs]
+        assert related1_urn in related_urns
+        assert related2_urn in related_urns
+
+        # Verify that the related documents have resolved titles
+        for doc in related_docs:
+            assert doc["document"]["info"]["title"].startswith("Related")
+
+        # Cleanup
+        delete_mutation = """
+            mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
+        """
+        execute_graphql(auth_session, delete_mutation, {"urn": main_urn})
+        execute_graphql(auth_session, delete_mutation, {"urn": related1_urn})
+        execute_graphql(auth_session, delete_mutation, {"urn": related2_urn})
+
+
+class TestDocumentSearchAndHistory:
+    def test_change_history(self, auth_session):
+        """
+        Test that change history is created for document edits and moves.
+        1. Create a document.
+        2. Update title.
+        3. Update content.
+        4. Create parent and move document.
+        5. Query change history and verify entries exist for each change.
+        6. Clean up.
+        """
+        document_id = _unique_id("smoke-doc-history")
+        parent_id = _unique_id("smoke-doc-history-parent")
+
+        # Create document
+        create_mutation = """
+            mutation CreateKA($input: CreateDocumentInput!) {
+              createDocument(input: $input)
+            }
+        """
+        doc_vars = {
+            "input": {
+                "id": document_id,
+                "subType": "guide",
+                "title": f"History Test {document_id}",
+                "contents": {"text": "Original content"},
+            }
+        }
+        doc_res = execute_graphql(auth_session, create_mutation, doc_vars)
+        doc_urn = doc_res["data"]["createDocument"]
+
+        # Update title
+        update_contents_mutation = """
+            mutation UpdateContents($input: UpdateDocumentContentsInput!) {
+              updateDocumentContents(input: $input)
+            }
+        """
+        update_vars = {
+            "input": {
+                "urn": doc_urn,
+                "title": f"Updated Title {document_id}",
+            }
+        }
+        execute_graphql(auth_session, update_contents_mutation, update_vars)
+
+        wait_for_writes_to_sync()
+
+        # Update content
+        update_content_vars = {
+            "input": {
+                "urn": doc_urn,
+                "contents": {"text": "Updated content"},
+            }
+        }
+        execute_graphql(auth_session, update_contents_mutation, update_content_vars)
+
+        wait_for_writes_to_sync()
+
+        # Create parent and move document
+        parent_vars = {
+            "input": {
+                "id": parent_id,
+                "subType": "guide",
+                "title": f"Parent {parent_id}",
+                "contents": {"text": "Parent content"},
+            }
+        }
+        parent_res = execute_graphql(auth_session, create_mutation, parent_vars)
+        parent_urn = parent_res["data"]["createDocument"]
+
+        move_mutation = """
+            mutation MoveDoc($input: MoveDocumentInput!) {
+              moveDocument(input: $input)
+            }
+        """
+        move_vars = {"input": {"urn": doc_urn, "parentDocument": parent_urn}}
+        execute_graphql(auth_session, move_mutation, move_vars)
+
+        # Query change history
+        history_query = """
+            query GetHistory($urn: String!) {
+              document(urn: $urn) {
+                changeHistory(limit: 100) {
+                  changeType
+                  description
+                  timestamp
+                  actor { urn }
+                }
+              }
+            }
+        """
+        history_res = execute_graphql(auth_session, history_query, {"urn": doc_urn})
+        assert "errors" not in history_res, (
+            f"GraphQL errors: {history_res.get('errors')}"
+        )
+        changes = history_res["data"]["document"]["changeHistory"]
+
+        # Verify we have change entries
+        assert len(changes) > 0, "Expected at least one change history entry"
+
+        # Look for specific changes using changeType field
+        change_types = [change.get("changeType", "").upper() for change in changes]
+        descriptions = [change.get("description", "").lower() for change in changes]
+
+        # At minimum, we should see document creation
+        assert "CREATED" in change_types or any(
+            "created" in desc or "create" in desc for desc in descriptions
+        ), (
+            f"Expected 'CREATED' in change history. Got change types: {change_types}, descriptions: {descriptions}"
+        )
+
+        # Cleanup
+        delete_mutation = """
+            mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
+        """
+        execute_graphql(auth_session, delete_mutation, {"urn": doc_urn})
+        execute_graphql(auth_session, delete_mutation, {"urn": parent_urn})
+
+    def test_search_documents_with_filters(self, auth_session):
+        """
+        Test searching documents with various filters.
+        1. Create parent document and child document.
+        2. Search for documents with parentDocuments filter.
+        3. Search for root-only documents.
+        4. Search by subType filter.
+        5. Clean up.
+        """
+        parent_id = _unique_id("smoke-search-parent")
+        child_id = _unique_id("smoke-search-child")
+        root_id = _unique_id("smoke-search-root")
+
+        # Create documents
+        create_mutation = """
+            mutation CreateKA($input: CreateDocumentInput!) {
+              createDocument(input: $input)
+            }
+        """
+
+        # Parent document
+        parent_vars = {
+            "input": {
+                "id": parent_id,
+                "subType": "faq",
+                "title": f"Search Parent {parent_id}",
+                "contents": {"text": "Parent content"},
+            }
+        }
+        parent_res = execute_graphql(auth_session, create_mutation, parent_vars)
+        parent_urn = parent_res["data"]["createDocument"]
+
+        # Child document
+        child_vars = {
+            "input": {
+                "id": child_id,
+                "subType": "tutorial",
+                "title": f"Search Child {child_id}",
+                "contents": {"text": "Child content"},
+            }
+        }
+        child_res = execute_graphql(auth_session, create_mutation, child_vars)
+        child_urn = child_res["data"]["createDocument"]
+
+        # Root document
+        root_vars = {
+            "input": {
+                "id": root_id,
+                "subType": "tutorial",
+                "title": f"Search Root {root_id}",
+                "contents": {"text": "Root content"},
+            }
+        }
+        root_res = execute_graphql(auth_session, create_mutation, root_vars)
+        root_urn = root_res["data"]["createDocument"]
+
+        # Move child to parent
+        move_mutation = """
+            mutation MoveDoc($input: MoveDocumentInput!) {
+              moveDocument(input: $input)
+            }
+        """
+        move_vars = {"input": {"urn": child_urn, "parentDocument": parent_urn}}
+        execute_graphql(auth_session, move_mutation, move_vars)
+
+        # Wait for search indexing
+        time.sleep(5)
+
+        # Search by parent document filter
+        search_query = """
+            query SearchDocs($input: SearchDocumentsInput!) {
+              searchDocuments(input: $input) {
+                total
+                documents {
                   urn
                   info { title }
                 }
               }
             }
-          }
+        """
+        search_vars = {
+            "input": {
+                "start": 0,
+                "count": 100,
+                "parentDocuments": [parent_urn],
+            }
         }
-    """
-    get_res = execute_graphql(auth_session, get_query, {"urn": child_urn})
-    parent_doc = get_res["data"]["document"]["info"]["parentDocument"]
-    assert parent_doc is not None
-    assert parent_doc["document"]["urn"] == parent_urn
-    assert parent_doc["document"]["info"]["title"].startswith("Parent ")
+        search_res = execute_graphql(auth_session, search_query, search_vars)
 
-    # Move child to root (null parent)
-    move_to_root_vars = {"input": {"urn": child_urn, "parentDocument": None}}
-    move_root_res = execute_graphql(auth_session, move_mutation, move_to_root_vars)
-    assert move_root_res["data"]["moveDocument"] is True
+        # Search can fail if index is not ready
+        if "errors" in search_res:
+            logger.info(
+                f"WARNING: Search with filters failed (index may not be ready): {search_res.get('errors')}"
+            )
+            # Cleanup and return early
+            delete_mutation = """
+                mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
+            """
+            for u in [child_urn, root_urn, parent_urn]:
+                execute_graphql(auth_session, delete_mutation, {"urn": u})
+            pytest.skip("Search index not available")
+            return
 
-    # Verify parent is removed
-    get_res2 = execute_graphql(auth_session, get_query, {"urn": child_urn})
-    parent_doc2 = get_res2["data"]["document"]["info"]["parentDocument"]
-    assert parent_doc2 is None
+        result = search_res["data"]["searchDocuments"]
+        urns = [doc["urn"] for doc in result["documents"]]
+        assert child_urn in urns, "Expected child document in parent filter results"
 
-    # Cleanup
-    delete_mutation = """
-        mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
-    """
-    execute_graphql(auth_session, delete_mutation, {"urn": child_urn})
-    execute_graphql(auth_session, delete_mutation, {"urn": parent_urn})
-
-
-@pytest.mark.dependency()
-def test_update_document_subtype(auth_session):
-    """
-    Test updating document sub-type.
-    1. Create a document with subType "guide".
-    2. Update sub-type to "tutorial".
-    3. Verify the change.
-    4. Clean up.
-    """
-    document_id = _unique_id("smoke-doc-subtype")
-
-    # Create document
-    create_mutation = """
-        mutation CreateKA($input: CreateDocumentInput!) {
-          createDocument(input: $input)
+        # Search for root-only documents
+        root_search_vars = {
+            "input": {
+                "start": 0,
+                "count": 100,
+                "rootOnly": True,
+            }
         }
-    """
-    variables = {
-        "input": {
-            "id": document_id,
-            "subType": "guide",
-            "title": f"SubType Test {document_id}",
-            "contents": {"text": "SubType content"},
+        root_search_res = execute_graphql(auth_session, search_query, root_search_vars)
+        root_result = root_search_res["data"]["searchDocuments"]
+        root_urns = [doc["urn"] for doc in root_result["documents"]]
+
+        # Root and parent should be in results, but not child
+        assert root_urn in root_urns or parent_urn in root_urns, (
+            "Expected root-level documents in rootOnly results"
+        )
+
+        # Search by type filter
+        type_search_vars = {
+            "input": {
+                "start": 0,
+                "count": 100,
+                "query": "*",
+                "types": ["tutorial"],
+            }
         }
-    }
-    create_res = execute_graphql(auth_session, create_mutation, variables)
-    urn = create_res["data"]["createDocument"]
+        type_search_res = execute_graphql(auth_session, search_query, type_search_vars)
+        assert "errors" not in type_search_res, (
+            f"GraphQL errors: {type_search_res.get('errors')}"
+        )
+        type_result = type_search_res["data"]["searchDocuments"]
+        type_urns = [doc["urn"] for doc in type_result["documents"]]
 
-    # Update sub-type
-    update_mutation = """
-        mutation UpdateSubType($input: UpdateDocumentSubTypeInput!) {
-          updateDocumentSubType(input: $input)
+        # Should find our tutorial documents (child and root both have tutorial subType)
+        # Note: Type filtering may not be fully indexed yet, so we make this a soft check
+        if len(type_urns) > 0:
+            assert child_urn in type_urns or root_urn in type_urns, (
+                f"Expected tutorial documents in type filter results. "
+                f"Found {len(type_urns)} documents but neither expected URN was present."
+            )
+
+        # Cleanup
+        delete_mutation = """
+            mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
+        """
+        execute_graphql(auth_session, delete_mutation, {"urn": child_urn})
+        execute_graphql(auth_session, delete_mutation, {"urn": parent_urn})
+        execute_graphql(auth_session, delete_mutation, {"urn": root_urn})
+
+
+class TestDocumentHierarchyAndSettings:
+    def test_parent_documents_hierarchy(self, auth_session):
+        """
+        Test the parentDocuments resolver that returns the full parent hierarchy.
+        1. Create grandparent -> parent -> child hierarchy.
+        2. Query parentDocuments on child.
+        3. Verify full hierarchy is returned.
+        4. Clean up.
+        """
+        grandparent_id = _unique_id("smoke-grandparent")
+        parent_id = _unique_id("smoke-parent")
+        child_id = _unique_id("smoke-child")
+
+        # Create documents
+        create_mutation = """
+            mutation CreateKA($input: CreateDocumentInput!) {
+              createDocument(input: $input)
+            }
+        """
+
+        grandparent_vars = {
+            "input": {
+                "id": grandparent_id,
+                "subType": "guide",
+                "title": f"Grandparent {grandparent_id}",
+                "contents": {"text": "Grandparent content"},
+            }
         }
-    """
-    update_vars = {"input": {"urn": urn, "subType": "tutorial"}}
-    update_res = execute_graphql(auth_session, update_mutation, update_vars)
-    assert update_res["data"]["updateDocumentSubType"] is True
+        grandparent_res = execute_graphql(
+            auth_session, create_mutation, grandparent_vars
+        )
+        grandparent_urn = grandparent_res["data"]["createDocument"]
 
-    wait_for_writes_to_sync()
-
-    # Verify update
-    get_query = """
-        query GetDoc($urn: String!) {
-          document(urn: $urn) {
-            subType
-          }
+        parent_vars = {
+            "input": {
+                "id": parent_id,
+                "subType": "guide",
+                "title": f"Parent {parent_id}",
+                "contents": {"text": "Parent content"},
+            }
         }
-    """
-    get_res = execute_graphql(auth_session, get_query, {"urn": urn})
-    assert get_res["data"]["document"]["subType"] == "tutorial"
+        parent_res = execute_graphql(auth_session, create_mutation, parent_vars)
+        parent_urn = parent_res["data"]["createDocument"]
 
-    # Cleanup
-    delete_mutation = """
-        mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
-    """
-    execute_graphql(auth_session, delete_mutation, {"urn": urn})
-
-
-@pytest.mark.dependency()
-def test_update_related_entities(auth_session):
-    """
-    Test updating related entities (related assets and related documents).
-    1. Create three documents (main, related1, related2).
-    2. Update main document's related documents.
-    3. Verify the relationships via GraphQL walk.
-    4. Clean up.
-    """
-    main_id = _unique_id("smoke-doc-main")
-    related1_id = _unique_id("smoke-doc-related1")
-    related2_id = _unique_id("smoke-doc-related2")
-
-    # Create documents
-    create_mutation = """
-        mutation CreateKA($input: CreateDocumentInput!) {
-          createDocument(input: $input)
+        child_vars = {
+            "input": {
+                "id": child_id,
+                "subType": "guide",
+                "title": f"Child {child_id}",
+                "contents": {"text": "Child content"},
+            }
         }
-    """
+        child_res = execute_graphql(auth_session, create_mutation, child_vars)
+        child_urn = child_res["data"]["createDocument"]
 
-    main_vars = {
-        "input": {
-            "id": main_id,
-            "subType": "guide",
-            "title": f"Main {main_id}",
-            "contents": {"text": "Main content"},
+        # Build hierarchy: grandparent -> parent
+        move_mutation = """
+            mutation MoveDoc($input: MoveDocumentInput!) {
+              moveDocument(input: $input)
+            }
+        """
+        move_parent_vars = {
+            "input": {"urn": parent_urn, "parentDocument": grandparent_urn}
         }
-    }
-    main_res = execute_graphql(auth_session, create_mutation, main_vars)
-    main_urn = main_res["data"]["createDocument"]
+        execute_graphql(auth_session, move_mutation, move_parent_vars)
 
-    related1_vars = {
-        "input": {
-            "id": related1_id,
-            "subType": "reference",
-            "title": f"Related1 {related1_id}",
-            "contents": {"text": "Related1 content"},
-        }
-    }
-    related1_res = execute_graphql(auth_session, create_mutation, related1_vars)
-    related1_urn = related1_res["data"]["createDocument"]
+        # Build hierarchy: parent -> child
+        move_child_vars = {"input": {"urn": child_urn, "parentDocument": parent_urn}}
+        execute_graphql(auth_session, move_mutation, move_child_vars)
 
-    related2_vars = {
-        "input": {
-            "id": related2_id,
-            "subType": "reference",
-            "title": f"Related2 {related2_id}",
-            "contents": {"text": "Related2 content"},
-        }
-    }
-    related2_res = execute_graphql(auth_session, create_mutation, related2_vars)
-    related2_urn = related2_res["data"]["createDocument"]
-
-    # Update related entities
-    update_mutation = """
-        mutation UpdateRelated($input: UpdateDocumentRelatedEntitiesInput!) {
-          updateDocumentRelatedEntities(input: $input)
-        }
-    """
-    update_vars = {
-        "input": {
-            "urn": main_urn,
-            "relatedDocuments": [related1_urn, related2_urn],
-        }
-    }
-    update_res = execute_graphql(auth_session, update_mutation, update_vars)
-    assert update_res["data"]["updateDocumentRelatedEntities"] is True
-
-    wait_for_writes_to_sync()
-
-    # Verify related documents via GraphQL walk
-    get_query = """
-        query GetDoc($urn: String!) {
-          document(urn: $urn) {
-            info {
-              relatedDocuments {
-                document {
-                  urn
-                  info {
-                    title
+        # Query parent hierarchy
+        hierarchy_query = """
+            query GetHierarchy($urn: String!) {
+              document(urn: $urn) {
+                parentDocuments {
+                  count
+                  documents {
+                    urn
+                    info {
+                      title
+                    }
                   }
                 }
               }
             }
-          }
-        }
-    """
-    get_res = execute_graphql(auth_session, get_query, {"urn": main_urn})
-    related_docs = get_res["data"]["document"]["info"]["relatedDocuments"]
-    assert related_docs is not None
-    assert len(related_docs) == 2
-
-    related_urns = [doc["document"]["urn"] for doc in related_docs]
-    assert related1_urn in related_urns
-    assert related2_urn in related_urns
-
-    # Verify that the related documents have resolved titles
-    for doc in related_docs:
-        assert doc["document"]["info"]["title"].startswith("Related")
-
-    # Cleanup
-    delete_mutation = """
-        mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
-    """
-    execute_graphql(auth_session, delete_mutation, {"urn": main_urn})
-    execute_graphql(auth_session, delete_mutation, {"urn": related1_urn})
-    execute_graphql(auth_session, delete_mutation, {"urn": related2_urn})
-
-
-@pytest.mark.dependency()
-def test_change_history(auth_session):
-    """
-    Test that change history is created for document edits and moves.
-    1. Create a document.
-    2. Update title.
-    3. Update content.
-    4. Create parent and move document.
-    5. Query change history and verify entries exist for each change.
-    6. Clean up.
-    """
-    document_id = _unique_id("smoke-doc-history")
-    parent_id = _unique_id("smoke-doc-history-parent")
-
-    # Create document
-    create_mutation = """
-        mutation CreateKA($input: CreateDocumentInput!) {
-          createDocument(input: $input)
-        }
-    """
-    doc_vars = {
-        "input": {
-            "id": document_id,
-            "subType": "guide",
-            "title": f"History Test {document_id}",
-            "contents": {"text": "Original content"},
-        }
-    }
-    doc_res = execute_graphql(auth_session, create_mutation, doc_vars)
-    doc_urn = doc_res["data"]["createDocument"]
-
-    # Update title
-    update_contents_mutation = """
-        mutation UpdateContents($input: UpdateDocumentContentsInput!) {
-          updateDocumentContents(input: $input)
-        }
-    """
-    update_vars = {
-        "input": {
-            "urn": doc_urn,
-            "title": f"Updated Title {document_id}",
-        }
-    }
-    execute_graphql(auth_session, update_contents_mutation, update_vars)
-
-    wait_for_writes_to_sync()
-
-    # Update content
-    update_content_vars = {
-        "input": {
-            "urn": doc_urn,
-            "contents": {"text": "Updated content"},
-        }
-    }
-    execute_graphql(auth_session, update_contents_mutation, update_content_vars)
-
-    wait_for_writes_to_sync()
-
-    # Create parent and move document
-    parent_vars = {
-        "input": {
-            "id": parent_id,
-            "subType": "guide",
-            "title": f"Parent {parent_id}",
-            "contents": {"text": "Parent content"},
-        }
-    }
-    parent_res = execute_graphql(auth_session, create_mutation, parent_vars)
-    parent_urn = parent_res["data"]["createDocument"]
-
-    move_mutation = """
-        mutation MoveDoc($input: MoveDocumentInput!) {
-          moveDocument(input: $input)
-        }
-    """
-    move_vars = {"input": {"urn": doc_urn, "parentDocument": parent_urn}}
-    execute_graphql(auth_session, move_mutation, move_vars)
-
-    # Query change history
-    history_query = """
-        query GetHistory($urn: String!) {
-          document(urn: $urn) {
-            changeHistory(limit: 100) {
-              changeType
-              description
-              timestamp
-              actor { urn }
-            }
-          }
-        }
-    """
-    history_res = execute_graphql(auth_session, history_query, {"urn": doc_urn})
-    assert "errors" not in history_res, f"GraphQL errors: {history_res.get('errors')}"
-    changes = history_res["data"]["document"]["changeHistory"]
-
-    # Verify we have change entries
-    assert len(changes) > 0, "Expected at least one change history entry"
-
-    # Look for specific changes using changeType field
-    change_types = [change.get("changeType", "").upper() for change in changes]
-    descriptions = [change.get("description", "").lower() for change in changes]
-
-    # At minimum, we should see document creation
-    assert "CREATED" in change_types or any(
-        "created" in desc or "create" in desc for desc in descriptions
-    ), (
-        f"Expected 'CREATED' in change history. Got change types: {change_types}, descriptions: {descriptions}"
-    )
-
-    # Cleanup
-    delete_mutation = """
-        mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
-    """
-    execute_graphql(auth_session, delete_mutation, {"urn": doc_urn})
-    execute_graphql(auth_session, delete_mutation, {"urn": parent_urn})
-
-
-@pytest.mark.dependency()
-def test_search_documents_with_filters(auth_session):
-    """
-    Test searching documents with various filters.
-    1. Create parent document and child document.
-    2. Search for documents with parentDocuments filter.
-    3. Search for root-only documents.
-    4. Search by subType filter.
-    5. Clean up.
-    """
-    parent_id = _unique_id("smoke-search-parent")
-    child_id = _unique_id("smoke-search-child")
-    root_id = _unique_id("smoke-search-root")
-
-    # Create documents
-    create_mutation = """
-        mutation CreateKA($input: CreateDocumentInput!) {
-          createDocument(input: $input)
-        }
-    """
-
-    # Parent document
-    parent_vars = {
-        "input": {
-            "id": parent_id,
-            "subType": "faq",
-            "title": f"Search Parent {parent_id}",
-            "contents": {"text": "Parent content"},
-        }
-    }
-    parent_res = execute_graphql(auth_session, create_mutation, parent_vars)
-    parent_urn = parent_res["data"]["createDocument"]
-
-    # Child document
-    child_vars = {
-        "input": {
-            "id": child_id,
-            "subType": "tutorial",
-            "title": f"Search Child {child_id}",
-            "contents": {"text": "Child content"},
-        }
-    }
-    child_res = execute_graphql(auth_session, create_mutation, child_vars)
-    child_urn = child_res["data"]["createDocument"]
-
-    # Root document
-    root_vars = {
-        "input": {
-            "id": root_id,
-            "subType": "tutorial",
-            "title": f"Search Root {root_id}",
-            "contents": {"text": "Root content"},
-        }
-    }
-    root_res = execute_graphql(auth_session, create_mutation, root_vars)
-    root_urn = root_res["data"]["createDocument"]
-
-    # Move child to parent
-    move_mutation = """
-        mutation MoveDoc($input: MoveDocumentInput!) {
-          moveDocument(input: $input)
-        }
-    """
-    move_vars = {"input": {"urn": child_urn, "parentDocument": parent_urn}}
-    execute_graphql(auth_session, move_mutation, move_vars)
-
-    # Wait for search indexing
-    time.sleep(5)
-
-    # Search by parent document filter
-    search_query = """
-        query SearchDocs($input: SearchDocumentsInput!) {
-          searchDocuments(input: $input) {
-            total
-            documents {
-              urn
-              info { title }
-            }
-          }
-        }
-    """
-    search_vars = {
-        "input": {
-            "start": 0,
-            "count": 100,
-            "parentDocuments": [parent_urn],
-        }
-    }
-    search_res = execute_graphql(auth_session, search_query, search_vars)
-
-    # Search can fail if index is not ready
-    if "errors" in search_res:
-        logger.info(
-            f"WARNING: Search with filters failed (index may not be ready): {search_res.get('errors')}"
+        """
+        hierarchy_res = execute_graphql(
+            auth_session, hierarchy_query, {"urn": child_urn}
         )
-        # Cleanup and return early
+        assert "errors" not in hierarchy_res, (
+            f"GraphQL errors: {hierarchy_res.get('errors')}"
+        )
+        parent_docs = hierarchy_res["data"]["document"]["parentDocuments"]
+
+        assert parent_docs is not None
+        assert parent_docs["count"] >= 2, "Expected at least 2 parents in hierarchy"
+
+        parent_urns = [p["urn"] for p in parent_docs["documents"]]
+        assert parent_urn in parent_urns, "Expected direct parent in hierarchy"
+        assert grandparent_urn in parent_urns, "Expected grandparent in hierarchy"
+
+        # Cleanup
         delete_mutation = """
             mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
         """
-        for u in [child_urn, root_urn, parent_urn]:
-            execute_graphql(auth_session, delete_mutation, {"urn": u})
-        pytest.skip("Search index not available")
-        return
+        execute_graphql(auth_session, delete_mutation, {"urn": child_urn})
+        execute_graphql(auth_session, delete_mutation, {"urn": parent_urn})
+        execute_graphql(auth_session, delete_mutation, {"urn": grandparent_urn})
 
-    result = search_res["data"]["searchDocuments"]
-    urns = [doc["urn"] for doc in result["documents"]]
-    assert child_urn in urns, "Expected child document in parent filter results"
+    def test_document_settings(self, auth_session):
+        """
+        Test document settings functionality.
+        1. Create a document with default settings (showInGlobalContext=true).
+        2. Verify settings are set correctly.
+        3. Create a document with showInGlobalContext=false (private context document).
+        4. Verify settings reflect the custom value.
+        5. Update settings from false to true.
+        6. Verify the update.
+        7. Clean up.
+        """
+        public_doc_id = _unique_id("smoke-doc-public")
+        private_doc_id = _unique_id("smoke-doc-private")
 
-    # Search for root-only documents
-    root_search_vars = {
-        "input": {
-            "start": 0,
-            "count": 100,
-            "rootOnly": True,
+        # Create document with default settings (should be showInGlobalContext=true)
+        create_mutation = """
+            mutation CreateDoc($input: CreateDocumentInput!) {
+              createDocument(input: $input)
+            }
+        """
+        public_vars = {
+            "input": {
+                "id": public_doc_id,
+                "subType": "guide",
+                "title": f"Public Document {public_doc_id}",
+                "contents": {"text": "This is a public document"},
+            }
         }
-    }
-    root_search_res = execute_graphql(auth_session, search_query, root_search_vars)
-    root_result = root_search_res["data"]["searchDocuments"]
-    root_urns = [doc["urn"] for doc in root_result["documents"]]
+        public_res = execute_graphql(auth_session, create_mutation, public_vars)
+        assert "errors" not in public_res, f"GraphQL errors: {public_res.get('errors')}"
+        public_urn = public_res["data"]["createDocument"]
 
-    # Root and parent should be in results, but not child
-    assert root_urn in root_urns or parent_urn in root_urns, (
-        "Expected root-level documents in rootOnly results"
-    )
-
-    # Search by type filter
-    type_search_vars = {
-        "input": {
-            "start": 0,
-            "count": 100,
-            "query": "*",
-            "types": ["tutorial"],
-        }
-    }
-    type_search_res = execute_graphql(auth_session, search_query, type_search_vars)
-    assert "errors" not in type_search_res, (
-        f"GraphQL errors: {type_search_res.get('errors')}"
-    )
-    type_result = type_search_res["data"]["searchDocuments"]
-    type_urns = [doc["urn"] for doc in type_result["documents"]]
-
-    # Should find our tutorial documents (child and root both have tutorial subType)
-    # Note: Type filtering may not be fully indexed yet, so we make this a soft check
-    if len(type_urns) > 0:
-        assert child_urn in type_urns or root_urn in type_urns, (
-            f"Expected tutorial documents in type filter results. "
-            f"Found {len(type_urns)} documents but neither expected URN was present."
-        )
-
-    # Cleanup
-    delete_mutation = """
-        mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
-    """
-    execute_graphql(auth_session, delete_mutation, {"urn": child_urn})
-    execute_graphql(auth_session, delete_mutation, {"urn": parent_urn})
-    execute_graphql(auth_session, delete_mutation, {"urn": root_urn})
-
-
-@pytest.mark.dependency()
-def test_parent_documents_hierarchy(auth_session):
-    """
-    Test the parentDocuments resolver that returns the full parent hierarchy.
-    1. Create grandparent -> parent -> child hierarchy.
-    2. Query parentDocuments on child.
-    3. Verify full hierarchy is returned.
-    4. Clean up.
-    """
-    grandparent_id = _unique_id("smoke-grandparent")
-    parent_id = _unique_id("smoke-parent")
-    child_id = _unique_id("smoke-child")
-
-    # Create documents
-    create_mutation = """
-        mutation CreateKA($input: CreateDocumentInput!) {
-          createDocument(input: $input)
-        }
-    """
-
-    grandparent_vars = {
-        "input": {
-            "id": grandparent_id,
-            "subType": "guide",
-            "title": f"Grandparent {grandparent_id}",
-            "contents": {"text": "Grandparent content"},
-        }
-    }
-    grandparent_res = execute_graphql(auth_session, create_mutation, grandparent_vars)
-    grandparent_urn = grandparent_res["data"]["createDocument"]
-
-    parent_vars = {
-        "input": {
-            "id": parent_id,
-            "subType": "guide",
-            "title": f"Parent {parent_id}",
-            "contents": {"text": "Parent content"},
-        }
-    }
-    parent_res = execute_graphql(auth_session, create_mutation, parent_vars)
-    parent_urn = parent_res["data"]["createDocument"]
-
-    child_vars = {
-        "input": {
-            "id": child_id,
-            "subType": "guide",
-            "title": f"Child {child_id}",
-            "contents": {"text": "Child content"},
-        }
-    }
-    child_res = execute_graphql(auth_session, create_mutation, child_vars)
-    child_urn = child_res["data"]["createDocument"]
-
-    # Build hierarchy: grandparent -> parent
-    move_mutation = """
-        mutation MoveDoc($input: MoveDocumentInput!) {
-          moveDocument(input: $input)
-        }
-    """
-    move_parent_vars = {"input": {"urn": parent_urn, "parentDocument": grandparent_urn}}
-    execute_graphql(auth_session, move_mutation, move_parent_vars)
-
-    # Build hierarchy: parent -> child
-    move_child_vars = {"input": {"urn": child_urn, "parentDocument": parent_urn}}
-    execute_graphql(auth_session, move_mutation, move_child_vars)
-
-    # Query parent hierarchy
-    hierarchy_query = """
-        query GetHierarchy($urn: String!) {
-          document(urn: $urn) {
-            parentDocuments {
-              count
-              documents {
+        # Query and verify default settings
+        get_query = """
+            query GetDoc($urn: String!) {
+              document(urn: $urn) {
                 urn
-                info {
-                  title
+                settings {
+                  showInGlobalContext
                 }
               }
             }
-          }
-        }
-    """
-    hierarchy_res = execute_graphql(auth_session, hierarchy_query, {"urn": child_urn})
-    assert "errors" not in hierarchy_res, (
-        f"GraphQL errors: {hierarchy_res.get('errors')}"
-    )
-    parent_docs = hierarchy_res["data"]["document"]["parentDocuments"]
+        """
+        public_get_res = execute_graphql(auth_session, get_query, {"urn": public_urn})
+        assert "errors" not in public_get_res, (
+            f"GraphQL errors: {public_get_res.get('errors')}"
+        )
+        public_doc = public_get_res["data"]["document"]
+        assert public_doc["settings"] is not None
+        assert public_doc["settings"]["showInGlobalContext"] is True, (
+            "Expected default showInGlobalContext to be True"
+        )
 
-    assert parent_docs is not None
-    assert parent_docs["count"] >= 2, "Expected at least 2 parents in hierarchy"
-
-    parent_urns = [p["urn"] for p in parent_docs["documents"]]
-    assert parent_urn in parent_urns, "Expected direct parent in hierarchy"
-    assert grandparent_urn in parent_urns, "Expected grandparent in hierarchy"
-
-    # Cleanup
-    delete_mutation = """
-        mutation DeleteKA($urn: String!) { deleteDocument(urn: $urn) }
-    """
-    execute_graphql(auth_session, delete_mutation, {"urn": child_urn})
-    execute_graphql(auth_session, delete_mutation, {"urn": parent_urn})
-    execute_graphql(auth_session, delete_mutation, {"urn": grandparent_urn})
-
-
-@pytest.mark.dependency()
-def test_document_settings(auth_session):
-    """
-    Test document settings functionality.
-    1. Create a document with default settings (showInGlobalContext=true).
-    2. Verify settings are set correctly.
-    3. Create a document with showInGlobalContext=false (private context document).
-    4. Verify settings reflect the custom value.
-    5. Update settings from false to true.
-    6. Verify the update.
-    7. Clean up.
-    """
-    public_doc_id = _unique_id("smoke-doc-public")
-    private_doc_id = _unique_id("smoke-doc-private")
-
-    # Create document with default settings (should be showInGlobalContext=true)
-    create_mutation = """
-        mutation CreateDoc($input: CreateDocumentInput!) {
-          createDocument(input: $input)
-        }
-    """
-    public_vars = {
-        "input": {
-            "id": public_doc_id,
-            "subType": "guide",
-            "title": f"Public Document {public_doc_id}",
-            "contents": {"text": "This is a public document"},
-        }
-    }
-    public_res = execute_graphql(auth_session, create_mutation, public_vars)
-    assert "errors" not in public_res, f"GraphQL errors: {public_res.get('errors')}"
-    public_urn = public_res["data"]["createDocument"]
-
-    # Query and verify default settings
-    get_query = """
-        query GetDoc($urn: String!) {
-          document(urn: $urn) {
-            urn
-            settings {
-              showInGlobalContext
+        # Create document with showInGlobalContext=false (private context document)
+        private_vars = {
+            "input": {
+                "id": private_doc_id,
+                "subType": "guide",
+                "title": f"Private Context Document {private_doc_id}",
+                "contents": {"text": "This is a private context document"},
+                "settings": {"showInGlobalContext": False},
             }
-          }
         }
-    """
-    public_get_res = execute_graphql(auth_session, get_query, {"urn": public_urn})
-    assert "errors" not in public_get_res, (
-        f"GraphQL errors: {public_get_res.get('errors')}"
-    )
-    public_doc = public_get_res["data"]["document"]
-    assert public_doc["settings"] is not None
-    assert public_doc["settings"]["showInGlobalContext"] is True, (
-        "Expected default showInGlobalContext to be True"
-    )
+        private_res = execute_graphql(auth_session, create_mutation, private_vars)
+        assert "errors" not in private_res, (
+            f"GraphQL errors: {private_res.get('errors')}"
+        )
+        private_urn = private_res["data"]["createDocument"]
 
-    # Create document with showInGlobalContext=false (private context document)
-    private_vars = {
-        "input": {
-            "id": private_doc_id,
-            "subType": "guide",
-            "title": f"Private Context Document {private_doc_id}",
-            "contents": {"text": "This is a private context document"},
-            "settings": {"showInGlobalContext": False},
+        wait_for_writes_to_sync()
+
+        # Query and verify custom settings
+        private_get_res = execute_graphql(auth_session, get_query, {"urn": private_urn})
+        assert "errors" not in private_get_res, (
+            f"GraphQL errors: {private_get_res.get('errors')}"
+        )
+        private_doc = private_get_res["data"]["document"]
+        assert private_doc["settings"] is not None
+        assert private_doc["settings"]["showInGlobalContext"] is False, (
+            "Expected showInGlobalContext to be False for private context document"
+        )
+
+        # Update settings from false to true
+        update_settings_mutation = """
+            mutation UpdateSettings($input: UpdateDocumentSettingsInput!) {
+              updateDocumentSettings(input: $input)
+            }
+        """
+        update_vars = {"input": {"urn": private_urn, "showInGlobalContext": True}}
+        update_res = execute_graphql(
+            auth_session, update_settings_mutation, update_vars
+        )
+        assert "errors" not in update_res, f"GraphQL errors: {update_res.get('errors')}"
+        assert update_res["data"]["updateDocumentSettings"] is True
+
+        wait_for_writes_to_sync()
+
+        # Verify the update
+        updated_get_res = execute_graphql(auth_session, get_query, {"urn": private_urn})
+        assert "errors" not in updated_get_res, (
+            f"GraphQL errors: {updated_get_res.get('errors')}"
+        )
+        updated_doc = updated_get_res["data"]["document"]
+        assert updated_doc["settings"] is not None
+        assert updated_doc["settings"]["showInGlobalContext"] is True, (
+            "Expected showInGlobalContext to be updated to True"
+        )
+
+        # Cleanup
+        delete_mutation = """
+            mutation DeleteDoc($urn: String!) { deleteDocument(urn: $urn) }
+        """
+        execute_graphql(auth_session, delete_mutation, {"urn": public_urn})
+        execute_graphql(auth_session, delete_mutation, {"urn": private_urn})
+
+    def test_search_ownership_filtering(self, auth_session):
+        """
+        Test that search respects ownership filtering:
+        - PUBLISHED documents are shown to all users
+        - UNPUBLISHED documents are only shown if owned by the current user or their groups
+
+        1. Create a PUBLISHED document (should be visible in search).
+        2. Create an UNPUBLISHED document owned by current user (should be visible in search).
+        3. Publish the unpublished document and verify it appears in search.
+        4. Unpublish it and verify it still appears (because user owns it).
+        5. Clean up.
+        """
+        published_doc_id = _unique_id("smoke-search-published")
+        unpublished_doc_id = _unique_id("smoke-search-unpublished")
+
+        create_mutation = """
+            mutation CreateDoc($input: CreateDocumentInput!) {
+              createDocument(input: $input)
+            }
+        """
+
+        # Create PUBLISHED document
+        published_vars = {
+            "input": {
+                "id": published_doc_id,
+                "subType": "guide",
+                "title": f"Published Doc {published_doc_id}",
+                "contents": {"text": "Published content"},
+                "state": "PUBLISHED",
+            }
         }
-    }
-    private_res = execute_graphql(auth_session, create_mutation, private_vars)
-    assert "errors" not in private_res, f"GraphQL errors: {private_res.get('errors')}"
-    private_urn = private_res["data"]["createDocument"]
+        published_res = execute_graphql(auth_session, create_mutation, published_vars)
+        assert "errors" not in published_res, (
+            f"GraphQL errors: {published_res.get('errors')}"
+        )
+        published_urn = published_res["data"]["createDocument"]
 
-    wait_for_writes_to_sync()
-
-    # Query and verify custom settings
-    private_get_res = execute_graphql(auth_session, get_query, {"urn": private_urn})
-    assert "errors" not in private_get_res, (
-        f"GraphQL errors: {private_get_res.get('errors')}"
-    )
-    private_doc = private_get_res["data"]["document"]
-    assert private_doc["settings"] is not None
-    assert private_doc["settings"]["showInGlobalContext"] is False, (
-        "Expected showInGlobalContext to be False for private context document"
-    )
-
-    # Update settings from false to true
-    update_settings_mutation = """
-        mutation UpdateSettings($input: UpdateDocumentSettingsInput!) {
-          updateDocumentSettings(input: $input)
+        # Create UNPUBLISHED document (owned by current user by default)
+        unpublished_vars = {
+            "input": {
+                "id": unpublished_doc_id,
+                "subType": "guide",
+                "title": f"Unpublished Doc {unpublished_doc_id}",
+                "contents": {"text": "Unpublished content"},
+                "state": "UNPUBLISHED",
+            }
         }
-    """
-    update_vars = {"input": {"urn": private_urn, "showInGlobalContext": True}}
-    update_res = execute_graphql(auth_session, update_settings_mutation, update_vars)
-    assert "errors" not in update_res, f"GraphQL errors: {update_res.get('errors')}"
-    assert update_res["data"]["updateDocumentSettings"] is True
+        unpublished_res = execute_graphql(
+            auth_session, create_mutation, unpublished_vars
+        )
+        assert "errors" not in unpublished_res, (
+            f"GraphQL errors: {unpublished_res.get('errors')}"
+        )
+        unpublished_urn = unpublished_res["data"]["createDocument"]
 
-    wait_for_writes_to_sync()
+        # Wait for search indexing
+        time.sleep(5)
 
-    # Verify the update
-    updated_get_res = execute_graphql(auth_session, get_query, {"urn": private_urn})
-    assert "errors" not in updated_get_res, (
-        f"GraphQL errors: {updated_get_res.get('errors')}"
-    )
-    updated_doc = updated_get_res["data"]["document"]
-    assert updated_doc["settings"] is not None
-    assert updated_doc["settings"]["showInGlobalContext"] is True, (
-        "Expected showInGlobalContext to be updated to True"
-    )
-
-    # Cleanup
-    delete_mutation = """
-        mutation DeleteDoc($urn: String!) { deleteDocument(urn: $urn) }
-    """
-    execute_graphql(auth_session, delete_mutation, {"urn": public_urn})
-    execute_graphql(auth_session, delete_mutation, {"urn": private_urn})
-
-
-@pytest.mark.dependency()
-def test_search_ownership_filtering(auth_session):
-    """
-    Test that search respects ownership filtering:
-    - PUBLISHED documents are shown to all users
-    - UNPUBLISHED documents are only shown if owned by the current user or their groups
-
-    1. Create a PUBLISHED document (should be visible in search).
-    2. Create an UNPUBLISHED document owned by current user (should be visible in search).
-    3. Publish the unpublished document and verify it appears in search.
-    4. Unpublish it and verify it still appears (because user owns it).
-    5. Clean up.
-    """
-    published_doc_id = _unique_id("smoke-search-published")
-    unpublished_doc_id = _unique_id("smoke-search-unpublished")
-
-    create_mutation = """
-        mutation CreateDoc($input: CreateDocumentInput!) {
-          createDocument(input: $input)
-        }
-    """
-
-    # Create PUBLISHED document
-    published_vars = {
-        "input": {
-            "id": published_doc_id,
-            "subType": "guide",
-            "title": f"Published Doc {published_doc_id}",
-            "contents": {"text": "Published content"},
-            "state": "PUBLISHED",
-        }
-    }
-    published_res = execute_graphql(auth_session, create_mutation, published_vars)
-    assert "errors" not in published_res, (
-        f"GraphQL errors: {published_res.get('errors')}"
-    )
-    published_urn = published_res["data"]["createDocument"]
-
-    # Create UNPUBLISHED document (owned by current user by default)
-    unpublished_vars = {
-        "input": {
-            "id": unpublished_doc_id,
-            "subType": "guide",
-            "title": f"Unpublished Doc {unpublished_doc_id}",
-            "contents": {"text": "Unpublished content"},
-            "state": "UNPUBLISHED",
-        }
-    }
-    unpublished_res = execute_graphql(auth_session, create_mutation, unpublished_vars)
-    assert "errors" not in unpublished_res, (
-        f"GraphQL errors: {unpublished_res.get('errors')}"
-    )
-    unpublished_urn = unpublished_res["data"]["createDocument"]
-
-    # Wait for search indexing
-    time.sleep(5)
-
-    # Search without state filter - should return BOTH documents
-    # (PUBLISHED because it's public, UNPUBLISHED because we own it)
-    search_query = """
-        query SearchDocs($input: SearchDocumentsInput!) {
-          searchDocuments(input: $input) {
-            total
-            documents {
-              urn
-              info {
-                title
-                status { state }
+        # Search without state filter - should return BOTH documents
+        # (PUBLISHED because it's public, UNPUBLISHED because we own it)
+        search_query = """
+            query SearchDocs($input: SearchDocumentsInput!) {
+              searchDocuments(input: $input) {
+                total
+                documents {
+                  urn
+                  info {
+                    title
+                    status { state }
+                  }
+                }
               }
             }
-          }
+        """
+        search_vars = {
+            "input": {
+                "start": 0,
+                "count": 100,
+                "query": "smoke-search",  # Search for our test documents
+            }
         }
-    """
-    search_vars = {
-        "input": {
-            "start": 0,
-            "count": 100,
-            "query": "smoke-search",  # Search for our test documents
-        }
-    }
-    search_res = execute_graphql(auth_session, search_query, search_vars)
+        search_res = execute_graphql(auth_session, search_query, search_vars)
 
-    # Search can fail if index is not ready
-    if "errors" in search_res:
-        logger.info(
-            f"WARNING: Ownership search failed (index may not be ready): {search_res.get('errors')}"
+        # Search can fail if index is not ready
+        if "errors" in search_res:
+            logger.info(
+                f"WARNING: Ownership search failed (index may not be ready): {search_res.get('errors')}"
+            )
+            # Cleanup and return early
+            delete_mutation = """
+                mutation DeleteDoc($urn: String!) { deleteDocument(urn: $urn) }
+            """
+            execute_graphql(auth_session, delete_mutation, {"urn": published_urn})
+            execute_graphql(auth_session, delete_mutation, {"urn": unpublished_urn})
+            pytest.skip("Search index not available")
+            return
+
+        result = search_res["data"]["searchDocuments"]
+        found_urns = [doc["urn"] for doc in result["documents"]]
+
+        # Both documents should be visible:
+        # - PUBLISHED doc is visible to everyone
+        # - UNPUBLISHED doc is visible because we own it
+        assert published_urn in found_urns, (
+            f"Expected PUBLISHED document {published_urn} in search results"
         )
-        # Cleanup and return early
+        assert unpublished_urn in found_urns, (
+            f"Expected UNPUBLISHED document {unpublished_urn} (owned by user) in search results"
+        )
+
+        # Verify the states
+        doc_states = {
+            doc["urn"]: doc["info"]["status"]["state"] for doc in result["documents"]
+        }
+        assert doc_states.get(published_urn) == "PUBLISHED"
+        assert doc_states.get(unpublished_urn) == "UNPUBLISHED"
+
+        # Now publish the unpublished document and verify it still appears
+        update_status_mutation = """
+            mutation UpdateStatus($input: UpdateDocumentStatusInput!) {
+              updateDocumentStatus(input: $input)
+            }
+        """
+        publish_vars = {"input": {"urn": unpublished_urn, "state": "PUBLISHED"}}
+        publish_res = execute_graphql(
+            auth_session, update_status_mutation, publish_vars
+        )
+        assert publish_res["data"]["updateDocumentStatus"] is True
+
+        wait_for_writes_to_sync()
+        time.sleep(3)
+
+        # Search again - both should still be visible (both PUBLISHED now)
+        search_res2 = execute_graphql(auth_session, search_query, search_vars)
+        result2 = search_res2["data"]["searchDocuments"]
+        found_urns2 = [doc["urn"] for doc in result2["documents"]]
+
+        assert published_urn in found_urns2
+        assert unpublished_urn in found_urns2
+
+        # Cleanup
         delete_mutation = """
             mutation DeleteDoc($urn: String!) { deleteDocument(urn: $urn) }
         """
         execute_graphql(auth_session, delete_mutation, {"urn": published_urn})
         execute_graphql(auth_session, delete_mutation, {"urn": unpublished_urn})
-        pytest.skip("Search index not available")
-        return
 
-    result = search_res["data"]["searchDocuments"]
-    found_urns = [doc["urn"] for doc in result["documents"]]
+    def test_context_documents_for_dataset(self, auth_session):
+        """
+        Test fetching context documents for a dataset entity.
+        1. Create a document.
+        2. Get or use an existing dataset (using bootstrap sample data).
+        3. Update the document to relate to the dataset.
+        4. Query the dataset's relatedDocuments field to verify it returns the document.
+        5. Clean up.
+        """
+        document_id = _unique_id("smoke-doc-context")
 
-    # Both documents should be visible:
-    # - PUBLISHED doc is visible to everyone
-    # - UNPUBLISHED doc is visible because we own it
-    assert published_urn in found_urns, (
-        f"Expected PUBLISHED document {published_urn} in search results"
-    )
-    assert unpublished_urn in found_urns, (
-        f"Expected UNPUBLISHED document {unpublished_urn} (owned by user) in search results"
-    )
-
-    # Verify the states
-    doc_states = {
-        doc["urn"]: doc["info"]["status"]["state"] for doc in result["documents"]
-    }
-    assert doc_states.get(published_urn) == "PUBLISHED"
-    assert doc_states.get(unpublished_urn) == "UNPUBLISHED"
-
-    # Now publish the unpublished document and verify it still appears
-    update_status_mutation = """
-        mutation UpdateStatus($input: UpdateDocumentStatusInput!) {
-          updateDocumentStatus(input: $input)
+        # Create a document
+        create_mutation = """
+            mutation CreateDoc($input: CreateDocumentInput!) {
+              createDocument(input: $input)
+            }
+        """
+        variables = {
+            "input": {
+                "id": document_id,
+                "subType": "guide",
+                "title": f"Context Test {document_id}",
+                "contents": {"text": "Document related to dataset"},
+            }
         }
-    """
-    publish_vars = {"input": {"urn": unpublished_urn, "state": "PUBLISHED"}}
-    publish_res = execute_graphql(auth_session, update_status_mutation, publish_vars)
-    assert publish_res["data"]["updateDocumentStatus"] is True
+        create_res = execute_graphql(auth_session, create_mutation, variables)
+        document_urn = create_res["data"]["createDocument"]
 
-    wait_for_writes_to_sync()
-    time.sleep(3)
+        # Use bootstrap sample dataset (commonly available in test environments)
+        # If this doesn't exist, the test will fail gracefully
+        dataset_urn = (
+            "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"
+        )
 
-    # Search again - both should still be visible (both PUBLISHED now)
-    search_res2 = execute_graphql(auth_session, search_query, search_vars)
-    result2 = search_res2["data"]["searchDocuments"]
-    found_urns2 = [doc["urn"] for doc in result2["documents"]]
+        # Verify dataset exists first
+        dataset_query = """
+            query GetDataset($urn: String!) {
+              dataset(urn: $urn) {
+                urn
+                name
+              }
+            }
+        """
+        dataset_res = execute_graphql(auth_session, dataset_query, {"urn": dataset_urn})
 
-    assert published_urn in found_urns2
-    assert unpublished_urn in found_urns2
+        # If dataset doesn't exist, skip the test
+        if "errors" in dataset_res or not dataset_res.get("data", {}).get("dataset"):
+            # Cleanup document and skip
+            delete_mutation = """
+                mutation DeleteDoc($urn: String!) { deleteDocument(urn: $urn) }
+            """
+            execute_graphql(auth_session, delete_mutation, {"urn": document_urn})
+            pytest.skip(f"Dataset {dataset_urn} not available for testing")
+            return
 
-    # Cleanup
-    delete_mutation = """
-        mutation DeleteDoc($urn: String!) { deleteDocument(urn: $urn) }
-    """
-    execute_graphql(auth_session, delete_mutation, {"urn": published_urn})
-    execute_graphql(auth_session, delete_mutation, {"urn": unpublished_urn})
-
-
-@pytest.mark.dependency()
-def test_context_documents_for_dataset(auth_session):
-    """
-    Test fetching context documents for a dataset entity.
-    1. Create a document.
-    2. Get or use an existing dataset (using bootstrap sample data).
-    3. Update the document to relate to the dataset.
-    4. Query the dataset's relatedDocuments field to verify it returns the document.
-    5. Clean up.
-    """
-    document_id = _unique_id("smoke-doc-context")
-
-    # Create a document
-    create_mutation = """
-        mutation CreateDoc($input: CreateDocumentInput!) {
-          createDocument(input: $input)
+        # Update document to relate to the dataset
+        update_mutation = """
+            mutation UpdateRelated($input: UpdateDocumentRelatedEntitiesInput!) {
+              updateDocumentRelatedEntities(input: $input)
+            }
+        """
+        update_vars = {
+            "input": {
+                "urn": document_urn,
+                "relatedAssets": [dataset_urn],
+            }
         }
-    """
-    variables = {
-        "input": {
-            "id": document_id,
-            "subType": "guide",
-            "title": f"Context Test {document_id}",
-            "contents": {"text": "Document related to dataset"},
+        update_res = execute_graphql(auth_session, update_mutation, update_vars)
+        assert update_res["data"]["updateDocumentRelatedEntities"] is True
+
+        wait_for_writes_to_sync()
+
+        # Wait for search indexing
+        time.sleep(5)
+
+        # Query relatedDocuments on the dataset entity
+        context_query = """
+            query GetRelatedDocuments($urn: String!, $input: RelatedDocumentsInput!) {
+              dataset(urn: $urn) {
+                urn
+                relatedDocuments(input: $input) {
+                  start
+                  count
+                  total
+                  documents {
+                    urn
+                    info {
+                      title
+                    }
+                  }
+                }
+              }
+            }
+        """
+        context_vars = {
+            "urn": dataset_urn,
+            "input": {
+                "start": 0,
+                "count": 100,
+            },
         }
-    }
-    create_res = execute_graphql(auth_session, create_mutation, variables)
-    document_urn = create_res["data"]["createDocument"]
+        context_res = execute_graphql(auth_session, context_query, context_vars)
 
-    # Use bootstrap sample dataset (commonly available in test environments)
-    # If this doesn't exist, the test will fail gracefully
-    dataset_urn = "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"
+        # Verify no errors
+        assert "errors" not in context_res, (
+            f"GraphQL errors: {context_res.get('errors')}"
+        )
 
-    # Verify dataset exists first
-    dataset_query = """
-        query GetDataset($urn: String!) {
-          dataset(urn: $urn) {
-            urn
-            name
-          }
+        # Verify relatedDocuments result
+        context_docs = context_res["data"]["dataset"]["relatedDocuments"]
+        assert context_docs is not None
+        assert context_docs["total"] >= 1, (
+            f"Expected at least 1 context document, got {context_docs['total']}"
+        )
+
+        # Verify our document is in the results
+        document_urns = [doc["urn"] for doc in context_docs["documents"]]
+        assert document_urn in document_urns, (
+            f"Expected document {document_urn} to be in context documents, "
+            f"but got: {document_urns}"
+        )
+
+        # Verify the document has the expected title
+        our_doc = next(
+            (doc for doc in context_docs["documents"] if doc["urn"] == document_urn),
+            None,
+        )
+        assert our_doc is not None
+        assert our_doc["info"]["title"] == f"Context Test {document_id}"
+
+        # Test with filters - query with rootOnly filter
+        context_query_filtered = """
+            query GetRelatedDocuments($urn: String!, $input: RelatedDocumentsInput!) {
+              dataset(urn: $urn) {
+                urn
+                relatedDocuments(input: $input) {
+                  start
+                  count
+                  total
+                  documents {
+                    urn
+                  }
+                }
+              }
+            }
+        """
+        context_vars_filtered = {
+            "urn": dataset_urn,
+            "input": {
+                "start": 0,
+                "count": 100,
+                "rootOnly": True,
+            },
         }
-    """
-    dataset_res = execute_graphql(auth_session, dataset_query, {"urn": dataset_urn})
+        context_res_filtered = execute_graphql(
+            auth_session, context_query_filtered, context_vars_filtered
+        )
+        assert "errors" not in context_res_filtered
+        # Our document should still be there (it's root-level)
+        filtered_docs = context_res_filtered["data"]["dataset"]["relatedDocuments"]
+        filtered_urns = [doc["urn"] for doc in filtered_docs["documents"]]
+        assert document_urn in filtered_urns
 
-    # If dataset doesn't exist, skip the test
-    if "errors" in dataset_res or not dataset_res.get("data", {}).get("dataset"):
-        # Cleanup document and skip
+        # Cleanup
         delete_mutation = """
             mutation DeleteDoc($urn: String!) { deleteDocument(urn: $urn) }
         """
         execute_graphql(auth_session, delete_mutation, {"urn": document_urn})
-        pytest.skip(f"Dataset {dataset_urn} not available for testing")
-        return
-
-    # Update document to relate to the dataset
-    update_mutation = """
-        mutation UpdateRelated($input: UpdateDocumentRelatedEntitiesInput!) {
-          updateDocumentRelatedEntities(input: $input)
-        }
-    """
-    update_vars = {
-        "input": {
-            "urn": document_urn,
-            "relatedAssets": [dataset_urn],
-        }
-    }
-    update_res = execute_graphql(auth_session, update_mutation, update_vars)
-    assert update_res["data"]["updateDocumentRelatedEntities"] is True
-
-    wait_for_writes_to_sync()
-
-    # Wait for search indexing
-    time.sleep(5)
-
-    # Query relatedDocuments on the dataset entity
-    context_query = """
-        query GetRelatedDocuments($urn: String!, $input: RelatedDocumentsInput!) {
-          dataset(urn: $urn) {
-            urn
-            relatedDocuments(input: $input) {
-              start
-              count
-              total
-              documents {
-                urn
-                info {
-                  title
-                }
-              }
-            }
-          }
-        }
-    """
-    context_vars = {
-        "urn": dataset_urn,
-        "input": {
-            "start": 0,
-            "count": 100,
-        },
-    }
-    context_res = execute_graphql(auth_session, context_query, context_vars)
-
-    # Verify no errors
-    assert "errors" not in context_res, f"GraphQL errors: {context_res.get('errors')}"
-
-    # Verify relatedDocuments result
-    context_docs = context_res["data"]["dataset"]["relatedDocuments"]
-    assert context_docs is not None
-    assert context_docs["total"] >= 1, (
-        f"Expected at least 1 context document, got {context_docs['total']}"
-    )
-
-    # Verify our document is in the results
-    document_urns = [doc["urn"] for doc in context_docs["documents"]]
-    assert document_urn in document_urns, (
-        f"Expected document {document_urn} to be in context documents, "
-        f"but got: {document_urns}"
-    )
-
-    # Verify the document has the expected title
-    our_doc = next(
-        (doc for doc in context_docs["documents"] if doc["urn"] == document_urn), None
-    )
-    assert our_doc is not None
-    assert our_doc["info"]["title"] == f"Context Test {document_id}"
-
-    # Test with filters - query with rootOnly filter
-    context_query_filtered = """
-        query GetRelatedDocuments($urn: String!, $input: RelatedDocumentsInput!) {
-          dataset(urn: $urn) {
-            urn
-            relatedDocuments(input: $input) {
-              start
-              count
-              total
-              documents {
-                urn
-              }
-            }
-          }
-        }
-    """
-    context_vars_filtered = {
-        "urn": dataset_urn,
-        "input": {
-            "start": 0,
-            "count": 100,
-            "rootOnly": True,
-        },
-    }
-    context_res_filtered = execute_graphql(
-        auth_session, context_query_filtered, context_vars_filtered
-    )
-    assert "errors" not in context_res_filtered
-    # Our document should still be there (it's root-level)
-    filtered_docs = context_res_filtered["data"]["dataset"]["relatedDocuments"]
-    filtered_urns = [doc["urn"] for doc in filtered_docs["documents"]]
-    assert document_urn in filtered_urns
-
-    # Cleanup
-    delete_mutation = """
-        mutation DeleteDoc($urn: String!) { deleteDocument(urn: $urn) }
-    """
-    execute_graphql(auth_session, delete_mutation, {"urn": document_urn})

--- a/smoke-test/tests/managed_ingestion/managed_ingestion_test.py
+++ b/smoke-test/tests/managed_ingestion/managed_ingestion_test.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import uuid
 from typing import Any, Dict
 
 import pytest
@@ -17,6 +18,8 @@ from tests.utils import (
 logger = logging.getLogger(__name__)
 
 _SMOKE_SECRET_NAMES = ["SMOKE_TEST", "SMOKE_TEST_BIGQUERY_KEY", "SMOKE_TEST_EDGE_CASES"]
+_SMOKE_INGESTION_SOURCE_PREFIX = "SMOKE_INGESTION_"
+_SMOKE_INGESTION_SOURCE_LEGACY_NAMES = ["My Test Ingestion Source"]
 _SECRET_GUARD_TEST_EMAIL = "managed.ingestion.secret.guard@smoke.datahub.test"
 _SECRET_GUARD_TEST_PASSWORD = "user"
 
@@ -63,6 +66,47 @@ def cleanup_smoke_secrets(auth_session: object):
     _delete_secrets_by_name(auth_session, _SMOKE_SECRET_NAMES)
     yield
     _delete_secrets_by_name(auth_session, _SMOKE_SECRET_NAMES)
+
+
+def _delete_ingestion_sources_by_name(auth_session: object, names: list[str]) -> None:
+    res_data = _get_ingestionSources(auth_session)
+    deleted = False
+    for source in res_data["data"]["listIngestionSources"]["ingestionSources"]:
+        query = """query ingestionSource($urn: String!) {\n
+            ingestionSource(urn: $urn) {\n
+              urn\n
+              name\n
+            }\n
+        }"""
+        source_data = execute_graphql(auth_session, query, {"urn": source["urn"]})
+        ingestion_source = source_data["data"]["ingestionSource"]
+        if ingestion_source is None:
+            continue
+        if ingestion_source["name"] in names or ingestion_source["name"].startswith(
+            _SMOKE_INGESTION_SOURCE_PREFIX
+        ):
+            execute_graphql(
+                auth_session,
+                """mutation deleteIngestionSource($urn: String!) {\n
+                    deleteIngestionSource(urn: $urn)
+                }""",
+                {"urn": ingestion_source["urn"]},
+            )
+            deleted = True
+    if deleted:
+        wait_for_writes_to_sync()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def cleanup_smoke_ingestion_sources(auth_session: object):
+    """Delete leftover smoke ingestion sources before and after the module."""
+    _delete_ingestion_sources_by_name(
+        auth_session, _SMOKE_INGESTION_SOURCE_LEGACY_NAMES
+    )
+    yield
+    _delete_ingestion_sources_by_name(
+        auth_session, _SMOKE_INGESTION_SOURCE_LEGACY_NAMES
+    )
 
 
 def _get_ingestionSources(auth_session):
@@ -131,11 +175,11 @@ def _ensure_secret_not_present(auth_session):
 
 @with_test_retry()
 def _ensure_ingestion_source_present(
-    auth_session, ingestion_source_urn, num_execs=None
+    auth_session, ingestion_source_urn, num_execs=None, *, execution_count: int = 20
 ):
     query = """query ingestionSource($urn: String!) {\n
             ingestionSource(urn: $urn) {\n
-              executions(start: 0, count: 1) {\n
+              executions(start: 0, count: %d) {\n
                   start\n
                   count\n
                   total\n
@@ -144,7 +188,7 @@ def _ensure_ingestion_source_present(
                   }\n
               }\n
             }\n
-        }"""
+        }""" % (execution_count)
     variables: Dict[str, Any] = {"urn": ingestion_source_urn}
     res_data = execute_graphql(auth_session, query, variables)
     logger.info(res_data)
@@ -434,7 +478,7 @@ def test_create_list_get_remove_ingestion_source(auth_session):
         }"""
     variables: Dict[str, Any] = {
         "input": {
-            "name": "My Test Ingestion Source",
+            "name": f"{_SMOKE_INGESTION_SOURCE_PREFIX}CRUD",
             "type": "mysql",
             "description": "My ingestion source description",
             "schedule": {"interval": "*/60 * * * *", "timezone": "UTC"},
@@ -477,7 +521,7 @@ def test_create_list_get_remove_ingestion_source(auth_session):
     ingestion_source = res_data["data"]["ingestionSource"]
     assert ingestion_source["urn"] == ingestion_source_urn
     assert ingestion_source["type"] == "mysql"
-    assert ingestion_source["name"] == "My Test Ingestion Source"
+    assert ingestion_source["name"] == f"{_SMOKE_INGESTION_SOURCE_PREFIX}CRUD"
     assert ingestion_source["schedule"]["interval"] == "*/60 * * * *"
     assert ingestion_source["schedule"]["timezone"] == "UTC"
     assert (
@@ -506,16 +550,18 @@ def test_create_list_get_remove_ingestion_source(auth_session):
     ]
 )
 def test_create_list_get_ingestion_execution_request(auth_session):
+    execution_source_name = (
+        f"{_SMOKE_INGESTION_SOURCE_PREFIX}EXEC_{uuid.uuid4().hex[:8]}"
+    )
     # Create new ingestion source
     query = """mutation createIngestionSource($input: UpdateIngestionSourceInput!) {\n
             createIngestionSource(input: $input)
         }"""
     variables: Dict[str, Any] = {
         "input": {
-            "name": "My Test Ingestion Source",
+            "name": execution_source_name,
             "type": "mysql",
-            "description": "My ingestion source description",
-            "schedule": {"interval": "*/5 * * * *", "timezone": "UTC"},
+            "description": "Smoke execution-request ingestion source",
             "config": {
                 "recipe": '{"source":{"type":"mysql","config":{"include_tables":true,"database":null,"password":"${MYSQL_PASSWORD}","profiling":{"enabled":false},"host_port":null,"include_views":true,"username":"${MYSQL_USERNAME}"}},"pipeline_name":"urn:li:dataHubIngestionSource:f38bd060-4ea8-459c-8f24-a773286a2927"}',
                 "version": "0.8.18",
@@ -544,10 +590,11 @@ def test_create_list_get_ingestion_execution_request(auth_session):
 
     ingestion_source = res_data["data"]["ingestionSource"]
 
-    assert (
-        ingestion_source["executions"]["executionRequests"][0]["urn"]
-        == execution_request_urn
-    )
+    listed_execution_urns = {
+        execution["urn"]
+        for execution in ingestion_source["executions"]["executionRequests"]
+    }
+    assert execution_request_urn in listed_execution_urns
 
     # Get the ingestion request back via direct lookup
     res_data = _ensure_execution_request_present(auth_session, execution_request_urn)

--- a/smoke-test/tests/metrics/test_usage_aggregation_audit.py
+++ b/smoke-test/tests/metrics/test_usage_aggregation_audit.py
@@ -69,335 +69,336 @@ def _require_prometheus_url() -> str:
 
 
 @pytest.mark.read_only
-def test_usage_aggregation_configured_admin_actor_class(auth_session):
-    """Smoke admin session resolves actor_class from CorpUserInfo flags."""
-    gms_url = _require_prometheus_url()
-    urn = session_corp_user_urn(auth_session)
-    assert urn == configured_admin_urn()
+class TestUsageAggregationAdminSessions:
+    def test_usage_aggregation_configured_admin_actor_class(self, auth_session):
+        """Smoke admin session resolves actor_class from CorpUserInfo flags."""
+        gms_url = _require_prometheus_url()
+        urn = session_corp_user_urn(auth_session)
+        assert urn == configured_admin_urn()
 
-    actor_class = resolve_usage_actor_class(auth_session)
-    assert actor_class in ("system", "support", "regular")
+        actor_class = resolve_usage_actor_class(auth_session)
+        assert actor_class in ("system", "support", "regular")
 
-    tags = graphql_metadata_query_tags(actor_class)
-    baseline = fetch_metric_total(auth_session, gms_url, INPUT_BYTES_METRIC, tags)
-    generate_graphql_read_traffic(auth_session, repeat=2)
-    wait_for_metric_delta(
-        auth_session,
-        gms_url,
-        INPUT_BYTES_METRIC,
-        baseline,
-        required_tags=tags,
-        min_delta=1.0,
-    )
-
-    content = get_prometheus_metrics(auth_session, gms_url)
-    samples = find_metric_samples(content, INPUT_BYTES_METRIC, required_tags=tags)
-    assert samples, f"No Prometheus samples for admin session (tags={tags})"
-    for line in samples:
-        tags_on_line = parse_prometheus_tags(line)
-        assert tags_on_line.get("actor_class") == actor_class
-        assert tags_on_line.get("request_api") == "graphql"
-    logger.info("admin session evidence: urn=%s actor_class=%s", urn, actor_class)
-
-
-@pytest.mark.read_only
-def test_usage_aggregation_pat_authenticated_traffic(auth_session):
-    """Configured admin exports traffic when authenticating via a minted PAT."""
-    gms_url = _require_prometheus_url()
-    admin_urn = session_corp_user_urn(auth_session)
-    actor_class = resolve_usage_actor_class(auth_session)
-
-    admin_pat = try_mint_personal_access_token(auth_session, admin_urn)
-    if admin_pat is None:
-        pytest.skip("Cannot mint PAT for configured admin in this environment")
-
-    pat_session = TestSessionWrapper(requests.Session(), prebuilt_token=admin_pat)
-    try:
-        tags = aggregation_tags(
-            actor_class, usage_operation="metadata_read", request_api="openapi"
-        )
-        baseline = fetch_metric_total(pat_session, gms_url, OUTPUT_BYTES_METRIC, tags)
-        generate_openapi_metadata_read_traffic(pat_session, repeat=2)
-        wait_for_metric_delta(
-            pat_session,
-            gms_url,
-            OUTPUT_BYTES_METRIC,
-            baseline,
-            required_tags=tags,
-            min_delta=1.0,
-        )
-        logger.info(
-            "PAT-authenticated admin evidence: urn=%s actor_class=%s",
-            admin_urn,
-            actor_class,
-        )
-    finally:
-        pat_session.destroy()
-
-
-@pytest.mark.read_only
-def test_usage_aggregation_fresh_admin_session_login(auth_session):
-    """Fresh frontend login for the configured admin exports GraphQL byte counters."""
-    gms_url = _require_prometheus_url()
-    username, password = get_admin_credentials()
-    session = login_as(username, password)
-    admin_session = TestSessionWrapper(session)
-    try:
-        assert session_corp_user_urn(admin_session) == configured_admin_urn()
-        actor_class = resolve_usage_actor_class(admin_session)
         tags = graphql_metadata_query_tags(actor_class)
-        baseline = fetch_metric_total(admin_session, gms_url, INPUT_BYTES_METRIC, tags)
-        generate_graphql_read_traffic(admin_session, repeat=2)
+        baseline = fetch_metric_total(auth_session, gms_url, INPUT_BYTES_METRIC, tags)
+        generate_graphql_read_traffic(auth_session, repeat=2)
         wait_for_metric_delta(
-            admin_session,
+            auth_session,
             gms_url,
             INPUT_BYTES_METRIC,
             baseline,
             required_tags=tags,
             min_delta=1.0,
         )
-        logger.info("fresh admin login evidence: actor_class=%s", actor_class)
-    finally:
-        admin_session.destroy()
 
+        content = get_prometheus_metrics(auth_session, gms_url)
+        samples = find_metric_samples(content, INPUT_BYTES_METRIC, required_tags=tags)
+        assert samples, f"No Prometheus samples for admin session (tags={tags})"
+        for line in samples:
+            tags_on_line = parse_prometheus_tags(line)
+            assert tags_on_line.get("actor_class") == actor_class
+            assert tags_on_line.get("request_api") == "graphql"
+        logger.info("admin session evidence: urn=%s actor_class=%s", urn, actor_class)
 
-@pytest.mark.read_only
-def test_usage_aggregation_admin_actor_class_and_tags(auth_session):
-    """Admin session maps to a usage actor_class with the full aggregation tag set."""
-    gms_url = _require_prometheus_url()
-    actor_class = expected_actor_class_for_admin_session(auth_session)
-    tags = graphql_metadata_query_tags(actor_class)
+    def test_usage_aggregation_pat_authenticated_traffic(self, auth_session):
+        """Configured admin exports traffic when authenticating via a minted PAT."""
+        gms_url = _require_prometheus_url()
+        admin_urn = session_corp_user_urn(auth_session)
+        actor_class = resolve_usage_actor_class(auth_session)
 
-    baseline = fetch_metric_total(auth_session, gms_url, INPUT_BYTES_METRIC, tags)
-    generate_graphql_read_traffic(auth_session, repeat=2)
+        admin_pat = try_mint_personal_access_token(auth_session, admin_urn)
+        if admin_pat is None:
+            pytest.skip("Cannot mint PAT for configured admin in this environment")
 
-    wait_for_metric_delta(
-        auth_session,
-        gms_url,
-        INPUT_BYTES_METRIC,
-        baseline,
-        required_tags=tags,
-        min_delta=1.0,
-    )
+        pat_session = TestSessionWrapper(requests.Session(), prebuilt_token=admin_pat)
+        try:
+            tags = aggregation_tags(
+                actor_class, usage_operation="metadata_read", request_api="openapi"
+            )
+            baseline = fetch_metric_total(
+                pat_session, gms_url, OUTPUT_BYTES_METRIC, tags
+            )
+            generate_openapi_metadata_read_traffic(pat_session, repeat=2)
+            wait_for_metric_delta(
+                pat_session,
+                gms_url,
+                OUTPUT_BYTES_METRIC,
+                baseline,
+                required_tags=tags,
+                min_delta=1.0,
+            )
+            logger.info(
+                "PAT-authenticated admin evidence: urn=%s actor_class=%s",
+                admin_urn,
+                actor_class,
+            )
+        finally:
+            pat_session.destroy()
 
-    content = get_prometheus_metrics(auth_session, gms_url)
-    samples = find_metric_samples(content, INPUT_BYTES_METRIC, required_tags=tags)
-    assert_samples_have_tag_keys(samples, AGGREGATION_TAG_KEYS)
+    def test_usage_aggregation_fresh_admin_session_login(self, auth_session):
+        """Fresh frontend login for the configured admin exports GraphQL byte counters."""
+        gms_url = _require_prometheus_url()
+        username, password = get_admin_credentials()
+        session = login_as(username, password)
+        admin_session = TestSessionWrapper(session)
+        try:
+            assert session_corp_user_urn(admin_session) == configured_admin_urn()
+            actor_class = resolve_usage_actor_class(admin_session)
+            tags = graphql_metadata_query_tags(actor_class)
+            baseline = fetch_metric_total(
+                admin_session, gms_url, INPUT_BYTES_METRIC, tags
+            )
+            generate_graphql_read_traffic(admin_session, repeat=2)
+            wait_for_metric_delta(
+                admin_session,
+                gms_url,
+                INPUT_BYTES_METRIC,
+                baseline,
+                required_tags=tags,
+                min_delta=1.0,
+            )
+            logger.info("fresh admin login evidence: actor_class=%s", actor_class)
+        finally:
+            admin_session.destroy()
 
+    def test_usage_aggregation_admin_actor_class_and_tags(self, auth_session):
+        """Admin session maps to a usage actor_class with the full aggregation tag set."""
+        gms_url = _require_prometheus_url()
+        actor_class = expected_actor_class_for_admin_session(auth_session)
+        tags = graphql_metadata_query_tags(actor_class)
 
-@pytest.mark.read_only
-def test_usage_aggregation_openapi_read_and_search(auth_session):
-    """OpenAPI entity list (GET) exports output bytes; scroll search (POST) exports input bytes."""
-    gms_url = _require_prometheus_url()
-    actor_class = expected_actor_class_for_admin_session(auth_session)
+        baseline = fetch_metric_total(auth_session, gms_url, INPUT_BYTES_METRIC, tags)
+        generate_graphql_read_traffic(auth_session, repeat=2)
 
-    read_tags = aggregation_tags(
-        actor_class, usage_operation="metadata_read", request_api="openapi"
-    )
-    search_tags = aggregation_tags(
-        actor_class, usage_operation="search_query", request_api="openapi"
-    )
-
-    read_output_baseline = fetch_metric_total(
-        auth_session, gms_url, OUTPUT_BYTES_METRIC, read_tags
-    )
-    search_input_baseline = fetch_metric_total(
-        auth_session, gms_url, INPUT_BYTES_METRIC, search_tags
-    )
-
-    generate_openapi_metadata_read_traffic(auth_session)
-    generate_openapi_search_traffic(auth_session)
-
-    wait_for_metric_delta(
-        auth_session,
-        gms_url,
-        OUTPUT_BYTES_METRIC,
-        read_output_baseline,
-        required_tags=read_tags,
-    )
-    wait_for_metric_delta(
-        auth_session,
-        gms_url,
-        INPUT_BYTES_METRIC,
-        search_input_baseline,
-        required_tags=search_tags,
-    )
-
-    content = get_prometheus_metrics(auth_session, gms_url)
-    out_samples = find_metric_samples(
-        content, OUTPUT_BYTES_METRIC, required_tags=read_tags
-    )
-    assert out_samples, (
-        "Expected output_bytes for OpenAPI metadata_read — "
-        "OpenAPI synchronous responses should be measurable"
-    )
-
-
-@pytest.mark.read_only
-def test_usage_aggregation_graphql_output_bytes(auth_session):
-    """GraphQL async responses record output_bytes after execution completes."""
-    gms_url = _require_prometheus_url()
-    actor_class = expected_actor_class_for_admin_session(auth_session)
-    tags = graphql_metadata_query_tags(actor_class)
-
-    output_baseline = fetch_metric_total(
-        auth_session, gms_url, OUTPUT_BYTES_METRIC, tags
-    )
-    generate_graphql_read_traffic(auth_session, repeat=2)
-
-    wait_for_metric_delta(
-        auth_session,
-        gms_url,
-        OUTPUT_BYTES_METRIC,
-        output_baseline,
-        required_tags=tags,
-        min_delta=1.0,
-    )
-
-    content = get_prometheus_metrics(auth_session, gms_url)
-    graphql_output = find_metric_samples(
-        content, OUTPUT_BYTES_METRIC, required_tags={"request_api": "graphql"}
-    )
-    assert graphql_output, (
-        "Expected datahub_usage_output_bytes for request_api=graphql after async GraphQL fix"
-    )
-
-
-@pytest.mark.read_only
-def test_usage_aggregation_graphql_output_bytes_not_double_counted(auth_session):
-    """Single GraphQL response should contribute output_bytes ~= body length, not ~2x.
-
-    Uses a dedicated support user so actor_class=support isolates this test from
-    admin (system) GraphQL traffic elsewhere in the pytest batch.
-    """
-    gms_url = _require_prometheus_url()
-    if not can_provision_native_users(auth_session):
-        pytest.skip(
-            "Session lacks manageIdentities — cannot provision a support user locally"
+        wait_for_metric_delta(
+            auth_session,
+            gms_url,
+            INPUT_BYTES_METRIC,
+            baseline,
+            required_tags=tags,
+            min_delta=1.0,
         )
 
-    from tests.metrics.usage_aggregation_metrics import _ME_QUERY, execute_graphql_raw
+        content = get_prometheus_metrics(auth_session, gms_url)
+        samples = find_metric_samples(content, INPUT_BYTES_METRIC, required_tags=tags)
+        assert_samples_have_tag_keys(samples, AGGREGATION_TAG_KEYS)
 
-    user_urn, support_session = make_support_actor_user(
-        auth_session, "usage-output-dedup"
-    )
-    tags = graphql_metadata_query_tags("support")
-    try:
+
+@pytest.mark.read_only
+class TestUsageAggregationByteMetrics:
+    def test_usage_aggregation_openapi_read_and_search(self, auth_session):
+        """OpenAPI entity list (GET) exports output bytes; scroll search (POST) exports input bytes."""
+        gms_url = _require_prometheus_url()
+        actor_class = expected_actor_class_for_admin_session(auth_session)
+
+        read_tags = aggregation_tags(
+            actor_class, usage_operation="metadata_read", request_api="openapi"
+        )
+        search_tags = aggregation_tags(
+            actor_class, usage_operation="search_query", request_api="openapi"
+        )
+
+        read_output_baseline = fetch_metric_total(
+            auth_session, gms_url, OUTPUT_BYTES_METRIC, read_tags
+        )
+        search_input_baseline = fetch_metric_total(
+            auth_session, gms_url, INPUT_BYTES_METRIC, search_tags
+        )
+
+        generate_openapi_metadata_read_traffic(auth_session)
+        generate_openapi_search_traffic(auth_session)
+
+        wait_for_metric_delta(
+            auth_session,
+            gms_url,
+            OUTPUT_BYTES_METRIC,
+            read_output_baseline,
+            required_tags=read_tags,
+        )
+        wait_for_metric_delta(
+            auth_session,
+            gms_url,
+            INPUT_BYTES_METRIC,
+            search_input_baseline,
+            required_tags=search_tags,
+        )
+
+        content = get_prometheus_metrics(auth_session, gms_url)
+        out_samples = find_metric_samples(
+            content, OUTPUT_BYTES_METRIC, required_tags=read_tags
+        )
+        assert out_samples, (
+            "Expected output_bytes for OpenAPI metadata_read — "
+            "OpenAPI synchronous responses should be measurable"
+        )
+
+    def test_usage_aggregation_graphql_output_bytes(self, auth_session):
+        """GraphQL async responses record output_bytes after execution completes."""
+        gms_url = _require_prometheus_url()
+        actor_class = expected_actor_class_for_admin_session(auth_session)
+        tags = graphql_metadata_query_tags(actor_class)
+
         output_baseline = fetch_metric_total(
             auth_session, gms_url, OUTPUT_BYTES_METRIC, tags
         )
-        response_text = execute_graphql_raw(support_session, _ME_QUERY)
-        response_len = len(response_text)
-        assert response_len > 0
+        generate_graphql_read_traffic(auth_session, repeat=2)
 
-        delta = wait_for_metric_delta(
+        wait_for_metric_delta(
             auth_session,
             gms_url,
             OUTPUT_BYTES_METRIC,
             output_baseline,
             required_tags=tags,
-            min_delta=float(response_len) * 0.95,
-        )
-        assert delta <= response_len * 2.1, (
-            f"output_bytes delta {delta} far exceeds response length {response_len}"
-        )
-    finally:
-        support_session.destroy()
-        cleanup_step_actor_user(auth_session, user_urn)
-
-
-@pytest.mark.read_only
-def test_usage_aggregation_openapi_search_output_bytes(auth_session):
-    """OpenAPI scroll search records output_bytes with search_query tags."""
-    gms_url = _require_prometheus_url()
-    actor_class = expected_actor_class_for_admin_session(auth_session)
-    search_tags = aggregation_tags(
-        actor_class, usage_operation="search_query", request_api="openapi"
-    )
-
-    output_baseline = fetch_metric_total(
-        auth_session, gms_url, OUTPUT_BYTES_METRIC, search_tags
-    )
-    generate_openapi_search_traffic(auth_session, repeat=2)
-    wait_for_metric_delta(
-        auth_session,
-        gms_url,
-        OUTPUT_BYTES_METRIC,
-        output_baseline,
-        required_tags=search_tags,
-        min_delta=1.0,
-    )
-
-
-@pytest.mark.read_only
-def test_usage_aggregation_regular_user_active_identities(auth_session):
-    """Distinct identity gauge reflects unique regular users in the flush window."""
-    gms_url = _require_prometheus_url()
-    if not can_provision_native_users(auth_session):
-        pytest.skip(
-            "Session lacks manageIdentities — cannot provision a regular user locally"
+            min_delta=1.0,
         )
 
-    user_urn, regular_session = make_step_actor_user(auth_session, "usage-metrics")
-    try:
-        identity_tags = {
+        content = get_prometheus_metrics(auth_session, gms_url)
+        graphql_output = find_metric_samples(
+            content, OUTPUT_BYTES_METRIC, required_tags={"request_api": "graphql"}
+        )
+        assert graphql_output, (
+            "Expected datahub_usage_output_bytes for request_api=graphql after async GraphQL fix"
+        )
+
+    def test_usage_aggregation_openapi_search_output_bytes(self, auth_session):
+        """OpenAPI scroll search records output_bytes with search_query tags."""
+        gms_url = _require_prometheus_url()
+        actor_class = expected_actor_class_for_admin_session(auth_session)
+        search_tags = aggregation_tags(
+            actor_class, usage_operation="search_query", request_api="openapi"
+        )
+
+        output_baseline = fetch_metric_total(
+            auth_session, gms_url, OUTPUT_BYTES_METRIC, search_tags
+        )
+        generate_openapi_search_traffic(auth_session, repeat=2)
+        wait_for_metric_delta(
+            auth_session,
+            gms_url,
+            OUTPUT_BYTES_METRIC,
+            output_baseline,
+            required_tags=search_tags,
+            min_delta=1.0,
+        )
+
+
+class TestUsageAggregationGraphqlOutputDedup:
+    def test_usage_aggregation_graphql_output_bytes_not_double_counted(
+        self, auth_session
+    ):
+        """Single GraphQL response should contribute output_bytes ~= body length, not ~2x.
+
+        Uses a dedicated support user so actor_class=support isolates this test from
+        admin (system) GraphQL traffic elsewhere in the pytest batch.
+        """
+        gms_url = _require_prometheus_url()
+        if not can_provision_native_users(auth_session):
+            pytest.skip(
+                "Session lacks manageIdentities — cannot provision a support user locally"
+            )
+
+        from tests.metrics.usage_aggregation_metrics import (
+            _ME_QUERY,
+            execute_graphql_raw,
+        )
+
+        user_urn, support_session = make_support_actor_user(
+            auth_session, "usage-output-dedup"
+        )
+        tags = graphql_metadata_query_tags("support")
+        try:
+            output_baseline = fetch_metric_total(
+                auth_session, gms_url, OUTPUT_BYTES_METRIC, tags
+            )
+            response_text = execute_graphql_raw(support_session, _ME_QUERY)
+            response_len = len(response_text)
+            assert response_len > 0
+
+            delta = wait_for_metric_delta(
+                auth_session,
+                gms_url,
+                OUTPUT_BYTES_METRIC,
+                output_baseline,
+                required_tags=tags,
+                min_delta=float(response_len) * 0.95,
+            )
+            assert delta <= response_len * 2.1, (
+                f"output_bytes delta {delta} far exceeds response length {response_len}"
+            )
+        finally:
+            support_session.destroy()
+            cleanup_step_actor_user(auth_session, user_urn)
+
+
+class TestUsageAggregationActiveIdentities:
+    def test_usage_aggregation_regular_user_active_identities(self, auth_session):
+        """Distinct identity gauge reflects unique regular users in the flush window."""
+        gms_url = _require_prometheus_url()
+        if not can_provision_native_users(auth_session):
+            pytest.skip(
+                "Session lacks manageIdentities — cannot provision a regular user locally"
+            )
+
+        user_urn, regular_session = make_step_actor_user(auth_session, "usage-metrics")
+        try:
+            identity_tags = {
+                "identity_metric": "active_users",
+                "actor_class": "regular",
+            }
+            generate_graphql_read_traffic(regular_session, repeat=2)
+
+            wait_for_metric_at_least(
+                auth_session,
+                gms_url,
+                ACTIVE_IDENTITIES_METRIC,
+                1.0,
+                required_tags=identity_tags,
+            )
+
+            search_tags = aggregation_tags(
+                "regular", usage_operation="search_query", request_api="graphql"
+            )
+            input_baseline = fetch_metric_total(
+                auth_session, gms_url, INPUT_BYTES_METRIC, search_tags
+            )
+            generate_graphql_search_traffic(regular_session)
+            wait_for_metric_delta(
+                auth_session,
+                gms_url,
+                INPUT_BYTES_METRIC,
+                input_baseline,
+                required_tags=search_tags,
+            )
+        finally:
+            regular_session.destroy()
+            cleanup_step_actor_user(auth_session, user_urn)
+
+    def test_usage_aggregation_admin_active_identities(self, auth_session):
+        """Admin actor_class appears in the distinct-identity gauge after traffic."""
+        gms_url = _require_prometheus_url()
+        actor_class = expected_actor_class_for_admin_session(auth_session)
+
+        tags = {
             "identity_metric": "active_users",
-            "actor_class": "regular",
+            "actor_class": actor_class,
         }
-        generate_graphql_read_traffic(regular_session, repeat=2)
+        generate_graphql_read_traffic(auth_session, repeat=3)
 
         wait_for_metric_at_least(
             auth_session,
             gms_url,
             ACTIVE_IDENTITIES_METRIC,
             1.0,
-            required_tags=identity_tags,
+            required_tags=tags,
         )
 
-        search_tags = aggregation_tags(
-            "regular", usage_operation="search_query", request_api="graphql"
+        content = get_prometheus_metrics(auth_session, gms_url)
+        samples = find_metric_samples(
+            content, ACTIVE_IDENTITIES_METRIC, required_tags=tags
         )
-        input_baseline = fetch_metric_total(
-            auth_session, gms_url, INPUT_BYTES_METRIC, search_tags
-        )
-        generate_graphql_search_traffic(regular_session)
-        wait_for_metric_delta(
-            auth_session,
-            gms_url,
-            INPUT_BYTES_METRIC,
-            input_baseline,
-            required_tags=search_tags,
-        )
-    finally:
-        regular_session.destroy()
-        cleanup_step_actor_user(auth_session, user_urn)
-
-
-@pytest.mark.read_only
-def test_usage_aggregation_admin_active_identities(auth_session):
-    """Admin actor_class appears in the distinct-identity gauge after traffic."""
-    gms_url = _require_prometheus_url()
-    actor_class = expected_actor_class_for_admin_session(auth_session)
-
-    tags = {
-        "identity_metric": "active_users",
-        "actor_class": actor_class,
-    }
-    generate_graphql_read_traffic(auth_session, repeat=3)
-
-    wait_for_metric_at_least(
-        auth_session,
-        gms_url,
-        ACTIVE_IDENTITIES_METRIC,
-        1.0,
-        required_tags=tags,
-    )
-
-    content = get_prometheus_metrics(auth_session, gms_url)
-    samples = find_metric_samples(content, ACTIVE_IDENTITIES_METRIC, required_tags=tags)
-    assert samples, f"Expected active_identities samples (tags={tags})"
-    for line in samples:
-        parsed = parse_prometheus_tags(line)
-        assert parsed.get("actor_class") == actor_class
-        assert parsed.get("identity_metric") == "active_users"
-        assert parse_sample_value(line) >= 1.0
+        assert samples, f"Expected active_identities samples (tags={tags})"
+        for line in samples:
+            parsed = parse_prometheus_tags(line)
+            assert parsed.get("actor_class") == actor_class
+            assert parsed.get("identity_metric") == "active_users"
+            assert parse_sample_value(line) >= 1.0

--- a/smoke-test/tests/policies/test_policies.py
+++ b/smoke-test/tests/policies/test_policies.py
@@ -6,6 +6,9 @@ import pytest
 from tests.utils import execute_graphql, get_root_urn, with_test_retry
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.global_policy_mutator
+
 TEST_POLICY_NAME = "Updated Platform Policy"
 
 

--- a/smoke-test/tests/policies/test_policy_eval_perf.py
+++ b/smoke-test/tests/policies/test_policy_eval_perf.py
@@ -18,6 +18,8 @@ from tests.utils import delete_urns, get_admin_credentials, get_frontend_url, lo
 
 logger = logging.getLogger(__name__)
 
+pytestmark = pytest.mark.global_policy_mutator
+
 PERF_NUM_QUERIES = 25
 PERF_LATENCY_RATIO_THRESHOLD = 2
 PERF_LATENCY_ABS_FLOOR_SECONDS = 0.05

--- a/smoke-test/tests/privileges/test_privileges.py
+++ b/smoke-test/tests/privileges/test_privileges.py
@@ -31,7 +31,7 @@ from tests.utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.global_policy_mutator]
 
 # Valid email for auth.native.signUp.enforceValidEmail (Play EmailValidator).
 TEST_PRIVILEGES_USER_EMAIL = "privileges.user@smoke.datahub.test"
@@ -47,7 +47,7 @@ def admin_session(auth_session):
 def privileges_and_test_user_setup(admin_session):
     """Fixture to execute setup before and tear down after all tests are run"""
     # Clean up any leftover test policies from previous failed runs
-    clear_polices(admin_session)
+    clear_polices(admin_session, name_prefix="Test Policy")
 
     # Disable 'All users' privileges
     set_base_platform_privileges_policy_status("INACTIVE", admin_session)
@@ -93,7 +93,7 @@ def privileges_and_test_user_setup(admin_session):
     remove_secret(admin_session, "urn:li:dataHubSecret:TestSecretName")
 
     # Remove test policies
-    clear_polices(admin_session)
+    clear_polices(admin_session, name_prefix="Test Policy")
 
     # Restore All users privileges
     set_base_platform_privileges_policy_status("ACTIVE", admin_session)

--- a/smoke-test/tests/privileges/utils.py
+++ b/smoke-test/tests/privileges/utils.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 # Smoke quickstart sets POLICY_CACHE_REFRESH_INTERVAL_SECONDS=10; allow scheduled refresh
 # plus async invalidate/rebuild under full-suite CI load.
-DEFAULT_POLICY_CACHE_AUTH_WAIT_SECONDS = 30
+DEFAULT_POLICY_CACHE_AUTH_WAIT_SECONDS = 60
 
 
 def is_graphql_auth_denied(res: dict[str, Any]) -> bool:
@@ -446,15 +446,23 @@ def create_metadata_policy(
     return res_data["data"]["createPolicy"]
 
 
-def create_user_policy(user_urn, privileges, session):
+def create_user_policy(
+    user_urn,
+    privileges,
+    session,
+    *,
+    name: str = "Test Policy Name",
+    description: str = "Test Policy Description",
+):
+    """Create a platform policy for a single user."""
     policy = {
         "query": """mutation createPolicy($input: PolicyUpdateInput!) {\n
             createPolicy(input: $input) }""",
         "variables": {
             "input": {
                 "type": "PLATFORM",
-                "name": "Test Policy Name",
-                "description": "Test Policy Description",
+                "name": name,
+                "description": description,
                 "state": "ACTIVE",
                 "resources": {"filter": {"criteria": []}},
                 "privileges": privileges,
@@ -605,18 +613,36 @@ def log_policies(session, context=""):
             logger.info(f"    Description: {desc_preview}")
 
 
-def clear_polices(session):
+def clear_polices(
+    session,
+    *,
+    name_prefix: str | None = None,
+    name_prefixes: list[str] | None = None,
+) -> None:
     logger.info("Starting policy cleanup (clear_polices)")
+
+    if name_prefixes is not None:
+        prefixes = name_prefixes
+    elif name_prefix is not None:
+        prefixes = [name_prefix]
+    else:
+        prefixes = []
 
     policies_data = list_policies(session)
     policies = policies_data["policies"]
 
     deleted_count = 0
     for policy in policies:
-        if "test" in policy["name"].lower() or "test" in policy["description"].lower():
-            logger.info(f"Deleting test policy: {policy['name']} ({policy['urn']})")
-            remove_policy(policy["urn"], session)
-            deleted_count += 1
+        name = policy.get("name") or ""
+        description = policy.get("description") or ""
+        if prefixes:
+            if not any(name.startswith(prefix) for prefix in prefixes):
+                continue
+        elif "test" not in name.lower() and "test" not in description.lower():
+            continue
+        logger.info(f"Deleting test policy: {name} ({policy['urn']})")
+        remove_policy(policy["urn"], session)
+        deleted_count += 1
 
     logger.info(f"Policy cleanup complete. Deleted {deleted_count} test policies")
 

--- a/smoke-test/tests/search/test_search_projection.py
+++ b/smoke-test/tests/search/test_search_projection.py
@@ -1,7 +1,9 @@
 import json
 import logging
+from typing import Any, Dict
 
 from datahub.cli.search_cli import _build_search_query
+from tests.utils import with_test_retry
 
 logger = logging.getLogger(__name__)
 
@@ -10,10 +12,23 @@ _BASE_VARIABLES = {
     "query": "*",
     "types": [],
     "orFilters": [],
-    "count": 3,
+    "count": 10,
     "start": 0,
     "viewUrn": None,
 }
+
+
+@with_test_retry()
+def _execute_search_with_results(graph_client, query: str, variables: Dict[str, Any]):
+    result = graph_client.execute_graphql(
+        query=query,
+        variables=variables,
+        operation_name="search",
+    )
+    search_data = result["searchAcrossEntities"]
+    assert search_data["total"] > 0
+    assert len(search_data["searchResults"]) > 0
+    return result
 
 
 class TestSearchProjection:
@@ -25,16 +40,9 @@ class TestSearchProjection:
         query = _build_search_query(semantic=False, projection="urn type")
         logger.info("Executing minimal projection query")
 
-        result = graph_client.execute_graphql(
-            query=query,
-            variables=_BASE_VARIABLES,
-            operation_name="search",
-        )
+        result = _execute_search_with_results(graph_client, query, _BASE_VARIABLES)
 
         search_data = result["searchAcrossEntities"]
-        assert search_data["total"] > 0
-        assert len(search_data["searchResults"]) > 0
-
         entity = search_data["searchResults"][0]["entity"]
         assert "urn" in entity
         assert "type" in entity

--- a/smoke-test/tests/status/test_lifecycle_state.py
+++ b/smoke-test/tests/status/test_lifecycle_state.py
@@ -339,7 +339,7 @@ class TestLifecycleStageAPIs:
         _set_lifecycle_stage_via_rest(auth_session, urn, stage_urn)
         wait_for_writes_to_sync()
 
-        @with_test_retry(max_attempts=12)
+        @with_test_retry(max_attempts=30)
         def _assert_hidden():
             urns = _search_documents(auth_session, title)
             assert urn not in urns, "Entity in hidden stage should not appear in search"

--- a/smoke-test/tests/timeline/timeline_change_history_auth_test.py
+++ b/smoke-test/tests/timeline/timeline_change_history_auth_test.py
@@ -32,7 +32,7 @@ from tests.utils import get_frontend_session, get_frontend_url, login_as
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.global_policy_mutator]
 
 # ---------------------------------------------------------------------------
 # Constants — unique per test run so the test is idempotent
@@ -71,8 +71,15 @@ query getTimeline($input: GetTimelineInput!) {
 # ---------------------------------------------------------------------------
 # Module fixture: create entities, lock down policies, create restricted user
 # ---------------------------------------------------------------------------
+TIMELINE_AUTH_POLICY_PREFIX = "Timeline auth test"
+
+
 @pytest.fixture(scope="module", autouse=True)
 def auth_test_setup(graph_client, auth_session):
+    yield from _timeline_auth_test_setup_impl(graph_client, auth_session)
+
+
+def _timeline_auth_test_setup_impl(graph_client, auth_session):
     """
     Setup:
       1. Create test Dataset + Domain via the graph client (as admin).
@@ -109,7 +116,7 @@ def auth_test_setup(graph_client, auth_session):
     admin_session = get_frontend_session()
 
     logger.info("auth_test_setup: clearing leftover test policies")
-    clear_polices(admin_session)
+    clear_polices(admin_session, name_prefix=TIMELINE_AUTH_POLICY_PREFIX)
 
     logger.info("auth_test_setup: disabling All-Users default policies")
     set_base_platform_privileges_policy_status("INACTIVE", admin_session)
@@ -124,7 +131,7 @@ def auth_test_setup(graph_client, auth_session):
 
     logger.info("auth_test_setup: teardown — restoring policies and cleaning up")
     remove_user(admin_session, TEST_USER_URN)
-    clear_polices(admin_session)
+    clear_polices(admin_session, name_prefix=TIMELINE_AUTH_POLICY_PREFIX)
 
     set_base_platform_privileges_policy_status("ACTIVE", admin_session)
     set_view_dataset_sensitive_info_policy_status("ACTIVE", admin_session)
@@ -172,6 +179,9 @@ def _graphql_as_user(email: str, password: str, urn: str) -> dict:
         (TEST_DATASET_URN, "Dataset"),
         (TEST_DOMAIN_URN, "Domain"),
     ],
+    # Stable ids required for pytest-xdist: module-level uuid makes URNs differ
+    # per worker at collection time, which otherwise fails the collected-set check.
+    ids=["Dataset", "Domain"],
 )
 def test_get_timeline_unauthorized_user_is_denied(urn, entity_label):
     """Unauthorized user must receive an authorization error from getTimeline."""

--- a/smoke-test/tests/tokens/revokable_access_token_test.py
+++ b/smoke-test/tests/tokens/revokable_access_token_test.py
@@ -9,7 +9,14 @@ from tests.utils import (
     wait_for_writes_to_sync,
 )
 
-from .token_utils import listUsers, removeUser
+from .token_utils import (
+    assert_graphql_mutation_succeeded,
+    listUsers,
+    removeUser,
+    token_name_filter,
+    wait_for_no_tokens_matching,
+    wait_for_user_in_list,
+)
 
 pytestmark = pytest.mark.no_cypress_suite1
 
@@ -20,22 +27,18 @@ os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"
 # Valid email for auth.native.signUp.enforceValidEmail (Play EmailValidator).
 REVOKE_SUITE_USER_EMAIL = "revokable.access@smoke.datahub.test"
 REVOKE_SUITE_USER_URN = f"urn:li:corpuser:{REVOKE_SUITE_USER_EMAIL}"
+REVOKE_SUITE_TOKEN_NAME = "revokable-suite-token"
+SUITE_TOKEN_FILTER = [token_name_filter(REVOKE_SUITE_TOKEN_NAME)]
 
 
-@pytest.fixture()
-def auth_exclude_filter():
-    return {
-        "field": "name",
-        "condition": "EQUAL",
-        "negated": True,
-        "values": ["Test Session Token"],
-    }
+def _ensure_no_suite_tokens(auth_session) -> None:
+    wait_for_no_tokens_matching(auth_session, SUITE_TOKEN_FILTER)
 
 
-@pytest.fixture(scope="class", autouse=True)
-def custom_user_setup():
+@pytest.fixture(scope="module", autouse=True)
+def custom_user_setup(auth_session):
     """Fixture to execute setup before and tear down after all tests are run"""
-    admin_session = login_as(admin_user, admin_pass)
+    admin_session = auth_session
 
     res_data = removeUser(admin_session, REVOKE_SUITE_USER_URN)
     assert res_data
@@ -72,7 +75,8 @@ def custom_user_setup():
         "inviteToken": invite_token,
     }
 
-    sign_up_response = admin_session.post(
+    sign_up_session = login_as(admin_user, admin_pass)
+    sign_up_response = sign_up_session.post(
         f"{get_frontend_url()}/signUp", json=sign_up_json
     )
     sign_up_response.raise_for_status()
@@ -80,10 +84,7 @@ def custom_user_setup():
     assert "error" not in sign_up_response
     # Sleep for eventual consistency
     wait_for_writes_to_sync()
-
-    # signUp will override the session cookie to the new user to be signed up.
-    admin_session.cookies.clear()
-    admin_session = login_as(admin_user, admin_pass)
+    wait_for_user_in_list(admin_session, REVOKE_SUITE_USER_EMAIL, present=True)
 
     # Make user created user is there.
     res_data = listUsers(admin_session)
@@ -93,7 +94,11 @@ def custom_user_setup():
         "users"
     ]
 
+    _ensure_no_suite_tokens(auth_session)
+
     yield
+
+    _ensure_no_suite_tokens(auth_session)
 
     # Delete created user
     res_data = removeUser(admin_session, REVOKE_SUITE_USER_URN)
@@ -110,42 +115,17 @@ def custom_user_setup():
     assert {"username": REVOKE_SUITE_USER_EMAIL} not in res_data["data"]["listUsers"][
         "users"
     ]
-
-
-@pytest.fixture(autouse=True)
-def access_token_setup(auth_session, auth_exclude_filter):
-    """Fixture to execute asserts before and after a test is run"""
-    admin_session = login_as(admin_user, admin_pass)
-
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
-    assert res_data
-    assert res_data["data"]
-
-    if res_data["data"]["listAccessTokens"]["tokens"]:
-        for metadata in res_data["data"]["listAccessTokens"]["tokens"]:
-            revokeAccessToken(admin_session, metadata["id"])
-        wait_for_writes_to_sync()
-
-    # Verify clean state after cleanup
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
-    assert res_data["data"]["listAccessTokens"]["total"] == 0
-    assert not res_data["data"]["listAccessTokens"]["tokens"]
-
-    yield
-
-    # Clean up after the test
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
-    for metadata in res_data["data"]["listAccessTokens"]["tokens"]:
-        revokeAccessToken(admin_session, metadata["id"])
     wait_for_writes_to_sync()
+    wait_for_user_in_list(admin_session, REVOKE_SUITE_USER_EMAIL, present=False)
 
 
-def test_admin_can_create_list_and_revoke_tokens(auth_exclude_filter):
-    admin_session = login_as(admin_user, admin_pass)
+def test_admin_can_create_list_and_revoke_tokens(auth_session):
+    _ensure_no_suite_tokens(auth_session)
+    admin_session = auth_session
     admin_user_urn = f"urn:li:corpuser:{admin_user}"
 
     # Using a super account, there should be no tokens
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
+    res_data = listAccessTokens(admin_session, filters=SUITE_TOKEN_FILTER)
     assert res_data
     assert res_data["data"]
     assert res_data["data"]["listAccessTokens"]["total"] is not None
@@ -153,8 +133,7 @@ def test_admin_can_create_list_and_revoke_tokens(auth_exclude_filter):
 
     # Using a super account, generate a token for itself.
     res_data = generateAccessToken_v2(admin_session, admin_user_urn)
-    assert res_data
-    assert res_data["data"]
+    assert_graphql_mutation_succeeded(res_data)
     assert res_data["data"]["createAccessToken"]
     assert res_data["data"]["createAccessToken"]["accessToken"]
     assert (
@@ -173,7 +152,7 @@ def test_admin_can_create_list_and_revoke_tokens(auth_exclude_filter):
     assert res_data["data"]["getAccessTokenMetadata"]["actorUrn"] == admin_user_urn
 
     # Using a super account, list the previously created token.
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
+    res_data = listAccessTokens(admin_session, filters=SUITE_TOKEN_FILTER)
     assert res_data
     assert res_data["data"]
     assert res_data["data"]["listAccessTokens"]["total"] is not None
@@ -193,18 +172,19 @@ def test_admin_can_create_list_and_revoke_tokens(auth_exclude_filter):
     assert res_data["data"]["revokeAccessToken"] is True
 
     # Using a super account, there should be no tokens
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
+    res_data = listAccessTokens(admin_session, filters=SUITE_TOKEN_FILTER)
     assert res_data
     assert res_data["data"]
     assert res_data["data"]["listAccessTokens"]["total"] is not None
     assert len(res_data["data"]["listAccessTokens"]["tokens"]) == 0
 
 
-def test_admin_can_create_and_revoke_tokens_for_other_user(auth_exclude_filter):
-    admin_session = login_as(admin_user, admin_pass)
+def test_admin_can_create_and_revoke_tokens_for_other_user(auth_session):
+    _ensure_no_suite_tokens(auth_session)
+    admin_session = auth_session
 
     # Using a super account, there should be no tokens
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
+    res_data = listAccessTokens(admin_session, filters=SUITE_TOKEN_FILTER)
     assert res_data
     assert res_data["data"]
     assert res_data["data"]["listAccessTokens"]["total"] is not None
@@ -212,8 +192,7 @@ def test_admin_can_create_and_revoke_tokens_for_other_user(auth_exclude_filter):
 
     # Using a super account, generate a token for another user.
     res_data = generateAccessToken_v2(admin_session, REVOKE_SUITE_USER_URN)
-    assert res_data
-    assert res_data["data"]
+    assert_graphql_mutation_succeeded(res_data)
     assert res_data["data"]["createAccessToken"]
     assert res_data["data"]["createAccessToken"]["accessToken"]
     assert (
@@ -225,7 +204,7 @@ def test_admin_can_create_and_revoke_tokens_for_other_user(auth_exclude_filter):
     wait_for_writes_to_sync()
 
     # Using a super account, list the previously created tokens.
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
+    res_data = listAccessTokens(admin_session, filters=SUITE_TOKEN_FILTER)
     assert res_data
     assert res_data["data"]
     assert res_data["data"]["listAccessTokens"]["total"] is not None
@@ -247,20 +226,20 @@ def test_admin_can_create_and_revoke_tokens_for_other_user(auth_exclude_filter):
     assert res_data["data"]["revokeAccessToken"] is True
 
     # Using a super account, there should be no tokens
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
+    res_data = listAccessTokens(admin_session, filters=SUITE_TOKEN_FILTER)
     assert res_data
     assert res_data["data"]
     assert res_data["data"]["listAccessTokens"]["total"] is not None
     assert len(res_data["data"]["listAccessTokens"]["tokens"]) == 0
 
 
-def test_non_admin_can_create_list_revoke_tokens(auth_exclude_filter):
+def test_non_admin_can_create_list_revoke_tokens(auth_session):
+    _ensure_no_suite_tokens(auth_session)
     user_session = login_as(REVOKE_SUITE_USER_EMAIL, "user")
 
     # Normal user should be able to generate token for himself.
     res_data = generateAccessToken_v2(user_session, REVOKE_SUITE_USER_URN)
-    assert res_data
-    assert res_data["data"]
+    assert_graphql_mutation_succeeded(res_data)
     assert res_data["data"]["createAccessToken"]
     assert res_data["data"]["createAccessToken"]["accessToken"]
     assert (
@@ -276,7 +255,7 @@ def test_non_admin_can_create_list_revoke_tokens(auth_exclude_filter):
         user_session,
         [
             {"field": "ownerUrn", "values": [REVOKE_SUITE_USER_URN]},
-            auth_exclude_filter,
+            *SUITE_TOKEN_FILTER,
         ],
     )
     assert res_data
@@ -305,7 +284,7 @@ def test_non_admin_can_create_list_revoke_tokens(auth_exclude_filter):
         user_session,
         [
             {"field": "ownerUrn", "values": [REVOKE_SUITE_USER_URN]},
-            auth_exclude_filter,
+            *SUITE_TOKEN_FILTER,
         ],
     )
     assert res_data
@@ -314,21 +293,20 @@ def test_non_admin_can_create_list_revoke_tokens(auth_exclude_filter):
     assert len(res_data["data"]["listAccessTokens"]["tokens"]) == 0
 
 
-def test_admin_can_manage_tokens_generated_by_other_user(auth_exclude_filter):
-    admin_session = login_as(admin_user, admin_pass)
+def test_admin_can_manage_tokens_generated_by_other_user(auth_session):
+    _ensure_no_suite_tokens(auth_session)
+    admin_session = auth_session
 
     # Using a super account, there should be no tokens
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
+    res_data = listAccessTokens(admin_session, filters=SUITE_TOKEN_FILTER)
     assert res_data
     assert res_data["data"]
     assert res_data["data"]["listAccessTokens"]["total"] is not None
     assert len(res_data["data"]["listAccessTokens"]["tokens"]) == 0
 
-    admin_session.cookies.clear()
     user_session = login_as(REVOKE_SUITE_USER_EMAIL, "user")
     res_data = generateAccessToken_v2(user_session, REVOKE_SUITE_USER_URN)
-    assert res_data
-    assert res_data["data"]
+    assert_graphql_mutation_succeeded(res_data)
     assert res_data["data"]["createAccessToken"]
     assert res_data["data"]["createAccessToken"]["accessToken"]
     assert (
@@ -345,12 +323,12 @@ def test_admin_can_manage_tokens_generated_by_other_user(auth_exclude_filter):
 
     # Admin should be able to list other tokens
     user_session.cookies.clear()
-    admin_session = login_as(admin_user, admin_pass)
+    admin_session = auth_session
     res_data = listAccessTokens(
         admin_session,
         [
             {"field": "ownerUrn", "values": [REVOKE_SUITE_USER_URN]},
-            auth_exclude_filter,
+            *SUITE_TOKEN_FILTER,
         ],
     )
     assert res_data
@@ -368,8 +346,7 @@ def test_admin_can_manage_tokens_generated_by_other_user(auth_exclude_filter):
     assert res_data["data"]["listAccessTokens"]["tokens"][0]["id"] == user_tokenId
 
     # Admin can delete token created by someone else.
-    admin_session.cookies.clear()
-    admin_session = login_as(admin_user, admin_pass)
+    admin_session = auth_session
     res_data = revokeAccessToken(admin_session, user_tokenId)
     assert res_data
     assert res_data["data"]
@@ -383,7 +360,7 @@ def test_admin_can_manage_tokens_generated_by_other_user(auth_exclude_filter):
         user_session,
         [
             {"field": "ownerUrn", "values": [REVOKE_SUITE_USER_URN]},
-            auth_exclude_filter,
+            *SUITE_TOKEN_FILTER,
         ],
     )
     assert res_data
@@ -392,12 +369,12 @@ def test_admin_can_manage_tokens_generated_by_other_user(auth_exclude_filter):
     assert len(res_data["data"]["listAccessTokens"]["tokens"]) == 0
 
     # Using the super account, check that all tokens where removed.
-    admin_session = login_as(admin_user, admin_pass)
+    admin_session = auth_session
     res_data = listAccessTokens(
         admin_session,
         [
             {"field": "ownerUrn", "values": [REVOKE_SUITE_USER_URN]},
-            auth_exclude_filter,
+            *SUITE_TOKEN_FILTER,
         ],
     )
     assert res_data
@@ -406,7 +383,8 @@ def test_admin_can_manage_tokens_generated_by_other_user(auth_exclude_filter):
     assert len(res_data["data"]["listAccessTokens"]["tokens"]) == 0
 
 
-def test_non_admin_can_not_generate_tokens_for_others():
+def test_non_admin_can_not_generate_tokens_for_others(auth_session):
+    _ensure_no_suite_tokens(auth_session)
     user_session = login_as(REVOKE_SUITE_USER_EMAIL, "user")
     # Normal user should not be able to generate token for another user
     res_data = generateAccessToken_v2(user_session, f"urn:li:corpuser:{admin_user}")
@@ -438,7 +416,7 @@ def generateAccessToken_v2(session, actorUrn):
                 "type": "PERSONAL",
                 "actorUrn": actorUrn,
                 "duration": "ONE_HOUR",
-                "name": "my token",
+                "name": REVOKE_SUITE_TOKEN_NAME,
             }
         },
     }

--- a/smoke-test/tests/tokens/session_access_token_test.py
+++ b/smoke-test/tests/tokens/session_access_token_test.py
@@ -27,9 +27,9 @@ user_urn = f"urn:li:corpuser:{SESSION_TEST_EMAIL}"
 
 
 @pytest.fixture(scope="class")
-def custom_user_session():
+def custom_user_session(auth_session):
     """Fixture to execute setup before and tear down after all tests are run"""
-    admin_session = login_as(admin_user, admin_pass)
+    admin_session = auth_session
 
     res_data = removeUser(admin_session, user_urn)
     assert res_data
@@ -66,18 +66,15 @@ def custom_user_session():
         "inviteToken": invite_token,
     }
 
-    sign_up_response = admin_session.post(
+    sign_up_session = login_as(admin_user, admin_pass)
+    sign_up_response = sign_up_session.post(
         f"{get_frontend_url()}/signUp", json=sign_up_json
     )
     sign_up_response.raise_for_status()
     assert sign_up_response
     assert "error" not in sign_up_response
     # Sleep for eventual consistency
-    wait_for_writes_to_sync()
-
-    # signUp will override the session cookie to the new user to be signed up.
-    admin_session.cookies.clear()
-    admin_session = login_as(admin_user, admin_pass)
+    wait_for_writes_to_sync(auth_session=auth_session)
 
     # Make user created user is there.
     res_data = listUsers(admin_session)
@@ -93,7 +90,7 @@ def custom_user_session():
     assert res_data["data"]
     assert res_data["data"]["removeUser"] is True
     # Sleep for eventual consistency
-    wait_for_writes_to_sync()
+    wait_for_writes_to_sync(auth_session=auth_session)
 
     # Make user created user is not there.
     res_data = listUsers(admin_session)
@@ -104,12 +101,12 @@ def custom_user_session():
     ]
 
 
-def test_01_soft_delete(graph_client, custom_user_session):
+def test_01_soft_delete(auth_session, graph_client, custom_user_session):
     # assert initial access
     assert getUserId(custom_user_session) == {"urn": user_urn}
 
     graph_client.soft_delete_entity(urn=user_urn)
-    wait_for_writes_to_sync()
+    wait_for_writes_to_sync(auth_session=auth_session)
 
     with pytest.raises(HTTPError) as req_info:
         getUserId(custom_user_session)
@@ -117,10 +114,10 @@ def test_01_soft_delete(graph_client, custom_user_session):
 
     # undo soft delete
     graph_client.set_soft_delete_status(urn=user_urn, delete=False)
-    wait_for_writes_to_sync()
+    wait_for_writes_to_sync(auth_session=auth_session)
 
 
-def test_02_suspend(graph_client, custom_user_session):
+def test_02_suspend(auth_session, graph_client, custom_user_session):
     # assert initial access
     assert getUserId(custom_user_session) == {"urn": user_urn}
 
@@ -138,7 +135,7 @@ def test_02_suspend(graph_client, custom_user_session):
             ),
         )
     )
-    wait_for_writes_to_sync()
+    wait_for_writes_to_sync(auth_session=auth_session)
 
     with pytest.raises(HTTPError) as req_info:
         getUserId(custom_user_session)
@@ -159,15 +156,15 @@ def test_02_suspend(graph_client, custom_user_session):
             ),
         )
     )
-    wait_for_writes_to_sync()
+    wait_for_writes_to_sync(auth_session=auth_session)
 
 
-def test_03_hard_delete(graph_client, custom_user_session):
+def test_03_hard_delete(auth_session, graph_client, custom_user_session):
     # assert initial access
     assert getUserId(custom_user_session) == {"urn": user_urn}
 
     graph_client.hard_delete_entity(urn=user_urn)
-    wait_for_writes_to_sync()
+    wait_for_writes_to_sync(auth_session=auth_session)
 
     with pytest.raises(HTTPError) as req_info:
         getUserId(custom_user_session)

--- a/smoke-test/tests/tokens/token_utils.py
+++ b/smoke-test/tests/tokens/token_utils.py
@@ -1,6 +1,110 @@
 import time
+from typing import Any, Dict, List
 
-from tests.utils import get_frontend_url
+from tests.utils import get_frontend_url, wait_for_writes_to_sync
+
+
+def token_name_filter(name: str) -> Dict[str, Any]:
+    return {
+        "field": "name",
+        "condition": "EQUAL",
+        "values": [name],
+    }
+
+
+def list_access_tokens(session, filters: List[Dict[str, Any]]) -> Dict[str, Any]:
+    token_input: Dict[str, Any] = {"start": 0, "count": 20}
+    if filters:
+        token_input["filters"] = filters
+
+    json_payload = {
+        "query": """query listAccessTokens($input: ListAccessTokenInput!) {
+            listAccessTokens(input: $input) {
+              start
+              count
+              total
+              tokens {
+                urn
+                id
+                actorUrn
+                ownerUrn
+              }
+            }
+        }""",
+        "variables": {"input": token_input},
+    }
+
+    response = session.post(f"{get_frontend_url()}/api/v2/graphql", json=json_payload)
+    response.raise_for_status()
+    return response.json()
+
+
+def revoke_access_token(session, token_id: str) -> Dict[str, Any]:
+    json_payload = {
+        "query": """mutation revokeAccessToken($tokenId: String!) {
+            revokeAccessToken(tokenId: $tokenId)
+        }""",
+        "variables": {"tokenId": token_id},
+    }
+
+    response = session.post(f"{get_frontend_url()}/api/v2/graphql", json=json_payload)
+    response.raise_for_status()
+    return response.json()
+
+
+def revoke_tokens_matching(session, filters: List[Dict[str, Any]]) -> None:
+    res_data = list_access_tokens(session, filters)
+    assert res_data
+    assert res_data["data"]
+
+    tokens = res_data["data"]["listAccessTokens"]["tokens"]
+    if tokens:
+        for metadata in tokens:
+            revoke_access_token(session, metadata["id"])
+        wait_for_writes_to_sync()
+
+
+def wait_for_no_tokens_matching(
+    session,
+    filters: List[Dict[str, Any]],
+    *,
+    max_timeout_in_sec: int = 60,
+) -> None:
+    """Revoke matching tokens and poll until listAccessTokens is empty.
+
+    Token search is ES-backed; revoke + wait_for_writes_to_sync is not always
+    enough under xdist load before the next assertion.
+    """
+    start = time.time()
+    last_total: int | None = None
+    while time.time() - start < max_timeout_in_sec:
+        revoke_tokens_matching(session, filters)
+        res_data = list_access_tokens(session, filters)
+        assert res_data
+        assert res_data["data"]
+        listing = res_data["data"]["listAccessTokens"]
+        last_total = listing["total"]
+        if last_total == 0 and not listing["tokens"]:
+            return
+        time.sleep(1)
+    raise AssertionError(
+        f"Timed out waiting for tokens matching {filters} to clear after "
+        f"{max_timeout_in_sec}s (last total={last_total})"
+    )
+
+
+def assert_no_tokens_matching(session, filters: List[Dict[str, Any]]) -> None:
+    res_data = list_access_tokens(session, filters)
+    assert res_data
+    assert res_data["data"]
+    assert res_data["data"]["listAccessTokens"]["total"] == 0
+    assert not res_data["data"]["listAccessTokens"]["tokens"]
+
+
+def assert_graphql_mutation_succeeded(res_data: Dict[str, Any]) -> None:
+    errors = res_data.get("errors")
+    assert not errors, errors
+    assert res_data.get("data")
 
 
 def getUserId(session):

--- a/smoke-test/tests/utilities/env_vars.py
+++ b/smoke-test/tests/utilities/env_vars.py
@@ -197,6 +197,11 @@ def get_kafka_broker_container() -> Optional[str]:
     return os.getenv("KAFKA_BROKER_CONTAINER")
 
 
+def get_datahub_usage_event_topic() -> str:
+    """DataHub usage event topic name."""
+    return str(os.getenv("DATAHUB_USAGE_EVENT_NAME", "DataHubUsageEvent_v1"))
+
+
 # ============================================================================
 # Cypress Testing
 # ============================================================================
@@ -210,6 +215,12 @@ def get_cypress_record_key() -> Optional[str]:
 def get_filtered_tests_file() -> Optional[str]:
     """Path to file containing filtered test paths (one per line)."""
     return os.getenv("FILTERED_TESTS")
+
+
+def get_smoke_policy_phase() -> Optional[str]:
+    """Smoke-test policy phase: ``1`` (non-mutators), ``2`` (mutators), or unset (all)."""
+    raw = os.getenv("SMOKE_POLICY_PHASE", "").strip()
+    return raw or None
 
 
 # ============================================================================

--- a/smoke-test/tests/utils.py
+++ b/smoke-test/tests/utils.py
@@ -5,7 +5,7 @@ import socket
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import quote, urlparse, urlunparse
 
 import click
 import click.testing
@@ -285,6 +285,90 @@ def is_k8s_enabled():
 def wait_for_healthcheck_util(auth_session):
     assert not check_endpoint(auth_session, f"{get_frontend_url()}/admin")
     assert not check_endpoint(auth_session, f"{get_gms_url()}/health")
+
+
+class AdminCorpUserBootstrapError(Exception):
+    """Admin corpUserInfo not yet visible or missing root-user bootstrap flags."""
+
+
+class AdminCorpUserInfoMutatedError(AssertionError):
+    """A smoke test overwrote privileged admin corpUserInfo fields."""
+
+
+_ADMIN_CORPUSER_PRIVILEGED_FLAGS = ("system", "isSupportUser")
+
+
+def get_admin_corpuser_urn() -> str:
+    return f"urn:li:corpuser:{get_admin_username()}"
+
+
+def fetch_admin_corpuser_info(auth_session) -> Dict[str, Any]:
+    """Return corpUserInfo.value for the configured smoke admin."""
+    expected_urn = get_admin_corpuser_urn()
+    encoded = quote(expected_urn, safe="")
+    response = auth_session.get(
+        f"{auth_session.gms_url()}/openapi/v3/entity/corpuser/{encoded}"
+    )
+    if response.status_code != 200:
+        raise AdminCorpUserBootstrapError(
+            f"Admin corpuser not readable: HTTP {response.status_code} for {expected_urn}"
+        )
+    corp_user_info = response.json().get("corpUserInfo")
+    if not corp_user_info or corp_user_info.get("value") is None:
+        raise AdminCorpUserBootstrapError(
+            f"corpUserInfo aspect missing for {expected_urn}"
+        )
+    return dict(corp_user_info.get("value", {}))
+
+
+def assert_admin_corpuser_info_preserved(
+    auth_session,
+    baseline: Dict[str, Any],
+    *,
+    context: str = "",
+) -> None:
+    """Fail if a test cleared privileged corpUserInfo flags on the smoke admin."""
+    current = fetch_admin_corpuser_info(auth_session)
+    cleared = {
+        flag: baseline.get(flag)
+        for flag in _ADMIN_CORPUSER_PRIVILEGED_FLAGS
+        if baseline.get(flag) and not current.get(flag)
+    }
+    if cleared:
+        suffix = f" after {context}" if context else ""
+        raise AdminCorpUserInfoMutatedError(
+            f"Privileged admin corpUserInfo flags were cleared{suffix}: "
+            f"cleared={cleared!r} baseline={baseline!r} current={current!r}"
+        )
+
+
+@tenacity.retry(
+    retry=tenacity.retry_if_exception_type(AdminCorpUserBootstrapError),
+    stop=tenacity.stop_after_attempt(40),
+    wait=tenacity.wait_fixed(3),
+    reraise=True,
+)
+def wait_for_admin_corpuser_system_bootstrap(auth_session) -> None:
+    """Wait until the configured smoke admin has corpUserInfo with system=true.
+
+    Quickstart relies on the root-user bootstrap MCP; GMS health can be ready before
+    that aspect is readable on the entity API (or before the session actor matches).
+    """
+    expected_urn = get_admin_corpuser_urn()
+    me = execute_graphql(auth_session, "query { me { corpUser { urn } } }")
+    actual_urn = me["data"]["me"]["corpUser"]["urn"]
+    if actual_urn != expected_urn:
+        raise AdminCorpUserBootstrapError(
+            f"Session corp user {actual_urn} != configured admin {expected_urn}"
+        )
+
+    info = fetch_admin_corpuser_info(auth_session)
+    if not info.get("system"):
+        raise AdminCorpUserBootstrapError(
+            f"corpUserInfo.system is not true for {expected_urn}: {info!r}"
+        )
+
+    logger.info("Verified admin corpUserInfo bootstrap: %s system=true", expected_urn)
 
 
 def check_endpoint(auth_session, url):
@@ -617,7 +701,9 @@ class TestSessionWrapper:
             }
 
             response = self._upstream.post(
-                f"{self._frontend_url}/api/v2/graphql", json=json
+                f"{self._frontend_url}/api/v2/graphql",
+                json=json,
+                headers={"Authorization": f"Bearer {self._gms_token}"},
             )
             response.raise_for_status()
             # Clear the token ID after successful revocation to prevent double-call issues


### PR DESCRIPTION
## Summary

Speeds up smoke CI with **pytest-xdist** (`-n 3 --dist=loadscope`), a **two-phase runner** for policy mutators, **refreshed batch weights**, and **parallel-test hardening** (from closed #18337).

## CI results (A/B on PR matrix)

Compared on the same 7-batch matrix against `master`:

| Metric | Serial ([29193706291](https://github.com/datahub-project/datahub/actions/runs/29193706291?pr=18270)) | xdist ([29197070047](https://github.com/datahub-project/datahub/actions/runs/29197070047?pr=18270)) |
|--------|--:|--:|
| Total workflow | 40m 31s | **26m 38s (−34%)** |
| Slowest batch | Batch 4 — 33.4m | Batch 6 — 19.0m (−43%) |
| Result | green | green |

Per-batch job time with xdist: 12–19m (was 19–33m serial). Batch balancing fixed the old ~36m skew; xdist saves another ~14m on top.

## Nightly performance (`BATCH_COUNT=1`, full suite)

Manual nightly on this branch: [29265207098](https://github.com/datahub-project/datahub/actions/runs/29265207098) (`7858570`, **green**, 1h 24m wall clock).

Compare against scheduled master nightly [29237994975](https://github.com/datahub-project/datahub/actions/runs/29237994975) (`d799e80`):

| Run | Scope | Result | Slowest smoke job | Notes |
|-----|-------|--------|-------------------|-------|
| Master **attempt 1** | Full suite (serial) | **failed** | **155m** | 1077 tests; 1 failure; serial `pytest` ~108m CPU (`quickstart-postgres` x64 junit) |
| Master **attempt 2** (final) | **10-test retry only** | green | 20m | Partial re-run of failed modules — **not comparable** to full-suite timing |
| Branch [29265207098](https://github.com/datahub-project/datahub/actions/runs/29265207098) | Full suite (xdist + 2-phase) | **green** | **84m** | 1077 tests (1045 phase-1 + 32 phase-2 mutators); all 8 profile×arch jobs pass |

**Full-suite nightly wall clock (apples-to-apples):** ~115–155m serial (master attempt 1, failed) → **~59–84m** with xdist (**~45–50% faster**), now green on both x64 and arm across all 4 quickstart profiles.

**pytest-reported time** (`quickstart-postgres` x64, same ~1077 tests):

| | Serial (master attempt 1) | xdist branch |
|--|--:|--:|
| Phase 1 (non-mutators, `-n 3`) | — | **40m** (1045 tests) |
| Phase 2 (mutators, serial) | — | **12m** (32 tests) |
| Single serial invocation | **108m** | — |
| **Total pytest CPU** | **108m** | **~52m (−52%)** |

Phase 2 adds ~12m of intentional serial overhead for `global_policy_mutator` modules (policy cache / shared platform state). That cost buys correctness; the PR matrix uses the same split.

**Profile spread (branch, wall clock):** `quickstart-postgres` ~59–62m; `quickstart-consumers*` ~82m; CDC profiles ~78–84m (slowest).

## Design

**Two pytest invocations per batch** (`smoke.sh`):

1. **Phase 1** — non-mutators; xdist when `PYTEST_XDIST_WORKERS` is set
2. **Phase 2** — `@pytest.mark.global_policy_mutator` only, always serial, `--reruns 1`

Batch assignment uses the full module set first, then the phase filter — both phases stay on the same `BATCH_NUMBER`.

| Path | `BATCH_COUNT` | `PYTEST_XDIST_WORKERS` |
|------|---------------|------------------------|
| PR matrix (`docker-unified.yml`) | 7 | `3` |
| Nightly (`docker-unified-nightly.yml`) | 1 | `3` |

Mutator modules: `test_privileges`, `test_policies`, `test_policy_eval_perf`, `test_aspect_write_auth`, `test_query_entity_read_auth`, `timeline_change_history_auth_test`.

## Other changes

- **Batch balancing**: refresh `pytest_test_weights.json`; class-aware weight fallback in `conftest.py`; pytest-only weight update scripts
- **Parallel hardening**: scoped token/policy cleanup, entity-scoped audit search, metrics class splits, authenticated lag polling, `auth_session` autouse for xdist workers
- **Stability**: managed ingestion and search projection fixes for parallel load; aspect-write auth tests made self-contained for policy-cache correctness on arm

## Test plan

- [x] Serial matrix baseline green ([29193706291](https://github.com/datahub-project/datahub/actions/runs/29193706291?pr=18270))
- [x] xdist matrix green ([29197070047](https://github.com/datahub-project/datahub/actions/runs/29197070047?pr=18270))
- [x] Nightly full matrix with xdist green ([29265207098](https://github.com/datahub-project/datahub/actions/runs/29265207098))
- [ ] `update-test-weights` workflow: manual `workflow_dispatch` with pytest-only scripts