### PR TITLE
fix(patch): only re-inject scalar keyed-array keys on rebase

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/ArrayMergingTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/ArrayMergingTemplate.java
@@ -13,8 +13,12 @@ import com.linkedin.data.template.DataTemplateUtil;
 import com.linkedin.data.template.RecordTemplate;
 import java.util.Collections;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public interface ArrayMergingTemplate<T extends RecordTemplate> extends Template<T> {
+
+  Logger log = LoggerFactory.getLogger(ArrayMergingTemplate.class);
 
   static final String UNIT_SEPARATOR_DELIMITER = "␟";
 
@@ -159,27 +163,39 @@ public interface ArrayMergingTemplate<T extends RecordTemplate> extends Template
     return mergingArray;
   }
 
-  // Best-effort resolution of the array element record schema; null when it can't be resolved.
+  // Best-effort resolution of the array element record schema. Returns null when it can't be
+  // resolved, in which case keys are not re-injected (see reinjectKey); the debug logs make a
+  // silent regression of that path traceable, as it is not expected for real aspects.
   default RecordDataSchema resolveArrayItemSchema(String arrayFieldName) {
     try {
       DataSchema aspectSchema = DataTemplateUtil.getSchema(getTemplateType());
-      if (!(aspectSchema instanceof RecordDataSchema)) {
-        return null;
-      }
-      RecordDataSchema.Field field = ((RecordDataSchema) aspectSchema).getField(arrayFieldName);
-      if (field == null) {
-        return null;
-      }
-      DataSchema fieldSchema = field.getType().getDereferencedDataSchema();
+      DataSchema fieldSchema =
+          aspectSchema instanceof RecordDataSchema
+              ? fieldSchemaOf((RecordDataSchema) aspectSchema, arrayFieldName)
+              : null;
       if (!(fieldSchema instanceof ArrayDataSchema)) {
+        log.debug(
+            "Could not resolve keyed-array field {} on aspect {}; skipping key re-injection",
+            arrayFieldName,
+            getTemplateType());
         return null;
       }
       DataSchema itemSchema =
           ((ArrayDataSchema) fieldSchema).getItems().getDereferencedDataSchema();
       return itemSchema instanceof RecordDataSchema ? (RecordDataSchema) itemSchema : null;
     } catch (RuntimeException e) {
+      log.debug(
+          "Failed to resolve schema for field {} on aspect {}; skipping key re-injection",
+          arrayFieldName,
+          getTemplateType(),
+          e);
       return null;
     }
+  }
+
+  private static DataSchema fieldSchemaOf(RecordDataSchema recordSchema, String fieldName) {
+    RecordDataSchema.Field field = recordSchema.getField(fieldName);
+    return field == null ? null : field.getType().getDereferencedDataSchema();
   }
 
   // Restores a key field that only lived in the patch path (e.g. a deep-path add) and would

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/ArrayMergingTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/ArrayMergingTemplate.java
@@ -6,6 +6,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.linkedin.data.schema.ArrayDataSchema;
+import com.linkedin.data.schema.DataSchema;
+import com.linkedin.data.schema.RecordDataSchema;
+import com.linkedin.data.template.DataTemplateUtil;
 import com.linkedin.data.template.RecordTemplate;
 import java.util.Collections;
 import java.util.List;
@@ -112,7 +116,7 @@ public interface ArrayMergingTemplate<T extends RecordTemplate> extends Template
     ArrayNode arrayNode;
 
     if (!keyFields.isEmpty()) {
-      arrayNode = mergeToArray(mapNode, keyFields);
+      arrayNode = mergeToArray(mapNode, keyFields, resolveArrayItemSchema(arrayFieldName));
     } else {
       // No keys, assume pure Strings
       arrayNode = instance.arrayNode();
@@ -121,7 +125,8 @@ public interface ArrayMergingTemplate<T extends RecordTemplate> extends Template
     return rebasedNode.set(arrayFieldName, arrayNode);
   }
 
-  default ArrayNode mergeToArray(JsonNode mapNode, List<String> keyFields) {
+  default ArrayNode mergeToArray(
+      JsonNode mapNode, List<String> keyFields, RecordDataSchema itemSchema) {
     if (keyFields.isEmpty()) {
       // When a plain add sets an array at an entity-key level (e.g. /tags/<urn> with
       // value [{...}]), the leaf ArrayNode's elements must be expanded into the result.
@@ -139,8 +144,8 @@ public interface ArrayMergingTemplate<T extends RecordTemplate> extends Template
           .fields()
           .forEachRemaining(
               entry -> {
-                ArrayNode merged = mergeToArray(entry.getValue(), remainingKeyFields);
-                reinjectKey(merged, keyField, entry.getKey());
+                ArrayNode merged = mergeToArray(entry.getValue(), remainingKeyFields, itemSchema);
+                reinjectKey(merged, keyField, entry.getKey(), itemSchema);
                 mergingArray.addAll(merged);
               });
     } else {
@@ -148,17 +153,50 @@ public interface ArrayMergingTemplate<T extends RecordTemplate> extends Template
       // map key to restore here, so preserve the original value-only merge.
       mapNode
           .elements()
-          .forEachRemaining(node -> mergingArray.addAll(mergeToArray(node, remainingKeyFields)));
+          .forEachRemaining(
+              node -> mergingArray.addAll(mergeToArray(node, remainingKeyFields, itemSchema)));
     }
     return mergingArray;
+  }
+
+  // Resolves the record schema of the array element type for a keyed array field (e.g. the
+  // TagAssociation record behind GlobalTags.tags). Best-effort: returns null when the schema
+  // cannot be resolved, in which case re-injection is skipped rather than guessed.
+  default RecordDataSchema resolveArrayItemSchema(String arrayFieldName) {
+    try {
+      DataSchema aspectSchema = DataTemplateUtil.getSchema(getTemplateType());
+      if (!(aspectSchema instanceof RecordDataSchema)) {
+        return null;
+      }
+      RecordDataSchema.Field field = ((RecordDataSchema) aspectSchema).getField(arrayFieldName);
+      if (field == null) {
+        return null;
+      }
+      DataSchema fieldSchema = field.getType().getDereferencedDataSchema();
+      if (!(fieldSchema instanceof ArrayDataSchema)) {
+        return null;
+      }
+      DataSchema itemSchema =
+          ((ArrayDataSchema) fieldSchema).getItems().getDereferencedDataSchema();
+      return itemSchema instanceof RecordDataSchema ? (RecordDataSchema) itemSchema : null;
+    } catch (RuntimeException e) {
+      return null;
+    }
   }
 
   // Restores the key field on elements created by a patch through a deeper path (e.g.
   // /editableSchemaFieldInfo/<fieldPath>/globalTags/...), which never materializes the key in the
   // value and would otherwise drop it, failing validation. No-op for normal round-trips that still
-  // carry the key. Compound/nested keys and empty keys are left as-is.
-  private static void reinjectKey(ArrayNode elements, String keyField, String key) {
-    if (key == null || key.isEmpty() || keyField.contains(UNIT_SEPARATOR_DELIMITER)) {
+  // carry the key. Only primitive/enum key fields are restored: the map key is a scalar path
+  // segment, so injecting it into a record- or collection-typed field (e.g. an optional
+  // attribution record used as a compound key) would corrupt the element and fail validation.
+  // Compound/nested keys and empty keys are left as-is.
+  private static void reinjectKey(
+      ArrayNode elements, String keyField, String key, RecordDataSchema itemSchema) {
+    if (key == null
+        || key.isEmpty()
+        || keyField.contains(UNIT_SEPARATOR_DELIMITER)
+        || !isScalarKeyField(itemSchema, keyField)) {
       return;
     }
     elements.forEach(
@@ -167,5 +205,27 @@ public interface ArrayMergingTemplate<T extends RecordTemplate> extends Template
             ((ObjectNode) element).set(keyField, TextNode.valueOf(key));
           }
         });
+  }
+
+  private static boolean isScalarKeyField(RecordDataSchema itemSchema, String keyField) {
+    if (itemSchema == null) {
+      return false;
+    }
+    RecordDataSchema.Field field = itemSchema.getField(keyField);
+    if (field == null) {
+      return false;
+    }
+    switch (field.getType().getDereferencedType()) {
+      case STRING:
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case BOOLEAN:
+      case ENUM:
+        return true;
+      default:
+        return false;
+    }
   }
 }

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/ArrayMergingTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/ArrayMergingTemplate.java
@@ -159,9 +159,7 @@ public interface ArrayMergingTemplate<T extends RecordTemplate> extends Template
     return mergingArray;
   }
 
-  // Resolves the record schema of the array element type for a keyed array field (e.g. the
-  // TagAssociation record behind GlobalTags.tags). Best-effort: returns null when the schema
-  // cannot be resolved, in which case re-injection is skipped rather than guessed.
+  // Best-effort resolution of the array element record schema; null when it can't be resolved.
   default RecordDataSchema resolveArrayItemSchema(String arrayFieldName) {
     try {
       DataSchema aspectSchema = DataTemplateUtil.getSchema(getTemplateType());
@@ -184,13 +182,9 @@ public interface ArrayMergingTemplate<T extends RecordTemplate> extends Template
     }
   }
 
-  // Restores the key field on elements created by a patch through a deeper path (e.g.
-  // /editableSchemaFieldInfo/<fieldPath>/globalTags/...), which never materializes the key in the
-  // value and would otherwise drop it, failing validation. No-op for normal round-trips that still
-  // carry the key. Only primitive/enum key fields are restored: the map key is a scalar path
-  // segment, so injecting it into a record- or collection-typed field (e.g. an optional
-  // attribution record used as a compound key) would corrupt the element and fail validation.
-  // Compound/nested keys and empty keys are left as-is.
+  // Restores a key field that only lived in the patch path (e.g. a deep-path add) and would
+  // otherwise be dropped. Only primitive/enum keys are restored: the key is a scalar path segment,
+  // so injecting it into a record- or collection-typed key field would corrupt the element.
   private static void reinjectKey(
       ArrayNode elements, String keyField, String key, RecordDataSchema itemSchema) {
     if (key == null

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/template/GenericPatchTemplateTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/template/GenericPatchTemplateTest.java
@@ -241,4 +241,42 @@ public class GenericPatchTemplateTest {
     Assert.assertTrue(tagToSourceMap.containsKey("urn:li:tag:newTag"));
     Assert.assertEquals(tagToSourceMap.get("urn:li:tag:newTag"), "");
   }
+
+  @Test
+  public void testRecordTypedFlatKeyFieldIsNotReinjectedAsString() throws Exception {
+    // A flat (non-nested) compound key that names the record-typed `attribution` field. The map key
+    // is a scalar path segment, so re-injecting it into `attribution` would produce a string where
+    // a
+    // record is expected ("record type is not backed by a DataMap"). The rebase must leave the
+    // record-typed key field untouched. See PR that fixed the patch-rebase key re-injection.
+    GlobalTags initialTags = new GlobalTags();
+    initialTags.setTags(new TagAssociationArray());
+
+    GenericJsonPatch.PatchOp patchOp = new GenericJsonPatch.PatchOp();
+    patchOp.setOp("add");
+    patchOp.setPath("/tags/urn:li:platformResource:my-source/urn:li:tag:tag1");
+    patchOp.setValue(Map.of("tag", "urn:li:tag:tag1"));
+
+    GenericJsonPatch genericJsonPatch =
+        GenericJsonPatch.builder()
+            .patch(List.of(patchOp))
+            .arrayPrimaryKeys(Map.of("tags", Arrays.asList("attribution", "source")))
+            .build();
+
+    GenericPatchTemplate<GlobalTags> template =
+        GenericPatchTemplate.<GlobalTags>builder()
+            .genericJsonPatch(genericJsonPatch)
+            .templateType(GlobalTags.class)
+            .templateDefault(new GlobalTags())
+            .build();
+
+    GlobalTags patchedTags = template.applyPatch(initialTags);
+
+    Assert.assertNotNull(patchedTags.getTags());
+    Assert.assertEquals(patchedTags.getTags().size(), 1);
+    TagAssociation tag = patchedTags.getTags().get(0);
+    Assert.assertEquals(tag.getTag().toString(), "urn:li:tag:tag1");
+    // The record-typed key field must not have been coerced into a string.
+    Assert.assertNull(tag.getAttribution());
+  }
 }

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/template/GenericPatchTemplateTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/template/GenericPatchTemplateTest.java
@@ -244,11 +244,8 @@ public class GenericPatchTemplateTest {
 
   @Test
   public void testRecordTypedFlatKeyFieldIsNotReinjectedAsString() throws Exception {
-    // A flat (non-nested) compound key that names the record-typed `attribution` field. The map key
-    // is a scalar path segment, so re-injecting it into `attribution` would produce a string where
-    // a
-    // record is expected ("record type is not backed by a DataMap"). The rebase must leave the
-    // record-typed key field untouched. See PR that fixed the patch-rebase key re-injection.
+    // Keying by the record-typed `attribution` field must not inject the scalar path segment into
+    // it, which would produce a string where a record is expected and fail validation.
     GlobalTags initialTags = new GlobalTags();
     initialTags.setTags(new TagAssociationArray());
 
@@ -276,7 +273,6 @@ public class GenericPatchTemplateTest {
     Assert.assertEquals(patchedTags.getTags().size(), 1);
     TagAssociation tag = patchedTags.getTags().get(0);
     Assert.assertEquals(tag.getTag().toString(), "urn:li:tag:tag1");
-    // The record-typed key field must not have been coerced into a string.
     Assert.assertNull(tag.getAttribution());
   }
 }


### PR DESCRIPTION
## Summary

PR #18334 added key re-injection during keyed-array patch rebase so that deep-path adds (e.g. `/owners/<urn>/<type>`) no longer drop the key that only lives in the patch path. The re-injected value is the map key, which is a **scalar path segment**. It was injected for **any** key field, including record-typed fields that are used as (part of) a compound key.

When a caller keys a keyed array by a record-typed field — e.g. `GlobalTags` keyed by its optional `attribution` record via `arrayPrimaryKeys: {"tags": ["attribution", "source"]}` — rebase injected the scalar path segment into `attribution`, producing a `string` where the model expects a record. Aspect validation then fails with:

```
ERROR :: /tags/1/attribution :: record type is not backed by a DataMap
```

This regressed `PrivilegeConstraintsValidatorTest` (`testValidateGlobalTagsPatchAuthorized`, `testValidateGlobalTagsPatchUnauthorized`) on `master`.

## Fix

Make re-injection **schema-aware** in `ArrayMergingTemplate`:

- Resolve the array element's record schema from the template's aspect type.
- Restore the key only for **primitive / enum** key fields.
- Leave record-, collection-, and unknown key fields untouched (falls back to the pre-#18334 behavior for those).

This keeps the scalar compound-key fix from #18334 working (Ownership `owner`+`type`, `EditableSchemaMetadata`) while no longer corrupting record-typed key fields.

## Testing

- `entity-registry`: all patch-template tests pass (47), including #18334's `OwnershipTemplateTest` deep-path/compound-key cases. Added a focused regression test in `GenericPatchTemplateTest` for a flat record-typed key field.
- `metadata-io`: `PrivilegeConstraintsValidatorTest` passes (29), previously 2 failing on `master`.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [ ] Docs added/updated (n/a)
- [ ] Breaking changes documented (n/a)