### PR TITLE
docs(ingest/mysql): document multi-database ingestion - CUS-9272

### DIFF
--- a/metadata-ingestion/docs/sources/mariadb/mariadb_pre.md
+++ b/metadata-ingestion/docs/sources/mariadb/mariadb_pre.md
@@ -9,6 +9,21 @@ Use the MariaDB source to ingest relational metadata from MariaDB databases, inc
 - Authentication details configured in the recipe (`username` and `password`).
 - If SSL is required, provide MariaDB TLS connect arguments (`ssl_ca`, `ssl_cert`, `ssl_key`) under `options.connect_args`.
 
+#### Multiple Databases
+
+Leave `database` unset to ingest every database the ingestion user can see. Use `database_pattern` to
+select which databases are ingested, for example:
+
+```yaml
+database_pattern:
+  allow:
+    - "^db_one$"
+    - "^db_two$"
+```
+
+Setting `database` restricts ingestion to that single database; a wildcard such as `*` is not a valid
+value for `database` — use `database_pattern` for multi-database ingestion.
+
 #### Usage Statistics Prerequisites
 
 Set `include_usage_statistics: true` to derive usage statistics and query-based lineage from query

--- a/metadata-ingestion/docs/sources/mysql/mysql_pre.md
+++ b/metadata-ingestion/docs/sources/mysql/mysql_pre.md
@@ -9,6 +9,21 @@ Grant the following privileges to the ingestion user:
 - `grant select on DATABASE.* to 'USERNAME'@'%'` (required for metadata and profiling)
 - `grant show view on DATABASE.* to 'USERNAME'@'%'` (required for view definitions)
 
+#### Multiple Databases
+
+Leave `database` unset to ingest every database the ingestion user can see. Use `database_pattern` to
+select which databases are ingested, for example:
+
+```yaml
+database_pattern:
+  allow:
+    - "^db_one$"
+    - "^db_two$"
+```
+
+Setting `database` restricts ingestion to that single database; a wildcard such as `*` is not a valid
+value for `database` — use `database_pattern` for multi-database ingestion.
+
 #### Usage Statistics
 
 Set `include_usage_statistics: true` to derive usage statistics and query-based lineage from query


### PR DESCRIPTION
## Summary

- Two-tier sources (MySQL/MariaDB) already ingest **every** visible database when `database` is left unset, filtered by `database_pattern`, but this was not documented.
- Users set a single `database` and tried `*` to ingest multiple databases, which is not valid in that field.
- Add a "Multiple Databases" section to the MySQL and MariaDB connector docs explaining that `database_pattern` is the mechanism for selecting multiple databases.

## Test plan

- Docs-only change; `mdPrettierCheck` passes.