### PR TITLE
fix(ingest/datalake): drop redundant full-table count in Spark profiler

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/s3/profiling.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/profiling.py
@@ -647,7 +647,8 @@ class SparkProfiler:
         else:
             self.report.report_warning(file, f"file {file} has unsupported extension")
             return None
-        logger.debug(f"dataframe read for file {file} with row count {df.count()}")
+        # NB: no df.count() debug log here. Counting forces a full scan of the whole
+        # table; the row count is already computed once later in _SingleTableProfiler.
         # replace periods in names because they break PyDeequ
         # see https://mungingdata.com/pyspark/avoid-dots-periods-column-names/
         return df.toDF(*(c.replace(".", "_") for c in df.columns))


### PR DESCRIPTION
## Summary

`read_file_spark` called `df.count()` only to populate a debug log line, forcing a full scan of the entire table on every profiled file. The row count is already computed once in `_SingleTableProfiler` (and reused for the emitted profile), so this was a wasteful second full pass. The debug line now logs without counting.

## Testing

- No new test: this is a one-line removal of wasteful work with no behavior change (a mock-count-call assertion would be a brittle, low-value test). Existing S3 unit tests remain green.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Links to related issues (n/a)
- [ ] Tests added/updated (n/a — no behavior change)
- [ ] Docs added/updated (n/a)
- [ ] Breaking changes (n/a)