### PR TITLE
feat(i18n): default the UI language to the user's browser locale

### DIFF
--- a/datahub-web-react/src/app/i18n/__tests__/utils.test.ts
+++ b/datahub-web-react/src/app/i18n/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { isSupportedLanguage } from '@app/i18n/utils';
+import { detectBrowserLanguage, isSupportedLanguage } from '@app/i18n/utils';
 
 describe('isSupportedLanguage', () => {
     it('returns true for supported languages', () => {
@@ -13,5 +13,49 @@ describe('isSupportedLanguage', () => {
         expect(isSupportedLanguage('unsupported')).toBe(false);
         expect(isSupportedLanguage('')).toBe(false);
         expect(isSupportedLanguage('EN')).toBe(false);
+    });
+});
+
+describe('detectBrowserLanguage', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    function stubLanguages(languages: string[]) {
+        vi.stubGlobal('navigator', { languages, language: languages[0] });
+    }
+
+    it('matches an exact supported locale', () => {
+        stubLanguages(['sv']);
+        expect(detectBrowserLanguage()).toBe('sv');
+    });
+
+    it('folds a region variant to its base language', () => {
+        stubLanguages(['de-DE', 'de']);
+        expect(detectBrowserLanguage()).toBe('de');
+        stubLanguages(['fr-CA']);
+        expect(detectBrowserLanguage()).toBe('fr');
+    });
+
+    it('maps any Portuguese variant to pt-BR', () => {
+        stubLanguages(['pt-PT']);
+        expect(detectBrowserLanguage()).toBe('pt-BR');
+        stubLanguages(['pt-BR']);
+        expect(detectBrowserLanguage()).toBe('pt-BR');
+    });
+
+    it('returns the first supported language in preference order', () => {
+        stubLanguages(['ja-JP', 'fr-FR', 'de']);
+        expect(detectBrowserLanguage()).toBe('fr');
+    });
+
+    it('returns undefined when no preferred language is supported', () => {
+        stubLanguages(['ja-JP', 'zh-CN']);
+        expect(detectBrowserLanguage()).toBeUndefined();
+    });
+
+    it('returns undefined when the browser exposes no languages', () => {
+        stubLanguages([]);
+        expect(detectBrowserLanguage()).toBeUndefined();
     });
 });

--- a/datahub-web-react/src/app/i18n/hooks/__tests__/useEffectiveLanguage.test.ts
+++ b/datahub-web-react/src/app/i18n/hooks/__tests__/useEffectiveLanguage.test.ts
@@ -4,56 +4,76 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_LANGUAGE } from '@app/i18n/constants';
 import { useEffectiveLanguage } from '@app/i18n/hooks/useEffectiveLanguage';
 import { useIsI18nEnabled } from '@app/i18n/hooks/useIsI18nEnabled';
+import { detectBrowserLanguage } from '@app/i18n/utils';
 import { useUserLanguage } from '@app/shared/hooks/useUserLanguage';
 
 vi.mock('@app/i18n/hooks/useIsI18nEnabled');
 vi.mock('@app/shared/hooks/useUserLanguage');
+vi.mock('@app/i18n/utils', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@app/i18n/utils')>();
+    return { ...actual, detectBrowserLanguage: vi.fn() };
+});
 
 const mockUseIsI18nEnabled = vi.mocked(useIsI18nEnabled);
 const mockUseUserLanguage = vi.mocked(useUserLanguage);
+const mockDetectBrowserLanguage = vi.mocked(detectBrowserLanguage);
 
 describe('useEffectiveLanguage', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mockDetectBrowserLanguage.mockReturnValue(undefined);
     });
 
-    it('returns DEFAULT_LANGUAGE when i18n is disabled', () => {
+    it('returns DEFAULT_LANGUAGE when i18n is disabled, even if the browser language is supported', () => {
         mockUseIsI18nEnabled.mockReturnValue(false);
-        mockUseUserLanguage.mockReturnValue('en');
+        mockUseUserLanguage.mockReturnValue('de');
+        mockDetectBrowserLanguage.mockReturnValue('de');
 
         const { result } = renderHook(() => useEffectiveLanguage());
 
         expect(result.current).toBe(DEFAULT_LANGUAGE);
     });
 
-    it('returns user language when i18n is enabled and language is supported', () => {
+    it('returns the user language when i18n is enabled and it is supported', () => {
         mockUseIsI18nEnabled.mockReturnValue(true);
-        mockUseUserLanguage.mockReturnValue('en');
+        mockUseUserLanguage.mockReturnValue('de');
 
         const { result } = renderHook(() => useEffectiveLanguage());
 
-        expect(result.current).toBe('en');
+        expect(result.current).toBe('de');
     });
 
-    it('returns DEFAULT_LANGUAGE when i18n is enabled but language is unsupported', () => {
+    it('prefers the in-app user language over the browser language', () => {
         mockUseIsI18nEnabled.mockReturnValue(true);
-        mockUseUserLanguage.mockReturnValue('unsupported');
+        mockUseUserLanguage.mockReturnValue('de');
+        mockDetectBrowserLanguage.mockReturnValue('fr');
 
         const { result } = renderHook(() => useEffectiveLanguage());
 
-        expect(result.current).toBe(DEFAULT_LANGUAGE);
+        expect(result.current).toBe('de');
     });
 
-    it('returns DEFAULT_LANGUAGE when i18n is enabled but language is null', () => {
+    it('falls back to the browser language when the user has no supported preference', () => {
         mockUseIsI18nEnabled.mockReturnValue(true);
         mockUseUserLanguage.mockReturnValue(null);
+        mockDetectBrowserLanguage.mockReturnValue('fr');
+
+        const { result } = renderHook(() => useEffectiveLanguage());
+
+        expect(result.current).toBe('fr');
+    });
+
+    it('falls back to DEFAULT_LANGUAGE when neither the user nor the browser language is supported', () => {
+        mockUseIsI18nEnabled.mockReturnValue(true);
+        mockUseUserLanguage.mockReturnValue('unsupported');
+        mockDetectBrowserLanguage.mockReturnValue(undefined);
 
         const { result } = renderHook(() => useEffectiveLanguage());
 
         expect(result.current).toBe(DEFAULT_LANGUAGE);
     });
 
-    it('updates when language changes', () => {
+    it('updates when the user language changes', () => {
         mockUseIsI18nEnabled.mockReturnValue(true);
         mockUseUserLanguage.mockReturnValue('en');
 

--- a/datahub-web-react/src/app/i18n/hooks/useEffectiveLanguage.ts
+++ b/datahub-web-react/src/app/i18n/hooks/useEffectiveLanguage.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { useDefaultLanguage } from '@app/i18n/hooks/useDefaultLanguage';
 import { useIsI18nEnabled } from '@app/i18n/hooks/useIsI18nEnabled';
 import { SupportedLanguage } from '@app/i18n/types';
-import { isSupportedLanguage } from '@app/i18n/utils';
+import { detectBrowserLanguage, isSupportedLanguage } from '@app/i18n/utils';
 import { useUserLanguage } from '@app/shared/hooks/useUserLanguage';
 
 export function useEffectiveLanguage(): SupportedLanguage {
@@ -11,8 +11,12 @@ export function useEffectiveLanguage(): SupportedLanguage {
     const userLanguage = useUserLanguage();
     const defaultLanguage = useDefaultLanguage();
 
-    return useMemo(
-        () => (i18nEnabled && userLanguage && isSupportedLanguage(userLanguage) ? userLanguage : defaultLanguage),
-        [i18nEnabled, userLanguage, defaultLanguage],
-    );
+    return useMemo(() => {
+        // i18n must be enabled for any non-English locale to take effect.
+        if (!i18nEnabled) return defaultLanguage;
+        // An explicit in-app choice (Settings -> Preferences) always wins.
+        if (userLanguage && isSupportedLanguage(userLanguage)) return userLanguage;
+        // Otherwise honor the user's browser/OS language, falling back to the default.
+        return detectBrowserLanguage() ?? defaultLanguage;
+    }, [i18nEnabled, userLanguage, defaultLanguage]);
 }

--- a/datahub-web-react/src/app/i18n/utils.ts
+++ b/datahub-web-react/src/app/i18n/utils.ts
@@ -4,3 +4,29 @@ import { SupportedLanguage } from '@app/i18n/types';
 export function isSupportedLanguage(lang: string): lang is SupportedLanguage {
     return lang in LOCALE_MAP;
 }
+
+/**
+ * Best-effort match of the browser's preferred languages (`navigator.languages`, most-preferred
+ * first) to a supported UI locale. Tries an exact, case-insensitive match first, then folds region
+ * variants to their base language (e.g. `de-DE` -> `de`, `fr-CA` -> `fr`, and `pt-PT` -> `pt-BR` as
+ * the only Portuguese variant). Returns `undefined` when nothing matches, so callers can fall back
+ * to the default language.
+ */
+export function detectBrowserLanguage(): SupportedLanguage | undefined {
+    const supported = Object.keys(LOCALE_MAP) as SupportedLanguage[];
+    const preferred = typeof navigator !== 'undefined' ? (navigator.languages ?? [navigator.language]) : [];
+
+    const matchTag = (tag: string | undefined): SupportedLanguage | undefined => {
+        if (!tag) return undefined;
+        const lower = tag.toLowerCase();
+        const base = lower.split('-')[0];
+        // Exact (case-insensitive) match first, then fold region variants to their base language.
+        return (
+            supported.find((locale) => locale.toLowerCase() === lower) ??
+            supported.find((locale) => locale.toLowerCase().split('-')[0] === base)
+        );
+    };
+
+    // navigator.languages is ordered most-preferred first; take the first tag that maps to a locale.
+    return preferred.map(matchTag).find((match): match is SupportedLanguage => match !== undefined);
+}


### PR DESCRIPTION
## Summary

Defaults the DataHub UI language to the user's **browser/OS locale** when they haven't chosen a language in **Settings → Preferences**. The browser language is already an explicit user preference, so honoring it is a better default than English-for-everyone — and it needs no configuration.

This **replaces the env-var approach in #18271** (now closed): rather than adding an `I18N_DEFAULT_LOCALE` operator variable, we respect the preference the user has already expressed in their browser. Pure frontend change — no backend, GraphQL, or config surface.

## Resolution order

`useEffectiveLanguage` now resolves (unchanged first and last rungs):

1. **i18n must be enabled** (`I18N_ENABLED`) — otherwise English, as today.
2. **In-app choice** (Settings → Preferences), if the user has set a supported one — always wins.
3. **Browser/OS language** (`navigator.languages`), if it maps to a supported locale — the new step.
4. **English** fallback.

## Changes

- `src/app/i18n/utils.ts` — new `detectBrowserLanguage()`: matches `navigator.languages` (most-preferred first) against the supported locales — exact case-insensitive match first, then folds region variants to their base language (`de-DE`→`de`, `fr-CA`→`fr`, `pt-PT`→`pt-BR`). Returns `undefined` when nothing matches.
- `src/app/i18n/hooks/useEffectiveLanguage.ts` — inserts the browser step between the in-app choice and the English fallback, gated by `i18nEnabled`.
- Tests: `utils.test.ts` (exact/base-language/pt-variant/preference-order/no-match/empty) and `useEffectiveLanguage.test.ts` (in-app choice wins over browser; browser used when no in-app pref; disabled → English; unsupported browser → English).

## Behavior notes

- A user who has explicitly picked a language in-app keeps it, regardless of the browser — so you can run DataHub in a different language than your browser.
- Browser detection only kicks in when i18n is enabled for the instance.
- Matching is best-effort on `navigator.languages`; unrecognized locales fall through to English.

## Verification

| Gate | Result |
| --- | --- |
| `yarn test src/app/i18n` | ✅ 30/30 (8 `utils`, 6 `useEffectiveLanguage`, + existing) |
| `yarn type-check` | ✅ clean |
| eslint (changed files) | ✅ 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
