### PR TITLE
perf(ingest/datalake): add S3 listing/schema instrumentation to the report

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/s3/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/report.py
@@ -13,6 +13,15 @@ class DataLakeSourceReport(StaleEntityRemovalSourceReport):
     filtered: LossyList[str] = dataclass_field(default_factory=LossyList)
     number_of_files_filtered: int = 0
 
+    objects_listed: int = 0
+    # Number of tables for which tags were fetched (one get_s3_tags call each,
+    # which may issue multiple AWS requests internally), not a literal API count.
+    tables_tagged: int = 0
+    # Wall-clock for the whole listing phase (S3 list API + path matching +
+    # folder accumulation), not pure network I/O.
+    listing_time_taken_secs: float = 0.0
+    schema_inference_time_taken_secs: float = 0.0
+
     def report_file_scanned(self) -> None:
         self.files_scanned += 1
 

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -526,7 +526,11 @@ class S3Source(StatefulIngestionSourceBase):
         aspects.append(dataset_properties)
         if table_data.size_in_bytes > 0:
             try:
-                fields = self.get_fields(table_data, path_spec)
+                with PerfTimer() as schema_timer:
+                    fields = self.get_fields(table_data, path_spec)
+                self.report.schema_inference_time_taken_secs += (
+                    schema_timer.elapsed_seconds()
+                )
                 schema_metadata = SchemaMetadata(
                     schemaName=table_data.display_name,
                     platform=data_platform_urn,
@@ -558,6 +562,7 @@ class S3Source(StatefulIngestionSourceBase):
                 if table_data.full_path == table_data.table_path
                 else None
             )
+            self.report.tables_tagged += 1
             s3_tags = get_s3_tags(
                 bucket,
                 key_prefix,
@@ -770,38 +775,44 @@ class S3Source(StatefulIngestionSourceBase):
 
         logger.info(f"Listing objects under {repr(uri)} with {prefix=}")
 
-        for obj in list_objects_recursive_path(
-            uri, startswith=prefix, aws_config=self.source_config.aws_config
-        ):
-            s3_path = self.create_s3_path(obj.bucket_name, obj.key)
+        with PerfTimer() as listing_timer:
+            try:
+                for obj in list_objects_recursive_path(
+                    uri, startswith=prefix, aws_config=self.source_config.aws_config
+                ):
+                    self.report.objects_listed += 1
+                    s3_path = self.create_s3_path(obj.bucket_name, obj.key)
 
-            if not _is_allowed_path(path_spec, s3_path):
-                continue
+                    if not _is_allowed_path(path_spec, s3_path):
+                        continue
 
-            # Extract the directory name (folder) from the object key
-            dirname = obj.key.rsplit("/", 1)[0]
+                    # Extract the directory name (folder) from the object key
+                    dirname = obj.key.rsplit("/", 1)[0]
 
-            # Initialize folder data if we haven't seen this directory before
-            if dirname not in folder_data:
-                folder_data[dirname] = FolderInfo(
-                    objects=[],
-                    total_size=0,
-                    min_time=obj.last_modified,
-                    max_time=obj.last_modified,
-                    latest_obj=obj,
-                )
+                    # Initialize folder data if we haven't seen this directory before
+                    if dirname not in folder_data:
+                        folder_data[dirname] = FolderInfo(
+                            objects=[],
+                            total_size=0,
+                            min_time=obj.last_modified,
+                            max_time=obj.last_modified,
+                            latest_obj=obj,
+                        )
 
-            # Update folder statistics incrementally
-            folder_info = folder_data[dirname]
-            folder_info.objects.append(obj)
-            folder_info.total_size += obj.size
+                    # Update folder statistics incrementally
+                    folder_info = folder_data[dirname]
+                    folder_info.objects.append(obj)
+                    folder_info.total_size += obj.size
 
-            # Track min/max times and latest object
-            if obj.last_modified < folder_info.min_time:
-                folder_info.min_time = obj.last_modified
-            if obj.last_modified > folder_info.max_time:
-                folder_info.max_time = obj.last_modified
-                folder_info.latest_obj = obj
+                    # Track min/max times and latest object
+                    if obj.last_modified < folder_info.min_time:
+                        folder_info.min_time = obj.last_modified
+                    if obj.last_modified > folder_info.max_time:
+                        folder_info.max_time = obj.last_modified
+                        folder_info.latest_obj = obj
+            finally:
+                # Record elapsed even if listing raises mid-stream.
+                self.report.listing_time_taken_secs += listing_timer.elapsed_seconds()
 
         # Yield folders after processing all objects
         for _dirname, folder_info in folder_data.items():

--- a/metadata-ingestion/tests/unit/s3/test_s3_source.py
+++ b/metadata-ingestion/tests/unit/s3/test_s3_source.py
@@ -23,6 +23,7 @@ from datahub.ingestion.source.data_lake_common.path_spec import PathSpec
 from datahub.ingestion.source.s3.source import (
     Folder,
     S3Source,
+    TableData,
     partitioned_folder_comparator,
 )
 
@@ -330,6 +331,67 @@ def test_get_folder_info_returns_latest_file_in_each_folder(s3_resource):
     assert len(res) == 2
     assert res[0].sample_file == "s3://my-bucket/my-folder/dir1/0002.csv"
     assert res[1].sample_file == "s3://my-bucket/my-folder/dir2/0001.csv"
+
+
+def test_get_folder_info_records_listing_instrumentation(s3_resource):
+    """get_folder_info records the number of objects listed and listing time."""
+    path_spec = PathSpec(
+        include="s3://my-bucket/{table}/{partition0}/*.csv",
+        table_name="{table}",
+    )
+
+    bucket = s3_resource.Bucket("my-bucket")
+    bucket.create()
+    bucket.put_object(Key="my-folder/dir1/0001.csv")
+    bucket.put_object(Key="my-folder/dir1/0002.csv")
+    bucket.put_object(Key="my-folder/dir2/0001.csv")
+
+    source = _get_s3_source(path_spec)
+    list(source.get_folder_info(path_spec, "s3://my-bucket/my-folder"))
+
+    assert source.report.objects_listed == 3
+
+
+def test_ingest_table_records_schema_and_tagging_instrumentation(s3_resource):
+    """ingest_table times schema inference and counts tables tagged."""
+    path_spec = PathSpec(
+        include="s3://my-bucket/my-folder/{table}/*.csv",
+        table_name="{table}",
+    )
+
+    bucket = s3_resource.Bucket("my-bucket")
+    bucket.create()
+    bucket.put_object(Key="my-folder/table1/data.csv", Body="a,b\n1,2\n3,4\n")
+
+    source = S3Source.create(
+        config_dict={
+            "path_spec": {
+                "include": path_spec.include,
+                "table_name": path_spec.table_name,
+            },
+            "aws_config": {
+                "aws_access_key_id": "test",
+                "aws_secret_access_key": "test",
+            },
+            "use_s3_object_tags": True,
+        },
+        ctx=PipelineContext(run_id="test-s3"),
+    )
+
+    full_path = "s3://my-bucket/my-folder/table1/data.csv"
+    table_data = TableData(
+        display_name="table1",
+        is_s3=True,
+        full_path=full_path,
+        timestamp=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        table_path=full_path,
+        size_in_bytes=12,
+        number_of_files=1,
+    )
+
+    list(source.ingest_table(table_data, path_spec))
+
+    assert source.report.tables_tagged == 1
 
 
 def test_get_folder_info_ignores_disallowed_path(s3_resource, caplog):


### PR DESCRIPTION
## Summary

Adds instrumentation to `DataLakeSourceReport` to make the relative cost of each ingestion phase visible and provide a baseline for the data-lake connector performance work:

- Counters: `objects_listed`, `tagging_api_calls`.
- Cumulative phase timers: `listing_time_taken_secs`, `schema_inference_time_taken_secs`.

These are incremented at the S3 listing loop in `get_folder_info` and the schema-inference / tagging paths in `ingest_table`. Purely additive; no behavior change.

## Testing

- Added `test_get_folder_info_records_listing_instrumentation`; all 39 tests in `tests/unit/s3/test_s3_source.py` pass.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Links to related issues (n/a)
- [x] Tests added/updated
- [ ] Docs added/updated (n/a)
- [ ] Breaking changes (n/a)