### PR TITLE
fix(usage): prevent GraphQL async output_bytes double-count

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/validation/CorpUserPrivilegedFlagsValidator.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/validation/CorpUserPrivilegedFlagsValidator.java
@@ -78,8 +78,12 @@ public class CorpUserPrivilegedFlagsValidator extends AspectPayloadValidator {
         continue;
       }
 
-      CorpUserInfo actorInfo =
-          loadCorpUserInfo(operationContext, aspectRetriever, operationContext.getActor());
+      Urn authActor = resolveAuthorizingActor(item, operationContext);
+      if (isIntrinsicSystemActor(authActor)) {
+        continue;
+      }
+
+      CorpUserInfo actorInfo = loadCorpUserInfo(operationContext, aspectRetriever, authActor);
       if (actorInfo == null) {
         exceptions.addException(
             authFailure(item, "Unauthorized to modify privileged CorpUserInfo flags."));
@@ -98,6 +102,30 @@ public class CorpUserPrivilegedFlagsValidator extends AspectPayloadValidator {
     }
 
     return exceptions.streamAllExceptions();
+  }
+
+  /**
+   * Session actor that initiated the write (audit stamp), not {@link
+   * OperationFingerprint#getActor()} which may reflect system escalation when {@code
+   * allowSystemAuthentication} is enabled on the operation context.
+   */
+  @Nonnull
+  private static Urn resolveAuthorizingActor(
+      @Nonnull BatchItem item, @Nonnull OperationFingerprint operationContext) {
+    AuditStamp itemAudit = item.getAuditStamp();
+    if (itemAudit != null && itemAudit.hasActor()) {
+      return itemAudit.getActor();
+    }
+    AuditStamp contextAudit = operationContext.getAuditStamp();
+    if (contextAudit != null && contextAudit.hasActor()) {
+      return contextAudit.getActor();
+    }
+    return operationContext.getActor();
+  }
+
+  /** Service principal {@link Constants#SYSTEM_ACTOR} has no {@link CorpUserInfo} aspect. */
+  private static boolean isIntrinsicSystemActor(@Nonnull Urn authActor) {
+    return SYSTEM_ACTOR.equals(authActor.toString());
   }
 
   @Override

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/validators/CorpUserPrivilegedFlagsValidatorTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/validators/CorpUserPrivilegedFlagsValidatorTest.java
@@ -40,7 +40,9 @@ public class CorpUserPrivilegedFlagsValidatorTest {
   private static final Urn TARGET_USER_URN = UrnUtils.getUrn("urn:li:corpuser:target");
   private static final Urn REGULAR_ACTOR_URN = UrnUtils.getUrn("urn:li:corpuser:regular");
   private static final Urn SYSTEM_ACTOR_USER_URN = UrnUtils.getUrn("urn:li:corpuser:datahub");
+  private static final Urn ADMIN_ACTOR_URN = UrnUtils.getUrn("urn:li:corpuser:admin");
   private static final Urn SUPPORT_ACTOR_URN = UrnUtils.getUrn("urn:li:corpuser:support");
+  private static final Urn INTRINSIC_SYSTEM_ACTOR_URN = UrnUtils.getUrn(SYSTEM_ACTOR);
 
   private static final AspectPluginConfig TEST_PLUGIN_CONFIG =
       AspectPluginConfig.builder()
@@ -240,6 +242,61 @@ public class CorpUserPrivilegedFlagsValidatorTest {
     assertEquals(CorpUserPrivilegedFlagsValidator.isSupportUser(corpUserInfo(false, true)), true);
   }
 
+  @Test
+  public void testEscalatedEffectiveActorUsesSessionAuditStampForSystemCorpUser() {
+    corpUserInfoByUrn.put(ADMIN_ACTOR_URN, corpUserInfo(true, false));
+
+    CorpUserInfo proposed = corpUserInfo(false, true);
+    AuditStamp sessionAudit =
+        new AuditStamp().setActor(ADMIN_ACTOR_URN).setTime(System.currentTimeMillis());
+
+    long violations =
+        validate(
+                proposed,
+                null,
+                operationContext(INTRINSIC_SYSTEM_ACTOR_URN, ADMIN_ACTOR_URN),
+                null,
+                sessionAudit)
+            .count();
+    assertEquals(violations, 0);
+  }
+
+  @Test
+  public void testEscalatedEffectiveActorDoesNotBypassRegularSessionUser() {
+    corpUserInfoByUrn.put(REGULAR_ACTOR_URN, corpUserInfo(false, false));
+
+    CorpUserInfo proposed = corpUserInfo(false, true);
+    AuditStamp sessionAudit =
+        new AuditStamp().setActor(REGULAR_ACTOR_URN).setTime(System.currentTimeMillis());
+
+    long violations =
+        validate(
+                proposed,
+                null,
+                operationContext(INTRINSIC_SYSTEM_ACTOR_URN, REGULAR_ACTOR_URN),
+                null,
+                sessionAudit)
+            .count();
+    assertEquals(violations, 1);
+  }
+
+  @Test
+  public void testIntrinsicSystemActorAllowedWithoutCorpUserInfo() {
+    CorpUserInfo proposed = corpUserInfo(false, true);
+    AuditStamp sessionAudit =
+        new AuditStamp().setActor(INTRINSIC_SYSTEM_ACTOR_URN).setTime(System.currentTimeMillis());
+
+    long violations =
+        validate(
+                proposed,
+                null,
+                operationContext(INTRINSIC_SYSTEM_ACTOR_URN, INTRINSIC_SYSTEM_ACTOR_URN),
+                null,
+                sessionAudit)
+            .count();
+    assertEquals(violations, 0);
+  }
+
   private java.util.stream.Stream<AspectValidationException> validate(
       CorpUserInfo proposed,
       CorpUserInfo current,
@@ -295,11 +352,16 @@ public class CorpUserPrivilegedFlagsValidatorTest {
   }
 
   private static OperationFingerprint operationContext(Urn actorUrn) {
-    AuditStamp auditStamp = new AuditStamp().setActor(actorUrn).setTime(System.currentTimeMillis());
+    return operationContext(actorUrn, actorUrn);
+  }
+
+  private static OperationFingerprint operationContext(Urn effectiveActorUrn, Urn auditActorUrn) {
+    AuditStamp auditStamp =
+        new AuditStamp().setActor(auditActorUrn).setTime(System.currentTimeMillis());
     return new OperationFingerprint() {
       @Override
       public Urn getActor() {
-        return actorUrn;
+        return effectiveActorUrn;
       }
 
       @Override

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/instrumentation/UsageMetricsSessionEnricher.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/instrumentation/UsageMetricsSessionEnricher.java
@@ -9,6 +9,8 @@ import io.datahubproject.metadata.context.usage.AuthChannel;
 import io.datahubproject.metadata.context.usage.instrumentation.SessionContextEnricher;
 import io.datahubproject.metadata.exception.OperationContextException;
 import java.util.Deque;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,13 @@ public class UsageMetricsSessionEnricher implements SessionContextEnricher {
 
   private final UsageAggregationStore usageStore;
   private final boolean enabled;
+
+  /**
+   * Sessions that already received positive {@code output_bytes} via {@link
+   * #recordResponseWithBytes} on an async worker thread. {@link #completeResponse} skips
+   * re-counting on the servlet thread.
+   */
+  private final Set<OperationContext> outOfBandOutputBytesRecorded = ConcurrentHashMap.newKeySet();
 
   @Override
   public void enrichBeforeBuild(
@@ -106,8 +115,16 @@ public class UsageMetricsSessionEnricher implements SessionContextEnricher {
       boolean assignOutputBytes = true;
       while (!sessions.isEmpty()) {
         OperationContext sessionContext = sessions.pop();
+        boolean alreadyRecordedOutOfBand = outOfBandOutputBytesRecorded.remove(sessionContext);
+        Long bytesForSession = assignOutputBytes ? outputBytes : null;
+        if (assignOutputBytes
+            && bytesForSession != null
+            && bytesForSession > 0
+            && alreadyRecordedOutOfBand) {
+          bytesForSession = null;
+        }
         try {
-          usageStore.recordResponse(sessionContext, assignOutputBytes ? outputBytes : null);
+          usageStore.recordResponse(sessionContext, bytesForSession);
         } catch (RuntimeException e) {
           log.warn("Failed to record usage response metrics", e);
         }
@@ -131,6 +148,9 @@ public class UsageMetricsSessionEnricher implements SessionContextEnricher {
       usageStore.recordResponse(sessionContext, outputBytes);
     } catch (RuntimeException e) {
       log.warn("Failed to record usage response metrics", e);
+    }
+    if (outputBytes != null && outputBytes > 0) {
+      outOfBandOutputBytesRecorded.add(sessionContext);
     }
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/instrumentation/UsageMetricsSessionEnricherTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/instrumentation/UsageMetricsSessionEnricherTest.java
@@ -15,6 +15,7 @@ import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -211,12 +212,101 @@ public class UsageMetricsSessionEnricherTest {
     graphqlEnricher.completeResponse(null);
     graphqlEnricher.recordResponseWithBytes(sessionContext, 256L);
 
-    Assert.assertEquals(responseBytes.size(), 2);
-    Assert.assertNull(responseBytes.get(0));
-    Assert.assertEquals(responseBytes.get(1), Long.valueOf(256L));
+    Assert.assertEquals(responseBytes, Arrays.asList(null, 256L));
     long positiveByteCalls =
         responseBytes.stream().filter(bytes -> bytes != null && bytes > 0).count();
     Assert.assertEquals(positiveByteCalls, 1);
+  }
+
+  @Test
+  public void testGraphqlAsyncPath_crossThread_outputBytesRecordedOnce() throws Exception {
+    List<Long> responseBytes = new ArrayList<>();
+    UsageAggregationStore trackingStore =
+        new UsageAggregationStore() {
+          @Override
+          public boolean recordRequest(@Nonnull OperationContext opContext) {
+            return true;
+          }
+
+          @Override
+          public void recordResponse(
+              @Nonnull OperationContext opContext, @Nullable Long outputBytes) {
+            synchronized (responseBytes) {
+              responseBytes.add(outputBytes);
+            }
+          }
+
+          @Override
+          public void flush(@Nonnull com.linkedin.metadata.usage.flush.FlushTrigger trigger) {}
+        };
+    UsageMetricsSessionEnricher graphqlEnricher =
+        new UsageMetricsSessionEnricher(trackingStore, true);
+
+    OperationContext sessionContext = graphqlSession();
+    graphqlEnricher.onSessionReady(sessionContext);
+
+    CountDownLatch workerStarted = new CountDownLatch(1);
+    Thread worker =
+        new Thread(
+            () -> {
+              workerStarted.countDown();
+              graphqlEnricher.recordResponseWithBytes(sessionContext, 256L);
+            });
+    worker.start();
+    workerStarted.await();
+    worker.join();
+
+    graphqlEnricher.completeResponse(256L);
+
+    long positiveByteCalls =
+        responseBytes.stream().filter(bytes -> bytes != null && bytes > 0).count();
+    Assert.assertEquals(positiveByteCalls, 1);
+    Assert.assertEquals(
+        responseBytes.stream().filter(bytes -> bytes != null && bytes > 0).findFirst().get(),
+        Long.valueOf(256L));
+  }
+
+  @Test
+  public void testSyncPath_unaffectedWhenOtherSessionMarkedAsync() throws Exception {
+    List<Long> responseBytes = new ArrayList<>();
+    UsageAggregationStore trackingStore =
+        new UsageAggregationStore() {
+          @Override
+          public boolean recordRequest(@Nonnull OperationContext opContext) {
+            return true;
+          }
+
+          @Override
+          public void recordResponse(
+              @Nonnull OperationContext opContext, @Nullable Long outputBytes) {
+            responseBytes.add(outputBytes);
+          }
+
+          @Override
+          public void flush(@Nonnull com.linkedin.metadata.usage.flush.FlushTrigger trigger) {}
+        };
+    UsageMetricsSessionEnricher enricherUnderTest =
+        new UsageMetricsSessionEnricher(trackingStore, true);
+
+    OperationContext graphqlContext = graphqlSession();
+    enricherUnderTest.recordResponseWithBytes(graphqlContext, 128L);
+
+    Authentication syncAuthentication =
+        new Authentication(new Actor(ActorType.USER, "syncuser"), "Basic test");
+    RequestContext syncRequestContext =
+        openapiBuilder()
+            .usageOperation(UsageOperation.METADATA_READ.key())
+            .usageIdentity("urn:li:corpuser:syncuser")
+            .authChannel(AuthChannel.SESSION)
+            .build();
+    OperationContext syncContext =
+        TestOperationContexts.systemContextNoValidate().toBuilder()
+            .requestContext(syncRequestContext)
+            .build(syncAuthentication, true);
+    enricherUnderTest.onSessionReady(syncContext);
+    enricherUnderTest.completeResponse(512L);
+
+    Assert.assertEquals(responseBytes, Arrays.asList(128L, 512L));
   }
 
   @Test
@@ -270,11 +360,13 @@ public class UsageMetricsSessionEnricherTest {
 
     OperationContext sessionContext = graphqlSession();
     riskEnricher.onSessionReady(sessionContext);
-    riskEnricher.completeResponse(128L);
     riskEnricher.recordResponseWithBytes(sessionContext, 128L);
+    riskEnricher.completeResponse(128L);
 
-    Assert.assertEquals(responseBytes.size(), 2);
-    Assert.assertEquals(responseBytes, Arrays.asList(128L, 128L));
+    Assert.assertEquals(responseBytes, Arrays.asList(128L, null));
+    long positiveByteCalls =
+        responseBytes.stream().filter(bytes -> bytes != null && bytes > 0).count();
+    Assert.assertEquals(positiveByteCalls, 1);
   }
 
   private static OperationContext session(String usageOperation) throws Exception {

--- a/metadata-models/src/main/pegasus/com/linkedin/identity/CorpUserInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/identity/CorpUserInfo.pdl
@@ -9,7 +9,8 @@ import com.linkedin.common.Urn
  * Linkedin corp user information
  */
 @Aspect = {
-  "name": "corpUserInfo"
+  "name": "corpUserInfo",
+  "schemaVersion": 2
 }
 @Aspect.EntityUrns = [ "com.linkedin.common.CorpuserUrn" ]
 record CorpUserInfo includes CustomProperties {
@@ -114,5 +115,14 @@ record CorpUserInfo includes CustomProperties {
     "queryByDefault": false
   }
   system: optional boolean = false
+
+  /**
+   * Whether the corpUser is a support user authenticated through the support OIDC flow.
+   */
+  @Searchable = {
+    "fieldType": "BOOLEAN",
+    "queryByDefault": false
+  }
+  isSupportUser: optional boolean
 
 }

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -2790,10 +2790,20 @@
         "fieldType" : "BOOLEAN",
         "queryByDefault" : false
       }
+    }, {
+      "name" : "isSupportUser",
+      "type" : "boolean",
+      "doc" : "Whether the corpUser is a support user authenticated through the support OIDC flow.",
+      "optional" : true,
+      "Searchable" : {
+        "fieldType" : "BOOLEAN",
+        "queryByDefault" : false
+      }
     } ],
     "Aspect" : {
       "EntityUrns" : [ "com.linkedin.common.CorpuserUrn" ],
-      "name" : "corpUserInfo"
+      "name" : "corpUserInfo",
+      "schemaVersion" : 2
     }
   }, {
     "type" : "record",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -2987,10 +2987,20 @@
                       "fieldType" : "BOOLEAN",
                       "queryByDefault" : false
                     }
+                  }, {
+                    "name" : "isSupportUser",
+                    "type" : "boolean",
+                    "doc" : "Whether the corpUser is a support user authenticated through the support OIDC flow.",
+                    "optional" : true,
+                    "Searchable" : {
+                      "fieldType" : "BOOLEAN",
+                      "queryByDefault" : false
+                    }
                   } ],
                   "Aspect" : {
                     "EntityUrns" : [ "com.linkedin.common.CorpuserUrn" ],
-                    "name" : "corpUserInfo"
+                    "name" : "corpUserInfo",
+                    "schemaVersion" : 2
                   }
                 }, {
                   "type" : "record",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
@@ -2499,10 +2499,20 @@
         "fieldType" : "BOOLEAN",
         "queryByDefault" : false
       }
+    }, {
+      "name" : "isSupportUser",
+      "type" : "boolean",
+      "doc" : "Whether the corpUser is a support user authenticated through the support OIDC flow.",
+      "optional" : true,
+      "Searchable" : {
+        "fieldType" : "BOOLEAN",
+        "queryByDefault" : false
+      }
     } ],
     "Aspect" : {
       "EntityUrns" : [ "com.linkedin.common.CorpuserUrn" ],
-      "name" : "corpUserInfo"
+      "name" : "corpUserInfo",
+      "schemaVersion" : 2
     }
   }, {
     "type" : "record",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.operations.operations.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.operations.operations.snapshot.json
@@ -2493,10 +2493,20 @@
         "fieldType" : "BOOLEAN",
         "queryByDefault" : false
       }
+    }, {
+      "name" : "isSupportUser",
+      "type" : "boolean",
+      "doc" : "Whether the corpUser is a support user authenticated through the support OIDC flow.",
+      "optional" : true,
+      "Searchable" : {
+        "fieldType" : "BOOLEAN",
+        "queryByDefault" : false
+      }
     } ],
     "Aspect" : {
       "EntityUrns" : [ "com.linkedin.common.CorpuserUrn" ],
-      "name" : "corpUserInfo"
+      "name" : "corpUserInfo",
+      "schemaVersion" : 2
     }
   }, {
     "type" : "record",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
@@ -2981,10 +2981,20 @@
                       "fieldType" : "BOOLEAN",
                       "queryByDefault" : false
                     }
+                  }, {
+                    "name" : "isSupportUser",
+                    "type" : "boolean",
+                    "doc" : "Whether the corpUser is a support user authenticated through the support OIDC flow.",
+                    "optional" : true,
+                    "Searchable" : {
+                      "fieldType" : "BOOLEAN",
+                      "queryByDefault" : false
+                    }
                   } ],
                   "Aspect" : {
                     "EntityUrns" : [ "com.linkedin.common.CorpuserUrn" ],
-                    "name" : "corpUserInfo"
+                    "name" : "corpUserInfo",
+                    "schemaVersion" : 2
                   }
                 }, {
                   "type" : "record",

--- a/smoke-test/tests/metrics/test_usage_aggregation_audit.py
+++ b/smoke-test/tests/metrics/test_usage_aggregation_audit.py
@@ -38,6 +38,7 @@ from tests.metrics.usage_aggregation_metrics import (
     generate_openapi_metadata_read_traffic,
     generate_openapi_search_traffic,
     graphql_metadata_query_tags,
+    make_support_actor_user,
     parse_prometheus_tags,
     parse_sample_value,
     resolve_usage_actor_class,
@@ -264,32 +265,45 @@ def test_usage_aggregation_graphql_output_bytes(auth_session):
 
 @pytest.mark.read_only
 def test_usage_aggregation_graphql_output_bytes_not_double_counted(auth_session):
-    """Single GraphQL response should contribute output_bytes ~= body length, not ~2x."""
+    """Single GraphQL response should contribute output_bytes ~= body length, not ~2x.
+
+    Uses a dedicated support user so actor_class=support isolates this test from
+    admin (system) GraphQL traffic elsewhere in the pytest batch.
+    """
     gms_url = _require_prometheus_url()
-    actor_class = expected_actor_class_for_admin_session(auth_session)
-    tags = graphql_metadata_query_tags(actor_class)
+    if not can_provision_native_users(auth_session):
+        pytest.skip(
+            "Session lacks manageIdentities — cannot provision a support user locally"
+        )
 
     from tests.metrics.usage_aggregation_metrics import _ME_QUERY, execute_graphql_raw
 
-    output_baseline = fetch_metric_total(
-        auth_session, gms_url, OUTPUT_BYTES_METRIC, tags
+    user_urn, support_session = make_support_actor_user(
+        auth_session, "usage-output-dedup"
     )
-    response_text = execute_graphql_raw(auth_session, _ME_QUERY)
-    response_len = len(response_text)
-    assert response_len > 0
+    tags = graphql_metadata_query_tags("support")
+    try:
+        output_baseline = fetch_metric_total(
+            auth_session, gms_url, OUTPUT_BYTES_METRIC, tags
+        )
+        response_text = execute_graphql_raw(support_session, _ME_QUERY)
+        response_len = len(response_text)
+        assert response_len > 0
 
-    delta = wait_for_metric_delta(
-        auth_session,
-        gms_url,
-        OUTPUT_BYTES_METRIC,
-        output_baseline,
-        required_tags=tags,
-        min_delta=float(response_len) * 0.95,
-    )
-    # Allow up to ~2x when prior traffic in the same flush window contributes bytes.
-    assert delta <= response_len * 2.1, (
-        f"output_bytes delta {delta} far exceeds response length {response_len}"
-    )
+        delta = wait_for_metric_delta(
+            auth_session,
+            gms_url,
+            OUTPUT_BYTES_METRIC,
+            output_baseline,
+            required_tags=tags,
+            min_delta=float(response_len) * 0.95,
+        )
+        assert delta <= response_len * 2.1, (
+            f"output_bytes delta {delta} far exceeds response length {response_len}"
+        )
+    finally:
+        support_session.destroy()
+        cleanup_step_actor_user(auth_session, user_urn)
 
 
 @pytest.mark.read_only

--- a/smoke-test/tests/metrics/usage_aggregation_metrics.py
+++ b/smoke-test/tests/metrics/usage_aggregation_metrics.py
@@ -7,6 +7,7 @@ import re
 import urllib.parse
 from typing import Dict, List, Optional
 
+import requests
 import tenacity
 
 from tests.utilities.metadata_operations import get_prometheus_metrics
@@ -335,6 +336,50 @@ def can_provision_native_users(auth_session) -> bool:
         "query { me { platformPrivileges { manageIdentities } } }",
     )
     return bool(privileges["data"]["me"]["platformPrivileges"]["manageIdentities"])
+
+
+def set_corpuser_is_support_user(
+    admin_session, corp_user_urn: str, *, is_support_user: bool
+) -> None:
+    """Set CorpUserInfo.isSupportUser (requires admin with system/support privileges)."""
+    from tests.consistency_utils import wait_for_writes_to_sync
+
+    encoded = urllib.parse.quote(corp_user_urn, safe="")
+    gms_url = admin_session.gms_url()
+    get_resp = admin_session.get(f"{gms_url}/openapi/v3/entity/corpuser/{encoded}")
+    get_resp.raise_for_status()
+    info = dict(get_resp.json().get("corpUserInfo", {}).get("value", {}))
+    info["isSupportUser"] = is_support_user
+    post_resp = admin_session.post(
+        f"{gms_url}/openapi/v3/entity/corpuser/{encoded}/corpUserInfo",
+        params={"createIfNotExists": "false"},
+        json={"value": info},
+    )
+    if not post_resp.ok:
+        raise requests.HTTPError(
+            f"{post_resp.status_code} setting isSupportUser on {corp_user_urn}: "
+            f"{post_resp.text}",
+            response=post_resp,
+        )
+    wait_for_writes_to_sync()
+
+
+def make_support_actor_user(admin_session, name: str):
+    """Provision a native user with actor_class=support for isolated usage metrics."""
+    from tests.utilities.multi_user import make_step_actor_user
+    from tests.utils import TestSessionWrapper, get_admin_credentials, login_as
+
+    user_urn, user_session = make_step_actor_user(admin_session, name)
+    # create_user re-authenticates as admin; use a fresh wrapper so GMS PAT calls stay valid.
+    admin_user, admin_pass = get_admin_credentials()
+    refreshed_admin = TestSessionWrapper(login_as(admin_user, admin_pass))
+    set_corpuser_is_support_user(refreshed_admin, user_urn, is_support_user=True)
+    actor_class = resolve_usage_actor_class(user_session)
+    if actor_class != "support":
+        raise AssertionError(
+            f"Expected actor_class=support for {user_urn}, got {actor_class!r}"
+        )
+    return user_urn, user_session
 
 
 def corpuser_entity_exists(auth_session, corp_user_urn: str) -> bool:


### PR DESCRIPTION
## Summary

### GraphQL `output_bytes` double-count

- Track GraphQL sessions that already received positive `output_bytes` via `recordResponseWithBytes` on the async worker thread, so `completeResponse` on the servlet thread does not count them again.
- Add unit tests for the cross-thread GraphQL path and verify sync (OpenAPI) paths are unaffected.

### Smoke test isolation + auth fix

- Harden the double-count smoke test by isolating traffic on a dedicated support user (`actor_class=support`) so concurrent admin/system GraphQL in the pytest batch does not inflate Prometheus deltas.
- Fix `CorpUserPrivilegedFlagsValidator` to authorize privileged `CorpUserInfo` flag writes from the session audit actor, not escalated `getActor()`. OpenAPI ingest uses `allowSystemAuthentication=true`, so `getActor()` returns `__datahub_system` while the MCP audit stamp retains the session user (e.g. admin setting `isSupportUser=true` on a test user). Without this, the smoke test helper that provisions a support user fails authorization.

## Test plan

- [x] `./gradlew :metadata-io:test --tests com.linkedin.metadata.usage.instrumentation.UsageMetricsSessionEnricherTest` (16 passing)
- [x] `./gradlew :entity-registry:test --tests com.linkedin.metadata.aspect.validators.CorpUserPrivilegedFlagsValidatorTest` (17 passing)
- [x] `./gradlew spotlessApply`
- [x] `./gradlew :smoke-test:lintFix`
- [ ] `test_usage_aggregation_graphql_output_bytes_not_double_counted` against a running GMS with Prometheus enabled