### PR TITLE
fix(ingest/abs): list folders with a server-side delimiter walk

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/azure/abs_folder_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/azure/abs_folder_utils.py
@@ -194,30 +194,15 @@ def list_folders(
 
     normalized_prefix = prefix.strip("/")
     prefix_with_separator = f"{normalized_prefix}/" if normalized_prefix else ""
-    blob_list = container_client.list_blobs(name_starts_with=prefix)
 
-    seen: set[str] = set()
-    for blob in blob_list:
-        blob_name = blob.name.strip("/")
-        if not blob_name:
+    # walk_blobs with a delimiter yields one BlobPrefix (name ends with "/") per
+    # immediate sub-folder; blobs at this level are skipped.
+    for item in container_client.walk_blobs(
+        name_starts_with=prefix_with_separator, delimiter="/"
+    ):
+        name = item.name
+        if not name.endswith("/"):
             continue
-
-        if prefix_with_separator:
-            if not blob_name.startswith(prefix_with_separator):
-                continue
-            relative_name = blob_name[len(prefix_with_separator) :]
-        else:
-            relative_name = blob_name
-
-        if "/" not in relative_name:
-            continue
-        child_folder = relative_name.split("/", 1)[0]
-        folder_name = (
-            f"{normalized_prefix}/{child_folder}" if normalized_prefix else child_folder
-        )
-
-        if folder_name in seen:
-            continue
-        seen.add(folder_name)
-
-        yield f"{folder_name}"
+        folder_name = name.strip("/")
+        if folder_name:
+            yield folder_name

--- a/metadata-ingestion/tests/unit/azure/test_abs_folder_utils.py
+++ b/metadata-ingestion/tests/unit/azure/test_abs_folder_utils.py
@@ -11,15 +11,20 @@ def test_list_folders_with_nested_prefix() -> None:
 
     azure_config.get_blob_service_client.return_value = blob_service_client
     blob_service_client.get_container_client.return_value = container_client
-    container_client.list_blobs.return_value = [
-        SimpleNamespace(name="database/table_one/_delta_log/000.json"),
-        SimpleNamespace(name="database/table_one/part-000.parquet"),
-        SimpleNamespace(name="database/table_two/_delta_log/000.json"),
+    # Sub-folders end with "/"; the blob at this level (rootfile.json) is skipped.
+    container_client.walk_blobs.return_value = [
+        SimpleNamespace(name="database/table_one/"),
+        SimpleNamespace(name="database/rootfile.json"),
+        SimpleNamespace(name="database/table_two/"),
     ]
 
     folders = list(list_folders("container", "database", azure_config))
 
     assert folders == ["database/table_one", "database/table_two"]
+    container_client.walk_blobs.assert_called_once_with(
+        name_starts_with="database/", delimiter="/"
+    )
+    container_client.list_blobs.assert_not_called()
 
 
 def test_list_folders_from_container_root() -> None:
@@ -29,11 +34,15 @@ def test_list_folders_from_container_root() -> None:
 
     azure_config.get_blob_service_client.return_value = blob_service_client
     blob_service_client.get_container_client.return_value = container_client
-    container_client.list_blobs.return_value = [
-        SimpleNamespace(name="database/table_one/_delta_log/000.json"),
-        SimpleNamespace(name="landing/file.json"),
+    container_client.walk_blobs.return_value = [
+        SimpleNamespace(name="database/"),
+        SimpleNamespace(name="landing/"),
     ]
 
     folders = list(list_folders("container", "", azure_config))
 
     assert folders == ["database", "landing"]
+    container_client.walk_blobs.assert_called_once_with(
+        name_starts_with="", delimiter="/"
+    )
+    container_client.list_blobs.assert_not_called()


### PR DESCRIPTION
## Summary

ABS `list_folders` called `list_blobs(name_starts_with=prefix)` with no delimiter, enumerating **every descendant blob** under the prefix and de-duplicating the immediate child folders in Python — re-listing whole subtrees at each recursion level.

Switched to `container_client.walk_blobs(name_starts_with=..., delimiter="/")` so Azure returns only the immediate child prefixes server-side. The output contract is unchanged (folder paths without a trailing slash).

## Testing

- Updated `tests/unit/azure/test_abs_folder_utils.py` to mock `walk_blobs`; both tests pass and assert the delimiter walk is used and that no descendant enumeration (`list_blobs`) occurs.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Links to related issues (n/a)
- [x] Tests added/updated
- [ ] Docs added/updated (n/a)
- [ ] Breaking changes (n/a)