### PR TITLE
ci(playwright): report individual test failures to PostHog for flake detection

### DIFF
--- a/.github/scripts/send_failed_tests_to_posthog.py
+++ b/.github/scripts/send_failed_tests_to_posthog.py
@@ -36,21 +36,42 @@ class PostHogConfig:
     timeout: int = 10
 
 
+def _detect_junit_subtype(xml_file: Path) -> str:
+    """
+    Distinguish between Playwright and Pytest JUnit XML by content.
+
+    Playwright's JUnit reporter sets testsuite.name to the spec file path
+    (e.g. "tests/domains/domains.spec.ts"), which is reliable for detection.
+    """
+    try:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        for ts in root.iter('testsuite'):
+            name = ts.get('name', '')
+            if '.spec.ts' in name or '.spec.js' in name or '.spec.tsx' in name:
+                return 'playwright'
+        return 'pytest'
+    except Exception:
+        return 'pytest'
+
+
 def detect_xml_type(xml_file: Path) -> str:
     """
     Detect the type of JUnit XML file.
 
-    Returns: 'cypress', 'pytest', 'java', or 'unknown'
+    Returns: 'cypress', 'playwright', 'pytest', 'java', or 'unknown'
     """
     filename = xml_file.name
 
     # Check filename patterns
     if filename.startswith('cypress-test-'):
         return 'cypress'
-    elif filename.startswith('junit') and filename.endswith('.xml'):
-        return 'pytest'
     elif filename.startswith('TEST-') and filename.endswith('.xml'):
         return 'java'
+    elif filename.startswith('junit') and filename.endswith('.xml'):
+        # Both Playwright (junit.xml) and Pytest (junit.*.xml) match this pattern.
+        # Peek at content to tell them apart.
+        return _detect_junit_subtype(xml_file)
 
     return 'unknown'
 
@@ -103,6 +124,56 @@ def parse_cypress_failures(xml_file: Path) -> List[FailedTest]:
                 test_type='cypress',
                 error_message=error_msg[:200] if error_msg else None
             ))
+
+    except ET.ParseError as e:
+        print(f"⚠️ Failed to parse {xml_file}: {e}", file=sys.stderr)
+    except Exception as e:
+        print(f"⚠️ Error processing {xml_file}: {e}", file=sys.stderr)
+
+    return failed_tests
+
+
+def parse_playwright_failures(xml_file: Path) -> List[FailedTest]:
+    """
+    Parse Playwright JUnit XML to extract failed tests.
+
+    Playwright sets testsuite.name to the spec file path and testcase.classname
+    to the describe-block title, so identifiers are formatted as:
+    "spec/file.spec.ts > Describe Block > test name"
+    """
+    failed_tests = []
+
+    try:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+
+        for testsuite in root.iter('testsuite'):
+            spec_file = testsuite.get('name', '')
+
+            for testcase in testsuite.findall('testcase'):
+                failure = testcase.find('failure')
+                error = testcase.find('error')
+
+                if failure is None and error is None:
+                    continue
+
+                classname = testcase.get('classname', '')
+                test_name = testcase.get('name', '')
+
+                parts = [p for p in [spec_file, classname, test_name] if p]
+                test_identifier = ' > '.join(parts) if parts else spec_file
+
+                error_msg = None
+                if failure is not None:
+                    error_msg = failure.get('message', failure.text or '')
+                elif error is not None:
+                    error_msg = error.get('message', error.text or '')
+
+                failed_tests.append(FailedTest(
+                    name=test_identifier,
+                    test_type='playwright',
+                    error_message=error_msg[:200] if error_msg else None
+                ))
 
     except ET.ParseError as e:
         print(f"⚠️ Failed to parse {xml_file}: {e}", file=sys.stderr)
@@ -235,6 +306,8 @@ def parse_all_failures(input_dir: Path) -> List[FailedTest]:
 
         if xml_type == 'cypress':
             failures = parse_cypress_failures(xml_file)
+        elif xml_type == 'playwright':
+            failures = parse_playwright_failures(xml_file)
         elif xml_type == 'pytest':
             failures = parse_pytest_failures(xml_file)
         elif xml_type == 'java':

--- a/.github/scripts/send_failed_tests_to_posthog.py
+++ b/.github/scripts/send_failed_tests_to_posthog.py
@@ -161,7 +161,7 @@ def parse_playwright_failures(xml_file: Path) -> List[FailedTest]:
                 test_name = testcase.get('name', '')
 
                 parts = [p for p in [spec_file, classname, test_name] if p]
-                test_identifier = ' > '.join(parts) if parts else spec_file
+                test_identifier = (' > '.join(parts) if parts else spec_file)[:200]
 
                 error_msg = None
                 if failure is not None:

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -884,6 +884,7 @@ jobs:
       local_build_flags: "-PpythonDockerVersion=${{ needs.setup.outputs.python_release_version }} -PdockerRegistry=acryldata"
       datahub_version: ${{ needs.setup.outputs.tag }}
       profile_name: ${{ needs.setup.outputs.smoke_profile_name || 'quickstart-consumers' }}
+      send_posthog_metrics: true
     secrets: inherit
 
   playwright_report:

--- a/.github/workflows/resusable-playwright-tests.yml
+++ b/.github/workflows/resusable-playwright-tests.yml
@@ -175,6 +175,32 @@ jobs:
           path: e2e-test/ui/playwright/test-results/junit.xml
           retention-days: 5
 
+      - name: Send failed test metrics to PostHog
+        if: failure()
+        continue-on-error: true
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          GH_HEAD_REF: ${{ github.head_ref || github.ref_name }}
+        run: |
+          if [ -z "$POSTHOG_API_KEY" ]; then
+            echo "⚠️ POSTHOG_API_KEY not configured, skipping test failure metrics"
+            exit 0
+          fi
+
+          python3 .github/scripts/send_failed_tests_to_posthog.py \
+            --input-dir e2e-test/ui/playwright/test-results \
+            --posthog-api-key "$POSTHOG_API_KEY" \
+            --posthog-host "${POSTHOG_HOST:-https://app.posthog.com}" \
+            --repository "${{ github.repository }}" \
+            --workflow-name "${{ github.workflow }}" \
+            --branch "${GH_HEAD_REF}" \
+            --run-id "${{ github.run_id }}" \
+            --run-attempt "${{ github.run_attempt }}" \
+            --batch "${{ inputs.shard }}" \
+            --batch-count "${{ inputs.shard_count }}" \
+            --test-strategy "playwright"
+
       - name: Store logs on failure
         if: failure()
         env:

--- a/.github/workflows/resusable-playwright-tests.yml
+++ b/.github/workflows/resusable-playwright-tests.yml
@@ -182,6 +182,12 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
           GH_HEAD_REF: ${{ github.head_ref || github.ref_name }}
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_WORKFLOW: ${{ github.workflow }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_RUN_ATTEMPT: ${{ github.run_attempt }}
+          SHARD: ${{ inputs.shard }}
+          SHARD_COUNT: ${{ inputs.shard_count }}
         run: |
           if [ -z "$POSTHOG_API_KEY" ]; then
             echo "⚠️ POSTHOG_API_KEY not configured, skipping test failure metrics"
@@ -192,13 +198,13 @@ jobs:
             --input-dir e2e-test/ui/playwright/test-results \
             --posthog-api-key "$POSTHOG_API_KEY" \
             --posthog-host "${POSTHOG_HOST:-https://app.posthog.com}" \
-            --repository "${{ github.repository }}" \
-            --workflow-name "${{ github.workflow }}" \
-            --branch "${GH_HEAD_REF}" \
-            --run-id "${{ github.run_id }}" \
-            --run-attempt "${{ github.run_attempt }}" \
-            --batch "${{ inputs.shard }}" \
-            --batch-count "${{ inputs.shard_count }}" \
+            --repository "$GH_REPOSITORY" \
+            --workflow-name "$GH_WORKFLOW" \
+            --branch "$GH_HEAD_REF" \
+            --run-id "$GH_RUN_ID" \
+            --run-attempt "$GH_RUN_ATTEMPT" \
+            --batch "$SHARD" \
+            --batch-count "$SHARD_COUNT" \
             --test-strategy "playwright"
 
       - name: Store logs on failure

--- a/.github/workflows/resusable-playwright-tests.yml
+++ b/.github/workflows/resusable-playwright-tests.yml
@@ -46,6 +46,11 @@ on:
         required: false
         type: string
         default: ${{ vars.DOCKER_REGISTRY }}
+      send_posthog_metrics:
+        description: "Whether to send test failure metrics to PostHog. Should only be true for scheduled/push runs, not workflow_dispatch."
+        required: false
+        type: boolean
+        default: false
 jobs:
   playwright_test:
     name: Playwright E2E Tests
@@ -176,7 +181,7 @@ jobs:
           retention-days: 5
 
       - name: Send failed test metrics to PostHog
-        if: failure()
+        if: failure() && inputs.send_posthog_metrics
         continue-on-error: true
         env:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}

--- a/e2e-test/ui/playwright/tests/home/homepage-visibility.spec.ts
+++ b/e2e-test/ui/playwright/tests/home/homepage-visibility.spec.ts
@@ -20,10 +20,4 @@ test.describe('Homepage Basic Visibility', () => {
     const isVisible = await homePage.isSearchBarVisible();
     expect(isVisible).toBe(true);
   });
-
-  // TEMP: fails on attempt 1, passes on attempt 2+ to verify PostHog flake detection
-  test('temp-posthog-verification: fails on first attempt only', async () => {
-    const attempt = parseInt(process.env.GITHUB_RUN_ATTEMPT ?? '1', 10);
-    expect(attempt).toBeGreaterThan(1);
-  });
 });

--- a/e2e-test/ui/playwright/tests/home/homepage-visibility.spec.ts
+++ b/e2e-test/ui/playwright/tests/home/homepage-visibility.spec.ts
@@ -20,4 +20,9 @@ test.describe('Homepage Basic Visibility', () => {
     const isVisible = await homePage.isSearchBarVisible();
     expect(isVisible).toBe(true);
   });
+
+  // TEMP: intentional failure to verify PostHog test failure reporting
+  test('temp-posthog-verification: this test always fails', async () => {
+    expect(true).toBe(false);
+  });
 });

--- a/e2e-test/ui/playwright/tests/home/homepage-visibility.spec.ts
+++ b/e2e-test/ui/playwright/tests/home/homepage-visibility.spec.ts
@@ -21,8 +21,9 @@ test.describe('Homepage Basic Visibility', () => {
     expect(isVisible).toBe(true);
   });
 
-  // TEMP: intentional failure to verify PostHog test failure reporting
-  test('temp-posthog-verification: this test always fails', async () => {
-    expect(true).toBe(false);
+  // TEMP: fails on attempt 1, passes on attempt 2+ to verify PostHog flake detection
+  test('temp-posthog-verification: fails on first attempt only', async () => {
+    const attempt = parseInt(process.env.GITHUB_RUN_ATTEMPT ?? '1', 10);
+    expect(attempt).toBeGreaterThan(1);
   });
 });


### PR DESCRIPTION
## Summary

- Extends existing CI test failure reporting infrastructure to cover Playwright E2E tests
- Adds content-based detection to distinguish Playwright JUnit XML from Pytest JUnit XML (both named `junit*.xml`) by peeking at `testsuite.name` for `.spec.ts` patterns
- Adds `parse_playwright_failures()` that formats test identifiers as `spec/file.spec.ts > Describe Block > test name`
- Adds a "Send failed test metrics to PostHog" step to the reusable Playwright workflow, firing on `failure()` with `run_attempt` wired in

## How flake detection works

A test is considered flaky if it appears in a `ci-test-failure` event with `run_attempt=1` but not `run_attempt=2` for the same `run_id`. No pass events needed — the existing failure-only approach is sufficient for this definition.

## Test plan

- [ ] Verify `detect_xml_type()` correctly identifies Playwright JUnit XML (`.spec.ts` in `testsuite.name`) vs Pytest JUnit XML (dotted classnames)
- [ ] Verify `parse_playwright_failures()` produces correctly formatted identifiers
- [ ] Verify PostHog step fires on Playwright test failure in CI with correct `run_attempt`, `shard`, and `shard_count` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)