### PR TITLE
perf(ingest/datalake): cache S3/Azure connection clients and enlarge the pool

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
@@ -11,6 +11,7 @@ from boto3.session import Session
 from botocore.config import DEFAULT_TIMEOUT, Config
 from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError
 from botocore.utils import fix_s3_host
+from pydantic import PrivateAttr
 from pydantic.fields import Field
 
 from datahub.configuration.common import (
@@ -32,6 +33,8 @@ from datahub.configuration.env_vars import (
 from datahub.configuration.source_common import EnvConfigMixin
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_POOL_CONNECTIONS = 25
 
 if TYPE_CHECKING:
     from mypy_boto3_dynamodb import DynamoDBClient
@@ -271,6 +274,9 @@ class AwsConnectionConfig(ConfigModel):
 
     _credentials_expiration: Optional[datetime] = None
     _cached_credentials: Optional[dict] = None
+    # Only clients are cached, keyed by verify_ssl: boto3 clients are thread-safe but
+    # resources are not, so get_s3_resource intentionally stays uncached.
+    _s3_clients: Dict[Any, Any] = PrivateAttr(default_factory=dict)
 
     aws_access_key_id: Optional[str] = Field(
         default=None,
@@ -448,6 +454,9 @@ class AwsConnectionConfig(ConfigModel):
         return {}
 
     def _aws_config(self) -> Config:
+        advanced_config = dict(self.aws_advanced_config)
+        # User-supplied aws_advanced_config wins if it sets max_pool_connections.
+        advanced_config.setdefault("max_pool_connections", DEFAULT_MAX_POOL_CONNECTIONS)
         return Config(
             proxies=self.aws_proxy,
             read_timeout=self.read_timeout,
@@ -455,18 +464,27 @@ class AwsConnectionConfig(ConfigModel):
                 "max_attempts": self.aws_retry_num,
                 "mode": self.aws_retry_mode,
             },
-            **self.aws_advanced_config,
+            **advanced_config,
         )
+
+    def _should_invalidate_client_cache(self) -> bool:
+        # A cached client bakes in credentials, so drop it when assumed-role creds are
+        # due for refresh. Static credentials and profiles never rotate.
+        return self.allowed_cred_refresh() and self._should_refresh_credentials()
 
     def get_s3_client(
         self, verify_ssl: Optional[Union[bool, str]] = None
     ) -> "S3Client":
-        return self.get_session().client(
-            "s3",
-            endpoint_url=self.aws_endpoint_url,
-            config=self._aws_config(),
-            verify=verify_ssl,
-        )
+        if self._should_invalidate_client_cache():
+            self._s3_clients.clear()
+        if verify_ssl not in self._s3_clients:
+            self._s3_clients[verify_ssl] = self.get_session().client(
+                "s3",
+                endpoint_url=self.aws_endpoint_url,
+                config=self._aws_config(),
+                verify=verify_ssl,
+            )
+        return self._s3_clients[verify_ssl]
 
     def get_s3_resource(
         self, verify_ssl: Optional[Union[bool, str]] = None

--- a/metadata-ingestion/src/datahub/ingestion/source/azure/azure_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/azure/azure_common.py
@@ -16,6 +16,11 @@ class AzureConnectionConfig(ConfigModel):
     https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-directory-file-acl-python
     """
 
+    # Safe to cache: credentials are static or self-refreshing
+    # (ClientSecretCredential refreshes its own tokens).
+    _blob_service_client: Optional[BlobServiceClient] = None
+    _data_lake_service_client: Optional[DataLakeServiceClient] = None
+
     base_path: str = Field(
         default="/",
         description="Base folder in hierarchical namespaces to start from.",
@@ -59,16 +64,20 @@ class AzureConnectionConfig(ConfigModel):
         )
 
     def get_blob_service_client(self):
-        return BlobServiceClient(
-            account_url=f"https://{self.account_name}.blob.core.windows.net",
-            credential=self.get_credentials(),
-        )
+        if self._blob_service_client is None:
+            self._blob_service_client = BlobServiceClient(
+                account_url=f"https://{self.account_name}.blob.core.windows.net",
+                credential=self.get_credentials(),
+            )
+        return self._blob_service_client
 
     def get_data_lake_service_client(self) -> DataLakeServiceClient:
-        return DataLakeServiceClient(
-            account_url=f"https://{self.account_name}.dfs.core.windows.net",
-            credential=self.get_credentials(),
-        )
+        if self._data_lake_service_client is None:
+            self._data_lake_service_client = DataLakeServiceClient(
+                account_url=f"https://{self.account_name}.dfs.core.windows.net",
+                credential=self.get_credentials(),
+            )
+        return self._data_lake_service_client
 
     def get_credentials(
         self,

--- a/metadata-ingestion/tests/unit/azure/test_azure_common.py
+++ b/metadata-ingestion/tests/unit/azure/test_azure_common.py
@@ -1,0 +1,21 @@
+from datahub.ingestion.source.azure.azure_common import AzureConnectionConfig
+
+
+def _config() -> AzureConnectionConfig:
+    return AzureConnectionConfig(
+        account_name="myaccount",
+        container_name="mycontainer",
+        account_key="fake-key",
+    )
+
+
+def test_blob_service_client_is_cached() -> None:
+    config = _config()
+    client = config.get_blob_service_client()
+    assert config.get_blob_service_client() is client
+
+
+def test_data_lake_service_client_is_cached() -> None:
+    config = _config()
+    client = config.get_data_lake_service_client()
+    assert config.get_data_lake_service_client() is client

--- a/metadata-ingestion/tests/unit/test_aws_common.py
+++ b/metadata-ingestion/tests/unit/test_aws_common.py
@@ -1,5 +1,6 @@
 import json
 import os
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import boto3
@@ -13,6 +14,7 @@ from botocore.exceptions import (
 from moto import mock_aws
 
 from datahub.ingestion.source.aws.aws_common import (
+    DEFAULT_MAX_POOL_CONNECTIONS,
     AwsConnectionConfig,
     AwsEnvironment,
     aws_error_code,
@@ -687,3 +689,47 @@ class TestAwsErrorCode:
             aws_error_code(ConnectTimeoutError(endpoint_url="https://x"))
             == "ConnectTimeoutError"
         )
+
+
+class TestS3ClientCaching:
+    @mock_aws
+    def test_s3_client_cached_for_static_credentials(self, mock_aws_config):
+        first = mock_aws_config.get_s3_client()
+        assert mock_aws_config.get_s3_client() is first
+        # a different verify_ssl value is cached under its own key
+        assert mock_aws_config.get_s3_client(verify_ssl=False) is not first
+
+    def test_s3_client_cache_invalidated_on_role_refresh(self):
+        config = AwsConnectionConfig(
+            aws_region="us-east-1",
+            aws_role="arn:aws:iam::123456789012:role/test-role",
+        )
+        session = MagicMock()
+        session.client.side_effect = [MagicMock(), MagicMock()]
+        with patch.object(AwsConnectionConfig, "get_session", return_value=session):
+            # Valid (non-expiring) assumed-role creds -> client is reused.
+            config._credentials_expiration = datetime.now(timezone.utc) + timedelta(
+                hours=1
+            )
+            first = config.get_s3_client()
+            assert config.get_s3_client() is first
+            assert session.client.call_count == 1
+
+            # Creds now due for refresh -> cache dropped, a fresh client is built.
+            config._credentials_expiration = datetime.now(timezone.utc) - timedelta(
+                minutes=1
+            )
+            assert config.get_s3_client() is not first
+            assert session.client.call_count == 2
+
+    def test_aws_config_max_pool_connections_default_and_override(self):
+        default_config = AwsConnectionConfig(aws_region="us-east-1")._aws_config()
+        assert (
+            default_config.max_pool_connections == DEFAULT_MAX_POOL_CONNECTIONS  # type: ignore[attr-defined]
+        )
+
+        overridden = AwsConnectionConfig(
+            aws_region="us-east-1",
+            aws_advanced_config={"max_pool_connections": 3},
+        )._aws_config()
+        assert overridden.max_pool_connections == 3  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Wave 2 (CLEAN-4) of the data lake connector performance overhaul.

`AwsConnectionConfig.get_s3_client()` rebuilt a boto3 `Session` + client on **every** listing, HEAD and schema-open call, and the ABS utilities rebuilt a `BlobServiceClient` on every folder/tag/property call. This memoizes the connection clients:

- **AWS**: cache S3 clients keyed by `verify_ssl`, dropping the cache when assumed-role credentials are due for refresh (static creds / profiles live for the whole run). Only *clients* are cached, not *resources* — boto3 clients are thread-safe but resources are not (matters for the upcoming concurrency PR).
- **Azure**: cache the blob and data-lake service clients (credentials are static or self-refreshing via `ClientSecretCredential`).
- **Pool**: `_aws_config()` now sets an overridable `max_pool_connections` default of 25 so listing-heavy (and, later, concurrent) runs don't serialize on botocore's default of 10. User-supplied `aws_advanced_config` still wins.

## Test plan

- [x] `TestS3ClientCaching` (static-cred reuse, role-refresh invalidation, pool default + override)
- [x] `test_azure_common.py` (blob + data-lake client caching)
- [x] `tests/unit/test_aws_common.py`, `tests/unit/s3`, `tests/unit/azure`, `tests/unit/glue` (232 passed)
- [x] `./gradlew :metadata-ingestion:lint` (ruff + mypy clean)

## Notes

CLEAN-2 (client `list_objects_v2` paginator) from the original Wave 2 plan is already implemented on master, so it is not included here.