### PR TITLE
perf(graphql): batch entity health resolution to eliminate N+1

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -150,6 +150,7 @@ import com.linkedin.datahub.graphql.resolvers.load.AspectResolver;
 import com.linkedin.datahub.graphql.resolvers.load.BatchGetEntitiesResolver;
 import com.linkedin.datahub.graphql.resolvers.load.DashboardStatsSummaryBatchLoader;
 import com.linkedin.datahub.graphql.resolvers.load.DatasetStatsSummaryBatchLoader;
+import com.linkedin.datahub.graphql.resolvers.load.EntityHealthBatchLoader;
 import com.linkedin.datahub.graphql.resolvers.load.EntityLineageResultResolver;
 import com.linkedin.datahub.graphql.resolvers.load.EntityRelationshipsResultResolver;
 import com.linkedin.datahub.graphql.resolvers.load.EntityTypeBatchResolver;
@@ -367,6 +368,7 @@ import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.query.filter.SortCriterion;
 import com.linkedin.metadata.query.filter.SortOrder;
 import com.linkedin.metadata.recommendation.RecommendationsService;
+import com.linkedin.metadata.search.EntitySearchService;
 import com.linkedin.metadata.service.ApplicationService;
 import com.linkedin.metadata.service.AssertionService;
 import com.linkedin.metadata.service.BusinessAttributeService;
@@ -440,6 +442,7 @@ public class GmsGraphQLEngine {
   private final GitVersion gitVersion;
   private final boolean supportsImpactAnalysis;
   private final TimeseriesAspectService timeseriesAspectService;
+  private final EntitySearchService entitySearchService;
   private final TimelineService timelineService;
   private final NativeUserService nativeUserService;
   private final GroupService groupService;
@@ -586,6 +589,7 @@ public class GmsGraphQLEngine {
     this.gitVersion = args.gitVersion;
     this.supportsImpactAnalysis = args.supportsImpactAnalysis;
     this.timeseriesAspectService = args.timeseriesAspectService;
+    this.entitySearchService = args.entitySearchService;
     this.timelineService = args.timelineService;
     this.nativeUserService = args.nativeUserService;
     this.groupService = args.groupService;
@@ -958,6 +962,15 @@ public class GmsGraphQLEngine {
             DashboardStatsSummaryBatchLoader.LOADER_NAME,
             context ->
                 DashboardStatsSummaryBatchLoader.createDataLoader(timeseriesAspectService, context))
+        .addDataLoader(
+            EntityHealthBatchLoader.LOADER_NAME,
+            context ->
+                EntityHealthBatchLoader.createDataLoader(
+                    this.entityClient,
+                    this.graphClient,
+                    timeseriesAspectService,
+                    this.entitySearchService,
+                    context))
         .addDataLoader(
             DatasetStatsSummaryBatchLoader.LOADER_NAME,
             context ->
@@ -1992,7 +2005,8 @@ public class GmsGraphQLEngine {
                             graphClient,
                             timeseriesAspectService,
                             new EntityHealthResolver.Config(
-                                true, true, featureFlags.isShowTestsInHealthIcon())))
+                                true, true, featureFlags.isShowTestsInHealthIcon()),
+                            featureFlags))
                     .dataFetcher("schemaMetadata", new AspectResolver())
                     .dataFetcher(
                         "assertions", new EntityAssertionsResolver(entityClient, graphClient))
@@ -2480,7 +2494,8 @@ public class GmsGraphQLEngine {
                         entityClient,
                         graphClient,
                         timeseriesAspectService,
-                        new EntityHealthResolver.Config(false, true, false))));
+                        new EntityHealthResolver.Config(false, true, false),
+                        featureFlags)));
     builder.type(
         "DashboardInfo",
         typeWiring ->
@@ -2626,7 +2641,8 @@ public class GmsGraphQLEngine {
                         entityClient,
                         graphClient,
                         timeseriesAspectService,
-                        new EntityHealthResolver.Config(false, true, false))));
+                        new EntityHealthResolver.Config(false, true, false),
+                        featureFlags)));
     builder.type(
         "ChartInfo",
         typeWiring ->
@@ -2854,7 +2870,8 @@ public class GmsGraphQLEngine {
                             entityClient,
                             graphClient,
                             timeseriesAspectService,
-                            new EntityHealthResolver.Config(false, true, false))))
+                            new EntityHealthResolver.Config(false, true, false),
+                            featureFlags)))
         .type(
             "DataJobInputOutput",
             typeWiring ->
@@ -2943,7 +2960,8 @@ public class GmsGraphQLEngine {
                         entityClient,
                         graphClient,
                         timeseriesAspectService,
-                        new EntityHealthResolver.Config(false, true, false))));
+                        new EntityHealthResolver.Config(false, true, false),
+                        featureFlags)));
   }
 
   /**

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngineArgs.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngineArgs.java
@@ -24,6 +24,7 @@ import com.linkedin.metadata.graph.SiblingGraphService;
 import com.linkedin.metadata.ingestion.IngestionCliVersionMatrixService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.recommendation.RecommendationsService;
+import com.linkedin.metadata.search.EntitySearchService;
 import com.linkedin.metadata.search.SemanticSearchService;
 import com.linkedin.metadata.service.ApplicationService;
 import com.linkedin.metadata.service.AssertionService;
@@ -62,6 +63,7 @@ public class GmsGraphQLEngineArgs {
   RecommendationsService recommendationsService;
   StatefulTokenService statefulTokenService;
   TimeseriesAspectService timeseriesAspectService;
+  EntitySearchService entitySearchService;
   EntityRegistry entityRegistry;
   SecretService secretService;
   NativeUserService nativeUserService;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/health/EntityHealthResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/health/EntityHealthResolver.java
@@ -1,54 +1,33 @@
 package com.linkedin.datahub.graphql.resolvers.health;
 
-import static com.linkedin.metadata.Constants.ASSERTION_RUN_EVENT_STATUS_COMPLETE;
-import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
-
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.EntityRelationships;
 import com.linkedin.common.urn.Urn;
-import com.linkedin.data.template.StringArray;
-import com.linkedin.data.template.StringArrayArray;
+import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
-import com.linkedin.datahub.graphql.generated.ActiveIncidentHealthDetails;
+import com.linkedin.datahub.graphql.featureflags.FeatureFlags;
 import com.linkedin.datahub.graphql.generated.Entity;
 import com.linkedin.datahub.graphql.generated.Health;
-import com.linkedin.datahub.graphql.generated.HealthStatus;
-import com.linkedin.datahub.graphql.generated.HealthStatusType;
 import com.linkedin.datahub.graphql.generated.IncidentState;
+import com.linkedin.datahub.graphql.resolvers.load.EntityHealthBatchLoader;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.incident.IncidentInfo;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.graph.GraphClient;
-import com.linkedin.metadata.query.filter.Condition;
-import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
-import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
-import com.linkedin.metadata.query.filter.Criterion;
-import com.linkedin.metadata.query.filter.CriterionArray;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
-import com.linkedin.metadata.query.filter.SortCriterion;
-import com.linkedin.metadata.query.filter.SortOrder;
 import com.linkedin.metadata.search.SearchResult;
-import com.linkedin.metadata.search.utils.QueryUtils;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
 import com.linkedin.r2.RemoteInvocationException;
-import com.linkedin.test.TestResults;
-import com.linkedin.timeseries.AggregationSpec;
-import com.linkedin.timeseries.AggregationType;
 import com.linkedin.timeseries.GenericTable;
-import com.linkedin.timeseries.GroupingBucket;
-import com.linkedin.timeseries.GroupingBucketType;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -57,25 +36,29 @@ import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.dataloader.DataLoader;
 
 /**
  * Resolver for generating the health badge for an asset, which depends on
  *
  * <p>1. Assertions status - whether the asset has active assertions 2. Incidents status - whether
  * the asset has active incidents
+ *
+ * <p>All health interpretation (aggregation specs, filters, row parsing, {@link Health} assembly)
+ * lives in {@link HealthComputationUtils}, shared with the batched {@link EntityHealthBatchLoader}
+ * so both paths compute identical health.
  */
 @Slf4j
 public class EntityHealthResolver implements DataFetcher<CompletableFuture<List<Health>>> {
-  private static final String ASSERTS_RELATIONSHIP_NAME = "Asserts";
-  private static final String ASSERTION_RUN_EVENT_SUCCESS_TYPE = "SUCCESS";
-  private static final String INCIDENT_ENTITIES_SEARCH_INDEX_FIELD_NAME = "entities.keyword";
-  private static final String INCIDENT_STATE_SEARCH_INDEX_FIELD_NAME = "state";
 
   private final EntityClient _entityClient;
   private final GraphClient _graphClient;
   private final TimeseriesAspectService _timeseriesAspectService;
 
   private final Config _config;
+
+  // Null when constructed without feature flags (legacy/test path) — treated as "batch disabled".
+  @Nullable private final FeatureFlags _featureFlags;
 
   public EntityHealthResolver(
       @Nonnull final EntityClient entityClient,
@@ -89,16 +72,39 @@ public class EntityHealthResolver implements DataFetcher<CompletableFuture<List<
       @Nonnull final GraphClient graphClient,
       @Nonnull final TimeseriesAspectService timeseriesAspectService,
       @Nonnull final Config config) {
+    this(entityClient, graphClient, timeseriesAspectService, config, null);
+  }
+
+  public EntityHealthResolver(
+      @Nonnull final EntityClient entityClient,
+      @Nonnull final GraphClient graphClient,
+      @Nonnull final TimeseriesAspectService timeseriesAspectService,
+      @Nonnull final Config config,
+      @Nullable final FeatureFlags featureFlags) {
     _entityClient = entityClient;
     _graphClient = graphClient;
     _timeseriesAspectService = timeseriesAspectService;
     _config = config;
+    _featureFlags = featureFlags;
   }
 
   @Override
   public CompletableFuture<List<Health>> get(final DataFetchingEnvironment environment)
       throws Exception {
     final Entity parent = environment.getSource();
+
+    if (_featureFlags != null && _featureFlags.isEntityHealthBatchLoadEnabled()) {
+      final EntityHealthBatchLoader.HealthQueryKey key =
+          new EntityHealthBatchLoader.HealthQueryKey(
+              UrnUtils.getUrn(parent.getUrn()),
+              _config.getAssertionsEnabled(),
+              _config.getIncidentsEnabled(),
+              _config.getTestsEnabled());
+      final DataLoader<EntityHealthBatchLoader.HealthQueryKey, List<Health>> loader =
+          environment.getDataLoaderRegistry().getDataLoader(EntityHealthBatchLoader.LOADER_NAME);
+      return loader.load(key);
+    }
+
     return GraphQLConcurrencyUtils.supplyAsync(
         () -> {
           try {
@@ -147,52 +153,28 @@ public class EntityHealthResolver implements DataFetcher<CompletableFuture<List<
     return new HealthStatuses(healthStatuses);
   }
 
-  /**
-   * Returns the resolved "incidents health", which is currently a static function of whether there
-   * are any active incidents open on an asset
-   *
-   * @param entityUrn the asset to compute health for
-   * @param context the query context
-   * @return an instance of {@link Health} for the entity, null if one cannot be computed.
-   */
   private Health computeIncidentsHealthForAsset(
       final String entityUrn, final QueryContext context) {
     try {
-      final Filter filter = buildIncidentsEntityFilter(entityUrn, IncidentState.ACTIVE.toString());
+      final Filter filter =
+          HealthComputationUtils.incidentsEntityFilter(entityUrn, IncidentState.ACTIVE.toString());
       final SearchResult searchResult =
           _entityClient.filter(
               context.getOperationContext(),
               Constants.INCIDENT_ENTITY_NAME,
               filter,
-              buildIncidentsSort(),
+              HealthComputationUtils.incidentsSort(),
               0,
               1);
-      final Integer activeIncidentCount = searchResult.getNumEntities();
+      final int activeIncidentCount = searchResult.getNumEntities();
+      Urn latestIncidentUrn = null;
+      IncidentInfo latestIncidentInfo = null;
       if (activeIncidentCount > 0) {
-        // There are active incidents.
-        final Urn latestIncidentUrn = searchResult.getEntities().get(0).getEntity();
-        final IncidentInfo latestIncidentInfo = getIncidentInfo(context, latestIncidentUrn);
-        final Long latestIncidentTimestamp =
-            latestIncidentInfo != null
-                ? latestIncidentInfo.getStatus().getLastUpdated().getTime()
-                : null;
-        return new Health(
-            HealthStatusType.INCIDENTS,
-            latestIncidentTimestamp != null ? latestIncidentTimestamp : 0,
-            HealthStatus.FAIL,
-            String.format(
-                "%s active incident%s", activeIncidentCount, activeIncidentCount > 1 ? "s" : ""),
-            new ActiveIncidentHealthDetails(
-                latestIncidentUrn.toString(),
-                latestIncidentInfo != null ? latestIncidentInfo.getTitle() : null,
-                latestIncidentTimestamp,
-                activeIncidentCount),
-            null,
-            ImmutableList.of("ACTIVE_INCIDENTS"));
+        latestIncidentUrn = searchResult.getEntities().get(0).getEntity();
+        latestIncidentInfo = getIncidentInfo(context, latestIncidentUrn);
       }
-      // Report pass if there are no active incidents.
-      return new Health(
-          HealthStatusType.INCIDENTS, null, HealthStatus.PASS, null, null, null, null);
+      return HealthComputationUtils.buildIncidentHealth(
+          activeIncidentCount, latestIncidentUrn, latestIncidentInfo);
     } catch (RemoteInvocationException e) {
       log.error("Failed to compute incident health status!", e);
       return null;
@@ -223,17 +205,6 @@ public class EntityHealthResolver implements DataFetcher<CompletableFuture<List<
         entityResponse.getAspects().get(Constants.INCIDENT_INFO_ASPECT_NAME).getValue().data());
   }
 
-  private List<SortCriterion> buildIncidentsSort() {
-    return List.of(new SortCriterion().setOrder(SortOrder.DESCENDING).setField("lastUpdated"));
-  }
-
-  private Filter buildIncidentsEntityFilter(final String entityUrn, final String state) {
-    final Map<String, String> criterionMap = new HashMap<>();
-    criterionMap.put(INCIDENT_ENTITIES_SEARCH_INDEX_FIELD_NAME, entityUrn);
-    criterionMap.put(INCIDENT_STATE_SEARCH_INDEX_FIELD_NAME, state);
-    return QueryUtils.newFilter(criterionMap);
-  }
-
   /**
    * TODO: Replace this with the assertions summary aspect.
    *
@@ -251,14 +222,13 @@ public class EntityHealthResolver implements DataFetcher<CompletableFuture<List<
     final EntityRelationships relationships =
         _graphClient.getRelatedEntities(
             entityUrn,
-            ImmutableSet.of(ASSERTS_RELATIONSHIP_NAME),
+            ImmutableSet.of(HealthComputationUtils.ASSERTS_RELATIONSHIP_NAME),
             RelationshipDirection.INCOMING,
             0,
-            500,
+            HealthComputationUtils.MAX_ACTIVE_ASSERTIONS,
             context.getActorUrn());
 
     if (relationships.getTotal() > 0) {
-
       // If there are assertions defined, then we should return a non-null health for this asset.
       final Set<String> activeAssertionUrns =
           relationships.getRelationships().stream()
@@ -268,29 +238,7 @@ public class EntityHealthResolver implements DataFetcher<CompletableFuture<List<
       final GenericTable assertionRunResults =
           getAssertionRunsTable(context.getOperationContext(), entityUrn);
 
-      if (!assertionRunResults.hasRows() || assertionRunResults.getRows().size() == 0) {
-        // No assertion run results found. Return empty health!
-        return null;
-      }
-
-      final List<String> failingAssertionUrns =
-          getFailingAssertionUrns(assertionRunResults, activeAssertionUrns);
-
-      // Finally compute & return the health.
-      final Health health = new Health();
-      health.setType(HealthStatusType.ASSERTIONS);
-      if (failingAssertionUrns.size() > 0) {
-        health.setStatus(HealthStatus.FAIL);
-        health.setMessage(
-            String.format(
-                "%s of %s assertions are failing",
-                failingAssertionUrns.size(), activeAssertionUrns.size()));
-        health.setCauses(failingAssertionUrns);
-      } else {
-        health.setStatus(HealthStatus.PASS);
-        health.setMessage("All assertions are passing");
-      }
-      return health;
+      return HealthComputationUtils.buildAssertionsHealth(assertionRunResults, activeAssertionUrns);
     }
     return null;
   }
@@ -301,9 +249,9 @@ public class EntityHealthResolver implements DataFetcher<CompletableFuture<List<
         opContext,
         Constants.ASSERTION_ENTITY_NAME,
         Constants.ASSERTION_RUN_EVENT_ASPECT_NAME,
-        createAssertionAggregationSpecs(),
-        createAssertionsFilter(asserteeUrn),
-        createAssertionGroupingBuckets());
+        HealthComputationUtils.assertionAggregationSpecs(),
+        HealthComputationUtils.assertionsFilter(asserteeUrn),
+        HealthComputationUtils.assertionGroupingBuckets());
   }
 
   /**
@@ -325,37 +273,8 @@ public class EntityHealthResolver implements DataFetcher<CompletableFuture<List<
               urn,
               ImmutableSet.of(Constants.TEST_RESULTS_ASPECT_NAME));
 
-      if (entityResponse == null
-          || !entityResponse.getAspects().containsKey(Constants.TEST_RESULTS_ASPECT_NAME)) {
-        return null;
-      }
-
-      final TestResults testResults =
-          new TestResults(
-              entityResponse
-                  .getAspects()
-                  .get(Constants.TEST_RESULTS_ASPECT_NAME)
-                  .getValue()
-                  .data());
-
-      final int passingCount = testResults.getPassing().size();
-      final int failingCount = testResults.getFailing().size();
-      final int totalCount = passingCount + failingCount;
-
-      if (totalCount == 0) {
-        return null;
-      }
-
-      final Health health = new Health();
-      health.setType(HealthStatusType.TESTS);
-      if (failingCount > 0) {
-        health.setStatus(HealthStatus.FAIL);
-        health.setMessage(String.format("%s of %s tests failing", failingCount, totalCount));
-      } else {
-        health.setStatus(HealthStatus.PASS);
-        health.setMessage("All tests are passing");
-      }
-      return health;
+      return HealthComputationUtils.buildTestsHealth(
+          HealthComputationUtils.extractTestResults(entityResponse));
     } catch (RemoteInvocationException e) {
       log.error("Failed to compute test health status!", e);
       return null;
@@ -363,74 +282,6 @@ public class EntityHealthResolver implements DataFetcher<CompletableFuture<List<
       log.error("Failed to parse incident URN!", e);
       return null;
     }
-  }
-
-  private List<String> getFailingAssertionUrns(
-      final GenericTable assertionRunsResult, final Set<String> candidateAssertionUrns) {
-    // Create the buckets based on the result
-    return resultToFailedAssertionUrns(assertionRunsResult.getRows(), candidateAssertionUrns);
-  }
-
-  private Filter createAssertionsFilter(final String datasetUrn) {
-    final Filter filter = new Filter();
-    final ArrayList<Criterion> criteria = new ArrayList<>();
-
-    // Add filter for asserteeUrn == datasetUrn
-    Criterion datasetUrnCriterion = buildCriterion("asserteeUrn", Condition.EQUAL, datasetUrn);
-    criteria.add(datasetUrnCriterion);
-
-    // Add filter for result == result
-    Criterion startTimeCriterion =
-        buildCriterion("status", Condition.EQUAL, ASSERTION_RUN_EVENT_STATUS_COMPLETE);
-    criteria.add(startTimeCriterion);
-
-    filter.setOr(
-        new ConjunctiveCriterionArray(
-            ImmutableList.of(new ConjunctiveCriterion().setAnd(new CriterionArray(criteria)))));
-    return filter;
-  }
-
-  private AggregationSpec[] createAssertionAggregationSpecs() {
-    // Simply fetch the timestamp, result type for the assertion URN.
-    AggregationSpec resultTypeAggregation =
-        new AggregationSpec().setAggregationType(AggregationType.LATEST).setFieldPath("type");
-    AggregationSpec timestampAggregation =
-        new AggregationSpec()
-            .setAggregationType(AggregationType.LATEST)
-            .setFieldPath("timestampMillis");
-    return new AggregationSpec[] {resultTypeAggregation, timestampAggregation};
-  }
-
-  private GroupingBucket[] createAssertionGroupingBuckets() {
-    // String grouping bucket on "assertionUrn"
-    GroupingBucket assertionUrnBucket = new GroupingBucket();
-    assertionUrnBucket.setKey("assertionUrn").setType(GroupingBucketType.STRING_GROUPING_BUCKET);
-    return new GroupingBucket[] {assertionUrnBucket};
-  }
-
-  private List<String> resultToFailedAssertionUrns(
-      final StringArrayArray rows, final Set<String> activeAssertionUrns) {
-    final List<String> failedAssertionUrns = new ArrayList<>();
-    for (StringArray row : rows) {
-      // Result structure should be assertionUrn, event.result.type, timestampMillis
-      if (row.size() != 3) {
-        throw new RuntimeException(
-            String.format(
-                "Failed to fetch assertion run events from Timeseries index! Expected row of size 3, found %s",
-                row.size()));
-      }
-
-      final String assertionUrn = row.get(0);
-      final String resultType = row.get(1);
-
-      // If assertion is "active" (not deleted) & is failing, then we report a degradation in
-      // health.
-      if (activeAssertionUrns.contains(assertionUrn)
-          && !ASSERTION_RUN_EVENT_SUCCESS_TYPE.equals(resultType)) {
-        failedAssertionUrns.add(assertionUrn);
-      }
-    }
-    return failedAssertionUrns;
   }
 
   @Data

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/health/HealthComputationUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/health/HealthComputationUtils.java
@@ -1,0 +1,240 @@
+package com.linkedin.datahub.graphql.resolvers.health;
+
+import static com.linkedin.metadata.Constants.ASSERTION_RUN_EVENT_STATUS_COMPLETE;
+import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.data.template.StringArrayArray;
+import com.linkedin.datahub.graphql.generated.ActiveIncidentHealthDetails;
+import com.linkedin.datahub.graphql.generated.Health;
+import com.linkedin.datahub.graphql.generated.HealthStatus;
+import com.linkedin.datahub.graphql.generated.HealthStatusType;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.incident.IncidentInfo;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.Criterion;
+import com.linkedin.metadata.query.filter.CriterionArray;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.query.filter.SortCriterion;
+import com.linkedin.metadata.query.filter.SortOrder;
+import com.linkedin.metadata.search.utils.QueryUtils;
+import com.linkedin.test.TestResults;
+import com.linkedin.timeseries.AggregationSpec;
+import com.linkedin.timeseries.AggregationType;
+import com.linkedin.timeseries.GenericTable;
+import com.linkedin.timeseries.GroupingBucket;
+import com.linkedin.timeseries.GroupingBucketType;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * Pure health-computation helpers shared by {@link EntityHealthResolver} (per-entity path) and
+ * {@link com.linkedin.datahub.graphql.resolvers.load.EntityHealthBatchLoader} (batched path).
+ *
+ * <p>Both paths MUST produce identical health for the same inputs; keeping the aggregation specs,
+ * filters, row parsing, and {@link Health} assembly in one place is what guarantees that — the two
+ * callers differ only in how they fetch the raw data (one URN at a time vs. batched), not in how
+ * they interpret it.
+ */
+public final class HealthComputationUtils {
+
+  public static final String ASSERTS_RELATIONSHIP_NAME = "Asserts";
+  public static final String ASSERTEE_URN_FIELD = "asserteeUrn";
+  public static final int MAX_ACTIVE_ASSERTIONS = 500;
+
+  private static final String ASSERTION_RUN_EVENT_SUCCESS_TYPE = "SUCCESS";
+  private static final String INCIDENT_ENTITIES_SEARCH_INDEX_FIELD_NAME = "entities.keyword";
+  private static final String INCIDENT_STATE_SEARCH_INDEX_FIELD_NAME = "state";
+
+  private HealthComputationUtils() {}
+
+  // ---- Assertions -----------------------------------------------------------
+
+  public static AggregationSpec[] assertionAggregationSpecs() {
+    // Fetch the latest result type + timestamp per assertion URN.
+    final AggregationSpec resultTypeAggregation =
+        new AggregationSpec().setAggregationType(AggregationType.LATEST).setFieldPath("type");
+    final AggregationSpec timestampAggregation =
+        new AggregationSpec()
+            .setAggregationType(AggregationType.LATEST)
+            .setFieldPath("timestampMillis");
+    return new AggregationSpec[] {resultTypeAggregation, timestampAggregation};
+  }
+
+  public static GroupingBucket[] assertionGroupingBuckets() {
+    final GroupingBucket assertionUrnBucket = new GroupingBucket();
+    assertionUrnBucket.setKey("assertionUrn").setType(GroupingBucketType.STRING_GROUPING_BUCKET);
+    return new GroupingBucket[] {assertionUrnBucket};
+  }
+
+  /** Per-URN filter (single-entity path): {@code asserteeUrn == urn AND status == COMPLETE}. */
+  public static Filter assertionsFilter(final String asserteeUrn) {
+    final List<Criterion> criteria = new ArrayList<>();
+    criteria.add(buildCriterion(ASSERTEE_URN_FIELD, Condition.EQUAL, asserteeUrn));
+    criteria.add(buildCriterion("status", Condition.EQUAL, ASSERTION_RUN_EVENT_STATUS_COMPLETE));
+    return new Filter()
+        .setOr(
+            new ConjunctiveCriterionArray(
+                ImmutableList.of(new ConjunctiveCriterion().setAnd(new CriterionArray(criteria)))));
+  }
+
+  /**
+   * Shared filter (batch path): {@code status == COMPLETE} only. The per-URN {@code asserteeUrn}
+   * criterion is intentionally omitted — {@code batchGetAggregatedStats} appends {@code asserteeUrn
+   * IN [urns]} itself as the outer terms bucket.
+   */
+  public static Filter sharedAssertionsFilter() {
+    final Criterion statusCriterion =
+        buildCriterion("status", Condition.EQUAL, ASSERTION_RUN_EVENT_STATUS_COMPLETE);
+    return new Filter()
+        .setOr(
+            new ConjunctiveCriterionArray(
+                ImmutableList.of(
+                    new ConjunctiveCriterion().setAnd(new CriterionArray(statusCriterion)))));
+  }
+
+  /**
+   * Assembles the assertions {@link Health} from an assertion-run aggregation table and the set of
+   * currently-active (non-deleted) assertion URNs. Returns null when there are no active assertions
+   * or no run results to evaluate.
+   */
+  @Nullable
+  public static Health buildAssertionsHealth(
+      @Nullable final GenericTable assertionRunResults, final Set<String> activeAssertionUrns) {
+    if (activeAssertionUrns.isEmpty()) {
+      return null;
+    }
+    if (assertionRunResults == null
+        || !assertionRunResults.hasRows()
+        || assertionRunResults.getRows().isEmpty()) {
+      return null;
+    }
+
+    final List<String> failingAssertionUrns =
+        resultToFailedAssertionUrns(assertionRunResults.getRows(), activeAssertionUrns);
+
+    final Health health = new Health();
+    health.setType(HealthStatusType.ASSERTIONS);
+    if (!failingAssertionUrns.isEmpty()) {
+      health.setStatus(HealthStatus.FAIL);
+      health.setMessage(
+          String.format(
+              "%s of %s assertions are failing",
+              failingAssertionUrns.size(), activeAssertionUrns.size()));
+      health.setCauses(failingAssertionUrns);
+    } else {
+      health.setStatus(HealthStatus.PASS);
+      health.setMessage("All assertions are passing");
+    }
+    return health;
+  }
+
+  private static List<String> resultToFailedAssertionUrns(
+      final StringArrayArray rows, final Set<String> activeAssertionUrns) {
+    final List<String> failedAssertionUrns = new ArrayList<>();
+    for (StringArray row : rows) {
+      // Row structure: assertionUrn, event.result.type, timestampMillis
+      if (row.size() != 3) {
+        throw new RuntimeException(
+            String.format(
+                "Failed to fetch assertion run events from Timeseries index! Expected row of size 3, found %s",
+                row.size()));
+      }
+      final String assertionUrn = row.get(0);
+      final String resultType = row.get(1);
+      if (activeAssertionUrns.contains(assertionUrn)
+          && !ASSERTION_RUN_EVENT_SUCCESS_TYPE.equals(resultType)) {
+        failedAssertionUrns.add(assertionUrn);
+      }
+    }
+    return failedAssertionUrns;
+  }
+
+  // ---- Tests ----------------------------------------------------------------
+
+  @Nullable
+  public static TestResults extractTestResults(@Nullable final EntityResponse entityResponse) {
+    if (entityResponse == null
+        || !entityResponse.getAspects().containsKey(Constants.TEST_RESULTS_ASPECT_NAME)) {
+      return null;
+    }
+    return new TestResults(
+        entityResponse.getAspects().get(Constants.TEST_RESULTS_ASPECT_NAME).getValue().data());
+  }
+
+  @Nullable
+  public static Health buildTestsHealth(@Nullable final TestResults testResults) {
+    if (testResults == null) {
+      return null;
+    }
+    final int passingCount = testResults.getPassing().size();
+    final int failingCount = testResults.getFailing().size();
+    final int totalCount = passingCount + failingCount;
+    if (totalCount == 0) {
+      return null;
+    }
+    final Health health = new Health();
+    health.setType(HealthStatusType.TESTS);
+    if (failingCount > 0) {
+      health.setStatus(HealthStatus.FAIL);
+      health.setMessage(String.format("%s of %s tests failing", failingCount, totalCount));
+    } else {
+      health.setStatus(HealthStatus.PASS);
+      health.setMessage("All tests are passing");
+    }
+    return health;
+  }
+
+  // ---- Incidents ------------------------------------------------------------
+
+  public static List<SortCriterion> incidentsSort() {
+    return List.of(new SortCriterion().setOrder(SortOrder.DESCENDING).setField("lastUpdated"));
+  }
+
+  public static Filter incidentsEntityFilter(final String entityUrn, final String state) {
+    final Map<String, String> criterionMap = new HashMap<>();
+    criterionMap.put(INCIDENT_ENTITIES_SEARCH_INDEX_FIELD_NAME, entityUrn);
+    criterionMap.put(INCIDENT_STATE_SEARCH_INDEX_FIELD_NAME, state);
+    return QueryUtils.newFilter(criterionMap);
+  }
+
+  /**
+   * Assembles the incidents {@link Health} from an active-incident count and (when {@code count >
+   * 0}) the latest incident's URN and info. {@code count == 0} yields a PASS health.
+   */
+  public static Health buildIncidentHealth(
+      final int activeIncidentCount,
+      @Nullable final Urn latestIncidentUrn,
+      @Nullable final IncidentInfo latestIncidentInfo) {
+    if (activeIncidentCount <= 0) {
+      return new Health(
+          HealthStatusType.INCIDENTS, null, HealthStatus.PASS, null, null, null, null);
+    }
+    final Long latestIncidentTimestamp =
+        latestIncidentInfo != null
+            ? latestIncidentInfo.getStatus().getLastUpdated().getTime()
+            : null;
+    return new Health(
+        HealthStatusType.INCIDENTS,
+        latestIncidentTimestamp != null ? latestIncidentTimestamp : 0,
+        HealthStatus.FAIL,
+        String.format(
+            "%s active incident%s", activeIncidentCount, activeIncidentCount > 1 ? "s" : ""),
+        new ActiveIncidentHealthDetails(
+            latestIncidentUrn != null ? latestIncidentUrn.toString() : null,
+            latestIncidentInfo != null ? latestIncidentInfo.getTitle() : null,
+            latestIncidentTimestamp,
+            activeIncidentCount),
+        null,
+        ImmutableList.of("ACTIVE_INCIDENTS"));
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityHealthBatchLoader.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityHealthBatchLoader.java
@@ -1,0 +1,413 @@
+package com.linkedin.datahub.graphql.resolvers.load;
+
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.EntityRelationships;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
+import com.linkedin.datahub.graphql.generated.Health;
+import com.linkedin.datahub.graphql.resolvers.health.HealthComputationUtils;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.incident.IncidentInfo;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.graph.GraphClient;
+import com.linkedin.metadata.query.filter.RelationshipDirection;
+import com.linkedin.metadata.search.EntitySearchService;
+import com.linkedin.metadata.search.IncidentStats;
+import com.linkedin.metadata.timeseries.TimeseriesAspectService;
+import com.linkedin.test.TestResults;
+import com.linkedin.timeseries.GenericTable;
+import io.datahubproject.metadata.context.OperationContext;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.dataloader.BatchLoaderContextProvider;
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderOptions;
+
+/**
+ * DataLoader that batches {@code health} resolution across every entity in a single GraphQL
+ * request, replacing the per-entity fan-out in {@link
+ * com.linkedin.datahub.graphql.resolvers.health.EntityHealthResolver}. All health interpretation is
+ * shared with the per-entity resolver via {@link HealthComputationUtils}.
+ *
+ * <p>The heavy, N+1-prone dimensions are collapsed to one call per request:
+ *
+ * <ul>
+ *   <li><b>Assertion runs</b> — a single {@code batchGetAggregatedStats} over the assertion-run
+ *       timeseries index, keyed on {@code asserteeUrn} (one outer-terms-bucket ES query per
+ *       sub-batch instead of one aggregation per entity).
+ *   <li><b>Governance tests</b> — a single {@code batchGetV2} per entity type for the {@code
+ *       testResults} aspect.
+ *   <li><b>Active incidents</b> — a single {@link EntitySearchService#getActiveIncidentStats}
+ *       aggregation for counts/latest-incident-urn, plus a single {@code batchGetV2} for the latest
+ *       incidents' info.
+ * </ul>
+ *
+ * <p>One dimension has no batch primitive today and is still computed once per entity, but
+ * concurrently within this loader: active-assertion graph lookups ({@link
+ * GraphClient#getRelatedEntities}).
+ *
+ * <p><b>Failure isolation:</b> a failure in one dimension degrades to an empty result for that
+ * dimension (logged) rather than failing the whole page — both in the concurrent FETCH phase (each
+ * future has {@code .exceptionally}) and in the synchronous ASSEMBLE phase (each per-key dimension
+ * is wrapped). So the other dimensions, and every other entity, still return the health they could
+ * compute.
+ *
+ * <p>The batch key carries the per-type health config (mirroring {@code
+ * EntityHealthResolver.Config}) so entity types that disable a dimension coalesce into their own
+ * batch and never trigger the assertion/test calls.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class EntityHealthBatchLoader {
+
+  public static final String LOADER_NAME = "EntityHealth";
+
+  private final EntityClient entityClient;
+  private final GraphClient graphClient;
+  private final TimeseriesAspectService timeseriesAspectService;
+  private final EntitySearchService entitySearchService;
+
+  /** Composite DataLoader key: which entity, and which health dimensions to compute for it. */
+  @Value
+  public static class HealthQueryKey {
+    Urn urn;
+    boolean assertionsEnabled;
+    boolean incidentsEnabled;
+    boolean testsEnabled;
+  }
+
+  public static DataLoader<HealthQueryKey, List<Health>> createDataLoader(
+      final EntityClient entityClient,
+      final GraphClient graphClient,
+      final TimeseriesAspectService timeseriesAspectService,
+      final EntitySearchService entitySearchService,
+      final QueryContext queryContext) {
+    final EntityHealthBatchLoader loader =
+        new EntityHealthBatchLoader(
+            entityClient, graphClient, timeseriesAspectService, entitySearchService);
+    final BatchLoaderContextProvider provider = () -> queryContext;
+    final DataLoaderOptions options =
+        DataLoaderOptions.newOptions().setBatchLoaderContextProvider(provider);
+    return DataLoader.newDataLoader(
+        (keys, env) ->
+            GraphQLConcurrencyUtils.supplyAsync(
+                () -> loader.batchLoad(keys, (QueryContext) env.getContext()),
+                LOADER_NAME,
+                "batchLoad"),
+        options);
+  }
+
+  @WithSpan
+  public List<List<Health>> batchLoad(final List<HealthQueryKey> keys, final QueryContext context) {
+    final OperationContext opContext = context.getOperationContext();
+
+    final List<Urn> assertionUrns = distinctUrns(keys, HealthQueryKey::isAssertionsEnabled);
+    final List<Urn> incidentUrns = distinctUrns(keys, HealthQueryKey::isIncidentsEnabled);
+
+    // Fire the independent batches concurrently. Each dimension is isolated: a failure degrades to
+    // an empty result (logged) rather than failing the whole page.
+    // A: batched assertion-run aggregation (asserteeUrn outer bucket) — the headline N+1 fix.
+    final CompletableFuture<Map<Urn, GenericTable>> assertionRunsFuture =
+        GraphQLConcurrencyUtils.supplyAsync(
+                () -> batchAssertionRuns(opContext, assertionUrns),
+                LOADER_NAME,
+                "batchGetAggregatedStats:assertionRuns")
+            .exceptionally(
+                ex -> {
+                  log.error("Assertion-run batch failed; dropping assertions health", ex);
+                  return Collections.<Urn, GenericTable>emptyMap();
+                });
+
+    // B: active (non-deleted) assertion URNs — per-URN graph lookup, run concurrently.
+    final CompletableFuture<Map<Urn, Set<String>>> activeAssertionsFuture =
+        GraphQLConcurrencyUtils.supplyAsync(
+                () -> fetchActiveAssertions(assertionUrns, context),
+                LOADER_NAME,
+                "fetchActiveAssertions")
+            .exceptionally(
+                ex -> {
+                  log.error("Active-assertion lookup failed; dropping assertions health", ex);
+                  return Collections.<Urn, Set<String>>emptyMap();
+                });
+
+    // C: batched test-results aspect per entity type.
+    final CompletableFuture<Map<Urn, TestResults>> testResultsFuture =
+        GraphQLConcurrencyUtils.supplyAsync(
+                () -> batchTestResults(keys, opContext), LOADER_NAME, "batchGetV2:testResults")
+            .exceptionally(
+                ex -> {
+                  log.error("Test-results batch failed; dropping tests health", ex);
+                  return Collections.<Urn, TestResults>emptyMap();
+                });
+
+    // D: active-incident health — one getActiveIncidentStats aggregation + one batchGetV2 for info.
+    final CompletableFuture<Map<Urn, Health>> incidentHealthFuture =
+        GraphQLConcurrencyUtils.supplyAsync(
+                () -> fetchIncidentHealth(incidentUrns, context),
+                LOADER_NAME,
+                "fetchIncidentHealth")
+            .exceptionally(
+                ex -> {
+                  log.error("Incident health lookup failed; dropping incidents health", ex);
+                  return Collections.<Urn, Health>emptyMap();
+                });
+
+    CompletableFuture.allOf(
+            assertionRunsFuture, activeAssertionsFuture, testResultsFuture, incidentHealthFuture)
+        .join();
+
+    final Map<Urn, GenericTable> assertionRuns = assertionRunsFuture.join();
+    final Map<Urn, Set<String>> activeAssertions = activeAssertionsFuture.join();
+    final Map<Urn, TestResults> testResults = testResultsFuture.join();
+    final Map<Urn, Health> incidentHealth = incidentHealthFuture.join();
+
+    final List<List<Health>> results = new ArrayList<>(keys.size());
+    for (HealthQueryKey key : keys) {
+      results.add(
+          assembleHealth(key, incidentHealth, assertionRuns, activeAssertions, testResults));
+    }
+    return results;
+  }
+
+  /**
+   * Builds one entity's health list, isolating each dimension: a throw while assembling one
+   * dimension (e.g. a malformed assertion-run row) drops only that dimension for this entity — it
+   * does not fail the entity or the page.
+   */
+  private List<Health> assembleHealth(
+      final HealthQueryKey key,
+      final Map<Urn, Health> incidentHealth,
+      final Map<Urn, GenericTable> assertionRuns,
+      final Map<Urn, Set<String>> activeAssertions,
+      final Map<Urn, TestResults> testResults) {
+    final Urn urn = key.getUrn();
+    final List<Health> healths = new ArrayList<>();
+
+    if (key.isIncidentsEnabled()) {
+      final Health h = incidentHealth.get(urn);
+      if (h != null) {
+        healths.add(h);
+      }
+    }
+    if (key.isAssertionsEnabled()) {
+      try {
+        final Health h =
+            HealthComputationUtils.buildAssertionsHealth(
+                assertionRuns.get(urn), activeAssertions.getOrDefault(urn, Collections.emptySet()));
+        if (h != null) {
+          healths.add(h);
+        }
+      } catch (Exception e) {
+        log.warn("Failed to assemble assertion health for {}; dropping dimension", urn, e);
+      }
+    }
+    if (key.isTestsEnabled()) {
+      try {
+        final Health h = HealthComputationUtils.buildTestsHealth(testResults.get(urn));
+        if (h != null) {
+          healths.add(h);
+        }
+      } catch (Exception e) {
+        log.warn("Failed to assemble tests health for {}; dropping dimension", urn, e);
+      }
+    }
+    return healths;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Assertions
+  // ---------------------------------------------------------------------------
+
+  private Map<Urn, GenericTable> batchAssertionRuns(
+      final OperationContext opContext, final List<Urn> assertionUrns) {
+    if (assertionUrns.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    return timeseriesAspectService.batchGetAggregatedStats(
+        opContext,
+        Constants.ASSERTION_ENTITY_NAME,
+        Constants.ASSERTION_RUN_EVENT_ASPECT_NAME,
+        HealthComputationUtils.assertionAggregationSpecs(),
+        assertionUrns,
+        HealthComputationUtils.sharedAssertionsFilter(),
+        HealthComputationUtils.assertionGroupingBuckets(),
+        HealthComputationUtils.ASSERTEE_URN_FIELD);
+  }
+
+  private Map<Urn, Set<String>> fetchActiveAssertions(
+      final List<Urn> assertionUrns, final QueryContext context) {
+    if (assertionUrns.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    final Map<Urn, CompletableFuture<Set<String>>> futures = new LinkedHashMap<>();
+    for (Urn urn : assertionUrns) {
+      futures.put(
+          urn,
+          GraphQLConcurrencyUtils.supplyAsync(
+                  () -> {
+                    final EntityRelationships relationships =
+                        graphClient.getRelatedEntities(
+                            urn.toString(),
+                            ImmutableSet.of(HealthComputationUtils.ASSERTS_RELATIONSHIP_NAME),
+                            RelationshipDirection.INCOMING,
+                            0,
+                            HealthComputationUtils.MAX_ACTIVE_ASSERTIONS,
+                            context.getActorUrn());
+                    return relationships.getRelationships().stream()
+                        .map(relationship -> relationship.getEntity().toString())
+                        .collect(Collectors.toSet());
+                  },
+                  LOADER_NAME,
+                  "getRelatedEntities")
+              // Isolate per URN: one failed graph lookup drops only that entity's assertion
+              // health, not every entity's.
+              .exceptionally(
+                  ex -> {
+                    log.warn("Active-assertion lookup failed for {}; skipping", urn, ex);
+                    return Collections.<String>emptySet();
+                  }));
+    }
+    CompletableFuture.allOf(futures.values().toArray(new CompletableFuture[0])).join();
+    final Map<Urn, Set<String>> result = new HashMap<>();
+    futures.forEach((urn, future) -> result.put(urn, future.join()));
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tests
+  // ---------------------------------------------------------------------------
+
+  private Map<Urn, TestResults> batchTestResults(
+      final List<HealthQueryKey> keys, final OperationContext opContext) {
+    final List<Urn> testUrns = distinctUrns(keys, HealthQueryKey::isTestsEnabled);
+    if (testUrns.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    final Map<Urn, TestResults> result = new HashMap<>();
+    // batchGetV2 is scoped to a single entity type, so partition by entity type.
+    final Map<String, Set<Urn>> urnsByEntityType =
+        testUrns.stream().collect(Collectors.groupingBy(Urn::getEntityType, Collectors.toSet()));
+    for (Map.Entry<String, Set<Urn>> entry : urnsByEntityType.entrySet()) {
+      try {
+        final Map<Urn, EntityResponse> responses =
+            entityClient.batchGetV2(
+                opContext,
+                entry.getKey(),
+                entry.getValue(),
+                ImmutableSet.of(Constants.TEST_RESULTS_ASPECT_NAME));
+        for (Map.Entry<Urn, EntityResponse> response : responses.entrySet()) {
+          final TestResults testResults =
+              HealthComputationUtils.extractTestResults(response.getValue());
+          if (testResults != null) {
+            result.put(response.getKey(), testResults);
+          }
+        }
+      } catch (Exception e) {
+        log.error("Failed to batch-load test results for entity type {}", entry.getKey(), e);
+      }
+    }
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Incidents
+  // ---------------------------------------------------------------------------
+
+  private Map<Urn, Health> fetchIncidentHealth(
+      final List<Urn> incidentUrns, final QueryContext context) {
+    if (incidentUrns.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    final OperationContext opContext = context.getOperationContext();
+
+    // Phase 1: one aggregation for count + latest incident urn per entity.
+    final Map<Urn, IncidentStats> stats =
+        entitySearchService.getActiveIncidentStats(opContext, new HashSet<>(incidentUrns));
+
+    // Phase 2: one batchGetV2 for the latest incidents' info.
+    final Set<Urn> latestIncidentUrns =
+        stats.values().stream()
+            .map(IncidentStats::getLatestIncidentUrn)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+    final Map<Urn, IncidentInfo> incidentInfos =
+        batchGetIncidentInfo(latestIncidentUrns, opContext);
+
+    // Phase 3: assemble per-entity incident health.
+    final Map<Urn, Health> result = new HashMap<>();
+    for (Urn urn : incidentUrns) {
+      final IncidentStats stat = stats.get(urn);
+      final int count = stat != null ? stat.getActiveCount() : 0;
+      final Urn latestUrn = stat != null ? stat.getLatestIncidentUrn() : null;
+      final IncidentInfo info = latestUrn != null ? incidentInfos.get(latestUrn) : null;
+      final Health h = HealthComputationUtils.buildIncidentHealth(count, latestUrn, info);
+      if (h != null) {
+        result.put(urn, h);
+      }
+    }
+    return result;
+  }
+
+  private Map<Urn, IncidentInfo> batchGetIncidentInfo(
+      final Set<Urn> incidentUrns, final OperationContext opContext) {
+    if (incidentUrns.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    try {
+      final Map<Urn, EntityResponse> responses =
+          entityClient.batchGetV2(
+              opContext,
+              Constants.INCIDENT_ENTITY_NAME,
+              incidentUrns,
+              ImmutableSet.of(Constants.INCIDENT_INFO_ASPECT_NAME));
+      final Map<Urn, IncidentInfo> result = new HashMap<>();
+      responses.forEach(
+          (urn, response) -> {
+            if (response != null
+                && response.getAspects().containsKey(Constants.INCIDENT_INFO_ASPECT_NAME)) {
+              result.put(
+                  urn,
+                  new IncidentInfo(
+                      response
+                          .getAspects()
+                          .get(Constants.INCIDENT_INFO_ASPECT_NAME)
+                          .getValue()
+                          .data()));
+            }
+          });
+      return result;
+    } catch (Exception e) {
+      log.error("Failed to batch-fetch incident info", e);
+      return Collections.emptyMap();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private static List<Urn> distinctUrns(
+      final List<HealthQueryKey> keys, final Predicate<HealthQueryKey> dimensionEnabled) {
+    return keys.stream()
+        .filter(dimensionEnabled)
+        .map(HealthQueryKey::getUrn)
+        .distinct()
+        .collect(Collectors.toList());
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/health/EntityHealthResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/health/EntityHealthResolverTest.java
@@ -6,26 +6,34 @@ import static org.testng.Assert.*;
 import com.datahub.authentication.Authentication;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.AuditStamp;
 import com.linkedin.common.EntityRelationship;
 import com.linkedin.common.EntityRelationshipArray;
 import com.linkedin.common.EntityRelationships;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.data.template.StringArrayArray;
 import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.featureflags.FeatureFlags;
 import com.linkedin.datahub.graphql.generated.Dataset;
 import com.linkedin.datahub.graphql.generated.Health;
 import com.linkedin.datahub.graphql.generated.HealthStatus;
 import com.linkedin.datahub.graphql.generated.HealthStatusType;
 import com.linkedin.datahub.graphql.resolvers.dataset.DatasetHealthResolver;
+import com.linkedin.datahub.graphql.resolvers.load.EntityHealthBatchLoader;
 import com.linkedin.entity.Aspect;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspect;
 import com.linkedin.entity.EnvelopedAspectMap;
 import com.linkedin.entity.client.EntityClient;
+import com.linkedin.incident.IncidentInfo;
+import com.linkedin.incident.IncidentState;
+import com.linkedin.incident.IncidentStatus;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.graph.GraphClient;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
+import com.linkedin.metadata.search.SearchEntity;
 import com.linkedin.metadata.search.SearchEntityArray;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
@@ -39,6 +47,10 @@ import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderRegistry;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -587,5 +599,291 @@ public class EntityHealthResolverTest {
 
     List<Health> result = resolver.get(mockEnv).get();
     assertEquals(result.size(), 0);
+  }
+
+  @Test
+  public void testBatchLoadFlagEnabledDelegatesToDataLoader() throws Exception {
+    EntityClient entityClient = Mockito.mock(EntityClient.class);
+    GraphClient graphClient = Mockito.mock(GraphClient.class);
+    TimeseriesAspectService tsService = Mockito.mock(TimeseriesAspectService.class);
+
+    FeatureFlags flags = new FeatureFlags();
+    flags.setEntityHealthBatchLoadEnabled(true);
+
+    EntityHealthResolver resolver =
+        new EntityHealthResolver(
+            entityClient,
+            graphClient,
+            tsService,
+            new EntityHealthResolver.Config(true, true, true),
+            flags);
+
+    final Health expected = new Health();
+    expected.setType(HealthStatusType.INCIDENTS);
+    expected.setStatus(HealthStatus.FAIL);
+    final List<Health> expectedList = ImmutableList.of(expected);
+
+    @SuppressWarnings("unchecked")
+    final DataLoader<EntityHealthBatchLoader.HealthQueryKey, List<Health>> loader =
+        Mockito.mock(DataLoader.class);
+    Mockito.when(loader.load(any())).thenReturn(CompletableFuture.completedFuture(expectedList));
+    final DataLoaderRegistry registry = Mockito.mock(DataLoaderRegistry.class);
+    Mockito.when(registry.getDataLoader(EntityHealthBatchLoader.LOADER_NAME))
+        .thenReturn((DataLoader) loader);
+
+    QueryContext mockContext = Mockito.mock(QueryContext.class);
+    Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Mockito.when(mockEnv.getDataLoaderRegistry()).thenReturn(registry);
+    Dataset parentDataset = new Dataset();
+    parentDataset.setUrn(TEST_DATASET_URN);
+    Mockito.when(mockEnv.getSource()).thenReturn(parentDataset);
+
+    final List<Health> result = resolver.get(mockEnv).get();
+
+    // The flag path must delegate to the batch loader and return its result verbatim...
+    assertEquals(result, expectedList);
+    Mockito.verifyNoInteractions(graphClient, tsService);
+    // ...keyed by the source urn with the resolver's configured dimensions.
+    final ArgumentCaptor<EntityHealthBatchLoader.HealthQueryKey> keyCaptor =
+        ArgumentCaptor.forClass(EntityHealthBatchLoader.HealthQueryKey.class);
+    Mockito.verify(loader).load(keyCaptor.capture());
+    final EntityHealthBatchLoader.HealthQueryKey key = keyCaptor.getValue();
+    assertEquals(key.getUrn(), UrnUtils.getUrn(TEST_DATASET_URN));
+    assertTrue(key.isAssertionsEnabled());
+    assertTrue(key.isIncidentsEnabled());
+    assertTrue(key.isTestsEnabled());
+  }
+
+  /**
+   * Legacy per-entity path (flag off): a dataset with an active incident resolves to a failing
+   * INCIDENTS health that carries the latest incident's urn and title. Exercises
+   * computeIncidentsHealthForAsset (count > 0) and the getIncidentInfo aspect fetch.
+   */
+  @Test
+  public void testLegacyActiveIncidentReportsFailingHealth() throws Exception {
+    EntityClient mockEntityClient = Mockito.mock(EntityClient.class);
+    GraphClient mockGraphClient = Mockito.mock(GraphClient.class);
+    TimeseriesAspectService mockAspectService = Mockito.mock(TimeseriesAspectService.class);
+
+    final Urn incidentUrn = Urn.createFromString("urn:li:incident:i1");
+    Mockito.when(
+            mockEntityClient.filter(
+                any(),
+                Mockito.eq(Constants.INCIDENT_ENTITY_NAME),
+                any(),
+                any(),
+                Mockito.eq(0),
+                Mockito.eq(1)))
+        .thenReturn(
+            new SearchResult()
+                .setNumEntities(1)
+                .setEntities(
+                    new SearchEntityArray(
+                        ImmutableList.of(new SearchEntity().setEntity(incidentUrn)))));
+
+    final IncidentInfo info =
+        new IncidentInfo()
+            .setTitle("nightly load failed")
+            .setStatus(
+                new IncidentStatus()
+                    .setState(IncidentState.ACTIVE)
+                    .setLastUpdated(
+                        new AuditStamp()
+                            .setTime(999L)
+                            .setActor(Urn.createFromString("urn:li:corpuser:t"))));
+    final EnvelopedAspectMap incidentAspects = new EnvelopedAspectMap();
+    incidentAspects.put(
+        Constants.INCIDENT_INFO_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(info.data())));
+    Mockito.when(
+            mockEntityClient.getV2(
+                any(),
+                Mockito.eq(Constants.INCIDENT_ENTITY_NAME),
+                Mockito.eq(incidentUrn),
+                any(),
+                Mockito.anyBoolean()))
+        .thenReturn(new EntityResponse().setUrn(incidentUrn).setAspects(incidentAspects));
+
+    final EntityHealthResolver resolver =
+        new EntityHealthResolver(
+            mockEntityClient,
+            mockGraphClient,
+            mockAspectService,
+            new EntityHealthResolver.Config(false, true, false));
+
+    final List<Health> result = resolver.get(legacyEnv(TEST_DATASET_URN)).get();
+
+    assertEquals(result.size(), 1);
+    assertEquals(result.get(0).getType(), HealthStatusType.INCIDENTS);
+    assertEquals(result.get(0).getStatus(), HealthStatus.FAIL);
+    assertEquals(result.get(0).getMessage(), "1 active incident");
+    assertEquals(
+        result.get(0).getActiveIncidentHealthDetails().getLatestIncidentUrn(),
+        incidentUrn.toString());
+    assertEquals(
+        result.get(0).getActiveIncidentHealthDetails().getLatestIncidentTitle(),
+        "nightly load failed");
+  }
+
+  /**
+   * Legacy path: multiple active incidents whose latest incident has no incidentInfo aspect still
+   * yield a failing INCIDENTS health with the correct plural count — the missing info just leaves
+   * the title/timestamp unpopulated. Exercises the getIncidentInfo "no aspect" branch.
+   */
+  @Test
+  public void testLegacyActiveIncidentWithMissingInfoStillFails() throws Exception {
+    EntityClient mockEntityClient = Mockito.mock(EntityClient.class);
+    GraphClient mockGraphClient = Mockito.mock(GraphClient.class);
+    TimeseriesAspectService mockAspectService = Mockito.mock(TimeseriesAspectService.class);
+
+    final Urn incidentUrn = Urn.createFromString("urn:li:incident:i2");
+    Mockito.when(
+            mockEntityClient.filter(
+                any(),
+                Mockito.eq(Constants.INCIDENT_ENTITY_NAME),
+                any(),
+                any(),
+                Mockito.anyInt(),
+                Mockito.anyInt()))
+        .thenReturn(
+            new SearchResult()
+                .setNumEntities(2)
+                .setEntities(
+                    new SearchEntityArray(
+                        ImmutableList.of(new SearchEntity().setEntity(incidentUrn)))));
+    // Incident entity returns no incidentInfo aspect.
+    Mockito.when(mockEntityClient.getV2(any(), any(), any(), any(), Mockito.anyBoolean()))
+        .thenReturn(new EntityResponse().setUrn(incidentUrn).setAspects(new EnvelopedAspectMap()));
+
+    final EntityHealthResolver resolver =
+        new EntityHealthResolver(
+            mockEntityClient,
+            mockGraphClient,
+            mockAspectService,
+            new EntityHealthResolver.Config(false, true, false));
+
+    final List<Health> result = resolver.get(legacyEnv(TEST_DATASET_URN)).get();
+
+    assertEquals(result.size(), 1);
+    assertEquals(result.get(0).getStatus(), HealthStatus.FAIL);
+    assertEquals(result.get(0).getMessage(), "2 active incidents");
+    assertEquals(
+        result.get(0).getActiveIncidentHealthDetails().getLatestIncidentUrn(),
+        incidentUrn.toString());
+    assertNull(result.get(0).getActiveIncidentHealthDetails().getLatestIncidentTitle());
+  }
+
+  /**
+   * Legacy path: a dataset with an active assertion whose latest run FAILED resolves to a failing
+   * ASSERTIONS health. Exercises computeAssertionHealthForAsset and getAssertionRunsTable (the
+   * single-URN getAggregatedStats call, distinct from the batched path).
+   */
+  @Test
+  public void testLegacyFailingAssertionReportsFailingHealth() throws Exception {
+    EntityClient mockEntityClient = Mockito.mock(EntityClient.class);
+    GraphClient mockGraphClient = Mockito.mock(GraphClient.class);
+    TimeseriesAspectService mockAspectService = Mockito.mock(TimeseriesAspectService.class);
+
+    Mockito.when(
+            mockGraphClient.getRelatedEntities(
+                Mockito.eq(TEST_DATASET_URN),
+                Mockito.eq(ImmutableSet.of("Asserts")),
+                Mockito.eq(RelationshipDirection.INCOMING),
+                Mockito.eq(0),
+                Mockito.eq(500),
+                any()))
+        .thenReturn(
+            new EntityRelationships()
+                .setStart(0)
+                .setCount(1)
+                .setTotal(1)
+                .setRelationships(
+                    new EntityRelationshipArray(
+                        ImmutableList.of(
+                            new EntityRelationship()
+                                .setEntity(Urn.createFromString(TEST_ASSERTION_URN))
+                                .setType("Asserts")))));
+    Mockito.when(
+            mockAspectService.getAggregatedStats(
+                any(),
+                Mockito.eq(Constants.ASSERTION_ENTITY_NAME),
+                Mockito.eq(Constants.ASSERTION_RUN_EVENT_ASPECT_NAME),
+                any(),
+                any(),
+                any()))
+        .thenReturn(
+            new GenericTable()
+                .setColumnNames(
+                    new StringArray(ImmutableList.of("assertionUrn", "type", "timestampMillis")))
+                .setColumnTypes(new StringArray("string", "string", "long"))
+                .setRows(
+                    new StringArrayArray(
+                        ImmutableList.of(
+                            new StringArray(
+                                ImmutableList.of(TEST_ASSERTION_URN, "FAILURE", "0"))))));
+
+    final EntityHealthResolver resolver =
+        new EntityHealthResolver(
+            mockEntityClient,
+            mockGraphClient,
+            mockAspectService,
+            new EntityHealthResolver.Config(true, false, false));
+
+    final List<Health> result = resolver.get(legacyEnv(TEST_DATASET_URN)).get();
+
+    assertEquals(result.size(), 1);
+    assertEquals(result.get(0).getType(), HealthStatusType.ASSERTIONS);
+    assertEquals(result.get(0).getStatus(), HealthStatus.FAIL);
+    assertEquals(result.get(0).getMessage(), "1 of 1 assertions are failing");
+  }
+
+  /**
+   * Legacy path resilience: when the incident search backend errors, the incidents dimension
+   * degrades to no health rather than failing the whole field. Exercises the
+   * computeIncidentsHealthForAsset catch path.
+   */
+  @Test
+  public void testLegacyIncidentBackendFailureDegradesGracefully() throws Exception {
+    EntityClient mockEntityClient = Mockito.mock(EntityClient.class);
+    GraphClient mockGraphClient = Mockito.mock(GraphClient.class);
+    TimeseriesAspectService mockAspectService = Mockito.mock(TimeseriesAspectService.class);
+
+    Mockito.when(
+            mockEntityClient.filter(
+                any(),
+                Mockito.eq(Constants.INCIDENT_ENTITY_NAME),
+                any(),
+                any(),
+                Mockito.anyInt(),
+                Mockito.anyInt()))
+        .thenThrow(new RemoteInvocationException("incident index down"));
+
+    final EntityHealthResolver resolver =
+        new EntityHealthResolver(
+            mockEntityClient,
+            mockGraphClient,
+            mockAspectService,
+            new EntityHealthResolver.Config(false, true, false));
+
+    final List<Health> result = resolver.get(legacyEnv(TEST_DATASET_URN)).get();
+
+    // Incident dimension dropped; the field still resolves (no crash).
+    assertEquals(result.size(), 0);
+  }
+
+  /** Builds a DataFetchingEnvironment for the legacy (non-batch) resolver path. */
+  private static DataFetchingEnvironment legacyEnv(final String datasetUrn) {
+    final QueryContext context = Mockito.mock(QueryContext.class);
+    Mockito.when(context.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    Mockito.when(context.getActorUrn()).thenReturn("urn:li:corpuser:test");
+    Mockito.when(context.getOperationContext()).thenReturn(Mockito.mock(OperationContext.class));
+    final DataFetchingEnvironment env = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(env.getContext()).thenReturn(context);
+    final Dataset parentDataset = new Dataset();
+    parentDataset.setUrn(datasetUrn);
+    Mockito.when(env.getSource()).thenReturn(parentDataset);
+    return env;
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityHealthBatchLoaderTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityHealthBatchLoaderTest.java
@@ -1,0 +1,597 @@
+package com.linkedin.datahub.graphql.resolvers.load;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.testng.Assert.*;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.EntityRelationship;
+import com.linkedin.common.EntityRelationshipArray;
+import com.linkedin.common.EntityRelationships;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.data.template.StringArrayArray;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.Health;
+import com.linkedin.datahub.graphql.generated.HealthStatus;
+import com.linkedin.datahub.graphql.generated.HealthStatusType;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.incident.IncidentInfo;
+import com.linkedin.incident.IncidentState;
+import com.linkedin.incident.IncidentStatus;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.graph.GraphClient;
+import com.linkedin.metadata.search.EntitySearchService;
+import com.linkedin.metadata.search.IncidentStats;
+import com.linkedin.metadata.timeseries.TimeseriesAspectService;
+import com.linkedin.test.TestResult;
+import com.linkedin.test.TestResultArray;
+import com.linkedin.test.TestResultType;
+import com.linkedin.test.TestResults;
+import com.linkedin.timeseries.GenericTable;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+public class EntityHealthBatchLoaderTest {
+
+  private static final String DATASET_A = "urn:li:dataset:(urn:li:dataPlatform:test,a,PROD)";
+  private static final String DATASET_B = "urn:li:dataset:(urn:li:dataPlatform:test,b,PROD)";
+  private static final String CHART_C = "urn:li:chart:(test,c)";
+  private static final String ASSERTION_A = "urn:li:assertion:a";
+  private static final String ASSERTION_B = "urn:li:assertion:b";
+
+  /**
+   * The core N+1 guarantee: two assertion-bearing URNs produce exactly ONE {@code
+   * batchGetAggregatedStats} call and ZERO single-URN {@code getAggregatedStats} calls, and each
+   * URN's health is assembled from its own slice of the batch result.
+   */
+  @Test
+  public void testSingleBatchCallForMultipleUrns() throws Exception {
+    final EntityClient entityClient = Mockito.mock(EntityClient.class);
+    final GraphClient graphClient = Mockito.mock(GraphClient.class);
+    final TimeseriesAspectService timeseriesAspectService =
+        Mockito.mock(TimeseriesAspectService.class);
+    final EntitySearchService entitySearchService = Mockito.mock(EntitySearchService.class);
+
+    stubActiveAssertions(graphClient, DATASET_A, ASSERTION_A);
+    stubActiveAssertions(graphClient, DATASET_B, ASSERTION_B);
+
+    final Map<Urn, GenericTable> batchResult = new HashMap<>();
+    batchResult.put(Urn.createFromString(DATASET_A), assertionRunTable(ASSERTION_A, "FAILURE"));
+    batchResult.put(Urn.createFromString(DATASET_B), assertionRunTable(ASSERTION_B, "SUCCESS"));
+    Mockito.when(
+            timeseriesAspectService.batchGetAggregatedStats(
+                any(),
+                Mockito.eq(Constants.ASSERTION_ENTITY_NAME),
+                Mockito.eq(Constants.ASSERTION_RUN_EVENT_ASPECT_NAME),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()))
+        .thenReturn(batchResult);
+
+    final EntityHealthBatchLoader loader =
+        new EntityHealthBatchLoader(
+            entityClient, graphClient, timeseriesAspectService, entitySearchService);
+
+    final List<List<Health>> result =
+        loader.batchLoad(
+            ImmutableList.of(assertionsOnlyKey(DATASET_A), assertionsOnlyKey(DATASET_B)),
+            mockContext());
+
+    // One batched aggregation query for both URNs, and never the single-URN fallback.
+    Mockito.verify(timeseriesAspectService, Mockito.times(1))
+        .batchGetAggregatedStats(any(), any(), any(), any(), any(), any(), any(), any());
+    Mockito.verify(timeseriesAspectService, Mockito.times(0))
+        .getAggregatedStats(any(), any(), any(), any(), any(), any());
+
+    // Per-URN assembly: A is failing, B is passing.
+    assertEquals(result.size(), 2);
+    assertEquals(result.get(0).size(), 1);
+    assertEquals(result.get(0).get(0).getType(), HealthStatusType.ASSERTIONS);
+    assertEquals(result.get(0).get(0).getStatus(), HealthStatus.FAIL);
+    assertEquals(result.get(1).get(0).getStatus(), HealthStatus.PASS);
+  }
+
+  /**
+   * Keys whose config disables assertions must not contribute their URN to the assertion batch, and
+   * the shared filter passed to the batch must carry {@code asserteeUrn} as the urn field path (the
+   * per-URN criterion is added by the batch method, not the caller).
+   */
+  @Test
+  public void testAssertionBatchExcludesConfigDisabledUrns() throws Exception {
+    final EntityClient entityClient = Mockito.mock(EntityClient.class);
+    final GraphClient graphClient = Mockito.mock(GraphClient.class);
+    final TimeseriesAspectService timeseriesAspectService =
+        Mockito.mock(TimeseriesAspectService.class);
+    final EntitySearchService entitySearchService = Mockito.mock(EntitySearchService.class);
+
+    stubActiveAssertions(graphClient, DATASET_A, ASSERTION_A);
+    // Incident lookups return "no active incidents" so incident health is PASS with no batchGetV2.
+    Mockito.when(entitySearchService.getActiveIncidentStats(any(), any())).thenReturn(Map.of());
+
+    final Map<Urn, GenericTable> batchResult = new HashMap<>();
+    batchResult.put(Urn.createFromString(DATASET_A), assertionRunTable(ASSERTION_A, "SUCCESS"));
+    Mockito.when(
+            timeseriesAspectService.batchGetAggregatedStats(
+                any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(batchResult);
+
+    final EntityHealthBatchLoader loader =
+        new EntityHealthBatchLoader(
+            entityClient, graphClient, timeseriesAspectService, entitySearchService);
+
+    // A: dataset (assertions + incidents). C: chart (incidents only, assertions disabled).
+    final EntityHealthBatchLoader.HealthQueryKey datasetKey =
+        new EntityHealthBatchLoader.HealthQueryKey(
+            Urn.createFromString(DATASET_A), true, true, false);
+    final EntityHealthBatchLoader.HealthQueryKey chartKey =
+        new EntityHealthBatchLoader.HealthQueryKey(
+            Urn.createFromString(CHART_C), false, true, false);
+
+    final List<List<Health>> result =
+        loader.batchLoad(ImmutableList.of(datasetKey, chartKey), mockContext());
+
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<List<Urn>> urnsCaptor = ArgumentCaptor.forClass(List.class);
+    final ArgumentCaptor<String> urnFieldCaptor = ArgumentCaptor.forClass(String.class);
+    Mockito.verify(timeseriesAspectService)
+        .batchGetAggregatedStats(
+            any(),
+            any(),
+            any(),
+            any(),
+            urnsCaptor.capture(),
+            any(),
+            any(),
+            urnFieldCaptor.capture());
+
+    // Only the assertions-enabled dataset URN is in the batch; the chart URN is excluded.
+    assertEquals(urnsCaptor.getValue(), ImmutableList.of(Urn.createFromString(DATASET_A)));
+    assertEquals(urnFieldCaptor.getValue(), "asserteeUrn");
+
+    // Dataset gets both incident (PASS) and assertion (PASS) health; chart gets incident only.
+    assertEquals(result.get(0).size(), 2);
+    assertEquals(result.get(1).size(), 1);
+    assertEquals(result.get(1).get(0).getType(), HealthStatusType.INCIDENTS);
+  }
+
+  /**
+   * Test results are fetched with a single {@code batchGetV2} rather than one {@code getV2} per
+   * URN.
+   */
+  @Test
+  public void testTestResultsBatchedViaBatchGetV2() throws Exception {
+    final EntityClient entityClient = Mockito.mock(EntityClient.class);
+    final GraphClient graphClient = Mockito.mock(GraphClient.class);
+    final TimeseriesAspectService timeseriesAspectService =
+        Mockito.mock(TimeseriesAspectService.class);
+    final EntitySearchService entitySearchService = Mockito.mock(EntitySearchService.class);
+
+    final Map<Urn, EntityResponse> testResponses = new HashMap<>();
+    testResponses.put(Urn.createFromString(DATASET_A), testResultsResponse(1, 0)); // failing
+    testResponses.put(Urn.createFromString(DATASET_B), testResultsResponse(0, 1)); // passing
+    Mockito.when(
+            entityClient.batchGetV2(
+                any(),
+                Mockito.eq("dataset"),
+                Mockito.eq(
+                    ImmutableSet.of(
+                        Urn.createFromString(DATASET_A), Urn.createFromString(DATASET_B))),
+                Mockito.eq(ImmutableSet.of(Constants.TEST_RESULTS_ASPECT_NAME))))
+        .thenReturn(testResponses);
+
+    final EntityHealthBatchLoader loader =
+        new EntityHealthBatchLoader(
+            entityClient, graphClient, timeseriesAspectService, entitySearchService);
+
+    final EntityHealthBatchLoader.HealthQueryKey keyA =
+        new EntityHealthBatchLoader.HealthQueryKey(
+            Urn.createFromString(DATASET_A), false, false, true);
+    final EntityHealthBatchLoader.HealthQueryKey keyB =
+        new EntityHealthBatchLoader.HealthQueryKey(
+            Urn.createFromString(DATASET_B), false, false, true);
+
+    final List<List<Health>> result = loader.batchLoad(ImmutableList.of(keyA, keyB), mockContext());
+
+    Mockito.verify(entityClient, Mockito.times(1)).batchGetV2(any(), any(), any(), any());
+    Mockito.verify(entityClient, Mockito.times(0)).getV2(any(), any(), any(), any());
+
+    assertEquals(result.get(0).get(0).getType(), HealthStatusType.TESTS);
+    assertEquals(result.get(0).get(0).getStatus(), HealthStatus.FAIL);
+    assertEquals(result.get(1).get(0).getStatus(), HealthStatus.PASS);
+  }
+
+  /**
+   * Per-dimension failure isolation: when the assertion batch call throws, the loader must NOT fail
+   * the whole page — it drops only the assertions dimension and still returns incidents and tests
+   * health for every entity. This is the batch-only gap the expanded validation surfaced.
+   */
+  @Test
+  public void testAssertionDimensionFailureIsIsolated() throws Exception {
+    final EntityClient entityClient = Mockito.mock(EntityClient.class);
+    final GraphClient graphClient = Mockito.mock(GraphClient.class);
+    final TimeseriesAspectService timeseriesAspectService =
+        Mockito.mock(TimeseriesAspectService.class);
+    final EntitySearchService entitySearchService = Mockito.mock(EntitySearchService.class);
+
+    stubActiveAssertions(graphClient, DATASET_A, ASSERTION_A);
+    // Assertion aggregation blows up (e.g. timeseries index unavailable).
+    Mockito.when(
+            timeseriesAspectService.batchGetAggregatedStats(
+                any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenThrow(new RuntimeException("boom: assertion index down"));
+    // Incidents: none active -> PASS. Tests: one failing.
+    Mockito.when(entitySearchService.getActiveIncidentStats(any(), any())).thenReturn(Map.of());
+    final Map<Urn, EntityResponse> testResponses = new HashMap<>();
+    testResponses.put(Urn.createFromString(DATASET_A), testResultsResponse(1, 0));
+    Mockito.when(entityClient.batchGetV2(any(), any(), any(), any())).thenReturn(testResponses);
+
+    final EntityHealthBatchLoader loader =
+        new EntityHealthBatchLoader(
+            entityClient, graphClient, timeseriesAspectService, entitySearchService);
+
+    final EntityHealthBatchLoader.HealthQueryKey key =
+        new EntityHealthBatchLoader.HealthQueryKey(
+            Urn.createFromString(DATASET_A), true, true, true);
+
+    // Must not throw despite the assertion failure.
+    final List<List<Health>> result = loader.batchLoad(ImmutableList.of(key), mockContext());
+
+    final List<HealthStatusType> types =
+        result.get(0).stream().map(Health::getType).collect(Collectors.toList());
+    // Assertions dropped; incidents + tests survive.
+    assertFalse(types.contains(HealthStatusType.ASSERTIONS));
+    assertTrue(types.contains(HealthStatusType.INCIDENTS));
+    assertTrue(types.contains(HealthStatusType.TESTS));
+  }
+
+  /**
+   * Assembly-phase isolation: a malformed assertion-run row (size != 3) throws while assembling ONE
+   * entity's assertion health, but must not fail the page — the malformed entity drops its
+   * assertions dimension while other entities resolve normally.
+   */
+  @Test
+  public void testMalformedAssertionRowIsolatedToOneEntity() throws Exception {
+    final EntityClient entityClient = Mockito.mock(EntityClient.class);
+    final GraphClient graphClient = Mockito.mock(GraphClient.class);
+    final TimeseriesAspectService timeseriesAspectService =
+        Mockito.mock(TimeseriesAspectService.class);
+    final EntitySearchService entitySearchService = Mockito.mock(EntitySearchService.class);
+
+    stubActiveAssertions(graphClient, DATASET_A, ASSERTION_A);
+    stubActiveAssertions(graphClient, DATASET_B, ASSERTION_B);
+
+    final Map<Urn, GenericTable> batchResult = new HashMap<>();
+    batchResult.put(Urn.createFromString(DATASET_A), malformedAssertionRunTable()); // size-2 row
+    batchResult.put(Urn.createFromString(DATASET_B), assertionRunTable(ASSERTION_B, "FAILURE"));
+    Mockito.when(
+            timeseriesAspectService.batchGetAggregatedStats(
+                any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(batchResult);
+
+    final EntityHealthBatchLoader loader =
+        new EntityHealthBatchLoader(
+            entityClient, graphClient, timeseriesAspectService, entitySearchService);
+
+    // Must not throw despite A's malformed row.
+    final List<List<Health>> result =
+        loader.batchLoad(
+            ImmutableList.of(assertionsOnlyKey(DATASET_A), assertionsOnlyKey(DATASET_B)),
+            mockContext());
+
+    assertEquals(result.size(), 2);
+    // A: malformed row -> assertions dimension dropped for this entity only.
+    assertTrue(result.get(0).isEmpty());
+    // B: unaffected, resolves to a failing assertions health.
+    assertEquals(result.get(1).size(), 1);
+    assertEquals(result.get(1).get(0).getType(), HealthStatusType.ASSERTIONS);
+    assertEquals(result.get(1).get(0).getStatus(), HealthStatus.FAIL);
+  }
+
+  /**
+   * Fetch-phase isolation for a non-assertion dimension: when the test-results batch throws, the
+   * tests dimension is dropped but the page still returns and other dimensions survive.
+   */
+  @Test
+  public void testTestsFetchFailureIsIsolated() throws Exception {
+    final EntityClient entityClient = Mockito.mock(EntityClient.class);
+    final GraphClient graphClient = Mockito.mock(GraphClient.class);
+    final TimeseriesAspectService timeseriesAspectService =
+        Mockito.mock(TimeseriesAspectService.class);
+    final EntitySearchService entitySearchService = Mockito.mock(EntitySearchService.class);
+
+    // Incidents: none active -> PASS. Tests: batch fetch blows up.
+    Mockito.when(entitySearchService.getActiveIncidentStats(any(), any())).thenReturn(Map.of());
+    Mockito.when(entityClient.batchGetV2(any(), any(), any(), any()))
+        .thenThrow(new RuntimeException("boom: test-results backend down"));
+
+    final EntityHealthBatchLoader loader =
+        new EntityHealthBatchLoader(
+            entityClient, graphClient, timeseriesAspectService, entitySearchService);
+
+    // incidents + tests enabled, assertions off.
+    final EntityHealthBatchLoader.HealthQueryKey key =
+        new EntityHealthBatchLoader.HealthQueryKey(
+            Urn.createFromString(DATASET_A), false, true, true);
+
+    final List<List<Health>> result = loader.batchLoad(ImmutableList.of(key), mockContext());
+
+    final List<HealthStatusType> types =
+        result.get(0).stream().map(Health::getType).collect(Collectors.toList());
+    assertFalse(types.contains(HealthStatusType.TESTS)); // dropped
+    assertTrue(types.contains(HealthStatusType.INCIDENTS)); // survives
+  }
+
+  /**
+   * Per-URN graph-lookup isolation: one entity's failing active-assertion lookup drops only that
+   * entity's assertions dimension; a sibling entity is unaffected.
+   */
+  @Test
+  public void testPerUrnGraphFailureIsolated() throws Exception {
+    final EntityClient entityClient = Mockito.mock(EntityClient.class);
+    final GraphClient graphClient = Mockito.mock(GraphClient.class);
+    final TimeseriesAspectService timeseriesAspectService =
+        Mockito.mock(TimeseriesAspectService.class);
+    final EntitySearchService entitySearchService = Mockito.mock(EntitySearchService.class);
+
+    // A's graph lookup throws; B's succeeds.
+    Mockito.when(
+            graphClient.getRelatedEntities(
+                Mockito.eq(DATASET_A), any(), any(), Mockito.anyInt(), Mockito.anyInt(), any()))
+        .thenThrow(new RuntimeException("boom: graph down for A"));
+    stubActiveAssertions(graphClient, DATASET_B, ASSERTION_B);
+
+    final Map<Urn, GenericTable> batchResult = new HashMap<>();
+    batchResult.put(Urn.createFromString(DATASET_B), assertionRunTable(ASSERTION_B, "FAILURE"));
+    Mockito.when(
+            timeseriesAspectService.batchGetAggregatedStats(
+                any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(batchResult);
+
+    final EntityHealthBatchLoader loader =
+        new EntityHealthBatchLoader(
+            entityClient, graphClient, timeseriesAspectService, entitySearchService);
+
+    final List<List<Health>> result =
+        loader.batchLoad(
+            ImmutableList.of(assertionsOnlyKey(DATASET_A), assertionsOnlyKey(DATASET_B)),
+            mockContext());
+
+    assertEquals(result.size(), 2);
+    assertTrue(result.get(0).isEmpty()); // A: graph failed -> assertions dropped for A only
+    assertEquals(result.get(1).size(), 1); // B: unaffected
+    assertEquals(result.get(1).get(0).getType(), HealthStatusType.ASSERTIONS);
+  }
+
+  /**
+   * The incident dimension's N+1 guarantee: one {@code getActiveIncidentStats} aggregation call
+   * produces the count and latest-incident urn, and the latest incident's info is fetched with a
+   * single {@code batchGetV2} rather than a per-entity {@code filter}+{@code getV2}.
+   */
+  @Test
+  public void testIncidentsBatchedViaGetActiveIncidentStats() throws Exception {
+    final EntityClient entityClient = Mockito.mock(EntityClient.class);
+    final GraphClient graphClient = Mockito.mock(GraphClient.class);
+    final TimeseriesAspectService timeseriesAspectService =
+        Mockito.mock(TimeseriesAspectService.class);
+    final EntitySearchService entitySearchService = Mockito.mock(EntitySearchService.class);
+
+    final Urn datasetUrn = Urn.createFromString(DATASET_A);
+    final Urn incidentUrn = Urn.createFromString("urn:li:incident:i1");
+
+    Mockito.when(entitySearchService.getActiveIncidentStats(any(), Mockito.eq(Set.of(datasetUrn))))
+        .thenReturn(Map.of(datasetUrn, new IncidentStats(2, incidentUrn)));
+
+    final IncidentInfo info =
+        new IncidentInfo()
+            .setStatus(
+                new IncidentStatus()
+                    .setState(IncidentState.ACTIVE)
+                    .setLastUpdated(
+                        new AuditStamp()
+                            .setTime(123L)
+                            .setActor(Urn.createFromString("urn:li:corpuser:t"))));
+    final EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    aspectMap.put(
+        Constants.INCIDENT_INFO_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(info.data())));
+    Mockito.when(
+            entityClient.batchGetV2(
+                any(),
+                Mockito.eq(Constants.INCIDENT_ENTITY_NAME),
+                Mockito.eq(Set.of(incidentUrn)),
+                any()))
+        .thenReturn(
+            Map.of(incidentUrn, new EntityResponse().setUrn(incidentUrn).setAspects(aspectMap)));
+
+    final EntityHealthBatchLoader loader =
+        new EntityHealthBatchLoader(
+            entityClient, graphClient, timeseriesAspectService, entitySearchService);
+    final List<List<Health>> results =
+        loader.batchLoad(
+            List.of(new EntityHealthBatchLoader.HealthQueryKey(datasetUrn, false, true, false)),
+            mockContext());
+
+    assertEquals(results.get(0).get(0).getType(), HealthStatusType.INCIDENTS);
+    assertEquals(results.get(0).get(0).getStatus(), HealthStatus.FAIL);
+    Mockito.verify(entitySearchService, Mockito.times(1)).getActiveIncidentStats(any(), any());
+  }
+
+  /**
+   * Fetch-phase isolation for the incident dimension: when the active-incident aggregation throws,
+   * incidents are dropped but the page still returns and other dimensions survive. Completes the
+   * failure-isolation matrix (assertions/tests/graph are covered above).
+   */
+  @Test
+  public void testIncidentDimensionFailureIsIsolated() throws Exception {
+    final EntityClient entityClient = Mockito.mock(EntityClient.class);
+    final GraphClient graphClient = Mockito.mock(GraphClient.class);
+    final TimeseriesAspectService timeseriesAspectService =
+        Mockito.mock(TimeseriesAspectService.class);
+    final EntitySearchService entitySearchService = Mockito.mock(EntitySearchService.class);
+
+    // Incident aggregation blows up (e.g. incident search index unavailable).
+    Mockito.when(entitySearchService.getActiveIncidentStats(any(), any()))
+        .thenThrow(new RuntimeException("boom: incident index down"));
+    // Tests: one failing, so the tests dimension is present to prove it survives.
+    final Map<Urn, EntityResponse> testResponses = new HashMap<>();
+    testResponses.put(Urn.createFromString(DATASET_A), testResultsResponse(1, 0));
+    Mockito.when(entityClient.batchGetV2(any(), any(), any(), any())).thenReturn(testResponses);
+
+    final EntityHealthBatchLoader loader =
+        new EntityHealthBatchLoader(
+            entityClient, graphClient, timeseriesAspectService, entitySearchService);
+
+    // incidents + tests enabled, assertions off.
+    final EntityHealthBatchLoader.HealthQueryKey key =
+        new EntityHealthBatchLoader.HealthQueryKey(
+            Urn.createFromString(DATASET_A), false, true, true);
+
+    final List<List<Health>> result = loader.batchLoad(ImmutableList.of(key), mockContext());
+
+    final List<HealthStatusType> types =
+        result.get(0).stream().map(Health::getType).collect(Collectors.toList());
+    assertFalse(types.contains(HealthStatusType.INCIDENTS)); // dropped
+    assertTrue(types.contains(HealthStatusType.TESTS)); // survives
+  }
+
+  /**
+   * The incident count survives a failure to fetch the latest incident's info: the aggregation
+   * yields count + latest-urn, but if the follow-up {@code batchGetV2} for incidentInfo throws, the
+   * dimension still reports FAIL with the correct count — only the title/timestamp are unpopulated.
+   */
+  @Test
+  public void testIncidentInfoFetchFailureKeepsCount() throws Exception {
+    final EntityClient entityClient = Mockito.mock(EntityClient.class);
+    final GraphClient graphClient = Mockito.mock(GraphClient.class);
+    final TimeseriesAspectService timeseriesAspectService =
+        Mockito.mock(TimeseriesAspectService.class);
+    final EntitySearchService entitySearchService = Mockito.mock(EntitySearchService.class);
+
+    final Urn datasetUrn = Urn.createFromString(DATASET_A);
+    final Urn incidentUrn = Urn.createFromString("urn:li:incident:i1");
+    Mockito.when(entitySearchService.getActiveIncidentStats(any(), Mockito.eq(Set.of(datasetUrn))))
+        .thenReturn(Map.of(datasetUrn, new IncidentStats(3, incidentUrn)));
+    // The incidentInfo batchGetV2 fails.
+    Mockito.when(entityClient.batchGetV2(any(), any(), any(), any()))
+        .thenThrow(new RuntimeException("boom: incident info fetch down"));
+
+    final EntityHealthBatchLoader loader =
+        new EntityHealthBatchLoader(
+            entityClient, graphClient, timeseriesAspectService, entitySearchService);
+
+    final List<List<Health>> result =
+        loader.batchLoad(
+            List.of(new EntityHealthBatchLoader.HealthQueryKey(datasetUrn, false, true, false)),
+            mockContext());
+
+    final Health h = result.get(0).get(0);
+    assertEquals(h.getType(), HealthStatusType.INCIDENTS);
+    assertEquals(h.getStatus(), HealthStatus.FAIL);
+    assertEquals(h.getMessage(), "3 active incidents");
+    // Latest-incident urn is known from the aggregation; the title is null because info fetch
+    // failed.
+    assertEquals(h.getActiveIncidentHealthDetails().getLatestIncidentUrn(), incidentUrn.toString());
+    assertNull(h.getActiveIncidentHealthDetails().getLatestIncidentTitle());
+  }
+
+  private static GenericTable malformedAssertionRunTable() {
+    // Only two columns instead of the expected [assertionUrn, type, timestampMillis].
+    return new GenericTable()
+        .setColumnNames(new StringArray(ImmutableList.of("assertionUrn", "type")))
+        .setColumnTypes(new StringArray("string", "string"))
+        .setRows(
+            new StringArrayArray(
+                ImmutableList.of(new StringArray(ImmutableList.of(ASSERTION_A, "SUCCESS")))));
+  }
+
+  private static EntityHealthBatchLoader.HealthQueryKey assertionsOnlyKey(final String urn)
+      throws Exception {
+    return new EntityHealthBatchLoader.HealthQueryKey(
+        Urn.createFromString(urn), true, false, false);
+  }
+
+  private static void stubActiveAssertions(
+      final GraphClient graphClient, final String assetUrn, final String assertionUrn)
+      throws Exception {
+    Mockito.when(
+            graphClient.getRelatedEntities(
+                Mockito.eq(assetUrn),
+                Mockito.eq(ImmutableSet.of("Asserts")),
+                any(),
+                Mockito.anyInt(),
+                Mockito.anyInt(),
+                any()))
+        .thenReturn(
+            new EntityRelationships()
+                .setStart(0)
+                .setCount(1)
+                .setTotal(1)
+                .setRelationships(
+                    new EntityRelationshipArray(
+                        ImmutableList.of(
+                            new EntityRelationship()
+                                .setEntity(Urn.createFromString(assertionUrn))
+                                .setType("Asserts")))));
+  }
+
+  private static GenericTable assertionRunTable(
+      final String assertionUrn, final String resultType) {
+    return new GenericTable()
+        .setColumnNames(
+            new StringArray(ImmutableList.of("assertionUrn", "type", "timestampMillis")))
+        .setColumnTypes(new StringArray("string", "string", "long"))
+        .setRows(
+            new StringArrayArray(
+                ImmutableList.of(
+                    new StringArray(ImmutableList.of(assertionUrn, resultType, "0")))));
+  }
+
+  private static EntityResponse testResultsResponse(final int failing, final int passing)
+      throws Exception {
+    final TestResults testResults = new TestResults();
+    final TestResultArray failingArray = new TestResultArray();
+    for (int i = 0; i < failing; i++) {
+      failingArray.add(
+          new TestResult()
+              .setTest(Urn.createFromString("urn:li:test:fail-" + i))
+              .setType(TestResultType.FAILURE));
+    }
+    final TestResultArray passingArray = new TestResultArray();
+    for (int i = 0; i < passing; i++) {
+      passingArray.add(
+          new TestResult()
+              .setTest(Urn.createFromString("urn:li:test:pass-" + i))
+              .setType(TestResultType.SUCCESS));
+    }
+    testResults.setFailing(failingArray);
+    testResults.setPassing(passingArray);
+
+    final EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    aspectMap.put(
+        Constants.TEST_RESULTS_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(testResults.data())));
+    return new EntityResponse().setAspects(aspectMap);
+  }
+
+  private static QueryContext mockContext() {
+    final QueryContext context = Mockito.mock(QueryContext.class);
+    Mockito.when(context.getActorUrn()).thenReturn("urn:li:corpuser:test");
+    Mockito.when(context.getOperationContext()).thenReturn(Mockito.mock(OperationContext.class));
+    return context;
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -591,6 +591,7 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "featureFlags.i18nEnabled",
           "featureFlags.timeseriesAspectBatchLoadEnabled",
           "featureFlags.timeseriesAspectAggBatchLoadEnabled",
+          "featureFlags.entityHealthBatchLoadEnabled",
           "featureFlags.datasetStatsSummaryBatchLoadEnabled",
           "featureFlags.themeV2Default",
           "featureFlags.themeV2Enabled",

--- a/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
@@ -76,4 +76,5 @@ public class FeatureFlags {
   // browserTracingEnabled so vitals can stay off while browser request tracing is validated.
   private boolean browserWebVitalsEnabled = false;
   private boolean datasetStatsSummaryBatchLoadEnabled = true;
+  private boolean entityHealthBatchLoadEnabled = true;
 }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -1530,6 +1530,8 @@ featureFlags:
   i18nEnabled: ${I18N_ENABLED:true} # If enabled, internationalization (i18n) features are active
   timeseriesAspectBatchLoadEnabled: ${TIMESERIES_ASPECT_BATCH_LOAD_ENABLED:true} # If enabled, TimeSeriesAspectResolver uses the DataLoader batch path; disable to revert to single-URN queries
   timeseriesAspectAggBatchLoadEnabled: ${TIMESERIES_ASPECT_AGG_BATCH_LOAD_ENABLED:true} # If enabled, Dashboard.statsSummary uses the batch aggregation DataLoader; disable to revert to per-URN queries
+
+  entityHealthBatchLoadEnabled: ${ENTITY_HEALTH_BATCH_LOAD_ENABLED:true} # If enabled, the entity `health` field uses the batch DataLoader (batches incident, assertion-run and test-result fetches across a request); disable to revert to per-entity resolution
   datasetStatsSummaryBatchLoadEnabled: ${DATASET_STATS_SUMMARY_BATCH_LOAD_ENABLED:true} # If enabled, Dataset.statsSummary uses the batch aggregation DataLoader (batches usage aggregations across a request); disable to revert to per-dataset queries
   createSchemaVersionIndex: ${CREATE_SCHEMA_VERSION_INDEX:${ZDU_STAGE_10:false}} # Creates schemaVersionIndex on metadata_aspect_v2 for ZDU schema version queries
   aspectMigrationMutatorEnabled: ${ASPECT_MIGRATION_MUTATOR_ENABLED:${ZDU_STAGE_20:false}} # Populates AspectMigrationMutatorChain with registered mutators

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
@@ -35,6 +35,7 @@ import com.linkedin.metadata.graph.SiblingGraphService;
 import com.linkedin.metadata.ingestion.IngestionCliVersionMatrixService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.recommendation.RecommendationsService;
+import com.linkedin.metadata.search.EntitySearchService;
 import com.linkedin.metadata.search.SemanticSearchService;
 import com.linkedin.metadata.service.ApplicationService;
 import com.linkedin.metadata.service.AssertionService;
@@ -116,6 +117,10 @@ public class GraphQLEngineFactory {
   @Autowired
   @Qualifier("timeseriesAspectService")
   private TimeseriesAspectService timeseriesAspectService;
+
+  @Autowired
+  @Qualifier("entitySearchService")
+  private EntitySearchService entitySearchService;
 
   @Autowired
   @Qualifier("recommendationsService")
@@ -275,6 +280,7 @@ public class GraphQLEngineFactory {
     args.setRecommendationsService(recommendationsService);
     args.setStatefulTokenService(statefulTokenService);
     args.setTimeseriesAspectService(timeseriesAspectService);
+    args.setEntitySearchService(entitySearchService);
     args.setEntityRegistry(entityRegistry);
     args.setSecretService(secretService);
     args.setNativeUserService(nativeUserService);

--- a/smoke-test/tests/incidents/health_batch_data.json
+++ b/smoke-test/tests/incidents/health_batch_data.json
@@ -1,0 +1,134 @@
+[
+  {
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:kafka,health_batch_ds_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+      "value": "{\"name\": \"health_batch_ds_1\", \"description\": \"health batch loader test dataset 1\"}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:kafka,health_batch_ds_2,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+      "value": "{\"name\": \"health_batch_ds_2\", \"description\": \"health batch loader test dataset 2\"}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:kafka,health_batch_ds_3,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+      "value": "{\"name\": \"health_batch_ds_3\", \"description\": \"health batch loader test dataset 3\"}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:kafka,health_batch_ds_4,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+      "value": "{\"name\": \"health_batch_ds_4\", \"description\": \"health batch loader test dataset 4\"}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "incident",
+    "entityUrn": "urn:li:incident:health-batch-1a",
+    "changeType": "UPSERT",
+    "aspectName": "incidentInfo",
+    "aspect": {
+      "value": "{\"type\": \"OPERATIONAL\", \"title\": \"ds1 incident A\", \"description\": \"older active incident on ds1\", \"entities\": [\"urn:li:dataset:(urn:li:dataPlatform:kafka,health_batch_ds_1,PROD)\"], \"status\": { \"state\": \"ACTIVE\", \"lastUpdated\": { \"time\": 1000, \"actor\": \"urn:li:corpuser:admin\" } }, \"source\": { \"type\": \"MANUAL\" }, \"created\": { \"time\": 1000, \"actor\": \"urn:li:corpuser:admin\" } }",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "incident",
+    "entityUrn": "urn:li:incident:health-batch-1b",
+    "changeType": "UPSERT",
+    "aspectName": "incidentInfo",
+    "aspect": {
+      "value": "{\"type\": \"OPERATIONAL\", \"title\": \"ds1 incident B\", \"description\": \"newer active incident on ds1\", \"entities\": [\"urn:li:dataset:(urn:li:dataPlatform:kafka,health_batch_ds_1,PROD)\"], \"status\": { \"state\": \"ACTIVE\", \"lastUpdated\": { \"time\": 2000, \"actor\": \"urn:li:corpuser:admin\" } }, \"source\": { \"type\": \"MANUAL\" }, \"created\": { \"time\": 2000, \"actor\": \"urn:li:corpuser:admin\" } }",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "incident",
+    "entityUrn": "urn:li:incident:health-batch-2a",
+    "changeType": "UPSERT",
+    "aspectName": "incidentInfo",
+    "aspect": {
+      "value": "{\"type\": \"OPERATIONAL\", \"title\": \"ds2 incident\", \"description\": \"single active incident on ds2\", \"entities\": [\"urn:li:dataset:(urn:li:dataPlatform:kafka,health_batch_ds_2,PROD)\"], \"status\": { \"state\": \"ACTIVE\", \"lastUpdated\": { \"time\": 500, \"actor\": \"urn:li:corpuser:admin\" } }, \"source\": { \"type\": \"MANUAL\" }, \"created\": { \"time\": 500, \"actor\": \"urn:li:corpuser:admin\" } }",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "incident",
+    "entityUrn": "urn:li:incident:health-batch-3a",
+    "changeType": "UPSERT",
+    "aspectName": "incidentInfo",
+    "aspect": {
+      "value": "{\"type\": \"OPERATIONAL\", \"title\": \"ds3 resolved incident\", \"description\": \"resolved incident on ds3 must not count as active\", \"entities\": [\"urn:li:dataset:(urn:li:dataPlatform:kafka,health_batch_ds_3,PROD)\"], \"status\": { \"state\": \"RESOLVED\", \"lastUpdated\": { \"time\": 3000, \"actor\": \"urn:li:corpuser:admin\" } }, \"source\": { \"type\": \"MANUAL\" }, \"created\": { \"time\": 3000, \"actor\": \"urn:li:corpuser:admin\" } }",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:kafka,health_batch_ds_5,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+      "value": "{\"name\": \"health_batch_ds_5\", \"description\": \"health batch loader test dataset 5\"}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "incident",
+    "entityUrn": "urn:li:incident:health-batch-5a",
+    "changeType": "UPSERT",
+    "aspectName": "incidentInfo",
+    "aspect": {
+      "value": "{\"type\": \"OPERATIONAL\", \"title\": \"ds5 active incident\", \"description\": \"active incident on ds5\", \"entities\": [\"urn:li:dataset:(urn:li:dataPlatform:kafka,health_batch_ds_5,PROD)\"], \"status\": { \"state\": \"ACTIVE\", \"lastUpdated\": { \"time\": 400, \"actor\": \"urn:li:corpuser:admin\" } }, \"source\": { \"type\": \"MANUAL\" }, \"created\": { \"time\": 400, \"actor\": \"urn:li:corpuser:admin\" } }",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "incident",
+    "entityUrn": "urn:li:incident:health-batch-5r",
+    "changeType": "UPSERT",
+    "aspectName": "incidentInfo",
+    "aspect": {
+      "value": "{\"type\": \"OPERATIONAL\", \"title\": \"ds5 resolved incident\", \"description\": \"newer resolved incident on ds5 must be excluded from count and latest\", \"entities\": [\"urn:li:dataset:(urn:li:dataPlatform:kafka,health_batch_ds_5,PROD)\"], \"status\": { \"state\": \"RESOLVED\", \"lastUpdated\": { \"time\": 5000, \"actor\": \"urn:li:corpuser:admin\" } }, \"source\": { \"type\": \"MANUAL\" }, \"created\": { \"time\": 5000, \"actor\": \"urn:li:corpuser:admin\" } }",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  }
+]

--- a/smoke-test/tests/incidents/health_batch_test.py
+++ b/smoke-test/tests/incidents/health_batch_test.py
@@ -1,0 +1,109 @@
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from conftest import _ingest_cleanup_data_impl
+from tests.utils import execute_graphql, wait_for_writes_to_sync, with_test_retry
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ingest_cleanup_data(auth_session, graph_client):
+    yield from _ingest_cleanup_data_impl(
+        auth_session,
+        graph_client,
+        "tests/incidents/health_batch_data.json",
+        "health_batch",
+    )
+
+
+def _ds(n: int) -> str:
+    return f"urn:li:dataset:(urn:li:dataPlatform:kafka,health_batch_ds_{n},PROD)"
+
+
+def _inc(slug: str) -> str:
+    return f"urn:li:incident:health-batch-{slug}"
+
+
+# alias -> (dataset urn, expected active-incident count, expected latest active incident urn).
+# count == 0 means the incidents dimension must resolve to PASS (no active incidents).
+EXPECTATIONS: Dict[str, Tuple[str, int, Optional[str]]] = {
+    # two active incidents -> FAIL, latest is the newer one (time 2000).
+    "d1": (_ds(1), 2, _inc("1b")),
+    # one active incident -> FAIL.
+    "d2": (_ds(2), 1, _inc("2a")),
+    # only a RESOLVED incident -> PASS.
+    "d3": (_ds(3), 0, None),
+    # no incidents at all -> PASS.
+    "d4": (_ds(4), 0, None),
+    # one ACTIVE + one newer RESOLVED incident -> the state=ACTIVE filter must exclude the
+    # resolved one from both the count and the "latest" selection, so count 1 with the active urn.
+    "d5": (_ds(5), 1, _inc("5a")),
+}
+
+# Multi-alias query: resolving every dataset's `health` field in a single GraphQL request forces the
+# EntityHealthBatchLoader DataLoader to accumulate all keys into one batch, which exercises the
+# batched getActiveIncidentStats aggregation (a single terms(entities.keyword) + top_hits query)
+# rather than the per-entity path. This is the code path enabled by entityHealthBatchLoadEnabled.
+_FRAGMENT = """fragment health on Dataset {
+  urn
+  health {
+    type
+    status
+    message
+    activeIncidentHealthDetails {
+      latestIncidentUrn
+    }
+  }
+}"""
+
+
+def _build_query() -> Tuple[str, Dict[str, Any]]:
+    var_decls = ", ".join(f"${alias}: String!" for alias in EXPECTATIONS)
+    selections = "\n".join(
+        f"  {alias}: dataset(urn: ${alias}) {{ ...health }}" for alias in EXPECTATIONS
+    )
+    query = f"query healthBatch({var_decls}) {{\n{selections}\n}}\n\n{_FRAGMENT}"
+    variables = {alias: urn for alias, (urn, _, _) in EXPECTATIONS.items()}
+    return query, variables
+
+
+def _incident_health(dataset: Dict[str, Any]) -> Dict[str, Any]:
+    healths: List[Dict[str, Any]] = dataset["health"] or []
+    incident_entries = [h for h in healths if h["type"] == "INCIDENTS"]
+    # The incidents dimension is always enabled for datasets, so there is exactly one entry.
+    assert len(incident_entries) == 1, (
+        f"expected exactly one INCIDENTS health entry, got {healths}"
+    )
+    return incident_entries[0]
+
+
+def test_batched_incident_health(auth_session):
+    wait_for_writes_to_sync()
+    query, variables = _build_query()
+
+    @with_test_retry()
+    def check():
+        data = execute_graphql(auth_session, query, variables)["data"]
+
+        for alias, (_, expected_count, expected_latest) in EXPECTATIONS.items():
+            health = _incident_health(data[alias])
+            if expected_count == 0:
+                assert health["status"] == "PASS", f"{alias}: {health}"
+                assert health["activeIncidentHealthDetails"] is None, (
+                    f"{alias}: {health}"
+                )
+            else:
+                plural = "s" if expected_count > 1 else ""
+                assert health["status"] == "FAIL", f"{alias}: {health}"
+                assert (
+                    health["message"] == f"{expected_count} active incident{plural}"
+                ), f"{alias}: {health}"
+                assert (
+                    health["activeIncidentHealthDetails"]["latestIncidentUrn"]
+                    == expected_latest
+                ), f"{alias}: {health}"
+
+    check()

--- a/smoke-test/tests/incidents/health_batch_test.py
+++ b/smoke-test/tests/incidents/health_batch_test.py
@@ -80,6 +80,60 @@ def _incident_health(dataset: Dict[str, Any]) -> Dict[str, Any]:
     return incident_entries[0]
 
 
+_SOFT_DELETE_MUTATION = """mutation batchUpdateSoftDeleted($urns: [String!]!, $deleted: Boolean!) {
+  batchUpdateSoftDeleted(input: {urns: $urns, deleted: $deleted})
+}"""
+
+_SINGLE_HEALTH_QUERY = f"""query health($urn: String!) {{
+  dataset(urn: $urn) {{ ...health }}
+}}
+
+{_FRAGMENT}"""
+
+
+def _set_soft_deleted(auth_session, urn: str, deleted: bool) -> None:
+    execute_graphql(
+        auth_session, _SOFT_DELETE_MUTATION, {"urns": [urn], "deleted": deleted}
+    )
+    wait_for_writes_to_sync()
+
+
+def test_incident_health_survives_soft_deleted_asset(auth_session):
+    """A soft-deleted asset still resolves the same incident health.
+
+    The batched aggregation queries the incident index, where an asset's own `removed` flag is not
+    present, so soft-deleting the asset must not change its active-incident count or latest-incident
+    urn. This asserts the batched path agrees with the unbatched one on that, since the two differ in
+    how they reach the incident documents.
+
+    Note on the inverse case: a soft-deleted *incident* is not reachable here, because the incident
+    entity declares no `status` aspect, so `removed` is never indexed on incident documents and the
+    aspect cannot be written. The soft-delete clause the query builds for that case is asserted in
+    ESSearchDAOIncidentStatsTest instead.
+    """
+    urn, expected_count, expected_latest = EXPECTATIONS["d2"]
+    _set_soft_deleted(auth_session, urn, True)
+    try:
+
+        @with_test_retry()
+        def check_soft_deleted():
+            data = execute_graphql(auth_session, _SINGLE_HEALTH_QUERY, {"urn": urn})[
+                "data"
+            ]
+            health = _incident_health(data["dataset"])
+            assert health["status"] == "FAIL", health
+            assert health["message"] == f"{expected_count} active incident", health
+            assert (
+                health["activeIncidentHealthDetails"]["latestIncidentUrn"]
+                == expected_latest
+            ), health
+
+        check_soft_deleted()
+    finally:
+        # Restore, so ordering against the other tests in this module does not matter.
+        _set_soft_deleted(auth_session, urn, False)
+
+
 def test_batched_incident_health(auth_session):
     wait_for_writes_to_sync()
     query, variables = _build_query()


### PR DESCRIPTION
## Summary

**Stacked on #18585** (the `getActiveIncidentStats` search primitive). This PR is the GraphQL/health half of the original change; the search primitive was split out into #18585 for reviewability. Merge #18585 first.

The entity `health` field (`Dataset`, `Chart`, `Dashboard`, `DataFlow`, `DataJob`) is resolved by a **per-entity** `DataFetcher` (`EntityHealthResolver`). On any list/search/browse page that selects `health`, it fires once per entity — an N+1 fan-out of ES aggregations, graph lookups, and incident searches.

This PR adds **`EntityHealthBatchLoader`**, a GraphQL `DataLoader` that batches health resolution across all entities in a single request, selected by the feature flag **`entityHealthBatchLoadEnabled`** (**on by default**).

What gets batched (one call per request instead of one per entity):

- **Assertion-run aggregations** — N per-entity `getAggregatedStats` ES queries collapse to a **single** outer-terms-bucket `batchGetAggregatedStats` query (keyed on `asserteeUrn`).
- **Test results** — one `batchGetV2` per entity type instead of one `getV2` per entity.
- **Incidents** — consumes the **`getActiveIncidentStats`** primitive from #18585 (active-incident **count + latest active incident per entity** in a single ES `terms(entities.keyword)` + `top_hits` aggregation), followed by **one** `batchGetV2` for the latest incidents' `incidentInfo`. Replaces the previous N per-entity `filter()` searches + N `getV2` info fetches.

Health *interpretation* (filters, aggregation specs, row parsing, `Health` assembly) is extracted into a shared **`HealthComputationUtils`** used by both the per-entity resolver and the batch loader, so the two paths compute identical health.

**Failure isolation:** a failure in one dimension degrades to an empty result for that dimension (logged) rather than failing the page — both in the concurrent fetch phase (per-dimension `.exceptionally`) and the synchronous assemble phase (per-entity, per-dimension try/catch). Strictly more resilient than the legacy per-entity path under partial failure.

Only the graph active-assertion lookups (`getRelatedEntities`) remain per-URN — no batch relationship primitive exists yet — but they run concurrently within the loader.

## Rollout

Enabled **by default** (`entityHealthBatchLoadEnabled=true`); revert per environment with `ENTITY_HEALTH_BATCH_LOAD_ENABLED=false`, which runs the legacy per-entity path unchanged. Output is byte-identical between the two paths (see below), so this is a code-path change, not a behavior change.

## Verification

Validated end-to-end on a local instance by toggling the flag on the same build (so before/after is a pure path comparison).

- **Unit tests:** loader batch/failure-isolation tests + the `getActiveIncidentStats` request-shape test + a resolver flag-path test proving delegation to the DataLoader; the pre-existing resolver tests (unchanged) prove the shared-util refactor preserved behavior.
- **Functional parity — byte-identical.** Full ordered `health` response (type/status/message across the page) is SHA-256-identical flag-off vs flag-on at **every** page size tested (N = 1, 20, 50, 100, 200).

### Latency + DB benchmark — incident dimension (this revision)

Local instance, 200 seeded datasets each with one active incident; a single `searchAcrossEntities` request resolving `health` per row; warm JVM, 40 reps. Flag off (legacy per-entity) vs on (batched), same build.

| N (page size) | p50 before | p50 after | Δ latency | incident aspect reads before → after |
| --: | --: | --: | --: | --: |
| 1 | 34.3 ms | 32.5 ms | −5% | 2 → 1 |
| 20 | 44.2 ms | 43.9 ms | ~0% | 40 → 1 |
| 50 | 60.0 ms | 56.2 ms | −6% | 100 → 1 |
| 100 | 90.7 ms | 77.3 ms | **−15%** | 200 → 1 |
| 200 | 169.7 ms | 132.3 ms | **−22%** | 400 → 2 |

- **DB reads go O(N) → O(1):** the legacy path issues ~2·N incident-aspect reads (one `getV2` per incident); the batched path issues **one** `batchGetV2` for all incidents regardless of page size (2 at N=200 from key-chunking). The per-entity ES incident searches likewise collapse to one aggregation.
- **Scales with fan-out; no small-N regression.** At N=1 the change is within run-to-run noise (fixed GraphQL/search overhead dominates); the win emerges as the page grows and the per-entity incident work would otherwise dominate — ~15% at N=100, ~22% at N=200. This is the real-world case (search results, entity lists).

## Follow-ups (intentionally out of scope)

- Batch the graph active-assertion lookups (needs a batch relationship API) — the last remaining per-URN dimension.
- Guard the assertion aggregation against `search.max_buckets` for very high assertion cardinality (currently degrades gracefully by dropping the dimension for that sub-batch).
- Delete the now-superseded, unwired `DatasetHealthResolver`; converge and remove the legacy path once the flag has soaked.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Links to related issues (n/a)
- [x] Tests added/updated
- [ ] Docs added/updated (n/a — internal perf change behind a flag)
- [ ] Breaking changes documented in `updating-datahub.md` (n/a — output is byte-identical; flag revertible via env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

