### PR TITLE
feat(i18n): make the default UI locale configurable via I18N_DEFAULT_LOCALE

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -497,12 +497,14 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
     return isEnabledInConfig && _isS3Enabled;
   }
 
-  // Supported UI locales -- keep in sync with SupportedLanguage in
-  // datahub-web-react/src/app/i18n/types.ts. Used only to warn operators about an
-  // unrecognized I18N_DEFAULT_LOCALE value; the web app performs the authoritative
-  // validation and falls back to English, so a stale entry here only affects the warning.
-  private static final Set<String> SUPPORTED_UI_LOCALES =
-      Set.of("en", "de", "es", "pt-BR", "fr", "it");
+  // The set of UI locales the frontend can render, used ONLY to warn operators when
+  // I18N_DEFAULT_LOCALE is set to an unrecognized value. The web app performs the authoritative
+  // validation and fallback, so a stale entry here can only affect the warning, never override a
+  // valid locale. This MUST mirror the frontend's SupportedLanguage union in
+  // datahub-web-react/src/app/i18n/types.ts (the source of truth);
+  // AppConfigResolverTest#testSupportedUiLocalesMatchFrontendSupportedLanguage fails on drift.
+  // Package-private so that guard test can read it without reflection.
+  static final Set<String> SUPPORTED_UI_LOCALES = Set.of("en", "de", "es", "pt-BR", "fr", "it");
 
   private static String resolveI18nDefaultLocale(final String configuredLocale) {
     if (configuredLocale == null || configuredLocale.isBlank()) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -16,6 +16,7 @@ import com.linkedin.metadata.version.GitVersion;
 import com.linkedin.settings.global.GlobalSettingsInfo;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -290,6 +291,7 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
             .setGlossaryBasedPoliciesEnabled(_featureFlags.isGlossaryBasedPoliciesEnabled())
             .setShowTestsInHealthIcon(_featureFlags.isShowTestsInHealthIcon())
             .setI18nEnabled(_featureFlags.isI18nEnabled())
+            .setI18nDefaultLocale(resolveI18nDefaultLocale(_featureFlags.getI18nDefaultLocale()))
             .build();
 
     appConfig.setFeatureFlags(featureFlagsConfig);
@@ -493,5 +495,26 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
   private boolean isDocumentationFileUploadV1Enabled() {
     boolean isEnabledInConfig = _featureFlags.isDocumentationFileUploadV1();
     return isEnabledInConfig && _isS3Enabled;
+  }
+
+  // Supported UI locales -- keep in sync with SupportedLanguage in
+  // datahub-web-react/src/app/i18n/types.ts. Used only to warn operators about an
+  // unrecognized I18N_DEFAULT_LOCALE value; the web app performs the authoritative
+  // validation and falls back to English, so a stale entry here only affects the warning.
+  private static final Set<String> SUPPORTED_UI_LOCALES =
+      Set.of("en", "de", "es", "pt-BR", "fr", "it");
+
+  private static String resolveI18nDefaultLocale(final String configuredLocale) {
+    if (configuredLocale == null || configuredLocale.isBlank()) {
+      return "en";
+    }
+    if (!SUPPORTED_UI_LOCALES.contains(configuredLocale)) {
+      log.warn(
+          "I18N_DEFAULT_LOCALE '{}' is not a supported UI locale {}; users without a language "
+              + "preference will fall back to English.",
+          configuredLocale,
+          SUPPORTED_UI_LOCALES);
+    }
+    return configuredLocale;
   }
 }

--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -890,6 +890,12 @@ type FeatureFlagsConfig {
   If enabled, internationalization (i18n) features are active.
   """
   i18nEnabled: Boolean!
+
+  """
+  The default UI locale (BCP-47 code) applied when a user has not selected a supported
+  language. Falls back to English if unset or not a supported locale.
+  """
+  i18nDefaultLocale: String!
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolverTest.java
@@ -23,10 +23,15 @@ import com.linkedin.metadata.version.GitVersion;
 import com.linkedin.settings.global.ApplicationsSettings;
 import com.linkedin.settings.global.GlobalSettingsInfo;
 import graphql.schema.DataFetchingEnvironment;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
@@ -1059,5 +1064,51 @@ public class AppConfigResolverTest {
           expectedModelEmbeddingKey,
           "Model embedding key derivation failed for model ID: " + modelId);
     }
+  }
+
+  @Test
+  public void testSupportedUiLocalesMatchFrontendSupportedLanguage() throws Exception {
+    // Drift guard: AppConfigResolver.SUPPORTED_UI_LOCALES (used only to warn on an unrecognized
+    // I18N_DEFAULT_LOCALE) must mirror the frontend's authoritative SupportedLanguage union in
+    // datahub-web-react/src/app/i18n/types.ts, which is what the UI actually validates against.
+    Path typesFile = locateFrontendI18nTypesFile();
+    String contents = Files.readString(typesFile);
+
+    Matcher union = Pattern.compile("SupportedLanguage\\s*=\\s*([^;]+);").matcher(contents);
+    assertTrue(union.find(), "Could not find the SupportedLanguage union in " + typesFile);
+
+    Set<String> frontendLocales = new HashSet<>();
+    Matcher codes = Pattern.compile("'([^']+)'").matcher(union.group(1));
+    while (codes.find()) {
+      frontendLocales.add(codes.group(1));
+    }
+    assertFalse(
+        frontendLocales.isEmpty(), "Parsed no locale codes from the SupportedLanguage union");
+
+    assertTrue(
+        AppConfigResolver.SUPPORTED_UI_LOCALES.equals(frontendLocales),
+        "AppConfigResolver.SUPPORTED_UI_LOCALES "
+            + AppConfigResolver.SUPPORTED_UI_LOCALES
+            + " is out of sync with the frontend SupportedLanguage union "
+            + frontendLocales
+            + " (datahub-web-react/src/app/i18n/types.ts). Update the backend set to match.");
+  }
+
+  private static Path locateFrontendI18nTypesFile() {
+    Path relative = Paths.get("datahub-web-react", "src", "app", "i18n", "types.ts");
+    Path dir = Paths.get("").toAbsolutePath();
+    for (int i = 0; i < 6 && dir != null; i++) {
+      Path candidate = dir.resolve(relative);
+      if (Files.exists(candidate)) {
+        return candidate;
+      }
+      dir = dir.getParent();
+    }
+    throw new IllegalStateException(
+        "Could not locate "
+            + relative
+            + " by walking up from "
+            + Paths.get("").toAbsolutePath()
+            + "; the frontend source is required for this drift-guard test.");
   }
 }

--- a/datahub-web-react/src/app/i18n/hooks/__tests__/useDefaultLanguage.test.ts
+++ b/datahub-web-react/src/app/i18n/hooks/__tests__/useDefaultLanguage.test.ts
@@ -1,0 +1,40 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_LANGUAGE } from '@app/i18n/constants';
+import { useDefaultLanguage } from '@app/i18n/hooks/useDefaultLanguage';
+import { useAppConfig } from '@app/useAppConfig';
+
+vi.mock('@app/useAppConfig');
+
+const mockUseAppConfig = vi.mocked(useAppConfig);
+
+function mockConfiguredLocale(i18nDefaultLocale?: string) {
+    mockUseAppConfig.mockReturnValue({
+        config: { featureFlags: { i18nDefaultLocale } },
+    } as unknown as ReturnType<typeof useAppConfig>);
+}
+
+describe('useDefaultLanguage', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns the configured locale when it is a supported language', () => {
+        mockConfiguredLocale('de');
+        const { result } = renderHook(() => useDefaultLanguage());
+        expect(result.current).toBe('de');
+    });
+
+    it('falls back to English when the configured locale is not supported', () => {
+        mockConfiguredLocale('xx');
+        const { result } = renderHook(() => useDefaultLanguage());
+        expect(result.current).toBe(DEFAULT_LANGUAGE);
+    });
+
+    it('falls back to English when no locale is configured', () => {
+        mockConfiguredLocale(undefined);
+        const { result } = renderHook(() => useDefaultLanguage());
+        expect(result.current).toBe(DEFAULT_LANGUAGE);
+    });
+});

--- a/datahub-web-react/src/app/i18n/hooks/useDefaultLanguage.ts
+++ b/datahub-web-react/src/app/i18n/hooks/useDefaultLanguage.ts
@@ -1,6 +1,15 @@
 import { DEFAULT_LANGUAGE } from '@app/i18n/constants';
 import { SupportedLanguage } from '@app/i18n/types';
+import { isSupportedLanguage } from '@app/i18n/utils';
+import { useAppConfig } from '@app/useAppConfig';
 
+/**
+ * The UI-wide default language for users who have not selected a supported language of their own.
+ * Sourced from the `I18N_DEFAULT_LOCALE` env var (surfaced via appConfig). Falls back to English
+ * when the configured value is unset or not a supported locale — GMS logs a warning for an
+ * unsupported value, and this is the authoritative client-side guard.
+ */
 export function useDefaultLanguage(): SupportedLanguage {
-    return DEFAULT_LANGUAGE;
+    const configuredLocale = useAppConfig().config?.featureFlags?.i18nDefaultLocale;
+    return configuredLocale && isSupportedLanguage(configuredLocale) ? configuredLocale : DEFAULT_LANGUAGE;
 }

--- a/datahub-web-react/src/appConfigContext.tsx
+++ b/datahub-web-react/src/appConfigContext.tsx
@@ -104,6 +104,7 @@ export const DEFAULT_APP_CONFIG = {
         multipleDataProductsPerAsset: false,
         showTestsInHealthIcon: false,
         i18nEnabled: false,
+        i18nDefaultLocale: 'en',
     },
     chromeExtensionConfig: {
         enabled: false,

--- a/datahub-web-react/src/graphql/app.graphql
+++ b/datahub-web-react/src/graphql/app.graphql
@@ -127,6 +127,7 @@ query appConfig {
             multipleDataProductsPerAsset
             showTestsInHealthIcon
             i18nEnabled
+            i18nDefaultLocale
         }
         chromeExtensionConfig {
             enabled

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -562,6 +562,7 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "featureFlags.showSeparateSiblings",
           "featureFlags.showSimplifiedHomepageByDefault",
           "featureFlags.showTestsInHealthIcon",
+          "featureFlags.i18nDefaultLocale",
           "featureFlags.i18nEnabled",
           "featureFlags.timeseriesAspectBatchLoadEnabled",
           "featureFlags.timeseriesAspectAggBatchLoadEnabled",

--- a/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
@@ -64,6 +64,7 @@ public class FeatureFlags {
   private boolean createSchemaVersionIndex = false;
   private boolean aspectMigrationMutatorEnabled = false;
   private boolean i18nEnabled = false;
+  private String i18nDefaultLocale = "en";
   private boolean timeseriesAspectBatchLoadEnabled = true;
   private boolean timeseriesAspectAggBatchLoadEnabled = true;
 }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -1479,6 +1479,7 @@ featureFlags:
   glossaryBasedPoliciesEnabled: ${GLOSSARY_BASED_POLICIES_ENABLED:false} # Enables glossary-based policies to be created
   showTestsInHealthIcon: ${SHOW_TESTS_IN_HEALTH_ICON:false} # If enabled, shows tests status in the health icon on entity pages
   i18nEnabled: ${I18N_ENABLED:false} # If enabled, internationalization (i18n) features are active
+  i18nDefaultLocale: ${I18N_DEFAULT_LOCALE:en} # Default UI locale (BCP-47) for users who have not chosen a language; falls back to English if unset or not a supported locale. Only takes effect when i18nEnabled is true.
   timeseriesAspectBatchLoadEnabled: ${TIMESERIES_ASPECT_BATCH_LOAD_ENABLED:true} # If enabled, TimeSeriesAspectResolver uses the DataLoader batch path; disable to revert to single-URN queries
   timeseriesAspectAggBatchLoadEnabled: ${TIMESERIES_ASPECT_AGG_BATCH_LOAD_ENABLED:true} # If enabled, Dashboard.statsSummary uses the batch aggregation DataLoader; disable to revert to per-URN queries
   createSchemaVersionIndex: ${CREATE_SCHEMA_VERSION_INDEX:${ZDU_STAGE_10:false}} # Creates schemaVersionIndex on metadata_aspect_v2 for ZDU schema version queries


### PR DESCRIPTION
## Summary

Makes the DataHub UI's **default language configurable** via a new `I18N_DEFAULT_LOCALE` environment variable. Previously the default was hardcoded to English (`en`) in the frontend. Operators can now set the organization-wide default locale for users who haven't chosen their own language.

This mirrors the existing `I18N_ENABLED` flow: a GMS env var → `featureFlags` config → `appConfig` GraphQL query → frontend.

## Behavior

- **Unset** → defaults to English (`en`), unchanged from today.
- **Set to a supported locale** (e.g. `de`, `fr`, `it`) → users who haven't picked a language in **Settings → Preferences** see the UI in that locale. A user's own language choice always takes precedence.
- **Set to an invalid/unsupported value** → GMS logs a warning at config resolution, and the UI falls back to English.
- Only takes effect when i18n is enabled (`I18N_ENABLED=true`).
- i18next's missing-key fallback stays English, so any untranslated string still renders in English rather than showing a gap.

## Changes

**Backend (GMS):**
- `application.yaml` — `featureFlags.i18nDefaultLocale: ${I18N_DEFAULT_LOCALE:en}`
- `FeatureFlags.java` — new `i18nDefaultLocale` field (default `"en"`)
- `app.graphql` — `i18nDefaultLocale: String!` on `FeatureFlagsConfig`
- `AppConfigResolver` — exposes the value; `resolveI18nDefaultLocale(...)` logs a warning when the configured value isn't a recognized UI locale (validated against a documented `SUPPORTED_UI_LOCALES` set). The raw value is passed through; the web app performs the authoritative validation, so a stale backend set can only affect the warning, never override a valid locale.
- `PropertiesCollectorConfigurationTest` — classified the new property as non-sensitive

**Frontend:**
- `app.graphql` query + `appConfigContext` default — surface/consume the new field
- `useDefaultLanguage` — reads the configured locale and validates it with `isSupportedLanguage`, falling back to English otherwise (authoritative client-side guard)
- `useDefaultLanguage.test.ts` — supported value passes through; unsupported/unset → English

## Notes

- Two-layer validation by design: the server-side warning is for operator visibility (where the env var is set); the frontend owns the authoritative `SupportedLanguage` list and the final fallback. The backend `SUPPORTED_UI_LOCALES` set (used only for the warning — GMS can't import the frontend TS source of truth at runtime) is protected by a **drift-guard unit test** (`AppConfigResolverTest#testSupportedUiLocalesMatchFrontendSupportedLanguage`) that parses the frontend `SupportedLanguage` union and fails if the two diverge, mirroring the existing `PropertiesCollectorConfigurationTest` guard pattern.
- No metadata-model / PDL changes; the per-user locale mechanism is untouched.

## Verification

| Gate | Result |
| --- | --- |
| `datahub-graphql-core` + config module compile (SDL codegen picks up the new field) | ✅ BUILD SUCCESSFUL |
| `PropertiesCollectorConfigurationTest` | ✅ passed |
| `AppConfigResolverTest` (incl. new locale drift guard) | ✅ 36/36, 0 failures |
| Frontend `yarn generate` (types include `i18nDefaultLocale`) | ✅ |
| `yarn test src/app/i18n` | ✅ 26/26 (incl. new `useDefaultLanguage` tests) |
| `yarn type-check` | ✅ clean |
| eslint (changed files) | ✅ 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
