### PR TITLE
fix(ingestion): support Qlik stale metadata removal

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/qlik_sense/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/qlik_sense/config.py
@@ -11,6 +11,7 @@ from datahub.configuration.source_common import (
 )
 from datahub.ingestion.source.state.stale_entity_removal_handler import (
     StaleEntityRemovalSourceReport,
+    StatefulStaleMetadataRemovalConfig,
 )
 from datahub.ingestion.source.state.stateful_ingestion_base import (
     StatefulIngestionConfigBase,
@@ -114,6 +115,10 @@ class QlikSourceConfig(
 ):
     tenant_hostname: str = pydantic.Field(description="Qlik Tenant hostname")
     api_key: TransparentSecretStr = pydantic.Field(description="Qlik API Key")
+    stateful_ingestion: Optional[StatefulStaleMetadataRemovalConfig] = pydantic.Field(
+        default=None,
+        description="Configuration for stateful ingestion and stale metadata removal.",
+    )
     # Qlik space identifier
     space_pattern: AllowDenyPattern = pydantic.Field(
         default=AllowDenyPattern.allow_all(),

--- a/metadata-ingestion/tests/unit/qlik_sense/test_qlik_sense_config.py
+++ b/metadata-ingestion/tests/unit/qlik_sense/test_qlik_sense_config.py
@@ -1,0 +1,17 @@
+from datahub.ingestion.source.qlik_sense.config import QlikSourceConfig
+
+
+def test_stateful_ingestion_supports_stale_removal_config():
+    config = QlikSourceConfig.model_validate(
+        {
+            "tenant_hostname": "tenant.example",
+            "api_key": "secret",
+            "stateful_ingestion": {
+                "enabled": True,
+                "remove_stale_metadata": True,
+            },
+        }
+    )
+
+    assert config.stateful_ingestion is not None
+    assert config.stateful_ingestion.remove_stale_metadata is True

--- a/metadata-ingestion/tests/unit/qlik_sense/test_qlik_sense_stateful.py
+++ b/metadata-ingestion/tests/unit/qlik_sense/test_qlik_sense_stateful.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock, patch
+
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.qlik_sense.config import QlikSourceConfig
+from datahub.ingestion.source.qlik_sense.qlik_sense import QlikSenseSource
+from datahub.ingestion.workunit_processors.auto_stale_entity_removal import (
+    AutoStaleEntityRemovalProcessor,
+)
+
+
+@patch("datahub.ingestion.source.qlik_sense.qlik_sense.QlikAPI")
+def test_stateful_ingestion_registers_stale_removal_processor(mock_qlik_api):
+    config = QlikSourceConfig.model_validate(
+        {
+            "tenant_hostname": "tenant.example",
+            "api_key": "secret",
+            "stateful_ingestion": {
+                "enabled": True,
+                "remove_stale_metadata": True,
+            },
+        }
+    )
+    ctx = PipelineContext(
+        run_id="test-stateful",
+        pipeline_name="test-pipeline",
+        graph=MagicMock(),
+    )
+    source = QlikSenseSource(config, ctx)
+
+    processors = source.get_workunit_processors()
+
+    matching = [
+        processor
+        for processor in processors
+        if isinstance(
+            getattr(processor, "__self__", None), AutoStaleEntityRemovalProcessor
+        )
+    ]
+    assert len(matching) == 1


### PR DESCRIPTION
## Summary

- parse Qlik stateful ingestion with the stale-metadata removal configuration
- add a config regression for `remove_stale_metadata`
- verify the Qlik source registers the automatic stale-entity removal processor

Fixes #18288.

## Root cause

`QlikSourceConfig` used the generic `StatefulIngestionConfig`, which does not
define `remove_stale_metadata`. The ingestion framework still enables automatic
stale removal for the Qlik source report, so processor initialization attempted
to read a field that the connector configuration could not represent.

This change redeclares Qlik's inherited `stateful_ingestion` field with the
existing `StatefulStaleMetadataRemovalConfig` type. No source lifecycle or
workunit behavior is otherwise changed.

## Verification

- `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/qlik_sense/`
- `./gradlew :metadata-ingestion:lintFix`
- `./gradlew :metadata-ingestion:lint`

The focused test run passes both regressions. Ruff and formatting pass, and
mypy reports no issues across 2,699 source files.
