### PR TITLE
fix(mce-consumer): catch RejectedExecutionException in commitAndContinue

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -121,6 +121,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -1353,6 +1354,19 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                             if (txContext != null) {
                               try {
                                 txContext.commitAndContinue();
+                              } catch (RejectedExecutionException e) {
+                                log.warn(
+                                    "Post-commit cache notification failed (executor terminated),"
+                                        + " cache may serve stale data until TTL expiry",
+                                    e);
+                                opContext
+                                    .getMetricUtils()
+                                    .ifPresent(
+                                        metricUtils ->
+                                            metricUtils.increment(
+                                                EntityServiceImpl.class,
+                                                "post_commit_notify_rejected",
+                                                1));
                               } catch (EntityNotFoundException e) {
                                 if (e.getMessage() != null
                                     && e.getMessage().contains("No rows updated")) {


### PR DESCRIPTION
## Summary

- Ebean's `DefaultBackgroundExecutor` thread pool can terminate during pod shutdown while Kafka consumers are still draining in-flight batches
- The post-commit L2 cache notification throws `RejectedExecutionException`, which propagates uncaught through the transaction retry loop (`EbeanAspectDao.runInTransactionWithRetryUnlocked` only catches `PersistenceException`) into `BatchMetadataChangeProposalsProcessor.processBatch`, whose `catch (Throwable)` sends the entire batch to the FailedMCP dead-letter topic — **even though the MySQL commit already succeeded**
- This has caused ~39,600 phantom failures across multiple tenants since April 2025 (Sentry: [MCE-CONSUMER-2N](https://acryl-data.sentry.io/issues/6542949931/))

The fix catches `RejectedExecutionException` at the `commitAndContinue` call site in `EntityServiceImpl`, logs a warning, and emits a `post_commit_notify_rejected` metric. The L2 cache miss is benign — entries expire via TTL.

Fixes MCE-CONSUMER-2N