### PR TITLE
feat(graphql): add Metric and SemanticModel entity model, GraphQL schema, and shared edge mapper

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/EdgeMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/EdgeMapper.java
@@ -1,0 +1,72 @@
+package com.linkedin.datahub.graphql.types.common.mappers;
+
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.AuditStamp;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.EntityEdge;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Maps {@link com.linkedin.common.Edge} Pegasus records to the generated GraphQL {@link
+ * EntityEdge}.
+ */
+@Slf4j
+public class EdgeMapper {
+
+  private EdgeMapper() {}
+
+  /**
+   * Maps a single PDL {@link com.linkedin.common.Edge} to a GraphQL {@link EntityEdge}. Returns
+   * {@code null} when the destination URN cannot be resolved (unknown entity type).
+   */
+  @Nullable
+  public static EntityEdge map(
+      @Nullable QueryContext context, @Nonnull com.linkedin.common.Edge edge) {
+    Entity destination = UrnToEntityMapper.map(context, edge.getDestinationUrn());
+    if (destination == null) {
+      log.warn(
+          "EdgeMapper: could not resolve destination URN {} — skipping edge",
+          edge.getDestinationUrn());
+      return null;
+    }
+
+    EntityEdge result = new EntityEdge();
+    result.setDestination(destination);
+
+    if (edge.hasCreated() && edge.getCreated() != null) {
+      AuditStamp created = AuditStampMapper.map(context, edge.getCreated());
+      result.setCreated(created);
+    }
+    if (edge.hasLastModified() && edge.getLastModified() != null) {
+      AuditStamp lastModified = AuditStampMapper.map(context, edge.getLastModified());
+      result.setLastModified(lastModified);
+    }
+    if (edge.hasProperties() && edge.getProperties() != null) {
+      result.setProperties(StringMapMapper.map(context, edge.getProperties()));
+    }
+
+    return result;
+  }
+
+  /**
+   * Maps a list of PDL {@link com.linkedin.common.Edge} objects, drops and warns any whose
+   * destination cannot be resolved.
+   */
+  @Nonnull
+  public static List<EntityEdge> mapList(
+      @Nullable QueryContext context, @Nullable List<com.linkedin.common.Edge> edges) {
+    if (edges == null) {
+      return Collections.emptyList();
+    }
+    return edges.stream()
+        .map(e -> map(context, e))
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/UrnToEntityMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/UrnToEntityMapper.java
@@ -37,6 +37,7 @@ import com.linkedin.datahub.graphql.generated.MLFeatureTable;
 import com.linkedin.datahub.graphql.generated.MLModel;
 import com.linkedin.datahub.graphql.generated.MLModelGroup;
 import com.linkedin.datahub.graphql.generated.MLPrimaryKey;
+import com.linkedin.datahub.graphql.generated.Metric;
 import com.linkedin.datahub.graphql.generated.Notebook;
 import com.linkedin.datahub.graphql.generated.OwnershipTypeEntity;
 import com.linkedin.datahub.graphql.generated.Post;
@@ -44,6 +45,7 @@ import com.linkedin.datahub.graphql.generated.QueryEntity;
 import com.linkedin.datahub.graphql.generated.Restricted;
 import com.linkedin.datahub.graphql.generated.Role;
 import com.linkedin.datahub.graphql.generated.SchemaFieldEntity;
+import com.linkedin.datahub.graphql.generated.SemanticModel;
 import com.linkedin.datahub.graphql.generated.StructuredPropertyEntity;
 import com.linkedin.datahub.graphql.generated.Tag;
 import com.linkedin.datahub.graphql.generated.Test;
@@ -272,6 +274,16 @@ public class UrnToEntityMapper implements ModelMapper<com.linkedin.common.urn.Ur
       partialEntity = new Document();
       ((Document) partialEntity).setUrn(input.toString());
       ((Document) partialEntity).setType(EntityType.DOCUMENT);
+    }
+    if (input.getEntityType().equals(METRIC_ENTITY_NAME)) {
+      partialEntity = new Metric();
+      ((Metric) partialEntity).setUrn(input.toString());
+      ((Metric) partialEntity).setType(EntityType.METRIC);
+    }
+    if (input.getEntityType().equals(SEMANTIC_MODEL_ENTITY_NAME)) {
+      partialEntity = new SemanticModel();
+      ((SemanticModel) partialEntity).setUrn(input.toString());
+      ((SemanticModel) partialEntity).setType(EntityType.SEMANTIC_MODEL);
     }
     return partialEntity;
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/entitytype/EntityTypeMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/entitytype/EntityTypeMapper.java
@@ -61,6 +61,8 @@ public class EntityTypeMapper {
           .put(EntityType.DATA_CONTRACT, Constants.DATA_CONTRACT_ENTITY_NAME)
           .put(EntityType.APPLICATION, Constants.APPLICATION_ENTITY_NAME)
           .put(EntityType.DOCUMENT, Constants.DOCUMENT_ENTITY_NAME)
+          .put(EntityType.METRIC, Constants.METRIC_ENTITY_NAME)
+          .put(EntityType.SEMANTIC_MODEL, Constants.SEMANTIC_MODEL_ENTITY_NAME)
           .build();
 
   private static final Map<String, EntityType> ENTITY_NAME_TO_TYPE =

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/entitytype/EntityTypeUrnMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/entitytype/EntityTypeUrnMapper.java
@@ -80,6 +80,8 @@ public class EntityTypeUrnMapper {
               "urn:li:entityType:datahub.businessAttribute")
           .put(Constants.APPLICATION_ENTITY_NAME, "urn:li:entityType:datahub.application")
           .put(Constants.DOCUMENT_ENTITY_NAME, "urn:li:entityType:datahub.document")
+          .put(Constants.METRIC_ENTITY_NAME, "urn:li:entityType:datahub.metric")
+          .put(Constants.SEMANTIC_MODEL_ENTITY_NAME, "urn:li:entityType:datahub.semanticModel")
           .build();
 
   private static final Map<String, String> ENTITY_TYPE_URN_TO_NAME =

--- a/datahub-graphql-core/src/main/resources/common.graphql
+++ b/datahub-graphql-core/src/main/resources/common.graphql
@@ -47,3 +47,14 @@ type MetadataAttribution {
   """
   sourceDetail: [StringMapEntry!]
 }
+
+"""
+A generic aspect-stored edge: resolved destination entity, optional audit
+stamps, and a free-form properties bag. Backed by com.linkedin.common.Edge.
+"""
+type EntityEdge {
+  destination: Entity!
+  created: AuditStamp
+  lastModified: AuditStamp
+  properties: [StringMapEntry!]
+}

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -1404,6 +1404,16 @@ enum EntityType {
   An DataHub File
   """
   DATAHUB_FILE
+
+  """
+  A Metric entity from a semantic layer or metric store.
+  """
+  METRIC
+
+  """
+  A Semantic Model entity that groups datasets and defines metrics context.
+  """
+  SEMANTIC_MODEL
 }
 
 """

--- a/datahub-graphql-core/src/main/resources/metrics.graphql
+++ b/datahub-graphql-core/src/main/resources/metrics.graphql
@@ -1,0 +1,504 @@
+extend type Query {
+  """
+  Fetch a Metric by URN.
+  """
+  metric(urn: String!): Metric
+
+  """
+  Fetch a SemanticModel by URN.
+  """
+  semanticModel(urn: String!): SemanticModel
+
+  """
+  List root-level Metrics (paginated).
+  """
+  getRootMetrics(input: GetRootEntitiesInput!): GetRootMetricsResult
+
+  """
+  List root-level SemanticModels (paginated).
+  """
+  getRootSemanticModels(
+    input: GetRootEntitiesInput!
+  ): GetRootSemanticModelsResult
+}
+
+"""
+Shared pagination input for root-entity listing queries.
+"""
+input GetRootEntitiesInput {
+  start: Int = 0
+  count: Int = 25
+  query: String = "*"
+}
+
+type GetRootMetricsResult {
+  metrics: [Metric!]!
+  start: Int!
+  count: Int!
+  total: Int!
+}
+
+type GetRootSemanticModelsResult {
+  semanticModels: [SemanticModel!]!
+  start: Int!
+  count: Int!
+  total: Int!
+}
+
+"""
+A Metric entity from a semantic layer or metric store.
+"""
+type Metric implements Entity {
+  """
+  The primary key of the Metric.
+  """
+  urn: String!
+
+  """
+  A standard Entity Type.
+  """
+  type: EntityType!
+
+  """
+  The timestamp of the last time this Metric was ingested.
+  """
+  lastIngested: Long
+
+  """
+  The platform that this Metric originates in.
+  """
+  platform: DataPlatform!
+
+  """
+  The path component of the three-part key (platform, path, id).
+  """
+  path: String!
+
+  """
+  The id component of the three-part key (platform, path, id).
+  """
+  id: String!
+
+  """
+  Core information about the Metric.
+  """
+  info: MetricInfo
+
+  """
+  Relationships to other Metrics.
+  """
+  metricRelationships: MetricRelationships
+
+  """
+  Upstream datasets and schema fields consumed by this Metric.
+  """
+  metricUpstreams: MetricUpstreams
+
+  """
+  The SemanticModel that defines this Metric.
+  """
+  semanticModel: SemanticModel
+
+  """
+  Parent metrics in the metric hierarchy.
+  """
+  parentMetrics: ParentMetricsResult
+
+  """
+  Child metrics in the metric hierarchy.
+  """
+  childMetrics(input: ScrollAcrossEntitiesInput!): ScrollResults
+
+  """
+  Ownership metadata of the Metric.
+  """
+  ownership: Ownership
+
+  """
+  The browse path V2 corresponding to this entity.
+  """
+  browsePathV2: BrowsePathV2
+
+  """
+  Tags applied to the Metric.
+  """
+  tags: GlobalTags
+
+  """
+  Glossary terms associated with the Metric.
+  """
+  glossaryTerms: GlossaryTerms
+
+  """
+  The Domain associated with the Metric.
+  """
+  domain: DomainAssociation
+
+  """
+  References to internal resources related to the Metric.
+  """
+  institutionalMemory: InstitutionalMemory
+
+  """
+  Structured properties about this asset.
+  """
+  structuredProperties: StructuredProperties
+
+  """
+  Status of this Metric (soft-deleted, etc.).
+  """
+  status: Status
+
+  """
+  Deprecation metadata for this Metric.
+  """
+  deprecation: Deprecation
+
+  """
+  Data Platform Instance associated with the Metric.
+  """
+  dataPlatformInstance: DataPlatformInstance
+
+  """
+  Sub-types associated with this entity.
+  """
+  subTypes: SubTypes
+
+  """
+  Documentation aspect containing editable description for this Metric.
+  """
+  documentation: Documentation
+
+  """
+  Applications associated with this Metric.
+  """
+  applications: EntityRelationshipsResult
+
+  """
+  Privileges given to a user relevant to this entity.
+  """
+  privileges: EntityPrivileges
+
+  """
+  Whether or not this entity exists on DataHub.
+  """
+  exists: Boolean
+
+  """
+  Edges extending from this entity.
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
+}
+
+"""
+A Semantic Model entity that groups datasets and defines metrics context.
+"""
+type SemanticModel implements Entity {
+  """
+  The primary key of the SemanticModel.
+  """
+  urn: String!
+
+  """
+  A standard Entity Type.
+  """
+  type: EntityType!
+
+  """
+  The timestamp of the last time this SemanticModel was ingested.
+  """
+  lastIngested: Long
+
+  """
+  The platform that this SemanticModel originates in.
+  """
+  platform: DataPlatform!
+
+  """
+  The path component of the three-part key (platform, path, id).
+  """
+  path: String!
+
+  """
+  The id component of the three-part key (platform, path, id).
+  """
+  id: String!
+
+  """
+  Core information about the SemanticModel.
+  """
+  info: SemanticModelInfo
+
+  """
+  Column-level lineage from the upstreamLineage aspect.
+  Table-level lineage is surfaced via the standard relationships field.
+  """
+  fineGrainedLineages: [FineGrainedLineage!]
+
+  """
+  Metrics defined within this SemanticModel (field-resolver in CAT-2566).
+  """
+  metrics(input: ScrollAcrossEntitiesInput!): ScrollResults
+
+  """
+  Count of Metrics defined within this SemanticModel (field-resolver in CAT-2566).
+  """
+  metricsCount: SemanticModelMetricsCount
+
+  """
+  Ownership metadata of the SemanticModel.
+  """
+  ownership: Ownership
+
+  """
+  The browse path V2 corresponding to this entity.
+  """
+  browsePathV2: BrowsePathV2
+
+  """
+  Tags applied to the SemanticModel.
+  """
+  tags: GlobalTags
+
+  """
+  Glossary terms associated with the SemanticModel.
+  """
+  glossaryTerms: GlossaryTerms
+
+  """
+  The Domain associated with the SemanticModel.
+  """
+  domain: DomainAssociation
+
+  """
+  References to internal resources related to the SemanticModel.
+  """
+  institutionalMemory: InstitutionalMemory
+
+  """
+  Structured properties about this asset.
+  """
+  structuredProperties: StructuredProperties
+
+  """
+  Status of this SemanticModel (soft-deleted, etc.).
+  """
+  status: Status
+
+  """
+  Deprecation metadata for this SemanticModel.
+  """
+  deprecation: Deprecation
+
+  """
+  Data Platform Instance associated with the SemanticModel.
+  """
+  dataPlatformInstance: DataPlatformInstance
+
+  """
+  Sub-types associated with this entity.
+  """
+  subTypes: SubTypes
+
+  """
+  Documentation aspect containing editable description for this SemanticModel.
+  """
+  documentation: Documentation
+
+  """
+  Applications associated with this SemanticModel.
+  """
+  applications: EntityRelationshipsResult
+
+  """
+  Privileges given to a user relevant to this entity.
+  """
+  privileges: EntityPrivileges
+
+  """
+  Whether or not this entity exists on DataHub.
+  """
+  exists: Boolean
+
+  """
+  Edges extending from this entity.
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
+}
+
+"""
+Core information about a Metric.
+"""
+type MetricInfo {
+  name: String!
+  description: String
+  created: ResolvedAuditStamp
+  lastModified: ResolvedAuditStamp
+  expression: MetricExpression
+  aiContext: AiContext
+}
+
+"""
+Relationship edges from a Metric to other Metrics.
+"""
+type MetricRelationships {
+  """
+  The immediate parent in the metric hierarchy.
+  """
+  parentMetric: Metric
+
+  """
+  Edges to metrics that this metric is derived from.
+  """
+  derivedFrom: [EntityEdge!]!
+
+  """
+  Edges to metrics that are related to this metric.
+  """
+  relatedMetrics: [EntityEdge!]!
+}
+
+"""
+Upstream lineage for a Metric: datasets and schema fields it consumes.
+"""
+type MetricUpstreams {
+  """
+  Dataset-level upstream edges.
+  """
+  datasetUpstreams: [EntityEdge!]
+
+  """
+  Schema-field-level upstream edges.
+  """
+  fieldUpstreams: [EntityEdge!]
+}
+
+"""
+Core information about a SemanticModel.
+"""
+type SemanticModelInfo {
+  name: String!
+  description: String
+  created: ResolvedAuditStamp
+  lastModified: ResolvedAuditStamp
+  """
+  The native definition of the semantic model (e.g., YAML config, SQL DDL).
+  """
+  nativeDefinition: String
+  aiContext: AiContext
+  datasets: [ModelDataset!]!
+  relationships: [SemanticModelRelationship!]
+}
+
+"""
+A logical dataset referenced by a SemanticModel. `source` may be a Dataset
+(the common case) or a Query (inline SQL with no backing table).
+"""
+type ModelDataset {
+  name: String!
+  """
+  The backing entity — a Dataset or a Query — resolved via UrnToEntityMapper.
+  """
+  source: Entity!
+  fields: [SemanticField!]
+}
+
+"""
+A field (dimension, measure, filter, or other) exposed by a semantic model dataset.
+The `type` discriminator is required and determines whether `dimension` is populated.
+Identity and governance surface (fieldPath, description, tags, glossaryTerms, etc.)
+live on the inline `schemaField`.
+"""
+type SemanticField {
+  schemaField: SchemaField!
+  type: SemanticFieldType!
+  expression: MetricExpression!
+  dimension: Dimension
+  aiContext: AiContext
+}
+
+"""
+Discriminator for a SemanticField indicating its role in the semantic model.
+"""
+enum SemanticFieldType {
+  DIMENSION
+  MEASURE
+  FILTER
+  OTHER
+}
+
+"""
+Additional metadata for a dimension-type SemanticField.
+"""
+type Dimension {
+  isTime: Boolean!
+}
+
+"""
+A join relationship between two datasets within a SemanticModel.
+"""
+type SemanticModelRelationship {
+  name: String
+  from: String!
+  fromColumns: [String!]!
+  to: String!
+  toColumns: [String!]!
+  """
+  Reuses the ERModelRelationshipCardinality enum defined in entity.graphql.
+  """
+  cardinality: ERModelRelationshipCardinality
+  aiContext: AiContext
+}
+
+"""
+A SQL or dialect-specific expression backing a Metric or SemanticField.
+"""
+type MetricExpression {
+  dialects: [DialectExpression!]!
+}
+
+"""
+A dialect-specific expression string.
+"""
+type DialectExpression {
+  dialect: Dialect!
+  expression: String!
+}
+
+"""
+SQL dialects supported for metric and field expressions.
+"""
+enum Dialect {
+  ANSI_SQL
+  SNOWFLAKE
+  MDX
+  TABLEAU
+  DATABRICKS
+  MAQL
+  OTHER
+}
+
+"""
+AI/LLM context attached to a Metric, SemanticField, or SemanticModelRelationship
+to improve natural-language understanding and query generation.
+"""
+type AiContext {
+  synonyms: [String!]
+  instructions: String
+  examples: [String!]
+  customInstructions: String
+}
+
+"""
+The ordered chain of ancestor metrics from direct parent up to the root.
+"""
+type ParentMetricsResult {
+  metrics: [Metric!]!
+}
+
+"""
+Count of Metrics associated with a SemanticModel.
+"""
+type SemanticModelMetricsCount {
+  total: Int!
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/common/mappers/EdgeMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/common/mappers/EdgeMapperTest.java
@@ -1,0 +1,111 @@
+package com.linkedin.datahub.graphql.types.common.mappers;
+
+import static org.testng.Assert.*;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.Edge;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.StringMap;
+import com.linkedin.datahub.graphql.generated.EntityEdge;
+import com.linkedin.datahub.graphql.generated.StringMapEntry;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.testng.annotations.Test;
+
+public class EdgeMapperTest {
+
+  private static final String DATASET_URN =
+      "urn:li:dataset:(urn:li:dataPlatform:mysql,db.table,PROD)";
+  private static final String ACTOR_URN = "urn:li:corpuser:test";
+  private static final long TIMESTAMP = 1_000_000L;
+
+  @Test
+  public void testMapResolvableDestination() throws URISyntaxException {
+    Edge edge = new Edge().setDestinationUrn(Urn.createFromString(DATASET_URN));
+
+    EntityEdge result = EdgeMapper.map(null, edge);
+
+    assertNotNull(result);
+    assertNotNull(result.getDestination());
+    assertEquals(result.getDestination().getUrn(), DATASET_URN);
+  }
+
+  @Test
+  public void testMapUnresolvableDestinationReturnsNull() throws URISyntaxException {
+    // "unknownEntity" is not handled by UrnToEntityMapper, so destination resolves to null.
+    Edge edge = new Edge().setDestinationUrn(Urn.createFromString("urn:li:unknownEntity:someId"));
+
+    EntityEdge result = EdgeMapper.map(null, edge);
+
+    assertNull(result);
+  }
+
+  @Test
+  public void testMapListFiltersUnresolvableEdges() throws URISyntaxException {
+    Edge resolvable = new Edge().setDestinationUrn(Urn.createFromString(DATASET_URN));
+    Edge unresolvable =
+        new Edge().setDestinationUrn(Urn.createFromString("urn:li:unknownEntity:someId"));
+
+    List<EntityEdge> results = EdgeMapper.mapList(null, Arrays.asList(resolvable, unresolvable));
+
+    assertEquals(results.size(), 1);
+    assertEquals(results.get(0).getDestination().getUrn(), DATASET_URN);
+  }
+
+  @Test
+  public void testMapListNullReturnsEmpty() {
+    List<EntityEdge> results = EdgeMapper.mapList(null, null);
+    assertNotNull(results);
+    assertTrue(results.isEmpty());
+  }
+
+  @Test
+  public void testMapListEmptyReturnsEmpty() {
+    List<EntityEdge> results = EdgeMapper.mapList(null, Collections.emptyList());
+    assertNotNull(results);
+    assertTrue(results.isEmpty());
+  }
+
+  @Test
+  public void testMapAuditStamps() throws URISyntaxException {
+    AuditStamp created =
+        new AuditStamp().setActor(Urn.createFromString(ACTOR_URN)).setTime(TIMESTAMP);
+    AuditStamp lastModified =
+        new AuditStamp().setActor(Urn.createFromString(ACTOR_URN)).setTime(TIMESTAMP + 1_000L);
+
+    Edge edge =
+        new Edge()
+            .setDestinationUrn(Urn.createFromString(DATASET_URN))
+            .setCreated(created)
+            .setLastModified(lastModified);
+
+    EntityEdge result = EdgeMapper.map(null, edge);
+
+    assertNotNull(result);
+    assertNotNull(result.getCreated());
+    assertEquals(result.getCreated().getActor(), ACTOR_URN);
+    assertEquals((long) result.getCreated().getTime(), TIMESTAMP);
+    assertNotNull(result.getLastModified());
+    assertEquals(result.getLastModified().getActor(), ACTOR_URN);
+    assertEquals((long) result.getLastModified().getTime(), TIMESTAMP + 1_000L);
+  }
+
+  @Test
+  public void testMapProperties() throws URISyntaxException {
+    StringMap props = new StringMap();
+    props.put("key1", "value1");
+    Edge edge =
+        new Edge().setDestinationUrn(Urn.createFromString(DATASET_URN)).setProperties(props);
+
+    EntityEdge result = EdgeMapper.map(null, edge);
+
+    assertNotNull(result);
+    List<StringMapEntry> entries = result.getProperties();
+    assertNotNull(entries);
+    assertEquals(entries.size(), 1);
+    assertEquals(entries.get(0).getKey(), "key1");
+    assertEquals(entries.get(0).getValue(), "value1");
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/entitytype/EntityTypeUrnMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/entitytype/EntityTypeUrnMapperTest.java
@@ -27,4 +27,23 @@ public class EntityTypeUrnMapperTest {
         EntityTypeUrnMapper.getEntityTypeUrn(Constants.DATASET_ENTITY_NAME),
         "urn:li:entityType:datahub.dataset");
   }
+
+  @Test
+  public void testMetricRoundTrip() throws Exception {
+    final String metricUrn = "urn:li:entityType:datahub.metric";
+    assertEquals(EntityTypeUrnMapper.getName(metricUrn), Constants.METRIC_ENTITY_NAME);
+    assertEquals(EntityTypeUrnMapper.getEntityType(metricUrn), EntityType.METRIC);
+    assertEquals(EntityTypeUrnMapper.getEntityTypeUrn(Constants.METRIC_ENTITY_NAME), metricUrn);
+  }
+
+  @Test
+  public void testSemanticModelRoundTrip() throws Exception {
+    final String semanticModelUrn = "urn:li:entityType:datahub.semanticModel";
+    assertEquals(
+        EntityTypeUrnMapper.getName(semanticModelUrn), Constants.SEMANTIC_MODEL_ENTITY_NAME);
+    assertEquals(EntityTypeUrnMapper.getEntityType(semanticModelUrn), EntityType.SEMANTIC_MODEL);
+    assertEquals(
+        EntityTypeUrnMapper.getEntityTypeUrn(Constants.SEMANTIC_MODEL_ENTITY_NAME),
+        semanticModelUrn);
+  }
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
@@ -11,9 +11,7 @@ import com.linkedin.schema.SchemaField
 record SemanticField {
 
   /**
-   * Inline SchemaField describing this field's schema and identity.
-   * Its `fieldPath` composes into `urn:li:schemaField:(<parentSemanticModelUrn>,<fieldPath>)`,
-   * which serves as the endpoint for column-level lineage edges and as the anchor for
+   * Inline SchemaField describing this field's schema and identity for column-level lineage edges and as the anchor for
    * column-level governance (tags, glossary terms, description).
    */
   schemaField: SchemaField

--- a/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
@@ -11,7 +11,9 @@ import com.linkedin.schema.SchemaField
 record SemanticField {
 
   /**
-   * Inline SchemaField describing this field's schema and identity for column-level lineage edges and as the anchor for
+   * Inline SchemaField describing this field's schema and identity.
+   * Its `fieldPath` composes into `urn:li:schemaField:(<parentSemanticModelUrn>,<fieldPath>)`,
+   * which serves as the endpoint for column-level lineage edges and as the anchor for
    * column-level governance (tags, glossary terms, description).
    */
   schemaField: SchemaField


### PR DESCRIPTION
## Summary

- Adds `metrics.graphql` with the full GraphQL contract for the `Metric` and `SemanticModel` entities (entity types, aspect types, root queries).
- Extends `entity.graphql` with `METRIC` and `SEMANTIC_MODEL` enum members and relocates `EntityEdge` to `common.graphql`.
- Adds `EdgeMapper` to map PDL `Edge` → GraphQL `EntityEdge`.
- Extends `UrnToEntityMapper`, `EntityTypeMapper`, and `EntityTypeUrnMapper` with `metric` / `semanticModel` entries.

**Resolvers and `GmsGraphQLEngine` wiring are intentionally deferred to a follow-up PR.** The new query fields in `metrics.graphql` are not registered with the engine and are therefore not served at runtime, so there is no risk of missing-resolver failures.

## Test plan

- [ ] `EdgeMapperTest` (new): resolvable destination sets `EntityEdge.destination`; unresolvable destination returns `null`; `mapList` filters out nulls; audit stamps and properties are forwarded correctly.
- [ ] `EntityTypeUrnMapperTest` (extended): `metric` and `semanticModel` round-trip via `getName` / `getEntityType` / `getEntityTypeUrn`.
- [ ] `./gradlew :datahub-graphql-core:build` passes (codegen + compile + all tests green).

## Checklist

- [x] PR conforms to the Contributing Guideline
- [x] Tests added/updated
- [ ] No breaking changes (resolvers deferred; no runtime schema change)

Made with [Cursor](https://cursor.com)