### PR TITLE
docs(teams): correct required Microsoft Graph permissions for Teams app

### DIFF
--- a/docs/managed-datahub/teams/saas-teams-setup.md
+++ b/docs/managed-datahub/teams/saas-teams-setup.md
@@ -18,11 +18,12 @@ need to provide this list during your organization's security review.
 These permissions are granted on the Azure AD app registration and are used to resolve users,
 teams, and channels referenced from DataHub.
 
-| Permission              | Why it's needed                                                        |
-| ----------------------- | ---------------------------------------------------------------------- |
-| `User.Read.All`         | Resolve Teams user IDs to names and email addresses for DM recipients. |
-| `TeamMember.Read.All`   | Read team membership for channel-scoped notifications.                 |
-| `Channel.ReadBasic.All` | List channels in the Teams picker and resolve a channel to its team.   |
+| Permission              | Why it's needed                                                               |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| `User.ReadBasic.All`    | Resolve Teams users to names and email addresses for notification recipients. |
+| `Team.ReadBasic.All`    | List teams in order to resolve the channels referenced from DataHub.          |
+| `Channel.ReadBasic.All` | List channels in the Teams picker and resolve a channel to its team.          |
+| `TeamsActivity.Send`    | Send activity-feed notifications directly to individual users.                |
 
 ### Bot Framework (separate authentication, not a Graph scope)
 


### PR DESCRIPTION
## Summary

Corrects the **Required Permissions** table in `docs/managed-datahub/teams/saas-teams-setup.md` so the documented Microsoft Graph application permissions match the Teams app's actual Graph calls and its install manifest. The list added in #17305 named permissions the app doesn't request and omitted two it genuinely needs, which could lead a security team to grant the wrong set during app approval.

## Changes

| Permission | Before | After | Reason |
| --- | --- | --- | --- |
| `User.Read.All` | listed | → `User.ReadBasic.All` | The app only reads basic profile fields (`/users`) to resolve names/emails. |
| `TeamMember.Read.All` | listed | removed | No application-permission `/members` call exists; team membership is only read in the delegated sign-in flow, which doesn't require this app scope. |
| `Team.ReadBasic.All` | — | added | Listing teams (`/teams`) to resolve the channels referenced from DataHub. |
| `TeamsActivity.Send` | — | added | Sending per-user activity-feed notifications (`/users/{id}/teamwork/sendActivityNotification`). |
| `Channel.ReadBasic.All` | listed | unchanged | Correct as-is. |

The resulting set matches the four application permissions the Teams app install manifest provisions.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [ ] Links to related issues (if applicable) — follow-up to #17305
- [ ] Tests for the changes have been added/updated (if applicable) — N/A (docs-only)
- [x] Docs related to the changes have been added/updated
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in Updating DataHub — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)