### PR TITLE
feat(usage): optional UTC-aligned flush window boundaries

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/README.md
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/README.md
@@ -1,31 +1,25 @@
-# API usage aggregation (`com.linkedin.metadata.usage`)
+### Flush alignment
 
-In-memory rollup for **GMS API traffic** — operational Micrometer metrics and optional
-commercial extension overlays.
+When `alignmentPeriodSeconds` is non-zero, flush batches are split at UTC calendar
+boundaries — a drain that would cross a boundary ends the current batch at the
+boundary and starts a fresh window there. Multiple batches per period are normal;
+flush consumers should sum additive rows and union distinct identities per aligned
+`window_start`.
 
-## Package layout
+The flush coordinator ticks on `scheduledIntervalSeconds` (default 60s). Each tick
+flushes before the next boundary when within one interval of it, otherwise on the
+normal schedule.
 
-| Package                     | Role                                                                 |
-| --------------------------- | -------------------------------------------------------------------- |
-| `usage.store`               | In-memory aggregation (`UsageAggregationStore`, flush window state)  |
-| `usage.flush`               | Flush batch DTOs, sinks, coordinator                                 |
-| `usage.registry.operations` | `usage_operations.yaml` runtime registry (`UsageOperationsRegistry`) |
-| `usage.registry.metrics`    | `usage_metric_registry.yaml` runtime registry + increment resolver   |
-| `usage.registry.graphql`    | GraphQL classification registry builder                              |
-| `usage.instrumentation`     | HTTP session enrichment, auth-channel resolution                     |
-| `usage.identity`            | Actor-class classification                                           |
+| `alignmentPeriodSeconds` | Grid (UTC)   |
+| ------------------------ | ------------ |
+| `0` (default)            | Disabled     |
+| `3600`                   | Top of hour  |
+| `900`                    | 15 minutes   |
+| `86400`                  | UTC midnight |
 
-Configuration YAML loaders and manifests live in `com.linkedin.metadata.config.usage.*`
-(`manifest`, `loader`, `overlay`, `graphql`, `metric`).
-
-## Enable flags
-
-- `USAGE_AGGREGATION_ENABLED` — GMS aggregation + flush coordinator
-- `USAGE_AGGREGATION_MICROMETER_EXPORT_ENABLED` — Micrometer sink (default on)
-
-**Queue-path ingest** (`metadata_ingest` with `request_api=messaging`) is recorded on the MCE
-consumer when `USAGE_AGGREGATION_ENABLED=true` there — see `UsageQueueIngestRecorder` and
-`MceUsageAggregationFactory`. Async REST ingest dedup uses MCP `headers` (`X-DataHub-Usage-PreRecorded`)
-via `UsageMetadataChangeProposalEnricher` on publish.
-
-See [`store/README.md`](store/README.md) for store-level types.
+Set `USAGE_AGGREGATION_ALIGNMENT_PERIOD_SECONDS` to enable alignment (e.g. `3600` for
+hourly). When alignment is on, keep `scheduledIntervalSeconds` > 0 so the
+coordinator can flush before each boundary. With `scheduledIntervalSeconds=0`, no
+periodic ticks run — flushes rely on `maxWindowSeconds` and cardinality triggers
+only, which can miss boundary timing unless `maxWindowSeconds` divides the alignment
+period cleanly.

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/flush/AdaptiveFlushCoordinator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/flush/AdaptiveFlushCoordinator.java
@@ -1,6 +1,10 @@
 package com.linkedin.metadata.usage.flush;
 
 import com.linkedin.metadata.usage.store.InMemoryUsageAggregationStore;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -11,14 +15,40 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class AdaptiveFlushCoordinator implements AutoCloseable {
 
+  private static final ZoneOffset ALIGNMENT_ZONE = ZoneOffset.UTC;
+
   private final InMemoryUsageAggregationStore store;
   private final long scheduledIntervalSeconds;
+  private final Duration boundarySkew;
+  private final Clock clock;
   private final ScheduledExecutorService scheduler;
+  private volatile long lastScheduledFlushMillis;
 
   public AdaptiveFlushCoordinator(
       @Nonnull InMemoryUsageAggregationStore store, long scheduledIntervalSeconds) {
+    this(store, scheduledIntervalSeconds, Clock.systemUTC());
+  }
+
+  public AdaptiveFlushCoordinator(
+      @Nonnull InMemoryUsageAggregationStore store,
+      long scheduledIntervalSeconds,
+      @Nonnull Clock clock) {
+    this(store, scheduledIntervalSeconds, clock, true);
+  }
+
+  AdaptiveFlushCoordinator(
+      @Nonnull InMemoryUsageAggregationStore store,
+      long scheduledIntervalSeconds,
+      @Nonnull Clock clock,
+      boolean enableSchedulers) {
     this.store = store;
     this.scheduledIntervalSeconds = scheduledIntervalSeconds;
+    this.clock = clock;
+    this.boundarySkew =
+        scheduledIntervalSeconds > 0
+            ? Duration.ofSeconds(scheduledIntervalSeconds)
+            : Duration.ofSeconds(1);
+    this.lastScheduledFlushMillis = clock.millis();
     this.scheduler =
         Executors.newSingleThreadScheduledExecutor(
             runnable -> {
@@ -26,22 +56,58 @@ public class AdaptiveFlushCoordinator implements AutoCloseable {
               thread.setDaemon(true);
               return thread;
             });
-    if (scheduledIntervalSeconds > 0) {
+    if (enableSchedulers && scheduledIntervalSeconds > 0) {
       scheduler.scheduleAtFixedRate(
           this::tick, scheduledIntervalSeconds, scheduledIntervalSeconds, TimeUnit.SECONDS);
     }
   }
 
-  private void tick() {
+  /** Package-visible for deterministic tests with a controllable {@link Clock}. */
+  void tick() {
     try {
+      if (store.isAlignmentEnabled() && shouldFlushForAlignmentBoundary()) {
+        store.flush(FlushTrigger.SCHEDULED);
+        lastScheduledFlushMillis = clock.millis();
+        return;
+      }
       if (store.isWindowExpired()) {
         store.flush(FlushTrigger.MAX_WINDOW);
-      } else {
+        lastScheduledFlushMillis = clock.millis();
+        return;
+      }
+      if (!store.isAlignmentEnabled()) {
         store.flush(FlushTrigger.SCHEDULED);
+        lastScheduledFlushMillis = clock.millis();
+        return;
+      }
+      if (scheduledIntervalElapsed()) {
+        store.flush(FlushTrigger.SCHEDULED);
+        lastScheduledFlushMillis = clock.millis();
       }
     } catch (RuntimeException e) {
       log.warn("Scheduled usage aggregation flush failed", e);
     }
+  }
+
+  private boolean scheduledIntervalElapsed() {
+    return scheduledIntervalSeconds > 0
+        && clock.millis() - lastScheduledFlushMillis
+            >= TimeUnit.SECONDS.toMillis(scheduledIntervalSeconds);
+  }
+
+  private boolean shouldFlushForAlignmentBoundary() {
+    Duration alignmentPeriod = store.alignmentPeriod();
+    if (alignmentPeriod == null) {
+      return false;
+    }
+    Instant now = clock.instant();
+    Instant boundary =
+        UsageFlushBoundaryUtils.nextBoundary(
+            store.windowStartSnapshot(), alignmentPeriod, ALIGNMENT_ZONE);
+    if (!now.isBefore(boundary)) {
+      return true;
+    }
+    return !now.isBefore(boundary.minus(boundarySkew));
   }
 
   public void shutdown() {

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/flush/UsageFlushBoundaryUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/flush/UsageFlushBoundaryUtils.java
@@ -1,0 +1,72 @@
+package com.linkedin.metadata.usage.flush;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import javax.annotation.Nonnull;
+
+/** Calendar-grid helpers for optional usage flush window alignment. */
+public final class UsageFlushBoundaryUtils {
+
+  private UsageFlushBoundaryUtils() {}
+
+  /**
+   * Floor {@code instant} to the containing alignment period in {@code zone}.
+   *
+   * <p>Invariant for a well-formed batch: {@code alignDown(windowStart) == alignDown(windowEnd -
+   * 1ms)}.
+   */
+  @Nonnull
+  public static Instant alignDown(
+      @Nonnull Instant instant, @Nonnull Duration period, @Nonnull ZoneId zone) {
+    requirePositivePeriod(period);
+    long periodSeconds = period.getSeconds();
+    ZonedDateTime zdt = instant.atZone(zone);
+    if (periodSeconds == ChronoUnit.HOURS.getDuration().getSeconds()) {
+      return zdt.truncatedTo(ChronoUnit.HOURS).toInstant();
+    }
+    if (periodSeconds == ChronoUnit.DAYS.getDuration().getSeconds()) {
+      return zdt.truncatedTo(ChronoUnit.DAYS).toInstant();
+    }
+    if (periodSeconds < ChronoUnit.HOURS.getDuration().getSeconds()
+        && ChronoUnit.HOURS.getDuration().getSeconds() % periodSeconds == 0) {
+      int periodMinutes = (int) (periodSeconds / 60);
+      int alignedMinute = (zdt.getMinute() / periodMinutes) * periodMinutes;
+      return zdt.withMinute(alignedMinute).withSecond(0).withNano(0).toInstant();
+    }
+
+    ZonedDateTime dayStart = zdt.truncatedTo(ChronoUnit.DAYS);
+    long periodMillis = period.toMillis();
+    long millisSinceDayStart = Duration.between(dayStart.toInstant(), instant).toMillis();
+    long alignedMillisSinceDayStart = (millisSinceDayStart / periodMillis) * periodMillis;
+    return dayStart.plus(alignedMillisSinceDayStart, ChronoUnit.MILLIS).toInstant();
+  }
+
+  /** Start of the next alignment period strictly after {@code instant}. */
+  @Nonnull
+  public static Instant nextBoundary(
+      @Nonnull Instant instant, @Nonnull Duration period, @Nonnull ZoneId zone) {
+    return alignDown(instant, period, zone).plus(period);
+  }
+
+  /** Whether {@code [start, end)} spans more than one alignment bucket. */
+  public static boolean crossesBoundary(
+      @Nonnull Instant start,
+      @Nonnull Instant end,
+      @Nonnull Duration period,
+      @Nonnull ZoneId zone) {
+    if (!end.isAfter(start)) {
+      return false;
+    }
+    Instant endInclusive = end.minusMillis(1);
+    return !alignDown(start, period, zone).equals(alignDown(endInclusive, period, zone));
+  }
+
+  private static void requirePositivePeriod(@Nonnull Duration period) {
+    if (period.isZero() || period.isNegative()) {
+      throw new IllegalArgumentException("alignment period must be positive");
+    }
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/store/InMemoryUsageAggregationStore.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/store/InMemoryUsageAggregationStore.java
@@ -116,6 +116,29 @@ public class InMemoryUsageAggregationStore implements UsageAggregationStore {
       long maxWindowSeconds,
       int retryAttempts,
       long retryInitialBackoffMillis,
+      long alignmentPeriodSeconds) {
+    this(
+        usageOperationsRegistry,
+        metricRegistry,
+        actorClassResolver,
+        flushSink,
+        maxCardinality,
+        maxWindowSeconds,
+        retryAttempts,
+        retryInitialBackoffMillis,
+        alignmentPeriodSeconds,
+        Clock.systemUTC());
+  }
+
+  public InMemoryUsageAggregationStore(
+      @Nonnull UsageOperationsRegistry usageOperationsRegistry,
+      @Nonnull UsageMetricRegistry metricRegistry,
+      @Nonnull UsageActorClassResolver actorClassResolver,
+      @Nonnull UsageFlushSink flushSink,
+      int maxCardinality,
+      long maxWindowSeconds,
+      int retryAttempts,
+      long retryInitialBackoffMillis,
       @Nullable Long alignmentPeriodSeconds,
       @Nonnull Clock clock) {
     this.usageOperationsRegistry = usageOperationsRegistry;

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/store/InMemoryUsageAggregationStore.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/store/InMemoryUsageAggregationStore.java
@@ -7,6 +7,7 @@ import com.linkedin.metadata.usage.flush.DistinctIdentitySet;
 import com.linkedin.metadata.usage.flush.DistinctUsageSnapshot;
 import com.linkedin.metadata.usage.flush.FlushTrigger;
 import com.linkedin.metadata.usage.flush.UsageFlushBatch;
+import com.linkedin.metadata.usage.flush.UsageFlushBoundaryUtils;
 import com.linkedin.metadata.usage.flush.UsageFlushSink;
 import com.linkedin.metadata.usage.identity.UsageActorClassResolver;
 import com.linkedin.metadata.usage.registry.metrics.UsageMetricIncrementResolver;
@@ -19,7 +20,10 @@ import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.RequestContext;
 import io.datahubproject.metadata.context.usage.AttributionType;
 import io.datahubproject.metadata.context.usage.UsageActorClass;
+import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -45,6 +49,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class InMemoryUsageAggregationStore implements UsageAggregationStore {
 
+  private static final ZoneOffset ALIGNMENT_ZONE = ZoneOffset.UTC;
+
   private final UsageOperationsRegistry usageOperationsRegistry;
   private final UsageMetricRegistry metricRegistry;
   private final UsageActorClassResolver actorClassResolver;
@@ -53,11 +59,13 @@ public class InMemoryUsageAggregationStore implements UsageAggregationStore {
   private final long maxWindowMillis;
   private final int retryAttempts;
   private final long retryInitialBackoffMillis;
+  @Nullable private final Duration alignmentPeriod;
+  @Nonnull private final Clock clock;
 
   /** Protects active-window swap; concurrent recorders share the read lock. */
   private final ReentrantReadWriteLock windowLock = new ReentrantReadWriteLock();
 
-  private volatile ActiveWindow activeWindow = new ActiveWindow(Instant.now());
+  private volatile ActiveWindow activeWindow;
 
   public InMemoryUsageAggregationStore(
       @Nonnull UsageOperationsRegistry usageOperationsRegistry,
@@ -86,6 +94,30 @@ public class InMemoryUsageAggregationStore implements UsageAggregationStore {
       long maxWindowSeconds,
       int retryAttempts,
       long retryInitialBackoffMillis) {
+    this(
+        usageOperationsRegistry,
+        metricRegistry,
+        actorClassResolver,
+        flushSink,
+        maxCardinality,
+        maxWindowSeconds,
+        retryAttempts,
+        retryInitialBackoffMillis,
+        null,
+        Clock.systemUTC());
+  }
+
+  public InMemoryUsageAggregationStore(
+      @Nonnull UsageOperationsRegistry usageOperationsRegistry,
+      @Nonnull UsageMetricRegistry metricRegistry,
+      @Nonnull UsageActorClassResolver actorClassResolver,
+      @Nonnull UsageFlushSink flushSink,
+      int maxCardinality,
+      long maxWindowSeconds,
+      int retryAttempts,
+      long retryInitialBackoffMillis,
+      @Nullable Long alignmentPeriodSeconds,
+      @Nonnull Clock clock) {
     this.usageOperationsRegistry = usageOperationsRegistry;
     this.metricRegistry = metricRegistry;
     this.actorClassResolver = actorClassResolver;
@@ -94,6 +126,12 @@ public class InMemoryUsageAggregationStore implements UsageAggregationStore {
     this.maxWindowMillis = maxWindowSeconds * 1000L;
     this.retryAttempts = Math.max(1, retryAttempts);
     this.retryInitialBackoffMillis = Math.max(0, retryInitialBackoffMillis);
+    this.alignmentPeriod =
+        alignmentPeriodSeconds != null && alignmentPeriodSeconds > 0
+            ? Duration.ofSeconds(alignmentPeriodSeconds)
+            : null;
+    this.clock = clock;
+    this.activeWindow = newActiveWindow(null);
   }
 
   @Override
@@ -191,8 +229,34 @@ public class InMemoryUsageAggregationStore implements UsageAggregationStore {
 
   @Override
   public void flush(@Nonnull FlushTrigger trigger) {
-    UsageFlushBatch batch = swapAndExtractBlocking(trigger);
-    publishBatch(batch, trigger);
+    if (alignmentPeriod == null) {
+      publishBatch(swapAndExtractBlocking(trigger), trigger);
+      return;
+    }
+    while (true) {
+      Instant now = clock.instant();
+      Instant windowStart = windowStartSnapshot();
+      Instant boundary =
+          UsageFlushBoundaryUtils.nextBoundary(windowStart, alignmentPeriod, ALIGNMENT_ZONE);
+      boolean splitAtBoundary = !now.isBefore(boundary);
+      Instant batchEnd = splitAtBoundary ? boundary : now;
+
+      ActiveWindow retired;
+      windowLock.writeLock().lock();
+      try {
+        retired = swapActiveWindowLocked(splitAtBoundary ? boundary : null);
+      } finally {
+        windowLock.writeLock().unlock();
+      }
+      publishBatch(buildBatchFrom(retired, trigger, batchEnd), trigger);
+
+      if (!splitAtBoundary) {
+        return;
+      }
+      if (clock.instant().isBefore(nextAlignmentBoundary(activeWindow.windowStart))) {
+        return;
+      }
+    }
   }
 
   public int currentCardinality() {
@@ -201,11 +265,25 @@ public class InMemoryUsageAggregationStore implements UsageAggregationStore {
 
   public boolean isWindowExpired() {
     ActiveWindow window = activeWindow;
-    return Instant.now().toEpochMilli() - window.windowStart.toEpochMilli() >= maxWindowMillis;
+    return clock.instant().toEpochMilli() - window.windowStart.toEpochMilli() >= maxWindowMillis;
   }
 
-  /** Visible for tests in the same package. */
-  Instant windowStartSnapshot() {
+  public boolean isAlignmentEnabled() {
+    return alignmentPeriod != null;
+  }
+
+  @Nullable
+  public Duration alignmentPeriod() {
+    return alignmentPeriod;
+  }
+
+  @Nonnull
+  public Clock clock() {
+    return clock;
+  }
+
+  /** Visible for flush coordination and tests. */
+  public Instant windowStartSnapshot() {
     return activeWindow.windowStart;
   }
 
@@ -245,8 +323,28 @@ public class InMemoryUsageAggregationStore implements UsageAggregationStore {
       }
     }
     if (retired != null) {
-      publishBatch(buildBatchFrom(retired, FlushTrigger.CARDINALITY), FlushTrigger.CARDINALITY);
+      publishExtractedWindow(retired, FlushTrigger.CARDINALITY);
     }
+  }
+
+  private void publishExtractedWindow(
+      @Nonnull ActiveWindow retired, @Nonnull FlushTrigger trigger) {
+    Instant now = clock.instant();
+    if (alignmentPeriod == null) {
+      publishBatch(buildBatchFrom(retired, trigger, now), trigger);
+      return;
+    }
+    Instant boundary = nextAlignmentBoundary(retired.windowStart);
+    if (now.isBefore(boundary)) {
+      publishBatch(buildBatchFrom(retired, trigger, now), trigger);
+      return;
+    }
+    publishBatch(buildBatchFrom(retired, trigger, boundary), trigger);
+  }
+
+  @Nonnull
+  private Instant nextAlignmentBoundary(@Nonnull Instant windowStart) {
+    return UsageFlushBoundaryUtils.nextBoundary(windowStart, alignmentPeriod, ALIGNMENT_ZONE);
   }
 
   @Nullable
@@ -258,21 +356,41 @@ public class InMemoryUsageAggregationStore implements UsageAggregationStore {
     } finally {
       windowLock.writeLock().unlock();
     }
-    return buildBatchFrom(retired, trigger);
+    return buildBatchFrom(retired, trigger, clock.instant());
   }
 
   /** Caller must hold {@link ReentrantReadWriteLock#writeLock()}. */
   @Nonnull
   private ActiveWindow swapActiveWindowLocked() {
+    return swapActiveWindowLocked(null);
+  }
+
+  /** Caller must hold {@link ReentrantReadWriteLock#writeLock()}. */
+  @Nonnull
+  private ActiveWindow swapActiveWindowLocked(@Nullable Instant nextWindowStart) {
     ActiveWindow retired = activeWindow;
-    activeWindow = new ActiveWindow(Instant.now());
+    activeWindow = newActiveWindow(nextWindowStart);
     return retired;
+  }
+
+  @Nonnull
+  private ActiveWindow newActiveWindow(@Nullable Instant explicitStart) {
+    Instant windowStart = explicitStart != null ? explicitStart : clock.instant();
+    if (alignmentPeriod != null && explicitStart == null) {
+      windowStart = UsageFlushBoundaryUtils.alignDown(windowStart, alignmentPeriod, ALIGNMENT_ZONE);
+    }
+    return new ActiveWindow(windowStart);
   }
 
   @Nullable
   private UsageFlushBatch buildBatchFrom(
       @Nonnull ActiveWindow window, @Nonnull FlushTrigger trigger) {
-    Instant windowEnd = Instant.now();
+    return buildBatchFrom(window, trigger, clock.instant());
+  }
+
+  @Nullable
+  private UsageFlushBatch buildBatchFrom(
+      @Nonnull ActiveWindow window, @Nonnull FlushTrigger trigger, @Nonnull Instant windowEnd) {
     List<AdditiveUsageRow> additiveRows = drainAdditive(window.additiveBuckets);
     List<DistinctUsageSnapshot> distinctSnapshots = drainDistinct(window.distinctBuckets);
     if (additiveRows.isEmpty()

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/store/README.md
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/store/README.md
@@ -33,3 +33,5 @@ to avoid colliding with the legacy product-usage rollup package in this module.
 
 - `USAGE_AGGREGATION_ENABLED` — GMS aggregation + flush coordinator
 - `USAGE_AGGREGATION_MICROMETER_EXPORT_ENABLED` — Micrometer sink (default on)
+- `USAGE_AGGREGATION_ALIGNMENT_PERIOD_SECONDS` — UTC calendar grid for flush windows
+  (`0` default; e.g. `3600` for hourly). See [usage README](../README.md#flush-alignment).

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -525,6 +525,7 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "datahub.usage.aggregation.flush.scheduledIntervalSeconds",
           "datahub.usage.aggregation.flush.retryAttempts",
           "datahub.usage.aggregation.flush.retryInitialBackoffMillis",
+          "datahub.usage.aggregation.flush.alignmentPeriodSeconds",
           // Messaging transport
           "datahub.messaging.transport",
           // Feature flags

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/flush/AdaptiveFlushCoordinatorAlignmentTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/flush/AdaptiveFlushCoordinatorAlignmentTest.java
@@ -1,0 +1,223 @@
+package com.linkedin.metadata.usage.flush;
+
+import com.datahub.authentication.Actor;
+import com.datahub.authentication.ActorType;
+import com.datahub.authentication.Authentication;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.linkedin.metadata.config.usage.loader.UsageMetricRegistryLoader;
+import com.linkedin.metadata.config.usage.loader.UsageOperationsLoader;
+import com.linkedin.metadata.usage.identity.AspectCorpUserFlagsProvider;
+import com.linkedin.metadata.usage.identity.UsageActorClassResolver;
+import com.linkedin.metadata.usage.registry.metrics.UsageMetricRegistry;
+import com.linkedin.metadata.usage.registry.operations.UsageOperationsRegistry;
+import com.linkedin.metadata.usage.store.InMemoryUsageAggregationStore;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.RequestContext;
+import io.datahubproject.metadata.context.usage.AuthChannel;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Random;
+import javax.annotation.Nonnull;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class AdaptiveFlushCoordinatorAlignmentTest {
+
+  private UsageOperationsRegistry usageRegistry;
+  private UsageMetricRegistry metricRegistry;
+  private UsageActorClassResolver actorClassResolver;
+
+  @BeforeMethod
+  public void setup() {
+    YAMLMapper yamlMapper = yamlMapper();
+    usageRegistry = UsageOperationsRegistry.loadOssOnly(new UsageOperationsLoader(yamlMapper));
+    metricRegistry =
+        UsageMetricRegistry.loadBundled(new UsageMetricRegistryLoader(yamlMapper), List.of());
+    actorClassResolver = new UsageActorClassResolver(new AspectCorpUserFlagsProvider());
+  }
+
+  @Test
+  public void testHourlyAlignmentFlushesBeforeBoundary() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-07-10T10:50:00Z"));
+    RecordingUsageFlushSink sink = new RecordingUsageFlushSink();
+    InMemoryUsageAggregationStore store = alignedStore(sink, clock, 3600L, 3600);
+
+    AdaptiveFlushCoordinator coordinator = new AdaptiveFlushCoordinator(store, 30, clock, false);
+    try {
+      clock.advance(Duration.ofMinutes(9).plusSeconds(30));
+      coordinator.tick();
+
+      Assert.assertFalse(sink.batches().isEmpty());
+      UsageFlushBatch batch =
+          sink.batches().stream()
+              .filter(b -> b.trigger() == FlushTrigger.SCHEDULED)
+              .findFirst()
+              .orElseThrow();
+      Assert.assertTrue(batch.windowEnd().isBefore(Instant.parse("2026-07-10T11:00:00Z")));
+      Assert.assertEquals(store.windowStartSnapshot(), Instant.parse("2026-07-10T10:00:00Z"));
+
+      clock.advance(Duration.ofSeconds(30));
+      coordinator.tick();
+      Assert.assertEquals(store.windowStartSnapshot(), Instant.parse("2026-07-10T11:00:00Z"));
+    } finally {
+      coordinator.shutdown();
+    }
+  }
+
+  @Test
+  public void testFifteenMinuteAlignmentTickStaysWithinBucket() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-07-10T10:14:00Z"));
+    RecordingUsageFlushSink sink = new RecordingUsageFlushSink();
+    InMemoryUsageAggregationStore store = alignedStore(sink, clock, 900L, 3600);
+
+    AdaptiveFlushCoordinator coordinator = new AdaptiveFlushCoordinator(store, 30, clock, false);
+    try {
+      clock.advance(Duration.ofMinutes(1));
+      coordinator.tick();
+    } finally {
+      coordinator.shutdown();
+    }
+
+    UsageFlushBatch batch =
+        sink.batches().stream()
+            .filter(b -> b.trigger() == FlushTrigger.SCHEDULED)
+            .findFirst()
+            .orElseThrow();
+    Assert.assertFalse(
+        UsageFlushBoundaryUtils.crossesBoundary(
+            batch.windowStart(), batch.windowEnd(), Duration.ofSeconds(900), ZoneOffset.UTC));
+  }
+
+  @Test
+  public void testRandomFlushSequencesNeverCrossBoundary() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-07-10T00:00:00Z"));
+    RecordingUsageFlushSink sink = new RecordingUsageFlushSink();
+    InMemoryUsageAggregationStore store = alignedStore(sink, clock, 3600L, 3600);
+    AdaptiveFlushCoordinator coordinator = new AdaptiveFlushCoordinator(store, 30, clock, false);
+    Random random = new Random(42);
+
+    try {
+      for (int i = 0; i < 50; i++) {
+        store.recordRequest(session("urn:li:corpuser:user-" + i, "metadata_read", null));
+        clock.advance(Duration.ofSeconds(10 + random.nextInt(20)));
+        coordinator.tick();
+      }
+    } finally {
+      coordinator.shutdown();
+    }
+
+    for (UsageFlushBatch batch : sink.batches()) {
+      if (batch.trigger() == FlushTrigger.SHUTDOWN) {
+        continue;
+      }
+      Assert.assertFalse(
+          UsageFlushBoundaryUtils.crossesBoundary(
+              batch.windowStart(), batch.windowEnd(), Duration.ofHours(1), ZoneOffset.UTC),
+          "batch crossed boundary: " + batch.windowStart() + " -> " + batch.windowEnd());
+    }
+  }
+
+  @Test
+  public void testAlignmentOffPreservesExistingScheduledBehavior() throws Exception {
+    RecordingUsageFlushSink sink = new RecordingUsageFlushSink();
+    InMemoryUsageAggregationStore store = store(sink, 300);
+    try (AdaptiveFlushCoordinator coordinator = new AdaptiveFlushCoordinator(store, 1)) {
+      Thread.sleep(1500);
+      Assert.assertTrue(
+          sink.batches().stream().anyMatch(batch -> batch.trigger() == FlushTrigger.SCHEDULED));
+    }
+  }
+
+  private InMemoryUsageAggregationStore alignedStore(
+      RecordingUsageFlushSink sink,
+      MutableClock clock,
+      long alignmentPeriodSeconds,
+      long maxWindow) {
+    return new InMemoryUsageAggregationStore(
+        usageRegistry,
+        metricRegistry,
+        actorClassResolver,
+        sink,
+        10_000,
+        maxWindow,
+        3,
+        100L,
+        alignmentPeriodSeconds,
+        clock);
+  }
+
+  private InMemoryUsageAggregationStore store(UsageFlushSink sink, long maxWindowSeconds) {
+    return new InMemoryUsageAggregationStore(
+        usageRegistry, metricRegistry, actorClassResolver, sink, 10_000, maxWindowSeconds);
+  }
+
+  private static YAMLMapper yamlMapper() {
+    YAMLMapper yamlMapper = new YAMLMapper();
+    yamlMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    return yamlMapper;
+  }
+
+  private static OperationContext session(String actorUrn, String usageOperation, Long inputBytes) {
+    RequestContext requestContext =
+        RequestContext.builder()
+            .actorUrn(actorUrn)
+            .sourceIP("127.0.0.1")
+            .requestAPI(RequestContext.RequestAPI.OPENAPI)
+            .requestID("testAction")
+            .userAgent("test-agent")
+            .usageOperation(usageOperation)
+            .usageIdentity(actorUrn)
+            .authChannel(AuthChannel.SESSION)
+            .inputBytes(inputBytes)
+            .requestBodyMaterialized(inputBytes != null)
+            .build();
+    try {
+      return TestOperationContexts.systemContextNoValidate().toBuilder()
+          .requestContext(requestContext)
+          .build(userAuth(actorUrn), true);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static Authentication userAuth(String actorUrn) {
+    String actorId =
+        actorUrn.startsWith("urn:li:corpuser:")
+            ? actorUrn.substring("urn:li:corpuser:".length())
+            : actorUrn;
+    return new Authentication(new Actor(ActorType.USER, actorId), "Basic test");
+  }
+
+  static final class MutableClock extends Clock {
+    private Instant instant;
+
+    MutableClock(@Nonnull Instant start) {
+      this.instant = start;
+    }
+
+    void advance(@Nonnull Duration duration) {
+      instant = instant.plus(duration);
+    }
+
+    @Override
+    public java.time.ZoneId getZone() {
+      return ZoneOffset.UTC;
+    }
+
+    @Override
+    public Clock withZone(java.time.ZoneId zone) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Instant instant() {
+      return instant;
+    }
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/flush/UsageFlushBoundaryUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/flush/UsageFlushBoundaryUtilsTest.java
@@ -1,0 +1,67 @@
+package com.linkedin.metadata.usage.flush;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class UsageFlushBoundaryUtilsTest {
+
+  private static final ZoneId UTC = ZoneOffset.UTC;
+
+  @Test
+  public void testAlignDownHourlyUtc() {
+    Instant instant = Instant.parse("2026-07-10T10:37:42.123Z");
+    Instant aligned = UsageFlushBoundaryUtils.alignDown(instant, Duration.ofHours(1), UTC);
+    Assert.assertEquals(aligned, Instant.parse("2026-07-10T10:00:00Z"));
+  }
+
+  @Test
+  public void testAlignDownDailyUtc() {
+    Instant instant = Instant.parse("2026-07-10T23:59:59Z");
+    Instant aligned = UsageFlushBoundaryUtils.alignDown(instant, Duration.ofDays(1), UTC);
+    Assert.assertEquals(aligned, Instant.parse("2026-07-10T00:00:00Z"));
+  }
+
+  @Test
+  public void testAlignDownFifteenMinutes() {
+    Instant instant = Instant.parse("2026-07-10T10:17:42Z");
+    Instant aligned = UsageFlushBoundaryUtils.alignDown(instant, Duration.ofSeconds(900), UTC);
+    Assert.assertEquals(aligned, Instant.parse("2026-07-10T10:15:00Z"));
+  }
+
+  @Test
+  public void testNextBoundaryHourlyUtc() {
+    Instant instant = Instant.parse("2026-07-10T10:37:42Z");
+    Instant next = UsageFlushBoundaryUtils.nextBoundary(instant, Duration.ofHours(1), UTC);
+    Assert.assertEquals(next, Instant.parse("2026-07-10T11:00:00Z"));
+  }
+
+  @Test
+  public void testCrossesBoundaryFalseWithinSameHour() {
+    Instant start = Instant.parse("2026-07-10T10:05:00Z");
+    Instant end = Instant.parse("2026-07-10T10:59:59.999Z");
+    Assert.assertFalse(
+        UsageFlushBoundaryUtils.crossesBoundary(start, end, Duration.ofHours(1), UTC));
+  }
+
+  @Test
+  public void testCrossesBoundaryTrueAcrossHour() {
+    Instant start = Instant.parse("2026-07-10T10:50:00Z");
+    Instant end = Instant.parse("2026-07-10T11:05:00Z");
+    Assert.assertTrue(
+        UsageFlushBoundaryUtils.crossesBoundary(start, end, Duration.ofHours(1), UTC));
+  }
+
+  @Test
+  public void testBatchInvariantEndMinusOneMillisecond() {
+    Instant start = Instant.parse("2026-07-10T10:00:00Z");
+    Instant end = Instant.parse("2026-07-10T10:59:59.999Z");
+    Instant alignedStart = UsageFlushBoundaryUtils.alignDown(start, Duration.ofHours(1), UTC);
+    Instant alignedEnd =
+        UsageFlushBoundaryUtils.alignDown(end.minusMillis(1), Duration.ofHours(1), UTC);
+    Assert.assertEquals(alignedStart, alignedEnd);
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/store/InMemoryUsageAggregationStoreAlignmentTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/store/InMemoryUsageAggregationStoreAlignmentTest.java
@@ -1,0 +1,271 @@
+package com.linkedin.metadata.usage.store;
+
+import com.datahub.authentication.Actor;
+import com.datahub.authentication.ActorType;
+import com.datahub.authentication.Authentication;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.linkedin.metadata.config.usage.loader.UsageMetricRegistryLoader;
+import com.linkedin.metadata.config.usage.loader.UsageOperationsLoader;
+import com.linkedin.metadata.usage.UsageTestFixtures;
+import com.linkedin.metadata.usage.flush.FlushTrigger;
+import com.linkedin.metadata.usage.flush.RecordingUsageFlushSink;
+import com.linkedin.metadata.usage.flush.UsageFlushBatch;
+import com.linkedin.metadata.usage.flush.UsageFlushBoundaryUtils;
+import com.linkedin.metadata.usage.identity.CorpUserFlagsProvider;
+import com.linkedin.metadata.usage.identity.UsageActorClassResolver;
+import com.linkedin.metadata.usage.registry.metrics.UsageMetricRegistry;
+import com.linkedin.metadata.usage.registry.operations.UsageOperationsRegistry;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.RequestContext;
+import io.datahubproject.metadata.context.usage.AuthChannel;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class InMemoryUsageAggregationStoreAlignmentTest {
+
+  private static final ZoneId UTC = ZoneOffset.UTC;
+
+  private UsageOperationsRegistry usageRegistry;
+  private UsageMetricRegistry metricRegistry;
+  private UsageActorClassResolver actorClassResolver;
+
+  @BeforeMethod
+  public void setup() {
+    YAMLMapper yamlMapper = yamlMapper();
+    usageRegistry = UsageOperationsRegistry.loadOssOnly(new UsageOperationsLoader(yamlMapper));
+    metricRegistry =
+        UsageMetricRegistry.loadBundled(new UsageMetricRegistryLoader(yamlMapper), List.of());
+    actorClassResolver =
+        new UsageActorClassResolver(
+            new CorpUserFlagsProvider() {
+              @Override
+              public boolean isSystemCorpUser(String corpUserUrn) {
+                return false;
+              }
+
+              @Override
+              public boolean isSupportUser(String corpUserUrn) {
+                return false;
+              }
+
+              @Override
+              public CorpUserFlags resolveWithContext(
+                  OperationContext opContext, String corpUserUrn) {
+                return new CorpUserFlags(false, false);
+              }
+            });
+  }
+
+  @Test
+  public void testAlignedWindowStartsOnGrid() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-07-10T10:37:00Z"));
+    RecordingUsageFlushSink sink = new RecordingUsageFlushSink();
+    InMemoryUsageAggregationStore store =
+        alignedStore(sink, clock, Duration.ofHours(1), 10_000, 300);
+
+    Assert.assertEquals(store.windowStartSnapshot(), Instant.parse("2026-07-10T10:00:00Z"));
+  }
+
+  @Test
+  public void testAlignedBatchDoesNotCrossHourBoundary() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-07-10T10:50:00Z"));
+    RecordingUsageFlushSink sink = new RecordingUsageFlushSink();
+    InMemoryUsageAggregationStore store =
+        alignedStore(sink, clock, Duration.ofHours(1), 10_000, 300);
+
+    store.recordRequest(session(UsageTestFixtures.REGULAR_CORP_USER_URN, "metadata_read", null));
+    clock.advance(Duration.ofMinutes(9).plusSeconds(30));
+    store.flush(FlushTrigger.SCHEDULED);
+
+    Assert.assertEquals(sink.batches().size(), 1);
+    UsageFlushBatch batch = sink.batches().get(0);
+    Assert.assertFalse(
+        UsageFlushBoundaryUtils.crossesBoundary(
+            batch.windowStart(), batch.windowEnd(), Duration.ofHours(1), UTC));
+    Assert.assertTrue(batch.windowEnd().isBefore(Instant.parse("2026-07-10T11:00:00Z")));
+    Assert.assertEquals(store.windowStartSnapshot(), Instant.parse("2026-07-10T10:00:00Z"));
+
+    clock.advance(Duration.ofSeconds(30));
+    store.flush(FlushTrigger.SCHEDULED);
+    Assert.assertEquals(store.windowStartSnapshot(), Instant.parse("2026-07-10T11:00:00Z"));
+  }
+
+  @Test
+  public void testFifteenMinuteAlignment() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-07-10T10:17:00Z"));
+    RecordingUsageFlushSink sink = new RecordingUsageFlushSink();
+    InMemoryUsageAggregationStore store =
+        alignedStore(sink, clock, Duration.ofSeconds(900), 10_000, 300);
+
+    store.recordRequest(session(UsageTestFixtures.REGULAR_CORP_USER_URN, "metadata_read", null));
+    clock.advance(Duration.ofMinutes(2));
+    store.flush(FlushTrigger.SCHEDULED);
+
+    UsageFlushBatch batch = sink.batches().get(0);
+    Assert.assertEquals(batch.windowStart(), Instant.parse("2026-07-10T10:15:00Z"));
+    Assert.assertFalse(
+        UsageFlushBoundaryUtils.crossesBoundary(
+            batch.windowStart(), batch.windowEnd(), Duration.ofSeconds(900), UTC));
+  }
+
+  @Test
+  public void testCardinalityMidPeriodFlushStaysWithinBucket() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-07-10T10:00:00Z"));
+    RecordingUsageFlushSink sink = new RecordingUsageFlushSink();
+    InMemoryUsageAggregationStore store = alignedStore(sink, clock, Duration.ofHours(1), 2, 300);
+
+    store.recordRequest(session("urn:li:corpuser:a", "metadata_read", null));
+    store.recordRequest(session("urn:li:corpuser:b", "metadata_read", null));
+
+    Assert.assertTrue(
+        sink.batches().stream().anyMatch(batch -> batch.trigger() == FlushTrigger.CARDINALITY));
+    UsageFlushBatch batch =
+        sink.batches().stream()
+            .filter(b -> b.trigger() == FlushTrigger.CARDINALITY)
+            .findFirst()
+            .orElseThrow();
+    Assert.assertFalse(
+        UsageFlushBoundaryUtils.crossesBoundary(
+            batch.windowStart(), batch.windowEnd(), Duration.ofHours(1), UTC));
+    Assert.assertEquals(store.windowStartSnapshot(), Instant.parse("2026-07-10T10:00:00Z"));
+  }
+
+  @Test
+  public void testFlushPastBoundarySplitsAtBoundary() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-07-10T10:50:00Z"));
+    RecordingUsageFlushSink sink = new RecordingUsageFlushSink();
+    InMemoryUsageAggregationStore store =
+        alignedStore(sink, clock, Duration.ofHours(1), 10_000, 300);
+
+    store.recordRequest(session(UsageTestFixtures.REGULAR_CORP_USER_URN, "metadata_read", null));
+    clock.advance(Duration.ofMinutes(15));
+    store.flush(FlushTrigger.SCHEDULED);
+
+    Assert.assertEquals(sink.batches().size(), 1);
+    UsageFlushBatch batch = sink.batches().get(0);
+    Assert.assertEquals(batch.windowStart(), Instant.parse("2026-07-10T10:00:00Z"));
+    Assert.assertEquals(batch.windowEnd(), Instant.parse("2026-07-10T11:00:00Z"));
+    Assert.assertEquals(store.windowStartSnapshot(), Instant.parse("2026-07-10T11:00:00Z"));
+  }
+
+  @Test
+  public void testAlignmentDisabledMatchesProcessRelativeWindows() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-07-10T10:50:00Z"));
+    RecordingUsageFlushSink sink = new RecordingUsageFlushSink();
+    InMemoryUsageAggregationStore store =
+        new InMemoryUsageAggregationStore(
+            usageRegistry,
+            metricRegistry,
+            actorClassResolver,
+            sink,
+            10_000,
+            300,
+            3,
+            100L,
+            null,
+            clock);
+
+    Instant windowStart = store.windowStartSnapshot();
+    Assert.assertEquals(windowStart, clock.instant());
+    clock.advance(Duration.ofMinutes(5));
+    store.flush(FlushTrigger.SCHEDULED);
+    UsageFlushBatch batch = sink.batches().get(0);
+    Assert.assertEquals(batch.windowStart(), windowStart);
+    Assert.assertTrue(batch.windowEnd().isAfter(windowStart));
+  }
+
+  private InMemoryUsageAggregationStore alignedStore(
+      RecordingUsageFlushSink sink,
+      MutableClock clock,
+      Duration alignmentPeriod,
+      int maxCardinality,
+      long maxWindowSeconds) {
+    return new InMemoryUsageAggregationStore(
+        usageRegistry,
+        metricRegistry,
+        actorClassResolver,
+        sink,
+        maxCardinality,
+        maxWindowSeconds,
+        3,
+        100L,
+        alignmentPeriod.getSeconds(),
+        clock);
+  }
+
+  private static YAMLMapper yamlMapper() {
+    YAMLMapper yamlMapper = new YAMLMapper();
+    yamlMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    return yamlMapper;
+  }
+
+  private static OperationContext session(String actorUrn, String usageOperation, Long inputBytes) {
+    RequestContext requestContext =
+        RequestContext.builder()
+            .actorUrn(actorUrn)
+            .sourceIP("127.0.0.1")
+            .requestAPI(RequestContext.RequestAPI.OPENAPI)
+            .requestID("testAction")
+            .userAgent("test-agent")
+            .usageOperation(usageOperation)
+            .usageIdentity(actorUrn)
+            .authChannel(AuthChannel.SESSION)
+            .inputBytes(inputBytes)
+            .requestBodyMaterialized(inputBytes != null)
+            .build();
+    try {
+      return TestOperationContexts.systemContextNoValidate().toBuilder()
+          .requestContext(requestContext)
+          .build(userAuth(actorUrn), true);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static Authentication userAuth(String actorUrn) {
+    String actorId =
+        actorUrn.startsWith("urn:li:corpuser:")
+            ? actorUrn.substring("urn:li:corpuser:".length())
+            : actorUrn;
+    return new Authentication(new Actor(ActorType.USER, actorId), "Basic test");
+  }
+
+  static final class MutableClock extends Clock {
+    private Instant instant;
+    private final ZoneId zone;
+
+    MutableClock(@Nonnull Instant start) {
+      this.instant = start;
+      this.zone = ZoneOffset.UTC;
+    }
+
+    void advance(@Nonnull Duration duration) {
+      instant = instant.plus(duration);
+    }
+
+    @Override
+    public ZoneId getZone() {
+      return zone;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Instant instant() {
+      return instant;
+    }
+  }
+}

--- a/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/gms/factory/usage/mce/MceUsageAggregationFactory.java
+++ b/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/gms/factory/usage/mce/MceUsageAggregationFactory.java
@@ -133,7 +133,8 @@ public class MceUsageAggregationFactory {
         flush.getMaxCardinality(),
         flush.getMaxWindowSeconds(),
         flush.getRetryAttempts(),
-        flush.getRetryInitialBackoffMillis());
+        flush.getRetryInitialBackoffMillis(),
+        flush.getAlignmentPeriodSeconds());
   }
 
   @Bean
@@ -145,7 +146,9 @@ public class MceUsageAggregationFactory {
         UsageAggregationFactory.resolveAggregationConfig(configurationProvider);
     adaptiveFlushCoordinator =
         new AdaptiveFlushCoordinator(
-            usageAggregationStore, config.getFlush().getScheduledIntervalSeconds());
+            usageAggregationStore,
+            config.getFlush().getScheduledIntervalSeconds(),
+            usageAggregationStore.clock());
     return adaptiveFlushCoordinator;
   }
 

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/UsageAggregationConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/UsageAggregationConfiguration.java
@@ -37,5 +37,11 @@ public class UsageAggregationConfiguration {
      * #retryAttempts} &gt; 1.
      */
     private long retryInitialBackoffMillis = 100;
+
+    /**
+     * Calendar grid size for flush windows (seconds). Boundaries are UTC hour/day truncations. Zero
+     * disables alignment (process-relative windows).
+     */
+    private long alignmentPeriodSeconds;
   }
 }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -320,6 +320,7 @@ datahub:
         scheduledIntervalSeconds: ${USAGE_AGGREGATION_FLUSH_INTERVAL_SECONDS:60}
         retryAttempts: ${USAGE_AGGREGATION_FLUSH_RETRY_ATTEMPTS:3}
         retryInitialBackoffMillis: ${USAGE_AGGREGATION_FLUSH_RETRY_INITIAL_BACKOFF_MILLIS:100}
+        alignmentPeriodSeconds: ${USAGE_AGGREGATION_ALIGNMENT_PERIOD_SECONDS:0}
 
   validation:
     aspectSize:

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/usage/UsageAggregationFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/usage/UsageAggregationFactory.java
@@ -113,7 +113,8 @@ public class UsageAggregationFactory {
         flush.getMaxCardinality(),
         flush.getMaxWindowSeconds(),
         flush.getRetryAttempts(),
-        flush.getRetryInitialBackoffMillis());
+        flush.getRetryInitialBackoffMillis(),
+        flush.getAlignmentPeriodSeconds());
   }
 
   @Bean
@@ -124,7 +125,9 @@ public class UsageAggregationFactory {
     UsageAggregationConfiguration config = resolveAggregationConfig(configurationProvider);
     adaptiveFlushCoordinator =
         new AdaptiveFlushCoordinator(
-            usageAggregationStore, config.getFlush().getScheduledIntervalSeconds());
+            usageAggregationStore,
+            config.getFlush().getScheduledIntervalSeconds(),
+            usageAggregationStore.clock());
     return adaptiveFlushCoordinator;
   }
 


### PR DESCRIPTION
## Summary

- Add optional `alignmentPeriodSeconds` flush config (default `0` / off) so usage aggregation batches can be split at UTC calendar boundaries instead of spanning hours.
- `InMemoryUsageAggregationStore` aligns window starts and splits drains at the boundary; `AdaptiveFlushCoordinator` flushes within one `scheduledIntervalSeconds` of each boundary on the existing tick.
- Wire through GMS/MCE factories, `application.yaml`, property classification, and usage docs (including `scheduledIntervalSeconds=0` behavior when alignment is enabled).

## Test plan

- [x] `./gradlew :metadata-io:test --tests "com.linkedin.metadata.usage.*"` (165 tests)
- [x] `UsageFlushBoundaryUtilsTest` — hourly/15-min UTC math
- [x] `InMemoryUsageAggregationStoreAlignmentTest` — aligned windows, boundary split on drain, cardinality mid-period, alignment off regression
- [x] `AdaptiveFlushCoordinatorAlignmentTest` — boundary flush before hour, random tick sequences


Made with [Cursor](https://cursor.com)