### PR TITLE
test(playwright): reconcile toast-component usage

### DIFF
--- a/e2e-test/ui/playwright/pages/base.page.ts
+++ b/e2e-test/ui/playwright/pages/base.page.ts
@@ -17,13 +17,18 @@
 import * as path from 'path';
 import type { Page } from '@playwright/test';
 import type { DataHubLogger } from '../utils/logger';
+import { ToastComponent } from './common/toast-component';
 
 export class BasePage {
+  protected readonly toast: ToastComponent;
+
   constructor(
     protected readonly page: Page,
     protected readonly logger?: DataHubLogger,
     protected readonly logDir?: string,
-  ) {}
+  ) {
+    this.toast = new ToastComponent(page);
+  }
 
   async navigate(url: string): Promise<void> {
     this.logger?.step('navigate', { url });

--- a/e2e-test/ui/playwright/pages/common/toast-component.ts
+++ b/e2e-test/ui/playwright/pages/common/toast-component.ts
@@ -19,16 +19,21 @@ export class ToastComponent {
     return this.container.getByText(text);
   }
 
-  async expectVisible(text: string | RegExp): Promise<void> {
-    await expect(this.getToast(text)).toBeVisible();
+  async expectVisible(text: string | RegExp, options?: { timeout?: number }): Promise<void> {
+    await expect(this.getToast(text)).toBeVisible(options);
   }
 
-  async expectHidden(text: string | RegExp): Promise<void> {
-    await expect(this.getToast(text)).toBeHidden();
+  async expectHidden(text: string | RegExp, options?: { timeout?: number }): Promise<void> {
+    await expect(this.getToast(text)).toBeHidden(options);
   }
 
-  async expectVisibleThenHidden(text: string | RegExp): Promise<void> {
-    await expect(this.getToast(text)).toBeVisible();
-    await expect(this.getToast(text)).toBeHidden();
+  // Toasts auto-dismiss, so the "hidden" leg rarely needs tuning; the "visible" leg
+  // often does, since the toast only appears after an async/backend action completes.
+  async expectVisibleThenHidden(
+    text: string | RegExp,
+    options?: { visibleTimeout?: number; hiddenTimeout?: number },
+  ): Promise<void> {
+    await this.expectVisible(text, { timeout: options?.visibleTimeout });
+    await this.expectHidden(text, { timeout: options?.hiddenTimeout });
   }
 }

--- a/e2e-test/ui/playwright/pages/dataset.page.ts
+++ b/e2e-test/ui/playwright/pages/dataset.page.ts
@@ -25,8 +25,6 @@ export class DatasetPage extends BasePage {
   readonly tagTermInput: Locator;
   readonly addTagFromModalButton: Locator;
   readonly tagUnassignConfirmButton: Locator;
-  readonly tagAddedToast: Locator;
-  readonly tagRemovedToast: Locator;
 
   // ── Close ─────────────────────────────────────────────────────────────────
   readonly modalCloseButton: Locator;
@@ -38,8 +36,6 @@ export class DatasetPage extends BasePage {
   readonly ownerDropdownSearchInput: Locator;
   readonly addOwnersSelectDropdown: Locator;
   readonly ownersDoneButton: Locator;
-  readonly ownersAddedToast: Locator;
-  readonly ownerRemovedToast: Locator;
   readonly ownerRemoveConfirmButton: Locator;
 
   // ── Business Attribute ────────────────────────────────────────────────────
@@ -77,8 +73,6 @@ export class DatasetPage extends BasePage {
     this.tagTermInput = page.getByTestId('dropdown-search-input');
     this.addTagFromModalButton = page.getByTestId('add-tag-term-from-modal-btn');
     this.tagUnassignConfirmButton = page.getByTestId('modal-confirm-button');
-    this.tagAddedToast = page.getByText('Added Tags!');
-    this.tagRemovedToast = page.getByText('Removed Tag!');
 
     this.modalCloseButton = page.getByRole('button', { name: 'Close' });
 
@@ -88,8 +82,6 @@ export class DatasetPage extends BasePage {
     this.ownerDropdownSearchInput = page.getByTestId('dropdown-search-input');
     this.addOwnersSelectDropdown = page.getByTestId('add-owners-select-dropdown');
     this.ownersDoneButton = page.getByRole('dialog').getByText('Done');
-    this.ownersAddedToast = page.getByText('Owners Added');
-    this.ownerRemovedToast = page.getByText('Owner Removed');
     this.ownerRemoveConfirmButton = page.getByRole('dialog').getByText('Yes');
 
     this.businessAttributeSection = page.getByTestId('sidebar-section-content-Business Attribute');
@@ -307,7 +299,7 @@ export class DatasetPage extends BasePage {
     await this.page.getByRole('listbox').locator('..').getByText(ownerType).click();
     await expect(this.page.getByRole('dialog').getByText(ownerType)).toBeVisible();
     await this.ownersDoneButton.click();
-    await expect(this.ownersAddedToast).toBeVisible({ timeout: 15000 });
+    await this.toast.expectVisible('Owners Added', { timeout: 15000 });
     await expect(this.page.getByText(ownerType)).toBeVisible();
     await expect(this.page.getByText(owner)).toBeVisible();
   }
@@ -318,7 +310,7 @@ export class DatasetPage extends BasePage {
     // eslint-disable-next-line playwright/no-raw-locators -- dynamic href/id selector passed from test; no semantic equivalent
     await this.page.locator(elementId).locator('xpath=following-sibling::*[1]').click();
     await this.ownerRemoveConfirmButton.click();
-    await expect(this.ownerRemovedToast).toBeVisible({ timeout: 15000 });
+    await this.toast.expectVisible('Owner Removed', { timeout: 15000 });
     await expect(this.page.getByText(owner)).not.toBeVisible({ timeout: 10000 });
   }
 
@@ -351,7 +343,7 @@ export class DatasetPage extends BasePage {
     await expect(this.addTagFromModalButton).toBeEnabled();
     await this.addTagFromModalButton.click();
 
-    await expect(this.tagAddedToast).toBeVisible();
+    await this.toast.expectVisible('Added Tags!');
   }
 
   async unassignTag(tagName: string): Promise<void> {
@@ -360,7 +352,7 @@ export class DatasetPage extends BasePage {
     await this.getTagRemoveIcon(tagName).click();
     await expect(this.tagUnassignConfirmButton).toBeVisible();
     await this.tagUnassignConfirmButton.click();
-    await expect(this.tagRemovedToast).toBeVisible();
+    await this.toast.expectVisible('Removed Tag!');
   }
 
   async expectTagAssigned(tagName: string): Promise<void> {

--- a/e2e-test/ui/playwright/pages/domains/domain-entity.page.ts
+++ b/e2e-test/ui/playwright/pages/domains/domain-entity.page.ts
@@ -123,7 +123,7 @@ export class DomainEntityPage extends BasePage {
     await this.createDomainConfirmButton.click();
 
     // Wait for success message indicating domain was created
-    await expect(this.page.getByText('Created domain!')).toBeVisible({ timeout: TIMEOUTS.LONG });
+    await this.toast.expectVisible('Created domain!', { timeout: TIMEOUTS.LONG });
 
     // Get URN from GraphQL response
     const response = await responsePromise;
@@ -153,7 +153,7 @@ export class DomainEntityPage extends BasePage {
     await this.moveDomainConfirmButton.click();
 
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
-    await expect(this.page.getByText('Moved Domain!')).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
+    await this.toast.expectVisible('Moved Domain!', { timeout: TIMEOUTS.MEDIUM });
   }
 
   async addDocumentation(description: string): Promise<void> {

--- a/e2e-test/ui/playwright/pages/entity-documentation.page.ts
+++ b/e2e-test/ui/playwright/pages/entity-documentation.page.ts
@@ -82,7 +82,7 @@ export class EntityDocumentationPage extends BasePage {
     await this.page.keyboard.press('ControlOrMeta+a');
     await this.page.keyboard.type(text);
     await this.saveDescriptionButton.click();
-    await expect(this.page.getByText('Description Updated')).toBeVisible({ timeout: 15000 });
+    await this.toast.expectVisible('Description Updated', { timeout: 15000 });
   }
 
   async clearDocumentation(): Promise<void> {
@@ -94,7 +94,7 @@ export class EntityDocumentationPage extends BasePage {
     await this.page.keyboard.press('ControlOrMeta+a');
     await this.page.keyboard.press('Delete');
     await this.saveDescriptionButton.click();
-    await expect(this.page.getByText('Description Updated')).toBeVisible({ timeout: 15000 });
+    await this.toast.expectVisible('Description Updated', { timeout: 15000 });
   }
 
   // ── Field documentation (v1 schema tab) ─────────────────────────────────
@@ -146,7 +146,7 @@ export class EntityDocumentationPage extends BasePage {
     await this.page.waitForTimeout(500);
     await this.page.keyboard.type(description);
     await this.fieldDescriptionUpdateButton.click();
-    await expect(this.page.getByText('Updated!')).toBeVisible({ timeout: 15000 });
+    await this.toast.expectVisible('Updated!', { timeout: 15000 });
   }
 
   // ── Link management ──────────────────────────────────────────────────────

--- a/e2e-test/ui/playwright/pages/entity/document.page.ts
+++ b/e2e-test/ui/playwright/pages/entity/document.page.ts
@@ -38,7 +38,6 @@ export class DocumentPage extends BasePage {
   readonly getDeleteButton: () => Locator;
   readonly getDeleteConfirmDialog: () => Locator;
   readonly getParentBreadcrumb: (title: string) => Locator;
-  readonly getMoveSuccessMessage: () => Locator;
   readonly getMoveSearchResultByText: (text: string) => Locator;
 
   constructor(page: Page, logger?: DataHubLogger, logDir?: string) {
@@ -76,7 +75,6 @@ export class DocumentPage extends BasePage {
     this.getDeleteButton = () => page.getByRole('button', { name: 'Delete' });
     this.getDeleteConfirmDialog = () => page.getByText('Delete Document');
     this.getParentBreadcrumb = (title: string) => page.getByTestId('parent-breadcrumb-link').filter({ hasText: title });
-    this.getMoveSuccessMessage = () => page.getByText(/moved successfully/i);
     this.getMoveSearchResultByText = (text: string) => this.movePopover.getByText(text, { exact: false });
   }
 
@@ -285,7 +283,7 @@ export class DocumentPage extends BasePage {
   }
 
   async expectMoveSuccessMessage(): Promise<void> {
-    await expect(this.getMoveSuccessMessage()).toBeVisible();
+    await this.toast.expectVisible(/moved successfully/i);
   }
 
   async clickActionsMenu(): Promise<void> {

--- a/e2e-test/ui/playwright/pages/glossary.page.ts
+++ b/e2e-test/ui/playwright/pages/glossary.page.ts
@@ -10,7 +10,6 @@ import { BasePage } from './base.page';
 import type { DataHubLogger } from '../utils/logger';
 import { GraphQLHelper } from '../helpers/graphql-helper';
 import { ModalComponent } from './common/modal-component';
-import { ToastComponent } from './common/toast-component';
 
 export class GlossaryPage extends BasePage {
   readonly modalComponent: ModalComponent;
@@ -69,12 +68,10 @@ export class GlossaryPage extends BasePage {
   readonly propertiesTab: Locator;
 
   private readonly graphqlHelper: GraphQLHelper;
-  private readonly toast: ToastComponent;
 
   constructor(page: Page, logger?: DataHubLogger, logDir?: string) {
     super(page, logger, logDir);
     this.graphqlHelper = new GraphQLHelper(page);
-    this.toast = new ToastComponent(page);
 
     this.modalComponent = new ModalComponent(page);
 

--- a/e2e-test/ui/playwright/pages/groups.page.ts
+++ b/e2e-test/ui/playwright/pages/groups.page.ts
@@ -9,13 +9,11 @@ export class GroupsPage extends BasePage {
   readonly advancedToggle: Locator;
   readonly groupIdInput: Locator;
   readonly submitCreateGroupButton: Locator;
-  readonly createdGroupToast: Locator;
   readonly addMemberButton: Locator;
   readonly addMembersSelect: Locator;
   readonly addMembersSelectBase: Locator;
   readonly memberDropdownSearchInput: Locator;
   readonly addMembersSelectDropdown: Locator;
-  readonly membersAddedToast: Locator;
 
   constructor(page: Page, logger?: DataHubLogger, logDir?: string) {
     super(page, logger, logDir);
@@ -25,13 +23,11 @@ export class GroupsPage extends BasePage {
     this.advancedToggle = page.getByText('Advanced');
     this.groupIdInput = page.getByLabel('Group Id');
     this.submitCreateGroupButton = page.getByRole('button', { name: 'Create' });
-    this.createdGroupToast = page.getByText('Created group!');
     this.addMemberButton = page.getByText('Add Member');
     this.addMembersSelect = page.getByTestId('add-members-select');
     this.addMembersSelectBase = page.getByTestId('add-members-select-base');
     this.memberDropdownSearchInput = page.getByTestId('dropdown-search-input');
     this.addMembersSelectDropdown = page.getByTestId('add-members-select-dropdown');
-    this.membersAddedToast = page.getByText('Group members added!');
   }
 
   async navigateToGroups(): Promise<void> {
@@ -48,7 +44,7 @@ export class GroupsPage extends BasePage {
     await expect(this.page.getByText('Group Id')).toBeVisible();
     await this.groupIdInput.fill(groupId);
     await this.submitCreateGroupButton.click();
-    await expect(this.createdGroupToast).toBeVisible({ timeout: 15000 });
+    await this.toast.expectVisible('Created group!', { timeout: 15000 });
     await expect(this.page.getByText(name)).toBeVisible();
   }
 
@@ -63,7 +59,7 @@ export class GroupsPage extends BasePage {
     await this.memberDropdownSearchInput.fill(memberName);
     await this.addMembersSelectDropdown.getByText(memberName).click({ force: true });
     await this.page.getByRole('dialog').getByRole('button', { name: 'Add' }).click({ force: true });
-    await expect(this.membersAddedToast).toBeVisible({ timeout: 15000 });
+    await this.toast.expectVisible('Group members added!', { timeout: 15000 });
     await expect(this.page.getByText(memberName)).toBeVisible({ timeout: 10000 });
   }
 }

--- a/e2e-test/ui/playwright/pages/ingestion/base/tabs/base.tab.ts
+++ b/e2e-test/ui/playwright/pages/ingestion/base/tabs/base.tab.ts
@@ -1,16 +1,21 @@
 import { expect, Locator, Page } from '@playwright/test';
 import { DataHubLogger } from '@utils/logger';
+import { ToastComponent } from '@pages/common/toast-component';
 
 export abstract class BaseTab {
   abstract readonly name: string;
   abstract readonly path: string;
   abstract readonly tabKey: string;
 
+  protected readonly toast: ToastComponent;
+
   constructor(
     protected readonly page: Page,
     protected readonly logger?: DataHubLogger,
     protected readonly logDir?: string,
-  ) {}
+  ) {
+    this.toast = new ToastComponent(page);
+  }
 
   get tab(): Locator {
     // eslint-disable-next-line playwright/no-raw-locators -- Ant Design tab node keyed by data-node-key; no ARIA role exposed

--- a/e2e-test/ui/playwright/pages/ingestion/base/tabs/secrets-base.tab.ts
+++ b/e2e-test/ui/playwright/pages/ingestion/base/tabs/secrets-base.tab.ts
@@ -3,7 +3,6 @@ import type { DataHubLogger } from '../../../../utils/logger';
 import { BaseTab } from './base.tab';
 import { ModalComponent } from '@pages/common/modal-component';
 import { ConfirmationModalComponent } from '@pages/common/confirmation-modal-component';
-import { ToastComponent } from '@pages/common/toast-component';
 import { GraphQLHelper } from '../../../../helpers/graphql-helper';
 
 export class SecretsBaseTab extends BaseTab {
@@ -17,7 +16,6 @@ export class SecretsBaseTab extends BaseTab {
   readonly secretDescriptionInput: Locator;
   readonly secretModalCreateButton: Locator;
 
-  protected readonly toast: ToastComponent;
   protected readonly graphql: GraphQLHelper;
 
   constructor(
@@ -36,7 +34,6 @@ export class SecretsBaseTab extends BaseTab {
     this.secretValueInput = page.getByTestId('secret-modal-value-input').getByRole('textbox');
     this.secretDescriptionInput = page.getByTestId('secret-modal-description-input').getByRole('textbox');
     this.secretModalCreateButton = page.getByTestId('secret-modal-create-button');
-    this.toast = new ToastComponent(page);
     this.graphql = new GraphQLHelper(page);
   }
 

--- a/e2e-test/ui/playwright/pages/ingestion/base/tabs/sources-base.tab.ts
+++ b/e2e-test/ui/playwright/pages/ingestion/base/tabs/sources-base.tab.ts
@@ -3,7 +3,6 @@ import { GraphQLHelper } from '../../../../helpers/graphql-helper';
 import type { DataHubLogger } from '../../../../utils/logger';
 import { BaseTab } from './base.tab';
 import { ConfirmationModalComponent } from '@pages/common/confirmation-modal-component';
-import { ToastComponent } from '@pages/common/toast-component';
 import { LONG_TIMEOUT } from '@utils/constants';
 import {
   DISPLAY_NAME_USERNAME_PASSWORD,
@@ -88,7 +87,6 @@ export abstract class SourcesBaseTab extends BaseTab {
   abstract readonly cliVersionInput: Locator;
 
   protected readonly graphql: GraphQLHelper;
-  protected readonly toast: ToastComponent;
 
   // Locators for the inline secret creation dialog (used in createSecretInlineForPassword).
   // Scoped to the ARIA dialog to avoid strict-mode violations when hidden modal instances
@@ -111,7 +109,6 @@ export abstract class SourcesBaseTab extends BaseTab {
     this.tabKey = 'Sources';
 
     this.graphql = new GraphQLHelper(page);
-    this.toast = new ToastComponent(page);
 
     this.inlineSecretDialog = page.getByRole('dialog', { name: 'Create a new Secret' });
     this.inlineSecretNameInput = this.inlineSecretDialog.getByTestId('secret-modal-name-input').getByRole('textbox');

--- a/e2e-test/ui/playwright/pages/policies.page.ts
+++ b/e2e-test/ui/playwright/pages/policies.page.ts
@@ -46,7 +46,7 @@ export class PoliciesPage extends BasePage {
         const deactivateItem = this.page.getByRole('menuitem').getByText('Deactivate');
         if ((await deactivateItem.count()) > 0) {
           await deactivateItem.click();
-          await expect(this.page.getByText('Successfully deactivated policy.')).toBeVisible({ timeout: 15000 });
+          await this.toast.expectVisible('Successfully deactivated policy.', { timeout: 15000 });
         }
       }
     }

--- a/e2e-test/ui/playwright/pages/settings/base.settings.page.ts
+++ b/e2e-test/ui/playwright/pages/settings/base.settings.page.ts
@@ -82,12 +82,6 @@ export class BaseSettingsPage extends BasePage {
     }
   }
 
-  async waitForToast(text: string): Promise<void> {
-    const toastMessage = this.page.getByText(text);
-    await expect(toastMessage).toBeVisible();
-    await expect(toastMessage).toBeHidden();
-  }
-
   async logout(): Promise<void> {
     if ((await this.modalDialog.count()) > 0) {
       await this.page.keyboard.press('Escape');

--- a/e2e-test/ui/playwright/pages/settings/groups.page.ts
+++ b/e2e-test/ui/playwright/pages/settings/groups.page.ts
@@ -126,7 +126,7 @@ export class GroupsPage extends BaseSettingsPage {
     await this.selectFromDropdown(this.addMembersSelectBase, this.addMembersSelectDropdown, username);
     await this.addMembersSelectBase.click();
     await this.addMemberConfirmButton.click();
-    await expect(this.page.getByText(TOAST_MESSAGES.GROUP_MEMBERS_ADDED)).toBeVisible();
+    await this.toast.expectVisible(TOAST_MESSAGES.GROUP_MEMBERS_ADDED);
     await expect(this.membersSection.getByText(username)).toBeVisible();
   }
 
@@ -138,7 +138,7 @@ export class GroupsPage extends BaseSettingsPage {
     await this.selectFromDropdown(this.addOwnersSelectBase, this.addOwnersSelectDropdown, username);
     await this.addOwnersSelectBase.click();
     await this.addOwnerConfirmButton.click();
-    await expect(this.page.getByText(TOAST_MESSAGES.OWNERS_ADDED)).toBeVisible();
+    await this.toast.expectVisible(TOAST_MESSAGES.OWNERS_ADDED);
   }
 
   async updateGroupInfo(email: string, slack: string, newName: string): Promise<void> {
@@ -153,11 +153,11 @@ export class GroupsPage extends BaseSettingsPage {
   }
 
   async verifyOwnersAdded(): Promise<void> {
-    await expect(this.page.getByText(TOAST_MESSAGES.OWNERS_ADDED)).toBeVisible();
+    await this.toast.expectVisible(TOAST_MESSAGES.OWNERS_ADDED);
   }
 
   async verifyGroupInfoUpdated(expectedEmail: string, expectedSlack: string): Promise<void> {
-    await expect(this.page.getByText(TOAST_MESSAGES.NAME_UPDATED)).toBeVisible();
+    await this.toast.expectVisible(TOAST_MESSAGES.NAME_UPDATED);
     await expect(this.page.getByText(expectedEmail)).toBeVisible();
     await expect(this.page.getByText(expectedSlack)).toBeVisible();
   }
@@ -172,7 +172,7 @@ export class GroupsPage extends BaseSettingsPage {
     await this.page.keyboard.press('End');
     await this.page.keyboard.type(append);
     await this.page.mouse.click(0, 0);
-    await this.waitForToast(TOAST_MESSAGES.CHANGES_SAVED);
+    await this.toast.expectVisibleThenHidden(TOAST_MESSAGES.CHANGES_SAVED);
     await expect(this.page.getByText(`${currentText}${append}`)).toBeVisible({ timeout: WAIT_TIMEOUT });
   }
 
@@ -197,7 +197,7 @@ export class GroupsPage extends BaseSettingsPage {
     await this.modalDeleteItem.click();
     await this.deleteGroupConfirmButton.waitFor({ state: 'visible', timeout: WAIT_TIMEOUT });
     await this.deleteGroupConfirmButton.click();
-    await expect(this.page.getByText(`Deleted ${groupName}!`)).toBeVisible();
+    await this.toast.expectVisible(`Deleted ${groupName}!`);
     await expect(this.page.getByText(groupName)).toBeHidden();
   }
 }

--- a/e2e-test/ui/playwright/pages/settings/home-page-posts.page.ts
+++ b/e2e-test/ui/playwright/pages/settings/home-page-posts.page.ts
@@ -83,7 +83,7 @@ export class HomePagePostsPage extends BaseSettingsPage {
     await this.submitCreateButton.click();
     // Wait for the toast first (confirms API call completed)
     // Then wait for networkidle to ensure page is fully updated
-    await this.waitForToast(TOAST_MESSAGES.CREATED_POST);
+    await this.toast.expectVisibleThenHidden(TOAST_MESSAGES.CREATED_POST);
     await this.page.waitForLoadState('networkidle');
   }
 
@@ -92,7 +92,7 @@ export class HomePagePostsPage extends BaseSettingsPage {
     await this.submitUpdateButton.click();
     // Wait for the toast first (confirms API call completed)
     // Then wait for networkidle to ensure page is fully updated
-    await this.waitForToast(TOAST_MESSAGES.UPDATED_POST);
+    await this.toast.expectVisibleThenHidden(TOAST_MESSAGES.UPDATED_POST);
     await this.page.waitForLoadState('networkidle');
   }
 

--- a/e2e-test/ui/playwright/pages/settings/policies.page.ts
+++ b/e2e-test/ui/playwright/pages/settings/policies.page.ts
@@ -153,7 +153,7 @@ export class PoliciesPage extends BaseSettingsPage {
     await this.saveButton.waitFor({ state: 'visible' });
     await this.saveButton.click();
 
-    await this.waitForToast(TOAST_MESSAGES.SUCCESSFULLY_SAVED_POLICY);
+    await this.toast.expectVisibleThenHidden(TOAST_MESSAGES.SUCCESSFULLY_SAVED_POLICY);
     await this.searchForPolicy(policyName);
     await expect(this.getPolicyRow(policyName)).toBeVisible();
   }
@@ -179,7 +179,7 @@ export class PoliciesPage extends BaseSettingsPage {
     await this.saveButton.waitFor({ state: 'visible' });
     await this.saveButton.click();
 
-    await this.waitForToast(TOAST_MESSAGES.SUCCESSFULLY_SAVED_POLICY);
+    await this.toast.expectVisibleThenHidden(TOAST_MESSAGES.SUCCESSFULLY_SAVED_POLICY);
     await this.searchForPolicy(newName);
     await this.getPolicyRow(newName).waitFor({ state: 'visible', timeout: WAIT_TIMEOUT });
   }
@@ -195,18 +195,18 @@ export class PoliciesPage extends BaseSettingsPage {
     await this.searchForPolicy(name);
     await this.openRowMenu(name);
     await this.clickMenuAction('Deactivate');
-    await this.waitForToast(TOAST_MESSAGES.SUCCESSFULLY_DEACTIVATED_POLICY);
+    await this.toast.expectVisibleThenHidden(TOAST_MESSAGES.SUCCESSFULLY_DEACTIVATED_POLICY);
 
     await this.searchForPolicy(name);
     await this.openRowMenu(name);
     await this.clickMenuAction('Activate');
-    await this.waitForToast(TOAST_MESSAGES.SUCCESSFULLY_ACTIVATED_POLICY);
+    await this.toast.expectVisibleThenHidden(TOAST_MESSAGES.SUCCESSFULLY_ACTIVATED_POLICY);
 
     await this.openRowMenu(name);
     await this.clickMenuAction('Delete');
     await expect(this.page.getByText(deleteDialogTitle)).toBeVisible();
     await this.confirmButton.click();
-    await this.waitForToast(TOAST_MESSAGES.SUCCESSFULLY_REMOVED_POLICY);
+    await this.toast.expectVisibleThenHidden(TOAST_MESSAGES.SUCCESSFULLY_REMOVED_POLICY);
     await expect(this.getPolicyRow(name)).toBeHidden();
   }
 
@@ -219,7 +219,7 @@ export class PoliciesPage extends BaseSettingsPage {
       const deactivateItem = this.getMenuItems().getByText('Deactivate');
       if ((await deactivateItem.count()) > 0) {
         await deactivateItem.click();
-        await this.waitForToast(TOAST_MESSAGES.SUCCESSFULLY_DEACTIVATED_POLICY);
+        await this.toast.expectVisibleThenHidden(TOAST_MESSAGES.SUCCESSFULLY_DEACTIVATED_POLICY);
       }
     }
   }

--- a/e2e-test/ui/playwright/pages/siblings.page.ts
+++ b/e2e-test/ui/playwright/pages/siblings.page.ts
@@ -14,7 +14,6 @@ export class SiblingsPage extends BasePage {
   private addTermsButton: Locator;
   private searchResults: Locator;
   private mergedIndicator: Locator;
-  private termAddedToast: Locator;
 
   constructor(page: Page, logger?: DataHubLogger, logDir?: string) {
     super(page, logger, logDir);
@@ -28,7 +27,6 @@ export class SiblingsPage extends BasePage {
     this.modalConfirmButton = page.getByTestId('modal-confirm-button');
     this.searchResults = page.getByTestId('search-result-item');
     this.mergedIndicator = this.entityHeader.getByText('&');
-    this.termAddedToast = page.getByText(/Added Terms/i);
   }
 
   // ── Private helper methods ────────────────────────────────────────────────
@@ -131,7 +129,7 @@ export class SiblingsPage extends BasePage {
   }
 
   async verifyTermAddedToast(): Promise<void> {
-    await expect(this.termAddedToast).toBeVisible();
+    await this.toast.expectVisible(/Added Terms/i);
   }
 
   // ── Interaction methods ───────────────────────────────────────────────────

--- a/e2e-test/ui/playwright/pages/tags.page.ts
+++ b/e2e-test/ui/playwright/pages/tags.page.ts
@@ -1,7 +1,6 @@
 import { Locator, Page, expect } from '@playwright/test';
 import { BasePage } from './base.page';
 import type { DataHubLogger } from '../utils/logger';
-import { ToastComponent } from './common/toast-component';
 
 /**
  * Page object for the Manage Tags page (/tags).
@@ -37,8 +36,6 @@ export class TagsPage extends BasePage {
   readonly deleteTagConfirmButton: Locator;
   readonly actionDeleteButton: Locator;
 
-  protected readonly toast: ToastComponent;
-
   constructor(page: Page, logger?: DataHubLogger, logDir?: string) {
     super(page, logger, logDir);
 
@@ -49,7 +46,6 @@ export class TagsPage extends BasePage {
 
     this.createTagCreateButton = page.getByTestId('create-tag-modal-create-button');
     this.createTagCancelButton = page.getByTestId('create-tag-modal-cancel-button');
-    this.toast = new ToastComponent(page);
     this.createTagModalContent = page
       .getByRole('dialog')
       .filter({ has: page.getByTestId('create-tag-modal-create-button') });


### PR DESCRIPTION
This PR refactors playwright tests to use ToastComponent

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
