### PR TITLE
perf(ingestion/dremio): make system-table fetch batch size configurable

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_api.py
@@ -41,9 +41,14 @@ DREMIO_SYSTEM_TABLES_PATTERN = [
     r"^sys\..*",
 ]
 
-# A single Dremio REST API job returns at most this many rows, so it is also the
-# largest usable LIMIT per paged fetch. Larger LIMITs would silently return only
-# this many rows, breaking the "short page means last page" pagination check.
+# Defensive ceiling on the LIMIT we ever issue per page. Dremio's REST job-results
+# endpoint paginates without a documented total-row cap (it streams 500-row pages
+# until a short page: https://docs.dremio.com/current/reference/api/job/job-results/),
+# so this is a safety bound rather than a hard API limit. It keeps the LIMIT — and
+# therefore a single job's result set — from growing unboundedly, which keeps the
+# "short page means last page" pagination check meaningful. If a page ever comes
+# back exactly this size we warn, since at that point a genuinely full page and a
+# server-truncated one are indistinguishable.
 DREMIO_MAX_JOB_OUTPUT_ROWS = 1_000_000
 
 
@@ -195,13 +200,21 @@ class DremioAPIOperations:
         self.start_time = connection_args.start_time
         self.end_time = connection_args.end_time
         self.report = report
-        # 0 means "as much as possible": use Dremio's per-job row cap. Any larger
-        # configured value is clamped to that cap for the same reason.
+        # 0 means "as much as possible": fetch pages at the safety ceiling. Any
+        # larger configured value is clamped to the ceiling for the same reason.
         self._chunk_size = (
             DREMIO_MAX_JOB_OUTPUT_ROWS
             if connection_args.batch_size == 0
             else min(connection_args.batch_size, DREMIO_MAX_JOB_OUTPUT_ROWS)
         )
+        if connection_args.batch_size > DREMIO_MAX_JOB_OUTPUT_ROWS:
+            self.report.warning(
+                message="Configured batch_size exceeds the Dremio fetch ceiling; "
+                "clamping to the maximum.",
+                context=f"batch_size={connection_args.batch_size}, using {self._chunk_size}",
+            )
+        # Emitted at most once per run when a page fills the ceiling exactly.
+        self._warned_page_at_job_cap = False
         # /catalog/{id} responses are id-keyed and immutable for a run, so
         # we reuse them across container walk + dataset fetch.
         self._catalog_cache: Dict[str, Any] = {}
@@ -760,6 +773,23 @@ class DremioAPIOperations:
             return DremioSQLQueries.QUERY_VIEW_DEFINITIONS_CLOUD
         return DremioSQLQueries.QUERY_VIEW_DEFINITIONS_CE
 
+    def _warn_if_page_at_job_cap(self, page_len: int) -> None:
+        """Surface (once) when a fetch page fills the job ceiling exactly.
+
+        At that size we can't distinguish a full page from a server-truncated one,
+        so if Dremio caps job output at/below the ceiling, later short pages would
+        look like end-of-data and rows would be dropped silently. Lowering
+        `batch_size` well below the ceiling avoids the ambiguity entirely.
+        """
+        if page_len >= DREMIO_MAX_JOB_OUTPUT_ROWS and not self._warned_page_at_job_cap:
+            self._warned_page_at_job_cap = True
+            self.report.warning(
+                message="A Dremio fetch page reached the maximum job output size. "
+                "If Dremio truncates job results at this size, some tables/views "
+                "may be silently skipped; lower `batch_size` if rows appear missing.",
+                context=f"page_size={page_len}",
+            )
+
     def _get_view_definitions(
         self,
         schema_condition: str,
@@ -808,6 +838,7 @@ class DremioAPIOperations:
                 if full_path:
                     definitions[full_path] = record.get("VIEW_DEFINITION")
 
+            self._warn_if_page_at_job_cap(len(chunk_results))
             if len(chunk_results) < chunk_size:
                 break
             offset += chunk_size
@@ -1055,6 +1086,7 @@ class DremioAPIOperations:
 
                         last_table_path = table_full_path
 
+                self._warn_if_page_at_job_cap(len(chunk_results))
                 if len(chunk_results) < chunk_size:
                     break
 
@@ -1219,6 +1251,7 @@ class DremioAPIOperations:
 
                 yield from chunk_results
 
+                self._warn_if_page_at_job_cap(len(chunk_results))
                 if len(chunk_results) < chunk_size:
                     break
 

--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_api.py
@@ -41,6 +41,11 @@ DREMIO_SYSTEM_TABLES_PATTERN = [
     r"^sys\..*",
 ]
 
+# A single Dremio REST API job returns at most this many rows, so it is also the
+# largest usable LIMIT per paged fetch. Larger LIMITs would silently return only
+# this many rows, breaking the "short page means last page" pagination check.
+DREMIO_MAX_JOB_OUTPUT_ROWS = 1_000_000
+
 
 class DremioAPIException(Exception):
     pass
@@ -190,7 +195,13 @@ class DremioAPIOperations:
         self.start_time = connection_args.start_time
         self.end_time = connection_args.end_time
         self.report = report
-        self._chunk_size = 1000  # Sensible default to prevent OOM
+        # 0 means "as much as possible": use Dremio's per-job row cap. Any larger
+        # configured value is clamped to that cap for the same reason.
+        self._chunk_size = (
+            DREMIO_MAX_JOB_OUTPUT_ROWS
+            if connection_args.batch_size == 0
+            else min(connection_args.batch_size, DREMIO_MAX_JOB_OUTPUT_ROWS)
+        )
         # /catalog/{id} responses are id-keyed and immutable for a run, so
         # we reuse them across container walk + dataset fetch.
         self._catalog_cache: Dict[str, Any] = {}

--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_api.py
@@ -774,19 +774,23 @@ class DremioAPIOperations:
         return DremioSQLQueries.QUERY_VIEW_DEFINITIONS_CE
 
     def _warn_if_page_at_job_cap(self, page_len: int) -> None:
-        """Surface (once) when a fetch page fills the job ceiling exactly.
+        """Nudge (once) when a fetch page reaches the configured ceiling.
 
-        At that size we can't distinguish a full page from a server-truncated one,
-        so if Dremio caps job output at/below the ceiling, later short pages would
-        look like end-of-data and rows would be dropped silently. Lowering
-        `batch_size` well below the ceiling avoids the ambiguity entirely.
+        This is a boundary/perf signal, not a truncation detector. A page can only
+        reach the ceiling when the operator has pushed `batch_size` to it (or set 0),
+        i.e. a genuinely full page at the maximum size. The opposite, dangerous case
+        — Dremio capping a job's output *below* the requested LIMIT — surfaces as a
+        short page that LIMIT/OFFSET pagination cannot distinguish from a legitimate
+        final page, so it is an accepted, undetectable limitation here rather than
+        something this warning covers. Keeping `batch_size` well below the ceiling
+        (the default) avoids operating anywhere near that boundary.
         """
         if page_len >= DREMIO_MAX_JOB_OUTPUT_ROWS and not self._warned_page_at_job_cap:
             self._warned_page_at_job_cap = True
             self.report.warning(
-                message="A Dremio fetch page reached the maximum job output size. "
-                "If Dremio truncates job results at this size, some tables/views "
-                "may be silently skipped; lower `batch_size` if rows appear missing.",
+                message="A Dremio fetch reached the configured maximum page size. "
+                "If you suspect rows are missing, lower `batch_size` so pages stay "
+                "well below Dremio's per-job limits.",
                 context=f"page_size={page_len}",
             )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_config.py
@@ -222,7 +222,8 @@ class DremioSourceConfig(
         "Dremio's system tables can be slow, so a larger batch reduces the number of "
         "round-trips. Set to 0 to fetch as much as possible per page. Values are "
         "clamped to a safety ceiling of 1,000,000 rows per page to keep pagination "
-        "reliable.",
+        "reliable. A larger batch also raises the amount Dremio must materialize per "
+        "job, so lower this value if Dremio runs out of memory during extraction.",
     )
 
     include_query_lineage: bool = Field(

--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_config.py
@@ -214,6 +214,17 @@ class DremioSourceConfig(
         description="Number of worker threads to use for parallel processing",
     )
 
+    batch_size: int = Field(
+        default=10000,
+        ge=0,
+        description="Number of rows to fetch per page when reading Dremio's system "
+        "tables (datasets, columns, view definitions, and queries) via LIMIT/OFFSET. "
+        "Dremio's system tables can be slow, so a larger batch reduces the number of "
+        "round-trips. Set to 0 to fetch as much as possible per page. Values are "
+        "capped at 1,000,000, the maximum number of rows a single Dremio REST API "
+        "job returns.",
+    )
+
     include_query_lineage: bool = Field(
         default=False,
         description="Whether to include query-based lineage information.",

--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_config.py
@@ -221,8 +221,8 @@ class DremioSourceConfig(
         "tables (datasets, columns, view definitions, and queries) via LIMIT/OFFSET. "
         "Dremio's system tables can be slow, so a larger batch reduces the number of "
         "round-trips. Set to 0 to fetch as much as possible per page. Values are "
-        "capped at 1,000,000, the maximum number of rows a single Dremio REST API "
-        "job returns.",
+        "clamped to a safety ceiling of 1,000,000 rows per page to keep pagination "
+        "reliable.",
     )
 
     include_query_lineage: bool = Field(

--- a/metadata-ingestion/tests/unit/dremio/test_dremio_chunking.py
+++ b/metadata-ingestion/tests/unit/dremio/test_dremio_chunking.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import pytest
 
 from datahub.ingestion.source.dremio.dremio_api import (
+    DREMIO_MAX_JOB_OUTPUT_ROWS,
     DremioAPIException,
     DremioAPIOperations,
     DremioEdition,
@@ -12,6 +13,36 @@ from datahub.ingestion.source.dremio.dremio_config import DremioSourceConfig
 from datahub.ingestion.source.dremio.dremio_reporting import DremioSourceReport
 from datahub.ingestion.source.dremio.dremio_sql_queries import DremioSQLQueries
 from datahub.utilities.file_backed_collections import FileBackedDict
+
+
+@pytest.mark.parametrize(
+    "configured,expected",
+    [
+        (10000, 10000),
+        (500, 500),
+        # 0 means "as much as possible" -> Dremio's per-job row cap.
+        (0, DREMIO_MAX_JOB_OUTPUT_ROWS),
+        # Anything above the cap is clamped so short-page pagination stays correct.
+        (5_000_000, DREMIO_MAX_JOB_OUTPUT_ROWS),
+    ],
+)
+def test_batch_size_resolves_to_chunk_size(monkeypatch, configured, expected):
+    mock_session = Mock()
+    monkeypatch.setattr("requests.Session", Mock(return_value=mock_session))
+    mock_session.post.return_value.json.return_value = {"token": "dummy-token"}
+    mock_session.post.return_value.status_code = 200
+
+    config = DremioSourceConfig(
+        hostname="dummy-host",
+        port=9047,
+        tls=False,
+        authentication_method="password",
+        username="dummy-user",
+        password="dummy-password",
+        batch_size=configured,
+    )
+    api = DremioAPIOperations(config, Mock(spec=DremioSourceReport))
+    assert api._chunk_size == expected
 
 
 class TestDremioChunking:
@@ -53,7 +84,7 @@ class TestDremioChunking:
 
         dremio_api.execute_query_iter.assert_called_once()
         query_arg = dremio_api.execute_query_iter.call_args[1]["query"]
-        assert "LIMIT 1000 OFFSET 0" in query_arg
+        assert "LIMIT 10000 OFFSET 0" in query_arg
 
     def test_get_queries_chunked_multiple_chunks(self, dremio_api):
         dremio_api._chunk_size = 1
@@ -182,7 +213,7 @@ class TestDremioChunking:
         assert tables[0]["TABLE_NAME"] == "table1"
 
         query_arg = dremio_api.execute_query_iter.call_args[1]["query"]
-        assert "LIMIT 1000 OFFSET 0" in query_arg
+        assert "LIMIT 10000 OFFSET 0" in query_arg
         # Global queries must not contain a LOCATE container filter.
         assert "LOCATE" not in query_arg
 

--- a/metadata-ingestion/tests/unit/dremio/test_dremio_chunking.py
+++ b/metadata-ingestion/tests/unit/dremio/test_dremio_chunking.py
@@ -15,56 +15,55 @@ from datahub.ingestion.source.dremio.dremio_sql_queries import DremioSQLQueries
 from datahub.utilities.file_backed_collections import FileBackedDict
 
 
+def _make_api_with_batch_size(monkeypatch, batch_size):
+    mock_session = Mock()
+    monkeypatch.setattr("requests.Session", Mock(return_value=mock_session))
+    mock_session.post.return_value.json.return_value = {"token": "dummy-token"}
+    mock_session.post.return_value.status_code = 200
+
+    config = DremioSourceConfig(
+        hostname="dummy-host",
+        port=9047,
+        tls=False,
+        authentication_method="password",
+        username="dummy-user",
+        password="dummy-password",
+        batch_size=batch_size,
+    )
+    report = Mock(spec=DremioSourceReport)
+    return DremioAPIOperations(config, report), report
+
+
 @pytest.mark.parametrize(
     "configured,expected",
     [
         (10000, 10000),
         (500, 500),
-        # 0 means "as much as possible" -> Dremio's per-job row cap.
+        # 0 means "as much as possible" -> the safety ceiling.
         (0, DREMIO_MAX_JOB_OUTPUT_ROWS),
-        # Anything above the cap is clamped so short-page pagination stays correct.
+        # Above the ceiling is clamped so short-page pagination stays correct.
         (5_000_000, DREMIO_MAX_JOB_OUTPUT_ROWS),
     ],
 )
 def test_batch_size_resolves_to_chunk_size(monkeypatch, configured, expected):
-    mock_session = Mock()
-    monkeypatch.setattr("requests.Session", Mock(return_value=mock_session))
-    mock_session.post.return_value.json.return_value = {"token": "dummy-token"}
-    mock_session.post.return_value.status_code = 200
-
-    config = DremioSourceConfig(
-        hostname="dummy-host",
-        port=9047,
-        tls=False,
-        authentication_method="password",
-        username="dummy-user",
-        password="dummy-password",
-        batch_size=configured,
-    )
-    api = DremioAPIOperations(config, Mock(spec=DremioSourceReport))
+    api, _ = _make_api_with_batch_size(monkeypatch, configured)
     assert api._chunk_size == expected
 
 
 def test_batch_size_over_ceiling_warns(monkeypatch):
-    mock_session = Mock()
-    monkeypatch.setattr("requests.Session", Mock(return_value=mock_session))
-    mock_session.post.return_value.json.return_value = {"token": "dummy-token"}
-    mock_session.post.return_value.status_code = 200
-
-    config = DremioSourceConfig(
-        hostname="dummy-host",
-        port=9047,
-        tls=False,
-        authentication_method="password",
-        username="dummy-user",
-        password="dummy-password",
-        batch_size=DREMIO_MAX_JOB_OUTPUT_ROWS + 1,
-    )
-    report = Mock(spec=DremioSourceReport)
-    api = DremioAPIOperations(config, report)
+    api, report = _make_api_with_batch_size(monkeypatch, DREMIO_MAX_JOB_OUTPUT_ROWS + 1)
 
     assert api._chunk_size == DREMIO_MAX_JOB_OUTPUT_ROWS
     report.warning.assert_called_once()
+
+
+def test_batch_size_at_ceiling_does_not_warn(monkeypatch):
+    # The clamp warning uses `>` while the page-cap nudge uses `>=`; they
+    # intentionally differ. Exactly at the ceiling is a valid value, not a clamp.
+    api, report = _make_api_with_batch_size(monkeypatch, DREMIO_MAX_JOB_OUTPUT_ROWS)
+
+    assert api._chunk_size == DREMIO_MAX_JOB_OUTPUT_ROWS
+    report.warning.assert_not_called()
 
 
 class TestDremioChunking:

--- a/metadata-ingestion/tests/unit/dremio/test_dremio_chunking.py
+++ b/metadata-ingestion/tests/unit/dremio/test_dremio_chunking.py
@@ -45,6 +45,28 @@ def test_batch_size_resolves_to_chunk_size(monkeypatch, configured, expected):
     assert api._chunk_size == expected
 
 
+def test_batch_size_over_ceiling_warns(monkeypatch):
+    mock_session = Mock()
+    monkeypatch.setattr("requests.Session", Mock(return_value=mock_session))
+    mock_session.post.return_value.json.return_value = {"token": "dummy-token"}
+    mock_session.post.return_value.status_code = 200
+
+    config = DremioSourceConfig(
+        hostname="dummy-host",
+        port=9047,
+        tls=False,
+        authentication_method="password",
+        username="dummy-user",
+        password="dummy-password",
+        batch_size=DREMIO_MAX_JOB_OUTPUT_ROWS + 1,
+    )
+    report = Mock(spec=DremioSourceReport)
+    api = DremioAPIOperations(config, report)
+
+    assert api._chunk_size == DREMIO_MAX_JOB_OUTPUT_ROWS
+    report.warning.assert_called_once()
+
+
 class TestDremioChunking:
     @pytest.fixture
     def dremio_api(self, monkeypatch):
@@ -110,6 +132,40 @@ class TestDremioChunking:
 
         # Three calls: two chunks of data, then an empty chunk that signals completion.
         assert dremio_api.execute_query_iter.call_count == 3
+
+    def test_get_queries_chunked_stops_on_short_nonempty_final_page(self, dremio_api):
+        # A final page shorter than chunk_size but non-empty must terminate the
+        # loop without an extra probing call, and without a truncation warning
+        # (the page is well under the job ceiling).
+        dremio_api._chunk_size = 2
+
+        full_page = [{"query_id": "q1"}, {"query_id": "q2"}]
+        short_page = [{"query_id": "q3"}]
+
+        dremio_api.execute_query_iter = Mock(
+            side_effect=[iter(full_page), iter(short_page)]
+        )
+
+        queries = list(
+            dremio_api._get_queries_chunked("SELECT * FROM jobs {limit_clause}")
+        )
+
+        assert [q["query_id"] for q in queries] == ["q1", "q2", "q3"]
+        assert dremio_api.execute_query_iter.call_count == 2
+        dremio_api.report.warning.assert_not_called()
+
+    def test_warn_if_page_at_job_cap_fires_once(self, dremio_api):
+        # A page filled to the ceiling is indistinguishable from a truncated one,
+        # so warn — but only once per run, no matter how many pages hit it.
+        dremio_api._warn_if_page_at_job_cap(DREMIO_MAX_JOB_OUTPUT_ROWS)
+        dremio_api._warn_if_page_at_job_cap(DREMIO_MAX_JOB_OUTPUT_ROWS)
+
+        dremio_api.report.warning.assert_called_once()
+
+    def test_warn_if_page_at_job_cap_silent_below_ceiling(self, dremio_api):
+        dremio_api._warn_if_page_at_job_cap(DREMIO_MAX_JOB_OUTPUT_ROWS - 1)
+
+        dremio_api.report.warning.assert_not_called()
 
     def test_get_queries_chunked_keyerror_rows(self, dremio_api):
         # KeyError: 'rows' is the symptom of a Dremio OOM crash mid-iteration.

--- a/metadata-ingestion/tests/unit/dremio/test_dremio_view_definitions.py
+++ b/metadata-ingestion/tests/unit/dremio/test_dremio_view_definitions.py
@@ -118,7 +118,7 @@ class TestGetViewDefinitions:
         assert isinstance(result, FileBackedDict)
         assert result == {"space.view_a": "SELECT 1", "space.view_b": "SELECT 2"}
         query_arg = api.execute_query_iter.call_args[1]["query"]
-        assert "LIMIT 1000 OFFSET 0" in query_arg
+        assert "LIMIT 10000 OFFSET 0" in query_arg
         result.close()
 
     def test_paginates_across_chunks(self, monkeypatch):


### PR DESCRIPTION
## Summary

Dremio's system tables (`INFORMATION_SCHEMA` / `SYS`) can be slow to query, and the paged dataset/column/view-definition/query fetches used a hardcoded `LIMIT/OFFSET` page size of `1000`. On large catalogs this issued far more round-trips than necessary, and each page waits on a slow Dremio job.

This PR exposes the page size as a `batch_size` config option and raises the default.

- **New `batch_size` config** (default **10000**, was hardcoded `1000`) controlling how many rows each paged fetch requests. Applies to datasets, columns, view definitions, and query extraction.
- **`0` means "as much as possible"** → fetches pages at a safety ceiling of `1,000,000` rows.
- **Values above the ceiling are clamped** to `1,000,000`, reported as a one-time warning instead of happening silently.

### OOM tradeoff (why the old default was 1000)

The previous hardcoded `1000` carried a `# prevent OOM` comment: it was chosen specifically because Dremio can raise `OversizedAllocationException` / crash mid-iteration when materializing a large per-job result set (there's an existing test covering that OOM-mid-iteration path). Raising the default 10x deliberately trades some of that OOM headroom for far fewer round-trips against slow system tables — the right default for most catalogs, and now fully configurable. The `batch_size` description tells operators to lower the value if they hit Dremio OOM during extraction.

### About the ceiling

`DREMIO_MAX_JOB_OUTPUT_ROWS = 1_000_000` is a **defensive ceiling** on the `LIMIT` we ever issue, not an asserted hard API limit. Dremio's REST job-results endpoint paginates _without_ a documented total-row cap (it streams 500-row pages until a short page — see the [Job Results docs](https://docs.dremio.com/current/reference/api/job/job-results/)), so the ceiling simply keeps a single job's result set from growing unboundedly and keeps `batch_size=0` well-defined.

**Honest scope of the runtime warning:** `LIMIT/OFFSET` short-page pagination treats "page shorter than the requested limit" as end-of-data and cannot distinguish that from a server-truncated page. The connector emits a one-time `report.warning` when a page comes back filled exactly to the ceiling — this is a **boundary/perf nudge**, not a truncation detector. The genuinely dangerous case (Dremio capping a job's output _below_ the requested LIMIT) would surface as a _short_ page and is an accepted, undetectable limitation of this pagination scheme; the safe default of 10000 keeps ingestion far from that boundary. This is documented at the call site so the warning isn't mistaken for full truncation coverage.

## Test plan

- [x] `test_batch_size_resolves_to_chunk_size` — `10000→10000`, `500→500`, `0→1,000,000`, `5,000,000→1,000,000` (clamp).
- [x] `test_batch_size_over_ceiling_warns` / `test_batch_size_at_ceiling_does_not_warn` — locks the intentional `>` (clamp) vs `>=` (page-cap) boundary.
- [x] `test_warn_if_page_at_job_cap_fires_once` / `_silent_below_ceiling` — page-cap nudge fires once at the ceiling, silent below it.
- [x] `test_get_queries_chunked_stops_on_short_nonempty_final_page` — terminates on a non-empty short final page without an extra probe or a false warning.
- [x] Updated existing pagination assertions from `LIMIT 1000` to the new `LIMIT 10000` default.
- [x] `./gradlew :metadata-ingestion:lint` (ruff + mypy) passes.
- [x] All Dremio unit tests pass.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing/#commit-message-format))
- [x] Tests added/updated