### PR TITLE
test(smoke-test): fix pytest warnings in smoke-test collection

### DIFF
--- a/smoke-test/pyproject.toml
+++ b/smoke-test/pyproject.toml
@@ -85,6 +85,7 @@ markers = [
     "read_only: marks tests as read only (deselect with '-m \"not read_only\"')",
     "no_cypress_suite1: main smoke tests, suite 1",
     "test_run_cypress: run cypress tests",
+    "integration: marks tests as integration tests requiring a running DataHub stack",
 ]
 filterwarnings = [
     # Ignore some warnings that come from dependencies.
@@ -92,6 +93,10 @@ filterwarnings = [
     "ignore:The new datahub SDK:datahub.errors.ExperimentalWarning",
     # We should not be unexpectedly seeing API tracing warnings.
     "error::datahub.errors.APITracingWarning",
+    # Prevent regressions: helper classes named Test* must set __test__ = False,
+    # and custom marks must be registered above.
+    "error::pytest.PytestCollectionWarning",
+    "error::pytest.PytestUnknownMarkWarning",
 ]
 # Logging configuration - formats test reports without interfering with CLI tests
 log_level = "INFO"

--- a/smoke-test/tests/utils.py
+++ b/smoke-test/tests/utils.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import json
 import logging
 import socket
@@ -355,7 +356,7 @@ def run_datahub_cmd(
     env: Optional[Dict[str, str]] = None,
 ) -> click.testing.Result:
     # TODO: Unify this with the run_datahub_cmd in the metadata-ingestion directory.
-    click_version: str = click.__version__  # type: ignore
+    click_version: str = importlib.metadata.version("click")
     if version.parse(click_version) >= version.parse("8.2.0"):
         runner = click.testing.CliRunner()
     else:
@@ -501,6 +502,8 @@ class TestSessionWrapper:
        GMS URL so GraphQL calls go to ``{gms_url}/api/graphql``.  ``destroy()``
        is a no-op — the externally-provided token is never revoked.
     """
+
+    __test__ = False
 
     def __init__(self, requests_session, *, prebuilt_token: str | None = None):
         self._upstream = requests_session

--- a/smoke-test/tests/zdu/framework/context.py
+++ b/smoke-test/tests/zdu/framework/context.py
@@ -401,6 +401,8 @@ class ValidationResult:
 
 @dataclass
 class TestContext:
+    __test__ = False
+
     gms_url: str = "http://localhost:8080"
 
     # BuildImagesPhase writes (Phase 0 — opt-in via ZDU_BUILD_IMAGES=1)


### PR DESCRIPTION
## Summary

The Pytest Smoke Tests CI job emitted **67 warnings** per run (e.g. [Batch 0/7 on #18359](https://github.com/datahub-project/datahub/actions/runs/29245686347/job/86803259557#step:20:294)). All 67 trace to 3 root causes in the `smoke-test/` package, and all are real code-quality issues rather than dependency noise (dependency warnings are already filtered in `pyproject.toml`).

- `PytestCollectionWarning: cannot collect test class 'TestContext' because it has a __init__ constructor` — `@dataclass TestContext` in `tests/zdu/framework/context.py`, imported by 22 zdu test modules (×22).
- `PytestCollectionWarning: cannot collect test class 'TestSessionWrapper' because it has a __init__ constructor` — `tests/utils.py`, imported by 4 test modules (×4).
- `PytestUnknownMarkWarning: Unknown pytest.mark.integration` — `tests/ml_models/test_ml_models.py:89` (×1).
- `DeprecationWarning: The '__version__' attribute is deprecated and will be removed in Click 9.1` — `click.__version__` in `tests/utils.py:run_datahub_cmd`, hit by `test_group_cmd.py` / `test_user_cmd.py` (×40).

### Changes

- Add `__test__ = False` to `TestSessionWrapper` and `TestContext` so pytest stops trying to collect these helper classes. (Safe on the dataclass: unannotated attributes aren't treated as fields.)
- Register the `integration` mark in `[tool.pytest.ini_options].markers`.
- Replace `click.__version__` with `importlib.metadata.version("click")` (Click 9.1-compatible).
- Promote `PytestCollectionWarning` and `PytestUnknownMarkWarning` to errors via `filterwarnings` as a regression guard.

## Verification

- `./gradlew :smoke-test:pythonLintFix` — ruff check + format + mypy clean (284 files).
- Static sweep confirmed the error-promotion is safe across all 7 batches: every `pytest.mark.*` is builtin, already registered, the newly-added `integration` mark, or registered by the installed `pytest-dependency` plugin; the only `Test*` classes in non-test helper modules are the two fixed, and no `Test*` class in any `test_*.py` defines `__init__`.
- `pytest tests/ --collect-only` after `:metadata-ingestion:installDev` → **997 tests collected, 0 warnings**. With the two warning classes promoted to errors, a clean collection confirms no remaining uncollectable `Test*` helpers or unregistered marks.

No production behavior changes — test-only.

## Test plan

- [x] `:smoke-test:pythonLintFix` passes
- [x] `pytest --collect-only` over the full smoke-test suite is warning-free
- [ ] CI: next `Pytest Smoke Tests` run reports 0 warnings (down from 67)

Made with [Cursor](https://cursor.com)