### PR TITLE
fix(ingest/datapack): retry transient HTTP errors when fetching datapack files

### DIFF
--- a/metadata-ingestion/src/datahub/cli/datapack/loader.py
+++ b/metadata-ingestion/src/datahub/cli/datapack/loader.py
@@ -17,7 +17,9 @@ from urllib.parse import urlparse
 
 import click
 import requests
+from requests.adapters import HTTPAdapter
 from typing_extensions import NotRequired, TypedDict
+from urllib3.util.retry import Retry
 
 from datahub.cli.config_utils import DATAHUB_ROOT_FOLDER, load_client_config
 from datahub.cli.datapack.models import DataPackInfo, LoadRecord, TrustTier
@@ -32,6 +34,30 @@ CACHE_DIR = os.path.join(DATAHUB_ROOT_FOLDER, "datapack-cache")
 LOADS_DIR = os.path.join(DATAHUB_ROOT_FOLDER, "datapack-loads")
 
 EMIT_MODE_ENV = "DATAHUB_EMIT_MODE"
+
+# Datapack files are fetched from a public host (e.g. raw.githubusercontent.com)
+# that rate-limits with HTTP 429 under load. Without retries a transient 429
+# silently drops a file and produces a partial, broken load. Retry transient
+# statuses with backoff (urllib3 also honors Retry-After for 429/503).
+_FETCH_RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
+_FETCH_RETRY_TOTAL = 5
+_FETCH_RETRY_BACKOFF_FACTOR = 1.0
+
+
+def _build_fetch_session() -> requests.Session:
+    """A requests session that retries transient HTTP errors with backoff."""
+    retry = Retry(
+        total=_FETCH_RETRY_TOTAL,
+        status_forcelist=list(_FETCH_RETRY_STATUSES),
+        allowed_methods=frozenset({"GET"}),
+        backoff_factor=_FETCH_RETRY_BACKOFF_FACTOR,
+        respect_retry_after_header=True,
+    )
+    session = requests.Session()
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
 
 
 def _cache_key(url: str) -> str:
@@ -76,21 +102,22 @@ def _fetch_url_to_path(url: str, dest: pathlib.Path) -> None:
             raise click.ClickException(f"Local file not found: {local_path}")
         shutil.copy2(local_path, dest)
     else:
-        response = requests.get(url, stream=True, timeout=120)
-        response.raise_for_status()
+        with _build_fetch_session() as session:
+            response = session.get(url, stream=True, timeout=120)
+            response.raise_for_status()
 
-        content_length = response.headers.get("content-length")
-        total = int(content_length) if content_length else None
+            content_length = response.headers.get("content-length")
+            total = int(content_length) if content_length else None
 
-        with open(dest, "wb") as f:
-            if total:
-                with click.progressbar(length=total, label="Downloading") as bar:
+            with open(dest, "wb") as f:
+                if total:
+                    with click.progressbar(length=total, label="Downloading") as bar:
+                        for chunk in response.iter_content(chunk_size=8192):
+                            f.write(chunk)
+                            bar.update(len(chunk))
+                else:
                     for chunk in response.iter_content(chunk_size=8192):
                         f.write(chunk)
-                        bar.update(len(chunk))
-            else:
-                for chunk in response.iter_content(chunk_size=8192):
-                    f.write(chunk)
 
 
 def _cached_index_version(pack: DataPackInfo) -> Optional[str]:

--- a/metadata-ingestion/tests/unit/cli/datapack/test_loader.py
+++ b/metadata-ingestion/tests/unit/cli/datapack/test_loader.py
@@ -15,6 +15,7 @@ from datahub.cli.datapack.loader import (
     IndexFileEntry,
     _apply_schema_filter,
     _build_datapack_sink_config,
+    _build_fetch_session,
     _cache_key,
     _cached_path,
     _datapack_emit_mode,
@@ -33,6 +34,18 @@ from datahub.cli.datapack.loader import (
 from datahub.cli.datapack.models import DataPackInfo, TrustTier
 from datahub.ingestion.graph.config import DatahubClientConfig
 from datahub.ingestion.graph.entity_aspect_specs import EntityAspectSpecs
+
+
+class TestFetchSession:
+    def test_retries_transient_statuses_with_backoff(self) -> None:
+        # Guards the fix for CDN rate-limiting: a transient 429 must be retried
+        # instead of silently dropping a datapack file into a broken load.
+        session = _build_fetch_session()
+        retry = session.get_adapter("https://raw.githubusercontent.com/x").max_retries
+        assert 429 in retry.status_forcelist
+        assert {500, 502, 503, 504}.issubset(set(retry.status_forcelist))
+        assert retry.total and retry.total >= 1
+        assert retry.backoff_factor > 0
 
 
 class TestDatapackSinkConfig:

--- a/metadata-ingestion/tests/unit/cli/datapack/test_loader.py
+++ b/metadata-ingestion/tests/unit/cli/datapack/test_loader.py
@@ -9,6 +9,8 @@ from unittest.mock import MagicMock, patch
 
 import click
 import pytest
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from datahub.cli.datapack.loader import (
     EMIT_MODE_ENV,
@@ -41,10 +43,12 @@ class TestFetchSession:
         # Guards the fix for CDN rate-limiting: a transient 429 must be retried
         # instead of silently dropping a datapack file into a broken load.
         session = _build_fetch_session()
-        retry = session.get_adapter("https://raw.githubusercontent.com/x").max_retries
-        assert 429 in retry.status_forcelist
-        assert {500, 502, 503, 504}.issubset(set(retry.status_forcelist))
-        assert retry.total and retry.total >= 1
+        adapter = session.get_adapter("https://raw.githubusercontent.com/x")
+        assert isinstance(adapter, HTTPAdapter)
+        retry = adapter.max_retries
+        assert isinstance(retry, Retry)
+        assert {429, 500, 502, 503, 504}.issubset(set(retry.status_forcelist or []))
+        assert retry.total is not None and retry.total >= 1
         assert retry.backoff_factor > 0
 
 


### PR DESCRIPTION
## Summary

`datahub datapack load` fetches pack definition files from a public host (`raw.githubusercontent.com`) at load time. That host rate-limits with **HTTP 429** under load, and the fetch had **no retries** — a single transient 429 was swallowed by `_resolve_index_file`, so the pack loaded *without* those definition files and cascaded into a large batch of downstream record-write failures.

This surfaced as a flaky `Docker Build, Scan, Test` smoke-test failure on `master`: the `showcase-ecommerce` datapack load in `TestShowcaseData` failed setup after 429s on `01-definitions.json` / `03-context.json`, producing ~500 `failed to write record` errors and, via `pytest-rerunfailures`, an `assert not self._finalizers` error on all 4 tests. The run recovered on a GitHub re-run once the rate limit reset — i.e. transient.

## What changed

- Fetch datapack files through a `requests` session backed by a `urllib3` `Retry`: retry on `429/500/502/503/504` with exponential backoff, honoring `Retry-After`.
- Reuses the retry pattern already used by the Superset/Mode/Redash sources.
- Added a guardrail unit test asserting the fetch session retries those transient statuses with backoff.

## Testing

- `./gradlew :metadata-ingestion:lintFix` — clean (ruff + mypy)
- `pytest tests/unit/cli/datapack/test_loader.py` — passing

## Follow-up (not in this PR)

`_resolve_index_file` still swallows a fetch failure and proceeds with a partial pack. Even with retries exhausted, that reproduces the same confusing write-error cascade instead of a clean "couldn't fetch required file" error. Worth a separate change to fail fast on required files.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added
- [ ] Docs — n/a
- [ ] Breaking changes — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)