### PR TITLE
feat(ingest/fabric-onelake): add schema_pattern for schema-level filtering

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/config.py
@@ -170,6 +170,15 @@ class FabricOneLakeSourceConfig(
         ),
     )
 
+    schema_pattern: AllowDenyPattern = Field(
+        default=AllowDenyPattern.allow_all(),
+        description=(
+            "Regex patterns to filter schemas by name. "
+            "Schemas denied by this pattern are skipped entirely, "
+            "including all their tables and views."
+        ),
+    )
+
     table_pattern: AllowDenyPattern = Field(
         default=AllowDenyPattern.allow_all(),
         description=(

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/report.py
@@ -50,6 +50,7 @@ class FabricOneLakeSourceReport(StaleEntityRemovalSourceReport):
     filtered_workspaces: LossyList[str] = field(default_factory=LossyList)
     filtered_lakehouses: LossyList[str] = field(default_factory=LossyList)
     filtered_warehouses: LossyList[str] = field(default_factory=LossyList)
+    filtered_schemas: LossyList[str] = field(default_factory=LossyList)
     filtered_tables: LossyList[str] = field(default_factory=LossyList)
     filtered_views: LossyList[str] = field(default_factory=LossyList)
 
@@ -112,6 +113,10 @@ class FabricOneLakeSourceReport(StaleEntityRemovalSourceReport):
     def report_schema_scanned(self) -> None:
         """Increment schemas scanned counter."""
         self.schemas_scanned += 1
+
+    def report_schema_filtered(self, schema_name: str) -> None:
+        """Record a filtered schema."""
+        self.filtered_schemas.append(schema_name)
 
     def report_table_scanned(self) -> None:
         """Increment tables scanned counter."""

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/source.py
@@ -593,6 +593,11 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
                     else FABRIC_SQL_DEFAULT_SCHEMA
                 )
 
+                # Filter schemas
+                if not self.config.schema_pattern.allowed(normalized_schema):
+                    self.report.report_schema_filtered(normalized_schema)
+                    continue
+
                 # Filter tables
                 table_full_name = f"{normalized_schema}.{table.name}"
 
@@ -903,6 +908,11 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
             normalized_schema = (
                 view.schema_name if view.schema_name else FABRIC_SQL_DEFAULT_SCHEMA
             )
+
+            # Filter schemas
+            if not self.config.schema_pattern.allowed(normalized_schema):
+                self.report.report_schema_filtered(normalized_schema)
+                continue
 
             view_full_name = f"{normalized_schema}.{view.name}"
             if not self.config.view_pattern.allowed(view_full_name):

--- a/metadata-ingestion/tests/integration/fabric/fabric_onelake/test_fabric_onelake_source.py
+++ b/metadata-ingestion/tests/integration/fabric/fabric_onelake/test_fabric_onelake_source.py
@@ -627,3 +627,125 @@ def test_fabric_onelake_dml_emits_operation_aspect() -> None:
 
     finally:
         Path(output_file).unlink(missing_ok=True)
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+@pytest.mark.integration
+def test_fabric_onelake_schema_pattern_filters_schemas() -> None:
+    """Schema pattern should exclude tables and schema containers for denied schemas."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+        output_file = tmp.name
+
+    try:
+        with (
+            patch.object(
+                OneLakeClient,
+                "list_workspaces",
+                return_value=[FabricWorkspace(id="ws-123", name="Test Workspace")],
+            ),
+            patch.object(
+                OneLakeClient,
+                "list_lakehouses",
+                return_value=[
+                    FabricLakehouse(
+                        id="lh-456",
+                        name="Test Lakehouse",
+                        workspace_id="ws-123",
+                        type="Lakehouse",
+                    )
+                ],
+            ),
+            patch.object(OneLakeClient, "list_warehouses", return_value=[]),
+            patch.object(
+                OneLakeClient,
+                "list_lakehouse_tables",
+                return_value=[
+                    FabricTable(
+                        name="customers",
+                        schema_name="dbo",
+                        item_id="lh-456",
+                        workspace_id="ws-123",
+                    ),
+                    FabricTable(
+                        name="orders",
+                        schema_name="dbo",
+                        item_id="lh-456",
+                        workspace_id="ws-123",
+                    ),
+                    FabricTable(
+                        name="raw_events",
+                        schema_name="staging",
+                        item_id="lh-456",
+                        workspace_id="ws-123",
+                    ),
+                    FabricTable(
+                        name="raw_users",
+                        schema_name="staging",
+                        item_id="lh-456",
+                        workspace_id="ws-123",
+                    ),
+                ],
+            ),
+        ):
+            pipeline = Pipeline.create(
+                {
+                    "source": {
+                        "type": "fabric-onelake",
+                        "config": {
+                            "credential": {
+                                "authentication_method": "service_principal",
+                                "client_id": "test-client",
+                                "client_secret": "test-secret",
+                                "tenant_id": "test-tenant",
+                            },
+                            "schema_pattern": {
+                                "allow": ["^dbo$"],
+                            },
+                        },
+                    },
+                    "sink": {
+                        "type": "file",
+                        "config": {"filename": output_file},
+                    },
+                }
+            )
+
+            pipeline.run()
+            pipeline.raise_from_status()
+
+            with Path(output_file).open() as f:
+                events = json.load(f)
+
+            # Collect all entity URNs from emitted events
+            dataset_urns = {
+                event["entityUrn"]
+                for event in events
+                if event.get("entityType") == "dataset"
+            }
+
+            # dbo tables should be present
+            assert any("dbo.customers" in urn for urn in dataset_urns), (
+                f"Expected dbo.customers dataset; got {dataset_urns}"
+            )
+            assert any("dbo.orders" in urn for urn in dataset_urns), (
+                f"Expected dbo.orders dataset; got {dataset_urns}"
+            )
+
+            # staging tables should be filtered out
+            assert not any("staging" in urn for urn in dataset_urns), (
+                f"staging tables should be excluded by schema_pattern; got {dataset_urns}"
+            )
+
+            # Verify no staging schema container was emitted
+            schema_containers = [
+                event
+                for event in events
+                if event.get("aspectName") == "containerProperties"
+                and "staging" in event.get("aspect", {}).get("json", {}).get("name", "")
+            ]
+            assert not schema_containers, (
+                "staging schema container should not be emitted when denied by schema_pattern"
+            )
+
+    finally:
+        Path(output_file).unlink(missing_ok=True)

--- a/metadata-ingestion/tests/unit/fabric_onelake/test_config.py
+++ b/metadata-ingestion/tests/unit/fabric_onelake/test_config.py
@@ -96,6 +96,36 @@ class TestFabricOneLakeSourceConfig:
         assert config.warehouse_pattern.allowed("warehouse-prod")
         assert not config.warehouse_pattern.allowed("lakehouse-prod")
 
+    def test_schema_pattern_filtering(self) -> None:
+        """Schema pattern should filter correctly."""
+        config = FabricOneLakeSourceConfig(
+            credential=AzureCredentialConfig(),
+            schema_pattern={"allow": ["^dbo$"], "deny": []},
+        )
+        assert config.schema_pattern.allowed("dbo")
+        assert not config.schema_pattern.allowed("staging")
+        assert not config.schema_pattern.allowed("INFORMATION_SCHEMA")
+
+    def test_schema_pattern_deny(self) -> None:
+        """Schema pattern deny should exclude matching schemas."""
+        config = FabricOneLakeSourceConfig(
+            credential=AzureCredentialConfig(),
+            schema_pattern={"deny": ["^sys$", "^INFORMATION_SCHEMA$"]},
+        )
+        assert config.schema_pattern.allowed("dbo")
+        assert config.schema_pattern.allowed("staging")
+        assert not config.schema_pattern.allowed("sys")
+        assert not config.schema_pattern.allowed("INFORMATION_SCHEMA")
+
+    def test_schema_pattern_defaults_to_allow_all(self) -> None:
+        """Schema pattern should default to allowing all schemas."""
+        config = FabricOneLakeSourceConfig(
+            credential=AzureCredentialConfig(),
+        )
+        assert config.schema_pattern.allowed("dbo")
+        assert config.schema_pattern.allowed("staging")
+        assert config.schema_pattern.allowed("anything")
+
     def test_table_pattern_filtering(self) -> None:
         """Table pattern should filter correctly."""
         config = FabricOneLakeSourceConfig(


### PR DESCRIPTION
Closes datahub-project/datahub#18371

## Summary

Adds `schema_pattern: AllowDenyPattern` to the fabric-onelake connector config, consistent with other SQL-based connectors (Snowflake, Databricks Unity, SQL common).

## Problem

Users who want to exclude entire schemas must use `table_pattern` with combined `schema.table` regex. This is unintuitive and less efficient — the connector still fetches and iterates all tables before filtering.

## Changes

* `config.py` — Added `schema_pattern: AllowDenyPattern` field (defaults to allow-all)
* `source.py` — Schema filter check applied before `table_pattern` in both table and view processing paths
* `report.py` — Added `filtered_schemas` list and `report_schema_filtered()` method for observability
* `test_config.py` — 3 unit tests: allow, deny, default-allows-all
* `test_fabric_onelake_source.py` — Integration test: verifies denied schemas and their tables/containers are excluded from pipeline output

## Example Usage

```yaml
source:
  type: fabric-onelake
  config:
    schema_pattern:
      allow:
        - "^dbo$"
```

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](<https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md>)
- [X] Links to related issue (datahub-project/datahub#18371)
- [X] Tests added