### PR TITLE
perf(graphql): batch entity hydration in parent-chain resolvers

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/container/ParentContainersResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/container/ParentContainersResolver.java
@@ -17,7 +17,9 @@ import com.linkedin.metadata.graph.cache.client.HierarchyBindings;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public class ParentContainersResolver
@@ -46,12 +48,24 @@ public class ParentContainersResolver
                     context.getMaxParentDepth());
 
             List<Container> containers = new ArrayList<>();
-            for (Urn parentUrn : parentUrns) {
-              EntityResponse response =
-                  _entityClient.getV2(
-                      context.getOperationContext(), parentUrn.getEntityType(), parentUrn, null);
-              if (response != null) {
-                containers.add(ContainerMapper.map(context, response));
+            if (!parentUrns.isEmpty()) {
+              // All ancestors in a container hierarchy are containers, so a single batch call
+              // over one entity type replaces the per-parent getV2 round-trips (N+1).
+              Map<Urn, EntityResponse> responses =
+                  _entityClient.batchGetV2(
+                      context.getOperationContext(),
+                      parentUrns.get(0).getEntityType(),
+                      new HashSet<>(parentUrns),
+                      null);
+
+              // batchGetV2 returns an unordered map; re-iterate parentUrns to preserve hierarchy
+              // order. Missing/unauthorized urns resolve to null and are skipped, matching the
+              // previous response != null behavior.
+              for (Urn parentUrn : parentUrns) {
+                EntityResponse response = responses.get(parentUrn);
+                if (response != null) {
+                  containers.add(ContainerMapper.map(context, response));
+                }
               }
             }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/ParentNodesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/ParentNodesResolver.java
@@ -7,7 +7,6 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
-import com.linkedin.datahub.graphql.exception.DataHubGraphQLException;
 import com.linkedin.datahub.graphql.generated.Entity;
 import com.linkedin.datahub.graphql.generated.GlossaryNode;
 import com.linkedin.datahub.graphql.generated.ParentNodesResult;
@@ -18,10 +17,11 @@ import com.linkedin.metadata.graph.cache.client.BoundHierarchyAccess;
 import com.linkedin.metadata.graph.cache.client.HierarchyBindings;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 
 public class ParentNodesResolver implements DataFetcher<CompletableFuture<ParentNodesResult>> {
 
@@ -46,41 +46,41 @@ public class ParentNodesResolver implements DataFetcher<CompletableFuture<Parent
                     sourceUrn,
                     context.getMaxParentDepth());
 
-            List<GlossaryNode> viewable =
-                parentUrns.stream()
-                    .map(parentUrn -> loadGlossaryNode(context, parentUrn))
-                    .filter(
-                        node ->
-                            canViewRelationship(
-                                context.getOperationContext(),
-                                UrnUtils.getUrn(node.getUrn()),
-                                sourceUrn))
-                    .collect(Collectors.toList());
+            List<GlossaryNode> viewable = new ArrayList<>();
+            if (!parentUrns.isEmpty()) {
+              // All ancestors in a glossary hierarchy are glossary nodes, so a single batch call
+              // over one entity type replaces the per-parent getV2 round-trips (N+1).
+              Map<Urn, EntityResponse> responses =
+                  _entityClient.batchGetV2(
+                      context.getOperationContext(),
+                      parentUrns.get(0).getEntityType(),
+                      new HashSet<>(parentUrns),
+                      null);
+
+              // Re-iterate parentUrns to preserve hierarchy order (batchGetV2 returns an unordered
+              // map), then apply the same relationship-visibility filter as before.
+              for (Urn parentUrn : parentUrns) {
+                EntityResponse response = responses.get(parentUrn);
+                if (response == null) {
+                  throw new RuntimeException("Failed to retrieve glossary node " + parentUrn);
+                }
+                GlossaryNode node = GlossaryNodeMapper.map(context, response);
+                if (canViewRelationship(
+                    context.getOperationContext(), UrnUtils.getUrn(node.getUrn()), sourceUrn)) {
+                  viewable.add(node);
+                }
+              }
+            }
 
             final ParentNodesResult result = new ParentNodesResult();
             result.setCount(viewable.size());
             result.setNodes(viewable);
             return result;
-          } catch (DataHubGraphQLException e) {
+          } catch (Exception e) {
             throw new RuntimeException("Failed to load parent nodes", e);
           }
         },
         this.getClass().getSimpleName(),
         "get");
-  }
-
-  @Nonnull
-  private GlossaryNode loadGlossaryNode(@Nonnull QueryContext context, @Nonnull Urn parentUrn) {
-    try {
-      EntityResponse response =
-          _entityClient.getV2(
-              context.getOperationContext(), parentUrn.getEntityType(), parentUrn, null);
-      if (response == null) {
-        throw new RuntimeException("Failed to retrieve glossary node " + parentUrn);
-      }
-      return GlossaryNodeMapper.map(context, response);
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to retrieve glossary node " + parentUrn, e);
-    }
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/ParentDocumentsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/ParentDocumentsResolver.java
@@ -33,44 +33,48 @@ public class ParentDocumentsResolver
   }
 
   private void aggregateParentDocuments(
-      List<Document> documents,
-      String urn,
-      QueryContext context,
-      Set<String> visitedUrns,
-      int depth) {
-    if (depth >= context.getMaxParentDepth() || !visitedUrns.add(urn)) {
-      return;
-    }
+      List<Document> documents, String startUrn, QueryContext context) {
+    // The parent chain is a linked list (each node points to its parent), so the walk is
+    // inherently sequential and cannot be batched. It can, however, fetch each node exactly once:
+    // an ancestor's full response already carries its DocumentInfo, so there is no need to
+    // re-fetch it to find the next hop (the previous per-level double getV2).
+    Set<String> visitedUrns = new HashSet<>();
+    visitedUrns.add(startUrn);
     try {
-      Urn entityUrn = new Urn(urn);
-      EntityResponse entityResponse =
+      Urn sourceUrn = new Urn(startUrn);
+      // The source entity itself is not part of the result; fetch only its DocumentInfo to find
+      // the first parent link.
+      EntityResponse response =
           _entityClient.getV2(
               context.getOperationContext(),
-              entityUrn.getEntityType(),
-              entityUrn,
+              sourceUrn.getEntityType(),
+              sourceUrn,
               Collections.singleton(DOCUMENT_INFO_ASPECT_NAME));
 
-      if (entityResponse != null
-          && entityResponse.getAspects().containsKey(DOCUMENT_INFO_ASPECT_NAME)) {
-        DataMap dataMap =
-            entityResponse.getAspects().get(DOCUMENT_INFO_ASPECT_NAME).getValue().data();
+      int depth = 0;
+      while (response != null
+          && response.getAspects().containsKey(DOCUMENT_INFO_ASPECT_NAME)
+          && depth < context.getMaxParentDepth()) {
+        DataMap dataMap = response.getAspects().get(DOCUMENT_INFO_ASPECT_NAME).getValue().data();
         com.linkedin.knowledge.DocumentInfo documentInfo =
             new com.linkedin.knowledge.DocumentInfo(dataMap);
-        if (documentInfo.hasParentDocument()) {
-          Urn parentUrn = documentInfo.getParentDocument().getDocument();
-          if (visitedUrns.contains(parentUrn.toString())) {
-            return;
-          }
-          EntityResponse response =
-              _entityClient.getV2(
-                  context.getOperationContext(), parentUrn.getEntityType(), parentUrn, null);
-          if (response != null) {
-            Document mappedDocument = DocumentMapper.map(context, response);
-            documents.add(mappedDocument);
-            aggregateParentDocuments(
-                documents, mappedDocument.getUrn(), context, visitedUrns, depth + 1);
-          }
+        if (!documentInfo.hasParentDocument()) {
+          break;
         }
+        Urn parentUrn = documentInfo.getParentDocument().getDocument();
+        if (!visitedUrns.add(parentUrn.toString())) {
+          break;
+        }
+        // Fetch the parent's full aspects once: used both to map it into a Document and, on the
+        // next iteration, to read its DocumentInfo for the following hop.
+        response =
+            _entityClient.getV2(
+                context.getOperationContext(), parentUrn.getEntityType(), parentUrn, null);
+        if (response == null) {
+          break;
+        }
+        documents.add(DocumentMapper.map(context, response));
+        depth++;
       }
     } catch (Exception e) {
       throw new RuntimeException("Failed to retrieve parent documents from GMS", e);
@@ -86,8 +90,7 @@ public class ParentDocumentsResolver
     return GraphQLConcurrencyUtils.supplyAsync(
         () -> {
           try {
-            Set<String> visitedUrns = new HashSet<>();
-            aggregateParentDocuments(documents, urn, context, visitedUrns, 0);
+            aggregateParentDocuments(documents, urn, context);
             final ParentDocumentsResult result = new ParentDocumentsResult();
 
             List<Document> viewable = new ArrayList<>(documents);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/container/ParentContainersResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/container/ParentContainersResolverTest.java
@@ -134,35 +134,30 @@ public class ParentContainersResolverTest {
         new EnvelopedAspect()
             .setValue(new Aspect(new ContainerProperties().setName("test_database").data())));
 
-    Mockito.when(
-            mockClient.getV2(
-                any(),
-                Mockito.eq(parentContainer1.getEntityType()),
-                Mockito.eq(parentContainer1),
-                Mockito.eq(null)))
-        .thenReturn(
-            new EntityResponse()
-                .setEntityName(CONTAINER_ENTITY_NAME)
-                .setUrn(parentContainer1)
-                .setAspects(new EnvelopedAspectMap(parentContainer1Aspects)));
+    Map<Urn, EntityResponse> batchResponse = new HashMap<>();
+    batchResponse.put(
+        parentContainer1,
+        new EntityResponse()
+            .setEntityName(CONTAINER_ENTITY_NAME)
+            .setUrn(parentContainer1)
+            .setAspects(new EnvelopedAspectMap(parentContainer1Aspects)));
+    batchResponse.put(
+        parentContainer2,
+        new EntityResponse()
+            .setEntityName(CONTAINER_ENTITY_NAME)
+            .setUrn(parentContainer2)
+            .setAspects(new EnvelopedAspectMap(parentContainer2Aspects)));
 
     Mockito.when(
-            mockClient.getV2(
-                any(),
-                Mockito.eq(parentContainer2.getEntityType()),
-                Mockito.eq(parentContainer2),
-                Mockito.eq(null)))
-        .thenReturn(
-            new EntityResponse()
-                .setEntityName(CONTAINER_ENTITY_NAME)
-                .setUrn(parentContainer2)
-                .setAspects(new EnvelopedAspectMap(parentContainer2Aspects)));
+            mockClient.batchGetV2(
+                any(), Mockito.eq(CONTAINER_ENTITY_NAME), any(), Mockito.eq(null)))
+        .thenReturn(batchResponse);
 
     ParentContainersResolver resolver = new ParentContainersResolver(mockClient);
     ParentContainersResult result = resolver.get(mockEnv).get();
 
-    Mockito.verify(mockClient, Mockito.times(2))
-        .getV2(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+    Mockito.verify(mockClient, Mockito.times(1))
+        .batchGetV2(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
     assertEquals(result.getCount(), 2);
     assertEquals(result.getContainers().get(0).getUrn(), parentContainer1.toString());
     assertEquals(result.getContainers().get(1).getUrn(), parentContainer2.toString());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/container/ParentContainersResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/container/ParentContainersResolverTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -161,5 +162,99 @@ public class ParentContainersResolverTest {
     assertEquals(result.getCount(), 2);
     assertEquals(result.getContainers().get(0).getUrn(), parentContainer1.toString());
     assertEquals(result.getContainers().get(1).getUrn(), parentContainer2.toString());
+  }
+
+  @Test
+  public void testGetNoParentContainers() throws Exception {
+    Urn datasetUrn = Urn.createFromString("urn:li:dataset:(test,no-parents,test)");
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    DataFetchingEnvironment mockEnv = envWithAncestors(datasetUrn, List.of(), mockClient);
+
+    ParentContainersResult result = new ParentContainersResolver(mockClient).get(mockEnv).get();
+
+    // No ancestors -> empty result and no hydration call at all.
+    assertEquals(result.getCount(), 0);
+    Mockito.verify(mockClient, Mockito.never())
+        .batchGetV2(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+  }
+
+  @Test
+  public void testGetSkipsParentMissingFromBatchResult() throws Exception {
+    Urn datasetUrn = Urn.createFromString("urn:li:dataset:(test,partial,test)");
+    Urn present = Urn.createFromString("urn:li:container:present");
+    Urn missing = Urn.createFromString("urn:li:container:missing");
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    DataFetchingEnvironment mockEnv =
+        envWithAncestors(datasetUrn, List.of(present, missing), mockClient);
+
+    Map<String, EnvelopedAspect> presentAspects = new HashMap<>();
+    presentAspects.put(
+        CONTAINER_PROPERTIES_ASPECT_NAME,
+        new EnvelopedAspect()
+            .setValue(new Aspect(new ContainerProperties().setName("kept").data())));
+    // batchGetV2 returns only the present urn; the missing/unauthorized urn is absent.
+    Map<Urn, EntityResponse> batchResponse = new HashMap<>();
+    batchResponse.put(
+        present,
+        new EntityResponse()
+            .setEntityName(CONTAINER_ENTITY_NAME)
+            .setUrn(present)
+            .setAspects(new EnvelopedAspectMap(presentAspects)));
+    Mockito.when(
+            mockClient.batchGetV2(
+                any(), Mockito.eq(CONTAINER_ENTITY_NAME), any(), Mockito.eq(null)))
+        .thenReturn(batchResponse);
+
+    ParentContainersResult result = new ParentContainersResolver(mockClient).get(mockEnv).get();
+
+    // The urn absent from the batch response is skipped, not surfaced as null.
+    assertEquals(result.getCount(), 1);
+    assertEquals(result.getContainers().get(0).getUrn(), present.toString());
+  }
+
+  private static DataFetchingEnvironment envWithAncestors(
+      Urn datasetUrn, List<Urn> ancestors, EntityClient mockClient) {
+    QueryContext mockContext = Mockito.mock(QueryContext.class);
+    Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    Mockito.when(mockContext.getMaxParentDepth()).thenReturn(50);
+
+    EntityGraphCache entityGraphCache = Mockito.mock(EntityGraphCache.class);
+    EntityGraphBinding binding =
+        EntityGraphBinding.builder().graphId("container").source(GraphSnapshotSource.GRAPH).build();
+    Mockito.when(entityGraphCache.bindingForKnownGraph(KnownEntityGraph.CONTAINER))
+        .thenReturn(Optional.of(binding));
+    Mockito.when(
+            entityGraphCache.walkOrderedForwardAncestors(
+                eq("container"),
+                eq(GraphSnapshotSource.GRAPH),
+                eq(datasetUrn.toString()),
+                eq(50),
+                eq(ReadMode.CACHED)))
+        .thenReturn(
+            AncestorWalkResult.fromAncestors(
+                ancestors.stream().map(Urn::toString).collect(Collectors.toList())));
+
+    OperationContext base = TestOperationContexts.systemContextNoSearchAuthorization();
+    RetrieverContext retrieverContext =
+        RetrieverContext.builder()
+            .graphRetriever(GraphRetriever.EMPTY)
+            .searchRetriever(SearchRetriever.EMPTY)
+            .cachingAspectRetriever(CachingAspectRetriever.EMPTY)
+            .aspectRetriever(Mockito.mock(AspectRetriever.class))
+            .entityGraphCache(entityGraphCache)
+            .build();
+    OperationContext operationContext =
+        base.toBuilder()
+            .retrieverContext(retrieverContext)
+            .build(base.getSessionAuthentication(), false);
+    Mockito.when(mockContext.getOperationContext()).thenReturn(operationContext);
+
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Dataset datasetEntity = new Dataset();
+    datasetEntity.setUrn(datasetUrn.toString());
+    datasetEntity.setType(EntityType.DATASET);
+    Mockito.when(mockEnv.getSource()).thenReturn(datasetEntity);
+    return mockEnv;
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/ParentNodesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/ParentNodesResolverTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 
 import com.datahub.authentication.Authentication;
 import com.linkedin.common.urn.GlossaryNodeUrn;
@@ -39,12 +40,14 @@ import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.RetrieverContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -133,6 +136,18 @@ public class ParentNodesResolverTest {
     assertEquals(result.getCount(), 2);
     assertEquals(result.getNodes().get(0).getUrn(), PARENT_NODE_1.toString());
     assertEquals(result.getNodes().get(1).getUrn(), PARENT_NODE_2.toString());
+  }
+
+  @Test
+  public void testThrowsWhenParentNodeNotFound() throws Exception {
+    Urn termUrn = Urn.createFromString("urn:li:glossaryTerm:11115397daf94708a8822b8106cfd451");
+
+    // The walk yields parent urns, but the batch hydration returns none of them.
+    EntityClient mockClient = mock(EntityClient.class);
+    when(mockClient.batchGetV2(any(), any(), any(), any())).thenReturn(Collections.emptyMap());
+
+    ParentNodesResolver resolver = new ParentNodesResolver(mockClient);
+    assertThrows(ExecutionException.class, () -> resolver.get(mockEnv(termUrn, true)).get());
   }
 
   private static DataFetchingEnvironment mockEnv(Urn sourceUrn, boolean term) {

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/ParentNodesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/ParentNodesResolverTest.java
@@ -234,21 +234,23 @@ public class ParentNodesResolverTest {
         GLOSSARY_NODE_INFO_ASPECT_NAME,
         new EnvelopedAspect().setValue(new Aspect(parent2Info.data())));
 
-    when(mockClient.getV2(
-            any(), Mockito.eq(parentNode1.getEntityType()), Mockito.eq(parentNode1), any()))
-        .thenReturn(
-            new EntityResponse()
-                .setEntityName(GLOSSARY_NODE_ENTITY_NAME)
-                .setUrn(parentNode1)
-                .setAspects(new EnvelopedAspectMap(parentNode1Aspects)));
+    Map<Urn, EntityResponse> batchResponse = new HashMap<>();
+    batchResponse.put(
+        parentNode1,
+        new EntityResponse()
+            .setEntityName(GLOSSARY_NODE_ENTITY_NAME)
+            .setUrn(parentNode1)
+            .setAspects(new EnvelopedAspectMap(parentNode1Aspects)));
+    batchResponse.put(
+        parentNode2,
+        new EntityResponse()
+            .setEntityName(GLOSSARY_NODE_ENTITY_NAME)
+            .setUrn(parentNode2)
+            .setAspects(new EnvelopedAspectMap(parentNode2Aspects)));
 
-    when(mockClient.getV2(
-            any(), Mockito.eq(parentNode2.getEntityType()), Mockito.eq(parentNode2), any()))
-        .thenReturn(
-            new EntityResponse()
-                .setEntityName(GLOSSARY_NODE_ENTITY_NAME)
-                .setUrn(parentNode2)
-                .setAspects(new EnvelopedAspectMap(parentNode2Aspects)));
+    when(mockClient.batchGetV2(
+            any(), Mockito.eq(parentNode1.getEntityType()), any(), Mockito.eq(null)))
+        .thenReturn(batchResponse);
 
     return mockClient;
   }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/ParentDocumentsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/ParentDocumentsResolverTest.java
@@ -8,6 +8,7 @@ import static org.testng.Assert.*;
 import com.datahub.authentication.Authentication;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.Document;
 import com.linkedin.datahub.graphql.generated.EntityType;
@@ -202,5 +203,103 @@ public class ParentDocumentsResolverTest {
 
     assertEquals(result.getCount(), 0);
     assertEquals(result.getDocuments().size(), 0);
+  }
+
+  @Test
+  public void testStopsAtMaxParentDepth() throws Exception {
+    Urn source = Urn.createFromString("urn:li:document:d-source");
+    Urn p1 = Urn.createFromString("urn:li:document:d-p1");
+    Urn p2 = Urn.createFromString("urn:li:document:d-p2");
+
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    stubDocInfo(mockClient, source, p1); // source -> p1
+    stubFullDoc(mockClient, p1, p2); // p1 -> p2
+    stubFullDoc(mockClient, p2, null); // p2 -> root
+
+    // maxParentDepth = 1 must stop after the first ancestor even though deeper parents exist.
+    ParentDocumentsResult result =
+        new ParentDocumentsResolver(mockClient).get(envFor(source, 1)).get();
+
+    assertEquals(result.getCount(), 1);
+    assertEquals(result.getDocuments().get(0).getUrn(), p1.toString());
+  }
+
+  @Test
+  public void testCycleDetectionStopsWalk() throws Exception {
+    Urn source = Urn.createFromString("urn:li:document:c-source");
+    Urn p1 = Urn.createFromString("urn:li:document:c-p1");
+
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    stubDocInfo(mockClient, source, p1); // source -> p1
+    stubFullDoc(mockClient, p1, source); // p1 -> source (cycle back to the origin)
+
+    // Must terminate (source already visited) and not loop forever.
+    ParentDocumentsResult result =
+        new ParentDocumentsResolver(mockClient).get(envFor(source, 50)).get();
+
+    assertEquals(result.getCount(), 1);
+    assertEquals(result.getDocuments().get(0).getUrn(), p1.toString());
+  }
+
+  @Test
+  public void testStopsWhenParentResponseNull() throws Exception {
+    Urn source = Urn.createFromString("urn:li:document:n-source");
+    Urn p1 = Urn.createFromString("urn:li:document:n-p1");
+
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    stubDocInfo(mockClient, source, p1); // source -> p1
+    // p1 full fetch is left unstubbed (returns null): the parent cannot be hydrated.
+
+    ParentDocumentsResult result =
+        new ParentDocumentsResolver(mockClient).get(envFor(source, 50)).get();
+
+    // A parent that cannot be fetched is not added and the walk stops.
+    assertEquals(result.getCount(), 0);
+  }
+
+  private static DataFetchingEnvironment envFor(Urn source, int maxParentDepth) {
+    QueryContext mockContext = Mockito.mock(QueryContext.class);
+    Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    Mockito.when(mockContext.getMaxParentDepth()).thenReturn(maxParentDepth);
+    Mockito.when(mockContext.getOperationContext())
+        .thenReturn(TestOperationContexts.systemContextNoSearchAuthorization());
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Document entity = new Document();
+    entity.setUrn(source.toString());
+    entity.setType(EntityType.DOCUMENT);
+    Mockito.when(mockEnv.getSource()).thenReturn(entity);
+    return mockEnv;
+  }
+
+  private static EntityResponse docInfoResponse(Urn urn, Urn parent) {
+    final DocumentContents content = new DocumentContents().setText("content");
+    final AuditStamp stamp =
+        new AuditStamp().setTime(1L).setActor(UrnUtils.getUrn("urn:li:corpuser:test"));
+    final DocumentInfo info =
+        new DocumentInfo().setContents(content).setCreated(stamp).setLastModified(stamp);
+    if (parent != null) {
+      info.setParentDocument(new ParentDocument().setDocument(parent));
+    }
+    Map<String, EnvelopedAspect> aspects = new HashMap<>();
+    aspects.put(DOCUMENT_INFO_ASPECT_NAME, new EnvelopedAspect().setValue(new Aspect(info.data())));
+    return new EntityResponse().setUrn(urn).setAspects(new EnvelopedAspectMap(aspects));
+  }
+
+  private static void stubDocInfo(EntityClient client, Urn urn, Urn parent) throws Exception {
+    Mockito.when(
+            client.getV2(
+                any(),
+                Mockito.eq(DOCUMENT_ENTITY_NAME),
+                Mockito.eq(urn),
+                Mockito.eq(Collections.singleton(DOCUMENT_INFO_ASPECT_NAME))))
+        .thenReturn(docInfoResponse(urn, parent));
+  }
+
+  private static void stubFullDoc(EntityClient client, Urn urn, Urn parent) throws Exception {
+    Mockito.when(
+            client.getV2(
+                any(), Mockito.eq(DOCUMENT_ENTITY_NAME), Mockito.eq(urn), Mockito.eq(null)))
+        .thenReturn(docInfoResponse(urn, parent));
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/ParentDocumentsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/ParentDocumentsResolverTest.java
@@ -108,29 +108,8 @@ public class ParentDocumentsResolverTest {
                 .setUrn(documentUrn)
                 .setAspects(new EnvelopedAspectMap(childDocAspects)));
 
-    Mockito.when(
-            mockClient.getV2(
-                any(),
-                Mockito.eq(DOCUMENT_ENTITY_NAME),
-                Mockito.eq(parentDoc1Urn),
-                Mockito.eq(Collections.singleton(DOCUMENT_INFO_ASPECT_NAME))))
-        .thenReturn(
-            new EntityResponse()
-                .setUrn(parentDoc1Urn)
-                .setAspects(new EnvelopedAspectMap(parent1DocAspects)));
-
-    Mockito.when(
-            mockClient.getV2(
-                any(),
-                Mockito.eq(DOCUMENT_ENTITY_NAME),
-                Mockito.eq(parentDoc2Urn),
-                Mockito.eq(Collections.singleton(DOCUMENT_INFO_ASPECT_NAME))))
-        .thenReturn(
-            new EntityResponse()
-                .setUrn(parentDoc2Urn)
-                .setAspects(new EnvelopedAspectMap(parent2DocAspects)));
-
-    // Mock client responses for fetching full parent documents (with null aspects param)
+    // Full parent fetches (null aspects) already carry DocumentInfo, so the walk reads the next
+    // hop from them directly rather than re-fetching each parent's DocumentInfo.
     Mockito.when(
             mockClient.getV2(
                 any(),
@@ -156,13 +135,11 @@ public class ParentDocumentsResolverTest {
     ParentDocumentsResolver resolver = new ParentDocumentsResolver(mockClient);
     ParentDocumentsResult result = resolver.get(mockEnv).get();
 
-    // Should have called getV2 five times:
-    // 1. Get child doc info (with aspect)
-    // 2. Get parent1 full doc (null aspects)
-    // 3. Get parent1 doc info (with aspect)
-    // 4. Get parent2 full doc (null aspects)
-    // 5. Get parent2 doc info (with aspect)
-    Mockito.verify(mockClient, Mockito.times(5))
+    // Should have called getV2 three times (each node fetched once):
+    // 1. Get child doc info (DOCUMENT_INFO only) to find the first parent
+    // 2. Get parent1 full doc (null aspects) — maps it and yields the next parent
+    // 3. Get parent2 full doc (null aspects) — maps it; no further parent
+    Mockito.verify(mockClient, Mockito.times(3))
         .getV2(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
 
     assertEquals(result.getCount(), 2);


### PR DESCRIPTION
## Summary

The parent-chain GraphQL resolvers hydrate an entity's ancestors from the primary aspect store. Two of them issued **one `getV2` per ancestor** (an N+1), and the document walk re-read each node's `DocumentInfo` a second time. This PR reduces those redundant reads:

- **`ParentContainersResolver`** — replace the per-ancestor `getV2` loop with a single `batchGetV2` over the ordered ancestor urns.
- **`ParentNodesResolver`** — same, for the glossary node chain.
- **`ParentDocumentsResolver`** — the parent chain is a linked list, so it can't be batched, but each node can be fetched **once**: the full response already carries `DocumentInfo` for the next hop, so the per-level re-fetch is removed (~2N → ~N reads).

Behavior is unchanged: same results, hierarchy order, missing/unauthorized-node handling, and glossary relationship-visibility filtering.

## Measured impact (end-to-end)

Benchmarked against a real GMS + MySQL with a 300-deep chain (`GRAPHQL_QUERY_MAX_PARENT_DEPTH=500`), before vs. after, same instance:

| Query | Correct? | p50 before → after | `metadata_aspect_v2` stmts before → after |
| --- | --- | --- | --- |
| `parentContainers` (300 ancestors) | 300 = 300 ✓ | 135 ms → 105 ms (**−22%**) | 602 → 320 (**−47%**); hydration 301 → 19 batched |
| `parentDocuments` (299 ancestors) | 299 = 299 ✓ | 114 ms → 84 ms (**−26%**) | 600 → 301 (**−50%**); redundant re-fetch 300 → 1 |
| `parentNodes` (25 ancestors) | 25 = 25 ✓ | 17 ms → 11 ms (**−34%**) | 25 → **1** (**−96%**); full chain in one batch |

`parentNodes` is shown at its maximum depth: the glossary hierarchy walk is capped at 25 ancestors (verified — a 300-deep glossary chain still returns 25), so it has no deeper regime. Its 25 per-ancestor reads collapse to a single batched statement.

Notes:
- On shallow chains (depth ~40) the effect is in the noise — the win scales with chain depth.
- The gain is larger for callers using the **remote** `EntityClient` (each `getV2` is a network round-trip); the in-process GMS path still benefits from the reduced DB statements shown above.
- Follow-up opportunity (not in this PR): `parentContainers` still issues one graph-walk aspect read per ancestor in `orderedParents` — a separate N+1 that now dominates its cost.

## Correctness verification

Beyond the unit tests, the full GraphQL responses were captured against a real GMS on both builds (before vs. after) and compared. For each resolver the response — `count`, the ordered list of ancestor urns, and nested mapped fields (`properties.name`, `subTypes`, `info.title`) — is **byte-for-byte identical** (matching SHA-256):

| Query | ancestors | response sha256 (before == after) |
| --- | --- | --- |
| `parentContainers` | 300 | `d4007bc196a1648a` ✓ |
| `parentNodes` | 25 | `16f0f2695418a8eb` ✓ |
| `parentDocuments` | 299 | `8c4a39c7b3251622` ✓ |

Ancestor set, hierarchy order, and field values are all unchanged.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR title format)
- [ ] Links to related issues (if applicable)
- [x] Tests added/updated — the three resolver tests now assert the reduced round-trips (`batchGetV2` called once; document walk `getV2` count reduced)



