### PR TITLE
feat(metadata-models): add lineage support to semanticModel entity

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/autogenerated/lineage.json
+++ b/metadata-ingestion/src/datahub/ingestion/autogenerated/lineage.json
@@ -169,6 +169,25 @@
         ]
       }
     },
+    "semanticModel": {
+      "upstreamLineage": {
+        "aspect": "upstreamLineage",
+        "fields": [
+          {
+            "name": "dataset",
+            "path": "upstreams.dataset",
+            "isLineage": true,
+            "relationship": {
+              "name": "DownstreamOf",
+              "entityTypes": [
+                "dataset"
+              ],
+              "isLineage": true
+            }
+          }
+        ]
+      }
+    },
     "chart": {
       "chartInfo": {
         "aspect": "chartInfo",
@@ -269,6 +288,23 @@
       }
     },
     "metric": {
+      "metricInfo": {
+        "aspect": "metricInfo",
+        "fields": [
+          {
+            "name": "semanticModel",
+            "path": "semanticModel",
+            "isLineage": true,
+            "relationship": {
+              "name": "ModeledBy",
+              "entityTypes": [
+                "semanticModel"
+              ],
+              "isLineage": true
+            }
+          }
+        ]
+      },
       "metricUpstreams": {
         "aspect": "metricUpstreams",
         "fields": [
@@ -434,5 +470,5 @@
     }
   },
   "generated_by": "metadata-ingestion/scripts/modeldocgen.py",
-  "generated_at": "2026-07-07T21:00:47.994417+00:00"
+  "generated_at": "2026-07-10T00:23:09.000683+00:00"
 }

--- a/metadata-models/docs/entities/metric.md
+++ b/metadata-models/docs/entities/metric.md
@@ -34,9 +34,11 @@ Core metadata is stored in the `metricInfo` aspect:
 - **`aiContext`** — optional hints for AI/LLM consumers: synonyms, natural-language instructions,
   few-shot examples, and custom instructions.
 - **`semanticModel`** -- URN of the `semanticModel` entity that defines this metric's
-  dimensional context. Optional: null when the metric
-  was ingested without a semantic model context (e.g. thin catalog-only metrics from BI
-  tools like Tableau) or is a native / SDK-authored metric awaiting a model.
+  dimensional context. Optional: null when the metric was ingested without a semantic model
+  context (e.g. thin catalog-only metrics from BI tools like Tableau) or is a native /
+  SDK-authored metric awaiting a model. The `ModeledBy` relationship on this field carries
+  `isLineage: true`, so when `semanticModel` is populated the metric automatically appears as a
+  downstream node in the semantic model's lineage explorer — no additional lineage MCPs are needed.
 
 ### Metric Relationships
 
@@ -60,20 +62,19 @@ The metric entity reuses these standard governance aspects: `ownership`, `domain
 
 ## Relationships with Other Entities
 
-| Relationship           | Direction | Target entity   | Aspect / edge name                 |
-| ---------------------- | --------- | --------------- | ---------------------------------- |
-| ModeledBy              | outbound  | `semanticModel` | `metricInfo`                       |
-| IsPartOf               | outbound  | `metric`        | `metricRelationships`              |
-| DerivedFrom            | outbound  | `metric`        | `metricRelationships`              |
-| RelatedTo              | outbound  | `metric`        | `metricRelationships`              |
-| Consumes (dataset)     | outbound  | `dataset`       | `metricUpstreams.datasetUpstreams` |
-| Consumes (schemaField) | outbound  | `schemaField`   | `metricUpstreams.fieldUpstreams`   |
+| Relationship           | Direction | Target entity   | Aspect / edge name                 | Lineage? |
+| ---------------------- | --------- | --------------- | ---------------------------------- | -------- |
+| ModeledBy              | outbound  | `semanticModel` | `metricInfo`                       | yes      |
+| IsPartOf               | outbound  | `metric`        | `metricRelationships`              | no       |
+| DerivedFrom            | outbound  | `metric`        | `metricRelationships`              | yes      |
+| RelatedTo              | outbound  | `metric`        | `metricRelationships`              | no       |
+| Consumes (dataset)     | outbound  | `dataset`       | `metricUpstreams.datasetUpstreams` | yes      |
+| Consumes (schemaField) | outbound  | `schemaField`   | `metricUpstreams.fieldUpstreams`   | yes      |
 
-Metric-to-dataset and metric-to-column lineage are carried by the dedicated
-`metricUpstreams` aspect. `datasetUpstreams` and `fieldUpstreams` are independently
-optional so ingestion sources can populate whichever granularity they can extract.
-Metric-to-metric derivation lineage lives on `metricRelationships.derivedFrom` and is
-not folded into `metricUpstreams`.
+Metric-to-dataset and metric-to-column lineage are carried by the dedicated `metricUpstreams`
+aspect. `datasetUpstreams` and `fieldUpstreams` are independently optional so ingestion sources
+can populate whichever granularity they can extract. Metric-to-metric derivation lineage lives on
+`metricRelationships.derivedFrom` and is not folded into `metricUpstreams`.
 
 ## Notable Exceptions
 

--- a/metadata-models/docs/entities/semanticModel.md
+++ b/metadata-models/docs/entities/semanticModel.md
@@ -59,15 +59,31 @@ DataHub represents these using the `query` entity:
 Each `ModelDataset` entry can carry a list of `SemanticField` records that describe the columns
 exposed by the semantic model:
 
+- **`schemaField`** — required inline `SchemaField` that gives this field its identity and
+  governance surface. The `fieldPath` inside it becomes the field-path component of the
+  `urn:li:schemaField:(<semanticModelUrn>,<fieldPath>)` URN used for column-level lineage edges.
 - **`type`** — required `SemanticFieldType` enum identifying the kind of field: `DIMENSION` (grouping /
   filtering attribute), `MEASURE` (aggregatable numeric value), `FILTER` (named boolean predicate),
   or `OTHER` (forward-compat escape hatch for source constructs that do not map cleanly to the
   three named kinds).
-- **`name`** — the field name as used in metric expressions.
 - **`expression`** — the underlying SQL expression(s) in one or more dialects.
 - **`dimension`** — optional `Dimension` record; populated only when `type == DIMENSION`. Currently
   exposes `isTime: boolean` to flag time dimensions used for date-range filtering.
 - **`aiContext`** — AI hints specific to this field.
+
+### Lineage
+
+Semantic models support both table-level and column-level lineage via the `upstreamLineage` aspect,
+the same aspect used by datasets.
+
+**Table-level upstream lineage** — populate `upstreamLineage.upstreams` with one `Upstream` entry
+per source table or query.
+
+**Column-level lineage** — populate `upstreamLineage.fineGrainedLineages` with `FineGrainedLineage`
+records.
+
+**Metrics as downstream nodes** — metrics that declare `metricInfo.semanticModel` pointing at this
+entity automatically appear as downstream nodes in the lineage explorer.
 
 ### Governance
 
@@ -81,11 +97,12 @@ The semantic model entity reuses these standard governance aspects: `ownership`,
 | Relationship | Direction | Target entity      | Aspect / edge name  |
 | ------------ | --------- | ------------------ | ------------------- |
 | SourcedBy    | outbound  | `dataset`, `query` | `semanticModelInfo` |
+| UpstreamOf   | outbound  | `dataset`, `query` | `upstreamLineage`   |
 | ModeledBy    | inbound   | `metric`           | `metricInfo`        |
 
-The `SourcedBy` edges are derived from the `datasets[].source` URN fields in `semanticModelInfo`,
-so every referenced dataset or query automatically appears as an upstream dependency in the
-lineage graph.
+The `SourcedBy` edges are derived from the `datasets[].source` URN fields in `semanticModelInfo`.
+The `upstreamLineage` aspect provides the full lineage graph traversal path (table-level and
+column-level), so both upstream sources and downstream metrics appear in the lineage explorer.
 
 ## Notable Exceptions
 

--- a/metadata-models/src/main/pegasus/com/linkedin/metric/MetricInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metric/MetricInfo.pdl
@@ -7,7 +7,8 @@ import com.linkedin.common.Urn
  * Core information about a Metric entity.
  */
 @Aspect = {
-  "name": "metricInfo"
+  "name": "metricInfo",
+  "schemaVersion": 2
 }
 record MetricInfo {
 
@@ -65,7 +66,8 @@ record MetricInfo {
    */
   @Relationship = {
     "name": "ModeledBy",
-    "entityTypes": [ "semanticModel" ]
+    "entityTypes": [ "semanticModel" ],
+    "isLineage": true
   }
   @Searchable = {
     "fieldName": "semanticModel",

--- a/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
@@ -2,6 +2,7 @@ namespace com.linkedin.semanticmodel
 
 import com.linkedin.metric.AiContext
 import com.linkedin.metric.MetricExpression
+import com.linkedin.schema.SchemaField
 
 /**
  * A named field defined inside a `SemanticModel` dataset (dimension, measure, filter, or other).
@@ -10,9 +11,12 @@ import com.linkedin.metric.MetricExpression
 record SemanticField {
 
   /**
-   * The name of this field as exposed by the semantic layer.
+   * Inline SchemaField describing this field's schema and identity.
+   * Its `fieldPath` composes into `urn:li:schemaField:(<parentSemanticModelUrn>,<fieldPath>)`,
+   * which serves as the endpoint for column-level lineage edges and as the anchor for
+   * column-level governance (tags, glossary terms, description).
    */
-  name: string
+  schemaField: SchemaField
 
   /**
    * The kind of this field. Must be set for every field; determines how downstream tools

--- a/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
@@ -11,9 +11,7 @@ import com.linkedin.schema.SchemaField
 record SemanticField {
 
   /**
-   * Inline SchemaField describing this field's schema and identity.
-   * Its `fieldPath` composes into `urn:li:schemaField:(<parentSemanticModelUrn>,<fieldPath>)`,
-   * which serves as the endpoint for column-level lineage edges and as the anchor for
+   * Inline SchemaField describing this field's schema and identity for column-level lineage edges and as the anchor for
    * column-level governance (tags, glossary terms, description).
    */
   schemaField: SchemaField

--- a/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticModelInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticModelInfo.pdl
@@ -7,7 +7,8 @@ import com.linkedin.metric.AiContext
  * Core information about a SemanticModel entity.
  */
 @Aspect = {
-  "name": "semanticModelInfo"
+  "name": "semanticModelInfo",
+  "schemaVersion": 2
 }
 record SemanticModelInfo {
 

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -695,6 +695,7 @@ entities:
     searchGroup: primary
     aspects:
       - semanticModelInfo
+      - upstreamLineage
       - ownership
       - domains
       - globalTags

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/graph/LineageGraphFiltersTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/graph/LineageGraphFiltersTest.java
@@ -48,7 +48,8 @@ public class LineageGraphFiltersTest {
             "chart",
             "dashboard",
             "mlPrimaryKey",
-            "metric"));
+            "metric",
+            "semanticModel"));
     assertNull(filters.getAllowedRelationshipTypes());
     assertTrue(filters.getEdgesPerEntityType().isEmpty());
 


### PR DESCRIPTION
This PR extends the semanticModel and metric data models to fully support lineage in the DataHub lineage explorer. Both table-level/column-level upstream lineage on semantic models, and metric-as-downstream-node lineage off the ModeledBy edge.

**SemanticField:** replace `name: string` with `schemaField: SchemaField` — each field now embeds a SchemaField record (mirroring the InputField pattern) whose fieldPath becomes the field-path component of the urn:li:schemaField:(<semanticModelUrn>,<fieldPath>) URN. This URN is the endpoint for column-level fineGrainedLineage edges and serves as the anchor for column-level governance (tags, glossary terms, description). The standalone name field is dropped to avoid duplication with schemaField.fieldPath. SemanticModelInfo receives an implicit schema version bump.

Register `upstreamLineage` on the `semanticModel` entity — adds the aspect to entity-registry.yml. No PDL change to UpstreamLineage.pdl is needed: Upstream.dataset accepts any URN (including urn:li:query:... for inline-SQL sources), and FineGrainedLineage.upstreams/downstreams already accept urn:li:schemaField:... with any parent entity. The ingestion SDK can now emit upstreamLineage MCPs against semantic model URNs using the same payload shape as datasets.

**MetricInfo.semanticModel:** `set isLineage: true` on `@Relationship` — the existing `ModeledBy` edge is promoted to a lineage edge. Any metric that populates metricInfo.semanticModel will automatically appear as a downstream node in the semantic model's lineage explorer, with no additional MCP emissions required from the metric side.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
