### PR TITLE
fix(ui): bake Alert action colors into the component and improve Butt…

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Alert/Alert.stories.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Alert/Alert.stories.tsx
@@ -5,13 +5,12 @@ import React from 'react';
 import { ThemeProvider } from 'styled-components';
 
 import { GridList } from '@components/.docs/mdx-components';
-import { Alert, VARIANT_BUTTON_COLOR_MAP } from '@components/components/Alert/Alert';
+import { Alert } from '@components/components/Alert/Alert';
 import { AlertVariant } from '@components/components/Alert/types';
-import { Button } from '@components/components/Button';
 
 import themes from '@conf/theme/themes';
 
-const VARIANTS: AlertVariant[] = ['success', 'error', 'warning', 'info', 'brand', 'unknown'];
+const VARIANTS: AlertVariant[] = ['success', 'error', 'warning', 'info', 'brand', 'gray'];
 
 const meta = {
     title: 'Components / Alert',
@@ -22,7 +21,7 @@ const meta = {
         badges: [BADGE.STABLE, 'readyForDesignReview'],
         docs: {
             subtitle:
-                'Inline status banner for surfacing success, error, warning, info, brand, or unknown messages within a page or panel. Colors come from semantic theme tokens — never pass hex values.',
+                'Inline status banner for surfacing success, error, warning, info, brand, or gray messages within a page or panel. Colors come from semantic theme tokens — never pass hex values. Action button color is derived from the alert variant automatically.',
         },
     },
 
@@ -71,9 +70,10 @@ const meta = {
             table: { type: { summary: '() => void' } },
         },
         action: {
-            description: 'Action element rendered on the right (e.g. a Retry button).',
+            description:
+                'Optional action button. Always rendered as a text button colored to match the alert variant — pass `{ label, onClick }`.',
             control: false,
-            table: { type: { summary: 'ReactNode' } },
+            table: { type: { summary: 'AlertAction' } },
         },
         actionPlacement: {
             description:
@@ -128,13 +128,7 @@ export const sandbox: StoryObj<SandboxArgs> = {
             {...props}
             actionPlacement={actionPlacement}
             onClose={showCloseButton ? () => {} : undefined}
-            action={
-                showAction ? (
-                    <Button variant="text" color={VARIANT_BUTTON_COLOR_MAP[props.variant]} size="sm">
-                        Retry
-                    </Button>
-                ) : undefined
-            }
+            action={showAction ? { label: 'Retry', onClick: () => {} } : undefined}
         />
     ),
 };
@@ -192,11 +186,7 @@ export const withAction = () => (
         variant="error"
         title="Connection lost"
         description="We could not reach the metadata service. Check your network and try again."
-        action={
-            <Button variant="text" color="red" size="sm">
-                Retry
-            </Button>
-        }
+        action={{ label: 'Retry', onClick: () => {} }}
     />
 );
 
@@ -206,11 +196,7 @@ export const topRightAction = () => (
             variant="info"
             title="Schema sync in progress"
             description="We are pulling the latest schema from the upstream warehouse."
-            action={
-                <Button variant="text" color="blue" size="sm">
-                    View progress
-                </Button>
-            }
+            action={{ label: 'View progress', onClick: () => {} }}
             actionPlacement="topRight"
             onClose={() => {
                 /* no-op for the story */
@@ -220,11 +206,7 @@ export const topRightAction = () => (
             variant="warning"
             title="Connection unstable"
             description="Some recent metadata may be stale."
-            action={
-                <Button variant="text" color="yellow" size="sm">
-                    Reconnect
-                </Button>
-            }
+            action={{ label: 'Reconnect', onClick: () => {} }}
             actionPlacement="topRight"
             onClose={() => {
                 /* no-op for the story */
@@ -248,11 +230,7 @@ export const kitchenSink = () => (
         title="Assertion run failed"
         description="The smart assertion encountered an error while executing against the Snowflake warehouse."
         errorMessage="SnowflakeQueryError: SQL compilation error: Object 'PROD.ANALYTICS.ORDERS' does not exist or not authorized."
-        action={
-            <Button variant="text" color="red" size="sm">
-                Retry
-            </Button>
-        }
+        action={{ label: 'Retry', onClick: () => {} }}
         onClose={() => {
             /* no-op for the story */
         }}

--- a/datahub-web-react/src/alchemy-components/components/Alert/Alert.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Alert/Alert.tsx
@@ -28,29 +28,30 @@ const DEFAULT_ICONS: Record<AlertVariant, React.ReactNode> = {
     warning: <WarningCircle size={20} weight="fill" />,
     info: <Info size={20} weight="fill" />,
     brand: <MegaphoneSimple size={20} weight="fill" />,
-    unknown: <Question size={20} weight="fill" />,
+    gray: <Question size={20} weight="fill" />,
 };
 
 /**
  * Mapping of Alert variant -> alchemy Button color, so that any in-Alert button
  * (close button, action slot) reads as the same hue as the surrounding banner.
  */
-export const VARIANT_BUTTON_COLOR_MAP: Record<AlertVariant, ColorOptions> = {
+const VARIANT_BUTTON_COLOR_MAP: Record<AlertVariant, ColorOptions> = {
     success: 'green',
     error: 'red',
     warning: 'yellow',
     info: 'blue',
     brand: 'primary',
-    unknown: 'gray',
+    gray: 'gray',
 };
 
 /**
- * Inline status banner for success, error, warning, info, brand, and unknown
+ * Inline status banner for success, error, warning, info, brand, and gray
  * messages. Layout is a header row (icon + title on the left, optional
  * topRight action + close button on the right) with description, errorMessage,
  * and inline actions stacked below the header at full content width.
  *
  * Colors are derived from semantic theme tokens based on the variant.
+ * Action and close buttons inherit the matching button color automatically.
  */
 export function Alert({
     variant,
@@ -67,10 +68,24 @@ export function Alert({
 }: AlertProps) {
     const { t: tc } = useTranslation('common.actions');
     const displayIcon = icon ?? DEFAULT_ICONS[variant];
+    const buttonColor = VARIANT_BUTTON_COLOR_MAP[variant];
     const showInlineAction = action && actionPlacement === 'inline';
     const showTopRightAction = action && actionPlacement === 'topRight';
     const hasHeaderRight = showTopRightAction || !!onClose;
     const hasBody = !!description || !!errorMessage || !!showInlineAction;
+
+    const actionButton = action ? (
+        <Button
+            variant="text"
+            color={buttonColor}
+            size="sm"
+            icon={action.icon}
+            onClick={action.onClick}
+            data-testid={action.dataTestId}
+        >
+            {action.label}
+        </Button>
+    ) : null;
 
     return (
         <AlertContainer
@@ -89,11 +104,11 @@ export function Alert({
                 </AlertHeaderLeft>
                 {hasHeaderRight && (
                     <AlertHeaderRight>
-                        {showTopRightAction && action}
+                        {showTopRightAction && actionButton}
                         {onClose && (
                             <Button
                                 variant="text"
-                                color={VARIANT_BUTTON_COLOR_MAP[variant]}
+                                color={buttonColor}
                                 type="button"
                                 aria-label={tc('close')}
                                 onClick={onClose}
@@ -108,7 +123,7 @@ export function Alert({
                 <AlertBody>
                     {description && <Text size="md">{description}</Text>}
                     {errorMessage && <AlertErrorMessage>{errorMessage}</AlertErrorMessage>}
-                    {showInlineAction && <AlertActions>{action}</AlertActions>}
+                    {showInlineAction && <AlertActions>{actionButton}</AlertActions>}
                 </AlertBody>
             )}
         </AlertContainer>

--- a/datahub-web-react/src/alchemy-components/components/Alert/__tests__/Alert.test.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Alert/__tests__/Alert.test.tsx
@@ -43,21 +43,25 @@ describe('Alert', () => {
         expect(screen.queryByText('All changes saved.')).not.toBeInTheDocument();
     });
 
-    it('should render an action element when provided', () => {
+    it('should render an action button when provided', () => {
+        const onClick = vi.fn();
         renderAlert({
             title: 'Error',
             variant: 'error',
-            action: <button type="button">Retry</button>,
+            action: { label: 'Retry', onClick },
         });
 
-        expect(screen.getByText('Retry')).toBeInTheDocument();
+        const retryButton = screen.getByRole('button', { name: 'Retry' });
+        expect(retryButton).toBeInTheDocument();
+        fireEvent.click(retryButton);
+        expect(onClick).toHaveBeenCalledOnce();
     });
 
     it('should still render the action when actionPlacement is "topRight"', () => {
         renderAlert({
             title: 'Error',
             variant: 'error',
-            action: <button type="button">Retry</button>,
+            action: { label: 'Retry', onClick: () => {} },
             actionPlacement: 'topRight',
             onClose: () => {},
         });
@@ -83,7 +87,7 @@ describe('Alert', () => {
         expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
     });
 
-    it.each<AlertVariant>(['success', 'error', 'warning', 'info', 'brand', 'unknown'])(
+    it.each<AlertVariant>(['success', 'error', 'warning', 'info', 'brand', 'gray'])(
         'should render without errors for variant "%s"',
         (variant) => {
             const { container } = renderAlert({ variant, title: `${variant} alert` });

--- a/datahub-web-react/src/alchemy-components/components/Alert/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/Alert/components.ts
@@ -10,7 +10,7 @@ const VARIANT_THEME_MAP: Record<AlertVariant, { bg: string; text: string; icon: 
     warning: { bg: 'bgSurfaceWarning', text: 'textWarning', icon: 'iconWarning' },
     info: { bg: 'bgSurfaceInfo', text: 'textInformation', icon: 'iconInformation' },
     brand: { bg: 'bgSurfaceBrand', text: 'textBrand', icon: 'iconBrand' },
-    unknown: { bg: 'bgSurface', text: 'textSecondary', icon: 'icon' },
+    gray: { bg: 'bgSurface', text: 'textSecondary', icon: 'icon' },
 };
 
 // Outer container is a vertical stack: header row, then description, errorMessage,

--- a/datahub-web-react/src/alchemy-components/components/Alert/index.ts
+++ b/datahub-web-react/src/alchemy-components/components/Alert/index.ts
@@ -1,2 +1,2 @@
 export { Alert } from './Alert';
-export type { AlertProps, AlertVariant } from './types';
+export type { AlertAction, AlertProps, AlertVariant } from './types';

--- a/datahub-web-react/src/alchemy-components/components/Alert/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Alert/types.ts
@@ -1,7 +1,16 @@
 import React from 'react';
 
+import { IconProps } from '@components/components/Icon/types';
+
 /** Supported visual variants for the Alert component */
-export type AlertVariant = 'success' | 'error' | 'warning' | 'info' | 'brand' | 'unknown';
+export type AlertVariant = 'success' | 'error' | 'warning' | 'info' | 'brand' | 'gray';
+
+export interface AlertAction {
+    label: string;
+    onClick: () => void;
+    icon?: IconProps;
+    dataTestId?: string;
+}
 
 export interface AlertProps {
     /** Visual style variant determining colors and default icon */
@@ -16,8 +25,12 @@ export interface AlertProps {
     icon?: React.ReactNode;
     /** Show a close/dismiss button */
     onClose?: () => void;
-    /** Additional action element rendered on the right */
-    action?: React.ReactNode;
+    /**
+     * Optional action button. Always rendered as a text button whose color
+     * matches the alert variant (e.g. success → green). Callers only pass
+     * label/onClick — no button variant or color to choose.
+     */
+    action?: AlertAction;
     /**
      * Where to render the `action` element.
      * - `'inline'` (default): under the description, inside the content column.

--- a/datahub-web-react/src/alchemy-components/components/Button/Button.stories.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Button/Button.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { GridList } from '@components/.docs/mdx-components';
 import { ButtonVariantValues } from '@components/components/Button/types';
 import { MATERIAL_UI_ICONS } from '@components/components/Icon/constants';
-import { SizeValues } from '@components/theme/config';
+import { ColorValues, SizeValues } from '@components/theme/config';
 
 import { Button, buttonDefaults } from '.';
 
@@ -45,7 +45,7 @@ const meta = {
         },
         color: {
             description: 'The color of the Button.',
-            options: ['violet', 'green', 'red', 'gray'],
+            options: Object.values(ColorValues).filter((c) => c !== 'black' && c !== 'white'),
             table: {
                 defaultValue: { summary: buttonDefaults.color },
             },
@@ -173,10 +173,12 @@ export const states = () => (
 
 export const colors = () => (
     <GridList>
-        <Button>Violet Button</Button>
+        <Button>Primary Button</Button>
+        <Button color="violet">Violet Button</Button>
         <Button color="green">Green Button</Button>
         <Button color="red">Red Button</Button>
         <Button color="blue">Blue Button</Button>
+        <Button color="yellow">Yellow Button</Button>
         <Button color="gray">Gray Button</Button>
     </GridList>
 );

--- a/datahub-web-react/src/alchemy-components/components/Button/utils.ts
+++ b/datahub-web-react/src/alchemy-components/components/Button/utils.ts
@@ -23,15 +23,98 @@ interface ColorStyles {
     disabledTextColor: string;
 }
 
+/**
+ * Foreground color for text / outline / link / secondary buttons.
+ * Uses semantic theme tokens (same ones Alert titles use) so status colors
+ * stay readable on tinted surfaces — foundation shade 500 is often too light
+ * (e.g. green[500] #77B750 vs textSuccess #0D7543).
+ */
+const getSemanticForegroundColor = (color: ColorOptions, theme: Theme): string | undefined => {
+    const themeColors = theme?.colors;
+    if (!themeColors) return undefined;
+
+    switch (color) {
+        case 'green':
+            return themeColors.textSuccess;
+        case 'red':
+            return themeColors.textError;
+        case 'blue':
+            return themeColors.textInformation;
+        case 'yellow':
+            return themeColors.textWarning;
+        case 'primary':
+        case 'violet':
+            return themeColors.textBrand ?? themeColors.buttonFillBrand;
+        case 'gray':
+            return themeColors.textSecondary;
+        default:
+            return undefined;
+    }
+};
+
+/**
+ * Soft surface backgrounds for secondary buttons, matched to the button color
+ * (same semantic surfaces Alert banners use). Brand/primary keep the violet
+ * brand surfaces; other colors previously incorrectly inherited those too.
+ */
+const getSecondarySurfaceColors = (
+    color: ColorOptions,
+    theme: Theme,
+): Pick<ColorStyles, 'bgColor' | 'hoverBgColor' | 'activeBgColor'> => {
+    const themeColors = theme?.colors;
+
+    switch (color) {
+        case 'green':
+            return {
+                bgColor: themeColors?.bgSurfaceSuccess ?? getColor('green', 0, theme),
+                hoverBgColor: themeColors?.bgSurfaceSuccessHover ?? getColor('green', 100, theme),
+                activeBgColor: themeColors?.bgSurfaceSuccessHover ?? getColor('green', 100, theme),
+            };
+        case 'red':
+            return {
+                bgColor: themeColors?.bgSurfaceError ?? getColor('red', 0, theme),
+                hoverBgColor: themeColors?.bgSurfaceErrorHover ?? getColor('red', 100, theme),
+                activeBgColor: themeColors?.bgSurfaceErrorHover ?? getColor('red', 100, theme),
+            };
+        case 'blue':
+            return {
+                bgColor: themeColors?.bgSurfaceInfo ?? getColor('blue', 0, theme),
+                hoverBgColor: themeColors?.bgSurfaceInformationHover ?? getColor('blue', 100, theme),
+                activeBgColor: themeColors?.bgSurfaceInformationHover ?? getColor('blue', 100, theme),
+            };
+        case 'yellow':
+            return {
+                bgColor: themeColors?.bgSurfaceWarning ?? getColor('yellow', 0, theme),
+                hoverBgColor: themeColors?.bgSurfaceWarningHover ?? getColor('yellow', 100, theme),
+                activeBgColor: themeColors?.bgSurfaceWarningHover ?? getColor('yellow', 100, theme),
+            };
+        case 'gray':
+            return {
+                bgColor: themeColors?.bgSurface ?? getColor('gray', 100, theme),
+                hoverBgColor: themeColors?.bgHover ?? getColor('gray', 100, theme),
+                activeBgColor: themeColors?.bgActive ?? getColor('gray', 200, theme),
+            };
+        case 'primary':
+        case 'violet':
+        default:
+            return {
+                bgColor: themeColors?.bgSurfaceBrand ?? getColor('violet', 0, theme),
+                hoverBgColor: themeColors?.bgSurfaceBrandHover ?? getColor('violet', 100, theme),
+                activeBgColor: themeColors?.buttonSurfaceBrandFocus ?? getColor('violet', 200, theme),
+            };
+    }
+};
+
 // Utility function to get color styles for button - does not generate CSS
 const getButtonColorStyles = (variant: ButtonVariant, color: ColorOptions, theme: Theme): ColorStyles => {
     const isViolet = color === 'violet';
     const isPrimary = isViolet || color === 'primary';
-    // Brand (primary/violet) buttons must follow the configurable CI brand color rather than the
-    // static foundation ramp. buttonFillBrand is the solid brand color that pairs with brandGradient,
-    // and it drives the filled-variant border plus the text/outline/link text color.
+    // Brand (primary/violet) filled buttons must follow the configurable CI brand color rather
+    // than the static foundation ramp. buttonFillBrand pairs with brandGradient.
     const color500 =
         isPrimary && theme?.colors?.buttonFillBrand ? theme.colors.buttonFillBrand : getColor(color, 500, theme); // value of 500 shade
+    // Readable on-surface color for non-filled variants (matches Alert / banner text).
+    const foregroundColor = getSemanticForegroundColor(color, theme) ?? color500;
 
     const base = {
         // Backgrounds
@@ -68,8 +151,8 @@ const getButtonColorStyles = (variant: ButtonVariant, color: ColorOptions, theme
         return {
             ...base,
             bgColor: 'transparent',
-            borderColor: color500,
-            textColor: color500,
+            borderColor: foregroundColor,
+            textColor: foregroundColor,
 
             hoverBgColor: getColor(color, 100, theme),
             activeBgColor: isViolet ? getColor(color, 100, theme) : getColor(color, 200, theme),
@@ -82,7 +165,7 @@ const getButtonColorStyles = (variant: ButtonVariant, color: ColorOptions, theme
     if (variant === 'text') {
         return {
             ...base,
-            textColor: color500,
+            textColor: foregroundColor,
 
             bgColor: 'transparent',
             borderColor: 'transparent',
@@ -95,12 +178,13 @@ const getButtonColorStyles = (variant: ButtonVariant, color: ColorOptions, theme
 
     // Override styles for secondary variant
     if (variant === 'secondary') {
+        const secondarySurfaces = getSecondarySurfaceColors(color, theme);
         return {
             ...base,
-            bgColor: theme?.colors?.bgSurfaceBrand ?? getColor('violet', 0, theme),
-            hoverBgColor: theme?.colors?.bgSurfaceBrandHover ?? getColor('violet', 100, theme),
-            activeBgColor: theme?.colors?.buttonSurfaceBrandFocus ?? getColor('violet', 200, theme),
-            textColor: color500,
+            bgColor: secondarySurfaces.bgColor,
+            hoverBgColor: secondarySurfaces.hoverBgColor,
+            activeBgColor: secondarySurfaces.activeBgColor,
+            textColor: foregroundColor,
             borderColor: 'transparent',
             disabledBgColor: 'transparent',
             disabledBorderColor: 'transparent',
@@ -111,7 +195,7 @@ const getButtonColorStyles = (variant: ButtonVariant, color: ColorOptions, theme
     if (variant === 'link') {
         return {
             ...base,
-            textColor: color500,
+            textColor: foregroundColor,
             bgColor: 'transparent',
             borderColor: 'transparent',
             activeBgColor: 'transparent',


### PR DESCRIPTION

<img width="974" height="139" alt="Screenshot 2026-07-09 at 4 14 04 PM" src="https://github.com/user-attachments/assets/79cd1a2a-b8c1-44fe-83fd-1f300b968207" />
<img width="967" height="101" alt="Screenshot 2026-07-09 at 4 14 59 PM" src="https://github.com/user-attachments/assets/1f83898c-ce93-4682-bc05-d2158d7485c2" />
<img width="966" height="129" alt="Screenshot 2026-07-09 at 4 14 53 PM" src="https://github.com/user-attachments/assets/0ef8c132-b943-4d7f-ad25-f9dd88c1ee7e" />
<img width="976" height="141" alt="Screenshot 2026-07-09 at 4 14 47 PM" src="https://github.com/user-attachments/assets/8c6fc8ca-d27d-4d86-806e-69cfbaeefed6" />
<img width="972" height="97" alt="Screenshot 2026-07-09 at 4 14 39 PM" src="https://github.com/user-attachments/assets/74c10d65-61f5-434f-8af7-c7b43a32e069" />
<img width="987" height="101" alt="Screenshot 2026-07-09 at 4 14 32 PM" src="https://github.com/user-attachments/assets/06cde4ec-1ccd-4d59-91af-3fd428be0a5e" />
<img width="971" height="134" alt="Screenshot 2026-07-09 at 4 14 28 PM" src="https://github.com/user-attachments/assets/a7354df6-9b89-495e-932e-08cf7e719506" />


Alert actions now always render as text buttons colored from the alert variant (success→green, etc.), and unknown was renamed to gray. Button text/outline/link use semantic text tokens for readable contrast, and secondary surfaces match each color instead of always using brand violet.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
