### PR TITLE
refactor(i18n): lazy-load antd locale bundles

### DIFF
--- a/datahub-web-react/src/app/i18n/antdLocale.ts
+++ b/datahub-web-react/src/app/i18n/antdLocale.ts
@@ -1,0 +1,26 @@
+import type { Locale } from 'antd/lib/locale-provider';
+
+import { SupportedLanguage } from '@app/i18n/types';
+
+// antd ships one Locale object per language. Importing them all eagerly pulls every language's
+// antd locale data into the main chunk; loading them dynamically keeps all but the active
+// language out of the main bundle — each chunk is fetched only when that language is selected.
+// Mirrors DAYJS_LOCALE_LOADERS in utils/dayjs.ts. Keep keys in sync with LOCALE_MAP in constants.
+const ANTD_LOCALE_LOADERS: Record<SupportedLanguage, () => Promise<{ default: Locale }>> = {
+    en: () => import('antd/lib/locale/en_US'),
+    de: () => import('antd/lib/locale/de_DE'),
+    es: () => import('antd/lib/locale/es_ES'),
+    'pt-BR': () => import('antd/lib/locale/pt_BR'),
+    fr: () => import('antd/lib/locale/fr_FR'),
+    it: () => import('antd/lib/locale/it_IT'),
+    sv: () => import('antd/lib/locale/sv_SE'),
+};
+
+/**
+ * Loads and returns antd's Locale for the given language. The chunk is fetched on demand; callers
+ * should render antd's built-in English default until this resolves.
+ */
+export async function loadAntdLocale(language: SupportedLanguage): Promise<Locale> {
+    const { default: locale } = await ANTD_LOCALE_LOADERS[language]();
+    return locale;
+}

--- a/datahub-web-react/src/app/i18n/constants.ts
+++ b/datahub-web-react/src/app/i18n/constants.ts
@@ -1,59 +1,45 @@
 import { SelectOption } from '@components';
-import deDE from 'antd/lib/locale/de_DE';
-import enUS from 'antd/lib/locale/en_US';
-import esES from 'antd/lib/locale/es_ES';
-import frFR from 'antd/lib/locale/fr_FR';
-import itIT from 'antd/lib/locale/it_IT';
-import ptBR from 'antd/lib/locale/pt_BR';
-import svSE from 'antd/lib/locale/sv_SE';
 
 import { LocaleConfig, SupportedLanguage } from '@app/i18n/types';
 
 export const EN_LOCALE_CONFIG: LocaleConfig = {
     lang: 'en',
-    antd: enUS,
     dayjs: 'en',
     label: 'English',
 };
 
 export const DE_LOCALE_CONFIG: LocaleConfig = {
     lang: 'de',
-    antd: deDE,
     dayjs: 'de',
     label: 'Deutsch',
 };
 
 export const ES_LOCALE_CONFIG: LocaleConfig = {
     lang: 'es',
-    antd: esES,
     dayjs: 'es',
     label: 'Español (Beta)',
 };
 
 export const PT_BR_LOCALE_CONFIG: LocaleConfig = {
     lang: 'pt-BR',
-    antd: ptBR,
     dayjs: 'pt-br',
     label: 'Português (Brasil) (Beta)',
 };
 
 export const FR_LOCALE_CONFIG: LocaleConfig = {
     lang: 'fr',
-    antd: frFR,
     dayjs: 'fr',
     label: 'Français (Beta)',
 };
 
 export const IT_LOCALE_CONFIG: LocaleConfig = {
     lang: 'it',
-    antd: itIT,
     dayjs: 'it',
     label: 'Italiano (Beta)',
 };
 
 export const SV_LOCALE_CONFIG: LocaleConfig = {
     lang: 'sv',
-    antd: svSE,
     dayjs: 'sv',
     label: 'Svenska (Beta)',
 };

--- a/datahub-web-react/src/app/i18n/context/I18nProvider.tsx
+++ b/datahub-web-react/src/app/i18n/context/I18nProvider.tsx
@@ -1,11 +1,31 @@
 import { ConfigProvider } from 'antd';
-import React from 'react';
+import type { Locale } from 'antd/lib/locale-provider';
+import React, { useEffect, useState } from 'react';
 
+import { loadAntdLocale } from '@app/i18n/antdLocale';
+import { useEffectiveLanguage } from '@app/i18n/hooks/useEffectiveLanguage';
 import { useLanguageSync } from '@app/i18n/hooks/useLanguageSync';
-import { useLocaleConfig } from '@app/i18n/hooks/useLocaleConfig';
 
 export default function I18nProvider({ children }: { children: React.ReactNode }) {
     useLanguageSync();
-    const { antd } = useLocaleConfig();
-    return <ConfigProvider locale={antd}>{children}</ConfigProvider>;
+    const language = useEffectiveLanguage();
+    const [antdLocale, setAntdLocale] = useState<Locale>();
+
+    useEffect(() => {
+        let active = true;
+        // Load antd's locale chunk on demand; until it resolves ConfigProvider uses antd's
+        // built-in English default. A newer language change supersedes an in-flight load.
+        loadAntdLocale(language)
+            .then((locale) => {
+                if (active) setAntdLocale(locale);
+            })
+            .catch(() => {
+                // Keep the antd default on load failure rather than blocking render.
+            });
+        return () => {
+            active = false;
+        };
+    }, [language]);
+
+    return <ConfigProvider locale={antdLocale}>{children}</ConfigProvider>;
 }

--- a/datahub-web-react/src/app/i18n/context/__tests__/I18nProvider.test.tsx
+++ b/datahub-web-react/src/app/i18n/context/__tests__/I18nProvider.test.tsx
@@ -1,21 +1,24 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { loadAntdLocale } from '@app/i18n/antdLocale';
 import I18nProvider from '@app/i18n/context/I18nProvider';
+import { useEffectiveLanguage } from '@app/i18n/hooks/useEffectiveLanguage';
 import { useLanguageSync } from '@app/i18n/hooks/useLanguageSync';
-import { useLocaleConfig } from '@app/i18n/hooks/useLocaleConfig';
 
 vi.mock('@app/i18n/hooks/useLanguageSync');
-vi.mock('@app/i18n/hooks/useLocaleConfig');
+vi.mock('@app/i18n/hooks/useEffectiveLanguage');
+vi.mock('@app/i18n/antdLocale');
 
-const mockAntdLocale = { locale: 'en' } as any;
+const mockAntdLocale = { locale: 'de' } as any;
 
 describe('I18nProvider', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.mocked(useLanguageSync).mockReturnValue(undefined);
-        vi.mocked(useLocaleConfig).mockReturnValue({ lang: 'en', label: 'English', antd: mockAntdLocale, dayjs: 'en' });
+        vi.mocked(useEffectiveLanguage).mockReturnValue('de');
+        vi.mocked(loadAntdLocale).mockResolvedValue(mockAntdLocale);
     });
 
     it('renders children', () => {
@@ -38,13 +41,13 @@ describe('I18nProvider', () => {
         expect(useLanguageSync).toHaveBeenCalled();
     });
 
-    it('uses locale from useLocaleConfig for ConfigProvider', () => {
+    it('loads the antd locale for the effective language', async () => {
         render(
             <I18nProvider>
                 <div />
             </I18nProvider>,
         );
 
-        expect(useLocaleConfig).toHaveBeenCalled();
+        await waitFor(() => expect(loadAntdLocale).toHaveBeenCalledWith('de'));
     });
 });

--- a/datahub-web-react/src/app/i18n/types.ts
+++ b/datahub-web-react/src/app/i18n/types.ts
@@ -1,10 +1,7 @@
-import { Locale } from 'antd/lib/locale-provider';
-
 export type SupportedLanguage = 'en' | 'de' | 'es' | 'pt-BR' | 'fr' | 'it' | 'sv';
 
 export type LocaleConfig = {
     lang: SupportedLanguage;
     label: string;
-    antd: Locale;
     dayjs: string;
 };


### PR DESCRIPTION
## Summary

Follow-up to #18265 (review feedback from @benjiaming): antd's per-language `Locale` bundles were all statically imported into the main chunk. This loads them **on demand** instead — mirroring the existing dayjs loader in `utils/dayjs.ts` — so all but the active language's antd locale data stays out of the main bundle.

## Changes

- New `src/app/i18n/antdLocale.ts` — a dynamic-import loader map (`ANTD_LOCALE_LOADERS`) keyed by `SupportedLanguage` + a `loadAntdLocale(language)` helper.
- `constants.ts` — removed the 8 static `antd/lib/locale/*` imports and the `antd` field from every `*_LOCALE_CONFIG`.
- `types.ts` — dropped the now-unused `antd: Locale` field from `LocaleConfig`.
- `I18nProvider.tsx` — resolves the active locale into state via `loadAntdLocale` and passes it to `ConfigProvider`, falling back to antd's built-in English until the chunk loads (same trade-off the dayjs precedent already accepts).
- Updated `I18nProvider.test.tsx` accordingly.

## Trade-off

Until the (~4–8 KB) antd locale chunk resolves, antd's built-in components (DatePicker, pagination, etc.) briefly render in English. This matches the existing dynamic dayjs behavior.

## Verification

- `yarn type-check` — clean
- `src/app/i18n` tests — 23 passed
- eslint + prettier — clean on all changed files

## Note

Based on `master`, which does not yet include the Norwegian locale (#18265). Once #18265 merges, this branch needs `master` merged in and a one-line `nb` entry added to `ANTD_LOCALE_LOADERS` (the `Record<SupportedLanguage, …>` type enforces this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)