### PR TITLE
fix(docs): add h1 title to usage README so docs generation passes

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/README.md
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/README.md
@@ -1,4 +1,4 @@
-### Flush alignment
+# Flush alignment
 
 When `alignmentPeriodSeconds` is non-zero, flush batches are split at UTC calendar
 boundaries — a drain that would cross a boundary ends the current batch at the


### PR DESCRIPTION
## Summary

- The docs generator (`docs-website/generateDocsDir.ts`) scans **all** markdown in the repo and derives each page title from its first `#` (h1) header. If a discovered README has no h1, the build hard-fails.
- `metadata-io/src/main/java/com/linkedin/metadata/usage/README.md` led with an `###` header, so the `gh-pages` / docs build fails with:

  ```
  Error: metadata-io/src/main/java/com/linkedin/metadata/usage/README.md must have at least one h1 header for setting the title
  ```

- This promotes the top header to an h1, unblocking the docs build. No content changes.

## What broke this

This README was originally added with an h1 (`# API usage aggregation ...`) in #18171. PR #18336 (`feat(usage): optional UTC-aligned flush window boundaries`) rewrote the file and replaced that h1 with an `### Flush alignment` h3, removing the only h1 and breaking the docs build on `master`. This currently fails the `gh-pages` check on every open PR.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in Updating DataHub