### PR TITLE
feat(tests): Add tests for change in chunking_source

### DIFF
--- a/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_chunking_source.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_chunking_source.py
@@ -1095,3 +1095,31 @@ def test_model_key_default_sanitizes_colon_in_titan_model_id(pipeline_context):
     keys = list(_semantic_embeddings(semantic_wu).keys())
     assert all(":" not in k for k in keys)
     assert "amazon_titan_embed_text_v2_0" in _semantic_embeddings(semantic_wu)
+
+
+def test_semantic_content_workunit_is_not_primary_source(pipeline_context):
+    """Workunits from _emit_semantic_content must have is_primary_source=False
+    so AutoStatusAspectProcessor does not inject a Status UPSERT that would
+    overwrite lifecycleStage set by other sources or users."""
+    config = DocumentChunkingSourceConfig(
+        embedding=EmbeddingConfig(
+            provider="bedrock",
+            model="cohere.embed-english-v3",
+            aws_region="us-east-1",
+            allow_local_embedding_config=True,
+        ),
+        chunking=ChunkingConfig(strategy="basic"),
+    )
+    source = DocumentChunkingSource(
+        ctx=pipeline_context, config=config, standalone=False, graph=None
+    )
+    source._provider = _mock_provider([[0.1, 0.2, 0.3]])
+
+    workunits = list(
+        source.process_elements_inline(
+            "urn:li:document:(test,doc1,PROD)",
+            [{"type": "NarrativeText", "text": "hello"}],
+        )
+    )
+    semantic_wu = next(wu for wu in workunits if "semanticContent" in wu.id)
+    assert semantic_wu.is_primary_source is False


### PR DESCRIPTION
Adds tests for the change in this PR: https://github.com/datahub-project/datahub/pull/18236

I'm making a similar change in SaaS and want to be consistent.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
