### PR TITLE
fix(ingest/mysql): strip QueuePool-only options from usage NullPool engine

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/mysql.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/mysql.py
@@ -61,9 +61,11 @@ _SYSTEM_SCHEMAS = frozenset(
     {"information_schema", "performance_schema", "mysql", "sys"}
 )
 
-# QueuePool-only sizing options. SQLAlchemySource._add_default_options injects
-# `max_overflow` into `options` whenever profiling is enabled, but NullPool
-# rejects these, so they must be dropped from the ephemeral usage engine.
+# QueuePool-only sizing options that NullPool rejects, so they must be dropped
+# from the ephemeral usage engine (which forces NullPool). DataHub itself only
+# auto-injects `max_overflow` (SQLAlchemySource._add_default_options, when
+# profiling is enabled); the other three are stripped defensively in case a user
+# sets them via `config.options`.
 _QUEUE_POOL_ONLY_OPTIONS = frozenset(
     {"pool_size", "max_overflow", "pool_timeout", "pool_use_lifo"}
 )
@@ -474,8 +476,8 @@ class MySQLSource(TwoTierSQLAlchemySource):
         # NullPool + dispose() so this one-shot fetch never leaves connections
         # open. poolclass is forced last so a pooled class in options (intended
         # for the long-lived inspection engine) can't silently re-pool this
-        # ephemeral engine. QueuePool sizing options are stripped because
-        # NullPool rejects them (profiling injects max_overflow into options).
+        # ephemeral engine; QueuePool-only options are dropped (see
+        # _QUEUE_POOL_ONLY_OPTIONS) because NullPool rejects them.
         usage_options = {
             key: value
             for key, value in self.config.options.items()

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/mysql.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/mysql.py
@@ -61,6 +61,13 @@ _SYSTEM_SCHEMAS = frozenset(
     {"information_schema", "performance_schema", "mysql", "sys"}
 )
 
+# QueuePool-only sizing options. SQLAlchemySource._add_default_options injects
+# `max_overflow` into `options` whenever profiling is enabled, but NullPool
+# rejects these, so they must be dropped from the ephemeral usage engine.
+_QUEUE_POOL_ONLY_OPTIONS = frozenset(
+    {"pool_size", "max_overflow", "pool_timeout", "pool_use_lifo"}
+)
+
 # One row per normalized statement: DIGEST_TEXT has literals stripped to `?`,
 # COUNT_STAR counts executions since the last reset, LAST_SEEN is the most recent.
 # Low-overhead query history when performance_schema is on (vs. the general log).
@@ -467,10 +474,16 @@ class MySQLSource(TwoTierSQLAlchemySource):
         # NullPool + dispose() so this one-shot fetch never leaves connections
         # open. poolclass is forced last so a pooled class in options (intended
         # for the long-lived inspection engine) can't silently re-pool this
-        # ephemeral engine.
+        # ephemeral engine. QueuePool sizing options are stripped because
+        # NullPool rejects them (profiling injects max_overflow into options).
+        usage_options = {
+            key: value
+            for key, value in self.config.options.items()
+            if key not in _QUEUE_POOL_ONLY_OPTIONS
+        }
         engine = create_engine(
             self.config.get_sql_alchemy_url(),
-            **{**self.config.options, "poolclass": NullPool},
+            **{**usage_options, "poolclass": NullPool},
         )
         self._setup_rds_iam_event_listener(engine)
         try:

--- a/metadata-ingestion/tests/unit/test_mysql_usage.py
+++ b/metadata-ingestion/tests/unit/test_mysql_usage.py
@@ -2,6 +2,8 @@ import datetime
 from typing import Optional
 from unittest.mock import MagicMock, patch
 
+from sqlalchemy.pool import NullPool
+
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.source.sql.mysql import (
     MySQLConfig,
@@ -93,6 +95,23 @@ def test_usage_connection_pins_utc_and_disposes_engine(mock_create_engine):
     )
     # Single-use engine must be disposed so the usage fetch leaks no connections.
     engine.dispose.assert_called_once()
+
+
+@patch("datahub.ingestion.source.sql.mysql.create_engine")
+def test_usage_connection_strips_queuepool_options_for_nullpool(mock_create_engine):
+    # When profiling is enabled, _add_default_options injects QueuePool sizing
+    # options (e.g. max_overflow) into options. NullPool rejects them, so they
+    # must not reach the ephemeral usage engine (else create_engine raises
+    # TypeError). Simulate that injected state directly.
+    mock_create_engine.return_value = _patch_rows([])
+
+    source = _source(options={"max_overflow": 10, "pool_size": 5})
+    list(source._fetch_performance_schema_queries())
+
+    kwargs = mock_create_engine.call_args.kwargs
+    assert kwargs["poolclass"] is NullPool
+    for option in ("pool_size", "max_overflow", "pool_timeout", "pool_use_lifo"):
+        assert option not in kwargs, f"{option} must be stripped for NullPool"
 
 
 @patch("datahub.ingestion.source.sql.mysql.create_engine")

--- a/metadata-ingestion/tests/unit/test_mysql_usage.py
+++ b/metadata-ingestion/tests/unit/test_mysql_usage.py
@@ -2,6 +2,8 @@ import datetime
 from typing import Optional
 from unittest.mock import MagicMock, patch
 
+import pytest
+from sqlalchemy import create_engine as real_create_engine
 from sqlalchemy.pool import NullPool
 
 from datahub.ingestion.api.common import PipelineContext
@@ -98,20 +100,34 @@ def test_usage_connection_pins_utc_and_disposes_engine(mock_create_engine):
 
 
 @patch("datahub.ingestion.source.sql.mysql.create_engine")
-def test_usage_connection_strips_queuepool_options_for_nullpool(mock_create_engine):
-    # When profiling is enabled, _add_default_options injects QueuePool sizing
-    # options (e.g. max_overflow) into options. NullPool rejects them, so they
-    # must not reach the ephemeral usage engine (else create_engine raises
-    # TypeError). Simulate that injected state directly.
-    mock_create_engine.return_value = _patch_rows([])
+def test_usage_connection_builds_valid_nullpool_engine(mock_create_engine):
+    url = "mysql+pymysql://u:p@h/db"
+    # The exact failure this PR fixes: NullPool rejects QueuePool sizing options.
+    # create_engine validates these eagerly, without opening a connection.
+    with pytest.raises(TypeError):
+        real_create_engine(url, poolclass=NullPool, max_overflow=10)
 
-    source = _source(options={"max_overflow": 10, "pool_size": 5})
+    # Delegate to the real create_engine so its eager kwarg validation runs
+    # against exactly what the source builds (would raise if a QueuePool-only
+    # option leaked through), then hand back a mock so no DB is contacted.
+    def _validate_then_mock(engine_url: str, **kwargs: object) -> MagicMock:
+        real_create_engine(engine_url, **kwargs).dispose()
+        return _patch_rows([])
+
+    mock_create_engine.side_effect = _validate_then_mock
+
+    # Set the options directly rather than enabling profiling (which would need
+    # the full get_workunits path) to mimic _add_default_options' injection.
+    source = _source(
+        options={
+            "max_overflow": 10,
+            "pool_size": 5,
+            "pool_timeout": 30,
+            "pool_use_lifo": True,
+        }
+    )
+    # Must not raise: the usage engine strips every QueuePool-only option.
     list(source._fetch_performance_schema_queries())
-
-    kwargs = mock_create_engine.call_args.kwargs
-    assert kwargs["poolclass"] is NullPool
-    for option in ("pool_size", "max_overflow", "pool_timeout", "pool_use_lifo"):
-        assert option not in kwargs, f"{option} must be stripped for NullPool"
 
 
 @patch("datahub.ingestion.source.sql.mysql.create_engine")

--- a/metadata-ingestion/tests/unit/test_mysql_usage.py
+++ b/metadata-ingestion/tests/unit/test_mysql_usage.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Optional
+from typing import Any, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -109,7 +109,7 @@ def test_usage_connection_builds_valid_nullpool_engine(mock_create_engine):
 
     # Delegate to the real create_engine so its validation runs on what the
     # source builds, then return a mock so no DB is contacted.
-    def _validate_then_mock(engine_url: str, **kwargs: object) -> MagicMock:
+    def _validate_then_mock(engine_url: str, **kwargs: Any) -> MagicMock:
         real_create_engine(engine_url, **kwargs).dispose()
         return _patch_rows([])
 

--- a/metadata-ingestion/tests/unit/test_mysql_usage.py
+++ b/metadata-ingestion/tests/unit/test_mysql_usage.py
@@ -102,22 +102,21 @@ def test_usage_connection_pins_utc_and_disposes_engine(mock_create_engine):
 @patch("datahub.ingestion.source.sql.mysql.create_engine")
 def test_usage_connection_builds_valid_nullpool_engine(mock_create_engine):
     url = "mysql+pymysql://u:p@h/db"
-    # The exact failure this PR fixes: NullPool rejects QueuePool sizing options.
-    # create_engine validates these eagerly, without opening a connection.
+    # create_engine validates pool kwargs eagerly (no connection), so this is the
+    # failure this PR fixes: NullPool rejects QueuePool sizing options.
     with pytest.raises(TypeError):
         real_create_engine(url, poolclass=NullPool, max_overflow=10)
 
-    # Delegate to the real create_engine so its eager kwarg validation runs
-    # against exactly what the source builds (would raise if a QueuePool-only
-    # option leaked through), then hand back a mock so no DB is contacted.
+    # Delegate to the real create_engine so its validation runs on what the
+    # source builds, then return a mock so no DB is contacted.
     def _validate_then_mock(engine_url: str, **kwargs: object) -> MagicMock:
         real_create_engine(engine_url, **kwargs).dispose()
         return _patch_rows([])
 
     mock_create_engine.side_effect = _validate_then_mock
 
-    # Set the options directly rather than enabling profiling (which would need
-    # the full get_workunits path) to mimic _add_default_options' injection.
+    # Set options directly instead of enabling profiling (which needs the full
+    # get_workunits path) to mimic _add_default_options' injection.
     source = _source(
         options={
             "max_overflow": 10,


### PR DESCRIPTION
## Summary

- When `include_usage_statistics` and profiling are both enabled, the pipeline aborts with `TypeError: Invalid argument(s) 'max_overflow' sent to create_engine(), using configuration MySQLDialect_pymysql/NullPool/Engine`.
- Cause: the base `SQLAlchemySource._add_default_options` injects `max_overflow` (= `profiling.max_workers`) into `config.options` whenever profiling is enabled. `MySQLSource._usage_connection` forces `poolclass=NullPool` for its one-shot query-history fetch but still spread `config.options`, and `NullPool` rejects QueuePool sizing arguments.
- Fix: drop the QueuePool-only options (`pool_size`, `max_overflow`, `pool_timeout`, `pool_use_lifo`) before constructing the ephemeral `NullPool` usage engine. The long-lived inspection/profiling engines are unaffected and keep those options.

## Test plan

- Added `test_usage_connection_strips_queuepool_options_for_nullpool` asserting the usage engine is built with `NullPool` and none of the QueuePool sizing options.
- `ruff`, `ruff format`, `mypy`, and all `tests/unit/test_mysql_usage.py` tests pass.