### PR TITLE
fix(openapi): surface Kubernetes API errors instead of masking as 500

### DIFF
--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/operations/k8/KubernetesController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/operations/k8/KubernetesController.java
@@ -46,6 +46,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -107,6 +108,21 @@ public class KubernetesController {
     this.authorizerChain = authorizerChain;
     this.kubernetesClient = kubernetesClient;
     this.k8sObjectMapper = k8sObjectMapper;
+  }
+
+  /**
+   * Surfaces the real Kubernetes API failure (its HTTP status and message) instead of letting it
+   * fall through to the global handler, which masks every exception as an opaque {@code 500
+   * "Internal server error occurred"}. A 403 (RBAC denied) or 404 is far more actionable for an
+   * operator than a generic 500. All endpoints here are MANAGE_SYSTEM_OPERATIONS-gated, so
+   * returning the raw API message is acceptable.
+   */
+  @ExceptionHandler(KubernetesClientException.class)
+  public ResponseEntity<Map<String, String>> handleKubernetesClientException(
+      KubernetesClientException e) {
+    int code = e.getCode() > 0 ? e.getCode() : HttpStatus.INTERNAL_SERVER_ERROR.value();
+    log.error("Kubernetes API call failed (HTTP {})", code, e);
+    return ResponseEntity.status(code).body(Map.of("error", e.getMessage()));
   }
 
   // ==================== Status ====================
@@ -472,6 +488,14 @@ public class KubernetesController {
               logs = "[truncated...]\n" + logs.substring(logs.length() - limit);
             }
             return ResponseEntity.ok(logs != null ? logs : "");
+          } catch (KubernetesClientException e) {
+            // Surface the real API status (e.g. 403/404) rather than a blanket 500. Handled here
+            // rather than via handleKubernetesClientException because this endpoint produces
+            // text/plain, so the error body must stay text/plain too.
+            int code = e.getCode() > 0 ? e.getCode() : HttpStatus.INTERNAL_SERVER_ERROR.value();
+            log.error(
+                "Failed to get logs for pod {}, container {} (HTTP {})", name, cr.name(), code, e);
+            return ResponseEntity.status(code).body("Failed to retrieve logs: " + e.getMessage());
           } catch (Exception e) {
             log.error("Failed to get logs for pod {}, container {}", name, cr.name(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/k8/KubernetesControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/k8/KubernetesControllerTest.java
@@ -722,6 +722,51 @@ public class KubernetesControllerTest extends AbstractTestNGSpringContextTests {
         .andExpect(content().string("Container logs"));
   }
 
+  // ==================== K8s API Error Surfacing Tests ====================
+
+  @Test
+  public void testListPodsSurfacesKubernetesClientError() throws Exception {
+    MixedOperation podsOp = mock(MixedOperation.class);
+    NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);
+
+    when(kubernetesClient.pods()).thenReturn(podsOp);
+    when(podsOp.inNamespace(NAMESPACE)).thenReturn(nsOp);
+    when(nsOp.list())
+        .thenThrow(
+            new KubernetesClientException(
+                "pods is forbidden: cannot list resource \"pods\"", 403, null));
+
+    mockMvc
+        .perform(MockMvcRequestBuilders.get(BASE_PATH + "/pods").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.error").value(org.hamcrest.Matchers.containsString("forbidden")));
+  }
+
+  @Test
+  public void testGetPodLogsSurfacesKubernetesClientError() throws Exception {
+    Pod pod = createTestPod("log-pod");
+
+    MixedOperation podsOp = mock(MixedOperation.class);
+    NonNamespaceOperation nsOp = mock(NonNamespaceOperation.class);
+    PodResource podResource = mock(PodResource.class);
+    ContainerResource containerResource = mock(ContainerResource.class);
+
+    when(kubernetesClient.pods()).thenReturn(podsOp);
+    when(podsOp.inNamespace(NAMESPACE)).thenReturn(nsOp);
+    when(nsOp.withName("log-pod")).thenReturn(podResource);
+    when(podResource.get()).thenReturn(pod);
+    when(podResource.inContainer("main")).thenReturn(containerResource);
+    when(containerResource.getLog())
+        .thenThrow(new KubernetesClientException("pods \"log-pod\" not found", 404, null));
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(BASE_PATH + "/pods/log-pod/logs")
+                .accept(MediaType.TEXT_PLAIN))
+        .andExpect(status().isNotFound())
+        .andExpect(content().string(org.hamcrest.Matchers.containsString("not found")));
+  }
+
   // ==================== Trigger CronJob Success Tests ====================
 
   @Test


### PR DESCRIPTION
## Summary

The Kubernetes operations endpoints under `/openapi/operations/k8/*` let `KubernetesClientException` propagate to the global exception handler, which collapses every failure into an opaque `500 {"error":"Internal server error occurred"}`. This discards the real HTTP status and message returned by the Kubernetes API, so a `403` (for example, the ServiceAccount lacking RBAC to `list`/`get` a resource) or a `404` is indistinguishable from a genuine server error — and impossible to diagnose from the API response alone.

## Changes

- Add a controller-local `@ExceptionHandler(KubernetesClientException.class)` in `KubernetesController` that maps the exception's HTTP status code and message onto the response. Being controller-local, it takes precedence over the global `@ControllerAdvice` and covers all JSON endpoints (`pods`, `deployments`, `jobs`, `cronjobs`, `configmaps` — list and get) in one place, with no change to the shared handler.
- `getPodLogs` handles `KubernetesClientException` locally instead, because that endpoint produces `text/plain` — routing its error through the JSON handler would fail content negotiation. It now returns the real status with a `text/plain` body rather than a hardcoded 500.
- Tests: a denied `list` call (403) and a denied log fetch (404) assert the real status and message are surfaced.

Success paths are unchanged; only error responses become more specific.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Links to related issues (n/a)
- [x] Tests for the changes have been added/updated
- [ ] Docs (n/a — behavior of error responses only)
- [ ] Breaking changes (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
