### PR TITLE
fix(ingest/tableau): preserve full project hierarchy under project_pattern filtering

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
@@ -4245,25 +4245,13 @@ class TableauSiteSource:
                 # Go to the parent project as we need to generate container first for parent
                 parent_project_key = self.gen_project_key(project_.parent_id)
 
-                # Fall back to all_project_map when the parent was filtered out of the
-                # registry, so we recurse to the root. Such ancestors become path-only
-                # containers (no content, since they're absent from the content registry).
-                parent_tableau_project: Optional[TableauProject] = (
-                    self.tableau_project_registry.get(project_.parent_id)
-                    or all_project_map.get(project_.parent_id)
-                )
-
-                if parent_tableau_project is None:
-                    # Parent unreachable (e.g. permissions); _get_all_project already
-                    # warned. Emit a single-level container and stop the upward walk.
-                    parent_tableau_project = TableauProject(
-                        id=project_.parent_id,
-                        name=project_.parent_name or project_.parent_id,
-                        description=None,
-                        parent_id=None,
-                        parent_name=None,
-                        path=[],
-                    )
+                # Resolve from the full project map, not tableau_project_registry, so
+                # we recurse to the root even through filtered-out ancestors (emitted as
+                # path-only containers). _get_all_project nulls out any parent_id absent
+                # from the map, so a non-None parent_id always resolves here.
+                parent_tableau_project: TableauProject = all_project_map[
+                    project_.parent_id
+                ]
 
                 yield from emit_project_in_topological_order(parent_tableau_project)
 

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
@@ -4245,13 +4245,17 @@ class TableauSiteSource:
                 # Go to the parent project as we need to generate container first for parent
                 parent_project_key = self.gen_project_key(project_.parent_id)
 
-                # Resolve from the full project map, not tableau_project_registry, so
-                # we recurse to the root even through filtered-out ancestors (emitted as
-                # path-only containers). _get_all_project nulls out any parent_id absent
-                # from the map, so a non-None parent_id always resolves here.
-                parent_tableau_project: TableauProject = all_project_map[
-                    project_.parent_id
-                ]
+                # Resolve from the full project map so we recurse to the root even
+                # through filtered-out ancestors. _get_all_project nulls out any
+                # parent_id absent from the map, so this always resolves; guard it so a
+                # future regression fails with context, not a bare KeyError.
+                parent_tableau_project = all_project_map.get(project_.parent_id)
+                if parent_tableau_project is None:
+                    raise ValueError(
+                        f"parent_id {project_.parent_id!r} of project "
+                        f"{project_.name!r} ({project_.id!r}) is missing from the "
+                        f"project map; expected _get_all_project to have nulled it out."
+                    )
 
                 yield from emit_project_in_topological_order(parent_tableau_project)
 

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
@@ -1471,10 +1471,10 @@ class TableauSiteSource:
                 continue
             self.workbook_project_map[wb.id] = wb.project_id
 
-    def _populate_projects_registry(self) -> None:
+    def _populate_projects_registry(self) -> Dict[str, TableauProject]:
         if self.server is None:
             logger.warning("server is None. Can not initialize the project registry")
-            return
+            return {}
 
         logger.info("Initializing site project registry")
 
@@ -1492,6 +1492,8 @@ class TableauSiteSource:
         logger.debug(
             f"Tableau workbooks {self.workbook_project_map}",
         )
+
+        return all_project_map
 
     def get_data_platform_instance(self) -> DataPlatformInstanceClass:
         return DataPlatformInstanceClass(
@@ -4212,7 +4214,9 @@ class TableauSiteSource:
 
         return None
 
-    def emit_project_containers(self) -> Iterable[MetadataWorkUnit]:
+    def emit_project_containers(
+        self, all_project_map: Dict[str, TableauProject]
+    ) -> Iterable[MetadataWorkUnit]:
         generated_project_keys: Set[str] = set()
 
         def emit_project_in_topological_order(
@@ -4241,19 +4245,20 @@ class TableauSiteSource:
                 # Go to the parent project as we need to generate container first for parent
                 parent_project_key = self.gen_project_key(project_.parent_id)
 
+                # Fall back to all_project_map when the parent was filtered out of the
+                # registry, so we recurse to the root. Such ancestors become path-only
+                # containers (no content, since they're absent from the content registry).
                 parent_tableau_project: Optional[TableauProject] = (
                     self.tableau_project_registry.get(project_.parent_id)
+                    or all_project_map.get(project_.parent_id)
                 )
 
-                if (
-                    parent_tableau_project is None
-                ):  # It is not in project registry because of project_pattern
-                    assert project_.parent_name, (
-                        f"project {project_.name} should not be null"
-                    )
+                if parent_tableau_project is None:
+                    # Parent unreachable (e.g. permissions); _get_all_project already
+                    # warned. Emit a single-level container and stop the upward walk.
                     parent_tableau_project = TableauProject(
                         id=project_.parent_id,
-                        name=project_.parent_name,
+                        name=project_.parent_name or project_.parent_id,
                         description=None,
                         parent_id=None,
                         parent_name=None,
@@ -4534,7 +4539,7 @@ class TableauSiteSource:
                     ] = timer.elapsed_seconds(digits=2)
 
             with PerfTimer() as timer:
-                self._populate_projects_registry()
+                all_project_map = self._populate_projects_registry()
                 self.report.populate_projects_registry_timer[self.site_content_url] = (
                     timer.elapsed_seconds(digits=2)
                 )
@@ -4544,7 +4549,7 @@ class TableauSiteSource:
 
             if self.config.add_site_container:
                 yield from self.emit_site_container()
-            yield from self.emit_project_containers()
+            yield from self.emit_project_containers(all_project_map)
 
             with PerfTimer() as timer:
                 yield from self.emit_workbooks()

--- a/metadata-ingestion/tests/unit/tableau/test_tableau_source.py
+++ b/metadata-ingestion/tests/unit/tableau/test_tableau_source.py
@@ -1,6 +1,6 @@
 import json
 import pathlib
-from typing import Any, Dict, List, Optional, Sequence, cast
+from typing import Any, Dict, List, Optional, Sequence, Tuple, cast
 from unittest import mock
 
 import pytest
@@ -34,6 +34,8 @@ from datahub.ingestion.source.tableau.tableau_common import (
 )
 from datahub.metadata.com.linkedin.pegasus2avro.schema import SchemaField
 from datahub.metadata.schema_classes import (
+    ContainerClass,
+    ContainerPropertiesClass,
     DatasetLineageTypeClass,
     DatasetPropertiesClass,
     FineGrainedLineageClass,
@@ -1313,6 +1315,270 @@ def _make_site_source() -> TableauSiteSource:
             report=TableauSourceReport(),
             server=mock.MagicMock(spec=Server),
         )
+
+
+def _tsc_project(id: str, name: str, parent_id: Optional[str]) -> mock.MagicMock:
+    """Minimal stand-in for a tableauserverclient ProjectItem, as returned by the
+    projects Pager."""
+    project = mock.MagicMock()
+    project.id = id
+    project.name = name
+    project.parent_id = parent_id
+    project.description = None
+    return project
+
+
+def _collect_container_tree(
+    source: TableauSiteSource,
+    all_project_map: Dict[str, TableauProject],
+) -> Dict[str, Dict[str, Optional[str]]]:
+    """Run emit_project_containers and return {project_id: {name, parent}} so
+    assertions read in terms of project ids rather than opaque container urns. A
+    root project's parent resolves to the "site" sentinel (its container nests under
+    the site container, which emit_site_container emits separately)."""
+    urn_to_id = {
+        source.gen_project_key(p.id).as_urn(): p.id for p in all_project_map.values()
+    }
+    urn_to_id[source.gen_site_key(source.site_id).as_urn()] = "site"
+
+    tree: Dict[str, Dict[str, Optional[str]]] = {}
+    for wu in source.emit_project_containers(all_project_map):
+        project_id = urn_to_id[wu.get_urn()]
+        entry = tree.setdefault(project_id, {"name": None, "parent": None})
+        props = wu.get_aspect_of_type(ContainerPropertiesClass)
+        if props is not None:
+            entry["name"] = props.name
+        parent = wu.get_aspect_of_type(ContainerClass)
+        if parent is not None:
+            entry["parent"] = urn_to_id.get(parent.container)
+    return tree
+
+
+class TestProjectContainerHierarchy:
+    """End-to-end tests for project container emission under project_pattern
+    filtering.
+
+    Each test declares a source project hierarchy plus a filter, then runs the real
+    pipeline -- fetch (via a mocked projects Pager) -> project_pattern filtering ->
+    registry building -> container emission -- and asserts the resulting browse
+    tree. The guiding invariant: every ingested project keeps its full folder path
+    up to the site, regardless of which ancestors matched the filter.
+    """
+
+    @staticmethod
+    def _run(
+        projects: List[Tuple[str, str, Optional[str]]],
+        *,
+        allow: Optional[List[str]] = None,
+        deny: Optional[List[str]] = None,
+        extract_project_hierarchy: bool = True,
+    ) -> Tuple[TableauSiteSource, Dict[str, Dict[str, Optional[str]]]]:
+        """Feed ``projects`` (id, name, parent_id) through the real projects Pager
+        and run filtering + registry building + container emission.
+
+        Returns (source, tree), where tree is {project_id: {name, parent}} and a
+        root project's parent resolves to the "site" sentinel (its container nests
+        under the site container). Sites are always added as containers here to
+        mirror a typical deployment.
+        """
+        project_pattern: Dict[str, List[str]] = {}
+        if allow is not None:
+            project_pattern["allow"] = allow
+        if deny is not None:
+            project_pattern["deny"] = deny
+
+        config_dict = {k: v for k, v in default_config.items() if k != "projects"}
+        config_dict.update(
+            project_pattern=project_pattern or {"allow": [".*"]},
+            extract_project_hierarchy=extract_project_hierarchy,
+            add_site_container=True,
+        )
+        config = TableauConfig.model_validate(config_dict)
+
+        with mock.patch("datahub.ingestion.source.tableau.tableau.Server"):
+            source = TableauSiteSource(
+                config=config,
+                ctx=PipelineContext(run_id="test"),
+                platform="tableau",
+                site=SiteIdContentUrl(site_id="s1", site_content_url="s1"),
+                report=TableauSourceReport(),
+                server=mock.MagicMock(),
+            )
+
+        project_items = [_tsc_project(*p) for p in projects]
+
+        def fake_pager(endpoint: Any, **kwargs: Any) -> Any:
+            # Only the projects endpoint has data; the datasource/workbook registries
+            # are irrelevant to project-container emission.
+            if endpoint is source.server.projects:
+                return iter(project_items)
+            return iter([])
+
+        with mock.patch(
+            "datahub.ingestion.source.tableau.tableau.TSC.Pager", side_effect=fake_pager
+        ):
+            all_project_map = source._populate_projects_registry()
+
+        return source, _collect_container_tree(source, all_project_map)
+
+    def test_reconstructs_unmatched_ancestors(self) -> None:
+        """A matched leaf keeps its full folder path when every ancestor is filtered
+        out.
+
+            Site
+            └── Project_1        filtered out
+                └── Project_2    filtered out
+                    └── Project_3    filtered out
+                        └── Project_4    MATCHES (leaf)
+        """
+        _, tree = self._run(
+            projects=[
+                ("p1", "Project_1", None),
+                ("p2", "Project_2", "p1"),
+                ("p3", "Project_3", "p2"),
+                ("p4", "Project_4", "p3"),
+            ],
+            allow=["^Project_4$"],
+        )
+
+        assert set(tree) == {"p1", "p2", "p3", "p4"}
+        assert tree["p4"]["parent"] == "p3"
+        assert tree["p3"]["parent"] == "p2"
+        assert tree["p2"]["parent"] == "p1"
+        assert tree["p1"]["parent"] == "site"
+        assert tree["p1"]["name"] == "Project_1"
+
+    def test_shares_common_ancestors_once(self) -> None:
+        """Two matched leaves keep their full paths and share ancestors exactly once,
+        with each branch nested correctly.
+
+            Site
+            └── Project_1                shared ancestor
+                └── Project_2            shared ancestor
+                    ├── Project_3
+                    │   └── Project_4        MATCHES (leaf)
+                    └── Project_5
+                        └── Project_6        MATCHES (leaf)
+        """
+        _, tree = self._run(
+            projects=[
+                ("p1", "Project_1", None),
+                ("p2", "Project_2", "p1"),
+                ("p3", "Project_3", "p2"),
+                ("p4", "Project_4", "p3"),
+                ("p5", "Project_5", "p2"),
+                ("p6", "Project_6", "p5"),
+            ],
+            allow=["^Project_4$", "^Project_6$"],
+        )
+
+        # Shared ancestors (p1, p2) appear once each -- keying by project id
+        # collapses duplicates, so an equal set means no ancestor was emitted twice
+        # under a different identity.
+        assert set(tree) == {"p1", "p2", "p3", "p4", "p5", "p6"}
+        assert tree["p4"]["parent"] == "p3"
+        assert tree["p3"]["parent"] == "p2"
+        assert tree["p6"]["parent"] == "p5"
+        assert tree["p5"]["parent"] == "p2"
+        assert tree["p2"]["parent"] == "p1"
+        assert tree["p1"]["parent"] == "site"
+
+    def test_middle_project_with_parent_and_child(self) -> None:
+        """A matched middle project (unmatched parent above, child below) links up to
+        its reconstructed parent and down to its child.
+
+            Site
+            └── Project_1        filtered out    -> path-only ancestor
+                └── Project_2    MATCHES         -> content container
+                    └── Project_3  child of match -> content container
+        """
+        source, tree = self._run(
+            projects=[
+                ("p1", "Project_1", None),
+                ("p2", "Project_2", "p1"),
+                ("p3", "Project_3", "p2"),
+            ],
+            allow=["^Project_2$"],
+        )
+
+        # Project_2 matched directly; Project_3 was pulled in as its child; the
+        # unmatched ancestor Project_1 stayed out of the content registry.
+        assert set(source.tableau_project_registry) == {"p2", "p3"}
+        assert set(tree) == {"p1", "p2", "p3"}
+        assert tree["p3"]["parent"] == "p2"
+        assert tree["p2"]["parent"] == "p1"
+        assert tree["p1"]["parent"] == "site"
+
+    def test_denied_ancestor_still_emitted_as_path_container(self) -> None:
+        """An explicitly denied ancestor carries no content but is still emitted as a
+        path container so the matched descendant's path stays unbroken."""
+        source, tree = self._run(
+            projects=[
+                ("p1", "Project_1", None),
+                ("p2", "Project_2", "p1"),
+                ("p3", "Project_3", "p2"),
+            ],
+            allow=["^Project_3$"],
+            deny=["^Project_1$"],
+        )
+
+        # Denied ancestor is not content-bearing...
+        assert "p1" not in source.tableau_project_registry
+        # ...but still appears in the browse tree, correctly nested.
+        assert set(tree) == {"p1", "p2", "p3"}
+        assert tree["p3"]["parent"] == "p2"
+        assert tree["p2"]["parent"] == "p1"
+        assert tree["p1"]["parent"] == "site"
+
+    def test_denied_child_excluded_while_sibling_emits(self) -> None:
+        """Under a matched parent, extract_project_hierarchy pulls in children --
+        except ones matching a deny rule. A denied child that is not an ancestor of
+        anything ingested emits no container at all, while its sibling emits
+        normally.
+
+            Site
+            └── Project_1    MATCHES (parent)
+                ├── Project_2    child, re-admitted -> emits
+                └── Project_3    DENIED             -> not emitted
+        """
+        source, tree = self._run(
+            projects=[
+                ("p1", "Project_1", None),
+                ("p2", "Project_2", "p1"),
+                ("p3", "Project_3", "p1"),
+            ],
+            allow=["^Project_1$"],
+            deny=["^Project_3$"],
+        )
+
+        # The denied child is excluded entirely; the parent and its other child emit.
+        assert set(source.tableau_project_registry) == {"p1", "p2"}
+        assert set(tree) == {"p1", "p2"}
+        assert "p3" not in tree
+        assert tree["p2"]["parent"] == "p1"
+        assert tree["p1"]["parent"] == "site"
+
+    def test_path_reconstructed_when_hierarchy_flag_disabled(self) -> None:
+        """Path correctness does not depend on extract_project_hierarchy: with the
+        flag off, no descendants are re-admitted, yet the matched project's full
+        ancestor path is still reconstructed."""
+        source, tree = self._run(
+            projects=[
+                ("p1", "Project_1", None),
+                ("p2", "Project_2", "p1"),
+                ("p3", "Project_3", "p2"),
+            ],
+            allow=["^Project_3$"],
+            extract_project_hierarchy=False,
+        )
+
+        # Only the matched leaf is content-bearing (no downward re-admission)...
+        assert set(source.tableau_project_registry) == {"p3"}
+        # ...yet the full ancestor path is still reconstructed.
+        assert set(tree) == {"p1", "p2", "p3"}
+        assert tree["p3"]["parent"] == "p2"
+        assert tree["p2"]["parent"] == "p1"
+        assert tree["p1"]["parent"] == "site"
 
 
 class TestNullApiResponseHandling:

--- a/metadata-ingestion/tests/unit/tableau/test_tableau_source.py
+++ b/metadata-ingestion/tests/unit/tableau/test_tableau_source.py
@@ -1616,6 +1616,27 @@ class TestProjectContainerHierarchy:
         # The dangling parent reference is surfaced to operators, not swallowed.
         assert "Incomplete project hierarchy" in source.report.as_string()
 
+    def test_dangling_parent_id_raises_actionable_error(self) -> None:
+        """emit_project_containers relies on _get_all_project having nulled out any
+        parent_id absent from the project map. If a future regression breaks that
+        normalization, the lookup should fail with an actionable error naming the
+        offending project -- not a bare KeyError."""
+        source = _make_site_source()
+        # A project pointing at a parent id that is not in the map -- the exact state
+        # _get_all_project is supposed to prevent.
+        orphan = TableauProject(
+            id="p2",
+            name="Project_2",
+            description=None,
+            parent_id="p1",
+            parent_name=None,
+            path=["Project_2"],
+        )
+        source.tableau_project_registry = {"p2": orphan}
+
+        with pytest.raises(ValueError, match="p1"):
+            list(source.emit_project_containers({"p2": orphan}))
+
 
 class TestNullApiResponseHandling:
     """Tableau's Metadata API occasionally returns None entries inside list fields

--- a/metadata-ingestion/tests/unit/tableau/test_tableau_source.py
+++ b/metadata-ingestion/tests/unit/tableau/test_tableau_source.py
@@ -1,6 +1,6 @@
 import json
 import pathlib
-from typing import Any, Dict, List, Optional, Sequence, Tuple, cast
+from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Tuple, cast
 from unittest import mock
 
 import pytest
@@ -1317,13 +1317,19 @@ def _make_site_source() -> TableauSiteSource:
         )
 
 
-def _tsc_project(id: str, name: str, parent_id: Optional[str]) -> mock.MagicMock:
+class ProjectSpec(NamedTuple):
+    id: str
+    name: str
+    parent_id: Optional[str]
+
+
+def _tsc_project(spec: ProjectSpec) -> mock.MagicMock:
     """Minimal stand-in for a tableauserverclient ProjectItem, as returned by the
     projects Pager."""
     project = mock.MagicMock()
-    project.id = id
-    project.name = name
-    project.parent_id = parent_id
+    project.id = spec.id
+    project.name = spec.name
+    project.parent_id = spec.parent_id
     project.description = None
     return project
 
@@ -1367,14 +1373,14 @@ class TestProjectContainerHierarchy:
 
     @staticmethod
     def _run(
-        projects: List[Tuple[str, str, Optional[str]]],
+        projects: List[ProjectSpec],
         *,
         allow: Optional[List[str]] = None,
         deny: Optional[List[str]] = None,
         extract_project_hierarchy: bool = True,
     ) -> Tuple[TableauSiteSource, Dict[str, Dict[str, Optional[str]]]]:
-        """Feed ``projects`` (id, name, parent_id) through the real projects Pager
-        and run filtering + registry building + container emission.
+        """Feed ``projects`` through the real projects Pager and run filtering +
+        registry building + container emission.
 
         Returns (source, tree), where tree is {project_id: {name, parent}} and a
         root project's parent resolves to the "site" sentinel (its container nests
@@ -1405,7 +1411,7 @@ class TestProjectContainerHierarchy:
                 server=mock.MagicMock(),
             )
 
-        project_items = [_tsc_project(*p) for p in projects]
+        project_items = [_tsc_project(p) for p in projects]
 
         def fake_pager(endpoint: Any, **kwargs: Any) -> Any:
             # Only the projects endpoint has data; the datasource/workbook registries
@@ -1433,10 +1439,10 @@ class TestProjectContainerHierarchy:
         """
         _, tree = self._run(
             projects=[
-                ("p1", "Project_1", None),
-                ("p2", "Project_2", "p1"),
-                ("p3", "Project_3", "p2"),
-                ("p4", "Project_4", "p3"),
+                ProjectSpec("p1", "Project_1", None),
+                ProjectSpec("p2", "Project_2", "p1"),
+                ProjectSpec("p3", "Project_3", "p2"),
+                ProjectSpec("p4", "Project_4", "p3"),
             ],
             allow=["^Project_4$"],
         )
@@ -1462,12 +1468,12 @@ class TestProjectContainerHierarchy:
         """
         _, tree = self._run(
             projects=[
-                ("p1", "Project_1", None),
-                ("p2", "Project_2", "p1"),
-                ("p3", "Project_3", "p2"),
-                ("p4", "Project_4", "p3"),
-                ("p5", "Project_5", "p2"),
-                ("p6", "Project_6", "p5"),
+                ProjectSpec("p1", "Project_1", None),
+                ProjectSpec("p2", "Project_2", "p1"),
+                ProjectSpec("p3", "Project_3", "p2"),
+                ProjectSpec("p4", "Project_4", "p3"),
+                ProjectSpec("p5", "Project_5", "p2"),
+                ProjectSpec("p6", "Project_6", "p5"),
             ],
             allow=["^Project_4$", "^Project_6$"],
         )
@@ -1494,9 +1500,9 @@ class TestProjectContainerHierarchy:
         """
         source, tree = self._run(
             projects=[
-                ("p1", "Project_1", None),
-                ("p2", "Project_2", "p1"),
-                ("p3", "Project_3", "p2"),
+                ProjectSpec("p1", "Project_1", None),
+                ProjectSpec("p2", "Project_2", "p1"),
+                ProjectSpec("p3", "Project_3", "p2"),
             ],
             allow=["^Project_2$"],
         )
@@ -1514,9 +1520,9 @@ class TestProjectContainerHierarchy:
         path container so the matched descendant's path stays unbroken."""
         source, tree = self._run(
             projects=[
-                ("p1", "Project_1", None),
-                ("p2", "Project_2", "p1"),
-                ("p3", "Project_3", "p2"),
+                ProjectSpec("p1", "Project_1", None),
+                ProjectSpec("p2", "Project_2", "p1"),
+                ProjectSpec("p3", "Project_3", "p2"),
             ],
             allow=["^Project_3$"],
             deny=["^Project_1$"],
@@ -1543,9 +1549,9 @@ class TestProjectContainerHierarchy:
         """
         source, tree = self._run(
             projects=[
-                ("p1", "Project_1", None),
-                ("p2", "Project_2", "p1"),
-                ("p3", "Project_3", "p1"),
+                ProjectSpec("p1", "Project_1", None),
+                ProjectSpec("p2", "Project_2", "p1"),
+                ProjectSpec("p3", "Project_3", "p1"),
             ],
             allow=["^Project_1$"],
             deny=["^Project_3$"],
@@ -1564,9 +1570,9 @@ class TestProjectContainerHierarchy:
         ancestor path is still reconstructed."""
         source, tree = self._run(
             projects=[
-                ("p1", "Project_1", None),
-                ("p2", "Project_2", "p1"),
-                ("p3", "Project_3", "p2"),
+                ProjectSpec("p1", "Project_1", None),
+                ProjectSpec("p2", "Project_2", "p1"),
+                ProjectSpec("p3", "Project_3", "p2"),
             ],
             allow=["^Project_3$"],
             extract_project_hierarchy=False,
@@ -1579,6 +1585,36 @@ class TestProjectContainerHierarchy:
         assert tree["p3"]["parent"] == "p2"
         assert tree["p2"]["parent"] == "p1"
         assert tree["p1"]["parent"] == "site"
+
+    def test_ancestor_absent_from_map_is_reparented_to_site(self) -> None:
+        """An ancestor entirely absent from the fetched project map (e.g. the API
+        omits it because of insufficient permissions) has no entry to recurse into.
+        _get_all_project nulls the dangling parent_id, so the orphaned project is
+        reparented under the site instead of dangling -- and container emission must
+        not fail looking up the missing ancestor.
+
+            Site
+            (Project_1)          NOT fetched -- absent from the map
+                └── Project_2    orphaned -> reparented under site
+                    └── Project_3    MATCHES (leaf)
+        """
+        source, tree = self._run(
+            # Project_1, the parent of Project_2, is intentionally not fetched.
+            projects=[
+                ProjectSpec("p2", "Project_2", "p1"),
+                ProjectSpec("p3", "Project_3", "p2"),
+            ],
+            allow=["^Project_3$"],
+        )
+
+        # The missing ancestor never emits a container...
+        assert "p1" not in tree
+        # ...and its orphaned child is reparented directly under the site.
+        assert set(tree) == {"p2", "p3"}
+        assert tree["p3"]["parent"] == "p2"
+        assert tree["p2"]["parent"] == "site"
+        # The dangling parent reference is surfaced to operators, not swallowed.
+        assert "Incomplete project hierarchy" in source.report.as_string()
 
 
 class TestNullApiResponseHandling:


### PR DESCRIPTION
## Summary

When a Tableau project matched `project_pattern` but its **ancestor** projects did not, the ingested project lost its full folder path in DataHub. Only the immediate parent survived, and it was re-rooted at the top level, so the browse tree did not reflect Tableau's actual folder structure.

Example — ingesting only a deeply nested project whose ancestors are filtered out:

```
Site
└── Project_1        (filtered out)
    └── Project_2    (filtered out)
        └── Project_3    (filtered out)
            └── Project_4    (matches filter)
```

Previously `Project_4` appeared nested only under a re-rooted `Project_3` at the top level; `Project_1`/`Project_2` were dropped.

## What changed

`emit_project_containers` now walks the full ancestor chain from the unfiltered project map and emits filtered-out ancestors as **path-only containers**:

- Ancestors are resolved from the full project map (returned by `_populate_projects_registry`) rather than only the filtered content registry, so the recursion reaches the true root.
- These ancestor containers carry **no content** — they never enter the content registry, so `project_pattern` still fully controls what is ingested.
- Path reconstruction is independent of the `extract_project_hierarchy` flag (that flag governs which content is ingested, not path correctness).
- Unreachable ancestors (e.g. insufficient permissions) degrade gracefully rather than truncating/erroring.

The full project map is threaded as an explicit argument instead of being stored on the source instance, so it is released as soon as emission completes.

## Testing

Added `TestProjectContainerHierarchy` — end-to-end tests that drive the real filtering pipeline (mocked projects fetch → `project_pattern` filtering → registry build → container emission) and assert the resulting browse tree for:

- Full reconstruction of a linear chain of unmatched ancestors
- Shared ancestors emitted exactly once across multiple matched leaves
- A matched middle project linking to both its reconstructed parent and its child
- A denied ancestor still emitted as a path-only container (path stays unbroken)
- A denied sibling excluded entirely while its sibling emits
- Path correctness preserved when `extract_project_hierarchy` is disabled

`./gradlew :metadata-ingestion:lint` and the full `tests/unit/tableau/` suite pass.

