### PR TITLE
ci(smoke-test): write pytest logs to a file, upload as artifact on failure

### DIFF
--- a/.github/workflows/docker-unified-nightly.yml
+++ b/.github/workflows/docker-unified-nightly.yml
@@ -432,6 +432,13 @@ jobs:
           name: docker-logs-${{ matrix.profile }}-${{ matrix.test_strategy }}-${{ matrix.architecture }}
           path: "docker_logs/*.log"
           retention-days: 5
+      - name: Upload pytest logs
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: failure()
+        with:
+          name: pytest-smoke-logs-${{ matrix.profile }}-${{ matrix.test_strategy }}-${{ matrix.architecture }}
+          path: "smoke-test/test-results/pytest-smoke.log"
+          retention-days: 5
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -803,6 +803,14 @@ jobs:
           path: "docker_logs/*.log"
           retention-days: 5
 
+      - name: Upload pytest logs
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: failure()
+        with:
+          name: pytest-smoke-logs-pytests-${{ matrix.batch }}
+          path: "smoke-test/test-results/pytest-smoke.log"
+          retention-days: 5
+
       - name: Report test results
         if: (!cancelled())
         uses: ./.github/actions/report-test-results

--- a/smoke-test/pyproject.toml
+++ b/smoke-test/pyproject.toml
@@ -79,7 +79,7 @@ disallow_incomplete_defs = false
 disallow_untyped_defs = false
 
 [tool.pytest.ini_options]
-addopts = "-s -v --junit-xml=test-results/junit.smoke.xml"
+addopts = "-v --junit-xml=test-results/junit.smoke.xml"
 junit_suite_name = "smoke-test-pytest"
 markers = [
     "read_only: marks tests as read only (deselect with '-m \"not read_only\"')",
@@ -97,5 +97,9 @@ filterwarnings = [
 log_level = "INFO"
 log_format = "%(asctime)s - %(name)s - %(funcName)s - %(levelname)s - %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"
+# Write INFO-level test logs to a file (uploaded as a CI artifact on failure).
+# log_file_format/log_file_date_format inherit from log_format/log_date_format above.
+log_file = "test-results/pytest-smoke.log"
+log_file_level = "INFO"
 # Note: log_cli is intentionally NOT configured to avoid interfering with
 # click.testing.CliRunner output capture in CLI command tests

--- a/smoke-test/smoke.sh
+++ b/smoke-test/smoke.sh
@@ -46,7 +46,7 @@ echo "TEST_STRATEGY: $TEST_STRATEGY, BATCH_COUNT: $BATCH_COUNT, BATCH_NUMBER: $B
 # increase, the batch_count config (in docker-unified.yml) may need adjustment.
 if [[ "${TEST_STRATEGY}" == "pytests" ]]; then
   #pytests only - github test matrix runs pytests in one of the runners when applicable.
-  pytest -rP --durations=20 -vv --continue-on-collection-errors --reruns 1 --reruns-delay 1 --junit-xml=junit.smoke-pytests.xml -k 'not test_run_cypress'
+  pytest -ra -vv --reruns 1 --reruns-delay 1 --junit-xml=junit.smoke-pytests.xml -k 'not test_run_cypress'
 elif [[ "${TEST_STRATEGY}" == "cypress" ]]; then
   # run only cypress tests. The test inspects BATCH_COUNT and BATCH_NUMBER and runs only a subset of tests in that batch.
   # github workflow test matrix will invoke this in multiple runners for each batch.


### PR DESCRIPTION
## Summary

The Pytest Smoke Tests job dumps a lot of output straight to the CLI (via `-s`, `-rP`, `--durations`), where it scrolls away and isn't recoverable after the run. This routes the smoke-test pytest logs to a file and uploads that file as a CI artifact on failure, and trims the noisiest flags.

### Changes

- **`smoke-test/pyproject.toml`**
  - Drop `-s` from `addopts` so capture is on for the `pytests` run — failed tests now show `Captured stdout/stderr/log` sections. (The `cypress`/`all` branches keep their own `-s` via `-vvs`, so they're unaffected. `CliRunner`-based CLI tests verified to work with capture on.)
  - Write INFO-level test logs to `test-results/pytest-smoke.log` via `log_file` / `log_file_level` (format inherited from the existing `log_format`).
- **`smoke-test/smoke.sh`** (`pytests` branch): `-rP` → `-ra` (stop dumping passing tests' captured logs), remove `--continue-on-collection-errors` and `--durations=20` (no slow-test logging).
- **`.github/workflows/docker-unified.yml`** (`pytest_tests` job) and **`.github/workflows/docker-unified-nightly.yml`** (`smoke_test` job): upload `smoke-test/test-results/pytest-smoke.log` as an artifact on failure.

### Notes

The log file contains INFO `logging` records only (not tracebacks/stdout). Failure tracebacks remain available in the console log and the JUnit XML artifact.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Links to related issues (n/a)
- [ ] Tests added/updated (n/a — CI/logging config)
- [ ] Docs added/updated (n/a)
- [ ] Breaking changes documented (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)