### PR TITLE
fix: UI queries for application references on DataFlows and DataProducts

### DIFF
--- a/datahub-web-react/src/graphql/__tests__/dataFlowApplicationsQuery.test.ts
+++ b/datahub-web-react/src/graphql/__tests__/dataFlowApplicationsQuery.test.ts
@@ -1,0 +1,11 @@
+import { print } from 'graphql';
+
+import { GetDataFlowDocument } from '@graphql/dataFlow.generated';
+
+describe('dataFlow query includes applications field', () => {
+    it('should request the applications field with entityApplication fragment', () => {
+        const queryText = print(GetDataFlowDocument);
+        expect(queryText).toContain('applications');
+        expect(queryText).toContain('entityApplication');
+    });
+});

--- a/datahub-web-react/src/graphql/__tests__/dataProductApplicationsQuery.test.ts
+++ b/datahub-web-react/src/graphql/__tests__/dataProductApplicationsQuery.test.ts
@@ -1,0 +1,11 @@
+import { print } from 'graphql';
+
+import { GetDataProductDocument } from '@graphql/dataProduct.generated';
+
+describe('dataProduct query includes applications field', () => {
+    it('should request the applications field with entityApplication fragment', () => {
+        const queryText = print(GetDataProductDocument);
+        expect(queryText).toContain('applications');
+        expect(queryText).toContain('entityApplication');
+    });
+});

--- a/datahub-web-react/src/graphql/dataFlow.graphql
+++ b/datahub-web-react/src/graphql/dataFlow.graphql
@@ -40,6 +40,9 @@ fragment dataFlowFields on DataFlow {
     domain {
         ...entityDomain
     }
+    applications {
+        ...entityApplication
+    }
     ...entityDataProduct
     status {
         removed

--- a/datahub-web-react/src/graphql/dataProduct.graphql
+++ b/datahub-web-react/src/graphql/dataProduct.graphql
@@ -78,6 +78,9 @@ fragment dataProductSearchFields on DataProduct {
     domain {
         ...entityDomain
     }
+    applications {
+        ...entityApplication
+    }
     entities(input: { start: 0, count: 0, query: "*" }) {
         total
     }


### PR DESCRIPTION
Application references were not shown on DataFlows and DataProducts even when the `applications` aspect was present in GMS. This PR updates the UI GraphQL fragments for DataFlows and DataProducts to request `applications`, matching the existing sidebar capability.

I also checked other entity application references; these were the only missing UI query fields found.