### PR TITLE
test(datahub-upgrade): stop connection-retry storms in Spring-context tests

### DIFF
--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/DatahubUpgradeNoSchemaRegistryTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/DatahubUpgradeNoSchemaRegistryTest.java
@@ -33,7 +33,6 @@ import org.testng.annotations.Test;
 @SpringBootTest(
     classes = {UpgradeCliApplication.class, UpgradeCliApplicationTestConfiguration.class},
     properties = {
-      "kafka.schemaRegistry.type=INTERNAL",
       "DATAHUB_UPGRADE_HISTORY_TOPIC_NAME=" + Topics.DATAHUB_UPGRADE_HISTORY_TOPIC_NAME,
       "METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME=" + Topics.METADATA_CHANGE_LOG_VERSIONED,
     },

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/DatahubUpgradeNonBlockingTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/DatahubUpgradeNonBlockingTest.java
@@ -57,7 +57,6 @@ import org.testng.annotations.Test;
     classes = {UpgradeCliApplication.class, UpgradeCliApplicationTestConfiguration.class},
     properties = {
       "BOOTSTRAP_SYSTEM_UPDATE_DATA_JOB_NODE_CLL_ENABLED=true",
-      "kafka.schemaRegistry.type=INTERNAL",
       "DATAHUB_UPGRADE_HISTORY_TOPIC_NAME=" + Topics.DATAHUB_UPGRADE_HISTORY_TOPIC_NAME,
       "METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME=" + Topics.METADATA_CHANGE_LOG_VERSIONED,
     },

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/UpgradeCliApplicationTestConfiguration.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/UpgradeCliApplicationTestConfiguration.java
@@ -9,6 +9,7 @@ import com.linkedin.gms.factory.search.semantic.EmbeddingProviderFactory;
 import com.linkedin.gms.factory.search.semantic.SemanticEntitySearchServiceFactory;
 import com.linkedin.metadata.EbeanTestUtils;
 import com.linkedin.metadata.EventSchemaData;
+import com.linkedin.metadata.dao.producer.KafkaEventProducer;
 import com.linkedin.metadata.graph.GraphService;
 import com.linkedin.metadata.models.registry.ConfigEntityRegistry;
 import com.linkedin.metadata.models.registry.EntityRegistry;
@@ -24,11 +25,14 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.annotation.Nonnull;
 import java.util.UUID;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.kafka.clients.producer.Producer;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -95,9 +99,15 @@ public class UpgradeCliApplicationTestConfiguration {
     return new EventSchemaData(systemOpContext.getYamlMapper());
   }
 
+  // @Lazy breaks a circular dependency that closes only in pgQueue mode: entityService ->
+  // kafkaEventProducer (PgQueueEventProducerFactory needs schemaRegistryService) ->
+  // schemaRegistryService -> eventSchemaData -> systemOperationContext -> entityService.
+  // SchemaRegistryServiceImpl only stores eventSchemaData (buildTopicToSchemaNameMap uses just the
+  // TopicConvention), so deferring its creation is safe and lets the in-process entity client work
+  // for pgQueue tests too.
   @Bean
   public SchemaRegistryService schemaRegistryService(
-      @Qualifier("eventSchemaData") final EventSchemaData eventSchemaData) {
+      @Lazy @Qualifier("eventSchemaData") final EventSchemaData eventSchemaData) {
     return new SchemaRegistryServiceImpl(new TopicConventionImpl(), eventSchemaData);
   }
 
@@ -135,5 +145,51 @@ public class UpgradeCliApplicationTestConfiguration {
     config.getNetworkConfig().getJoin().getKubernetesConfig().setEnabled(false);
     config.setClusterName("datahub-upgrade-test-" + UUID.randomUUID());
     return Hazelcast.newHazelcastInstance(config);
+  }
+
+  /**
+   * Replace the real Kafka producers with mocks.
+   *
+   * <p>{@code GeneralUpgradeConfiguration} component-scans {@code com.linkedin.gms.factory}, which
+   * pulls in {@code DataHubKafkaProducerFactory}. Its {@code kafkaProducer} and {@code
+   * dataHubUsageProducer} beans construct real {@link
+   * org.apache.kafka.clients.producer.KafkaProducer} instances that open network connections to the
+   * configured broker. No broker exists in this module's tests (UpgradeCli is mocked, so the topic
+   * create/wait steps never run), so every Spring context boot spawns producer network threads that
+   * spin in connection-retry loops -- thousands of WARN lines per run plus wasted time and CPU on
+   * every context startup.
+   *
+   * <p>These overrides (enabled by {@code spring.main.allow-bean-definition-overriding=true} in
+   * application-test.properties) keep the wiring intact -- {@code KafkaEventProducer} still wraps a
+   * {@link org.apache.kafka.clients.producer.Producer} -- while never touching the network.
+   */
+  @Bean(name = "kafkaProducer")
+  @Primary
+  @SuppressWarnings("unchecked")
+  public Producer<String, IndexedRecord> kafkaProducer() {
+    return Mockito.mock(Producer.class);
+  }
+
+  @Bean(name = "dataHubUsageProducer")
+  @Primary
+  @SuppressWarnings("unchecked")
+  public Producer<String, String> dataHubUsageProducer() {
+    return Mockito.mock(Producer.class);
+  }
+
+  /**
+   * Replace the DataHub-upgrade-history event producer with a mock.
+   *
+   * <p>{@code SystemUpdateKafkaMessagingConfig#duheKafkaEventProducer} builds its own {@link
+   * org.apache.kafka.clients.producer.KafkaProducer} directly (not via the {@code kafkaProducer}
+   * bean mocked above), so it opens its own broker connection. With the INTERNAL schema registry
+   * (the default for these tests) it also becomes the {@code @Primary kafkaEventProducer} used by
+   * EntityService, so mocking it here keeps the {@code kafkaEventProducer == duheKafkaEventProducer
+   * == entityService.getProducer()} identity that DatahubUpgradeNoSchemaRegistryTest and
+   * DatahubUpgradeNonBlockingTest assert, while removing the last real Kafka connection.
+   */
+  @Bean(name = "duheKafkaEventProducer")
+  public KafkaEventProducer duheKafkaEventProducer() {
+    return Mockito.mock(KafkaEventProducer.class);
   }
 }

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/config/ConsistencyServiceBeanTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/config/ConsistencyServiceBeanTest.java
@@ -26,7 +26,6 @@ import org.testng.annotations.Test;
 @ActiveProfiles("test")
 @SpringBootTest(
     classes = {UpgradeCliApplication.class, UpgradeCliApplicationTestConfiguration.class},
-    properties = {"kafka.schemaRegistry.type=INTERNAL"},
     args = {"-u", "SystemUpdateNonBlocking"})
 public class ConsistencyServiceBeanTest extends AbstractTestNGSpringContextTests {
 

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/config/SystemUpdateConfigTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/config/SystemUpdateConfigTest.java
@@ -21,7 +21,6 @@ import org.testng.annotations.Test;
 @ActiveProfiles("test")
 @SpringBootTest(
     classes = {UpgradeCliApplication.class, UpgradeCliApplicationTestConfiguration.class},
-    properties = {"kafka.schemaRegistry.type=INTERNAL"},
     args = {"-u", "SystemUpdateBlocking"})
 public class SystemUpdateConfigTest extends AbstractTestNGSpringContextTests {
 

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/kafka/ConfluentSchemaRegistryCleanupPolicyStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/kafka/ConfluentSchemaRegistryCleanupPolicyStepTest.java
@@ -17,6 +17,7 @@ import com.linkedin.metadata.config.kafka.ProducerConfiguration;
 import com.linkedin.metadata.config.kafka.SetupConfiguration;
 import com.linkedin.upgrade.DataHubUpgradeState;
 import io.datahubproject.metadata.context.OperationContext;
+import java.time.Duration;
 import java.util.Arrays;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
@@ -171,8 +172,17 @@ public class ConfluentSchemaRegistryCleanupPolicyStepTest {
 
   @Test
   public void testCreateAdminClientMethod() {
-    // Test that the createAdminClient method can be called
-    AdminClient adminClient = step.createAdminClient();
-    assertNotNull(adminClient);
+    // Verify createAdminClient() builds a client; close it immediately since there is no broker
+    // in tests -- otherwise its background network thread retries the broker for the rest of the
+    // JVM's life, spewing NetworkClient WARNs and burning CPU across the whole test run.
+    AdminClient adminClient = null;
+    try {
+      adminClient = step.createAdminClient();
+      assertNotNull(adminClient);
+    } finally {
+      if (adminClient != null) {
+        adminClient.close(Duration.ZERO);
+      }
+    }
   }
 }

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/kafka/CreateKafkaTopicsStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/kafka/CreateKafkaTopicsStepTest.java
@@ -19,6 +19,7 @@ import com.linkedin.metadata.config.kafka.SetupConfiguration;
 import com.linkedin.metadata.config.kafka.TopicsConfiguration;
 import com.linkedin.upgrade.DataHubUpgradeState;
 import io.datahubproject.metadata.context.OperationContext;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -623,9 +624,18 @@ public class CreateKafkaTopicsStepTest {
 
   @Test
   public void testCreateAdminClientMethod() {
-    // Test that the createAdminClient method can be called
-    AdminClient adminClient = step.createAdminClient();
-    assertNotNull(adminClient);
+    // Verify createAdminClient() builds a client; close it immediately since there is no broker
+    // in tests -- otherwise its background network thread retries the broker for the rest of the
+    // JVM's life, spewing NetworkClient WARNs and burning CPU across the whole test run.
+    AdminClient adminClient = null;
+    try {
+      adminClient = step.createAdminClient();
+      assertNotNull(adminClient);
+    } finally {
+      if (adminClient != null) {
+        adminClient.close(Duration.ZERO);
+      }
+    }
   }
 
   @Test

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/kafka/WaitForKafkaReadyStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/kafka/WaitForKafkaReadyStepTest.java
@@ -15,6 +15,7 @@ import com.linkedin.metadata.config.kafka.KafkaConfiguration;
 import com.linkedin.metadata.config.kafka.SetupConfiguration;
 import com.linkedin.upgrade.DataHubUpgradeState;
 import io.datahubproject.metadata.context.OperationContext;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -159,14 +160,20 @@ public class WaitForKafkaReadyStepTest {
 
   @Test
   public void testCreateAdminClientMethod() {
-    // Test that the createAdminClient method exists and can be called
-    // This will fail in tests since we don't have real Kafka configuration,
-    // but it verifies the method structure
+    // Verify createAdminClient() builds a client. There is no broker in tests, so close it
+    // immediately -- otherwise its background network thread spins in connection-retry loops
+    // for the rest of the JVM's life, spewing thousands of NetworkClient WARNs and burning CPU.
+    AdminClient adminClient = null;
     try {
-      step.createAdminClient();
+      adminClient = step.createAdminClient();
+      assertNotNull(adminClient);
     } catch (Exception e) {
-      // Expected to fail in test environment, but method should exist
+      // createAdminClient may throw on invalid config; the method still exists.
       assertNotNull(e);
+    } finally {
+      if (adminClient != null) {
+        adminClient.close(Duration.ZERO);
+      }
     }
   }
 }

--- a/datahub-upgrade/src/test/resources/application-test.properties
+++ b/datahub-upgrade/src/test/resources/application-test.properties
@@ -2,3 +2,42 @@ authentication.enabled=true
 authentication.tokenService.signingKey=test-signing-key-for-tests
 authentication.tokenService.salt=test-salt-for-tests
 datahub.gms.entityGraphCache.enabled=false
+
+# datahub-upgrade tests run without a Kafka broker (UpgradeCli is mocked, so the
+# topic create/wait steps never execute). The event producers (kafkaEventProducer /
+# duheKafkaEventProducer from SystemUpdateKafkaMessagingConfig) still initialize, and
+# their first metadata fetch blocks for max.block.ms (default 60000ms) before failing,
+# adding ~60s per blocked send to every Spring context boot.
+#
+# The producers are built from Spring's KafkaProperties.buildProducerProperties() and
+# DataHubKafkaProducerFactory never sets max.block.ms, so this passthrough applies.
+# (DataHub's own kafka.serde.event.properties[max.block.ms] is an equivalent path with
+# higher precedence -- it is putAll'd after the Spring props in buildProducerProperties;
+# the Spring form is used here because it also covers non-serde.event producers.)
+#
+# 1000ms captures ~98% of the win (the drop from 60s is what matters) while keeping a
+# small margin over CI scheduling jitter. No broker (real or embedded) exists in this
+# module's tests, so the send is doomed regardless and the outcome is identical -- just
+# ~60x faster to fail.
+spring.kafka.producer.properties.max.block.ms=1000
+
+# Replace the component-scanned Kafka producers with mocks (see
+# UpgradeCliApplicationTestConfiguration). Overriding must be enabled so the @Bean
+# definitions in the test configuration win over the ones registered by the scanned
+# DataHubKafkaProducerFactory. This is the standard pattern across DataHub's Spring tests.
+spring.main.allow-bean-definition-overriding=true
+
+# Use the in-process (INTERNAL) schema registry for all upgrade tests. There is no real
+# schema registry in this module's tests. This was previously set per-test via
+# @SpringBootTest(properties="kafka.schemaRegistry.type=INTERNAL"); centralizing it here
+# keeps behavior identical for those tests while removing the value from the per-test
+# ApplicationContext cache key, so tests that differ only by it now share one cached context.
+kafka.schemaRegistry.type=INTERNAL
+
+# Use the in-process (Java) entity client instead of rest.li. The upgrade app ships
+# entityClient.impl=restli (application.properties), which builds a rest.li R2 client to GMS
+# (datahub.gms.port, default 8080). No GMS runs in these tests, so that client spins in
+# connection-retry loops. SystemUpdateConfig already forces the Java client for blocking
+# updates; this extends it to the other modes. (DatahubUpgradeBlockingPgQueueTest overrides
+# back to restli -- the Java client's CDC/pgQueue wiring isn't satisfied in that context.)
+entityClient.impl=java


### PR DESCRIPTION
## Summary

`:datahub-upgrade:test` is one of the slowest tasks in the build. Its `@SpringBootTest` context
tests boot the full `UpgradeCliApplication` **without any backing services running** — `UpgradeCli`
is mocked, so the real upgrade steps never execute. But the Spring context still wires up real
clients that then spin in connection-retry loops against services that aren't there, and a few step
unit tests build real clients too. With no broker/GMS reachable (the normal state in CI), these
retry for minutes and emit tens of thousands of `NetworkClient` WARN lines.

There are three sources:

1. **Kafka producers** — `DataHubKafkaProducerFactory` (`kafkaProducer`, `dataHubUsageProducer`) and
   `SystemUpdateKafkaMessagingConfig` (`duheKafkaEventProducer`).
2. **GMS rest.li client** — `datahub-upgrade` ships `entityClient.impl=restli`, which builds a
   rest.li R2 client to GMS (`datahub.gms.port`, default 8080).
3. **Kafka admin clients** — three step unit tests (`WaitForKafkaReadyStepTest`,
   `CreateKafkaTopicsStepTest`, `ConfluentSchemaRegistryCleanupPolicyStepTest`) build a real
   `AdminClient` in their `testCreateAdminClientMethod` and never close it, leaving a background
   network thread retrying the broker for the rest of the JVM's life.

## Changes (test-only)

- **Mock the Kafka producers** in `UpgradeCliApplicationTestConfiguration` (`kafkaProducer`,
  `dataHubUsageProducer`, `duheKafkaEventProducer`), enabled by
  `spring.main.allow-bean-definition-overriding=true`. The `duheKafkaEventProducer` mock preserves
  the `kafkaEventProducer == duheKafkaEventProducer == entityService.getProducer()` identity that
  `DatahubUpgradeNoSchemaRegistryTest` / `DatahubUpgradeNonBlockingTest` assert.
- **Use the in-process Java entity client** (`entityClient.impl=java`) so no rest.li R2 client
  dials GMS.
- **Break a pgQueue-only circular dependency with `@Lazy`** so the Java client works there too:
  `entityService → kafkaEventProducer (PgQueueEventProducerFactory needs schemaRegistryService) →
  schemaRegistryService → eventSchemaData → systemOperationContext → entityService`. The cycle
  closes only in pgQueue mode (the Kafka producer doesn't need `schemaRegistryService`);
  `@Lazy`-injecting `eventSchemaData` into the test `schemaRegistryService` bean defers it (that
  bean only stores it — `buildTopicToSchemaNameMap` uses just the `TopicConvention`), breaking the
  cycle.
- **Close the leaked `AdminClient`** in the three step tests.
- **Cap producer `max.block.ms` at 1000ms** in `application-test.properties` (defense-in-depth for
  any producer not covered by a mock).
- **Centralize `kafka.schemaRegistry.type=INTERNAL`** into `application-test.properties` (it was
  repeated across several `@SpringBootTest(properties=…)`), removing it from per-test
  `ApplicationContext` cache keys so those contexts share one cached context.

## Impact

Measured locally on `:datahub-upgrade:test` with no reachable Kafka / GMS / OpenSearch (forcing a
clean re-run, Kafka pointed at a dead port): the task drops from **~13 min to ~4 min**, Kafka + GMS
connection-failure attempts drop from **~11,800 to ~100** (the ~100 are the brief window before the
admin clients close), and all tests pass.

## Checklist
- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing/#commit-messages))
- [x] Links to related issues (if applicable) — N/A (test-only performance fix)
- [x] Tests updated / added — this PR is test-only
