### PR TITLE
feat(ingest/clickhouse): migrate usage stats to SqlParsingAggregator

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/usage/clickhouse_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/clickhouse_usage.py
@@ -1,7 +1,9 @@
 import logging
+import re
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, Optional
 
+from pydantic import field_validator
 from pydantic.fields import Field
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
@@ -33,6 +35,12 @@ from datahub.sql_parsing.sql_parsing_aggregator import (
 
 logger = logging.getLogger(__name__)
 
+# A ClickHouse table identifier is at most `database.table`; restrict to characters
+# valid in an (optionally qualified) identifier. query_log_table is interpolated into
+# the fetch SQL as an identifier (identifiers cannot be bound as query parameters), so
+# validating it here is what prevents SQL injection through that config value.
+_QUERY_LOG_TABLE_PATTERN = re.compile(r"^[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)?$")
+
 # SELECT queries recorded in system.query_log. Each row's raw query text is fed
 # to the SqlParsingAggregator as an observed query; the aggregator does the SQL
 # parsing and usage aggregation (buckets, top users/queries), so this query only
@@ -61,6 +69,18 @@ class ClickHouseUsageConfig(ClickHouseConfig, BaseUsageConfig, EnvConfigMixin):
     )
     options: dict = Field(default={}, description="")
     query_log_table: str = Field(default="system.query_log", exclude=True)
+
+    @field_validator("query_log_table")
+    @classmethod
+    def validate_query_log_table(cls, v: str) -> str:
+        """Validate the query log table identifier to prevent SQL injection."""
+        if not _QUERY_LOG_TABLE_PATTERN.match(v):
+            raise ValueError(
+                f"Invalid query_log_table '{v}'. It must be an (optionally "
+                "database-qualified) identifier containing only alphanumeric "
+                "characters and underscores, e.g. 'system.query_log'."
+            )
+        return v
 
     def get_sql_alchemy_url(
         self,
@@ -139,6 +159,9 @@ class ClickHouseUsageSource(Source):
         start_time = get_time_bucket(
             self.config.start_time, self.config.bucket_duration
         )
+        # Security: the interpolated values are not injectable. start_time/end_time are
+        # datetime objects rendered via strftime (fixed numeric format, no user text),
+        # and query_log_table is validated to a safe identifier by validate_query_log_table.
         return CLICKHOUSE_USAGE_SQL.format(
             query_log_table=self.config.query_log_table,
             start_time=start_time.strftime(clickhouse_datetime_format),

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/clickhouse_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/clickhouse_usage.py
@@ -7,6 +7,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
 from datahub.configuration.source_common import EnvConfigMixin
+from datahub.configuration.time_window_config import get_time_bucket
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.decorators import (
     SourceCapability,
@@ -132,9 +133,15 @@ class ClickHouseUsageSource(Source):
         ) or self.config.view_pattern.allowed(name)
 
     def _make_usage_query(self) -> str:
+        # Floor start_time to the bucket boundary so the first (partial) bucket is
+        # fully populated, matching the aggregator's bucket list (buckets() floors
+        # start_time internally) and the query-log window in sql/clickhouse.py.
+        start_time = get_time_bucket(
+            self.config.start_time, self.config.bucket_duration
+        )
         return CLICKHOUSE_USAGE_SQL.format(
             query_log_table=self.config.query_log_table,
-            start_time=self.config.start_time.strftime(clickhouse_datetime_format),
+            start_time=start_time.strftime(clickhouse_datetime_format),
             end_time=self.config.end_time.strftime(clickhouse_datetime_format),
         )
 
@@ -167,16 +174,25 @@ class ClickHouseUsageSource(Source):
 
             timestamp = row_dict.get("starttime") or row_dict.get("endtime")
             if isinstance(timestamp, datetime):
-                timestamp = timestamp.astimezone(timezone.utc)
+                # system.query_log DateTime columns come back naive; they represent
+                # UTC instants, so tag them as UTC rather than astimezone(), which
+                # would (wrongly) reinterpret a naive value as the host's local time.
+                timestamp = (
+                    timestamp.replace(tzinfo=timezone.utc)
+                    if timestamp.tzinfo is None
+                    else timestamp.astimezone(timezone.utc)
+                )
 
             yield ObservedQuery(
                 query=query,
                 session_id=row_dict.get("query_id"),
                 timestamp=timestamp,
                 user=user_urn,
-                # ClickHouse uses 2-level (database.table) naming while sqlglot expects
-                # 3-level names. Passing a default_db causes it to be prepended to
-                # already-qualified names, producing incorrect URNs.
+                # Don't pass a default_db. ClickHouse uses 2-level (database.table)
+                # naming, but for a 2-level dialect sqlglot slots an existing database
+                # qualifier into `db` and lets default_db fill `catalog`, over-qualifying
+                # already-qualified names into incorrect URNs like
+                # "default.analytics_marts.table".
                 default_db=None,
                 query_hash=str(row_dict.get("normalized_query_hash", "")),
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/clickhouse_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/clickhouse_usage.py
@@ -1,18 +1,13 @@
-import collections
-import dataclasses
 import logging
-from datetime import datetime
-from typing import Any, Dict, Iterable, List, Optional
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, Optional
 
-from dateutil import parser
 from pydantic.fields import Field
-from pydantic.main import BaseModel
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
-import datahub.emitter.mce_builder as builder
 from datahub.configuration.source_common import EnvConfigMixin
-from datahub.configuration.time_window_config import get_time_bucket
+from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.decorators import (
     SourceCapability,
     SupportStatus,
@@ -22,55 +17,47 @@ from datahub.ingestion.api.decorators import (
     support_status,
 )
 from datahub.ingestion.api.source import Source, SourceReport
+from datahub.ingestion.api.source_helpers import auto_workunit
 from datahub.ingestion.api.workunit import MetadataWorkUnit
-from datahub.ingestion.source.sql.clickhouse import ClickHouseConfig
-from datahub.ingestion.source.usage.usage_common import (
-    BaseUsageConfig,
-    GenericAggregatedDataset,
+from datahub.ingestion.source.sql.clickhouse import (
+    ClickHouseConfig,
+    clickhouse_datetime_format,
+)
+from datahub.ingestion.source.usage.usage_common import BaseUsageConfig
+from datahub.metadata.urns import CorpUserUrn
+from datahub.sql_parsing.sql_parsing_aggregator import (
+    ObservedQuery,
+    SqlParsingAggregator,
 )
 
 logger = logging.getLogger(__name__)
 
-clickhouse_datetime_format = "%Y-%m-%d %H:%M:%S"
-
-clickhouse_usage_sql_comment = """\
-SELECT user                                                                       AS username
+# SELECT queries recorded in system.query_log. Each row's raw query text is fed
+# to the SqlParsingAggregator as an observed query; the aggregator does the SQL
+# parsing and usage aggregation (buckets, top users/queries), so this query only
+# needs to surface the raw statement plus the user and timestamp.
+CLICKHOUSE_USAGE_SQL = """\
+SELECT query_id
      , query
-     , substring(full_table_name, 1, position(full_table_name, '.') - 1)          AS database
-     , substring(full_table_name, position(full_table_name, '.') + 1)             AS table
-     , full_table_name
-     , arrayMap(x -> substr(x, length(full_table_name) + 2),
-                arrayFilter(x -> startsWith(x, full_table_name || '.'), columns)) AS columns
-     , query_start_time                                                           AS starttime
-     , event_time                                                                 AS endtime
+     , user                AS username
+     , query_start_time    AS starttime
+     , event_time          AS endtime
+     , normalized_query_hash
   FROM {query_log_table}
- ARRAY JOIN tables AS full_table_name
  WHERE is_initial_query
    AND type = 'QueryFinish'
    AND query_kind = 'Select'
-   AND full_table_name NOT LIKE 'system.%%'
-   AND full_table_name NOT LIKE '_table_function.%%'
-   AND table NOT LIKE '`.inner%%'
    AND event_time >= '{start_time}'
    AND event_time < '{end_time}'
+   AND query NOT LIKE '%%system.%%'
  ORDER BY event_time DESC"""
-
-ClickHouseTableRef = str
-AggregatedDataset = GenericAggregatedDataset[ClickHouseTableRef]
-
-
-class ClickHouseJoinedAccessEvent(BaseModel):
-    username: str = None  # type:ignore
-    query: str = None  # type: ignore
-    database: str = None  # type:ignore
-    table: str = None  # type:ignore
-    columns: List[str]
-    starttime: datetime
-    endtime: datetime
 
 
 class ClickHouseUsageConfig(ClickHouseConfig, BaseUsageConfig, EnvConfigMixin):
-    email_domain: str = Field(description="")
+    email_domain: str = Field(
+        description="Email domain appended to ClickHouse usernames to build the "
+        "user URNs surfaced in usage statistics."
+    )
     options: dict = Field(default={}, description="")
     query_log_table: str = Field(default="system.query_log", exclude=True)
 
@@ -90,44 +77,62 @@ class ClickHouseUsageConfig(ClickHouseConfig, BaseUsageConfig, EnvConfigMixin):
 )
 @capability(SourceCapability.DATA_PROFILING, "Optionally enabled via configuration")
 @capability(SourceCapability.USAGE_STATS, "Enabled by default to get usage stats")
-@dataclasses.dataclass
 class ClickHouseUsageSource(Source):
     """
     Source that extracts usage statistics from ClickHouse by analyzing system.query_log.
 
     Implementation notes:
     - Queries system.query_log (or custom view via query_log_table config) for SELECT queries
-    - Filters out system tables, table functions, and internal queries
-    - Uses SQLAlchemy to connect to ClickHouse
-    - Parses tables and columns arrays from query log
-    - Aggregates usage by time bucket using BaseUsageConfig
-    - Only processes QueryFinish events with Select query_kind
+    - Feeds each query into a SqlParsingAggregator as an observed query, so usage is
+      computed through the same SQL-parsing path as the rest of the ClickHouse connector
+      family (see the aggregator-based path in sql/clickhouse.py)
+    - The aggregator produces DatasetUsageStatistics (buckets, top users/queries) with
+      generate_usage_statistics=True
+
+    This remains a standalone source (rather than folding into sql/clickhouse.py) to preserve
+    the existing `clickhouse-usage` recipe entry point; it now delegates aggregation to the
+    shared aggregator instead of the legacy usage_common GenericAggregatedDataset.
     """
 
     config: ClickHouseUsageConfig
-    report: SourceReport = dataclasses.field(default_factory=SourceReport)
+    report: SourceReport
+
+    def __init__(self, config: ClickHouseUsageConfig, ctx: PipelineContext) -> None:
+        super().__init__(ctx)
+        self.config = config
+        self.report = SourceReport()
+
+        self.aggregator = SqlParsingAggregator(
+            platform="clickhouse",
+            platform_instance=self.config.platform_instance,
+            env=self.config.env,
+            graph=ctx.graph,
+            eager_graph_load=False,
+            generate_lineage=False,
+            generate_queries=True,
+            generate_usage_statistics=True,
+            generate_query_usage_statistics=True,
+            usage_config=self.config,
+            is_allowed_table=self._is_allowed_table,
+            format_queries=self.config.format_sql_queries,
+        )
 
     @classmethod
     def create(cls, config_dict, ctx):
         config = ClickHouseUsageConfig.model_validate(config_dict)
-        return cls(ctx, config)
+        return cls(config, ctx)
 
-    def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
-        """Gets ClickHouse usage stats as work units"""
-        access_events = self._get_clickhouse_history()
-        # If the query results is empty, we don't want to proceed
-        if not access_events:
-            return
-
-        joined_access_event = self._get_joined_access_event(access_events)
-        aggregated_info = self._aggregate_access_events(joined_access_event)
-
-        for time_bucket in aggregated_info.values():
-            for aggregate in time_bucket.values():
-                yield self._make_usage_stat(aggregate)
+    def _is_allowed_table(self, name: str) -> bool:
+        if "." in name:
+            database = name.split(".", 1)[0]
+            if not self.config.database_pattern.allowed(database):
+                return False
+        return self.config.table_pattern.allowed(
+            name
+        ) or self.config.view_pattern.allowed(name)
 
     def _make_usage_query(self) -> str:
-        return clickhouse_usage_sql_comment.format(
+        return CLICKHOUSE_USAGE_SQL.format(
             query_log_table=self.config.query_log_table,
             start_time=self.config.start_time.strftime(clickhouse_datetime_format),
             end_time=self.config.end_time.strftime(clickhouse_datetime_format),
@@ -136,124 +141,55 @@ class ClickHouseUsageSource(Source):
     def _make_sql_engine(self) -> Engine:
         url = self.config.get_sql_alchemy_url()
         logger.debug(f"sql_alchemy_url = {url}")
-        engine = create_engine(url, **self.config.options)
-        return engine
+        return create_engine(url, **self.config.options)
 
-    def _get_clickhouse_history(self):
-        query = self._make_usage_query()
+    def _get_observed_queries(self) -> Iterable[ObservedQuery]:
         engine = self._make_sql_engine()
-        results = engine.execute(query)
-        events = []
+        results = engine.execute(text(self._make_usage_query()))
         for row in results:
-            event_dict = row._asdict()
+            row_dict = dict(row._mapping)
 
-            # stripping extra spaces caused by above _asdict() conversion
-            for k, v in event_dict.items():
-                if isinstance(v, str):
-                    event_dict[k] = v.strip()
+            query = row_dict.get("query")
+            if not query:
+                continue
 
-            if not self.config.database_pattern.allowed(
-                event_dict.get("database")
-            ) or not (
-                self.config.table_pattern.allowed(event_dict.get("full_table_name"))
-                or self.config.view_pattern.allowed(event_dict.get("full_table_name"))
-            ):
-                logger.debug(
-                    f"Dropping usage event for {event_dict.get('full_table_name')}"
+            username = row_dict.get("username")
+            if isinstance(username, str):
+                username = username.strip()
+            user_urn: Optional[CorpUserUrn] = None
+            if username:
+                user_email = (
+                    username
+                    if "@" in username
+                    else f"{username}@{self.config.email_domain}"
                 )
-                continue
+                user_urn = CorpUserUrn(user_email)
 
-            if event_dict.get("starttime", None):
-                event_dict["starttime"] = event_dict.get("starttime").__str__()
-            if event_dict.get("endtime", None):
-                event_dict["endtime"] = event_dict.get("endtime").__str__()
-            # when the http protocol is used, the columns field is returned as a string
-            if isinstance(event_dict.get("columns"), str):
-                event_dict["columns"] = (
-                    event_dict.get("columns").replace("'", "").strip("][").split(",")
-                )
+            timestamp = row_dict.get("starttime") or row_dict.get("endtime")
+            if isinstance(timestamp, datetime):
+                timestamp = timestamp.astimezone(timezone.utc)
 
-            logger.debug(f"event_dict: {event_dict}")
-            events.append(event_dict)
-
-        if events:
-            return events
-
-        # SQL results can be empty. If results is empty, the SQL connection closes.
-        # Then, we don't want to proceed ingestion.
-        logging.info("SQL Result is empty")
-        return None
-
-    def _convert_str_to_datetime(self, v):
-        if isinstance(v, str):
-            isodate = parser.parse(v)  # compatible with Python 3.6+
-            return isodate.strftime(clickhouse_datetime_format)
-
-    def _get_joined_access_event(self, events):
-        joined_access_events = []
-        for event_dict in events:
-            event_dict["starttime"] = self._convert_str_to_datetime(
-                event_dict.get("starttime")
-            )
-            event_dict["endtime"] = self._convert_str_to_datetime(
-                event_dict.get("endtime")
+            yield ObservedQuery(
+                query=query,
+                session_id=row_dict.get("query_id"),
+                timestamp=timestamp,
+                user=user_urn,
+                # ClickHouse uses 2-level (database.table) naming while sqlglot expects
+                # 3-level names. Passing a default_db causes it to be prepended to
+                # already-qualified names, producing incorrect URNs.
+                default_db=None,
+                query_hash=str(row_dict.get("normalized_query_hash", "")),
             )
 
-            if not (event_dict.get("database", None) and event_dict.get("table", None)):
-                logging.info("An access event parameter(s) is missing. Skipping ....")
-                continue
+    def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
+        for observed_query in self._get_observed_queries():
+            self.aggregator.add(observed_query)
 
-            if not event_dict.get("username") or event_dict["username"] == "":
-                logging.info("The username parameter is missing. Skipping ....")
-                continue
-
-            joined_access_events.append(ClickHouseJoinedAccessEvent(**event_dict))
-
-        return joined_access_events
-
-    def _aggregate_access_events(
-        self, events: List[ClickHouseJoinedAccessEvent]
-    ) -> Dict[datetime, Dict[ClickHouseTableRef, AggregatedDataset]]:
-        datasets: Dict[datetime, Dict[ClickHouseTableRef, AggregatedDataset]] = (
-            collections.defaultdict(dict)
-        )
-
-        for event in events:
-            floored_ts = get_time_bucket(event.starttime, self.config.bucket_duration)
-
-            resource = (
-                f"{self.config.platform_instance + '.' if self.config.platform_instance else ''}"
-                f"{event.database}.{event.table}"
-            )
-
-            agg_bucket = datasets[floored_ts].setdefault(
-                resource,
-                AggregatedDataset(bucket_start_time=floored_ts, resource=resource),
-            )
-
-            # current limitation in user stats UI, we need to provide email to show users
-            user_email = f"{event.username if event.username else 'unknown'}"
-            if "@" not in user_email:
-                user_email += f"@{self.config.email_domain}"
-            logger.info(f"user_email: {user_email}")
-            agg_bucket.add_read_entry(
-                user_email,
-                event.query,
-                event.columns,
-            )
-        return datasets
-
-    def _make_usage_stat(self, agg: AggregatedDataset) -> MetadataWorkUnit:
-        return agg.make_usage_workunit(
-            self.config.bucket_duration,
-            lambda resource: builder.make_dataset_urn(
-                "clickhouse", resource, self.config.env
-            ),
-            self.config.top_n_queries,
-            self.config.format_sql_queries,
-            self.config.include_top_n_queries,
-            self.config.queries_character_limit,
-        )
+        yield from auto_workunit(self.aggregator.gen_metadata())
 
     def get_report(self) -> SourceReport:
         return self.report
+
+    def close(self) -> None:
+        self.aggregator.close()
+        super().close()

--- a/metadata-ingestion/tests/unit/test_clickhouse_usage_source.py
+++ b/metadata-ingestion/tests/unit/test_clickhouse_usage_source.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timezone
 
+import pytest
+
 import datahub.ingestion.source.usage.clickhouse_usage as clickhouse_usage
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.source import SourceReport
@@ -195,6 +197,19 @@ def test_create_builds_source_from_config_dict():
     assert isinstance(source, ClickHouseUsageSource)
     assert isinstance(source.get_report(), SourceReport)
     source.close()
+
+
+def test_query_log_table_rejects_injection():
+    # query_log_table is interpolated into the fetch SQL as an identifier, so a value
+    # carrying SQL punctuation must be rejected rather than concatenated into the query.
+    with pytest.raises(ValueError):
+        ClickHouseUsageConfig.model_validate(
+            {
+                "host_port": "localhost:8123",
+                "email_domain": "example.com",
+                "query_log_table": "system.query_log; DROP TABLE users --",
+            }
+        )
 
 
 def test_make_sql_engine_uses_config_url(monkeypatch):

--- a/metadata-ingestion/tests/unit/test_clickhouse_usage_source.py
+++ b/metadata-ingestion/tests/unit/test_clickhouse_usage_source.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timezone
 
+import datahub.ingestion.source.usage.clickhouse_usage as clickhouse_usage
 from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.source import SourceReport
 from datahub.ingestion.source.usage.clickhouse_usage import (
     ClickHouseUsageConfig,
     ClickHouseUsageSource,
@@ -129,6 +131,29 @@ def test_usage_statistics_generated_via_aggregator(monkeypatch):
     source.close()
 
 
+def test_observed_query_without_username_has_no_user(monkeypatch):
+    rows = [
+        _FakeRow(
+            {
+                "query_id": "q1",
+                "query": "SELECT col_a FROM my_db.events",
+                "username": None,
+                "starttime": datetime(2020, 4, 14, 6, 0, 0),
+                "endtime": datetime(2020, 4, 14, 6, 0, 1),
+                "normalized_query_hash": 12345,
+            }
+        )
+    ]
+    source = _make_source(rows, monkeypatch)
+
+    observed = list(source._get_observed_queries())
+
+    assert len(observed) == 1
+    # No username means no user URN is attributed to the query.
+    assert observed[0].user is None
+    source.close()
+
+
 def test_is_allowed_table_respects_patterns():
     config = ClickHouseUsageConfig.model_validate(
         {
@@ -141,4 +166,38 @@ def test_is_allowed_table_respects_patterns():
 
     assert source._is_allowed_table("my_db.events")
     assert not source._is_allowed_table("system.query_log")
+    source.close()
+
+
+def test_create_builds_source_from_config_dict():
+    source = ClickHouseUsageSource.create(
+        {
+            "host_port": "localhost:8123",
+            "email_domain": "example.com",
+        },
+        PipelineContext(run_id="test"),
+    )
+
+    assert isinstance(source, ClickHouseUsageSource)
+    assert isinstance(source.get_report(), SourceReport)
+    source.close()
+
+
+def test_make_sql_engine_uses_config_url(monkeypatch):
+    captured = {}
+
+    def _fake_create_engine(url, **options):
+        captured["url"] = url
+        captured["options"] = options
+        return "engine-sentinel"
+
+    monkeypatch.setattr(clickhouse_usage, "create_engine", _fake_create_engine)
+
+    source = ClickHouseUsageSource(
+        config=_make_config(), ctx=PipelineContext(run_id="test")
+    )
+
+    assert source._make_sql_engine() == "engine-sentinel"
+    # The engine is built from the config's SQLAlchemy URL.
+    assert captured["url"] == source.config.get_sql_alchemy_url()
     source.close()

--- a/metadata-ingestion/tests/unit/test_clickhouse_usage_source.py
+++ b/metadata-ingestion/tests/unit/test_clickhouse_usage_source.py
@@ -96,7 +96,8 @@ def test_observed_queries_mapping(monkeypatch):
     assert str(observed[0].user) == "urn:li:corpuser:alice@example.com"
     # An address that already contains '@' is used verbatim.
     assert str(observed[1].user) == "urn:li:corpuser:carol@corp.example"
-    # Timestamps are made timezone-aware (UTC).
+    # Naive system.query_log timestamps are tagged as UTC (not reinterpreted as
+    # host-local time), so this holds regardless of the test machine's timezone.
     assert observed[0].timestamp == datetime(2020, 4, 14, 6, 0, 0, tzinfo=timezone.utc)
     # ClickHouse is 2-level; default_db must not be passed to the parser.
     assert observed[0].default_db is None
@@ -154,6 +155,18 @@ def test_observed_query_without_username_has_no_user(monkeypatch):
     source.close()
 
 
+def test_is_allowed_table_default_allows_system():
+    # By default the database_pattern allows everything, so is_allowed_table does not
+    # filter the system database — system queries are excluded by the SQL NOT LIKE
+    # clause when fetching, not here.
+    config = _make_config()
+    source = ClickHouseUsageSource(config=config, ctx=PipelineContext(run_id="test"))
+
+    assert source._is_allowed_table("my_db.events")
+    assert source._is_allowed_table("system.query_log")
+    source.close()
+
+
 def test_is_allowed_table_respects_patterns():
     config = ClickHouseUsageConfig.model_validate(
         {
@@ -165,6 +178,7 @@ def test_is_allowed_table_respects_patterns():
     source = ClickHouseUsageSource(config=config, ctx=PipelineContext(run_id="test"))
 
     assert source._is_allowed_table("my_db.events")
+    # An explicit database deny is what makes is_allowed_table reject system tables.
     assert not source._is_allowed_table("system.query_log")
     source.close()
 

--- a/metadata-ingestion/tests/unit/test_clickhouse_usage_source.py
+++ b/metadata-ingestion/tests/unit/test_clickhouse_usage_source.py
@@ -1,0 +1,144 @@
+from datetime import datetime, timezone
+
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.usage.clickhouse_usage import (
+    ClickHouseUsageConfig,
+    ClickHouseUsageSource,
+)
+from datahub.metadata.schema_classes import DatasetUsageStatisticsClass
+
+
+class _FakeRow:
+    def __init__(self, mapping: dict):
+        self._mapping = mapping
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class _FakeEngine:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def execute(self, *args, **kwargs):
+        return _FakeResult(self._rows)
+
+
+def _make_config():
+    return ClickHouseUsageConfig.model_validate(
+        {
+            "host_port": "localhost:8123",
+            "email_domain": "example.com",
+            "start_time": "2020-04-14T00:00:00Z",
+            "end_time": "2020-04-15T00:00:00Z",
+        }
+    )
+
+
+def _make_source(rows, monkeypatch):
+    source = ClickHouseUsageSource(
+        config=_make_config(),
+        ctx=PipelineContext(run_id="test"),
+    )
+    monkeypatch.setattr(source, "_make_sql_engine", lambda: _FakeEngine(rows))
+    return source
+
+
+def test_observed_queries_mapping(monkeypatch):
+    rows = [
+        _FakeRow(
+            {
+                "query_id": "q1",
+                "query": "SELECT col_a FROM my_db.events",
+                "username": "  alice  ",
+                "starttime": datetime(2020, 4, 14, 6, 0, 0),
+                "endtime": datetime(2020, 4, 14, 6, 0, 1),
+                "normalized_query_hash": 12345,
+            }
+        ),
+        _FakeRow(
+            {
+                "query_id": "q2",
+                "query": "",  # empty query is skipped
+                "username": "bob",
+                "starttime": datetime(2020, 4, 14, 6, 5, 0),
+                "endtime": datetime(2020, 4, 14, 6, 5, 1),
+                "normalized_query_hash": 0,
+            }
+        ),
+        _FakeRow(
+            {
+                "query_id": "q3",
+                "query": "SELECT col_b FROM my_db.events",
+                "username": "carol@corp.example",  # already an email
+                "starttime": datetime(2020, 4, 14, 6, 10, 0),
+                "endtime": datetime(2020, 4, 14, 6, 10, 1),
+                "normalized_query_hash": 67890,
+            }
+        ),
+    ]
+    source = _make_source(rows, monkeypatch)
+
+    observed = list(source._get_observed_queries())
+
+    assert [o.query for o in observed] == [
+        "SELECT col_a FROM my_db.events",
+        "SELECT col_b FROM my_db.events",
+    ]
+    # Username is stripped and the email_domain is appended when absent.
+    assert str(observed[0].user) == "urn:li:corpuser:alice@example.com"
+    # An address that already contains '@' is used verbatim.
+    assert str(observed[1].user) == "urn:li:corpuser:carol@corp.example"
+    # Timestamps are made timezone-aware (UTC).
+    assert observed[0].timestamp == datetime(2020, 4, 14, 6, 0, 0, tzinfo=timezone.utc)
+    # ClickHouse is 2-level; default_db must not be passed to the parser.
+    assert observed[0].default_db is None
+    assert observed[0].query_hash == "12345"
+
+
+def test_usage_statistics_generated_via_aggregator(monkeypatch):
+    rows = [
+        _FakeRow(
+            {
+                "query_id": f"q{i}",
+                "query": "SELECT col_a FROM my_db.events",
+                "username": "alice",
+                "starttime": datetime(2020, 4, 14, 6, 0, 0),
+                "endtime": datetime(2020, 4, 14, 6, 0, 1),
+                "normalized_query_hash": 12345,
+            }
+        )
+        for i in range(3)
+    ]
+    source = _make_source(rows, monkeypatch)
+
+    usage_aspects = [
+        wu.metadata.aspect
+        for wu in source.get_workunits_internal()
+        if isinstance(getattr(wu.metadata, "aspect", None), DatasetUsageStatisticsClass)
+    ]
+
+    assert usage_aspects, "expected DatasetUsageStatistics to be produced"
+    total_query_count = sum(a.totalSqlQueries or 0 for a in usage_aspects)
+    assert total_query_count == 3
+    source.close()
+
+
+def test_is_allowed_table_respects_patterns():
+    config = ClickHouseUsageConfig.model_validate(
+        {
+            "host_port": "localhost:8123",
+            "email_domain": "example.com",
+            "database_pattern": {"deny": ["system"]},
+        }
+    )
+    source = ClickHouseUsageSource(config=config, ctx=PipelineContext(run_id="test"))
+
+    assert source._is_allowed_table("my_db.events")
+    assert not source._is_allowed_table("system.query_log")
+    source.close()


### PR DESCRIPTION
## Summary

`ClickHouseUsageSource` (the standalone `clickhouse-usage` source in `usage/clickhouse_usage.py`) aggregated `system.query_log` SELECT queries with the legacy `GenericAggregatedDataset` from `usage_common`. That computed usage independently of the SQL-parsing path the rest of the ClickHouse connector family now shares — notably the aggregator-based path already living in `sql/clickhouse.py` (`include_usage_statistics` → `generate_usage_statistics=True`).

This migrates the usage source off the legacy aggregator:

- The collected `system.query_log` queries are now fed into a `SqlParsingAggregator` as `ObservedQuery` observations, with `generate_usage_statistics=True` / `generate_query_usage_statistics=True`. Usage is parsed through the same path used for lineage, mirroring the reference `snowflake_queries` / bigquery queries-extractor migrations.
- `DatasetUsageStatistics` (buckets, top users/queries) is produced by the aggregator via the source's existing `BaseUsageConfig` settings (`bucket_duration`, `top_n_queries`, `format_sql_queries`, `include_top_n_queries`, `queries_character_limit`).
- The `email_domain` behavior and `database`/`table`/`view` pattern filtering are preserved — the latter via the aggregator's `is_allowed_table` hook.

**Design decision:** kept `ClickHouseUsageSource` as a standalone source rather than folding it into `sql/clickhouse.py`, to preserve the existing `clickhouse-usage` recipe entry point. It now delegates aggregation to the shared aggregator instead of `GenericAggregatedDataset`.

## Testing

- Added `tests/unit/test_clickhouse_usage_source.py` covering the `query_log` → `ObservedQuery` mapping (username stripping + email-domain, UTC timestamps, no `default_db`, query hash), end-to-end `DatasetUsageStatistics` emission through the aggregator, and pattern-based table filtering.
- `./gradlew :metadata-ingestion:lint` (ruff + mypy) passes.
- Existing `tests/unit/test_clickhouse_source.py` still passes.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [ ] Docs added/updated (n/a — no user-facing config change)
- [ ] Breaking changes documented (n/a — entry point and config preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
