### PR TITLE
fix(ingest/mysql): keep usage lineage from emitting phantom datasets

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/mysql.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/mysql.py
@@ -456,41 +456,31 @@ class MySQLSource(TwoTierSQLAlchemySource):
             generate_operations=False,
             usage_config=self.config.usage,
             eager_graph_load=False,
-            # Keep query-history lineage/usage in step with what we actually
-            # ingested. Without these, referenced tables that we never emitted as
-            # datasets (other databases, temp tables, mis-quoted identifiers) turn
-            # into phantom, column-less entities. See _is_allowed_table /
-            # _is_temp_table.
             is_allowed_table=self._is_allowed_table,
             is_temp_table=self._is_temp_table,
         )
 
     def _save_schema_to_resolver(self) -> bool:
-        # is_temp_table distinguishes real tables from phantom ones by membership
-        # in discovered_datasets, which is only populated when schemas are saved to
-        # the resolver. Usage needs that regardless of view lineage.
+        # is_temp_table reads discovered_datasets, which is only filled when
+        # schemas are saved; usage needs it regardless of view lineage.
         return (
             super()._save_schema_to_resolver() or self.config.include_usage_statistics
         )
 
     def _is_allowed_table(self, name: str) -> bool:
-        # name is the two-tier "database.table" dataset name (platform instance
-        # already stripped). The fetch-time filters only see each query's default
-        # schema; this additionally drops tables *referenced* in other databases,
-        # so a query in an allowed database can't attribute usage/lineage to one
-        # excluded by database_pattern (or a system schema).
+        # name is the two-tier "database.table" name. Unlike the fetch-time
+        # filters (which only see a query's default schema), this also drops
+        # tables referenced in databases excluded by database_pattern.
         database = name.split(".", 1)[0]
         if database.lower() in _SYSTEM_SCHEMAS:
             return False
         return self.config.database_pattern.allowed(database)
 
     def _is_temp_table(self, name: str) -> bool:
-        # The aggregator resolves lineage THROUGH "temp" tables but never emits
-        # them as datasets. Treating every table we did not ingest as temp keeps
-        # query history from creating phantom, column-less entities: genuine temp
-        # tables, tables in filtered-out databases, and mis-quoted `db.table`
-        # references (a single backticked identifier with an embedded dot) that the
-        # SQL parser expands into db.db.table.
+        # Tables we never ingested are treated as temp: the aggregator resolves
+        # lineage through them but doesn't emit them, avoiding phantom datasets
+        # (temp tables, filtered-out databases, and mis-quoted `db.table` refs
+        # the parser expands to db.db.table).
         return name not in self.discovered_datasets
 
     def _generate_aggregator_workunits(self) -> Iterable[MetadataWorkUnit]:

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/mysql.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/mysql.py
@@ -4,7 +4,7 @@ import re
 from collections import OrderedDict
 from contextlib import contextmanager
 from datetime import timezone
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, List, Optional
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, List, Optional, Set
 
 import pymysql  # noqa: F401
 from pydantic.fields import Field
@@ -282,6 +282,7 @@ class MySQLSource(TwoTierSQLAlchemySource):
     def __init__(self, config: MySQLConfig, ctx: Any):
         super().__init__(config, ctx, self.get_platform())
 
+        self._discovered_lower_cache: Optional[Set[str]] = None
         self._rds_iam_token_manager: Optional[RDSIAMTokenManager] = None
         if config.auth_mode == MySQLAuthMode.AWS_IAM:
             hostname, port = parse_host_port(config.host_port, default_port=3306)
@@ -467,21 +468,39 @@ class MySQLSource(TwoTierSQLAlchemySource):
             super()._save_schema_to_resolver() or self.config.include_usage_statistics
         )
 
+    def _is_allowed_database(self, database: str) -> bool:
+        if database.lower() in _SYSTEM_SCHEMAS:
+            return False
+        return self.config.database_pattern.allowed(database)
+
     def _is_allowed_table(self, name: str) -> bool:
         # name is the two-tier "database.table" name. Unlike the fetch-time
         # filters (which only see a query's default schema), this also drops
         # tables referenced in databases excluded by database_pattern.
-        database = name.split(".", 1)[0]
-        if database.lower() in _SYSTEM_SCHEMAS:
-            return False
-        return self.config.database_pattern.allowed(database)
+        return self._is_allowed_database(name.split(".", 1)[0])
 
     def _is_temp_table(self, name: str) -> bool:
         # Tables we never ingested are treated as temp: the aggregator resolves
         # lineage through them but doesn't emit them, avoiding phantom datasets
         # (temp tables, filtered-out databases, and mis-quoted `db.table` refs
-        # the parser expands to db.db.table).
-        return name not in self.discovered_datasets
+        # the parser expands to db.db.table). A table excluded only by
+        # table_pattern is likewise "temp" here: lineage flows through it rather
+        # than being cut off.
+        # Compare case-insensitively: the parser lowercases unresolved MySQL URNs
+        # (not in PLATFORMS_WITH_CASE_SENSITIVE_TABLES), so a reference whose case
+        # differs from the catalog would otherwise miss a real, ingested table.
+        if name in self.discovered_datasets or name.lower() in self._discovered_lower():
+            return False
+        self.report.num_usage_references_suppressed_as_temp += 1
+        self.report.usage_references_suppressed_as_temp_sample.append(name)
+        return True
+
+    def _discovered_lower(self) -> Set[str]:
+        # Built once lazily: discovered_datasets is fully populated during
+        # ingestion, before the usage phase invokes this.
+        if self._discovered_lower_cache is None:
+            self._discovered_lower_cache = {d.lower() for d in self.discovered_datasets}
+        return self._discovered_lower_cache
 
     def _generate_aggregator_workunits(self) -> Iterable[MetadataWorkUnit]:
         # Runs after the base registers table schemas, so unqualified references resolve.
@@ -556,9 +575,7 @@ class MySQLSource(TwoTierSQLAlchemySource):
             )
             for row in rows:
                 schema_name = row.SCHEMA_NAME
-                if schema_name.lower() in _SYSTEM_SCHEMAS:
-                    continue
-                if not self.config.database_pattern.allowed(schema_name):
+                if not self._is_allowed_database(schema_name):
                     continue
 
                 count = int(row.COUNT_STAR or 0)
@@ -638,9 +655,7 @@ class MySQLSource(TwoTierSQLAlchemySource):
 
                 # Refresh recency so long-lived active sessions aren't evicted.
                 session_db.move_to_end(session_id)
-                if schema_name.lower() in _SYSTEM_SCHEMAS:
-                    continue
-                if not self.config.database_pattern.allowed(schema_name):
+                if not self._is_allowed_database(schema_name):
                     continue
 
                 timestamp = row.event_time

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/mysql.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/mysql.py
@@ -486,9 +486,6 @@ class MySQLSource(TwoTierSQLAlchemySource):
         # the parser expands to db.db.table). A table excluded only by
         # table_pattern is likewise "temp" here: lineage flows through it rather
         # than being cut off.
-        # Compare case-insensitively: the parser lowercases unresolved MySQL URNs
-        # (not in PLATFORMS_WITH_CASE_SENSITIVE_TABLES), so a reference whose case
-        # differs from the catalog would otherwise miss a real, ingested table.
         if name in self.discovered_datasets or name.lower() in self._discovered_lower():
             return False
         self.report.num_usage_references_suppressed_as_temp += 1
@@ -496,8 +493,11 @@ class MySQLSource(TwoTierSQLAlchemySource):
         return True
 
     def _discovered_lower(self) -> Set[str]:
-        # Built once lazily: discovered_datasets is fully populated during
-        # ingestion, before the usage phase invokes this.
+        # Lowercased view of discovered_datasets for case-insensitive matching:
+        # the parser lowercases unresolved MySQL URNs (not in
+        # PLATFORMS_WITH_CASE_SENSITIVE_TABLES), so a reference whose case differs
+        # from the catalog would otherwise miss a real, ingested table. Built once
+        # lazily; discovered_datasets is fully populated before the usage phase.
         if self._discovered_lower_cache is None:
             self._discovered_lower_cache = {d.lower() for d in self.discovered_datasets}
         return self._discovered_lower_cache

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/mysql.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/mysql.py
@@ -456,7 +456,42 @@ class MySQLSource(TwoTierSQLAlchemySource):
             generate_operations=False,
             usage_config=self.config.usage,
             eager_graph_load=False,
+            # Keep query-history lineage/usage in step with what we actually
+            # ingested. Without these, referenced tables that we never emitted as
+            # datasets (other databases, temp tables, mis-quoted identifiers) turn
+            # into phantom, column-less entities. See _is_allowed_table /
+            # _is_temp_table.
+            is_allowed_table=self._is_allowed_table,
+            is_temp_table=self._is_temp_table,
         )
+
+    def _save_schema_to_resolver(self) -> bool:
+        # is_temp_table distinguishes real tables from phantom ones by membership
+        # in discovered_datasets, which is only populated when schemas are saved to
+        # the resolver. Usage needs that regardless of view lineage.
+        return (
+            super()._save_schema_to_resolver() or self.config.include_usage_statistics
+        )
+
+    def _is_allowed_table(self, name: str) -> bool:
+        # name is the two-tier "database.table" dataset name (platform instance
+        # already stripped). The fetch-time filters only see each query's default
+        # schema; this additionally drops tables *referenced* in other databases,
+        # so a query in an allowed database can't attribute usage/lineage to one
+        # excluded by database_pattern (or a system schema).
+        database = name.split(".", 1)[0]
+        if database.lower() in _SYSTEM_SCHEMAS:
+            return False
+        return self.config.database_pattern.allowed(database)
+
+    def _is_temp_table(self, name: str) -> bool:
+        # The aggregator resolves lineage THROUGH "temp" tables but never emits
+        # them as datasets. Treating every table we did not ingest as temp keeps
+        # query history from creating phantom, column-less entities: genuine temp
+        # tables, tables in filtered-out databases, and mis-quoted `db.table`
+        # references (a single backticked identifier with an embedded dot) that the
+        # SQL parser expands into db.db.table.
+        return name not in self.discovered_datasets
 
     def _generate_aggregator_workunits(self) -> Iterable[MetadataWorkUnit]:
         # Runs after the base registers table schemas, so unqualified references resolve.

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -1229,6 +1229,11 @@ class SQLAlchemySource(StatefulIngestionSourceBase, TestableSource):
                 context=f"{dataset_name}",
             )
             schema_metadata = None
+            # The view is still emitted as a real dataset below. Record it as
+            # discovered even without a schema so query-history consumers (e.g.
+            # usage temp-table detection) don't treat it as a phantom/temp table.
+            if self._save_schema_to_resolver():
+                self.discovered_datasets.add(dataset_name)
         else:
             schema_fields = self.get_schema_fields(dataset_name, columns, inspector)
             schema_metadata = get_schema_metadata(

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_report.py
@@ -60,8 +60,12 @@ class SQLSourceReport(
     num_queries_parsed: int = 0
     num_queries_parse_failures: int = 0
 
-    # Query-history references dropped as "temp" because the table was never
-    # ingested (temp tables, filtered-out databases, mis-quoted identifiers).
+    # Query-history references the aggregator resolved lineage through but did
+    # not emit, because the table is absent from discovered_datasets. This is
+    # broader than genuine temp tables: it also covers references filtered by
+    # database_pattern/table_pattern and real tables whose schema fetch failed
+    # (separately reported). Read it as "not among ingested tables", not "temp
+    # tables only", when triaging missing lineage.
     num_usage_references_suppressed_as_temp: int = 0
     usage_references_suppressed_as_temp_sample: LossyList[str] = field(
         default_factory=LossyList

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_report.py
@@ -60,6 +60,13 @@ class SQLSourceReport(
     num_queries_parsed: int = 0
     num_queries_parse_failures: int = 0
 
+    # Query-history references dropped as "temp" because the table was never
+    # ingested (temp tables, filtered-out databases, mis-quoted identifiers).
+    num_usage_references_suppressed_as_temp: int = 0
+    usage_references_suppressed_as_temp_sample: LossyList[str] = field(
+        default_factory=LossyList
+    )
+
     def report_entity_scanned(self, name: str, ent_type: str = "table") -> None:
         """
         Entity could be a view or a table

--- a/metadata-ingestion/tests/unit/test_mysql_usage.py
+++ b/metadata-ingestion/tests/unit/test_mysql_usage.py
@@ -388,19 +388,15 @@ def test_is_allowed_table_respects_pattern_and_system_schemas():
 def test_is_temp_table_flags_undiscovered_tables():
     source = _source()
     source.discovered_datasets.add("appdb.orders")
-    # A table we ingested is real; anything else (temp tables, filtered-out
-    # databases, phantom db.db.table names) is treated as temp so it is not
-    # emitted as its own dataset.
     assert not source._is_temp_table("appdb.orders")
     assert source._is_temp_table("appdb.tmp_scratch")
     assert source._is_temp_table("appdb.appdb.orders")
 
 
 def test_usage_skips_phantom_entity_from_mis_quoted_identifier():
-    # A single backticked identifier with an embedded dot parses as one table
-    # name, so the two-tier default_schema is prepended and the URN doubles the
-    # database (appdb.appdb.tmp_upsert). Since that phantom is not a discovered
-    # table it must be suppressed rather than emitted as a column-less dataset.
+    # `appdb.tmp_upsert` as one backticked identifier parses as a single table
+    # name, so default_schema is prepended into appdb.appdb.tmp_upsert. That
+    # undiscovered phantom must not be emitted.
     source = _source()
     source.discovered_datasets.add("appdb.orders")
     now = datetime.datetime.now(tz=datetime.timezone.utc)

--- a/metadata-ingestion/tests/unit/test_mysql_usage.py
+++ b/metadata-ingestion/tests/unit/test_mysql_usage.py
@@ -448,9 +448,8 @@ def test_usage_emits_lineage_between_discovered_tables():
 
 
 def test_process_view_without_columns_still_marks_discovered():
-    # A view whose columns can't be reflected (KeyError) is still emitted as a
-    # real dataset, so it must land in discovered_datasets or usage would later
-    # treat it as a phantom/temp table and drop its query-history lineage.
+    # A view with unreflectable columns is still emitted, so it must land in
+    # discovered_datasets; otherwise usage treats it as temp and drops lineage.
     source = _source()
     inspector = MagicMock()
     inspector.get_columns.side_effect = KeyError("no columns")
@@ -546,12 +545,10 @@ def test_usage_skips_phantom_entity_from_mis_quoted_identifier():
     assert not any("appdb.appdb" in urn for urn in urns), (
         f"phantom doubled-database URN must not be emitted; got {urns}"
     )
-    # Co-assert the real upstream is emitted, so a parse regression that drops
-    # all output can't let this pass vacuously.
+    # Co-assert the real upstream is emitted, guarding against a vacuous pass.
     assert any(urn.endswith("appdb.orders,PROD)") for urn in urns), (
         f"expected the discovered table appdb.orders to be emitted; got {urns}"
     )
-    # The suppression is observable via the report counter and sample.
     assert source.report.num_usage_references_suppressed_as_temp >= 1
     assert "appdb.appdb.tmp_upsert" in list(
         source.report.usage_references_suppressed_as_temp_sample
@@ -582,12 +579,10 @@ def test_usage_does_not_attribute_to_filtered_out_database():
     assert not any("drop_db" in urn for urn in urns), (
         f"filtered-out database must not appear in emitted URNs; got {urns}"
     )
-    # Co-assert the allowed table is emitted, so dropping all output can't let
-    # this pass vacuously.
+    # Co-assert the allowed table is emitted, guarding against a vacuous pass.
     assert any(urn.endswith("keep_db.orders,PROD)") for urn in urns), (
         f"expected the allowed table keep_db.orders to be emitted; got {urns}"
     )
-    # The filtered reference is observable via the report counter and sample.
     assert source.report.num_usage_references_suppressed_as_temp >= 1
     assert "drop_db.secrets" in list(
         source.report.usage_references_suppressed_as_temp_sample

--- a/metadata-ingestion/tests/unit/test_mysql_usage.py
+++ b/metadata-ingestion/tests/unit/test_mysql_usage.py
@@ -472,6 +472,11 @@ def test_usage_skips_phantom_entity_from_mis_quoted_identifier():
     assert not any("appdb.appdb" in urn for urn in urns), (
         f"phantom doubled-database URN must not be emitted; got {urns}"
     )
+    # Co-assert the real upstream is emitted, so a parse regression that drops
+    # all output can't let this pass vacuously.
+    assert any(urn.endswith("appdb.orders,PROD)") for urn in urns), (
+        f"expected the discovered table appdb.orders to be emitted; got {urns}"
+    )
 
 
 def test_usage_does_not_attribute_to_filtered_out_database():
@@ -497,6 +502,11 @@ def test_usage_does_not_attribute_to_filtered_out_database():
 
     assert not any("drop_db" in urn for urn in urns), (
         f"filtered-out database must not appear in emitted URNs; got {urns}"
+    )
+    # Co-assert the allowed table is emitted, so dropping all output can't let
+    # this pass vacuously.
+    assert any(urn.endswith("keep_db.orders,PROD)") for urn in urns), (
+        f"expected the allowed table keep_db.orders to be emitted; got {urns}"
     )
 
 

--- a/metadata-ingestion/tests/unit/test_mysql_usage.py
+++ b/metadata-ingestion/tests/unit/test_mysql_usage.py
@@ -447,6 +447,80 @@ def test_usage_emits_lineage_between_discovered_tables():
     )
 
 
+def test_process_view_without_columns_still_marks_discovered():
+    # A view whose columns can't be reflected (KeyError) is still emitted as a
+    # real dataset, so it must land in discovered_datasets or usage would later
+    # treat it as a phantom/temp table and drop its query-history lineage.
+    source = _source()
+    inspector = MagicMock()
+    inspector.get_columns.side_effect = KeyError("no columns")
+
+    with (
+        patch.object(source, "get_table_properties", return_value=("", {}, None)),
+        patch.object(source, "_get_view_definition", return_value=""),
+        patch.object(source, "get_db_name", return_value="appdb"),
+        patch.object(source, "add_table_to_schema_container", return_value=[]),
+    ):
+        list(
+            source._process_view(
+                dataset_name="appdb.myview",
+                inspector=inspector,
+                schema="appdb",
+                view="myview",
+                sql_config=source.config,
+            )
+        )
+
+    assert "appdb.myview" in source.discovered_datasets
+
+
+def test_usage_lineage_flows_through_table_pattern_excluded_table():
+    # A real table excluded by table_pattern is absent from discovered_datasets,
+    # so it is treated as temp: lineage is stitched THROUGH it (orders -> final)
+    # rather than cut off, and the excluded table is not emitted.
+    source = _source()
+    source.discovered_datasets.update({"appdb.orders", "appdb.final"})
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    with patch.object(
+        source,
+        "_fetch_performance_schema_queries",
+        return_value=[
+            ObservedQuery(
+                query="INSERT INTO staging SELECT id FROM orders",
+                timestamp=now,
+                default_schema="appdb",
+                usage_multiplier=1,
+            ),
+            ObservedQuery(
+                query="INSERT INTO final SELECT id FROM staging",
+                timestamp=now,
+                default_schema="appdb",
+                usage_multiplier=1,
+            ),
+        ],
+    ):
+        workunits = list(source._generate_aggregator_workunits())
+
+    upstreams_by_downstream = {
+        wu.get_urn(): [u.dataset for u in aspect.upstreams]
+        for wu in workunits
+        if (aspect := wu.get_aspect_of_type(UpstreamLineageClass)) is not None
+    }
+    final_upstreams = [
+        up
+        for urn, ups in upstreams_by_downstream.items()
+        if urn.endswith("appdb.final,PROD)")
+        for up in ups
+    ]
+    assert any("appdb.orders" in urn for urn in final_upstreams), (
+        f"lineage should flow orders -> final through staging; got {final_upstreams}"
+    )
+    assert not any("staging" in urn for urn in final_upstreams), (
+        "the table_pattern-excluded staging table must not be a lineage node"
+    )
+
+
 def test_usage_skips_phantom_entity_from_mis_quoted_identifier():
     # `appdb.tmp_upsert` as one backticked identifier parses as a single table
     # name, so default_schema is prepended into appdb.appdb.tmp_upsert. That
@@ -476,6 +550,11 @@ def test_usage_skips_phantom_entity_from_mis_quoted_identifier():
     # all output can't let this pass vacuously.
     assert any(urn.endswith("appdb.orders,PROD)") for urn in urns), (
         f"expected the discovered table appdb.orders to be emitted; got {urns}"
+    )
+    # The suppression is observable via the report counter and sample.
+    assert source.report.num_usage_references_suppressed_as_temp >= 1
+    assert "appdb.appdb.tmp_upsert" in list(
+        source.report.usage_references_suppressed_as_temp_sample
     )
 
 
@@ -507,6 +586,11 @@ def test_usage_does_not_attribute_to_filtered_out_database():
     # this pass vacuously.
     assert any(urn.endswith("keep_db.orders,PROD)") for urn in urns), (
         f"expected the allowed table keep_db.orders to be emitted; got {urns}"
+    )
+    # The filtered reference is observable via the report counter and sample.
+    assert source.report.num_usage_references_suppressed_as_temp >= 1
+    assert "drop_db.secrets" in list(
+        source.report.usage_references_suppressed_as_temp_sample
     )
 
 

--- a/metadata-ingestion/tests/unit/test_mysql_usage.py
+++ b/metadata-ingestion/tests/unit/test_mysql_usage.py
@@ -12,7 +12,10 @@ from datahub.ingestion.source.sql.mysql import (
     MySQLSource,
     _parse_general_log_user,
 )
-from datahub.metadata.schema_classes import DatasetUsageStatisticsClass
+from datahub.metadata.schema_classes import (
+    DatasetUsageStatisticsClass,
+    UpstreamLineageClass,
+)
 from datahub.metadata.urns import CorpUserUrn
 from datahub.sql_parsing.sql_parsing_aggregator import ObservedQuery
 
@@ -391,6 +394,57 @@ def test_is_temp_table_flags_undiscovered_tables():
     assert not source._is_temp_table("appdb.orders")
     assert source._is_temp_table("appdb.tmp_scratch")
     assert source._is_temp_table("appdb.appdb.orders")
+    # Each suppression is counted so a missing table is observable, not silent.
+    assert source.report.num_usage_references_suppressed_as_temp == 2
+
+
+def test_is_temp_table_matches_case_insensitively():
+    # A catalog holding mixed-case identifiers (e.g. lower_case_table_names=2)
+    # must still match a reference the parser lowercased, or real lineage would
+    # silently vanish.
+    source = _source()
+    source.discovered_datasets.add("AppDB.Orders")
+    assert not source._is_temp_table("appdb.orders")
+
+
+def test_save_schema_to_resolver_tracks_usage_flag():
+    assert _source(include_view_lineage=False)._save_schema_to_resolver()
+    off = MySQLConfig(include_usage_statistics=False, include_view_lineage=False)
+    assert not MySQLSource(
+        off, PipelineContext(run_id="mysql-usage-test")
+    )._save_schema_to_resolver()
+
+
+def test_usage_emits_lineage_between_discovered_tables():
+    # Positive counterpart to the phantom tests: when both tables are ingested,
+    # the query lineage edge must survive.
+    source = _source()
+    source.discovered_datasets.update({"appdb.orders", "appdb.summary"})
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    with patch.object(
+        source,
+        "_fetch_performance_schema_queries",
+        return_value=[
+            ObservedQuery(
+                query="INSERT INTO summary SELECT id FROM orders",
+                timestamp=now,
+                default_schema="appdb",
+                usage_multiplier=1,
+            )
+        ],
+    ):
+        workunits = list(source._generate_aggregator_workunits())
+
+    upstreams = [
+        upstream.dataset
+        for wu in workunits
+        if (aspect := wu.get_aspect_of_type(UpstreamLineageClass)) is not None
+        for upstream in aspect.upstreams
+    ]
+    assert any("appdb.orders" in urn for urn in upstreams), (
+        f"expected lineage from appdb.orders; got {upstreams}"
+    )
 
 
 def test_usage_skips_phantom_entity_from_mis_quoted_identifier():

--- a/metadata-ingestion/tests/unit/test_mysql_usage.py
+++ b/metadata-ingestion/tests/unit/test_mysql_usage.py
@@ -165,6 +165,8 @@ def test_fetch_performance_schema_respects_database_pattern(mock_create_engine):
 
 def test_usage_workunits_generated_for_two_tier_table():
     source = _source()
+    # Usage/lineage is only attributed to tables we ingested (is_temp_table).
+    source.discovered_datasets.add("appdb.orders")
     now = datetime.datetime.now(tz=datetime.timezone.utc)
 
     with patch.object(
@@ -373,6 +375,79 @@ def test_general_log_drops_query_from_unknown_session(mock_create_engine):
     observed = list(_source(usage_source="general_log")._fetch_general_log_queries())
 
     assert observed == []
+
+
+def test_is_allowed_table_respects_pattern_and_system_schemas():
+    source = _source(database_pattern={"allow": ["keep_db"]})
+    assert source._is_allowed_table("keep_db.orders")
+    assert not source._is_allowed_table("drop_db.orders")
+    # System schemas are never allowed, regardless of the pattern.
+    assert not source._is_allowed_table("mysql.user")
+
+
+def test_is_temp_table_flags_undiscovered_tables():
+    source = _source()
+    source.discovered_datasets.add("appdb.orders")
+    # A table we ingested is real; anything else (temp tables, filtered-out
+    # databases, phantom db.db.table names) is treated as temp so it is not
+    # emitted as its own dataset.
+    assert not source._is_temp_table("appdb.orders")
+    assert source._is_temp_table("appdb.tmp_scratch")
+    assert source._is_temp_table("appdb.appdb.orders")
+
+
+def test_usage_skips_phantom_entity_from_mis_quoted_identifier():
+    # A single backticked identifier with an embedded dot parses as one table
+    # name, so the two-tier default_schema is prepended and the URN doubles the
+    # database (appdb.appdb.tmp_upsert). Since that phantom is not a discovered
+    # table it must be suppressed rather than emitted as a column-less dataset.
+    source = _source()
+    source.discovered_datasets.add("appdb.orders")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    with patch.object(
+        source,
+        "_fetch_performance_schema_queries",
+        return_value=[
+            ObservedQuery(
+                query="INSERT INTO `appdb.tmp_upsert` SELECT id FROM orders",
+                timestamp=now,
+                default_schema="appdb",
+                usage_multiplier=3,
+            )
+        ],
+    ):
+        urns = {wu.get_urn() for wu in source._generate_aggregator_workunits()}
+
+    assert not any("appdb.appdb" in urn for urn in urns), (
+        f"phantom doubled-database URN must not be emitted; got {urns}"
+    )
+
+
+def test_usage_does_not_attribute_to_filtered_out_database():
+    # A query running in an allowed database that references a table in a
+    # filtered-out database must not resurrect that table as an entity.
+    source = _source(database_pattern={"allow": ["keep_db"]})
+    source.discovered_datasets.add("keep_db.orders")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    with patch.object(
+        source,
+        "_fetch_performance_schema_queries",
+        return_value=[
+            ObservedQuery(
+                query="INSERT INTO orders SELECT id FROM drop_db.secrets",
+                timestamp=now,
+                default_schema="keep_db",
+                usage_multiplier=5,
+            )
+        ],
+    ):
+        urns = {wu.get_urn() for wu in source._generate_aggregator_workunits()}
+
+    assert not any("drop_db" in urn for urn in urns), (
+        f"filtered-out database must not appear in emitted URNs; got {urns}"
+    )
 
 
 @patch("datahub.ingestion.source.sql.mysql.create_engine")


### PR DESCRIPTION
## Summary

When `include_usage_statistics` is enabled, query-history usage/lineage attributed metadata to tables that were never ingested as datasets, producing column-less phantom entities and ignoring `database_pattern`:

- **Filtered-out databases** — the fetch-time filters only checked each query's *default schema*, not tables *referenced inside* the SQL. A query in an allowed database could resurrect a table from a database excluded by `database_pattern`.
- **Three-layer URNs on two-tier sources** — a mis-quoted `` `db.table` `` reference (a single backtick-quoted identifier with an embedded dot) parses as one table name, so the two-tier `default_schema` is prepended and the URN doubles the database (`db.db.table`).

## Fix

Mirror the Redshift pattern by wiring two callbacks into the usage `SqlParsingAggregator` (inherited automatically by MariaDB):

- `is_allowed_table` — drops system schemas and databases excluded by `database_pattern`, applied to every referenced table.
- `is_temp_table` — treats any table not in `discovered_datasets` (the tables we actually ingested) as temp. The aggregator resolves lineage *through* temp tables but never emits them, so genuine temp tables, filtered-out databases, and the phantom `db.db.table` all stop producing entities.

Also override `_save_schema_to_resolver` so `discovered_datasets` is populated whenever usage is enabled (previously gated on view lineage). It is filled during ingestion, before the usage phase runs.

## Test plan

- [x] `tests/unit/test_mysql_usage.py` — added coverage for both callbacks, a regression test asserting the phantom `db.db.table` URN is never emitted, and one asserting a filtered-out database never appears in emitted URNs. 20 passed.
- [x] `./gradlew :metadata-ingestion:lintFix` clean.