### PR TITLE
ci: replace paths-ignore negation with paths filter

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,23 +5,25 @@ on:
       - master
       - releases/**
       - hotfixes/**
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - ".github/**"
-      - "!.github/workflows/build-and-test.yml"
-      - "!.github/actions/ensure-codegen-updated"
-      - "!.github/scripts/send_failed_tests_to_posthog.py"
+    paths:
+      - "**"
+      - "!docs/**"
+      - "!**.md"
+      - "!.github/**"
+      - ".github/workflows/build-and-test.yml"
+      - ".github/actions/ensure-codegen-updated"
+      - ".github/scripts/send_failed_tests_to_posthog.py"
   pull_request:
     branches:
       - "**"
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - ".github/**"
-      - "!.github/workflows/build-and-test.yml"
-      - "!.github/actions/ensure-codegen-updated"
-      - "!.github/scripts/send_failed_tests_to_posthog.py"
+    paths:
+      - "**"
+      - "!docs/**"
+      - "!**.md"
+      - "!.github/**"
+      - ".github/workflows/build-and-test.yml"
+      - ".github/actions/ensure-codegen-updated"
+      - ".github/scripts/send_failed_tests_to_posthog.py"
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *" # Run at midnight UTC every day

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -16,36 +16,38 @@ on:
     branches:
       - master
       - releases/**
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - ".github/**"
-      - "!.github/workflows/docker-unified.yml"
-      - "!.github/scripts/send_failed_tests_to_posthog.py"
-      - "!.github/scripts/docker_helpers.sh"
-      - "!.github/actions/ci-optimization"
-      - "!.github/actions/restore-dependency-caches"
-      - "!.github/scripts/check_python_package.py"
-      - "!.github/scripts/parse_failed_pytest_tests.py"
-      - "!.github/scripts/docker_logs.sh"
-      - "!.github/actions/smoke-test-retry"
+    paths:
+      - "**"
+      - "!docs/**"
+      - "!**.md"
+      - "!.github/**"
+      - ".github/workflows/docker-unified.yml"
+      - ".github/scripts/send_failed_tests_to_posthog.py"
+      - ".github/scripts/docker_helpers.sh"
+      - ".github/actions/ci-optimization"
+      - ".github/actions/restore-dependency-caches"
+      - ".github/scripts/check_python_package.py"
+      - ".github/scripts/parse_failed_pytest_tests.py"
+      - ".github/scripts/docker_logs.sh"
+      - ".github/actions/smoke-test-retry"
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
       - "**"
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - ".github/**"
-      - "!.github/workflows/docker-unified.yml"
-      - "!.github/scripts/send_failed_tests_to_posthog.py"
-      - "!.github/scripts/docker_helpers.sh"
-      - "!.github/actions/ci-optimization"
-      - "!.github/actions/restore-dependency-caches"
-      - "!.github/scripts/check_python_package.py"
-      - "!.github/scripts/parse_failed_pytest_tests.py"
-      - "!.github/scripts/docker_logs.sh"
-      - "!.github/actions/smoke-test-retry"
+    paths:
+      - "**"
+      - "!docs/**"
+      - "!**.md"
+      - "!.github/**"
+      - ".github/workflows/docker-unified.yml"
+      - ".github/scripts/send_failed_tests_to_posthog.py"
+      - ".github/scripts/docker_helpers.sh"
+      - ".github/actions/ci-optimization"
+      - ".github/actions/restore-dependency-caches"
+      - ".github/scripts/check_python_package.py"
+      - ".github/scripts/parse_failed_pytest_tests.py"
+      - ".github/scripts/docker_logs.sh"
+      - ".github/actions/smoke-test-retry"
   release:
     types: [published]
 

--- a/.github/workflows/publish-datahub-jars.yml
+++ b/.github/workflows/publish-datahub-jars.yml
@@ -4,11 +4,12 @@ on:
   push:
     branches:
       - master
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - ".github/**"
-      - "!.github/workflows/publish-datahub-jars.yml"
+    paths:
+      - "**"
+      - "!docs/**"
+      - "!**.md"
+      - "!.github/**"
+      - ".github/workflows/publish-datahub-jars.yml"
   release:
     types: [published]
 

--- a/.github/workflows/react-cloudflare-pages.yml
+++ b/.github/workflows/react-cloudflare-pages.yml
@@ -3,19 +3,21 @@ on:
   push:
     branches:
       - master
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - ".github/**"
-      - "!.github/workflows/react-cloudflare-pages.yml"
+    paths:
+      - "**"
+      - "!docs/**"
+      - "!**.md"
+      - "!.github/**"
+      - ".github/workflows/react-cloudflare-pages.yml"
   pull_request:
     branches:
       - "**"
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - ".github/**"
-      - "!.github/workflows/react-cloudflare-pages.yml"
+    paths:
+      - "**"
+      - "!docs/**"
+      - "!**.md"
+      - "!.github/**"
+      - ".github/workflows/react-cloudflare-pages.yml"
   release:
     types: [published]
 


### PR DESCRIPTION
## Summary
- GitHub Actions' `paths-ignore` filter does **not** support negation patterns (`!...`). Several workflows listed entries like `!.github/workflows/<name>.yml` under `paths-ignore`, but those `!` patterns are silently ignored — so the intended "re-include this specific file" behavior never actually took effect (all `.github/**` changes were ignored, including the listed files).
- Converted each affected `paths-ignore` block to the equivalent `paths` configuration, which supports negation: match everything with `**`, exclude the previously-ignored paths via `!`, then re-include the specific files as positive patterns listed after the negations.
- Affected workflows: `build-and-test.yml` (push + pull_request), `docker-unified.yml` (pull_request), `react-cloudflare-pages.yml` (push + pull_request), `publish-datahub-jars.yml` (push).

## Behavior change
This is not just a style change: previously the `!.github/...` entries had no effect, so edits to those specific `.github` files did **not** trigger the workflows. After this change, changes to the explicitly re-included files (the workflow file itself and its referenced actions/scripts) now correctly trigger the workflow, matching the original intent.

## Test plan
- [ ] Confirm workflow YAML lints pass (pre-commit `Lint GitHub Actions workflow files` passed locally; `githubActionsPrettierWrite` reported files unchanged).
- [ ] Open a PR touching only a re-included `.github` file (e.g. `.github/workflows/build-and-test.yml`) and verify the workflow triggers.
- [ ] Open a PR touching only `docs/` or a `*.md` file and verify the workflows do **not** trigger.

Made with [Cursor](https://cursor.com)