### PR TITLE
ci(docker): skip build workflow for docs-only changes

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -16,11 +16,26 @@ on:
     branches:
       - master
       - releases/**
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/**"
+      - "!.github/workflows/docker-unified.yml"
+      - "!.github/scripts/send_failed_tests_to_posthog.py"
+      - "!.github/scripts/docker_helpers.sh"
+      - "!.github/actions/ci-optimization"
+      - "!.github/actions/restore-dependency-caches"
+      - "!.github/scripts/check_python_package.py"
+      - "!.github/scripts/parse_failed_pytest_tests.py"
+      - "!.github/scripts/docker_logs.sh"
+      - "!.github/actions/smoke-test-retry"
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
       - "**"
     paths-ignore:
+      - "docs/**"
+      - "**.md"
       - ".github/**"
       - "!.github/workflows/docker-unified.yml"
       - "!.github/scripts/send_failed_tests_to_posthog.py"


### PR DESCRIPTION
Add `docs/**` and `**.md` to the push and pull_request paths-ignore of
the "Docker Build, Scan, Test" workflow so docs-only changes no longer
trigger a full docker image build and smoke-test run. Mirrors the
paths-ignore convention already used by the build-and-test workflow.

The push trigger previously had no paths-ignore, so it now also carries
the same .github/** negative-include list as pull_request. Manual
workflow_dispatch runs and release events are unaffected.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
