### PR TITLE
test: Ignore non-deterministic Doris table size in integration tests

### DIFF
--- a/metadata-ingestion/tests/integration/doris/test_doris.py
+++ b/metadata-ingestion/tests/integration/doris/test_doris.py
@@ -126,6 +126,10 @@ def test_doris_ingest(
         r"root\[\d+\]\['aspect'\]\['json'\]\['fieldProfiles'\]\[\d+\]\['min'\]",
         r"root\[\d+\]\['aspect'\]\['json'\]\['fieldProfiles'\]\[\d+\]\['max'\]",
         r"root\[\d+\]\['aspect'\]\['json'\]\['fieldProfiles'\]\[\d+\]\['sampleValues'\]",
+        # Doris reports table storage size (information_schema.tables.data_length)
+        # asynchronously and it reflects columnar segment/compaction state, so it
+        # varies between runs. Ignore it like the other non-deterministic profile fields.
+        r"root\[\d+\]\['aspect'\]\['json'\]\['sizeInBytes'\]",
     ]
 
     mce_helpers.check_golden_file(


### PR DESCRIPTION
## Description
Updates the Doris integration test to ignore the `sizeInBytes` field when comparing against golden files. This field is reported asynchronously by Doris and reflects the current columnar segment/compaction state, causing it to vary between test runs.

## Regression Analysis

The `test_doris_ingest[doris_profile.yml-doris_profile_golden.json]` test began failing on `master` with:

```
Failed: Metadata files differ (use `pytest --update-golden-files` to update):
{'dictionary_item_added': ["root[27]['aspect']['json']['sizeInBytes']",
                           "root[28]['aspect']['json']['sizeInBytes']",
                           "root[29]['aspect']['json']['sizeInBytes']"]}
```

**When:** The failure was introduced on **2026-07-10** by #18298 (*"fix(ingest/mysql): read profiling storage bytes case-insensitively - CUS-9272"*), merged at ~10:15 UTC.

**How:** The Doris connector extends `MySQLSource`, and the `sizeInBytes` value on profile aspects comes from `MySQLSource.add_profile_metadata()`, which reads `data_length` from `information_schema.tables`.

- Before #18298, that method accessed the result row via fixed upper-case attributes (`row.DATA_LENGTH`). MySQL upper-cases `information_schema` column labels, but Doris (like MariaDB) preserves the selected lower-case label, so the attribute lookup failed and the storage-size metadata was **silently dropped**. As a result `sizeInBytes` was never emitted for Doris, and the profile golden — last regenerated 2026-05-19 in #17465 — never contained it.
- #18298 changed the row to be unpacked positionally (case-independent). This correctly fixed MySQL/MariaDB, but as a side effect Doris now reports `data_length` too, so `sizeInBytes` began appearing on the three column-level profile aspects (`root[27..29]`) that the golden doesn't have.

**Why ignore rather than bake the value into the golden:** Doris populates `information_schema.tables.data_length` asynchronously and it reflects columnar segment/compaction state, so it is not stable across runs. This mirrors the existing treatment of the other non-deterministic profile fields in this test (`min` / `max` / `sampleValues`). (For MySQL/InnoDB the value is page-aligned and deterministic at `16384`, which is why it is baked into the MySQL goldens instead.)

## Changes
- Added `sizeInBytes` to the list of non-deterministic field patterns that are excluded from golden file comparison in the Doris integration test
- Added explanatory comment documenting why this field is non-deterministic

## Test Plan
Existing integration tests pass with this change. The test now properly handles the non-deterministic nature of Doris table size reporting.

https://claude.ai/code/session_01HrKVag7fkkzB1ATkqcgrq4