### PR TITLE
fix(ingest/fabric-onelake): use provisioningStatus instead of hostname pattern for SQL endpoint validation

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/schema_client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/schema_client.py
@@ -186,7 +186,7 @@ def create_schema_extraction_client(
                 raise ValueError(
                     f"SQL Analytics Endpoint URL is required for {item_type} {item_id}. "
                     "The endpoint URL must be obtained from the Fabric API and cannot be constructed. "
-                    "See: https://learn.microsoft.com/en-us/fabric/data-warehouse/what-is-the-sql-analytics-endpoint-for-a-lakehouse"
+                    "See: https://learn.microsoft.com/fabric/data-engineering/lakehouse-sql-analytics-endpoint"
                 )
 
             logger.info(
@@ -262,8 +262,7 @@ class SqlAnalyticsEndpointClient:
         predicted from workspace_id alone. The endpoint must be obtained from the API.
 
         References:
-        - https://learn.microsoft.com/en-us/fabric/data-warehouse/what-is-the-sql-analytics-endpoint-for-a-lakehouse
-        - https://learn.microsoft.com/en-us/fabric/data-warehouse/warehouse-connectivity
+        - https://learn.microsoft.com/fabric/data-engineering/lakehouse-sql-analytics-endpoint
         - https://learn.microsoft.com/en-us/rest/api/fabric/lakehouse/items/get-lakehouse
         - https://learn.microsoft.com/en-us/rest/api/fabric/warehouse/items/get-warehouse
 
@@ -289,11 +288,10 @@ class SqlAnalyticsEndpointClient:
             sql_endpoint_props = properties.get("sqlEndpointProperties")
 
             if isinstance(sql_endpoint_props, dict):
-                # Lakehouse: connectionString is often just the hostname
+                provisioning_status = sql_endpoint_props.get("provisioningStatus")
                 conn_str = sql_endpoint_props.get("connectionString")
-                if conn_str and isinstance(conn_str, str):
-                    if ".datawarehouse.fabric.microsoft.com" in conn_str:
-                        return conn_str.strip()
+                if provisioning_status == "Success" and conn_str:
+                    return conn_str.strip()
 
             # Warehouse API may expose connectionString at properties level
             # (e.g. staging warehouses: properties=['connectionInfo', 'connectionString', ...])
@@ -343,7 +341,7 @@ class SqlAnalyticsEndpointClient:
             raise ValueError(
                 f"SQL Analytics Endpoint URL is required for item {item_id}. "
                 "The endpoint URL must be obtained from the Fabric API and cannot be constructed. "
-                "See: https://learn.microsoft.com/en-us/fabric/data-warehouse/what-is-the-sql-analytics-endpoint-for-a-lakehouse"
+                "See: https://learn.microsoft.com/fabric/data-engineering/lakehouse-sql-analytics-endpoint"
             )
 
         try:
@@ -411,7 +409,7 @@ class SqlAnalyticsEndpointClient:
         Uses the endpoint_url configured during client initialization.
 
         References:
-        - https://learn.microsoft.com/en-us/fabric/data-warehouse/warehouse-connectivity
+        - https://learn.microsoft.com/fabric/data-engineering/lakehouse-sql-analytics-endpoint
         - https://learn.microsoft.com/en-us/fabric/data-warehouse/connect-to-fabric-data-warehouse
 
         Args:

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/schema_client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/schema_client.py
@@ -292,6 +292,12 @@ class SqlAnalyticsEndpointClient:
                 conn_str = sql_endpoint_props.get("connectionString")
                 if provisioning_status == "Success" and conn_str:
                     return conn_str.strip()
+                else:
+                    logger.warning(
+                        f"SQL Analytics Endpoint for {item_type} {item_id} has "
+                        f"provisioningStatus='{provisioning_status}' (expected 'Success'). "
+                        f"Skipping schema extraction for this item."
+                    )
 
             # Warehouse API may expose connectionString at properties level
             # (e.g. staging warehouses: properties=['connectionInfo', 'connectionString', ...])

--- a/metadata-ingestion/tests/unit/fabric_onelake/test_schema_client.py
+++ b/metadata-ingestion/tests/unit/fabric_onelake/test_schema_client.py
@@ -395,12 +395,13 @@ class TestGetSqlAnalyticsEndpointUrl:
     def test_returns_url_from_sql_endpoint_properties(
         self, item_type: Literal["Lakehouse", "Warehouse"], endpoint_path: str
     ) -> None:
-        """When sqlEndpointProperties.connectionString is a bare hostname, return it."""
+        """When sqlEndpointProperties has provisioningStatus=Success, return connectionString."""
         mock_response = Mock()
         mock_response.json.return_value = {
             "properties": {
                 "sqlEndpointProperties": {
                     "connectionString": "bare-host.datawarehouse.fabric.microsoft.com",
+                    "provisioningStatus": "Success",
                 },
             },
         }
@@ -416,6 +417,71 @@ class TestGetSqlAnalyticsEndpointUrl:
 
         assert url == "bare-host.datawarehouse.fabric.microsoft.com"
         mock_client.get.assert_called_once_with(endpoint_path)
+
+    @pytest.mark.parametrize(
+        "item_type,endpoint_path",
+        [
+            ("Lakehouse", "workspaces/ws-1/lakehouses/item-1"),
+            ("Warehouse", "workspaces/ws-1/warehouses/item-1"),
+        ],
+    )
+    def test_returns_url_with_nonstandard_hostname(
+        self, item_type: Literal["Lakehouse", "Warehouse"], endpoint_path: str
+    ) -> None:
+        """When connectionString has a non-standard hostname prefix, return it if provisioned."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "properties": {
+                "sqlEndpointProperties": {
+                    "connectionString": "bare-host.env-datawarehouse.fabric.microsoft.com",
+                    "provisioningStatus": "Success",
+                },
+            },
+        }
+        mock_client = Mock()
+        mock_client.get.return_value = mock_response
+
+        url = SqlAnalyticsEndpointClient.get_sql_analytics_endpoint_url(
+            mock_client,
+            workspace_id="ws-1",
+            item_id="item-1",
+            item_type=item_type,
+        )
+
+        assert url == "bare-host.env-datawarehouse.fabric.microsoft.com"
+        mock_client.get.assert_called_once_with(endpoint_path)
+
+    @pytest.mark.parametrize(
+        "item_type,endpoint_path",
+        [
+            ("Lakehouse", "workspaces/ws-1/lakehouses/item-1"),
+            ("Warehouse", "workspaces/ws-1/warehouses/item-1"),
+        ],
+    )
+    def test_returns_none_when_provisioning_not_success(
+        self, item_type: Literal["Lakehouse", "Warehouse"], endpoint_path: str
+    ) -> None:
+        """When provisioningStatus is not Success, fall through to other extraction methods."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "properties": {
+                "sqlEndpointProperties": {
+                    "connectionString": "bare-host.datawarehouse.fabric.microsoft.com",
+                    "provisioningStatus": "InProgress",
+                },
+            },
+        }
+        mock_client = Mock()
+        mock_client.get.return_value = mock_response
+
+        url = SqlAnalyticsEndpointClient.get_sql_analytics_endpoint_url(
+            mock_client,
+            workspace_id="ws-1",
+            item_id="item-1",
+            item_type=item_type,
+        )
+
+        assert url is None
 
     @pytest.mark.parametrize(
         "item_type,endpoint_path",


### PR DESCRIPTION
## Why this change

The `get_sql_analytics_endpoint_url` method validates the SQL Analytics Endpoint connection string by checking for the substring `.datawarehouse.fabric.microsoft.com`. This fails when the Fabric environment returns a hostname with a different prefix pattern (e.g., `env-datawarehouse.fabric.microsoft.com`), causing schema extraction to be silently skipped.

The Fabric REST API already provides a `provisioningStatus` field in `sqlEndpointProperties` that explicitly indicates whether the endpoint is ready. Checking this field is more robust than pattern-matching a hostname that could change across environments.

## What changed

* `schema_client.py`: Replaced hostname substring check with `provisioningStatus == \"Success\"` validation. If the API confirms the endpoint is provisioned and a connection string is present, we trust and return it.
* `schema_client.py`: Updated stale documentation URLs (two 404 links replaced with current Microsoft Learn references).
* `test_schema_client.py`: Updated existing test to include `provisioningStatus` field, added test for non-standard hostname with `Success` status, added test verifying `InProgress` status returns `None`.

## Validation

* Unit tests pass for all scenarios: standard hostname, non-standard hostname prefix, InProgress status, missing status, empty properties, Warehouse path routing.

Fixes datahub-project/datahub#18335