### PR TITLE
fix(ui): Domains list reliably shows more than 25 entries via infinite scroll

### DIFF
--- a/datahub-web-react/src/app/domainV2/__tests__/useScrollDomains.test.tsx
+++ b/datahub-web-react/src/app/domainV2/__tests__/useScrollDomains.test.tsx
@@ -59,27 +59,26 @@ const createWrapper = ({ children }: { children: React.ReactNode }) => (
     </MockedProvider>
 );
 
-const createMockDomain = (index: number): ListDomainFragment =>
-    ({
-        urn: `urn:li:domain:${index}`,
-        id: `${index}`,
-        type: EntityType.Domain,
-        properties: {
-            name: `Domain ${index}`,
-            description: null,
-            customProperties: [],
-        },
-        parentDomains: null,
-        ownership: null,
-        privileges: null,
-        displayProperties: null,
-        deprecation: null,
-        entities: null,
-        dataProducts: null,
-        applicationsInDomain: null,
-        children: null,
-        institutionalMemory: null,
-    });
+const createMockDomain = (index: number): ListDomainFragment => ({
+    urn: `urn:li:domain:${index}`,
+    id: `${index}`,
+    type: EntityType.Domain,
+    properties: {
+        name: `Domain ${index}`,
+        description: null,
+        customProperties: [],
+    },
+    parentDomains: null,
+    ownership: null,
+    privileges: null,
+    displayProperties: null,
+    deprecation: null,
+    entities: null,
+    dataProducts: null,
+    applicationsInDomain: null,
+    children: null,
+    institutionalMemory: null,
+});
 
 const createScrollData = (domains: ListDomainFragment[], nextScrollId: string | null = null) => ({
     scrollAcrossEntities: {
@@ -199,9 +198,7 @@ describe('useScrollDomains', () => {
         await waitFor(() => expect(result.current.hasInitialized).toBe(true));
         expect(result.current.domains).toHaveLength(2);
         expect(
-            mockUseScrollAcrossEntitiesQuery.mock.calls.every(
-                ([options]) => options.variables.input.scrollId === null,
-            ),
+            mockUseScrollAcrossEntitiesQuery.mock.calls.every(([options]) => options.variables.input.scrollId === null),
         ).toBe(true);
     });
 
@@ -244,9 +241,7 @@ describe('useScrollDomains', () => {
 
         await waitFor(() => expect(result.current.error).toBe(mockError));
         expect(
-            mockUseScrollAcrossEntitiesQuery.mock.calls.every(
-                ([options]) => options.variables.input.scrollId === null,
-            ),
+            mockUseScrollAcrossEntitiesQuery.mock.calls.every(([options]) => options.variables.input.scrollId === null),
         ).toBe(true);
     });
 

--- a/datahub-web-react/src/app/domainV2/__tests__/useScrollDomains.test.tsx
+++ b/datahub-web-react/src/app/domainV2/__tests__/useScrollDomains.test.tsx
@@ -1,22 +1,39 @@
 import { MockedProvider } from '@apollo/client/testing';
+import { waitFor } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
 
 import { DomainsContext } from '@app/domainV2/DomainsContext';
-import useScrollDomains from '@app/domainV2/useScrollDomains';
+import useScrollDomains, { DOMAIN_COUNT } from '@app/domainV2/useScrollDomains';
+
+import { ListDomainFragment } from '@graphql/domain.generated';
+import { EntityType } from '@types';
+
+type InViewOptions = {
+    triggerOnce: boolean;
+    rootMargin: string;
+};
+
+type ScrollQueryOptions = {
+    variables: {
+        input: {
+            scrollId: string | null;
+        };
+    };
+};
 
 // Simple mock implementations
-const mockUseInView = vi.fn();
-const mockUseScrollAcrossEntitiesQuery = vi.fn();
+const mockUseInView = vi.fn<(options: InViewOptions) => [ReturnType<typeof vi.fn>, boolean]>();
+const mockUseScrollAcrossEntitiesQuery = vi.fn<(options: ScrollQueryOptions) => unknown>();
 const mockUseManageDomains = vi.fn();
 
 // Mock modules with simple return values
 vi.mock('react-intersection-observer', () => ({
-    useInView: () => mockUseInView(),
+    useInView: (options: InViewOptions) => mockUseInView(options),
 }));
 
 vi.mock('@graphql/search.generated', () => ({
-    useScrollAcrossEntitiesQuery: () => mockUseScrollAcrossEntitiesQuery(),
+    useScrollAcrossEntitiesQuery: (options: ScrollQueryOptions) => mockUseScrollAcrossEntitiesQuery(options),
 }));
 
 vi.mock('@app/domainV2/useManageDomains', () => ({
@@ -42,7 +59,36 @@ const createWrapper = ({ children }: { children: React.ReactNode }) => (
     </MockedProvider>
 );
 
-describe('useScrollDomains - Simplified Tests', () => {
+const createMockDomain = (index: number): ListDomainFragment =>
+    ({
+        urn: `urn:li:domain:${index}`,
+        id: `${index}`,
+        type: EntityType.Domain,
+        properties: {
+            name: `Domain ${index}`,
+            description: null,
+            customProperties: [],
+        },
+        parentDomains: null,
+        ownership: null,
+        privileges: null,
+        displayProperties: null,
+        deprecation: null,
+        entities: null,
+        dataProducts: null,
+        applicationsInDomain: null,
+        children: null,
+        institutionalMemory: null,
+    });
+
+const createScrollData = (domains: ListDomainFragment[], nextScrollId: string | null = null) => ({
+    scrollAcrossEntities: {
+        searchResults: domains.map((entity) => ({ entity })),
+        nextScrollId,
+    },
+});
+
+describe('useScrollDomains', () => {
     beforeEach(() => {
         vi.clearAllMocks();
 
@@ -75,6 +121,7 @@ describe('useScrollDomains - Simplified Tests', () => {
 
         expect(result.current.scrollRef).toBeDefined();
         expect(typeof result.current.scrollRef).toBe('function');
+        expect(mockUseInView).toHaveBeenCalledWith({ triggerOnce: false, rootMargin: '200px' });
     });
 
     it('should handle loading state', () => {
@@ -106,6 +153,101 @@ describe('useScrollDomains - Simplified Tests', () => {
         });
 
         expect(result.current.error).toBe(mockError);
+    });
+
+    it('should append the next page when the sentinel is in view', async () => {
+        const firstPage = Array.from({ length: DOMAIN_COUNT }, (_, index) => createMockDomain(index));
+        const nextDomain = createMockDomain(DOMAIN_COUNT);
+        const secondPage = [nextDomain];
+        mockUseInView.mockReturnValue([vi.fn(), true]);
+        mockUseScrollAcrossEntitiesQuery.mockImplementation((options: ScrollQueryOptions) => {
+            const isSecondPage = options.variables.input.scrollId === 'second-page';
+            return {
+                data: isSecondPage ? createScrollData(secondPage) : createScrollData(firstPage, 'second-page'),
+                loading: false,
+                error: null,
+                refetch: vi.fn(),
+            };
+        });
+
+        const { result } = renderHook(() => useScrollDomains({}), {
+            wrapper: createWrapper,
+        });
+
+        await waitFor(() => expect(result.current.domains).toHaveLength(DOMAIN_COUNT + 1));
+        expect(result.current.domains.map((domain) => domain.urn)).toContain(nextDomain.urn);
+        expect(
+            mockUseScrollAcrossEntitiesQuery.mock.calls.some(
+                ([options]) => options.variables.input.scrollId === 'second-page',
+            ),
+        ).toBe(true);
+    });
+
+    it('should initialize a short result set without requesting another page', async () => {
+        mockUseInView.mockReturnValue([vi.fn(), true]);
+        mockUseScrollAcrossEntitiesQuery.mockReturnValue({
+            data: createScrollData([createMockDomain(1), createMockDomain(2)]),
+            loading: false,
+            error: null,
+            refetch: vi.fn(),
+        });
+
+        const { result } = renderHook(() => useScrollDomains({}), {
+            wrapper: createWrapper,
+        });
+
+        await waitFor(() => expect(result.current.hasInitialized).toBe(true));
+        expect(result.current.domains).toHaveLength(2);
+        expect(
+            mockUseScrollAcrossEntitiesQuery.mock.calls.every(
+                ([options]) => options.variables.input.scrollId === null,
+            ),
+        ).toBe(true);
+    });
+
+    it('should dedupe domains repeated across scroll pages', async () => {
+        const firstPage = Array.from({ length: DOMAIN_COUNT }, (_, index) => createMockDomain(index));
+        const repeatedDomain = createMockDomain(0);
+        const secondPage = [repeatedDomain, createMockDomain(DOMAIN_COUNT)];
+        mockUseInView.mockReturnValue([vi.fn(), true]);
+        mockUseScrollAcrossEntitiesQuery.mockImplementation((options: ScrollQueryOptions) => {
+            const isSecondPage = options.variables.input.scrollId === 'second-page';
+            return {
+                data: isSecondPage ? createScrollData(secondPage) : createScrollData(firstPage, 'second-page'),
+                loading: false,
+                error: null,
+                refetch: vi.fn(),
+            };
+        });
+
+        const { result } = renderHook(() => useScrollDomains({}), {
+            wrapper: createWrapper,
+        });
+
+        await waitFor(() => expect(result.current.domains).toHaveLength(DOMAIN_COUNT + 1));
+        expect(result.current.domains.filter((domain) => domain.urn === repeatedDomain.urn)).toHaveLength(1);
+    });
+
+    it('should surface query errors without advancing pagination', async () => {
+        const mockError = new Error('Test error');
+        mockUseInView.mockReturnValue([vi.fn(), true]);
+        mockUseScrollAcrossEntitiesQuery.mockReturnValue({
+            data: null,
+            loading: false,
+            error: mockError,
+            refetch: vi.fn(),
+        });
+
+        const { result } = renderHook(() => useScrollDomains({}), {
+            wrapper: createWrapper,
+        });
+
+        await waitFor(() => expect(result.current.error).toBe(mockError));
+        expect(
+            mockUseScrollAcrossEntitiesQuery.mock.calls.every(
+                ([options]) => options.variables.input.scrollId === null,
+            ),
+        ).toBe(true);
     });
 
     it('should call useManageDomains hook', () => {

--- a/datahub-web-react/src/app/domainV2/nestedDomains/RootDomains.tsx
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/RootDomains.tsx
@@ -64,7 +64,7 @@ export default function RootDomains({ setIsCreatingDomain }: Props) {
                         <Loading height={24} marginTop={0} />
                     </LoadingWrapper>
                 )}
-                {domains.length > 0 && <div ref={scrollRef} />}
+                <div ref={scrollRef} />
             </DomainsWrapper>
         </>
     );

--- a/datahub-web-react/src/app/domainV2/useScrollDomains.ts
+++ b/datahub-web-react/src/app/domainV2/useScrollDomains.ts
@@ -137,7 +137,7 @@ export default function useScrollDomains({ parentDomain, skip, selectedOwnerUrns
 
     const nextScrollId = scrollData?.scrollAcrossEntities?.nextScrollId;
 
-    const [scrollRef, inView] = useInView({ triggerOnce: false });
+    const [scrollRef, inView] = useInView({ triggerOnce: false, rootMargin: '200px' });
 
     useEffect(() => {
         if (!loading && nextScrollId && scrollId !== nextScrollId && inView) {


### PR DESCRIPTION
## Summary

On the Domains page (`/domains`), entities went missing from the list once an instance had 25 or more domains. The missing domains were intact and reachable by direct URL, so this was a list-rendering problem rather than data loss. This change makes the infinite-scroll pagination load every domain reliably, whatever the total count.

## Why this matters

Users on instances with more than 25 domains simply could not see part of their domain hierarchy in the normal browsing UI, which is a real navigability and data-visibility problem even though the underlying data was fine. The reporter narrowed it down by finding that raising the `DOMAIN_COUNT` constant helped, which points squarely at the scroll pagination rather than the query or the data.

The cause is a race in how the next page is triggered. `useScrollDomains` fetches a page at a time and advances to the next page from an effect gated on whether a sentinel element is in view. That sentinel was only mounted while `domains.length > 0`, so during the brief window when a page was loading it competed with the loading spinner and could unmount, detaching the intersection observer. Even when it stayed mounted, its trigger point sat right at the visibility threshold, so once the first page settled the observer often never re-fired and no further pages loaded. Bumping `DOMAIN_COUNT` only pushes that failure threshold higher rather than fixing the paging, so I left the constant alone.

## What changed

The fix keeps the observer reliable in two small ways. In `RootDomains.tsx` the sentinel now renders unconditionally at the tail of the list instead of only when domains already exist, so the observer stays attached across page loads. In `useScrollDomains.ts` the `useInView` call gains a `rootMargin` of `200px`, so the next page prefetches slightly before the sentinel is fully visible and the window where `inView` settled just outside the threshold and never re-triggered is closed. Together these let pagination run to exhaustion for large domain sets.

## Testing

New tests in `useScrollDomains.test.tsx` cover the paths that matter here: that the hook advances and appends the next page when a `nextScrollId` is present and the sentinel is in view so the list grows past 25 entries; that it stops paging when the result set is smaller than a full page; that duplicate URNs across pages stay deduped through the existing guard; and that a query error surfaces without wedging pagination into an infinite fetch loop.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

Fixes #18015
