### PR TITLE
fix(lineage): pass AlertAction object to empty graph nudge

### DIFF
--- a/datahub-web-react/src/app/lineage/LineageEmptyGraphNudge.tsx
+++ b/datahub-web-react/src/app/lineage/LineageEmptyGraphNudge.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button } from '@components';
+import { Alert } from '@components';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -59,12 +59,27 @@ export default function LineageEmptyGraphNudge({
         );
     }, [location, history]);
 
+    const action = useMemo(() => {
+        if (reasons.includes('timeFilter')) {
+            return {
+                label: t('emptyGraphNudge.showAllTimeAction'),
+                onClick: onShowAllTime,
+                dataTestId: 'lineage-empty-graph-show-all-time',
+            };
+        }
+        if (reasons.includes('hiddenEdges')) {
+            return {
+                label: t('emptyGraphNudge.showHiddenEdgesAction'),
+                onClick: () => setShowGhostEntities(true),
+                dataTestId: 'lineage-empty-graph-show-hidden-edges',
+            };
+        }
+        return undefined;
+    }, [reasons, t, onShowAllTime, setShowGhostEntities]);
+
     if (loading || !show || dismissed) {
         return null;
     }
-
-    const showAllTimeAction = reasons.includes('timeFilter');
-    const showHiddenEdgesAction = reasons.includes('hiddenEdges');
 
     return (
         <Panel position="top-center">
@@ -72,32 +87,7 @@ export default function LineageEmptyGraphNudge({
                 variant="brand"
                 title={t('emptyGraphNudge.title')}
                 description={description}
-                action={
-                    <>
-                        {showAllTimeAction && (
-                            <Button
-                                size="sm"
-                                variant="text"
-                                color="primary"
-                                data-testid="lineage-empty-graph-show-all-time"
-                                onClick={onShowAllTime}
-                            >
-                                {t('emptyGraphNudge.showAllTimeAction')}
-                            </Button>
-                        )}
-                        {showHiddenEdgesAction && (
-                            <Button
-                                size="sm"
-                                variant="text"
-                                color="primary"
-                                data-testid="lineage-empty-graph-show-hidden-edges"
-                                onClick={() => setShowGhostEntities(true)}
-                            >
-                                {t('emptyGraphNudge.showHiddenEdgesAction')}
-                            </Button>
-                        )}
-                    </>
-                }
+                action={action}
                 onClose={() => setDismissed(true)}
                 data-testid="lineage-empty-graph-nudge"
             />


### PR DESCRIPTION
Alert.action expects { label, onClick }, not JSX buttons.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
