### PR TITLE
fix(ingest/sql-parsing): guard sqlglot FLATTEN crash when flattened column is unschema'd

### DIFF
--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -863,37 +863,49 @@ def _statement_risks_unnest_resolver_recursion(
     """Detect the sqlglot resolver infinite-recursion trigger (sqlglot >= 30.7.0).
 
     sqlglot's column Resolver recurses without a re-entrancy guard when it tries
-    to type a ``LATERAL FLATTEN`` / ``UNNEST`` of an *unqualified* column whose
-    base table is absent from the schema, while a schema is otherwise present:
-    typing the unnested column disambiguates it via ``get_table``, which
-    enumerates every source's columns, which re-enters the same lateral source.
-    In the compiled ``sqlglot[c]`` build this overflows the native C stack into
-    an uncatchable SIGSEGV that kills the whole ingest process. We cannot
+    to type a ``LATERAL FLATTEN`` / ``UNNEST`` of an *unqualified* column that it
+    cannot resolve to a known column, while a schema is otherwise present: typing
+    the unnested column disambiguates it via ``get_table``, which enumerates
+    every source's columns, which re-enters the same lateral source. In the
+    compiled ``sqlglot[c]`` build this overflows the native C stack into an
+    uncatchable SIGSEGV that kills the whole ingest process. We cannot
     monkeypatch the compiled resolver (mypyc dispatches its internal calls
     natively), so we detect the trigger here and skip column-level lineage,
     keeping table-level lineage.
 
-    The conditions mirror the confirmed trigger, so safe LATERAL FLATTENs
-    (qualified column, base table schema'd, or no schema at all) are unaffected.
+    The column is unresolvable whenever it is not a known column of any schema'd
+    source -- either because its base table is absent from the schema, or
+    because the base table is present but the flattened column itself is missing
+    from it (e.g. a semi-structured VARIANT/array column that was not surfaced).
+    The latter is what makes real Snowflake ``FLATTEN(tags)`` statements crash
+    even when the base table is otherwise schema'd. Safe LATERAL FLATTENs
+    (qualified column, flattened column present in a schema'd source, or no
+    schema at all) are unaffected.
     """
     mapping = getattr(schema, "mapping", None) or {}
     if not mapping:
         # No schema -> sqlglot skips the type-resolution path; safe.
         return False
 
-    def _is_known(table: sqlglot.exp.Table) -> bool:
+    # Columns known across every schema'd table referenced by the statement.
+    # Matched case-insensitively: sqlglot's resolver normalizes per dialect and
+    # DataHub normalizes column casing before this runs.
+    known_columns: Set[str] = set()
+    for table in statement.find_all(sqlglot.exp.Table):
         try:
-            return bool(schema.column_names(table))
+            columns = schema.column_names(table)
         except Exception:
-            return False
-
-    if not any(not _is_known(table) for table in statement.find_all(sqlglot.exp.Table)):
-        # Every referenced table is schema'd -> type resolves directly; safe.
-        return False
+            columns = []
+        known_columns.update(col.upper() for col in columns)
 
     for unnest in statement.find_all(sqlglot.exp.Lateral, sqlglot.exp.Unnest):
-        if any(not col.table for col in unnest.find_all(sqlglot.exp.Column)):
-            return True
+        for col in unnest.find_all(sqlglot.exp.Column):
+            # A qualified column (``t.items``) resolves directly and is safe. An
+            # unqualified column that is not a known column of any schema'd
+            # source is what the resolver cannot type without re-entering the
+            # lateral.
+            if not col.table and col.name.upper() not in known_columns:
+                return True
     return False
 
 

--- a/metadata-ingestion/tests/unit/sql_parsing/test_unnest_resolver_guard.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_unnest_resolver_guard.py
@@ -35,6 +35,16 @@ def test_detector_flags_unqualified_unnest_over_unschemad_table() -> None:
     assert _statement_risks_unnest_resolver_recursion(_parse(_SELECT), schema) is True
 
 
+def test_detector_flags_unqualified_unnest_when_flatten_column_missing() -> None:
+    # Regression: the flatten's base table IS schema'd, but the
+    # flattened column (`items`) is absent from that schema -- e.g. a
+    # semi-structured VARIANT/array column that was not surfaced. The resolver
+    # still cannot type the unqualified column, so it hits the same recursion.
+    # The original guard only checked table presence and missed this.
+    schema = _schema({"my_db": {"raw_schema": {"events": {"other_col": "STRING"}}}})
+    assert _statement_risks_unnest_resolver_recursion(_parse(_SELECT), schema) is True
+
+
 def test_detector_allows_safe_cases() -> None:
     schema = _schema({"MY_DB": {"ANALYTICS": {"USAGE_VIEW": {"OBJ_ID": "VARIANT"}}}})
     # qualified flatten column -> safe
@@ -79,5 +89,29 @@ def test_risky_unnest_skips_cll_without_crashing() -> None:
         result.in_tables
     )
     assert any("usage_view" in t.lower() for t in result.out_tables), result.out_tables
+    assert result.debug_info.table_error is None
+    assert "LATERAL FLATTEN" in str(result.debug_info.column_error)
+
+
+def test_risky_unnest_skips_cll_when_flatten_column_missing() -> None:
+    # Regression: end-to-end shape where the flatten's source table
+    # is present in the schema but the flattened column itself is absent. Without
+    # the fix this recurses -- a catchable RecursionError on pure-python
+    # sqlglot, but an uncatchable SIGSEGV that kills ingestion on sqlglot[c].
+    # The guard must skip CLL and keep table-level lineage instead.
+    resolver = SchemaResolver(platform="snowflake")
+    resolver.add_raw_schema_info(
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.raw_schema.events,PROD)",
+        {"OTHER_COL": "STRING"},  # note: no `items` column
+    )
+    result = sqlglot_lineage(
+        _SELECT,
+        schema_resolver=resolver,
+        default_db="my_db",
+        default_schema="raw_schema",
+    )
+    assert any("raw_schema.events" in t.lower() for t in result.in_tables), (
+        result.in_tables
+    )
     assert result.debug_info.table_error is None
     assert "LATERAL FLATTEN" in str(result.debug_info.column_error)


### PR DESCRIPTION
## Summary

The `LATERAL FLATTEN` / `UNNEST` resolver-recursion guard in `sqlglot_lineage.py` (added to stop a sqlglot >= 30.7.0 crash) only skipped column-level lineage when a referenced **table** was entirely absent from the schema. The same sqlglot resolver recursion also fires when the base table **is** schema'd but the **flattened column itself is missing** from it — e.g. a semi-structured VARIANT/array column that was not surfaced into the schema. Those statements slipped past the guard and crashed ingestion.

On the compiled `sqlglot[c]` build the recursion overflows the native C stack into an **uncatchable SIGSEGV that kills the whole ingest process** (no traceback); on pure-Python sqlglot it surfaces as a catchable `RecursionError` and the run degrades but completes. This is why a real Snowflake `FLATTEN(<variant_col>)` query could hard-crash ingestion even on CLI builds that already contained the original guard.

## What changed

- Broadened `_statement_risks_unnest_resolver_recursion` to flag any `LATERAL FLATTEN`/`UNNEST` of an **unqualified column that is not a known column of any schema'd source**, rather than only the missing-table case. The new condition is strictly broader than the old one (every previously-detected case still fires), so existing coverage is preserved.
- Table-level lineage is unaffected; only column-level lineage is skipped for the risky statement.

## Testing

- Added two regression tests (detector-level and end-to-end) for the "base table schema'd, flattened column missing" case.
- New tests fail before the fix (detector returns `False`; end-to-end recurses) and pass after.
- Verified under the compiled `sqlglot[c]` build that the previously-crashing end-to-end case now completes cleanly (skips CLL, keeps table lineage) instead of segfaulting.
- Full `tests/unit/sql_parsing/` suite passes with no regressions.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [ ] Docs — n/a (internal SQL-parsing robustness fix)
- [ ] Breaking changes — none