### PR TITLE
refactor(usage): centralize usage metric dimension key constants

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/UsageDimensions.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/UsageDimensions.java
@@ -4,6 +4,7 @@ import io.datahubproject.metadata.context.RequestContext;
 import io.datahubproject.metadata.context.usage.AttributionType;
 import io.datahubproject.metadata.context.usage.AuthChannel;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -11,6 +12,21 @@ import javax.annotation.Nullable;
 
 /** Builds low-cardinality dimension maps for rollup keys. */
 public final class UsageDimensions {
+
+  public static final String USAGE_OPERATION = "usage_operation";
+  public static final String REQUEST_API = "request_api";
+  public static final String AGENT_CLASS = "agent_class";
+  public static final String AUTH_CHANNEL = "auth_channel";
+  public static final String INGESTION_RUNNER = "ingestion_runner";
+  public static final String ACTOR_CLASS = "actor_class";
+
+  /**
+   * Preferred key order when serializing dimension maps (access-channel keys first, then {@link
+   * #ACTOR_CLASS}).
+   */
+  public static final List<String> STABLE_KEY_ORDER =
+      List.of(
+          USAGE_OPERATION, REQUEST_API, AGENT_CLASS, AUTH_CHANNEL, INGESTION_RUNNER, ACTOR_CLASS);
 
   private UsageDimensions() {}
 
@@ -21,15 +37,15 @@ public final class UsageDimensions {
       @Nullable String actorClassDimension) {
     Map<String, String> dimensions = new LinkedHashMap<>();
     if (usageOperation != null) {
-      dimensions.put("usage_operation", usageOperation);
+      dimensions.put(USAGE_OPERATION, usageOperation);
     }
-    dimensions.put("request_api", requestContext.getRequestAPI().toMetricLabel());
-    dimensions.put("agent_class", requestContext.getAgentClass().toMetricLabel());
+    dimensions.put(REQUEST_API, requestContext.getRequestAPI().toMetricLabel());
+    dimensions.put(AGENT_CLASS, requestContext.getAgentClass().toMetricLabel());
     AuthChannel authChannel =
         Optional.ofNullable(requestContext.getAuthChannel()).orElse(AuthChannel.UNKNOWN);
-    dimensions.put("auth_channel", authChannel.dimensionValue());
+    dimensions.put(AUTH_CHANNEL, authChannel.dimensionValue());
     if (actorClassDimension != null) {
-      dimensions.put("actor_class", actorClassDimension);
+      dimensions.put(ACTOR_CLASS, actorClassDimension);
     }
     return Map.copyOf(dimensions);
   }

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/flush/MicrometerUsageFlushSink.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/flush/MicrometerUsageFlushSink.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.usage.flush;
 
+import com.linkedin.metadata.usage.UsageDimensions;
 import com.linkedin.metadata.usage.registry.metrics.UsageMetricIncrementResolver;
 import com.linkedin.metadata.usage.registry.metrics.UsageMetricRegistry;
 import io.datahubproject.metadata.context.usage.UsageActorClass;
@@ -59,7 +60,8 @@ public class MicrometerUsageFlushSink implements UsageFlushSink {
               AtomicInteger gaugeValue = new AtomicInteger(0);
               registry.gauge(
                   ACTIVE_IDENTITIES_METRIC,
-                  Tags.of("identity_metric", identityMetric, "actor_class", actorClass),
+                  Tags.of(
+                      "identity_metric", identityMetric, UsageDimensions.ACTOR_CLASS, actorClass),
                   gaugeValue,
                   AtomicInteger::get);
               return gaugeValue;
@@ -71,14 +73,18 @@ public class MicrometerUsageFlushSink implements UsageFlushSink {
   private Tags buildTags(
       @Nonnull Map<String, String> dimensions, @Nullable UsageActorClass actorClass) {
     Tags tags = Tags.empty();
-    tags = withTag(tags, "usage_operation", dimensions.get("usage_operation"));
-    tags = withTag(tags, "agent_class", dimensions.get("agent_class"));
-    tags = withTag(tags, "request_api", dimensions.get("request_api"));
-    tags = withTag(tags, "auth_channel", dimensions.get("auth_channel"));
+    tags =
+        withTag(
+            tags, UsageDimensions.USAGE_OPERATION, dimensions.get(UsageDimensions.USAGE_OPERATION));
+    tags = withTag(tags, UsageDimensions.AGENT_CLASS, dimensions.get(UsageDimensions.AGENT_CLASS));
+    tags = withTag(tags, UsageDimensions.REQUEST_API, dimensions.get(UsageDimensions.REQUEST_API));
+    tags =
+        withTag(tags, UsageDimensions.AUTH_CHANNEL, dimensions.get(UsageDimensions.AUTH_CHANNEL));
     if (actorClass != null) {
-      tags = withTag(tags, "actor_class", actorClass.dimensionValue());
+      tags = withTag(tags, UsageDimensions.ACTOR_CLASS, actorClass.dimensionValue());
     } else {
-      tags = withTag(tags, "actor_class", dimensions.get("actor_class"));
+      tags =
+          withTag(tags, UsageDimensions.ACTOR_CLASS, dimensions.get(UsageDimensions.ACTOR_CLASS));
     }
     return tags;
   }

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/UsageDimensionsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/UsageDimensionsTest.java
@@ -1,0 +1,92 @@
+package com.linkedin.metadata.usage;
+
+import io.datahubproject.metadata.context.RequestContext;
+import io.datahubproject.metadata.context.usage.AttributionType;
+import io.datahubproject.metadata.context.usage.AuthChannel;
+import java.util.List;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class UsageDimensionsTest {
+
+  @Test
+  public void testDimensionConstantValues() {
+    Assert.assertEquals(UsageDimensions.USAGE_OPERATION, "usage_operation");
+    Assert.assertEquals(UsageDimensions.REQUEST_API, "request_api");
+    Assert.assertEquals(UsageDimensions.AGENT_CLASS, "agent_class");
+    Assert.assertEquals(UsageDimensions.AUTH_CHANNEL, "auth_channel");
+    Assert.assertEquals(UsageDimensions.INGESTION_RUNNER, "ingestion_runner");
+    Assert.assertEquals(UsageDimensions.ACTOR_CLASS, "actor_class");
+  }
+
+  @Test
+  public void testStableKeyOrder() {
+    Assert.assertEquals(
+        UsageDimensions.STABLE_KEY_ORDER,
+        List.of(
+            UsageDimensions.USAGE_OPERATION,
+            UsageDimensions.REQUEST_API,
+            UsageDimensions.AGENT_CLASS,
+            UsageDimensions.AUTH_CHANNEL,
+            UsageDimensions.INGESTION_RUNNER,
+            UsageDimensions.ACTOR_CLASS));
+  }
+
+  @Test
+  public void testFromRequestContextIncludesOptionalDimensions() {
+    RequestContext requestContext =
+        RequestContext.builder()
+            .actorUrn("urn:li:corpuser:test")
+            .sourceIP("127.0.0.1")
+            .requestAPI(RequestContext.RequestAPI.OPENAPI)
+            .requestID("test")
+            .userAgent("Mozilla/5.0")
+            .authChannel(AuthChannel.SESSION)
+            .build();
+
+    Map<String, String> dimensions =
+        UsageDimensions.fromRequestContext(requestContext, "metadata_read", "regular");
+
+    Assert.assertEquals(dimensions.get(UsageDimensions.USAGE_OPERATION), "metadata_read");
+    Assert.assertEquals(dimensions.get(UsageDimensions.REQUEST_API), "openapi");
+    Assert.assertEquals(dimensions.get(UsageDimensions.AGENT_CLASS), "browser");
+    Assert.assertEquals(dimensions.get(UsageDimensions.AUTH_CHANNEL), "session");
+    Assert.assertEquals(dimensions.get(UsageDimensions.ACTOR_CLASS), "regular");
+    Assert.assertFalse(dimensions.containsKey(UsageDimensions.INGESTION_RUNNER));
+  }
+
+  @Test
+  public void testFromRequestContextOmitsNullOptionalsAndDefaultsAuthChannel() {
+    RequestContext requestContext =
+        RequestContext.builder()
+            .actorUrn("urn:li:corpuser:test")
+            .sourceIP("127.0.0.1")
+            .requestAPI(RequestContext.RequestAPI.GRAPHQL)
+            .requestID("test")
+            .userAgent("datahub-cli/1.0")
+            .build();
+
+    Map<String, String> dimensions = UsageDimensions.fromRequestContext(requestContext, null, null);
+
+    Assert.assertFalse(dimensions.containsKey(UsageDimensions.USAGE_OPERATION));
+    Assert.assertFalse(dimensions.containsKey(UsageDimensions.ACTOR_CLASS));
+    Assert.assertEquals(dimensions.get(UsageDimensions.REQUEST_API), "graphql");
+    Assert.assertEquals(dimensions.get(UsageDimensions.AUTH_CHANNEL), "unknown");
+    Assert.assertNotNull(dimensions.get(UsageDimensions.AGENT_CLASS));
+  }
+
+  @Test
+  public void testResolveAttribution() {
+    RequestContext requestContext =
+        RequestContext.builder()
+            .actorUrn("urn:li:corpuser:test")
+            .sourceIP("127.0.0.1")
+            .requestAPI(RequestContext.RequestAPI.OPENAPI)
+            .requestID("test")
+            .userAgent("Mozilla/5.0")
+            .build();
+
+    Assert.assertEquals(UsageDimensions.resolveAttribution(requestContext), AttributionType.HUMAN);
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/flush/MicrometerUsageFlushSinkTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/flush/MicrometerUsageFlushSinkTest.java
@@ -12,6 +12,7 @@ import com.linkedin.metadata.usage.flush.UsageFlushBatch;
 import com.linkedin.metadata.usage.registry.metrics.UsageMetricRegistry;
 import io.datahubproject.metadata.context.usage.UsageActorClass;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.testng.Assert;
@@ -33,13 +34,13 @@ public class MicrometerUsageFlushSinkTest {
 
     Map<String, String> dimensions =
         Map.of(
-            "usage_operation",
+            UsageDimensions.USAGE_OPERATION,
             "metadata_read",
-            "agent_class",
+            UsageDimensions.AGENT_CLASS,
             "browser",
-            "request_api",
+            UsageDimensions.REQUEST_API,
             "openapi",
-            "auth_channel",
+            UsageDimensions.AUTH_CHANNEL,
             "session");
     UsageFlushBatch batch =
         new UsageFlushBatch(
@@ -56,10 +57,47 @@ public class MicrometerUsageFlushSinkTest {
 
     Assert.assertEquals(registry.get("datahub_request_count").counter().count(), 3.0);
     Assert.assertEquals(
-        registry.get("datahub_request_count").tag("auth_channel", "session").counter().count(),
+        registry
+            .get("datahub_request_count")
+            .tag(UsageDimensions.AUTH_CHANNEL, "session")
+            .tag(UsageDimensions.ACTOR_CLASS, "regular")
+            .counter()
+            .count(),
         3.0);
     Assert.assertEquals(registry.get("datahub.usage.input_bytes").counter().count(), 100.0);
     Assert.assertEquals(registry.get("datahub.usage.output_bytes").counter().count(), 200.0);
+  }
+
+  @Test
+  public void testPublishesActorClassFromDimensionsWhenRowActorClassNull() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerUsageFlushSink sink = new MicrometerUsageFlushSink(metricRegistry(), registry);
+
+    Map<String, String> dimensions = new HashMap<>();
+    dimensions.put(UsageDimensions.USAGE_OPERATION, "metadata_read");
+    dimensions.put(UsageDimensions.AGENT_CLASS, "browser");
+    dimensions.put(UsageDimensions.REQUEST_API, "openapi");
+    dimensions.put(UsageDimensions.AUTH_CHANNEL, "session");
+    dimensions.put(UsageDimensions.ACTOR_CLASS, "support");
+
+    UsageFlushBatch batch =
+        new UsageFlushBatch(
+            java.time.Instant.now(),
+            java.time.Instant.now(),
+            FlushTrigger.SCHEDULED,
+            List.of(new AdditiveUsageRow("api_calls", null, dimensions, 2)),
+            List.of());
+
+    sink.publish(batch);
+
+    Assert.assertEquals(
+        registry
+            .get("datahub_request_count")
+            .tag(UsageDimensions.ACTOR_CLASS, "support")
+            .tag(UsageDimensions.USAGE_OPERATION, "metadata_read")
+            .counter()
+            .count(),
+        2.0);
   }
 
   @Test
@@ -87,7 +125,7 @@ public class MicrometerUsageFlushSinkTest {
     Assert.assertEquals(
         registry
             .get("datahub.usage.active_identities")
-            .tag("actor_class", "support")
+            .tag(UsageDimensions.ACTOR_CLASS, "support")
             .tag("identity_metric", "active_readers")
             .gauge()
             .value(),
@@ -119,7 +157,7 @@ public class MicrometerUsageFlushSinkTest {
     Assert.assertEquals(
         registry
             .get("datahub.usage.active_identities")
-            .tag("actor_class", "regular")
+            .tag(UsageDimensions.ACTOR_CLASS, "regular")
             .tag("identity_metric", "active_users")
             .gauge()
             .value(),
@@ -127,10 +165,10 @@ public class MicrometerUsageFlushSinkTest {
     var gauge =
         registry
             .get("datahub.usage.active_identities")
-            .tag("actor_class", "regular")
+            .tag(UsageDimensions.ACTOR_CLASS, "regular")
             .tag("identity_metric", "active_users")
             .gauge();
-    Assert.assertNull(gauge.getId().getTag("auth_channel"));
+    Assert.assertNull(gauge.getId().getTag(UsageDimensions.AUTH_CHANNEL));
   }
 
   @Test
@@ -162,7 +200,7 @@ public class MicrometerUsageFlushSinkTest {
         registry
             .get("datahub.usage.active_identities")
             .tag("identity_metric", "active_users")
-            .tag("actor_class", "regular")
+            .tag(UsageDimensions.ACTOR_CLASS, "regular")
             .gauge()
             .value(),
         2.0);
@@ -186,7 +224,7 @@ public class MicrometerUsageFlushSinkTest {
     Assert.assertEquals(
         registry
             .get("datahub.usage.active_identities")
-            .tag("actor_class", "support")
+            .tag(UsageDimensions.ACTOR_CLASS, "support")
             .tag("identity_metric", "active_users")
             .gauge()
             .value(),


### PR DESCRIPTION
## Summary
- Extract shared usage metric dimension key constants (`usage_operation`, `request_api`, `agent_class`, `auth_channel`, `ingestion_runner`, `actor_class`) and `STABLE_KEY_ORDER` on `UsageDimensions`
- Use those constants in `MicrometerUsageFlushSink` tag construction to avoid string-literal drift
- Add/extend unit tests for constant values, `fromRequestContext`, and the null `actorClass` Micrometer fallback path

## Test plan
- [x] `./gradlew :metadata-io:test --tests 'com.linkedin.metadata.usage.UsageDimensionsTest' --tests 'com.linkedin.metadata.usage.MicrometerUsageFlushSinkTest'`
- [ ] Confirm CI patch coverage for added/modified lines stays ≥75%


Made with [Cursor](https://cursor.com)