### PR TITLE
chore: remove native C lib (trade performance for stability)

### DIFF
--- a/metadata-ingestion/constraints.txt
+++ b/metadata-ingestion/constraints.txt
@@ -1573,9 +1573,6 @@ sqlglot==30.12.0
     # via
     #   acryl-datahub
     #   dlt
-    #   sqlglotc
-sqlglotc==30.12.0
-    # via sqlglot
 sqlparse==0.5.5
     # via
     #   acryl-datahub

--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -131,7 +131,7 @@ athena = [
     "PyAthena[SQLAlchemy]>=2.6.0,<3.0.0",
     "sqlalchemy-bigquery>=1.5.0,<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "tenacity!=8.4.0,<9.0.0",
 ]
@@ -172,7 +172,7 @@ bigquery = [
     "protobuf>=5.0.0,<7.0.0",
     "sqlalchemy-bigquery>=1.5.0,<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "wcmatch<11.0.0",
 ]
@@ -189,7 +189,7 @@ bigquery-queries = [
     "patchy==2.8.0",
     "sqlalchemy-bigquery>=1.5.0,<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "wcmatch<11.0.0",
 ]
@@ -221,7 +221,7 @@ clickhouse = [
     "greenlet<4.0.0",
     "patchy==2.8.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "zstd<1.5.6.8",
 ]
@@ -232,7 +232,7 @@ clickhouse-usage = [
     "greenlet<4.0.0",
     "patchy==2.8.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "zstd<1.5.6.8",
 ]
@@ -247,7 +247,7 @@ cockroachdb = [
     "psycopg2-binary<3.0.0",
     "sqlalchemy-cockroachdb<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "urllib3>=1.26,<3.0",
 ]
@@ -268,7 +268,7 @@ confluence = [
 cube = [
     "patchy==2.8.0",
     "requests<3.0.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
 ]
 
 databricks = [
@@ -281,7 +281,7 @@ databricks = [
     "pyspark~=3.5.6,<4.0.0",
     "requests<3.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
 ]
 
@@ -293,7 +293,7 @@ datahub = [
     "patchy==2.8.0",
     "pymysql>=1.0.2,<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
 ]
 
@@ -358,7 +358,7 @@ db2 = [
     "patchy==2.8.0",
     "pyodbc<6.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
 ]
 
@@ -368,7 +368,7 @@ dbt = [
     "more-itertools<11.0.0",
     "patchy==2.8.0",
     "requests<3.0.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "urllib3>=1.26,<3.0",
 ]
 
@@ -376,7 +376,7 @@ dbt-cloud = [
     "more-itertools<11.0.0",
     "patchy==2.8.0",
     "requests<3.0.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
 ]
 
 debug-recording = [
@@ -419,7 +419,7 @@ doris = [
     "patchy==2.8.0",
     "pymysql>=1.0.2,<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "urllib3>=1.26,<3.0",
 ]
@@ -430,7 +430,7 @@ dremio = [
     "patchy==2.8.0",
     "requests<3.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
 ]
 
@@ -440,7 +440,7 @@ druid = [
     "patchy==2.8.0",
     "pydruid>=0.6.2,<=0.6.9",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
 ]
 
@@ -489,7 +489,7 @@ fabric-onelake = [
     "pyodbc>=4.0,<6.0.0",
     "requests>=2.28.0,<3.0",
     "sqlalchemy>=1.4,<3.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
 ]
 
@@ -519,7 +519,7 @@ fivetran = [
     "snowflake-sqlalchemy>=1.8.0,<2.0.0",
     "sqlalchemy-bigquery>=1.5.0,<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "tenacity>=8.0.1,<9.0.0",
     "wcmatch<11.0.0",
 ]
@@ -571,7 +571,7 @@ glue = [
     "botocore!=1.23.0,<2.0.0",
     "cachetools<6.0.0",
     "patchy==2.8.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "urllib3>=1.26,<3.0",
 ]
@@ -579,7 +579,7 @@ glue = [
 grafana = [
     "patchy==2.8.0",
     "requests<3.0.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
 ]
 
 hana = [
@@ -590,14 +590,14 @@ hana = [
     "patchy==2.8.0",
     "sqlalchemy-hana>=0.5.0,<5.0.0; platform_machine != 'aarch64' and platform_machine != 'arm64'",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
 ]
 
 hex = [
     "patchy==2.8.0",
     "requests<3.0.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
 ]
 
 hive = [
@@ -607,7 +607,7 @@ hive = [
     "greenlet<4.0.0",
     "patchy==2.8.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
 ]
 
@@ -621,7 +621,7 @@ hive-metastore = [
     "pymetastore>=0.4.2,<1.0.0",
     "pymysql>=1.0.2,<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "tenacity>=8.0.1,<9.0.0",
 ]
@@ -663,7 +663,7 @@ kafka-connect = [
     "patchy==2.8.0",
     "requests<3.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
 ]
 
@@ -687,7 +687,7 @@ looker = [
     "looker-sdk>=23.0.0,<26.0.0",
     "patchy==2.8.0",
     "python-liquid>=2.0.0,<3.0.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
 ]
 
 lookml = [
@@ -697,7 +697,7 @@ lookml = [
     "looker-sdk>=23.0.0,<26.0.0",
     "patchy==2.8.0",
     "python-liquid>=2.0.0,<3.0.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
 ]
 
 mariadb = [
@@ -708,7 +708,7 @@ mariadb = [
     "patchy==2.8.0",
     "pymysql>=1.0.2,<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "urllib3>=1.26,<3.0",
 ]
@@ -716,20 +716,20 @@ mariadb = [
 matillion-dpc = [
     "patchy==2.8.0",
     "requests<3.0.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
 ]
 
 metabase = [
     "patchy==2.8.0",
     "requests<3.0.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
 ]
 
 microstrategy = [
     "patchy==2.8.0",
     "requests<3.0.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
 ]
 
 mlflow = [
@@ -742,7 +742,7 @@ mode = [
     "patchy==2.8.0",
     "python-liquid>=2.0.0,<3.0.0",
     "requests<3.0.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "tenacity>=8.0.1,<9.0.0",
 ]
 
@@ -758,7 +758,7 @@ mssql = [
     "pyOpenSSL>=26.0.0,<27.0.0",
     "sqlalchemy-pytds>=0.3,<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
 ]
 
@@ -770,7 +770,7 @@ mssql-odbc = [
     "pyOpenSSL>=26.0.0,<27.0.0",
     "sqlalchemy-pytds>=0.3,<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
 ]
 
@@ -782,7 +782,7 @@ mysql = [
     "patchy==2.8.0",
     "pymysql>=1.0.2,<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "urllib3>=1.26,<3.0",
 ]
@@ -825,7 +825,7 @@ oracle = [
     "oracledb<4.0.0",
     "patchy==2.8.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
 ]
 
@@ -842,7 +842,7 @@ postgres = [
     "patchy==2.8.0",
     "psycopg2-binary<3.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "urllib3>=1.26,<3.0",
 ]
@@ -853,7 +853,7 @@ powerbi = [
     "msal>=1.31.1,<2.0.0",
     "patchy==2.8.0",
     "setuptools<82",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<1.0.0",
     "stopit==1.1.2",
 ]
@@ -866,7 +866,7 @@ powerbi-report-server = [
 preset = [
     "patchy==2.8.0",
     "requests<3.0.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
 ]
 
 presto = [
@@ -875,7 +875,7 @@ presto = [
     "greenlet<4.0.0",
     "patchy==2.8.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "trino[sqlalchemy]>=0.308,<=0.336.0",
 ]
@@ -890,7 +890,7 @@ presto-on-hive = [
     "pymetastore>=0.4.2,<1.0.0",
     "pymysql>=1.0.2,<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "tenacity>=8.0.1,<9.0.0",
 ]
@@ -910,7 +910,7 @@ pulsar = [
 qlik-sense = [
     "patchy==2.8.0",
     "requests<3.0.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "websocket-client<2.0.0",
 ]
 
@@ -918,7 +918,7 @@ quicksight = [
     "boto3>=1.35.0,<2.0.0",
     "botocore!=1.23.0,<2.0.0",
     "patchy==2.8.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "urllib3>=1.26,<3.0",
 ]
 
@@ -932,7 +932,7 @@ redash = [
     "patchy==2.8.0",
     "redash-toolbelt<0.2.0",
     "sql-metadata<3.0.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
 ]
 
 redshift = [
@@ -945,7 +945,7 @@ redshift = [
     "redshift-connector>=2.1.14,<3.0.0",
     "sqlalchemy-redshift>=0.8.3,<=0.8.14",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "wcmatch<11.0.0",
 ]
@@ -958,7 +958,7 @@ redshift-slim = [
     "patchy==2.8.0",
     "redshift-connector>=2.1.14,<3.0.0",
     "sqlalchemy-redshift>=0.8.3,<=0.8.14",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "wcmatch<11.0.0",
 ]
@@ -1012,7 +1012,7 @@ salesforce = [
 sigma = [
     "patchy==2.8.0",
     "requests<3.0.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
 ]
 
@@ -1033,7 +1033,7 @@ snowflake = [
     "snowflake-connector-python>=4.4.0,<5.0.0",
     "snowflake-sqlalchemy>=1.8.0,<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "tenacity>=8.0.1,<9.0.0",
 ]
@@ -1048,7 +1048,7 @@ snowflake-queries = [
     "snowflake-connector-python>=4.4.0,<5.0.0",
     "snowflake-sqlalchemy>=1.8.0,<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "tenacity>=8.0.1,<9.0.0",
 ]
@@ -1073,7 +1073,7 @@ snowflake-summary = [
     "snowflake-connector-python>=4.4.0,<5.0.0",
     "snowflake-sqlalchemy>=1.8.0,<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "tenacity>=8.0.1,<9.0.0",
 ]
@@ -1084,7 +1084,7 @@ snowplow = [
 
 sql-parser = [
     "patchy==2.8.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
 ]
 
 sql-queries = [
@@ -1092,7 +1092,7 @@ sql-queries = [
     "botocore!=1.23.0,<2.0.0",
     "patchy==2.8.0",
     "smart-open[s3]>=5.2.1,<8.0.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "urllib3>=1.26,<3.0",
 ]
@@ -1102,7 +1102,7 @@ sqlalchemy = [
     "greenlet<4.0.0",
     "patchy==2.8.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
 ]
 
@@ -1111,7 +1111,7 @@ starburst-trino-usage = [
     "greenlet<4.0.0",
     "patchy==2.8.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "trino[sqlalchemy]>=0.308,<=0.336.0",
 ]
@@ -1122,7 +1122,7 @@ starrocks = [
     "lark>=1.3.1,<2.0",
     "patchy==2.8.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "starrocks>=1.3.3,<2.0",
 ]
@@ -1130,7 +1130,7 @@ starrocks = [
 superset = [
     "patchy==2.8.0",
     "requests<3.0.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
 ]
 
 sync-file-emitter = [
@@ -1139,7 +1139,7 @@ sync-file-emitter = [
 
 tableau = [
     "patchy==2.8.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "tableauserverclient>=0.24.0,<=0.40",
 ]
 
@@ -1148,14 +1148,14 @@ teradata = [
     "greenlet<4.0.0",
     "patchy==2.8.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "teradatasqlalchemy>=17.20.0.0,<=20.0.0.2",
 ]
 
 thoughtspot = [
     "patchy==2.8.0",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "thoughtspot_rest_api>=2.0.0,<3.0.0",
 ]
 
@@ -1167,7 +1167,7 @@ tidb = [
     "patchy==2.8.0",
     "pymysql>=1.0.2,<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "urllib3>=1.26,<3.0",
 ]
@@ -1181,7 +1181,7 @@ timescaledb = [
     "patchy==2.8.0",
     "psycopg2-binary<3.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "urllib3>=1.26,<3.0",
 ]
@@ -1191,7 +1191,7 @@ trino = [
     "greenlet<4.0.0",
     "patchy==2.8.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "trino[sqlalchemy]>=0.308,<=0.336.0",
 ]
@@ -1206,7 +1206,7 @@ unity-catalog = [
     "pyspark~=3.5.6,<4.0.0",
     "requests<3.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
 ]
 
@@ -1229,7 +1229,7 @@ vertica = [
     "greenlet<4.0.0",
     "patchy==2.8.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "vertica-sqlalchemy-dialect[vertica-python]==0.0.8.2",
 ]
@@ -1349,7 +1349,7 @@ all = [
     "sqlalchemy-pytds>=0.3,<2.0.0",
     "sqlalchemy-redshift>=0.8.3,<=0.8.14",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "starrocks>=1.3.3,<2.0",
     "stopit==1.1.2",
@@ -1520,7 +1520,7 @@ dev = [
     "sqlalchemy-redshift>=0.8.3,<=0.8.14",
     "sqlalchemy2-stubs<0.1.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "stopit==1.1.2",
     "tableauserverclient>=0.24.0,<=0.40",
@@ -1710,7 +1710,7 @@ docs = [
     "sqlalchemy-redshift>=0.8.3,<=0.8.14",
     "sqlalchemy2-stubs<0.1.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "stopit==1.1.2",
     "tableauserverclient>=0.24.0,<=0.40",
@@ -1825,7 +1825,7 @@ integration-tests = [
     "sqlalchemy-hana>=0.5.0,<5.0.0; platform_machine != 'aarch64' and platform_machine != 'arm64'",
     "sqlalchemy-pytds>=0.3,<2.0.0",
     "sqlalchemy>=1.4.39,<2",
-    "sqlglot[c]==30.12.0",
+    "sqlglot==30.12.0",
     "sqlparse<0.6.0",
     "starrocks>=1.3.3,<2.0",
     "tableschema>=1.20.2,<2.0.0",

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -149,7 +149,8 @@ sqlglot_lib = {
     # sqlglot[c] was removed in a prior PR as a workaround for a memory leak
     # (https://github.com/tobymao/sqlglot/issues/7506). 30.8.0 fixes the leak
     # upstream, so we restore [c] here for performance.
-    "sqlglot[c]==30.12.0",
+    # removing nativ c lib because https://github.com/python/mypy/issues/21716 https://github.com/tobymao/sqlglot/issues/7853
+    "sqlglot==30.12.0",
     "patchy==2.8.0",
 }
 

--- a/metadata-ingestion/uv.lock
+++ b/metadata-ingestion/uv.lock
@@ -218,7 +218,7 @@ all = [
     { name = "sqlalchemy-hana", marker = "platform_machine != 'aarch64' and platform_machine != 'arm64'" },
     { name = "sqlalchemy-pytds" },
     { name = "sqlalchemy-redshift" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "starrocks" },
     { name = "stopit" },
@@ -245,7 +245,7 @@ athena = [
     { name = "pyathena", extra = ["sqlalchemy"] },
     { name = "sqlalchemy" },
     { name = "sqlalchemy-bigquery" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "tenacity" },
 ]
@@ -279,7 +279,7 @@ bigquery = [
     { name = "protobuf" },
     { name = "sqlalchemy" },
     { name = "sqlalchemy-bigquery" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "wcmatch" },
 ]
@@ -295,7 +295,7 @@ bigquery-queries = [
     { name = "patchy" },
     { name = "sqlalchemy" },
     { name = "sqlalchemy-bigquery" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "wcmatch" },
 ]
@@ -323,7 +323,7 @@ clickhouse = [
     { name = "greenlet" },
     { name = "patchy" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "zstd" },
 ]
@@ -333,7 +333,7 @@ clickhouse-usage = [
     { name = "greenlet" },
     { name = "patchy" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "zstd" },
 ]
@@ -350,7 +350,7 @@ cockroachdb = [
     { name = "psycopg2-binary" },
     { name = "sqlalchemy" },
     { name = "sqlalchemy-cockroachdb" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "urllib3" },
 ]
@@ -369,7 +369,7 @@ confluence = [
 cube = [
     { name = "patchy" },
     { name = "requests" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
 ]
 databricks = [
     { name = "cachetools" },
@@ -381,7 +381,7 @@ databricks = [
     { name = "pyspark" },
     { name = "requests" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
 ]
 datahub = [
@@ -392,7 +392,7 @@ datahub = [
     { name = "patchy" },
     { name = "pymysql" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
 ]
 datahub-debug = [
@@ -443,7 +443,7 @@ db2 = [
     { name = "patchy" },
     { name = "pyodbc" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
 ]
 dbt = [
@@ -452,14 +452,14 @@ dbt = [
     { name = "more-itertools" },
     { name = "patchy" },
     { name = "requests" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "urllib3" },
 ]
 dbt-cloud = [
     { name = "more-itertools" },
     { name = "patchy" },
     { name = "requests" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
 ]
 debug = [
     { name = "memray" },
@@ -637,7 +637,7 @@ dev = [
     { name = "sqlalchemy-pytds" },
     { name = "sqlalchemy-redshift" },
     { name = "sqlalchemy2-stubs" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "stopit" },
     { name = "tableauserverclient" },
@@ -829,7 +829,7 @@ docs = [
     { name = "sqlalchemy-pytds" },
     { name = "sqlalchemy-redshift" },
     { name = "sqlalchemy2-stubs" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "stopit" },
     { name = "tableauserverclient" },
@@ -878,7 +878,7 @@ doris = [
     { name = "patchy" },
     { name = "pymysql" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "urllib3" },
 ]
@@ -888,7 +888,7 @@ dremio = [
     { name = "patchy" },
     { name = "requests" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
 ]
 druid = [
@@ -897,7 +897,7 @@ druid = [
     { name = "patchy" },
     { name = "pydruid" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
 ]
 dynamodb = [
@@ -941,7 +941,7 @@ fabric-onelake = [
     { name = "pyodbc" },
     { name = "requests" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
 ]
 feast = [
@@ -969,7 +969,7 @@ fivetran = [
     { name = "snowflake-sqlalchemy" },
     { name = "sqlalchemy" },
     { name = "sqlalchemy-bigquery" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "tenacity" },
     { name = "wcmatch" },
 ]
@@ -1014,14 +1014,14 @@ glue = [
     { name = "botocore" },
     { name = "cachetools" },
     { name = "patchy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "urllib3" },
 ]
 grafana = [
     { name = "patchy" },
     { name = "requests" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
 ]
 hana = [
     { name = "cachetools" },
@@ -1031,13 +1031,13 @@ hana = [
     { name = "patchy" },
     { name = "sqlalchemy" },
     { name = "sqlalchemy-hana", marker = "platform_machine != 'aarch64' and platform_machine != 'arm64'" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
 ]
 hex = [
     { name = "patchy" },
     { name = "requests" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
 ]
 hive = [
     { name = "acryl-pyhive", extra = ["hive-pure-sasl"] },
@@ -1046,7 +1046,7 @@ hive = [
     { name = "greenlet" },
     { name = "patchy" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
 ]
 hive-metastore = [
@@ -1059,7 +1059,7 @@ hive-metastore = [
     { name = "pymetastore" },
     { name = "pymysql" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "tenacity" },
 ]
@@ -1135,7 +1135,7 @@ integration-tests = [
     { name = "sqlalchemy-bigquery" },
     { name = "sqlalchemy-hana", marker = "platform_machine != 'aarch64' and platform_machine != 'arm64'" },
     { name = "sqlalchemy-pytds" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "starrocks" },
     { name = "tableschema" },
@@ -1166,7 +1166,7 @@ kafka-connect = [
     { name = "patchy" },
     { name = "requests" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
 ]
 kinesis = [
@@ -1192,7 +1192,7 @@ looker = [
     { name = "looker-sdk" },
     { name = "patchy" },
     { name = "python-liquid" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
 ]
 lookml = [
     { name = "deepmerge" },
@@ -1201,7 +1201,7 @@ lookml = [
     { name = "looker-sdk" },
     { name = "patchy" },
     { name = "python-liquid" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
 ]
 mariadb = [
     { name = "boto3" },
@@ -1211,25 +1211,25 @@ mariadb = [
     { name = "patchy" },
     { name = "pymysql" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "urllib3" },
 ]
 matillion-dpc = [
     { name = "patchy" },
     { name = "requests" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
 ]
 metabase = [
     { name = "patchy" },
     { name = "requests" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
 ]
 microstrategy = [
     { name = "patchy" },
     { name = "requests" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
 ]
 mlflow = [
     { name = "mlflow-skinny" },
@@ -1240,7 +1240,7 @@ mode = [
     { name = "patchy" },
     { name = "python-liquid" },
     { name = "requests" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "tenacity" },
 ]
 mongodb = [
@@ -1254,7 +1254,7 @@ mssql = [
     { name = "pyopenssl" },
     { name = "sqlalchemy" },
     { name = "sqlalchemy-pytds" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
 ]
 mssql-odbc = [
@@ -1265,7 +1265,7 @@ mssql-odbc = [
     { name = "pyopenssl" },
     { name = "sqlalchemy" },
     { name = "sqlalchemy-pytds" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
 ]
 mysql = [
@@ -1276,7 +1276,7 @@ mysql = [
     { name = "patchy" },
     { name = "pymysql" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "urllib3" },
 ]
@@ -1313,7 +1313,7 @@ oracle = [
     { name = "oracledb" },
     { name = "patchy" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
 ]
 pinecone = [
@@ -1328,7 +1328,7 @@ postgres = [
     { name = "patchy" },
     { name = "psycopg2-binary" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "urllib3" },
 ]
@@ -1338,7 +1338,7 @@ powerbi = [
     { name = "msal" },
     { name = "patchy" },
     { name = "setuptools" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "stopit" },
 ]
@@ -1349,7 +1349,7 @@ powerbi-report-server = [
 preset = [
     { name = "patchy" },
     { name = "requests" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
 ]
 presto = [
     { name = "acryl-pyhive", extra = ["hive-pure-sasl"] },
@@ -1357,7 +1357,7 @@ presto = [
     { name = "greenlet" },
     { name = "patchy" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "trino", extra = ["sqlalchemy"] },
 ]
@@ -1371,7 +1371,7 @@ presto-on-hive = [
     { name = "pymetastore" },
     { name = "pymysql" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "tenacity" },
 ]
@@ -1389,14 +1389,14 @@ pulsar = [
 qlik-sense = [
     { name = "patchy" },
     { name = "requests" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "websocket-client" },
 ]
 quicksight = [
     { name = "boto3" },
     { name = "botocore" },
     { name = "patchy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "urllib3" },
 ]
 rdf = [
@@ -1408,7 +1408,7 @@ redash = [
     { name = "patchy" },
     { name = "redash-toolbelt" },
     { name = "sql-metadata" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
 ]
 redshift = [
     { name = "cachetools" },
@@ -1420,7 +1420,7 @@ redshift = [
     { name = "redshift-connector" },
     { name = "sqlalchemy" },
     { name = "sqlalchemy-redshift" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "wcmatch" },
 ]
@@ -1432,7 +1432,7 @@ redshift-slim = [
     { name = "patchy" },
     { name = "redshift-connector" },
     { name = "sqlalchemy-redshift" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "wcmatch" },
 ]
@@ -1480,7 +1480,7 @@ salesforce = [
 sigma = [
     { name = "patchy" },
     { name = "requests" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
 ]
 slack = [
@@ -1497,7 +1497,7 @@ snowflake = [
     { name = "snowflake-connector-python" },
     { name = "snowflake-sqlalchemy" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "tenacity" },
 ]
@@ -1511,7 +1511,7 @@ snowflake-queries = [
     { name = "snowflake-connector-python" },
     { name = "snowflake-sqlalchemy" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "tenacity" },
 ]
@@ -1534,7 +1534,7 @@ snowflake-summary = [
     { name = "snowflake-connector-python" },
     { name = "snowflake-sqlalchemy" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "tenacity" },
 ]
@@ -1543,14 +1543,14 @@ snowplow = [
 ]
 sql-parser = [
     { name = "patchy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
 ]
 sql-queries = [
     { name = "boto3" },
     { name = "botocore" },
     { name = "patchy" },
     { name = "smart-open", extra = ["s3"] },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "urllib3" },
 ]
@@ -1559,7 +1559,7 @@ sqlalchemy = [
     { name = "greenlet" },
     { name = "patchy" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
 ]
 starburst-trino-usage = [
@@ -1567,7 +1567,7 @@ starburst-trino-usage = [
     { name = "greenlet" },
     { name = "patchy" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "trino", extra = ["sqlalchemy"] },
 ]
@@ -1577,21 +1577,21 @@ starrocks = [
     { name = "lark" },
     { name = "patchy" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "starrocks" },
 ]
 superset = [
     { name = "patchy" },
     { name = "requests" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
 ]
 sync-file-emitter = [
     { name = "filelock" },
 ]
 tableau = [
     { name = "patchy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "tableauserverclient" },
 ]
 teradata = [
@@ -1599,7 +1599,7 @@ teradata = [
     { name = "greenlet" },
     { name = "patchy" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "teradatasqlalchemy" },
 ]
@@ -1613,7 +1613,7 @@ testing-utils = [
 ]
 thoughtspot = [
     { name = "patchy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "thoughtspot-rest-api" },
 ]
 tidb = [
@@ -1624,7 +1624,7 @@ tidb = [
     { name = "patchy" },
     { name = "pymysql" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "urllib3" },
 ]
@@ -1637,7 +1637,7 @@ timescaledb = [
     { name = "patchy" },
     { name = "psycopg2-binary" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "urllib3" },
 ]
@@ -1646,7 +1646,7 @@ trino = [
     { name = "greenlet" },
     { name = "patchy" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "trino", extra = ["sqlalchemy"] },
 ]
@@ -1660,7 +1660,7 @@ unity-catalog = [
     { name = "pyspark" },
     { name = "requests" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
 ]
 unstructured = [
@@ -1680,7 +1680,7 @@ vertica = [
     { name = "greenlet" },
     { name = "patchy" },
     { name = "sqlalchemy" },
-    { name = "sqlglot", extra = ["c"] },
+    { name = "sqlglot" },
     { name = "sqlparse" },
     { name = "vertica-sqlalchemy-dialect", extra = ["vertica-python"] },
 ]
@@ -2756,73 +2756,73 @@ requires-dist = [
     { name = "sqlalchemy-redshift", marker = "extra == 'redshift-slim'", specifier = ">=0.8.3,<=0.8.14" },
     { name = "sqlalchemy2-stubs", marker = "extra == 'dev'", specifier = "<0.1.0" },
     { name = "sqlalchemy2-stubs", marker = "extra == 'docs'", specifier = "<0.1.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'all'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'athena'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'bigquery'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'bigquery-queries'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'clickhouse'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'clickhouse-usage'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'cockroachdb'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'cube'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'databricks'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'datahub'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'db2'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'dbt'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'dbt-cloud'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'dev'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'docs'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'doris'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'dremio'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'druid'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'fabric-onelake'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'fivetran'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'glue'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'grafana'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'hana'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'hex'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'hive'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'hive-metastore'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'integration-tests'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'kafka-connect'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'looker'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'lookml'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'mariadb'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'matillion-dpc'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'metabase'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'microstrategy'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'mode'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'mssql'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'mssql-odbc'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'mysql'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'oracle'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'postgres'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'powerbi'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'preset'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'presto'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'presto-on-hive'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'qlik-sense'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'quicksight'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'redash'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'redshift'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'redshift-slim'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'sigma'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'snowflake'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'snowflake-queries'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'snowflake-summary'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'sql-parser'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'sql-queries'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'sqlalchemy'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'starburst-trino-usage'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'starrocks'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'superset'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'tableau'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'teradata'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'thoughtspot'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'tidb'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'timescaledb'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'trino'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'unity-catalog'", specifier = "==30.12.0" },
-    { name = "sqlglot", extras = ["c"], marker = "extra == 'vertica'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'all'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'athena'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'bigquery'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'bigquery-queries'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'clickhouse'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'clickhouse-usage'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'cockroachdb'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'cube'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'databricks'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'datahub'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'db2'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'dbt'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'dbt-cloud'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'dev'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'docs'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'doris'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'dremio'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'druid'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'fabric-onelake'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'fivetran'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'glue'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'grafana'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'hana'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'hex'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'hive'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'hive-metastore'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'integration-tests'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'kafka-connect'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'looker'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'lookml'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'mariadb'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'matillion-dpc'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'metabase'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'microstrategy'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'mode'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'mssql'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'mssql-odbc'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'mysql'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'oracle'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'postgres'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'powerbi'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'preset'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'presto'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'presto-on-hive'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'qlik-sense'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'quicksight'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'redash'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'redshift'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'redshift-slim'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'sigma'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'snowflake'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'snowflake-queries'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'snowflake-summary'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'sql-parser'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'sql-queries'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'sqlalchemy'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'starburst-trino-usage'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'starrocks'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'superset'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'tableau'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'teradata'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'thoughtspot'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'tidb'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'timescaledb'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'trino'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'unity-catalog'", specifier = "==30.12.0" },
+    { name = "sqlglot", marker = "extra == 'vertica'", specifier = "==30.12.0" },
     { name = "sqlparse", marker = "extra == 'all'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'athena'", specifier = "<0.6.0" },
     { name = "sqlparse", marker = "extra == 'bigquery'", specifier = "<0.6.0" },
@@ -11787,42 +11787,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/ed/a6c45aec29353b6392ea34548c40af3ac6ffd6bc5572cf23b2ce250876fc/sqlglot-30.12.0.tar.gz", hash = "sha256:6b8369704662d4f654bc934cea4dd31c916c2a571b389210cb9e951a275e5fd9", size = 5905110, upload-time = "2026-06-26T14:09:40.408Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/9e/82a390ecc85f066ff80affa01d195f744e3de60ad4d695b8de31c9a66da3/sqlglot-30.12.0-py3-none-any.whl", hash = "sha256:86cccc610073c645c03e72b55b60ae0518aa3253a7fc3bd56551370d003c6554", size = 707583, upload-time = "2026-06-26T14:09:38.525Z" },
-]
-
-[package.optional-dependencies]
-c = [
-    { name = "sqlglotc" },
-]
-
-[[package]]
-name = "sqlglotc"
-version = "30.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sqlglot" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/36/05/bdb3c3433f19324ed3499bc51adb6db934f77d947ed1c624554523b22966/sqlglotc-30.12.0.tar.gz", hash = "sha256:7c4c9c7d76026b75f64a6682faf84cf5145e3304190c07807b86962d8d535f74", size = 491114, upload-time = "2026-06-26T14:08:47.042Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/79/69af8ad60cfbef116a2f63bf5d455bdcaafb369fa27772b4936051e76063/sqlglotc-30.12.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1e5ad6689bf76f226e4a3182f3819e9e4056ea0d2b7c1fd610dad22e065b7a10", size = 32008565, upload-time = "2026-06-26T14:08:02.422Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/93/bc5cf48a0fcbc5967687a4f2dfaedf7d2dfd03ae0bca0a57d95e7cbf6495/sqlglotc-30.12.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8412ddb9bb2e3832e36a9d2c279a2c64ffa0d695295f2daae72cef4f68114cb0", size = 24435127, upload-time = "2026-06-26T14:08:05.123Z" },
-    { url = "https://files.pythonhosted.org/packages/07/51/6db6cf0fc07ee398995582dd367fba286be419c06d27c51bf941bc9d09a0/sqlglotc-30.12.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:30fe29c8287dc681b8e6c1514c4138861230314ebe86a47081cf4d1141dd2f89", size = 25549128, upload-time = "2026-06-26T14:08:07.303Z" },
-    { url = "https://files.pythonhosted.org/packages/92/a4/74764a4cb764d8acfd4e85127724ce3ca22a663c34cebe3cfd8f4a864224/sqlglotc-30.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:671d7fcb7261b297c014f7cdc54703e28d3de6e58e94a5652beb5a661a3d0786", size = 10735833, upload-time = "2026-06-26T14:08:09.436Z" },
-    { url = "https://files.pythonhosted.org/packages/98/00/82c2bc0c49aacdfe53006ebd75d00e9cca536b3d0fe5c661d4c1d36ca27c/sqlglotc-30.12.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:05f0cf61aba3207aa8d9fe10646168eac01595f521f3d81390ba215a15e8f6b7", size = 31721081, upload-time = "2026-06-26T14:08:11.587Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/fb/dac3d917d445301af839bd6ab165edac2378f9d6f0ef583d6e53cd1acd46/sqlglotc-30.12.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:71784e43ef4af200a3e8e04f42b9977f405cfeee025c7dbeb703b862029b2b3f", size = 24638763, upload-time = "2026-06-26T14:08:14.062Z" },
-    { url = "https://files.pythonhosted.org/packages/40/67/c4c8258fc706dd8b349e39fb76b7f26ed3478f6fbbdfe688f341d68c981e/sqlglotc-30.12.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a84dd9d7565b782bef07e577b3400cdcddc81ffaae963d5e8460e431c4e70e27", size = 25798453, upload-time = "2026-06-26T14:08:16.347Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/36/dc0265b1c7abab70d1011b2390dcace13a157b2fa3b1fc753be0144a9566/sqlglotc-30.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:4588ea73e99ec2f106cd688e6c12199b99c509497ec16fa858b645f748f461d0", size = 10729513, upload-time = "2026-06-26T14:08:18.477Z" },
-    { url = "https://files.pythonhosted.org/packages/70/b2/246dba0b5ca294ba6c8d087e7b6bbd56c94e17298ff14a0232af70ba086a/sqlglotc-30.12.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4c4016010ecf0b3473f0b2004f9bf352b9c694644a18867e290cf1ddfcd994a1", size = 32052780, upload-time = "2026-06-26T14:08:20.419Z" },
-    { url = "https://files.pythonhosted.org/packages/62/b9/7ead345c4a6395a1eef166db6589e32082a8184da6ba8042b115015449c6/sqlglotc-30.12.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ddad6b33e98f040aa2493e6187e83235c57a4d52ba573a2f94c32d9209b3e7e0", size = 25534639, upload-time = "2026-06-26T14:08:22.499Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/91/7e596f8be4116adc0b9911fc87c214a0ebea55fffac1ca7068483ef0fb07/sqlglotc-30.12.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d998e3b5eddf5db65573009f86cb6a0378efb7e1780d19a6357bce67afb05f0d", size = 26748971, upload-time = "2026-06-26T14:08:25.177Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/57/6e9a29b08a51f2fe8d3774bc1d051e8232375557fa57cbc9b7b6f000d53b/sqlglotc-30.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:1075dbee8fde16aa372ac42a63941cde50d533e57bbe0a34ddc6ab8c328dbf45", size = 10945978, upload-time = "2026-06-26T14:08:27.377Z" },
-    { url = "https://files.pythonhosted.org/packages/90/a3/1e89af7986c5ffd58809ddb756c0a3d85129658e10cb023b1cf7aa61ac3e/sqlglotc-30.12.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cad61b20aa2e8ed01efca83d6fa475d14214bcb1caba5eb11ab3b5b6fdd50ba5", size = 31880909, upload-time = "2026-06-26T14:08:29.476Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/d6/a99f862c66e5662bf20fb77d62012cba2f2dfbd0f9d63c97fe30468fd3ff/sqlglotc-30.12.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bb8836127f5233606bc63c2f56dc529e5ee9c96b1e317f434c65d90984fcdad1", size = 25120994, upload-time = "2026-06-26T14:08:31.753Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/66/7e359fa2e6197d1c6566175428cf1af029602858b477fd07ea0986dae236/sqlglotc-30.12.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1153b757420fc712163bb8da12a14f2603bcd6cdd40b0aedd526e16c68f56b9c", size = 26371919, upload-time = "2026-06-26T14:08:34.368Z" },
-    { url = "https://files.pythonhosted.org/packages/37/b4/5774537e439018c42618b2084fb0a127d62687153b0b2b6893d0d39e17f0/sqlglotc-30.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:2b7454ebbd97d3a197d946fa352ce64f58d6bdacac27883929fd9d45900618f8", size = 10933673, upload-time = "2026-06-26T14:08:36.374Z" },
-    { url = "https://files.pythonhosted.org/packages/79/21/762087c42e56c126ab20c98cb029ef895a666ab7f77af1ca144e0333225c/sqlglotc-30.12.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:1ede716d4bc7bda5558354deb545dda7400ae475c543af08bbb46fc2bab99aae", size = 31785229, upload-time = "2026-06-26T14:08:38.703Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/e5/70f14f11fd5e5f3be654529909dcb2036baddd95fbaa3b221276d13a53a7/sqlglotc-30.12.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4cdb2e5f7416daaa5f3046cc790e2ab31ddbde930443ecfe548cfd1e5f9552e7", size = 25117316, upload-time = "2026-06-26T14:08:41.004Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/ad/6cf38b0203f9c81588aca6be4e40679acf8f2087ca4fee7cc67f4af15a71/sqlglotc-30.12.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0756aff3d6617d8587027981b15a57b27a698f3082ed7d333d313fed0e59de5d", size = 26272124, upload-time = "2026-06-26T14:08:43.104Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/bd/efe78e48b97593e01ceb91090aeb9dfb69e470c6f2dcd7fc5f0f0b637e46/sqlglotc-30.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:efcf65f06d5de8b594cb7bda5dbc2e2b29e06eaef1d90044778751fed455b1dd", size = 11065847, upload-time = "2026-06-26T14:08:45.229Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
removing native c lib because of https://github.com/python/mypy/issues/21716 https://github.com/tobymao/sqlglot/issues/7853

In those cases where performance is still critical, `sqlglot[c]` can be explicitly added