### PR TITLE
fix(ingest/client): Updates scroll_entities behavior when aspects=None

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/graph/openapi.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/openapi.py
@@ -137,7 +137,14 @@ class OpenApiAPI(OpenAPIGraphProtocol):
         entities: List[Dict[str, Any]],
         with_system_metadata: bool,
         context: str = "response",
+        allow_empty: bool = False,
     ) -> Dict[str, EntityAspects]:
+        """Deserialize entity dicts into typed aspects keyed by urn.
+
+        By default, entities that come back with no (deserializable) aspects are
+        dropped. Set ``allow_empty=True`` to keep them as urn -> {} — useful when
+        scrolling without requesting aspects, where the server returns urns only.
+        """
         result: Dict[str, EntityAspects] = {}
         for entity in entities:
             entity_urn = entity.get("urn")
@@ -184,7 +191,7 @@ class OpenApiAPI(OpenAPIGraphProtocol):
                     logger.error(f"Error deserializing aspect {aspect_name}: {e}")
                     raise
 
-            if entity_aspects:
+            if entity_aspects or allow_empty:
                 result[entity_urn] = entity_aspects
 
         return result
@@ -248,7 +255,9 @@ class OpenApiAPI(OpenAPIGraphProtocol):
         Args:
             entity_names: Entity type names to restrict results to (e.g. ["dataset", "dashboard"]).
                 If None or empty, all entity types are returned.
-            aspects: Aspect names to include in the response. If None, all aspects are returned.
+            aspects: Aspect names to include in the response. If None, no aspects are fetched and
+                only urns are returned (see allow_empty). Pass an empty list to fetch all aspects,
+                or a specific list to fetch just those.
             count: Number of results per page.
             query: Search query string.
             scroll_id: Pagination cursor from a previous scroll response.
@@ -320,6 +329,7 @@ class OpenApiAPI(OpenAPIGraphProtocol):
                 resp_json.get("entities", []),
                 with_system_metadata=bool(with_system_metadata),
                 context="scroll response",
+                allow_empty=aspects is None,
             ),
             total_count=resp_json.get("totalCount", 0),
         )

--- a/smoke-test/tests/openapi/v3/test_scroll_entities.py
+++ b/smoke-test/tests/openapi/v3/test_scroll_entities.py
@@ -1,6 +1,5 @@
 """Smoke tests for the scroll_entities DataHubGraph method."""
 
-import logging
 from typing import cast
 
 import pytest
@@ -11,8 +10,6 @@ from datahub.ingestion.graph.filters import RawSearchFilter
 from datahub.ingestion.graph.openapi import SortCriterionDict
 from datahub.metadata.schema_classes import DatasetKeyClass
 from tests.utils import with_test_retry
-
-logger = logging.getLogger(__name__)
 
 PLATFORM = "urn:li:dataPlatform:scrolltest"
 ALPHA = "urn:li:dataset:(urn:li:dataPlatform:scrolltest,alpha,PROD)"
@@ -53,9 +50,6 @@ def test_scroll_entities_basic(graph_client: DataHubGraph) -> None:
     assert len(result.entities) == 5
     assert result.scroll_id is not None
     assert isinstance(result.entities, dict)
-    logger.info(
-        f"scroll_entities basic: total_count={result.total_count}, returned={len(result.entities)}"
-    )
 
 
 def test_scroll_entities_aspects_none_returns_urns_only(
@@ -72,9 +66,6 @@ def test_scroll_entities_aspects_none_returns_urns_only(
     assert set(result.entities.keys()) == ALL_DATASET_URNS
     assert all(aspects == {} for aspects in result.entities.values()), (
         f"aspects=None should return no aspects, got: {result.entities}"
-    )
-    logger.info(
-        f"scroll_entities aspects=None: {len(result.entities)} urn-only entities"
     )
 
 
@@ -95,7 +86,6 @@ def test_scroll_entities_aspects_empty_returns_all_aspects(
         assert "datasetProperties" in aspects, (
             f"datasetProperties missing for {urn}: {aspects}"
         )
-    logger.info("scroll_entities aspects=[]: all aspects returned for each dataset")
 
 
 def test_scroll_entities_aspects_single_returns_only_that_aspect(
@@ -113,9 +103,6 @@ def test_scroll_entities_aspects_single_returns_only_that_aspect(
         assert set(aspects.keys()) == {"datasetProperties"}, (
             f"Expected only datasetProperties for {urn}, got: {set(aspects.keys())}"
         )
-    logger.info(
-        "scroll_entities aspects=['datasetProperties']: only that aspect returned"
-    )
 
 
 def test_scroll_entities_by_entity_type(graph_client: DataHubGraph) -> None:
@@ -145,11 +132,6 @@ def test_scroll_entities_by_entity_type(graph_client: DataHubGraph) -> None:
     for urn in models.entities:
         assert urn.startswith("urn:li:mlModel:")
 
-    logger.info(
-        f"scroll_entities by entity type: {len(datasets.entities)} datasets, "
-        f"{len(models.entities)} ML models"
-    )
-
 
 def test_scroll_entities_by_multiple_entity_types(graph_client: DataHubGraph) -> None:
     """Requesting entity_names=["dataset","mlModel"] with the shared platform filter should
@@ -163,10 +145,6 @@ def test_scroll_entities_by_multiple_entity_types(graph_client: DataHubGraph) ->
     assert set(result.entities.keys()) == ALL_DATASET_URNS | ALL_MODEL_URNS
     for urn in result.entities:
         assert urn.startswith("urn:li:dataset:") or urn.startswith("urn:li:mlModel:")
-    logger.info(
-        f"scroll_entities multiple types: {len(result.entities)} scrolltest entities "
-        f"({len(ALL_DATASET_URNS)} datasets + {len(ALL_MODEL_URNS)} ML models)"
-    )
 
 
 def test_scroll_entities_filter_is_applied(graph_client: DataHubGraph) -> None:
@@ -195,9 +173,6 @@ def test_scroll_entities_filter_is_applied(graph_client: DataHubGraph) -> None:
     assert result.total_count == 0, (
         f"Impossible filter should return no results, got {result.total_count}"
     )
-    logger.info(
-        "scroll_entities filter is applied: impossible filter returned 0 results"
-    )
 
 
 def test_scroll_entities_pagination(graph_client: DataHubGraph) -> None:
@@ -222,9 +197,6 @@ def test_scroll_entities_pagination(graph_client: DataHubGraph) -> None:
         "Second page should return different URNs than the first"
     )
     assert set(first.entities) | set(second.entities) == ALL_DATASET_URNS
-    logger.info(
-        "scroll_entities pagination: two pages of 3 cover all 6 scrolltest URNs"
-    )
 
 
 def test_scroll_entities_with_sort_criteria(graph_client: DataHubGraph) -> None:
@@ -239,9 +211,6 @@ def test_scroll_entities_with_sort_criteria(graph_client: DataHubGraph) -> None:
     assert set(result.entities.keys()) == ALL_DATASET_URNS
     urns = list(result.entities)
     assert urns == sorted(urns), "Results should be sorted ascending by URN"
-    logger.info(
-        f"scroll_entities sort_criteria: {len(urns)} scrolltest datasets in URN order"
-    )
 
 
 def test_scroll_entities_with_query(graph_client: DataHubGraph) -> None:
@@ -261,9 +230,6 @@ def test_scroll_entities_with_query(graph_client: DataHubGraph) -> None:
         assert ALPHA in result.entities, (
             f"ALPHA should appear in query='alpha' results, got: {set(result.entities)}"
             f"\ntotal_count={result.total_count}"
-        )
-        logger.info(
-            f"scroll_entities with_query: query='alpha' returned {result.total_count} result(s)"
         )
 
     _assert()
@@ -285,9 +251,6 @@ def test_scroll_entities_with_system_metadata(graph_client: DataHubGraph) -> Non
             f"system_metadata should be populated for {urn} when with_system_metadata=True"
         )
         assert sys_meta.runId, f"system_metadata.runId should be set for {urn}"
-    logger.info(
-        "scroll_entities with_system_metadata: all aspects have system metadata"
-    )
 
 
 def test_scroll_entities_parallel_slicing(graph_client: DataHubGraph) -> None:
@@ -315,8 +278,4 @@ def test_scroll_entities_parallel_slicing(graph_client: DataHubGraph) -> None:
     )
     assert combined == ALL_DATASET_URNS, (
         f"Union of all slices should equal ALL_DATASET_URNS, got: {combined}"
-    )
-    logger.info(
-        f"scroll_entities parallel_slicing: slice0={len(slice0.entities)}, "
-        f"slice1={len(slice1.entities)}, combined={len(combined)}"
     )

--- a/smoke-test/tests/openapi/v3/test_scroll_entities.py
+++ b/smoke-test/tests/openapi/v3/test_scroll_entities.py
@@ -58,6 +58,66 @@ def test_scroll_entities_basic(graph_client: DataHubGraph) -> None:
     )
 
 
+def test_scroll_entities_aspects_none_returns_urns_only(
+    graph_client: DataHubGraph,
+) -> None:
+    """aspects=None fetches no aspects: every matching entity is returned as a
+    urn mapped to an empty aspect dict (rather than being dropped)."""
+    result = graph_client.scroll_entities(
+        entity_names=["dataset"],
+        filter=SCROLLTEST_FILTER,
+        aspects=None,
+        count=10,
+    )
+    assert set(result.entities.keys()) == ALL_DATASET_URNS
+    assert all(aspects == {} for aspects in result.entities.values()), (
+        f"aspects=None should return no aspects, got: {result.entities}"
+    )
+    logger.info(
+        f"scroll_entities aspects=None: {len(result.entities)} urn-only entities"
+    )
+
+
+def test_scroll_entities_aspects_empty_returns_all_aspects(
+    graph_client: DataHubGraph,
+) -> None:
+    """aspects=[] fetches all aspects: datasets come back with both their
+    auto-generated key aspect and the ingested datasetProperties."""
+    result = graph_client.scroll_entities(
+        entity_names=["dataset"],
+        filter=SCROLLTEST_FILTER,
+        aspects=[],
+        count=10,
+    )
+    assert set(result.entities.keys()) == ALL_DATASET_URNS
+    for urn, aspects in result.entities.items():
+        assert "datasetKey" in aspects, f"datasetKey missing for {urn}: {aspects}"
+        assert "datasetProperties" in aspects, (
+            f"datasetProperties missing for {urn}: {aspects}"
+        )
+    logger.info("scroll_entities aspects=[]: all aspects returned for each dataset")
+
+
+def test_scroll_entities_aspects_single_returns_only_that_aspect(
+    graph_client: DataHubGraph,
+) -> None:
+    """aspects=["datasetProperties"] fetches only that aspect."""
+    result = graph_client.scroll_entities(
+        entity_names=["dataset"],
+        filter=SCROLLTEST_FILTER,
+        aspects=["datasetProperties"],
+        count=10,
+    )
+    assert set(result.entities.keys()) == ALL_DATASET_URNS
+    for urn, aspects in result.entities.items():
+        assert set(aspects.keys()) == {"datasetProperties"}, (
+            f"Expected only datasetProperties for {urn}, got: {set(aspects.keys())}"
+        )
+    logger.info(
+        "scroll_entities aspects=['datasetProperties']: only that aspect returned"
+    )
+
+
 def test_scroll_entities_by_entity_type(graph_client: DataHubGraph) -> None:
     # Filter by "dataset" — should return only our 6 datasets, not the 2 ML models.
     datasets = graph_client.scroll_entities(


### PR DESCRIPTION
Clarifies and fixes the aspects argument semantics in the OpenAPI client's scroll_entities:
  - aspects=None → returns urns only (no aspects fetched)
  - aspects=[] → returns all aspects
  - aspects=[...] → returns only the requested aspects

Previously, urn-only entities were silently dropped during deserialization when `aspects == None`. Adds smoke tests for this use case.


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
