### PR TITLE
feat(ece): Add source details to attribution ece parameters

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/ChangeEventParameterUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/ChangeEventParameterUtils.java
@@ -1,12 +1,11 @@
 package com.linkedin.metadata.timeline.data.entity;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.common.MetadataAttribution;
+import io.datahubproject.metadata.context.ObjectMapperContext;
 import javax.annotation.Nullable;
 
 /** Helpers for building ChangeEvent parameter maps shared across entity change events. */
 public class ChangeEventParameterUtils {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final String EMPTY_JSON = "{}";
 
   private ChangeEventParameterUtils() {}
@@ -20,6 +19,6 @@ public class ChangeEventParameterUtils {
     if (attribution == null) {
       return EMPTY_JSON;
     }
-    return OBJECT_MAPPER.valueToTree(attribution.getSourceDetail()).toString();
+    return ObjectMapperContext.defaultMapper.valueToTree(attribution.getSourceDetail()).toString();
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/ChangeEventParameterUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/ChangeEventParameterUtils.java
@@ -1,0 +1,25 @@
+package com.linkedin.metadata.timeline.data.entity;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.common.MetadataAttribution;
+import javax.annotation.Nullable;
+
+/** Helpers for building ChangeEvent parameter maps shared across entity change events. */
+public class ChangeEventParameterUtils {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final String EMPTY_JSON = "{}";
+
+  private ChangeEventParameterUtils() {}
+
+  /**
+   * Serialize a MetadataAttribution's sourceDetail map to a JSON string, so propagation consumers
+   * can read attribution details (origin, direction, depth, ...) off the emitted ECE. Returns "{}"
+   * when attribution is absent.
+   */
+  public static String serializeSourceDetail(@Nullable final MetadataAttribution attribution) {
+    if (attribution == null) {
+      return EMPTY_JSON;
+    }
+    return OBJECT_MAPPER.valueToTree(attribution.getSourceDetail()).toString();
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/GlossaryTermChangeEvent.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/GlossaryTermChangeEvent.java
@@ -1,11 +1,12 @@
 package com.linkedin.metadata.timeline.data.entity;
 
+import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.GlossaryTermAssociation;
 import com.linkedin.metadata.timeline.data.ChangeCategory;
 import com.linkedin.metadata.timeline.data.ChangeEvent;
 import com.linkedin.metadata.timeline.data.ChangeOperation;
 import com.linkedin.metadata.timeline.data.SemanticChangeType;
-import java.util.Map;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -23,18 +24,34 @@ public class GlossaryTermChangeEvent extends ChangeEvent {
       ChangeCategory category,
       ChangeOperation operation,
       String modifier,
-      Map<String, Object> parameters,
       AuditStamp auditStamp,
       SemanticChangeType semVerChange,
-      String description) {
+      String description,
+      GlossaryTermAssociation glossaryTermAssociation) {
     super(
         entityUrn,
         category,
         operation,
         modifier,
-        parameters,
+        buildParameters(glossaryTermAssociation),
         auditStamp,
         semVerChange,
         description);
+  }
+
+  private static ImmutableMap<String, Object> buildParameters(
+      GlossaryTermAssociation glossaryTermAssociation) {
+    return new ImmutableMap.Builder<String, Object>()
+        .put("termUrn", glossaryTermAssociation.getUrn().toString())
+        .put(
+            "context",
+            glossaryTermAssociation.getContext() != null
+                ? glossaryTermAssociation.getContext()
+                : "{}")
+        .put(
+            "sourceDetails",
+            ChangeEventParameterUtils.serializeSourceDetail(
+                glossaryTermAssociation.getAttribution()))
+        .build();
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/OwnerChangeEvent.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/OwnerChangeEvent.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.timeline.data.entity;
 
 import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.MetadataAttribution;
 import com.linkedin.common.OwnershipType;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.timeline.data.ChangeCategory;
@@ -28,20 +29,21 @@ public class OwnerChangeEvent extends ChangeEvent {
       String description,
       Urn ownerUrn,
       OwnershipType ownerType,
-      Urn ownerTypeUrn) {
+      Urn ownerTypeUrn,
+      MetadataAttribution attribution) {
     super(
         entityUrn,
         category,
         operation,
         modifier,
-        buildParameters(ownerUrn, ownerType, ownerTypeUrn),
+        buildParameters(ownerUrn, ownerType, ownerTypeUrn, attribution),
         auditStamp,
         semVerChange,
         description);
   }
 
   private static ImmutableMap<String, Object> buildParameters(
-      Urn ownerUrn, OwnershipType ownerType, Urn ownerTypeUrn) {
+      Urn ownerUrn, OwnershipType ownerType, Urn ownerTypeUrn, MetadataAttribution attribution) {
     ImmutableMap.Builder<String, Object> builder =
         new ImmutableMap.Builder<String, Object>()
             .put("ownerUrn", ownerUrn.toString())
@@ -49,6 +51,7 @@ public class OwnerChangeEvent extends ChangeEvent {
     if (ownerTypeUrn != null) {
       builder.put("ownerTypeUrn", ownerTypeUrn.toString());
     }
+    builder.put("sourceDetails", ChangeEventParameterUtils.serializeSourceDetail(attribution));
 
     return builder.build();
   }

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/StructuredPropertyAssignmentChangeEvent.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/StructuredPropertyAssignmentChangeEvent.java
@@ -66,10 +66,13 @@ public class StructuredPropertyAssignmentChangeEvent extends ChangeEvent {
               }
             });
 
-    ImmutableMap.Builder<String, Object> builder =
-        new ImmutableMap.Builder<String, Object>()
-            .put("propertyUrn", structuredPropertyValueAssignment.getPropertyUrn().toString())
-            .put("propertyValues", arrayNode.toString());
-    return builder.build();
+    return new ImmutableMap.Builder<String, Object>()
+        .put("propertyUrn", structuredPropertyValueAssignment.getPropertyUrn().toString())
+        .put("propertyValues", arrayNode.toString())
+        .put(
+            "sourceDetails",
+            ChangeEventParameterUtils.serializeSourceDetail(
+                structuredPropertyValueAssignment.getAttribution()))
+        .build();
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/TagChangeEvent.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/TagChangeEvent.java
@@ -1,11 +1,12 @@
 package com.linkedin.metadata.timeline.data.entity;
 
+import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.TagAssociation;
 import com.linkedin.metadata.timeline.data.ChangeCategory;
 import com.linkedin.metadata.timeline.data.ChangeEvent;
 import com.linkedin.metadata.timeline.data.ChangeOperation;
 import com.linkedin.metadata.timeline.data.SemanticChangeType;
-import java.util.Map;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -23,18 +24,28 @@ public class TagChangeEvent extends ChangeEvent {
       ChangeCategory category,
       ChangeOperation operation,
       String modifier,
-      Map<String, Object> parameters,
       AuditStamp auditStamp,
       SemanticChangeType semVerChange,
-      String description) {
+      String description,
+      TagAssociation tagAssociation) {
     super(
         entityUrn,
         category,
         operation,
         modifier,
-        parameters,
+        buildParameters(tagAssociation),
         auditStamp,
         semVerChange,
         description);
+  }
+
+  private static ImmutableMap<String, Object> buildParameters(TagAssociation tagAssociation) {
+    return new ImmutableMap.Builder<String, Object>()
+        .put("tagUrn", tagAssociation.getTag().toString())
+        .put("context", tagAssociation.getContext() != null ? tagAssociation.getContext() : "{}")
+        .put(
+            "sourceDetails",
+            ChangeEventParameterUtils.serializeSourceDetail(tagAssociation.getAttribution()))
+        .build();
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/GlobalTagsChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/GlobalTagsChangeEventGenerator.java
@@ -3,7 +3,6 @@ package com.linkedin.metadata.timeline.eventgenerator;
 import static com.linkedin.metadata.Constants.*;
 
 import com.datahub.util.RecordUtils;
-import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.GlobalTags;
 import com.linkedin.common.TagAssociation;
@@ -20,7 +19,6 @@ import jakarta.json.JsonPatch;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nonnull;
 
 public class GlobalTagsChangeEventGenerator extends EntityChangeEventGenerator<GlobalTags> {
@@ -55,12 +53,6 @@ public class GlobalTagsChangeEventGenerator extends EntityChangeEventGenerator<G
         ++targetTagIdx;
       } else if (comparison < 0) {
         // Tag got removed.
-        Map<String, Object> parameters =
-            ImmutableMap.of(
-                "tagUrn",
-                baseTagAssociation.getTag().toString(),
-                "context",
-                baseTagAssociation.getContext() != null ? baseTagAssociation.getContext() : "{}");
         changeEvents.add(
             TagChangeEvent.entityTagChangeEventBuilder()
                 .modifier(baseTagAssociation.getTag().toString())
@@ -71,20 +63,12 @@ public class GlobalTagsChangeEventGenerator extends EntityChangeEventGenerator<G
                 .description(
                     String.format(
                         TAG_REMOVED_FORMAT, baseTagAssociation.getTag().getId(), entityUrn))
-                .parameters(parameters)
+                .tagAssociation(baseTagAssociation)
                 .auditStamp(auditStamp)
                 .build());
         ++baseTagIdx;
       } else {
         // Tag got added.
-        Map<String, Object> parameters =
-            ImmutableMap.of(
-                "tagUrn",
-                targetTagAssociation.getTag().toString(),
-                "context",
-                targetTagAssociation.getContext() != null
-                    ? targetTagAssociation.getContext()
-                    : "{}");
         changeEvents.add(
             TagChangeEvent.entityTagChangeEventBuilder()
                 .modifier(targetTagAssociation.getTag().toString())
@@ -95,7 +79,7 @@ public class GlobalTagsChangeEventGenerator extends EntityChangeEventGenerator<G
                 .description(
                     String.format(
                         TAG_ADDED_FORMAT, targetTagAssociation.getTag().getId(), entityUrn))
-                .parameters(parameters)
+                .tagAssociation(targetTagAssociation)
                 .auditStamp(auditStamp)
                 .build());
         ++targetTagIdx;
@@ -114,14 +98,7 @@ public class GlobalTagsChangeEventGenerator extends EntityChangeEventGenerator<G
               .semVerChange(SemanticChangeType.MINOR)
               .description(
                   String.format(TAG_REMOVED_FORMAT, baseTagAssociation.getTag().getId(), entityUrn))
-              .parameters(
-                  ImmutableMap.of(
-                      "tagUrn",
-                      baseTagAssociation.getTag().toString(),
-                      "context",
-                      baseTagAssociation.getContext() != null
-                          ? baseTagAssociation.getContext()
-                          : "{}"))
+              .tagAssociation(baseTagAssociation)
               .auditStamp(auditStamp)
               .build());
       ++baseTagIdx;
@@ -138,14 +115,7 @@ public class GlobalTagsChangeEventGenerator extends EntityChangeEventGenerator<G
               .semVerChange(SemanticChangeType.MINOR)
               .description(
                   String.format(TAG_ADDED_FORMAT, targetTagAssociation.getTag().getId(), entityUrn))
-              .parameters(
-                  ImmutableMap.of(
-                      "tagUrn",
-                      targetTagAssociation.getTag().toString(),
-                      "context",
-                      targetTagAssociation.getContext() != null
-                          ? targetTagAssociation.getContext()
-                          : "{}"))
+              .tagAssociation(targetTagAssociation)
               .auditStamp(auditStamp)
               .build());
       ++targetTagIdx;

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/GlossaryTermsChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/GlossaryTermsChangeEventGenerator.java
@@ -3,7 +3,6 @@ package com.linkedin.metadata.timeline.eventgenerator;
 import static com.linkedin.metadata.Constants.*;
 
 import com.datahub.util.RecordUtils;
-import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.GlossaryTermAssociation;
 import com.linkedin.common.GlossaryTermAssociationArray;
@@ -20,7 +19,6 @@ import jakarta.json.JsonPatch;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.Nonnull;
 
 public class GlossaryTermsChangeEventGenerator extends EntityChangeEventGenerator<GlossaryTerms> {
@@ -62,14 +60,6 @@ public class GlossaryTermsChangeEventGenerator extends EntityChangeEventGenerato
         ++targetGlossaryTermIdx;
       } else if (comparison < 0) {
         // GlossaryTerm got removed.
-        Map<String, Object> parameters =
-            ImmutableMap.of(
-                "termUrn",
-                baseGlossaryTermAssociation.getUrn().toString(),
-                "context",
-                baseGlossaryTermAssociation.getContext() != null
-                    ? baseGlossaryTermAssociation.getContext()
-                    : "{}");
         changeEvents.add(
             GlossaryTermChangeEvent.entityGlossaryTermChangeEventBuilder()
                 .modifier(baseGlossaryTermAssociation.getUrn().toString())
@@ -82,20 +72,12 @@ public class GlossaryTermsChangeEventGenerator extends EntityChangeEventGenerato
                         GLOSSARY_TERM_REMOVED_FORMAT,
                         baseGlossaryTermAssociation.getUrn().getId(),
                         entityUrn))
-                .parameters(parameters)
+                .glossaryTermAssociation(baseGlossaryTermAssociation)
                 .auditStamp(auditStamp)
                 .build());
         ++baseGlossaryTermIdx;
       } else {
         // GlossaryTerm got added.
-        Map<String, Object> parameters =
-            ImmutableMap.of(
-                "termUrn",
-                targetGlossaryTermAssociation.getUrn().toString(),
-                "context",
-                targetGlossaryTermAssociation.getContext() != null
-                    ? targetGlossaryTermAssociation.getContext()
-                    : "{}");
         changeEvents.add(
             GlossaryTermChangeEvent.entityGlossaryTermChangeEventBuilder()
                 .modifier(targetGlossaryTermAssociation.getUrn().toString())
@@ -108,7 +90,7 @@ public class GlossaryTermsChangeEventGenerator extends EntityChangeEventGenerato
                         GLOSSARY_TERM_ADDED_FORMAT,
                         targetGlossaryTermAssociation.getUrn().getId(),
                         entityUrn))
-                .parameters(parameters)
+                .glossaryTermAssociation(targetGlossaryTermAssociation)
                 .auditStamp(auditStamp)
                 .build());
         ++targetGlossaryTermIdx;
@@ -130,14 +112,7 @@ public class GlossaryTermsChangeEventGenerator extends EntityChangeEventGenerato
                       GLOSSARY_TERM_REMOVED_FORMAT,
                       baseGlossaryTermAssociation.getUrn().getId(),
                       entityUrn))
-              .parameters(
-                  ImmutableMap.of(
-                      "termUrn",
-                      baseGlossaryTermAssociation.getUrn().toString(),
-                      "context",
-                      baseGlossaryTermAssociation.getContext() != null
-                          ? baseGlossaryTermAssociation.getContext()
-                          : "{}"))
+              .glossaryTermAssociation(baseGlossaryTermAssociation)
               .auditStamp(auditStamp)
               .build());
       ++baseGlossaryTermIdx;
@@ -158,14 +133,7 @@ public class GlossaryTermsChangeEventGenerator extends EntityChangeEventGenerato
                       GLOSSARY_TERM_ADDED_FORMAT,
                       targetGlossaryTermAssociation.getUrn().getId(),
                       entityUrn))
-              .parameters(
-                  ImmutableMap.of(
-                      "termUrn",
-                      targetGlossaryTermAssociation.getUrn().toString(),
-                      "context",
-                      targetGlossaryTermAssociation.getContext() != null
-                          ? targetGlossaryTermAssociation.getContext()
-                          : "{}"))
+              .glossaryTermAssociation(targetGlossaryTermAssociation)
               .auditStamp(auditStamp)
               .build());
       ++targetGlossaryTermIdx;

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/OwnershipChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/OwnershipChangeEventGenerator.java
@@ -108,6 +108,7 @@ public class OwnershipChangeEventGenerator extends EntityChangeEventGenerator<Ow
         .ownerUrn(newOwner.getOwner())
         .ownerType(newOwner.getType())
         .ownerTypeUrn(newOwner.getTypeUrn())
+        .attribution(newOwner.getAttribution())
         .auditStamp(auditStamp)
         .build();
   }
@@ -126,6 +127,7 @@ public class OwnershipChangeEventGenerator extends EntityChangeEventGenerator<Ow
         .ownerUrn(oldOwner.getOwner())
         .ownerType(oldOwner.getType())
         .ownerTypeUrn(oldOwner.getTypeUrn())
+        .attribution(oldOwner.getAttribution())
         .auditStamp(auditStamp)
         .build();
   }

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SingleDomainChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SingleDomainChangeEventGenerator.java
@@ -6,6 +6,7 @@ import com.datahub.util.RecordUtils;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.MetadataAttribution;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.domain.DomainAssociation;
 import com.linkedin.domain.Domains;
@@ -15,6 +16,7 @@ import com.linkedin.metadata.timeline.data.ChangeEvent;
 import com.linkedin.metadata.timeline.data.ChangeOperation;
 import com.linkedin.metadata.timeline.data.ChangeTransaction;
 import com.linkedin.metadata.timeline.data.SemanticChangeType;
+import com.linkedin.metadata.timeline.data.entity.ChangeEventParameterUtils;
 import com.linkedin.metadata.timeline.data.entity.DomainChangeEvent;
 import jakarta.json.JsonPatch;
 import java.util.ArrayList;
@@ -101,7 +103,11 @@ public class SingleDomainChangeEventGenerator extends EntityChangeEventGenerator
               .operation(ChangeOperation.ADD)
               .entityUrn(entityUrn)
               .modifier(domainUrn.toString())
-              .parameters(buildParameters(domainUrn, getContext(targetDomains, domainUrn)))
+              .parameters(
+                  buildParameters(
+                      domainUrn,
+                      getContext(targetDomains, domainUrn),
+                      getAttribution(targetDomains, domainUrn)))
               .description(String.format(DOMAIN_ADDED_FORMAT, domainUrn.getId(), entityUrn))
               .auditStamp(auditStamp)
               .build());
@@ -116,7 +122,11 @@ public class SingleDomainChangeEventGenerator extends EntityChangeEventGenerator
               .operation(ChangeOperation.REMOVE)
               .entityUrn(entityUrn)
               .modifier(domainUrn.toString())
-              .parameters(buildParameters(domainUrn, getContext(baseDomains, domainUrn)))
+              .parameters(
+                  buildParameters(
+                      domainUrn,
+                      getContext(baseDomains, domainUrn),
+                      getAttribution(baseDomains, domainUrn)))
               .description(String.format(DOMAIN_REMOVED_FORMAT, domainUrn.getId(), entityUrn))
               .auditStamp(auditStamp)
               .build());
@@ -134,7 +144,10 @@ public class SingleDomainChangeEventGenerator extends EntityChangeEventGenerator
               .entityUrn(entityUrn)
               .modifier(removedDomainUrn.toString())
               .parameters(
-                  buildParameters(removedDomainUrn, getContext(baseDomains, removedDomainUrn)))
+                  buildParameters(
+                      removedDomainUrn,
+                      getContext(baseDomains, removedDomainUrn),
+                      getAttribution(baseDomains, removedDomainUrn)))
               .description(
                   String.format(DOMAIN_REMOVED_FORMAT, removedDomainUrn.getId(), entityUrn))
               .auditStamp(auditStamp)
@@ -146,7 +159,10 @@ public class SingleDomainChangeEventGenerator extends EntityChangeEventGenerator
               .entityUrn(entityUrn)
               .modifier(addedDomainUrn.toString())
               .parameters(
-                  buildParameters(addedDomainUrn, getContext(targetDomains, addedDomainUrn)))
+                  buildParameters(
+                      addedDomainUrn,
+                      getContext(targetDomains, addedDomainUrn),
+                      getAttribution(targetDomains, addedDomainUrn)))
               .description(String.format(DOMAIN_ADDED_FORMAT, addedDomainUrn.getId(), entityUrn))
               .auditStamp(auditStamp)
               .build());
@@ -174,9 +190,14 @@ public class SingleDomainChangeEventGenerator extends EntityChangeEventGenerator
   }
 
   private static Map<String, Object> buildParameters(
-      @Nonnull Urn domainUrn, @Nullable String context) {
+      @Nonnull Urn domainUrn, @Nullable String context, @Nullable MetadataAttribution attribution) {
     return ImmutableMap.of(
-        "domainUrn", domainUrn.toString(), "context", context != null ? context : "{}");
+        "domainUrn",
+        domainUrn.toString(),
+        "context",
+        context != null ? context : "{}",
+        "sourceDetails",
+        ChangeEventParameterUtils.serializeSourceDetail(attribution));
   }
 
   @Nullable
@@ -188,6 +209,19 @@ public class SingleDomainChangeEventGenerator extends EntityChangeEventGenerator
         .filter(da -> da.getDomain().equals(domainUrn) && da.hasContext())
         .findFirst()
         .map(DomainAssociation::getContext)
+        .orElse(null);
+  }
+
+  @Nullable
+  private static MetadataAttribution getAttribution(
+      @Nonnull final Domains domains, @Nonnull final Urn domainUrn) {
+    if (!domains.hasDomainAssociations()) {
+      return null;
+    }
+    return domains.getDomainAssociations().stream()
+        .filter(da -> da.getDomain().equals(domainUrn) && da.hasAttribution())
+        .findFirst()
+        .map(DomainAssociation::getAttribution)
         .orElse(null);
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/ChangeEventGeneratorUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/ChangeEventGeneratorUtilsTest.java
@@ -3,8 +3,11 @@ package com.linkedin.metadata.timeline.eventgenerator;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
-import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.GlossaryTermAssociation;
+import com.linkedin.common.TagAssociation;
+import com.linkedin.common.urn.GlossaryTermUrn;
+import com.linkedin.common.urn.TagUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.timeline.data.ChangeCategory;
 import com.linkedin.metadata.timeline.data.ChangeEvent;
@@ -49,10 +52,10 @@ public class ChangeEventGeneratorUtilsTest extends AbstractTestNGSpringContextTe
             .category(ChangeCategory.TAG)
             .operation(ChangeOperation.ADD)
             .modifier(TEST_TAG_URN)
-            .parameters(
-                ImmutableMap.of(
-                    "tagUrn", TEST_TAG_URN,
-                    "context", TEST_CONTEXT))
+            .tagAssociation(
+                new TagAssociation()
+                    .setTag(TagUrn.createFromString(TEST_TAG_URN))
+                    .setContext(TEST_CONTEXT))
             .auditStamp(auditStamp)
             .semVerChange(SemanticChangeType.MINOR)
             .description("Test tag added")
@@ -87,18 +90,16 @@ public class ChangeEventGeneratorUtilsTest extends AbstractTestNGSpringContextTe
     AuditStamp auditStamp = getTestAuditStamp();
 
     // Create a GlossaryTermChangeEvent with context
-    Map<String, Object> parameters =
-        ImmutableMap.of(
-            "termUrn", TEST_GLOSSARY_TERM_URN,
-            "context", TEST_CONTEXT);
-
     GlossaryTermChangeEvent glossaryTermChangeEvent =
         GlossaryTermChangeEvent.entityGlossaryTermChangeEventBuilder()
             .entityUrn(TEST_ENTITY_URN)
             .category(ChangeCategory.GLOSSARY_TERM)
             .operation(ChangeOperation.ADD)
             .modifier(TEST_GLOSSARY_TERM_URN)
-            .parameters(parameters)
+            .glossaryTermAssociation(
+                new GlossaryTermAssociation()
+                    .setUrn(GlossaryTermUrn.createFromString(TEST_GLOSSARY_TERM_URN))
+                    .setContext(TEST_CONTEXT))
             .auditStamp(auditStamp)
             .semVerChange(SemanticChangeType.MINOR)
             .description("Test glossary term added")
@@ -142,7 +143,7 @@ public class ChangeEventGeneratorUtilsTest extends AbstractTestNGSpringContextTe
             .category(ChangeCategory.TAG)
             .operation(ChangeOperation.REMOVE)
             .modifier(TEST_TAG_URN)
-            .parameters(ImmutableMap.of("tagUrn", TEST_TAG_URN, "context", "{}"))
+            .tagAssociation(new TagAssociation().setTag(TagUrn.createFromString(TEST_TAG_URN)))
             .auditStamp(auditStamp)
             .semVerChange(SemanticChangeType.MINOR)
             .description("Test tag removed")
@@ -174,16 +175,15 @@ public class ChangeEventGeneratorUtilsTest extends AbstractTestNGSpringContextTe
     AuditStamp auditStamp = getTestAuditStamp();
 
     // Create a GlossaryTermChangeEvent without context
-    Map<String, Object> parameters =
-        ImmutableMap.of("termUrn", TEST_GLOSSARY_TERM_URN, "context", "{}");
-
     GlossaryTermChangeEvent glossaryTermChangeEvent =
         GlossaryTermChangeEvent.entityGlossaryTermChangeEventBuilder()
             .entityUrn(TEST_ENTITY_URN)
             .category(ChangeCategory.GLOSSARY_TERM)
             .operation(ChangeOperation.REMOVE)
             .modifier(TEST_GLOSSARY_TERM_URN)
-            .parameters(parameters)
+            .glossaryTermAssociation(
+                new GlossaryTermAssociation()
+                    .setUrn(GlossaryTermUrn.createFromString(TEST_GLOSSARY_TERM_URN)))
             .auditStamp(auditStamp)
             .semVerChange(SemanticChangeType.MINOR)
             .description("Test glossary term removed")
@@ -218,27 +218,20 @@ public class ChangeEventGeneratorUtilsTest extends AbstractTestNGSpringContextTe
     AuditStamp auditStamp = getTestAuditStamp();
 
     // Create multiple GlossaryTermChangeEvents
-    Map<String, Object> addParameters =
-        ImmutableMap.of(
-            "termUrn", TEST_GLOSSARY_TERM_URN,
-            "context", TEST_CONTEXT);
-
     GlossaryTermChangeEvent addEvent =
         GlossaryTermChangeEvent.entityGlossaryTermChangeEventBuilder()
             .entityUrn(TEST_ENTITY_URN)
             .category(ChangeCategory.GLOSSARY_TERM)
             .operation(ChangeOperation.ADD)
             .modifier(TEST_GLOSSARY_TERM_URN)
-            .parameters(addParameters)
+            .glossaryTermAssociation(
+                new GlossaryTermAssociation()
+                    .setUrn(GlossaryTermUrn.createFromString(TEST_GLOSSARY_TERM_URN))
+                    .setContext(TEST_CONTEXT))
             .auditStamp(auditStamp)
             .semVerChange(SemanticChangeType.MINOR)
             .description("Test glossary term added")
             .build();
-
-    Map<String, Object> removeParameters =
-        ImmutableMap.of(
-            "termUrn", "urn:li:glossaryTerm:Test.Term2",
-            "context", "{}");
 
     GlossaryTermChangeEvent removeEvent =
         GlossaryTermChangeEvent.entityGlossaryTermChangeEventBuilder()
@@ -246,7 +239,9 @@ public class ChangeEventGeneratorUtilsTest extends AbstractTestNGSpringContextTe
             .category(ChangeCategory.GLOSSARY_TERM)
             .operation(ChangeOperation.REMOVE)
             .modifier("urn:li:glossaryTerm:Test.Term2")
-            .parameters(removeParameters)
+            .glossaryTermAssociation(
+                new GlossaryTermAssociation()
+                    .setUrn(GlossaryTermUrn.createFromString("urn:li:glossaryTerm:Test.Term2")))
             .auditStamp(auditStamp)
             .semVerChange(SemanticChangeType.MINOR)
             .description("Test glossary term removed")
@@ -292,19 +287,14 @@ public class ChangeEventGeneratorUtilsTest extends AbstractTestNGSpringContextTe
             .category(ChangeCategory.TAG)
             .operation(ChangeOperation.ADD)
             .modifier(TEST_TAG_URN)
-            .parameters(
-                ImmutableMap.of(
-                    "tagUrn", TEST_TAG_URN,
-                    "context", TEST_CONTEXT))
+            .tagAssociation(
+                new TagAssociation()
+                    .setTag(TagUrn.createFromString(TEST_TAG_URN))
+                    .setContext(TEST_CONTEXT))
             .auditStamp(auditStamp)
             .semVerChange(SemanticChangeType.MINOR)
             .description("Test tag added")
             .build();
-
-    Map<String, Object> glossaryTermParameters =
-        ImmutableMap.of(
-            "termUrn", TEST_GLOSSARY_TERM_URN,
-            "context", TEST_CONTEXT);
 
     GlossaryTermChangeEvent glossaryTermChangeEvent =
         GlossaryTermChangeEvent.entityGlossaryTermChangeEventBuilder()
@@ -312,7 +302,10 @@ public class ChangeEventGeneratorUtilsTest extends AbstractTestNGSpringContextTe
             .category(ChangeCategory.GLOSSARY_TERM)
             .operation(ChangeOperation.ADD)
             .modifier(TEST_GLOSSARY_TERM_URN)
-            .parameters(glossaryTermParameters)
+            .glossaryTermAssociation(
+                new GlossaryTermAssociation()
+                    .setUrn(GlossaryTermUrn.createFromString(TEST_GLOSSARY_TERM_URN))
+                    .setContext(TEST_CONTEXT))
             .auditStamp(auditStamp)
             .semVerChange(SemanticChangeType.MINOR)
             .description("Test glossary term added")

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/GlobalTagsChangeEventGeneratorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/GlobalTagsChangeEventGeneratorTest.java
@@ -1,0 +1,98 @@
+package com.linkedin.metadata.timeline.eventgenerator;
+
+import static org.testng.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.GlobalTags;
+import com.linkedin.common.MetadataAttribution;
+import com.linkedin.common.TagAssociation;
+import com.linkedin.common.TagAssociationArray;
+import com.linkedin.common.urn.TagUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.StringMap;
+import com.linkedin.metadata.timeline.data.ChangeEvent;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+public class GlobalTagsChangeEventGeneratorTest {
+
+  private static final String TEST_ENTITY_URN =
+      "urn:li:dataset:(urn:li:dataPlatform:hive,SampleTable,PROD)";
+  private static final String TEST_TAG_URN = "urn:li:tag:TestTag";
+  private static final String TEST_ACTION_URN = "urn:li:dataHubAction:test";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static AuditStamp getTestAuditStamp() throws URISyntaxException {
+    return new AuditStamp()
+        .setActor(Urn.createFromString("urn:li:corpuser:__datahub_system"))
+        .setTime(1683829509553L);
+  }
+
+  private static GlobalTags globalTagsWith(TagAssociation tagAssociation) {
+    return new GlobalTags().setTags(new TagAssociationArray(List.of(tagAssociation)));
+  }
+
+  @Test
+  public void testAddedTagWithAttributionEmitsSourceDetails() throws Exception {
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    StringMap sourceDetail =
+        new StringMap(
+            ImmutableMap.of(
+                "propagated",
+                "true",
+                "propagation_direction",
+                "downstream",
+                "propagation_relationship",
+                "lineage",
+                "propagation_depth",
+                "1"));
+    TagAssociation tagAssociation =
+        new TagAssociation()
+            .setTag(TagUrn.createFromString(TEST_TAG_URN))
+            .setAttribution(
+                new MetadataAttribution()
+                    .setTime(auditStamp.getTime())
+                    .setActor(auditStamp.getActor())
+                    .setSource(Urn.createFromString(TEST_ACTION_URN))
+                    .setSourceDetail(sourceDetail));
+
+    List<ChangeEvent> events =
+        GlobalTagsChangeEventGenerator.computeDiffs(
+            null, globalTagsWith(tagAssociation), TEST_ENTITY_URN, auditStamp);
+
+    assertEquals(events.size(), 1);
+    Map<String, Object> parameters = events.get(0).getParameters();
+    assertEquals(parameters.get("tagUrn"), TEST_TAG_URN);
+    assertEquals(parameters.get("context"), "{}");
+
+    // sourceDetails is a JSON-stringified copy of the attribution's sourceDetail map.
+    Map<String, String> parsedSourceDetails =
+        OBJECT_MAPPER.readValue(
+            (String) parameters.get("sourceDetails"),
+            OBJECT_MAPPER.getTypeFactory().constructMapType(Map.class, String.class, String.class));
+    assertEquals(parsedSourceDetails, sourceDetail);
+  }
+
+  @Test
+  public void testAddedTagWithoutAttributionEmitsEmptySourceDetails() throws Exception {
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    TagAssociation tagAssociation =
+        new TagAssociation().setTag(TagUrn.createFromString(TEST_TAG_URN));
+
+    List<ChangeEvent> events =
+        GlobalTagsChangeEventGenerator.computeDiffs(
+            null, globalTagsWith(tagAssociation), TEST_ENTITY_URN, auditStamp);
+
+    assertEquals(events.size(), 1);
+    Map<String, Object> parameters = events.get(0).getParameters();
+    assertEquals(parameters.get("tagUrn"), TEST_TAG_URN);
+    assertEquals(parameters.get("context"), "{}");
+    assertEquals(parameters.get("sourceDetails"), "{}");
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/GlossaryTermContextPropagationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/GlossaryTermContextPropagationTest.java
@@ -3,12 +3,16 @@ package com.linkedin.metadata.timeline.eventgenerator;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.GlossaryTermAssociation;
 import com.linkedin.common.GlossaryTermAssociationArray;
 import com.linkedin.common.GlossaryTerms;
+import com.linkedin.common.MetadataAttribution;
 import com.linkedin.common.urn.GlossaryTermUrn;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.StringMap;
 import com.linkedin.metadata.timeline.data.ChangeEvent;
 import com.linkedin.metadata.timeline.data.ChangeOperation;
 import com.linkedin.metadata.timeline.data.dataset.schema.SchemaFieldGlossaryTermChangeEvent;
@@ -41,19 +45,17 @@ public class GlossaryTermContextPropagationTest extends AbstractTestNGSpringCont
   public void testEntityGlossaryTermChangeEventWithContext() throws Exception {
     AuditStamp auditStamp = getTestAuditStamp();
 
-    // Test that GlossaryTermChangeEvent can be created with context in parameters
-    Map<String, Object> parameters =
-        com.google.common.collect.ImmutableMap.of(
-            "termUrn", TEST_GLOSSARY_TERM_URN,
-            "context", TEST_CONTEXT);
-
+    // Test that GlossaryTermChangeEvent can be created with context via the association
     GlossaryTermChangeEvent event =
         GlossaryTermChangeEvent.entityGlossaryTermChangeEventBuilder()
             .entityUrn(TEST_ENTITY_URN)
             .category(com.linkedin.metadata.timeline.data.ChangeCategory.GLOSSARY_TERM)
             .operation(ChangeOperation.ADD)
             .modifier(TEST_GLOSSARY_TERM_URN)
-            .parameters(parameters)
+            .glossaryTermAssociation(
+                new GlossaryTermAssociation()
+                    .setUrn(GlossaryTermUrn.createFromString(TEST_GLOSSARY_TERM_URN))
+                    .setContext(TEST_CONTEXT))
             .auditStamp(auditStamp)
             .semVerChange(com.linkedin.metadata.timeline.data.SemanticChangeType.MINOR)
             .description("Test glossary term added")
@@ -183,22 +185,74 @@ public class GlossaryTermContextPropagationTest extends AbstractTestNGSpringCont
   }
 
   @Test
+  public void testGlossaryTermsChangeEventGeneratorEmitsSourceDetails() throws Exception {
+    GlossaryTermsChangeEventGenerator generator = new GlossaryTermsChangeEventGenerator();
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    Urn urn = Urn.createFromString(TEST_ENTITY_URN);
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    StringMap sourceDetail =
+        new StringMap(
+            ImmutableMap.of(
+                "propagated",
+                "true",
+                "propagation_direction",
+                "downstream",
+                "propagation_relationship",
+                "lineage",
+                "propagation_depth",
+                "1"));
+
+    GlossaryTermAssociation termAssociation =
+        new GlossaryTermAssociation()
+            .setUrn(GlossaryTermUrn.createFromString(TEST_GLOSSARY_TERM_URN))
+            .setContext(TEST_CONTEXT)
+            .setAttribution(
+                new MetadataAttribution()
+                    .setTime(auditStamp.getTime())
+                    .setActor(auditStamp.getActor())
+                    .setSource(Urn.createFromString("urn:li:dataHubAction:test"))
+                    .setSourceDetail(sourceDetail));
+
+    Aspect<GlossaryTerms> from =
+        new Aspect<>(
+            new GlossaryTerms().setTerms(new GlossaryTermAssociationArray()), new SystemMetadata());
+    Aspect<GlossaryTerms> to =
+        new Aspect<>(
+            new GlossaryTerms()
+                .setTerms(new GlossaryTermAssociationArray(List.of(termAssociation))),
+            new SystemMetadata());
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(urn, "dataset", "glossaryTerms", from, to, auditStamp);
+
+    assertEquals(actual.size(), 1);
+    Map<String, Object> parameters = actual.get(0).getParameters();
+    // Both context (legacy) and sourceDetails are populated.
+    assertEquals(parameters.get("context"), TEST_CONTEXT);
+    Map<String, String> parsedSourceDetails =
+        objectMapper.readValue(
+            (String) parameters.get("sourceDetails"),
+            objectMapper.getTypeFactory().constructMapType(Map.class, String.class, String.class));
+    assertEquals(parsedSourceDetails, sourceDetail);
+  }
+
+  @Test
   public void testConvertEntityToSchemaFieldEventWithContext() throws Exception {
     AuditStamp auditStamp = getTestAuditStamp();
 
-    // Create entity-level event with context
-    Map<String, Object> entityParameters =
-        com.google.common.collect.ImmutableMap.of(
-            "termUrn", TEST_GLOSSARY_TERM_URN,
-            "context", TEST_CONTEXT);
-
+    // Create entity-level event with context via the association
     GlossaryTermChangeEvent entityEvent =
         GlossaryTermChangeEvent.entityGlossaryTermChangeEventBuilder()
             .entityUrn(TEST_ENTITY_URN)
             .category(com.linkedin.metadata.timeline.data.ChangeCategory.GLOSSARY_TERM)
             .operation(ChangeOperation.ADD)
             .modifier(TEST_GLOSSARY_TERM_URN)
-            .parameters(entityParameters)
+            .glossaryTermAssociation(
+                new GlossaryTermAssociation()
+                    .setUrn(GlossaryTermUrn.createFromString(TEST_GLOSSARY_TERM_URN))
+                    .setContext(TEST_CONTEXT))
             .auditStamp(auditStamp)
             .semVerChange(com.linkedin.metadata.timeline.data.SemanticChangeType.MINOR)
             .description("Test glossary term added")

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/StructuredPropertiesChangeEventGeneratorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/StructuredPropertiesChangeEventGeneratorTest.java
@@ -2,8 +2,12 @@ package com.linkedin.metadata.timeline.eventgenerator;
 
 import static org.testng.AssertJUnit.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.MetadataAttribution;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.StringMap;
 import com.linkedin.metadata.timeline.data.ChangeEvent;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.structured.PrimitivePropertyValue;
@@ -12,6 +16,7 @@ import com.linkedin.structured.StructuredProperties;
 import com.linkedin.structured.StructuredPropertyValueAssignment;
 import com.linkedin.structured.StructuredPropertyValueAssignmentArray;
 import java.util.List;
+import java.util.Map;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
 
@@ -48,6 +53,63 @@ public class StructuredPropertiesChangeEventGeneratorTest extends AbstractTestNG
     List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, to, to, auditStamp);
 
     assertEquals(0, actual.size());
+  }
+
+  @Test
+  public void testAddedPropertyWithAttributionEmitsSourceDetails() throws Exception {
+    StructuredPropertyChangeEventGenerator test = new StructuredPropertyChangeEventGenerator();
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    Urn urn =
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hdfs,SampleHdfsDataset,PROD)");
+    AuditStamp auditStamp =
+        new AuditStamp()
+            .setActor(Urn.createFromString("urn:li:corpuser:__datahub_system"))
+            .setTime(1683829509553L);
+
+    StringMap sourceDetail =
+        new StringMap(
+            ImmutableMap.of(
+                "propagated",
+                "true",
+                "propagation_direction",
+                "downstream",
+                "propagation_relationship",
+                "lineage",
+                "propagation_depth",
+                "1"));
+
+    StructuredProperties structuredPropertiesTo = new StructuredProperties();
+    StructuredPropertyValueAssignmentArray a = new StructuredPropertyValueAssignmentArray();
+    StructuredPropertyValueAssignment prop1 = new StructuredPropertyValueAssignment();
+    prop1.setPropertyUrn(new Urn("urn:li:structuredProperty:io.acryl.privacy.retentionTime"));
+    PrimitivePropertyValueArray value = new PrimitivePropertyValueArray();
+    value.add(PrimitivePropertyValue.create("90"));
+    prop1.setValues(value);
+    prop1.setAttribution(
+        new MetadataAttribution()
+            .setTime(auditStamp.getTime())
+            .setActor(auditStamp.getActor())
+            .setSource(Urn.createFromString("urn:li:dataHubAction:test"))
+            .setSourceDetail(sourceDetail));
+    a.add(prop1);
+    structuredPropertiesTo.setProperties(a);
+
+    Aspect<StructuredProperties> from = new Aspect<>(null, new SystemMetadata());
+    Aspect<StructuredProperties> to = new Aspect<>(structuredPropertiesTo, new SystemMetadata());
+
+    List<ChangeEvent> actual =
+        test.getChangeEvents(urn, "dataset", "structuredProperties", from, to, auditStamp);
+
+    assertEquals(1, actual.size());
+    assertEquals("ADD", actual.get(0).getOperation().toString());
+
+    // sourceDetails is a JSON-stringified copy of the assignment's attribution sourceDetail map.
+    Map<String, String> parsedSourceDetails =
+        objectMapper.readValue(
+            (String) actual.get(0).getParameters().get("sourceDetails"),
+            objectMapper.getTypeFactory().constructMapType(Map.class, String.class, String.class));
+    assertEquals(sourceDetail, parsedSourceDetails);
   }
 
   @Test

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHook.java
@@ -69,6 +69,7 @@ public class PlatformEventGeneratorHook implements MetadataChangeLogHook {
           Constants.DEPRECATION_ASPECT_NAME,
           Constants.DATASET_PROPERTIES_ASPECT_NAME,
           Constants.EDITABLE_DATASET_PROPERTIES_ASPECT_NAME,
+          Constants.DOCUMENTATION_ASPECT_NAME,
           Constants.ASSERTION_RUN_EVENT_ASPECT_NAME,
           Constants.DATA_PROCESS_INSTANCE_RUN_EVENT_ASPECT_NAME,
           Constants.BUSINESS_ATTRIBUTE_INFO_ASPECT_NAME,

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHookTest.java
@@ -145,7 +145,7 @@ public class PlatformEventGeneratorHookTest {
             ChangeCategory.TAG,
             ChangeOperation.ADD,
             newTagUrn.toString(),
-            ImmutableMap.of("tagUrn", newTagUrn.toString(), "context", "{}"),
+            ImmutableMap.of("tagUrn", newTagUrn.toString(), "context", "{}", "sourceDetails", "{}"),
             actorUrn);
 
     verifyProducePlatformEvent(mockProducer, platformEvent);
@@ -177,7 +177,7 @@ public class PlatformEventGeneratorHookTest {
             ChangeCategory.TAG,
             ChangeOperation.REMOVE,
             newTagUrn.toString(),
-            ImmutableMap.of("tagUrn", newTagUrn.toString(), "context", "{}"),
+            ImmutableMap.of("tagUrn", newTagUrn.toString(), "context", "{}", "sourceDetails", "{}"),
             actorUrn);
 
     verifyProducePlatformEvent(mockProducer, platformEvent);
@@ -213,7 +213,8 @@ public class PlatformEventGeneratorHookTest {
             ChangeCategory.GLOSSARY_TERM,
             ChangeOperation.ADD,
             glossaryTermUrn.toString(),
-            ImmutableMap.of("termUrn", glossaryTermUrn.toString(), "context", "{}"),
+            ImmutableMap.of(
+                "termUrn", glossaryTermUrn.toString(), "context", "{}", "sourceDetails", "{}"),
             actorUrn);
 
     verifyProducePlatformEvent(mockProducer, platformEvent);
@@ -249,7 +250,8 @@ public class PlatformEventGeneratorHookTest {
             ChangeCategory.GLOSSARY_TERM,
             ChangeOperation.REMOVE,
             glossaryTermUrn.toString(),
-            ImmutableMap.of("termUrn", glossaryTermUrn.toString(), "context", "{}"),
+            ImmutableMap.of(
+                "termUrn", glossaryTermUrn.toString(), "context", "{}", "sourceDetails", "{}"),
             actorUrn);
 
     verifyProducePlatformEvent(mockProducer, platformEvent);
@@ -280,7 +282,8 @@ public class PlatformEventGeneratorHookTest {
             ChangeCategory.DOMAIN,
             ChangeOperation.ADD,
             domainUrn.toString(),
-            ImmutableMap.of("domainUrn", domainUrn.toString(), "context", "{}"),
+            ImmutableMap.of(
+                "domainUrn", domainUrn.toString(), "context", "{}", "sourceDetails", "{}"),
             actorUrn);
 
     verifyProducePlatformEvent(mockProducer, platformEvent);
@@ -311,7 +314,8 @@ public class PlatformEventGeneratorHookTest {
             ChangeCategory.DOMAIN,
             ChangeOperation.REMOVE,
             domainUrn.toString(),
-            ImmutableMap.of("domainUrn", domainUrn.toString(), "context", "{}"),
+            ImmutableMap.of(
+                "domainUrn", domainUrn.toString(), "context", "{}", "sourceDetails", "{}"),
             actorUrn);
 
     verifyProducePlatformEvent(mockProducer, platformEvent);
@@ -359,7 +363,9 @@ public class PlatformEventGeneratorHookTest {
                 "ownerUrn",
                 ownerUrn1.toString(),
                 "ownerType",
-                OwnershipType.TECHNICAL_OWNER.toString()),
+                OwnershipType.TECHNICAL_OWNER.toString(),
+                "sourceDetails",
+                "{}"),
             actorUrn);
     verifyProducePlatformEvent(mockProducer, platformEvent1, false);
 
@@ -374,7 +380,9 @@ public class PlatformEventGeneratorHookTest {
                 "ownerUrn",
                 ownerUrn2.toString(),
                 "ownerType",
-                OwnershipType.BUSINESS_OWNER.toString()),
+                OwnershipType.BUSINESS_OWNER.toString(),
+                "sourceDetails",
+                "{}"),
             actorUrn);
     verifyProducePlatformEvent(mockProducer, platformEvent2, false);
 
@@ -391,7 +399,9 @@ public class PlatformEventGeneratorHookTest {
                 "ownerType",
                 OwnershipType.CUSTOM.toString(),
                 "ownerTypeUrn",
-                "urn:li:ownershipType:my_custom_type"),
+                "urn:li:ownershipType:my_custom_type",
+                "sourceDetails",
+                "{}"),
             actorUrn);
     verifyProducePlatformEvent(mockProducer, platformEvent3, true);
   }
@@ -1897,7 +1907,12 @@ public class PlatformEventGeneratorHookTest {
             ChangeOperation.ADD,
             propertyUrn.toString(),
             ImmutableMap.of(
-                "propertyUrn", propertyUrn.toString(), "propertyValues", "[\"testValue\"]"),
+                "propertyUrn",
+                propertyUrn.toString(),
+                "propertyValues",
+                "[\"testValue\"]",
+                "sourceDetails",
+                "{}"),
             actorUrn);
 
     verifyProducePlatformEvent(mockProducer, platformEvent);
@@ -1936,7 +1951,12 @@ public class PlatformEventGeneratorHookTest {
             ChangeOperation.REMOVE,
             propertyUrn.toString(),
             ImmutableMap.of(
-                "propertyUrn", propertyUrn.toString(), "propertyValues", "[\"testValue\"]"),
+                "propertyUrn",
+                propertyUrn.toString(),
+                "propertyValues",
+                "[\"testValue\"]",
+                "sourceDetails",
+                "{}"),
             actorUrn);
 
     verifyProducePlatformEvent(mockProducer, platformEvent);
@@ -1985,7 +2005,12 @@ public class PlatformEventGeneratorHookTest {
             ChangeOperation.MODIFY,
             propertyUrn.toString(),
             ImmutableMap.of(
-                "propertyUrn", propertyUrn.toString(), "propertyValues", "[\"newValue\"]"),
+                "propertyUrn",
+                propertyUrn.toString(),
+                "propertyValues",
+                "[\"newValue\"]",
+                "sourceDetails",
+                "{}"),
             actorUrn);
 
     verifyProducePlatformEvent(mockProducer, platformEvent);


### PR DESCRIPTION
Standardizes behavior across ECEs for aspects with `MetadataAttribution` to store `sourceDetails` on the ECE parameters. Also standardizes parameter creation on the Event class rather than ChangeEventGenerator.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
