### PR TITLE
feat(smoke-test): enable configurable pytest-xdist in unified workflows

### DIFF
--- a/.github/workflows/docker-unified-nightly.yml
+++ b/.github/workflows/docker-unified-nightly.yml
@@ -396,9 +396,11 @@ jobs:
           DATAHUB_VERSION: ${{ needs.setup.outputs.tag }}
           CLEANUP_DATA: "false"
           TEST_STRATEGY: ${{ matrix.test_strategy }}
-          # BATCH_COUNT=1: no matrix module slicing; PYTEST_XDIST_WORKERS enables in-process parallelism.
+          # Parallelism is profile×arch matrix jobs, not BATCH_COUNT slicing — run the full suite per cell.
           BATCH_COUNT: "1"
           BATCH_NUMBER: "0"
+          # pytest-xdist is controlled only by workflow-level PYTEST_XDIST_WORKERS (independent of BATCH_COUNT).
+          PYTEST_XDIST_WORKERS: ${{ env.PYTEST_XDIST_WORKERS }}
           FILTERED_TESTS: ${{ steps.parse-pytest-failures.outputs.filtered_tests_file || '' }}
           DATAHUB_SMOKETEST_EXECUTOR_ID: "${{ github.sha }}-${{ matrix.test_strategy }}-${{ matrix.architecture }}"
           PROFILE_NAME: ${{ matrix.profile }}

--- a/.github/workflows/docker-unified-nightly.yml
+++ b/.github/workflows/docker-unified-nightly.yml
@@ -19,6 +19,7 @@ env:
   DOCKER_CACHE: "DEPOT"
   DEPOT_PROJECT_ID: "${{ vars.DEPOT_PROJECT_ID }}"
   DEPOT_TOKEN: "${{ secrets.DEPOT_TOKEN }}"
+  PYTEST_XDIST_WORKERS: "3"
 
 permissions:
   contents: read
@@ -395,7 +396,8 @@ jobs:
           DATAHUB_VERSION: ${{ needs.setup.outputs.tag }}
           CLEANUP_DATA: "false"
           TEST_STRATEGY: ${{ matrix.test_strategy }}
-          BATCH_COUNT: "1" # since this workflow runs only on schedule trigger, batching isn't really needed.
+          # BATCH_COUNT=1: no matrix module slicing; PYTEST_XDIST_WORKERS enables in-process parallelism.
+          BATCH_COUNT: "1"
           BATCH_NUMBER: "0"
           FILTERED_TESTS: ${{ steps.parse-pytest-failures.outputs.filtered_tests_file || '' }}
           DATAHUB_SMOKETEST_EXECUTOR_ID: "${{ github.sha }}-${{ matrix.test_strategy }}-${{ matrix.architecture }}"

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: "5"
         type: string
+      pytest_xdist_workers:
+        description: "pytest-xdist worker count per smoke-test matrix job (0 disables xdist)"
+        required: false
+        default: "3"
+        type: string
   push:
     branches:
       - master
@@ -51,6 +56,7 @@ env:
   IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
   DEPOT_TOKEN: "${{ secrets.DEPOT_TOKEN }}"
   PLAYWRIGHT_SHARD_COUNT: "8"
+  PYTEST_XDIST_WORKERS: "${{ github.event.inputs.pytest_xdist_workers || '3' }}"
 
 permissions:
   contents: read

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -775,6 +775,7 @@ jobs:
           TEST_STRATEGY: pytests
           BATCH_COUNT: ${{ matrix.batch_count }}
           BATCH_NUMBER: ${{ matrix.batch }}
+          PYTEST_XDIST_WORKERS: ${{ env.PYTEST_XDIST_WORKERS }}
           FILTERED_TESTS: ${{ steps.retry-check.outputs.filtered_tests_file || '' }}
         run: |
           if [[ -n "$FILTERED_TESTS" && -f "$FILTERED_TESTS" ]]; then

--- a/smoke-test/smoke.sh
+++ b/smoke-test/smoke.sh
@@ -37,6 +37,15 @@ source ./set-test-env-vars.sh
 
 echo "TEST_STRATEGY: $TEST_STRATEGY, BATCH_COUNT: $BATCH_COUNT, BATCH_NUMBER: $BATCH_NUMBER"
 
+# PYTEST_XDIST_WORKERS: optional pytest-xdist worker count (workflows set this, e.g. 3).
+# Matrix jobs slice modules via BATCH_COUNT/BATCH_NUMBER; xdist parallelizes within each slice.
+# --dist=loadscope groups by class (or whole module for module-level tests).
+xdist_args=()
+if [[ "${PYTEST_XDIST_WORKERS:-0}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "PYTEST_XDIST_WORKERS=${PYTEST_XDIST_WORKERS}: enabling pytest-xdist -n ${PYTEST_XDIST_WORKERS} --dist=loadscope"
+  xdist_args=(-n "${PYTEST_XDIST_WORKERS}" --dist=loadscope)
+fi
+
 # TEST_STRATEGY:
 #   if set to pytests, runs all pytests, skips cypress tests(though cypress test launch is via  a pytest).
 #   if set tp cypress, runs all cypress tests
@@ -46,13 +55,18 @@ echo "TEST_STRATEGY: $TEST_STRATEGY, BATCH_COUNT: $BATCH_COUNT, BATCH_NUMBER: $B
 # increase, the batch_count config (in docker-unified.yml) may need adjustment.
 if [[ "${TEST_STRATEGY}" == "pytests" ]]; then
   #pytests only - github test matrix runs pytests in one of the runners when applicable.
-  pytest -rP --durations=20 -vv --continue-on-collection-errors --reruns 1 --reruns-delay 1 --junit-xml=junit.smoke-pytests.xml -k 'not test_run_cypress'
+  pytest -rP --durations=20 -vv --continue-on-collection-errors --reruns 1 --reruns-delay 1 \
+    ${xdist_args[@]+"${xdist_args[@]}"} \
+    --junit-xml=junit.smoke-pytests.xml -k 'not test_run_cypress'
 elif [[ "${TEST_STRATEGY}" == "cypress" ]]; then
   # run only cypress tests. The test inspects BATCH_COUNT and BATCH_NUMBER and runs only a subset of tests in that batch.
   # github workflow test matrix will invoke this in multiple runners for each batch.
   # Skipping the junit at the pytest level since cypress itself generates junits on a per-test basis. The pytest is a single test for all cypress
   # tests and isnt very helpful.
+  # Cypress is launched from a single pytest module; xdist is not useful here.
   pytest -rP --durations=20 -vvs --continue-on-collection-errors tests/cypress/integration_test.py
 else
-  pytest -rP --durations=20 -vvs --continue-on-collection-errors --junit-xml=junit.smoke-all.xml
+  pytest -rP --durations=20 -vvs --continue-on-collection-errors \
+    ${xdist_args[@]+"${xdist_args[@]}"} \
+    --junit-xml=junit.smoke-all.xml
 fi

--- a/smoke-test/smoke.sh
+++ b/smoke-test/smoke.sh
@@ -38,7 +38,7 @@ source ./set-test-env-vars.sh
 echo "TEST_STRATEGY: $TEST_STRATEGY, BATCH_COUNT: $BATCH_COUNT, BATCH_NUMBER: $BATCH_NUMBER"
 
 # PYTEST_XDIST_WORKERS: optional pytest-xdist worker count (workflows set this, e.g. 3).
-# Matrix jobs slice modules via BATCH_COUNT/BATCH_NUMBER; xdist parallelizes within each slice.
+# Independent of BATCH_COUNT/BATCH_NUMBER — matrix batching and xdist are orthogonal knobs.
 # --dist=loadscope groups by class (or whole module for module-level tests).
 xdist_args=()
 if [[ "${PYTEST_XDIST_WORKERS:-0}" =~ ^[1-9][0-9]*$ ]]; then


### PR DESCRIPTION
## Summary

- Add `PYTEST_XDIST_WORKERS` to `smoke-test/smoke.sh` so pytest runs with `-n N --dist=loadscope` when workflows set a positive worker count.
- Enable **3 xdist workers per matrix job** in `docker-unified.yml` (default for push/PR/schedule) and `docker-unified-nightly.yml`.
- Add a `workflow_dispatch` input on `docker-unified.yml` (`pytest_xdist_workers`, default `3`) to tune or disable xdist on manual runs.

**xdist is independent of `BATCH_COUNT`.** Module slicing (`BATCH_COUNT` / `BATCH_NUMBER`) and in-process parallelism (`PYTEST_XDIST_WORKERS`) are separate knobs — unified CI uses both (7 batch jobs × 3 xdist workers); nightly uses profile×arch matrix with `BATCH_COUNT=1` plus xdist via the env var.

## Motivation

Nightly smoke runs on `feat/nightly-smoke-xdist` showed pytest-xdist can cut suite time significantly. This extends the same pattern to regular unified smoke tests in a workflow-configurable way, without replacing the existing batch matrix.

## Configuration

| Workflow | How to set | Default |
|----------|------------|---------|
| `docker-unified.yml` | top-level `PYTEST_XDIST_WORKERS` env; override via `workflow_dispatch` input `pytest_xdist_workers` | `3` |
| `docker-unified-nightly.yml` | top-level `PYTEST_XDIST_WORKERS` env | `3` |
| Local / unset | omit env var or set `0` | xdist off |

## Test plan

- [x] Local `quickstartDebug`: usage aggregation smoke test passes with `PYTEST_XDIST_WORKERS` unset
- [ ] `docker-unified` PR CI: smoke matrix jobs log `PYTEST_XDIST_WORKERS=3: enabling pytest-xdist`
- [ ] Nightly workflow: all 8 profile×arch cells run with xdist enabled