### PR TITLE
fix(structured-properties): preserve allowedValues order in search fi…

### DIFF
--- a/datahub-web-react/src/app/searchV2/filters/value/__tests__/utils.test.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/__tests__/utils.test.tsx
@@ -7,13 +7,14 @@ import {
     getDefaultFieldOperatorType,
     getEntityTypeFilterValueDisplayName,
     mapFilterCountsToZero,
+    mergeFilterOptionsInAllowedValuesOrder,
     useLoadAggregationOptions,
 } from '@app/searchV2/filters/value/utils';
 import { FILTER_DELIMITER } from '@app/searchV2/utils/constants';
 import useGetSearchQueryInputs from '@src/app/search/useGetSearchQueryInputs';
 
 import { useAggregateAcrossEntitiesQuery } from '@graphql/search.generated';
-import { EntityType } from '@types';
+import { AllowedValue, EntityType } from '@types';
 
 // Mock the GraphQL queries
 vi.mock('@graphql/search.generated', () => ({
@@ -99,6 +100,54 @@ describe('deduplicateOptions', () => {
 
         const baseOptions: FilterValueOption[] = [{ value: 'option1', displayName: 'Option 1' }];
         expect(deduplicateOptions(baseOptions, [])).toEqual([]);
+    });
+});
+
+const stringAllowedValue = (value: string): AllowedValue => ({
+    value: { __typename: 'StringValue', stringValue: value },
+    description: null,
+});
+
+describe('mergeFilterOptionsInAllowedValuesOrder', () => {
+    it('preserves definition order instead of aggregation order', () => {
+        const allowedValues = [
+            stringAllowedValue('Zebra'),
+            stringAllowedValue('Delta'),
+            stringAllowedValue('Charlie'),
+            stringAllowedValue('Bravo'),
+            stringAllowedValue('Alpha'),
+        ];
+
+        const aggregationOptions: FilterValueOption[] = [
+            { value: 'Alpha', count: 1, displayName: 'Alpha' },
+            { value: 'Bravo', count: 2, displayName: 'Bravo' },
+            { value: 'Charlie', count: 3, displayName: 'Charlie' },
+            { value: 'Delta', count: 4, displayName: 'Delta' },
+            { value: 'Zebra', count: 5, displayName: 'Zebra' },
+        ];
+
+        const merged = mergeFilterOptionsInAllowedValuesOrder(aggregationOptions, allowedValues, (rawValue) => ({
+            value: rawValue,
+            count: 0,
+            displayName: rawValue,
+        }));
+
+        expect(merged.map((option) => option.value)).toEqual(['Zebra', 'Delta', 'Charlie', 'Bravo', 'Alpha']);
+        expect(merged[0].count).toBe(5);
+        expect(merged[4].count).toBe(1);
+    });
+
+    it('includes definition values missing from aggregations', () => {
+        const allowedValues = [stringAllowedValue('Zebra'), stringAllowedValue('Alpha')];
+
+        const merged = mergeFilterOptionsInAllowedValuesOrder(
+            [{ value: 'Alpha', count: 1, displayName: 'Alpha' }],
+            allowedValues,
+            (rawValue) => ({ value: rawValue, count: 0, displayName: rawValue }),
+        );
+
+        expect(merged.map((option) => option.value)).toEqual(['Zebra', 'Alpha']);
+        expect(merged[0].count).toBe(0);
     });
 });
 

--- a/datahub-web-react/src/app/searchV2/filters/value/utils.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/utils.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 
+import { getStructuredPropertyValue } from '@app/entity/shared/utils';
 import {
     EntityFilterField,
     FieldType,
@@ -21,7 +22,7 @@ import {
     useGetAutoCompleteMultipleResultsQuery,
     useGetSearchResultsForMultipleQuery,
 } from '@graphql/search.generated';
-import { AndFilterInput, EntityType, NumberValue, StringValue, StructuredPropertyEntity } from '@types';
+import { AllowedValue, AndFilterInput, EntityType, StructuredPropertyEntity } from '@types';
 
 const MAX_AGGREGATION_COUNT = 40;
 
@@ -32,6 +33,34 @@ const MAX_AGGREGATION_COUNT = 40;
 export const deduplicateOptions = (baseOptions: FilterValueOption[], moreOptions: FilterValueOption[]) => {
     const baseValues = baseOptions.map((op) => op.value);
     return moreOptions.filter((op) => !baseValues.includes(op.value));
+};
+
+const getAllowedValueFilterKey = (allowedValue: AllowedValue): string | null => {
+    const raw = getStructuredPropertyValue(allowedValue.value);
+    if (raw === null || raw === undefined) {
+        return null;
+    }
+    return String(raw);
+};
+
+export const mergeFilterOptionsInAllowedValuesOrder = (
+    aggregationOptions: FilterValueOption[],
+    allowedValuesFromDefinition: AllowedValue[],
+    buildMissingOption: (rawValue: string) => FilterValueOption,
+): FilterValueOption[] => {
+    const aggByValue = new Map(aggregationOptions.map((option) => [option.value, option]));
+
+    const definitionValues = allowedValuesFromDefinition
+        .map(getAllowedValueFilterKey)
+        .filter((rawValue): rawValue is string => rawValue !== null);
+
+    const orderedFromDefinition = definitionValues.map(
+        (rawValue) => aggByValue.get(rawValue) ?? buildMissingOption(rawValue),
+    );
+
+    const remainingOptions = aggregationOptions.filter((option) => !definitionValues.includes(option.value));
+
+    return [...orderedFromDefinition, ...remainingOptions];
 };
 
 export const mapFilterCountsToZero = (options: FilterValueOption[]) => {
@@ -110,25 +139,15 @@ export const useLoadAggregationOptions = ({
             : undefined;
     const allowedValuesFromDefinition = structuredPropEntity?.definition?.allowedValues;
     if (allowedValuesFromDefinition?.length) {
-        const existingValues = new Set((options || []).map((o) => o.value));
-        const extraOptions: FilterValueOption[] = allowedValuesFromDefinition
-            .map((av): FilterValueOption | null => {
-                let rawValue: string | null = null;
-                if (av.value?.__typename === 'StringValue') {
-                    rawValue = (av.value as StringValue).stringValue;
-                } else if (av.value?.__typename === 'NumberValue') {
-                    rawValue = String((av.value as NumberValue).numberValue);
-                }
-                if (rawValue === null || existingValues.has(rawValue)) return null;
-                return {
-                    value: rawValue,
-                    icon: field.icon,
-                    count: includeCounts ? 0 : undefined,
-                    displayName: getStructuredPropFilterDisplayName(field.field, rawValue, field.entity),
-                };
-            })
-            .filter((opt): opt is FilterValueOption => opt !== null);
-        return { options: [...(options || []), ...extraOptions], loading };
+        return {
+            options: mergeFilterOptionsInAllowedValuesOrder(options || [], allowedValuesFromDefinition, (rawValue) => ({
+                value: rawValue,
+                icon: field.icon,
+                count: includeCounts ? 0 : undefined,
+                displayName: getStructuredPropFilterDisplayName(field.field, rawValue, field.entity),
+            })),
+            loading,
+        };
     }
 
     return { options: options || [], loading };


### PR DESCRIPTION
…lters

Search filter options for structured properties were built from Elasticsearch aggregation order first, which alphabetizes values before the definition list is applied. When a property has allowedValues, merge options in definition order instead so the UI matches API send order.

Adds regression tests for mergeFilterOptionsInAllowedValuesOrder (CAT-2443).

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
