### PR TITLE
fix(smoke-test): harden token, audit, and metrics tests for parallel runs

### DIFF
--- a/smoke-test/test_authentication_e2e.py
+++ b/smoke-test/test_authentication_e2e.py
@@ -33,6 +33,7 @@ import pytest
 import requests
 
 from tests.privileges.utils import create_user, remove_user
+from tests.tokens.token_utils import assert_graphql_mutation_succeeded
 from tests.utils import (
     TestSessionWrapper,
     get_admin_credentials,
@@ -45,6 +46,7 @@ from tests.utils import (
 logger = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.no_cypress_suite1
+
 
 # Test constants
 restli_default_headers = {
@@ -90,7 +92,9 @@ def extract_api_token_from_session(session: TestSessionWrapper) -> Tuple[str, st
     response = session.post(f"{get_frontend_url()}/api/v2/graphql", json=json_payload)
     response.raise_for_status()
 
-    token_data = response.json()["data"]["createAccessToken"]
+    res_data = response.json()
+    assert_graphql_mutation_succeeded(res_data)
+    token_data = res_data["data"]["createAccessToken"]
     return token_data["accessToken"], token_data["metadata"]["id"]
 
 
@@ -355,10 +359,11 @@ def test_admin_endpoints_require_privileges(auth_session) -> None:
     limited_auth_email = "limited.auth.test@smoke.datahub.test"
     test_user_urn = f"urn:li:corpuser:{limited_auth_email}"
     token_id = None
+    limited_session = None
 
     try:
-        # Create limited user
-        create_user(admin_session, limited_auth_email, "testpass123")
+        # Create limited user (returns a fresh admin session after /signUp)
+        admin_session = create_user(admin_session, limited_auth_email, "testpass123")
 
         # Login as limited user and get API token
         limited_session = login_as(limited_auth_email, "testpass123")
@@ -383,7 +388,7 @@ def test_admin_endpoints_require_privileges(auth_session) -> None:
     finally:
         # Cleanup
         try:
-            if token_id:
+            if token_id and limited_session is not None:
                 revoke_api_token(limited_session, token_id)
             # Remove test user
             admin_cleanup_session = login_as(admin_user, admin_pass)

--- a/smoke-test/test_system_info.py
+++ b/smoke-test/test_system_info.py
@@ -4,11 +4,13 @@ import pytest
 import requests
 
 from tests.privileges.utils import create_user, remove_user
+from tests.tokens.token_utils import assert_graphql_mutation_succeeded
 from tests.utils import get_admin_credentials, get_frontend_url, get_gms_url, login_as
 
 logger = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.no_cypress_suite1
+
 
 # ==============================================
 # SYSTEM INFO API TESTS
@@ -260,7 +262,9 @@ def extract_api_token_from_session(session):
     response = session.post(f"{get_frontend_url()}/api/v2/graphql", json=json_payload)
     response.raise_for_status()
 
-    token_data = response.json()["data"]["createAccessToken"]
+    res_data = response.json()
+    assert_graphql_mutation_succeeded(res_data)
+    token_data = res_data["data"]["createAccessToken"]
     return token_data["accessToken"], token_data["metadata"]["id"]
 
 
@@ -278,6 +282,7 @@ def test_system_info_authenticated_non_admin_user_returns_403(auth_session):
     limited_test_email = "limited.test.user@smoke.datahub.test"
     test_user_urn = f"urn:li:corpuser:{limited_test_email}"
     token_id = None
+    limited_user_session = None
 
     try:
         # Create a limited-privilege user (no special privileges by default)
@@ -325,7 +330,7 @@ def test_system_info_authenticated_non_admin_user_returns_403(auth_session):
     finally:
         # Clean up: revoke the API token and remove the test user
         try:
-            if token_id:
+            if token_id and limited_user_session is not None:
                 # Revoke the API token
                 revoke_json = {
                     "query": """mutation revokeAccessToken($tokenId: String!) {

--- a/smoke-test/tests/audit_events/audit_events_test.py
+++ b/smoke-test/tests/audit_events/audit_events_test.py
@@ -5,7 +5,14 @@ from typing import Dict, List, Set
 
 import pytest
 
-from tests.tokens.token_utils import removeUser, wait_for_user_in_list
+from tests.tokens.token_utils import (
+    assert_graphql_mutation_succeeded,
+    removeUser,
+    revoke_tokens_matching,
+    token_name_filter,
+    wait_for_no_tokens_matching,
+    wait_for_user_in_list,
+)
 from tests.utils import (
     get_admin_credentials,
     get_frontend_url,
@@ -24,19 +31,15 @@ os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"
 # Valid email for auth.native.signUp.enforceValidEmail (Play EmailValidator).
 AUDIT_SUITE_USER_EMAIL = "audit.events.user@smoke.datahub.test"
 AUDIT_SUITE_USER_URN = f"urn:li:corpuser:{AUDIT_SUITE_USER_EMAIL}"
+AUDIT_SUITE_TOKEN_NAME = "audit-suite-token"
 
 
 @pytest.fixture()
-def auth_exclude_filter():
-    return {
-        "field": "name",
-        "condition": "EQUAL",
-        "negated": True,
-        "values": ["Test Session Token"],
-    }
+def suite_token_filter():
+    return [token_name_filter(AUDIT_SUITE_TOKEN_NAME)]
 
 
-@pytest.fixture(scope="class", autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def custom_user_setup():
     admin_session = login_as(admin_user, admin_pass)
     try:
@@ -105,40 +108,23 @@ def custom_user_setup():
 
 
 @pytest.fixture(autouse=True)
-def access_token_setup(auth_session, auth_exclude_filter):
-    """Fixture to execute asserts before and after a test is run"""
+def access_token_setup(suite_token_filter):
+    """Revoke only this suite's tokens so parallel workers do not interfere."""
     admin_session = login_as(admin_user, admin_pass)
 
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
-    assert res_data
-    assert res_data["data"]
-
-    if res_data["data"]["listAccessTokens"]["tokens"]:
-        for metadata in res_data["data"]["listAccessTokens"]["tokens"]:
-            revokeAccessToken(admin_session, metadata["id"])
-        wait_for_writes_to_sync()
-
-    # Verify clean state after cleanup
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
-    assert res_data["data"]["listAccessTokens"]["total"] == 0
-    assert not res_data["data"]["listAccessTokens"]["tokens"]
+    wait_for_no_tokens_matching(admin_session, suite_token_filter)
 
     yield
 
-    # Clean up after the test
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
-    for metadata in res_data["data"]["listAccessTokens"]["tokens"]:
-        revokeAccessToken(admin_session, metadata["id"])
-    wait_for_writes_to_sync()
+    revoke_tokens_matching(admin_session, suite_token_filter)
 
 
-def test_audit_token_events(auth_exclude_filter):
+def test_audit_token_events():
     user_session = login_as(AUDIT_SUITE_USER_EMAIL, "user")
 
     # Normal user should be able to generate token for himself.
     res_data = generateAccessToken_v2(user_session, AUDIT_SUITE_USER_URN)
-    assert res_data
-    assert res_data["data"]
+    assert_graphql_mutation_succeeded(res_data)
     assert res_data["data"]["createAccessToken"]
     assert res_data["data"]["createAccessToken"]["accessToken"]
     assert (
@@ -184,7 +170,7 @@ def test_audit_token_events(auth_exclude_filter):
     )
 
 
-def test_login_events(auth_exclude_filter):
+def test_login_events():
     user_session = login_as(AUDIT_SUITE_USER_EMAIL, "user")
     time.sleep(10)
 
@@ -207,7 +193,7 @@ def test_login_events(auth_exclude_filter):
     user_session.cookies.clear()
 
 
-def test_failed_login_events(auth_exclude_filter):
+def test_failed_login_events():
     try:
         user_session = login_as(AUDIT_SUITE_USER_EMAIL, "NOTMYPASSWORD")
     except Exception:
@@ -234,7 +220,7 @@ def test_failed_login_events(auth_exclude_filter):
     user_session.cookies.clear()
 
 
-def test_policy_events(auth_exclude_filter):
+def test_policy_events():
     user_session = login_as(admin_user, admin_pass)
     json = {
         "query": """mutation createPolicy($input: PolicyUpdateInput!) {\n
@@ -312,7 +298,7 @@ def test_policy_events(auth_exclude_filter):
     user_session.cookies.clear()
 
 
-def test_ingestion_source_events(auth_exclude_filter):
+def test_ingestion_source_events():
     user_session = login_as(admin_user, admin_pass)
     json = {
         "query": """mutation createIngestionSource($input: UpdateIngestionSourceInput!) {\n
@@ -383,54 +369,47 @@ def test_ingestion_source_events(auth_exclude_filter):
     user_session.cookies.clear()
 
 
-def test_user_events(auth_exclude_filter):
+def test_user_events():
     user_session = login_as(admin_user, admin_pass)
     wait_for_writes_to_sync(consumer_group="datahub-usage-event-consumer-job-client")
 
-    # TODO: This feels wrong, sign up link should have the user who created the sign up link as the actor, but this
-    #       requires a fairly significant refactor that's not in scope right now
-    res_data = searchForAuditEvents(
+    # TODO: sign-up link actor should be the admin who created the invite, not __datahub_system.
+    event_types = ["CreateUserEvent", "UpdateUserEvent"]
+    actor_urns = ["urn:li:corpuser:__datahub_system"]
+    aspect_names = [
+        "corpUserKey",
+        "corpUserInfo",
+        "corpUserStatus",
+        "corpUserCredentials",
+    ]
+
+    wait_for_audit_event_types_for_entity(
         user_session,
-        4,
-        ["CreateUserEvent", "UpdateUserEvent"],
-        ["urn:li:corpuser:__datahub_system"],
-        ["corpUserKey", "corpUserInfo", "corpUserStatus", "corpUserCredentials"],
-    )
-    logger.info(res_data)
-    assert len(res_data["usageEvents"]) == 4
-    assert res_data["usageEvents"][0]["eventType"] == "UpdateUserEvent"
-    assert res_data["usageEvents"][0]["entityUrn"] == AUDIT_SUITE_USER_URN
-    # Credentials and settings are in random order due to async
-    assert res_data["usageEvents"][0]["aspectName"] == "corpUserCredentials"
-
-    assert res_data["usageEvents"][1]["eventType"] == "UpdateUserEvent"
-    assert res_data["usageEvents"][1]["entityUrn"] == AUDIT_SUITE_USER_URN
-    assert res_data["usageEvents"][1]["aspectName"] == "corpUserStatus"
-
-    # These get created at the same time
-    assert (
-        res_data["usageEvents"][2]["eventType"] == "UpdateUserEvent"
-        or res_data["usageEvents"][2]["eventType"] == "CreateUserEvent"
-    )
-    assert res_data["usageEvents"][2]["entityUrn"] == AUDIT_SUITE_USER_URN
-    assert (
-        res_data["usageEvents"][2]["aspectName"] == "corpUserInfo"
-        or res_data["usageEvents"][2]["aspectName"] == "corpUserKey"
+        AUDIT_SUITE_USER_URN,
+        {"CreateUserEvent", "UpdateUserEvent"},
+        event_types,
+        actor_urns,
+        aspect_names,
+        search_size=20,
     )
 
-    assert (
-        res_data["usageEvents"][3]["eventType"] == "UpdateUserEvent"
-        or res_data["usageEvents"][3]["eventType"] == "CreateUserEvent"
+    res_data = searchForAuditEvents(
+        user_session, 20, event_types, actor_urns, aspect_names
     )
-    assert res_data["usageEvents"][3]["entityUrn"] == AUDIT_SUITE_USER_URN
-    assert (
-        res_data["usageEvents"][3]["aspectName"] == "corpUserInfo"
-        or res_data["usageEvents"][3]["aspectName"] == "corpUserKey"
+    entity_events = audit_events_for_entity(
+        res_data.get("usageEvents", []), AUDIT_SUITE_USER_URN
     )
+    logger.info({"auditSuiteUserEvents": entity_events})
+
+    assert len(entity_events) == 4
+    assert {event["aspectName"] for event in entity_events} == set(aspect_names)
+    found_types = {event["eventType"] for event in entity_events}
+    assert "CreateUserEvent" in found_types
+    assert "UpdateUserEvent" in found_types
     user_session.cookies.clear()
 
 
-def test_policy_create_delete(auth_exclude_filter):
+def test_policy_create_delete():
     user_session = login_as(admin_user, admin_pass)
     json = {
         "query": """mutation createPolicy($input: PolicyUpdateInput!) {\n
@@ -516,7 +495,7 @@ def generateAccessToken_v2(session, actorUrn):
                 "type": "PERSONAL",
                 "actorUrn": actorUrn,
                 "duration": "ONE_HOUR",
-                "name": "my token",
+                "name": AUDIT_SUITE_TOKEN_NAME,
             }
         },
     }

--- a/smoke-test/tests/metrics/test_usage_aggregation_audit.py
+++ b/smoke-test/tests/metrics/test_usage_aggregation_audit.py
@@ -69,335 +69,333 @@ def _require_prometheus_url() -> str:
 
 
 @pytest.mark.read_only
-def test_usage_aggregation_configured_admin_actor_class(auth_session):
-    """Smoke admin session resolves actor_class from CorpUserInfo flags."""
-    gms_url = _require_prometheus_url()
-    urn = session_corp_user_urn(auth_session)
-    assert urn == configured_admin_urn()
+class TestUsageAggregationAdminSessions:
+    def test_usage_aggregation_configured_admin_actor_class(self, auth_session):
+        """Smoke admin session resolves actor_class from CorpUserInfo flags."""
+        gms_url = _require_prometheus_url()
+        urn = session_corp_user_urn(auth_session)
+        assert urn == configured_admin_urn()
 
-    actor_class = resolve_usage_actor_class(auth_session)
-    assert actor_class in ("system", "support", "regular")
+        actor_class = resolve_usage_actor_class(auth_session)
+        assert actor_class in ("system", "support", "regular")
 
-    tags = graphql_metadata_query_tags(actor_class)
-    baseline = fetch_metric_total(auth_session, gms_url, INPUT_BYTES_METRIC, tags)
-    generate_graphql_read_traffic(auth_session, repeat=2)
-    wait_for_metric_delta(
-        auth_session,
-        gms_url,
-        INPUT_BYTES_METRIC,
-        baseline,
-        required_tags=tags,
-        min_delta=1.0,
-    )
-
-    content = get_prometheus_metrics(auth_session, gms_url)
-    samples = find_metric_samples(content, INPUT_BYTES_METRIC, required_tags=tags)
-    assert samples, f"No Prometheus samples for admin session (tags={tags})"
-    for line in samples:
-        tags_on_line = parse_prometheus_tags(line)
-        assert tags_on_line.get("actor_class") == actor_class
-        assert tags_on_line.get("request_api") == "graphql"
-    logger.info("admin session evidence: urn=%s actor_class=%s", urn, actor_class)
-
-
-@pytest.mark.read_only
-def test_usage_aggregation_pat_authenticated_traffic(auth_session):
-    """Configured admin exports traffic when authenticating via a minted PAT."""
-    gms_url = _require_prometheus_url()
-    admin_urn = session_corp_user_urn(auth_session)
-    actor_class = resolve_usage_actor_class(auth_session)
-
-    admin_pat = try_mint_personal_access_token(auth_session, admin_urn)
-    if admin_pat is None:
-        pytest.skip("Cannot mint PAT for configured admin in this environment")
-
-    pat_session = TestSessionWrapper(requests.Session(), prebuilt_token=admin_pat)
-    try:
-        tags = aggregation_tags(
-            actor_class, usage_operation="metadata_read", request_api="openapi"
-        )
-        baseline = fetch_metric_total(pat_session, gms_url, OUTPUT_BYTES_METRIC, tags)
-        generate_openapi_metadata_read_traffic(pat_session, repeat=2)
-        wait_for_metric_delta(
-            pat_session,
-            gms_url,
-            OUTPUT_BYTES_METRIC,
-            baseline,
-            required_tags=tags,
-            min_delta=1.0,
-        )
-        logger.info(
-            "PAT-authenticated admin evidence: urn=%s actor_class=%s",
-            admin_urn,
-            actor_class,
-        )
-    finally:
-        pat_session.destroy()
-
-
-@pytest.mark.read_only
-def test_usage_aggregation_fresh_admin_session_login(auth_session):
-    """Fresh frontend login for the configured admin exports GraphQL byte counters."""
-    gms_url = _require_prometheus_url()
-    username, password = get_admin_credentials()
-    session = login_as(username, password)
-    admin_session = TestSessionWrapper(session)
-    try:
-        assert session_corp_user_urn(admin_session) == configured_admin_urn()
-        actor_class = resolve_usage_actor_class(admin_session)
         tags = graphql_metadata_query_tags(actor_class)
-        baseline = fetch_metric_total(admin_session, gms_url, INPUT_BYTES_METRIC, tags)
-        generate_graphql_read_traffic(admin_session, repeat=2)
+        baseline = fetch_metric_total(auth_session, gms_url, INPUT_BYTES_METRIC, tags)
+        generate_graphql_read_traffic(auth_session, repeat=2)
         wait_for_metric_delta(
-            admin_session,
+            auth_session,
             gms_url,
             INPUT_BYTES_METRIC,
             baseline,
             required_tags=tags,
             min_delta=1.0,
         )
-        logger.info("fresh admin login evidence: actor_class=%s", actor_class)
-    finally:
-        admin_session.destroy()
 
+        content = get_prometheus_metrics(auth_session, gms_url)
+        samples = find_metric_samples(content, INPUT_BYTES_METRIC, required_tags=tags)
+        assert samples, f"No Prometheus samples for admin session (tags={tags})"
+        for line in samples:
+            tags_on_line = parse_prometheus_tags(line)
+            assert tags_on_line.get("actor_class") == actor_class
+            assert tags_on_line.get("request_api") == "graphql"
+        logger.info("admin session evidence: urn=%s actor_class=%s", urn, actor_class)
 
-@pytest.mark.read_only
-def test_usage_aggregation_admin_actor_class_and_tags(auth_session):
-    """Admin session maps to a usage actor_class with the full aggregation tag set."""
-    gms_url = _require_prometheus_url()
-    actor_class = expected_actor_class_for_admin_session(auth_session)
-    tags = graphql_metadata_query_tags(actor_class)
+    def test_usage_aggregation_pat_authenticated_traffic(self, auth_session):
+        """Configured admin exports traffic when authenticating via a minted PAT."""
+        gms_url = _require_prometheus_url()
+        admin_urn = session_corp_user_urn(auth_session)
+        actor_class = resolve_usage_actor_class(auth_session)
 
-    baseline = fetch_metric_total(auth_session, gms_url, INPUT_BYTES_METRIC, tags)
-    generate_graphql_read_traffic(auth_session, repeat=2)
+        admin_pat = try_mint_personal_access_token(auth_session, admin_urn)
+        if admin_pat is None:
+            pytest.skip("Cannot mint PAT for configured admin in this environment")
 
-    wait_for_metric_delta(
-        auth_session,
-        gms_url,
-        INPUT_BYTES_METRIC,
-        baseline,
-        required_tags=tags,
-        min_delta=1.0,
-    )
+        pat_session = TestSessionWrapper(requests.Session(), prebuilt_token=admin_pat)
+        try:
+            tags = aggregation_tags(
+                actor_class, usage_operation="metadata_read", request_api="openapi"
+            )
+            baseline = fetch_metric_total(
+                pat_session, gms_url, OUTPUT_BYTES_METRIC, tags
+            )
+            generate_openapi_metadata_read_traffic(pat_session, repeat=2)
+            wait_for_metric_delta(
+                pat_session,
+                gms_url,
+                OUTPUT_BYTES_METRIC,
+                baseline,
+                required_tags=tags,
+                min_delta=1.0,
+            )
+            logger.info(
+                "PAT-authenticated admin evidence: urn=%s actor_class=%s",
+                admin_urn,
+                actor_class,
+            )
+        finally:
+            pat_session.destroy()
 
-    content = get_prometheus_metrics(auth_session, gms_url)
-    samples = find_metric_samples(content, INPUT_BYTES_METRIC, required_tags=tags)
-    assert_samples_have_tag_keys(samples, AGGREGATION_TAG_KEYS)
+    def test_usage_aggregation_fresh_admin_session_login(self, auth_session):
+        """Fresh frontend login for the configured admin exports GraphQL byte counters."""
+        gms_url = _require_prometheus_url()
+        username, password = get_admin_credentials()
+        session = login_as(username, password)
+        admin_session = TestSessionWrapper(session)
+        try:
+            assert session_corp_user_urn(admin_session) == configured_admin_urn()
+            actor_class = resolve_usage_actor_class(admin_session)
+            tags = graphql_metadata_query_tags(actor_class)
+            baseline = fetch_metric_total(
+                admin_session, gms_url, INPUT_BYTES_METRIC, tags
+            )
+            generate_graphql_read_traffic(admin_session, repeat=2)
+            wait_for_metric_delta(
+                admin_session,
+                gms_url,
+                INPUT_BYTES_METRIC,
+                baseline,
+                required_tags=tags,
+                min_delta=1.0,
+            )
+            logger.info("fresh admin login evidence: actor_class=%s", actor_class)
+        finally:
+            admin_session.destroy()
 
+    def test_usage_aggregation_admin_actor_class_and_tags(self, auth_session):
+        """Admin session maps to a usage actor_class with the full aggregation tag set."""
+        gms_url = _require_prometheus_url()
+        actor_class = expected_actor_class_for_admin_session(auth_session)
+        tags = graphql_metadata_query_tags(actor_class)
 
-@pytest.mark.read_only
-def test_usage_aggregation_openapi_read_and_search(auth_session):
-    """OpenAPI entity list (GET) exports output bytes; scroll search (POST) exports input bytes."""
-    gms_url = _require_prometheus_url()
-    actor_class = expected_actor_class_for_admin_session(auth_session)
+        baseline = fetch_metric_total(auth_session, gms_url, INPUT_BYTES_METRIC, tags)
+        generate_graphql_read_traffic(auth_session, repeat=2)
 
-    read_tags = aggregation_tags(
-        actor_class, usage_operation="metadata_read", request_api="openapi"
-    )
-    search_tags = aggregation_tags(
-        actor_class, usage_operation="search_query", request_api="openapi"
-    )
-
-    read_output_baseline = fetch_metric_total(
-        auth_session, gms_url, OUTPUT_BYTES_METRIC, read_tags
-    )
-    search_input_baseline = fetch_metric_total(
-        auth_session, gms_url, INPUT_BYTES_METRIC, search_tags
-    )
-
-    generate_openapi_metadata_read_traffic(auth_session)
-    generate_openapi_search_traffic(auth_session)
-
-    wait_for_metric_delta(
-        auth_session,
-        gms_url,
-        OUTPUT_BYTES_METRIC,
-        read_output_baseline,
-        required_tags=read_tags,
-    )
-    wait_for_metric_delta(
-        auth_session,
-        gms_url,
-        INPUT_BYTES_METRIC,
-        search_input_baseline,
-        required_tags=search_tags,
-    )
-
-    content = get_prometheus_metrics(auth_session, gms_url)
-    out_samples = find_metric_samples(
-        content, OUTPUT_BYTES_METRIC, required_tags=read_tags
-    )
-    assert out_samples, (
-        "Expected output_bytes for OpenAPI metadata_read — "
-        "OpenAPI synchronous responses should be measurable"
-    )
-
-
-@pytest.mark.read_only
-def test_usage_aggregation_graphql_output_bytes(auth_session):
-    """GraphQL async responses record output_bytes after execution completes."""
-    gms_url = _require_prometheus_url()
-    actor_class = expected_actor_class_for_admin_session(auth_session)
-    tags = graphql_metadata_query_tags(actor_class)
-
-    output_baseline = fetch_metric_total(
-        auth_session, gms_url, OUTPUT_BYTES_METRIC, tags
-    )
-    generate_graphql_read_traffic(auth_session, repeat=2)
-
-    wait_for_metric_delta(
-        auth_session,
-        gms_url,
-        OUTPUT_BYTES_METRIC,
-        output_baseline,
-        required_tags=tags,
-        min_delta=1.0,
-    )
-
-    content = get_prometheus_metrics(auth_session, gms_url)
-    graphql_output = find_metric_samples(
-        content, OUTPUT_BYTES_METRIC, required_tags={"request_api": "graphql"}
-    )
-    assert graphql_output, (
-        "Expected datahub_usage_output_bytes for request_api=graphql after async GraphQL fix"
-    )
-
-
-@pytest.mark.read_only
-def test_usage_aggregation_graphql_output_bytes_not_double_counted(auth_session):
-    """Single GraphQL response should contribute output_bytes ~= body length, not ~2x.
-
-    Uses a dedicated support user so actor_class=support isolates this test from
-    admin (system) GraphQL traffic elsewhere in the pytest batch.
-    """
-    gms_url = _require_prometheus_url()
-    if not can_provision_native_users(auth_session):
-        pytest.skip(
-            "Session lacks manageIdentities — cannot provision a support user locally"
+        wait_for_metric_delta(
+            auth_session,
+            gms_url,
+            INPUT_BYTES_METRIC,
+            baseline,
+            required_tags=tags,
+            min_delta=1.0,
         )
 
-    from tests.metrics.usage_aggregation_metrics import _ME_QUERY, execute_graphql_raw
+        content = get_prometheus_metrics(auth_session, gms_url)
+        samples = find_metric_samples(content, INPUT_BYTES_METRIC, required_tags=tags)
+        assert_samples_have_tag_keys(samples, AGGREGATION_TAG_KEYS)
 
-    user_urn, support_session = make_support_actor_user(
-        auth_session, "usage-output-dedup"
-    )
-    tags = graphql_metadata_query_tags("support")
-    try:
+
+class TestUsageAggregationByteMetrics:
+    def test_usage_aggregation_openapi_read_and_search(self, auth_session):
+        """OpenAPI entity list (GET) exports output bytes; scroll search (POST) exports input bytes."""
+        gms_url = _require_prometheus_url()
+        actor_class = expected_actor_class_for_admin_session(auth_session)
+
+        read_tags = aggregation_tags(
+            actor_class, usage_operation="metadata_read", request_api="openapi"
+        )
+        search_tags = aggregation_tags(
+            actor_class, usage_operation="search_query", request_api="openapi"
+        )
+
+        read_output_baseline = fetch_metric_total(
+            auth_session, gms_url, OUTPUT_BYTES_METRIC, read_tags
+        )
+        search_input_baseline = fetch_metric_total(
+            auth_session, gms_url, INPUT_BYTES_METRIC, search_tags
+        )
+
+        generate_openapi_metadata_read_traffic(auth_session)
+        generate_openapi_search_traffic(auth_session)
+
+        wait_for_metric_delta(
+            auth_session,
+            gms_url,
+            OUTPUT_BYTES_METRIC,
+            read_output_baseline,
+            required_tags=read_tags,
+        )
+        wait_for_metric_delta(
+            auth_session,
+            gms_url,
+            INPUT_BYTES_METRIC,
+            search_input_baseline,
+            required_tags=search_tags,
+        )
+
+        content = get_prometheus_metrics(auth_session, gms_url)
+        out_samples = find_metric_samples(
+            content, OUTPUT_BYTES_METRIC, required_tags=read_tags
+        )
+        assert out_samples, (
+            "Expected output_bytes for OpenAPI metadata_read — "
+            "OpenAPI synchronous responses should be measurable"
+        )
+
+    def test_usage_aggregation_graphql_output_bytes(self, auth_session):
+        """GraphQL async responses record output_bytes after execution completes."""
+        gms_url = _require_prometheus_url()
+        actor_class = expected_actor_class_for_admin_session(auth_session)
+        tags = graphql_metadata_query_tags(actor_class)
+
         output_baseline = fetch_metric_total(
             auth_session, gms_url, OUTPUT_BYTES_METRIC, tags
         )
-        response_text = execute_graphql_raw(support_session, _ME_QUERY)
-        response_len = len(response_text)
-        assert response_len > 0
+        generate_graphql_read_traffic(auth_session, repeat=2)
 
-        delta = wait_for_metric_delta(
+        wait_for_metric_delta(
             auth_session,
             gms_url,
             OUTPUT_BYTES_METRIC,
             output_baseline,
             required_tags=tags,
-            min_delta=float(response_len) * 0.95,
-        )
-        assert delta <= response_len * 2.1, (
-            f"output_bytes delta {delta} far exceeds response length {response_len}"
-        )
-    finally:
-        support_session.destroy()
-        cleanup_step_actor_user(auth_session, user_urn)
-
-
-@pytest.mark.read_only
-def test_usage_aggregation_openapi_search_output_bytes(auth_session):
-    """OpenAPI scroll search records output_bytes with search_query tags."""
-    gms_url = _require_prometheus_url()
-    actor_class = expected_actor_class_for_admin_session(auth_session)
-    search_tags = aggregation_tags(
-        actor_class, usage_operation="search_query", request_api="openapi"
-    )
-
-    output_baseline = fetch_metric_total(
-        auth_session, gms_url, OUTPUT_BYTES_METRIC, search_tags
-    )
-    generate_openapi_search_traffic(auth_session, repeat=2)
-    wait_for_metric_delta(
-        auth_session,
-        gms_url,
-        OUTPUT_BYTES_METRIC,
-        output_baseline,
-        required_tags=search_tags,
-        min_delta=1.0,
-    )
-
-
-@pytest.mark.read_only
-def test_usage_aggregation_regular_user_active_identities(auth_session):
-    """Distinct identity gauge reflects unique regular users in the flush window."""
-    gms_url = _require_prometheus_url()
-    if not can_provision_native_users(auth_session):
-        pytest.skip(
-            "Session lacks manageIdentities — cannot provision a regular user locally"
+            min_delta=1.0,
         )
 
-    user_urn, regular_session = make_step_actor_user(auth_session, "usage-metrics")
-    try:
-        identity_tags = {
+        content = get_prometheus_metrics(auth_session, gms_url)
+        graphql_output = find_metric_samples(
+            content, OUTPUT_BYTES_METRIC, required_tags={"request_api": "graphql"}
+        )
+        assert graphql_output, (
+            "Expected datahub_usage_output_bytes for request_api=graphql after async GraphQL fix"
+        )
+
+    def test_usage_aggregation_graphql_output_bytes_not_double_counted(
+        self, auth_session
+    ):
+        """Single GraphQL response should contribute output_bytes ~= body length, not ~2x.
+
+        Uses a dedicated support user so actor_class=support isolates this test from
+        admin (system) GraphQL traffic elsewhere in the pytest batch.
+        """
+        gms_url = _require_prometheus_url()
+        if not can_provision_native_users(auth_session):
+            pytest.skip(
+                "Session lacks manageIdentities — cannot provision a support user locally"
+            )
+
+        from tests.metrics.usage_aggregation_metrics import (
+            _ME_QUERY,
+            execute_graphql_raw,
+        )
+
+        user_urn, support_session = make_support_actor_user(
+            auth_session, "usage-output-dedup"
+        )
+        tags = graphql_metadata_query_tags("support")
+        try:
+            output_baseline = fetch_metric_total(
+                auth_session, gms_url, OUTPUT_BYTES_METRIC, tags
+            )
+            response_text = execute_graphql_raw(support_session, _ME_QUERY)
+            response_len = len(response_text)
+            assert response_len > 0
+
+            delta = wait_for_metric_delta(
+                auth_session,
+                gms_url,
+                OUTPUT_BYTES_METRIC,
+                output_baseline,
+                required_tags=tags,
+                min_delta=float(response_len) * 0.95,
+            )
+            assert delta <= response_len * 2.1, (
+                f"output_bytes delta {delta} far exceeds response length {response_len}"
+            )
+        finally:
+            support_session.destroy()
+            cleanup_step_actor_user(auth_session, user_urn)
+
+    def test_usage_aggregation_openapi_search_output_bytes(self, auth_session):
+        """OpenAPI scroll search records output_bytes with search_query tags."""
+        gms_url = _require_prometheus_url()
+        actor_class = expected_actor_class_for_admin_session(auth_session)
+        search_tags = aggregation_tags(
+            actor_class, usage_operation="search_query", request_api="openapi"
+        )
+
+        output_baseline = fetch_metric_total(
+            auth_session, gms_url, OUTPUT_BYTES_METRIC, search_tags
+        )
+        generate_openapi_search_traffic(auth_session, repeat=2)
+        wait_for_metric_delta(
+            auth_session,
+            gms_url,
+            OUTPUT_BYTES_METRIC,
+            output_baseline,
+            required_tags=search_tags,
+            min_delta=1.0,
+        )
+
+
+class TestUsageAggregationActiveIdentities:
+    def test_usage_aggregation_regular_user_active_identities(self, auth_session):
+        """Distinct identity gauge reflects unique regular users in the flush window."""
+        gms_url = _require_prometheus_url()
+        if not can_provision_native_users(auth_session):
+            pytest.skip(
+                "Session lacks manageIdentities — cannot provision a regular user locally"
+            )
+
+        user_urn, regular_session = make_step_actor_user(auth_session, "usage-metrics")
+        try:
+            identity_tags = {
+                "identity_metric": "active_users",
+                "actor_class": "regular",
+            }
+            generate_graphql_read_traffic(regular_session, repeat=2)
+
+            wait_for_metric_at_least(
+                auth_session,
+                gms_url,
+                ACTIVE_IDENTITIES_METRIC,
+                1.0,
+                required_tags=identity_tags,
+            )
+
+            search_tags = aggregation_tags(
+                "regular", usage_operation="search_query", request_api="graphql"
+            )
+            input_baseline = fetch_metric_total(
+                auth_session, gms_url, INPUT_BYTES_METRIC, search_tags
+            )
+            generate_graphql_search_traffic(regular_session)
+            wait_for_metric_delta(
+                auth_session,
+                gms_url,
+                INPUT_BYTES_METRIC,
+                input_baseline,
+                required_tags=search_tags,
+            )
+        finally:
+            regular_session.destroy()
+            cleanup_step_actor_user(auth_session, user_urn)
+
+    def test_usage_aggregation_admin_active_identities(self, auth_session):
+        """Admin actor_class appears in the distinct-identity gauge after traffic."""
+        gms_url = _require_prometheus_url()
+        actor_class = expected_actor_class_for_admin_session(auth_session)
+
+        tags = {
             "identity_metric": "active_users",
-            "actor_class": "regular",
+            "actor_class": actor_class,
         }
-        generate_graphql_read_traffic(regular_session, repeat=2)
+        generate_graphql_read_traffic(auth_session, repeat=3)
 
         wait_for_metric_at_least(
             auth_session,
             gms_url,
             ACTIVE_IDENTITIES_METRIC,
             1.0,
-            required_tags=identity_tags,
+            required_tags=tags,
         )
 
-        search_tags = aggregation_tags(
-            "regular", usage_operation="search_query", request_api="graphql"
+        content = get_prometheus_metrics(auth_session, gms_url)
+        samples = find_metric_samples(
+            content, ACTIVE_IDENTITIES_METRIC, required_tags=tags
         )
-        input_baseline = fetch_metric_total(
-            auth_session, gms_url, INPUT_BYTES_METRIC, search_tags
-        )
-        generate_graphql_search_traffic(regular_session)
-        wait_for_metric_delta(
-            auth_session,
-            gms_url,
-            INPUT_BYTES_METRIC,
-            input_baseline,
-            required_tags=search_tags,
-        )
-    finally:
-        regular_session.destroy()
-        cleanup_step_actor_user(auth_session, user_urn)
-
-
-@pytest.mark.read_only
-def test_usage_aggregation_admin_active_identities(auth_session):
-    """Admin actor_class appears in the distinct-identity gauge after traffic."""
-    gms_url = _require_prometheus_url()
-    actor_class = expected_actor_class_for_admin_session(auth_session)
-
-    tags = {
-        "identity_metric": "active_users",
-        "actor_class": actor_class,
-    }
-    generate_graphql_read_traffic(auth_session, repeat=3)
-
-    wait_for_metric_at_least(
-        auth_session,
-        gms_url,
-        ACTIVE_IDENTITIES_METRIC,
-        1.0,
-        required_tags=tags,
-    )
-
-    content = get_prometheus_metrics(auth_session, gms_url)
-    samples = find_metric_samples(content, ACTIVE_IDENTITIES_METRIC, required_tags=tags)
-    assert samples, f"Expected active_identities samples (tags={tags})"
-    for line in samples:
-        parsed = parse_prometheus_tags(line)
-        assert parsed.get("actor_class") == actor_class
-        assert parsed.get("identity_metric") == "active_users"
-        assert parse_sample_value(line) >= 1.0
+        assert samples, f"Expected active_identities samples (tags={tags})"
+        for line in samples:
+            parsed = parse_prometheus_tags(line)
+            assert parsed.get("actor_class") == actor_class
+            assert parsed.get("identity_metric") == "active_users"
+            assert parse_sample_value(line) >= 1.0

--- a/smoke-test/tests/privileges/utils.py
+++ b/smoke-test/tests/privileges/utils.py
@@ -446,15 +446,23 @@ def create_metadata_policy(
     return res_data["data"]["createPolicy"]
 
 
-def create_user_policy(user_urn, privileges, session):
+def create_user_policy(
+    user_urn,
+    privileges,
+    session,
+    *,
+    name: str = "Test Policy Name",
+    description: str = "Test Policy Description",
+):
+    """Create a platform policy for a single user."""
     policy = {
         "query": """mutation createPolicy($input: PolicyUpdateInput!) {\n
             createPolicy(input: $input) }""",
         "variables": {
             "input": {
                 "type": "PLATFORM",
-                "name": "Test Policy Name",
-                "description": "Test Policy Description",
+                "name": name,
+                "description": description,
                 "state": "ACTIVE",
                 "resources": {"filter": {"criteria": []}},
                 "privileges": privileges,
@@ -605,18 +613,36 @@ def log_policies(session, context=""):
             logger.info(f"    Description: {desc_preview}")
 
 
-def clear_polices(session):
+def clear_polices(
+    session,
+    *,
+    name_prefix: str | None = None,
+    name_prefixes: list[str] | None = None,
+) -> None:
     logger.info("Starting policy cleanup (clear_polices)")
+
+    if name_prefixes is not None:
+        prefixes = name_prefixes
+    elif name_prefix is not None:
+        prefixes = [name_prefix]
+    else:
+        prefixes = []
 
     policies_data = list_policies(session)
     policies = policies_data["policies"]
 
     deleted_count = 0
     for policy in policies:
-        if "test" in policy["name"].lower() or "test" in policy["description"].lower():
-            logger.info(f"Deleting test policy: {policy['name']} ({policy['urn']})")
-            remove_policy(policy["urn"], session)
-            deleted_count += 1
+        name = policy.get("name") or ""
+        description = policy.get("description") or ""
+        if prefixes:
+            if not any(name.startswith(prefix) for prefix in prefixes):
+                continue
+        elif "test" not in name.lower() and "test" not in description.lower():
+            continue
+        logger.info(f"Deleting test policy: {name} ({policy['urn']})")
+        remove_policy(policy["urn"], session)
+        deleted_count += 1
 
     logger.info(f"Policy cleanup complete. Deleted {deleted_count} test policies")
 

--- a/smoke-test/tests/tokens/revokable_access_token_test.py
+++ b/smoke-test/tests/tokens/revokable_access_token_test.py
@@ -9,7 +9,14 @@ from tests.utils import (
     wait_for_writes_to_sync,
 )
 
-from .token_utils import listUsers, removeUser
+from .token_utils import (
+    assert_graphql_mutation_succeeded,
+    listUsers,
+    removeUser,
+    token_name_filter,
+    wait_for_no_tokens_matching,
+    wait_for_user_in_list,
+)
 
 pytestmark = pytest.mark.no_cypress_suite1
 
@@ -20,19 +27,16 @@ os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"
 # Valid email for auth.native.signUp.enforceValidEmail (Play EmailValidator).
 REVOKE_SUITE_USER_EMAIL = "revokable.access@smoke.datahub.test"
 REVOKE_SUITE_USER_URN = f"urn:li:corpuser:{REVOKE_SUITE_USER_EMAIL}"
+REVOKE_SUITE_TOKEN_NAME = "revokable-suite-token"
+SUITE_TOKEN_FILTER = [token_name_filter(REVOKE_SUITE_TOKEN_NAME)]
 
 
-@pytest.fixture()
-def auth_exclude_filter():
-    return {
-        "field": "name",
-        "condition": "EQUAL",
-        "negated": True,
-        "values": ["Test Session Token"],
-    }
+def _ensure_no_suite_tokens() -> None:
+    admin_session = login_as(admin_user, admin_pass)
+    wait_for_no_tokens_matching(admin_session, SUITE_TOKEN_FILTER)
 
 
-@pytest.fixture(scope="class", autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def custom_user_setup():
     """Fixture to execute setup before and tear down after all tests are run"""
     admin_session = login_as(admin_user, admin_pass)
@@ -80,6 +84,7 @@ def custom_user_setup():
     assert "error" not in sign_up_response
     # Sleep for eventual consistency
     wait_for_writes_to_sync()
+    wait_for_user_in_list(admin_session, REVOKE_SUITE_USER_EMAIL, present=True)
 
     # signUp will override the session cookie to the new user to be signed up.
     admin_session.cookies.clear()
@@ -93,7 +98,11 @@ def custom_user_setup():
         "users"
     ]
 
+    _ensure_no_suite_tokens()
+
     yield
+
+    _ensure_no_suite_tokens()
 
     # Delete created user
     res_data = removeUser(admin_session, REVOKE_SUITE_USER_URN)
@@ -110,42 +119,17 @@ def custom_user_setup():
     assert {"username": REVOKE_SUITE_USER_EMAIL} not in res_data["data"]["listUsers"][
         "users"
     ]
-
-
-@pytest.fixture(autouse=True)
-def access_token_setup(auth_session, auth_exclude_filter):
-    """Fixture to execute asserts before and after a test is run"""
-    admin_session = login_as(admin_user, admin_pass)
-
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
-    assert res_data
-    assert res_data["data"]
-
-    if res_data["data"]["listAccessTokens"]["tokens"]:
-        for metadata in res_data["data"]["listAccessTokens"]["tokens"]:
-            revokeAccessToken(admin_session, metadata["id"])
-        wait_for_writes_to_sync()
-
-    # Verify clean state after cleanup
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
-    assert res_data["data"]["listAccessTokens"]["total"] == 0
-    assert not res_data["data"]["listAccessTokens"]["tokens"]
-
-    yield
-
-    # Clean up after the test
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
-    for metadata in res_data["data"]["listAccessTokens"]["tokens"]:
-        revokeAccessToken(admin_session, metadata["id"])
     wait_for_writes_to_sync()
+    wait_for_user_in_list(admin_session, REVOKE_SUITE_USER_EMAIL, present=False)
 
 
-def test_admin_can_create_list_and_revoke_tokens(auth_exclude_filter):
+def test_admin_can_create_list_and_revoke_tokens():
+    _ensure_no_suite_tokens()
     admin_session = login_as(admin_user, admin_pass)
     admin_user_urn = f"urn:li:corpuser:{admin_user}"
 
     # Using a super account, there should be no tokens
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
+    res_data = listAccessTokens(admin_session, filters=SUITE_TOKEN_FILTER)
     assert res_data
     assert res_data["data"]
     assert res_data["data"]["listAccessTokens"]["total"] is not None
@@ -153,8 +137,7 @@ def test_admin_can_create_list_and_revoke_tokens(auth_exclude_filter):
 
     # Using a super account, generate a token for itself.
     res_data = generateAccessToken_v2(admin_session, admin_user_urn)
-    assert res_data
-    assert res_data["data"]
+    assert_graphql_mutation_succeeded(res_data)
     assert res_data["data"]["createAccessToken"]
     assert res_data["data"]["createAccessToken"]["accessToken"]
     assert (
@@ -173,7 +156,7 @@ def test_admin_can_create_list_and_revoke_tokens(auth_exclude_filter):
     assert res_data["data"]["getAccessTokenMetadata"]["actorUrn"] == admin_user_urn
 
     # Using a super account, list the previously created token.
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
+    res_data = listAccessTokens(admin_session, filters=SUITE_TOKEN_FILTER)
     assert res_data
     assert res_data["data"]
     assert res_data["data"]["listAccessTokens"]["total"] is not None
@@ -193,18 +176,19 @@ def test_admin_can_create_list_and_revoke_tokens(auth_exclude_filter):
     assert res_data["data"]["revokeAccessToken"] is True
 
     # Using a super account, there should be no tokens
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
+    res_data = listAccessTokens(admin_session, filters=SUITE_TOKEN_FILTER)
     assert res_data
     assert res_data["data"]
     assert res_data["data"]["listAccessTokens"]["total"] is not None
     assert len(res_data["data"]["listAccessTokens"]["tokens"]) == 0
 
 
-def test_admin_can_create_and_revoke_tokens_for_other_user(auth_exclude_filter):
+def test_admin_can_create_and_revoke_tokens_for_other_user():
+    _ensure_no_suite_tokens()
     admin_session = login_as(admin_user, admin_pass)
 
     # Using a super account, there should be no tokens
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
+    res_data = listAccessTokens(admin_session, filters=SUITE_TOKEN_FILTER)
     assert res_data
     assert res_data["data"]
     assert res_data["data"]["listAccessTokens"]["total"] is not None
@@ -212,8 +196,7 @@ def test_admin_can_create_and_revoke_tokens_for_other_user(auth_exclude_filter):
 
     # Using a super account, generate a token for another user.
     res_data = generateAccessToken_v2(admin_session, REVOKE_SUITE_USER_URN)
-    assert res_data
-    assert res_data["data"]
+    assert_graphql_mutation_succeeded(res_data)
     assert res_data["data"]["createAccessToken"]
     assert res_data["data"]["createAccessToken"]["accessToken"]
     assert (
@@ -225,7 +208,7 @@ def test_admin_can_create_and_revoke_tokens_for_other_user(auth_exclude_filter):
     wait_for_writes_to_sync()
 
     # Using a super account, list the previously created tokens.
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
+    res_data = listAccessTokens(admin_session, filters=SUITE_TOKEN_FILTER)
     assert res_data
     assert res_data["data"]
     assert res_data["data"]["listAccessTokens"]["total"] is not None
@@ -247,20 +230,20 @@ def test_admin_can_create_and_revoke_tokens_for_other_user(auth_exclude_filter):
     assert res_data["data"]["revokeAccessToken"] is True
 
     # Using a super account, there should be no tokens
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
+    res_data = listAccessTokens(admin_session, filters=SUITE_TOKEN_FILTER)
     assert res_data
     assert res_data["data"]
     assert res_data["data"]["listAccessTokens"]["total"] is not None
     assert len(res_data["data"]["listAccessTokens"]["tokens"]) == 0
 
 
-def test_non_admin_can_create_list_revoke_tokens(auth_exclude_filter):
+def test_non_admin_can_create_list_revoke_tokens():
+    _ensure_no_suite_tokens()
     user_session = login_as(REVOKE_SUITE_USER_EMAIL, "user")
 
     # Normal user should be able to generate token for himself.
     res_data = generateAccessToken_v2(user_session, REVOKE_SUITE_USER_URN)
-    assert res_data
-    assert res_data["data"]
+    assert_graphql_mutation_succeeded(res_data)
     assert res_data["data"]["createAccessToken"]
     assert res_data["data"]["createAccessToken"]["accessToken"]
     assert (
@@ -276,7 +259,7 @@ def test_non_admin_can_create_list_revoke_tokens(auth_exclude_filter):
         user_session,
         [
             {"field": "ownerUrn", "values": [REVOKE_SUITE_USER_URN]},
-            auth_exclude_filter,
+            *SUITE_TOKEN_FILTER,
         ],
     )
     assert res_data
@@ -305,7 +288,7 @@ def test_non_admin_can_create_list_revoke_tokens(auth_exclude_filter):
         user_session,
         [
             {"field": "ownerUrn", "values": [REVOKE_SUITE_USER_URN]},
-            auth_exclude_filter,
+            *SUITE_TOKEN_FILTER,
         ],
     )
     assert res_data
@@ -314,11 +297,12 @@ def test_non_admin_can_create_list_revoke_tokens(auth_exclude_filter):
     assert len(res_data["data"]["listAccessTokens"]["tokens"]) == 0
 
 
-def test_admin_can_manage_tokens_generated_by_other_user(auth_exclude_filter):
+def test_admin_can_manage_tokens_generated_by_other_user():
+    _ensure_no_suite_tokens()
     admin_session = login_as(admin_user, admin_pass)
 
     # Using a super account, there should be no tokens
-    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
+    res_data = listAccessTokens(admin_session, filters=SUITE_TOKEN_FILTER)
     assert res_data
     assert res_data["data"]
     assert res_data["data"]["listAccessTokens"]["total"] is not None
@@ -327,8 +311,7 @@ def test_admin_can_manage_tokens_generated_by_other_user(auth_exclude_filter):
     admin_session.cookies.clear()
     user_session = login_as(REVOKE_SUITE_USER_EMAIL, "user")
     res_data = generateAccessToken_v2(user_session, REVOKE_SUITE_USER_URN)
-    assert res_data
-    assert res_data["data"]
+    assert_graphql_mutation_succeeded(res_data)
     assert res_data["data"]["createAccessToken"]
     assert res_data["data"]["createAccessToken"]["accessToken"]
     assert (
@@ -350,7 +333,7 @@ def test_admin_can_manage_tokens_generated_by_other_user(auth_exclude_filter):
         admin_session,
         [
             {"field": "ownerUrn", "values": [REVOKE_SUITE_USER_URN]},
-            auth_exclude_filter,
+            *SUITE_TOKEN_FILTER,
         ],
     )
     assert res_data
@@ -383,7 +366,7 @@ def test_admin_can_manage_tokens_generated_by_other_user(auth_exclude_filter):
         user_session,
         [
             {"field": "ownerUrn", "values": [REVOKE_SUITE_USER_URN]},
-            auth_exclude_filter,
+            *SUITE_TOKEN_FILTER,
         ],
     )
     assert res_data
@@ -397,7 +380,7 @@ def test_admin_can_manage_tokens_generated_by_other_user(auth_exclude_filter):
         admin_session,
         [
             {"field": "ownerUrn", "values": [REVOKE_SUITE_USER_URN]},
-            auth_exclude_filter,
+            *SUITE_TOKEN_FILTER,
         ],
     )
     assert res_data
@@ -407,6 +390,7 @@ def test_admin_can_manage_tokens_generated_by_other_user(auth_exclude_filter):
 
 
 def test_non_admin_can_not_generate_tokens_for_others():
+    _ensure_no_suite_tokens()
     user_session = login_as(REVOKE_SUITE_USER_EMAIL, "user")
     # Normal user should not be able to generate token for another user
     res_data = generateAccessToken_v2(user_session, f"urn:li:corpuser:{admin_user}")
@@ -438,7 +422,7 @@ def generateAccessToken_v2(session, actorUrn):
                 "type": "PERSONAL",
                 "actorUrn": actorUrn,
                 "duration": "ONE_HOUR",
-                "name": "my token",
+                "name": REVOKE_SUITE_TOKEN_NAME,
             }
         },
     }

--- a/smoke-test/tests/tokens/token_utils.py
+++ b/smoke-test/tests/tokens/token_utils.py
@@ -1,6 +1,110 @@
 import time
+from typing import Any, Dict, List
 
-from tests.utils import get_frontend_url
+from tests.utils import get_frontend_url, wait_for_writes_to_sync
+
+
+def token_name_filter(name: str) -> Dict[str, Any]:
+    return {
+        "field": "name",
+        "condition": "EQUAL",
+        "values": [name],
+    }
+
+
+def list_access_tokens(session, filters: List[Dict[str, Any]]) -> Dict[str, Any]:
+    token_input: Dict[str, Any] = {"start": 0, "count": 20}
+    if filters:
+        token_input["filters"] = filters
+
+    json_payload = {
+        "query": """query listAccessTokens($input: ListAccessTokenInput!) {
+            listAccessTokens(input: $input) {
+              start
+              count
+              total
+              tokens {
+                urn
+                id
+                actorUrn
+                ownerUrn
+              }
+            }
+        }""",
+        "variables": {"input": token_input},
+    }
+
+    response = session.post(f"{get_frontend_url()}/api/v2/graphql", json=json_payload)
+    response.raise_for_status()
+    return response.json()
+
+
+def revoke_access_token(session, token_id: str) -> Dict[str, Any]:
+    json_payload = {
+        "query": """mutation revokeAccessToken($tokenId: String!) {
+            revokeAccessToken(tokenId: $tokenId)
+        }""",
+        "variables": {"tokenId": token_id},
+    }
+
+    response = session.post(f"{get_frontend_url()}/api/v2/graphql", json=json_payload)
+    response.raise_for_status()
+    return response.json()
+
+
+def revoke_tokens_matching(session, filters: List[Dict[str, Any]]) -> None:
+    res_data = list_access_tokens(session, filters)
+    assert res_data
+    assert res_data["data"]
+
+    tokens = res_data["data"]["listAccessTokens"]["tokens"]
+    if tokens:
+        for metadata in tokens:
+            revoke_access_token(session, metadata["id"])
+        wait_for_writes_to_sync()
+
+
+def wait_for_no_tokens_matching(
+    session,
+    filters: List[Dict[str, Any]],
+    *,
+    max_timeout_in_sec: int = 60,
+) -> None:
+    """Revoke matching tokens and poll until listAccessTokens is empty.
+
+    Token search is ES-backed; revoke + wait_for_writes_to_sync is not always
+    enough under xdist load before the next assertion.
+    """
+    start = time.time()
+    last_total: int | None = None
+    while time.time() - start < max_timeout_in_sec:
+        revoke_tokens_matching(session, filters)
+        res_data = list_access_tokens(session, filters)
+        assert res_data
+        assert res_data["data"]
+        listing = res_data["data"]["listAccessTokens"]
+        last_total = listing["total"]
+        if last_total == 0 and not listing["tokens"]:
+            return
+        time.sleep(1)
+    raise AssertionError(
+        f"Timed out waiting for tokens matching {filters} to clear after "
+        f"{max_timeout_in_sec}s (last total={last_total})"
+    )
+
+
+def assert_no_tokens_matching(session, filters: List[Dict[str, Any]]) -> None:
+    res_data = list_access_tokens(session, filters)
+    assert res_data
+    assert res_data["data"]
+    assert res_data["data"]["listAccessTokens"]["total"] == 0
+    assert not res_data["data"]["listAccessTokens"]["tokens"]
+
+
+def assert_graphql_mutation_succeeded(res_data: Dict[str, Any]) -> None:
+    errors = res_data.get("errors")
+    assert not errors, errors
+    assert res_data.get("data")
 
 
 def getUserId(session):


### PR DESCRIPTION
## Summary

Extract smoke-test hardening from the xdist CI work so parallel/nightly failures can land independently.

- Scope access-token cleanup per suite (`token_utils`) instead of revoking all tokens globally
- Assert GraphQL mutations succeeded before reading `data` (`test_system_info`, audit/tokens)
- Filter audit event assertions by entity URN (fixes flaky positional results under parallel runs)
- Split `test_usage_aggregation_audit` into classes (enables balanced scheduling; restores support-user metrics coverage)
- Scope `clear_polices()` by name prefix so privileges cleanup does not delete PAT policies from other suites

## Context

These changes address smoke failures seen while enabling pytest-xdist, including nightly `test_usage_aggregation_graphql_output_bytes_not_double_counted` cross-contamination and audit/token flakes when workers share platform state.

Stacked follow-up: #18270 (xdist CI) should rebase onto this branch once merged, or target this branch as its base.

## Test plan

- [x] `./gradlew :smoke-test:lintFix`
- [ ] `docker-unified` smoke batches (no xdist required for these fixes to help serial runs too)
- [ ] Nightly matrix: usage-aggregation audit + audit-events suites


Made with [Cursor](https://cursor.com)