### PR TITLE
feat(graphql): add Metric entity GraphQL type and mappers

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/metric/MetricType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/metric/MetricType.java
@@ -1,0 +1,144 @@
+package com.linkedin.datahub.graphql.types.metric;
+
+import static com.linkedin.datahub.graphql.authorization.AuthorizationUtils.canView;
+
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.AutoCompleteResults;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.FacetFilterInput;
+import com.linkedin.datahub.graphql.generated.Metric;
+import com.linkedin.datahub.graphql.generated.SearchResults;
+import com.linkedin.datahub.graphql.types.SearchableEntityType;
+import com.linkedin.datahub.graphql.types.mappers.AutoCompleteResultsMapper;
+import com.linkedin.datahub.graphql.types.metric.mappers.MetricMapper;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
+import graphql.execution.DataFetcherResult;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.NotImplementedException;
+
+public class MetricType implements SearchableEntityType<Metric, String> {
+
+  public static final Set<String> ASPECTS_TO_FETCH =
+      ImmutableSet.of(
+          Constants.METRIC_KEY_ASPECT_NAME,
+          Constants.METRIC_INFO_ASPECT_NAME,
+          Constants.METRIC_RELATIONSHIPS_ASPECT_NAME,
+          Constants.METRIC_UPSTREAMS_ASPECT_NAME,
+          Constants.OWNERSHIP_ASPECT_NAME,
+          Constants.DOMAINS_ASPECT_NAME,
+          Constants.GLOBAL_TAGS_ASPECT_NAME,
+          Constants.GLOSSARY_TERMS_ASPECT_NAME,
+          Constants.INSTITUTIONAL_MEMORY_ASPECT_NAME,
+          Constants.STRUCTURED_PROPERTIES_ASPECT_NAME,
+          Constants.STATUS_ASPECT_NAME,
+          Constants.DEPRECATION_ASPECT_NAME,
+          Constants.DATA_PLATFORM_INSTANCE_ASPECT_NAME,
+          Constants.SUB_TYPES_ASPECT_NAME,
+          Constants.DOCUMENTATION_ASPECT_NAME,
+          Constants.BROWSE_PATHS_V2_ASPECT_NAME,
+          Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME);
+
+  private final EntityClient _entityClient;
+
+  public MetricType(final EntityClient entityClient) {
+    _entityClient = entityClient;
+  }
+
+  @Override
+  public EntityType type() {
+    return EntityType.METRIC;
+  }
+
+  @Override
+  public Function<Entity, String> getKeyProvider() {
+    return Entity::getUrn;
+  }
+
+  @Override
+  public Class<Metric> objectClass() {
+    return Metric.class;
+  }
+
+  @Override
+  public List<DataFetcherResult<Metric>> batchLoad(
+      @Nonnull List<String> urns, @Nonnull QueryContext context) throws Exception {
+    final List<Urn> metricUrns = urns.stream().map(this::getUrn).collect(Collectors.toList());
+
+    try {
+      final Map<Urn, EntityResponse> entities =
+          _entityClient.batchGetV2(
+              context.getOperationContext(),
+              Constants.METRIC_ENTITY_NAME,
+              metricUrns.stream()
+                  .filter(urn -> canView(context.getOperationContext(), urn))
+                  .collect(Collectors.toSet()),
+              ASPECTS_TO_FETCH,
+              true);
+
+      final List<EntityResponse> gmsResults = new ArrayList<>(urns.size());
+      for (Urn urn : metricUrns) {
+        gmsResults.add(entities.getOrDefault(urn, null));
+      }
+      return gmsResults.stream()
+          .map(
+              gmsResult ->
+                  gmsResult == null
+                      ? null
+                      : DataFetcherResult.<Metric>newResult()
+                          .data(MetricMapper.map(context, gmsResult))
+                          .build())
+          .collect(Collectors.toList());
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to batch load Metrics", e);
+    }
+  }
+
+  @Override
+  public SearchResults search(
+      @Nonnull String query,
+      @Nullable List<FacetFilterInput> filters,
+      int start,
+      @Nullable Integer count,
+      @Nonnull final QueryContext context)
+      throws Exception {
+    throw new NotImplementedException(
+        "Searchable type (deprecated) not implemented on Metric entity type. Use searchAcrossEntities instead.");
+  }
+
+  @Override
+  public AutoCompleteResults autoComplete(
+      @Nonnull String query,
+      @Nullable String field,
+      @Nullable Filter filters,
+      @Nullable Integer limit,
+      @Nonnull final QueryContext context)
+      throws Exception {
+    final AutoCompleteResult result =
+        _entityClient.autoComplete(
+            context.getOperationContext(), Constants.METRIC_ENTITY_NAME, query, filters, limit);
+    return AutoCompleteResultsMapper.map(context, result);
+  }
+
+  private Urn getUrn(final String urnStr) {
+    try {
+      return Urn.createFromString(urnStr);
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(String.format("Failed to convert urn string %s into Urn", urnStr));
+    }
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/metric/mappers/AiContextMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/metric/mappers/AiContextMapper.java
@@ -1,0 +1,45 @@
+package com.linkedin.datahub.graphql.types.metric.mappers;
+
+import com.linkedin.datahub.graphql.generated.AiContext;
+import java.util.ArrayList;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Maps {@link com.linkedin.metric.AiContext} Pegasus records to the generated GraphQL {@link
+ * AiContext}.
+ */
+public class AiContextMapper {
+
+  private AiContextMapper() {}
+
+  @Nullable
+  public static AiContext map(@Nullable com.linkedin.metric.AiContext pdl) {
+    if (pdl == null) {
+      return null;
+    }
+
+    AiContext result = new AiContext();
+
+    if (pdl.hasSynonyms() && pdl.getSynonyms() != null) {
+      result.setSynonyms(new ArrayList<>(pdl.getSynonyms()));
+    }
+    if (pdl.hasInstructions() && pdl.getInstructions() != null) {
+      result.setInstructions(pdl.getInstructions());
+    }
+    if (pdl.hasExamples() && pdl.getExamples() != null) {
+      result.setExamples(new ArrayList<>(pdl.getExamples()));
+    }
+    if (pdl.hasCustomInstructions() && pdl.getCustomInstructions() != null) {
+      result.setCustomInstructions(pdl.getCustomInstructions());
+    }
+
+    return result;
+  }
+
+  @Nonnull
+  public static AiContext mapNonNull(@Nonnull com.linkedin.metric.AiContext pdl) {
+    AiContext result = map(pdl);
+    return result != null ? result : new AiContext();
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricExpressionMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricExpressionMapper.java
@@ -1,0 +1,62 @@
+package com.linkedin.datahub.graphql.types.metric.mappers;
+
+import com.linkedin.datahub.graphql.generated.Dialect;
+import com.linkedin.datahub.graphql.generated.DialectExpression;
+import com.linkedin.datahub.graphql.generated.MetricExpression;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Maps {@link com.linkedin.metric.MetricExpression} Pegasus records to the generated GraphQL {@link
+ * MetricExpression}.
+ */
+@Slf4j
+public class MetricExpressionMapper {
+
+  private MetricExpressionMapper() {}
+
+  @Nullable
+  public static MetricExpression map(@Nullable com.linkedin.metric.MetricExpression pdl) {
+    if (pdl == null) {
+      return null;
+    }
+
+    List<DialectExpression> dialects;
+    if (pdl.hasDialects() && pdl.getDialects() != null) {
+      dialects =
+          pdl.getDialects().stream()
+              .map(MetricExpressionMapper::mapDialectExpression)
+              .collect(Collectors.toList());
+    } else {
+      dialects = Collections.emptyList();
+    }
+
+    MetricExpression result = new MetricExpression();
+    result.setDialects(dialects);
+    return result;
+  }
+
+  @Nonnull
+  private static DialectExpression mapDialectExpression(
+      @Nonnull com.linkedin.metric.DialectExpression pdl) {
+    DialectExpression result = new DialectExpression();
+    result.setExpression(pdl.getExpression());
+
+    Dialect dialect;
+    try {
+      dialect = Dialect.valueOf(pdl.getDialect().name());
+    } catch (IllegalArgumentException e) {
+      log.warn(
+          "MetricExpressionMapper: unknown Dialect value '{}', falling back to OTHER",
+          pdl.getDialect().name());
+      dialect = Dialect.OTHER;
+    }
+    result.setDialect(dialect);
+
+    return result;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricExpressionMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricExpressionMapper.java
@@ -3,18 +3,17 @@ package com.linkedin.datahub.graphql.types.metric.mappers;
 import com.linkedin.datahub.graphql.generated.Dialect;
 import com.linkedin.datahub.graphql.generated.DialectExpression;
 import com.linkedin.datahub.graphql.generated.MetricExpression;
+import com.linkedin.datahub.graphql.types.mappers.PdlEnumMapper;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Maps {@link com.linkedin.metric.MetricExpression} Pegasus records to the generated GraphQL {@link
  * MetricExpression}.
  */
-@Slf4j
 public class MetricExpressionMapper {
 
   private MetricExpressionMapper() {}
@@ -45,18 +44,7 @@ public class MetricExpressionMapper {
       @Nonnull com.linkedin.metric.DialectExpression pdl) {
     DialectExpression result = new DialectExpression();
     result.setExpression(pdl.getExpression());
-
-    Dialect dialect;
-    try {
-      dialect = Dialect.valueOf(pdl.getDialect().name());
-    } catch (IllegalArgumentException e) {
-      log.warn(
-          "MetricExpressionMapper: unknown Dialect value '{}', falling back to OTHER",
-          pdl.getDialect().name());
-      dialect = Dialect.OTHER;
-    }
-    result.setDialect(dialect);
-
+    result.setDialect(PdlEnumMapper.map(Dialect.class, pdl.getDialect(), Dialect.OTHER));
     return result;
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricMapper.java
@@ -1,0 +1,258 @@
+package com.linkedin.datahub.graphql.types.metric.mappers;
+
+import static com.linkedin.datahub.graphql.authorization.AuthorizationUtils.canView;
+
+import com.linkedin.common.BrowsePathsV2;
+import com.linkedin.common.DataPlatformInstance;
+import com.linkedin.common.Deprecation;
+import com.linkedin.common.Documentation;
+import com.linkedin.common.GlobalTags;
+import com.linkedin.common.GlossaryTerms;
+import com.linkedin.common.InstitutionalMemory;
+import com.linkedin.common.Ownership;
+import com.linkedin.common.Status;
+import com.linkedin.common.SubTypes;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.DataPlatform;
+import com.linkedin.datahub.graphql.generated.EntityEdge;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.Metric;
+import com.linkedin.datahub.graphql.generated.MetricInfo;
+import com.linkedin.datahub.graphql.generated.SemanticModel;
+import com.linkedin.datahub.graphql.types.common.mappers.BrowsePathsV2Mapper;
+import com.linkedin.datahub.graphql.types.common.mappers.DataPlatformInstanceAspectMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.DeprecationMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.DocumentationMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.EdgeMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.InstitutionalMemoryMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.OwnershipMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.StatusMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.SubTypesMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.UrnToEntityMapper;
+import com.linkedin.datahub.graphql.types.domain.DomainAssociationMapper;
+import com.linkedin.datahub.graphql.types.glossary.mappers.GlossaryTermsMapper;
+import com.linkedin.datahub.graphql.types.mappers.MapperUtils;
+import com.linkedin.datahub.graphql.types.structuredproperty.StructuredPropertiesMapper;
+import com.linkedin.datahub.graphql.types.tag.mappers.GlobalTagsMapper;
+import com.linkedin.domain.Domains;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.key.MetricKey;
+import com.linkedin.structured.StructuredProperties;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+public class MetricMapper {
+
+  private MetricMapper() {}
+
+  public static Metric map(@Nullable QueryContext context, final EntityResponse entityResponse) {
+    final Metric result = new Metric();
+    final Urn entityUrn = entityResponse.getUrn();
+    final EnvelopedAspectMap aspects = entityResponse.getAspects();
+
+    result.setUrn(entityUrn.toString());
+    result.setType(EntityType.METRIC);
+
+    final EnvelopedAspect envelopedKey = aspects.get(Constants.METRIC_KEY_ASPECT_NAME);
+    if (envelopedKey != null) {
+      final MetricKey key = new MetricKey(envelopedKey.getValue().data());
+      result.setPlatform(
+          DataPlatform.builder()
+              .setType(EntityType.DATA_PLATFORM)
+              .setUrn(key.getPlatform().toString())
+              .build());
+      result.setPath(key.getPath());
+      result.setId(key.getId());
+    }
+
+    final EnvelopedAspect envelopedInfo = aspects.get(Constants.METRIC_INFO_ASPECT_NAME);
+    if (envelopedInfo != null) {
+      final com.linkedin.metric.MetricInfo pdlInfo =
+          new com.linkedin.metric.MetricInfo(envelopedInfo.getValue().data());
+      result.setInfo(mapMetricInfo(pdlInfo));
+      if (pdlInfo.hasSemanticModel() && pdlInfo.getSemanticModel() != null) {
+        final SemanticModel semanticModelStub = new SemanticModel();
+        semanticModelStub.setUrn(pdlInfo.getSemanticModel().toString());
+        semanticModelStub.setType(EntityType.SEMANTIC_MODEL);
+        result.setSemanticModel(semanticModelStub);
+      }
+    }
+
+    final EnvelopedAspect envelopedRelationships =
+        aspects.get(Constants.METRIC_RELATIONSHIPS_ASPECT_NAME);
+    if (envelopedRelationships != null) {
+      result.setMetricRelationships(
+          mapMetricRelationships(
+              context,
+              new com.linkedin.metric.MetricRelationships(
+                  envelopedRelationships.getValue().data())));
+    }
+
+    final EnvelopedAspect envelopedUpstreams = aspects.get(Constants.METRIC_UPSTREAMS_ASPECT_NAME);
+    if (envelopedUpstreams != null) {
+      result.setMetricUpstreams(
+          MetricUpstreamsMapper.map(
+              context,
+              new com.linkedin.metric.MetricUpstreams(envelopedUpstreams.getValue().data())));
+    }
+
+    final EnvelopedAspect envelopedOwnership = aspects.get(Constants.OWNERSHIP_ASPECT_NAME);
+    if (envelopedOwnership != null) {
+      result.setOwnership(
+          OwnershipMapper.map(
+              context, new Ownership(envelopedOwnership.getValue().data()), entityUrn));
+    }
+
+    final EnvelopedAspect envelopedGlobalTags = aspects.get(Constants.GLOBAL_TAGS_ASPECT_NAME);
+    if (envelopedGlobalTags != null) {
+      result.setTags(
+          GlobalTagsMapper.map(
+              context, new GlobalTags(envelopedGlobalTags.getValue().data()), entityUrn));
+    }
+
+    final EnvelopedAspect envelopedGlossaryTerms =
+        aspects.get(Constants.GLOSSARY_TERMS_ASPECT_NAME);
+    if (envelopedGlossaryTerms != null) {
+      result.setGlossaryTerms(
+          GlossaryTermsMapper.map(
+              context, new GlossaryTerms(envelopedGlossaryTerms.getValue().data()), entityUrn));
+    }
+
+    final EnvelopedAspect envelopedDomains = aspects.get(Constants.DOMAINS_ASPECT_NAME);
+    if (envelopedDomains != null) {
+      final Domains domains = new Domains(envelopedDomains.getValue().data());
+      if (domains.hasDomains() && !domains.getDomains().isEmpty()) {
+        result.setDomain(DomainAssociationMapper.map(context, domains, entityUrn.toString()));
+      }
+    }
+
+    final EnvelopedAspect envelopedInstitutionalMemory =
+        aspects.get(Constants.INSTITUTIONAL_MEMORY_ASPECT_NAME);
+    if (envelopedInstitutionalMemory != null) {
+      result.setInstitutionalMemory(
+          InstitutionalMemoryMapper.map(
+              context,
+              new InstitutionalMemory(envelopedInstitutionalMemory.getValue().data()),
+              entityUrn));
+    }
+
+    final EnvelopedAspect envelopedStructuredProps =
+        aspects.get(Constants.STRUCTURED_PROPERTIES_ASPECT_NAME);
+    if (envelopedStructuredProps != null) {
+      result.setStructuredProperties(
+          StructuredPropertiesMapper.map(
+              context,
+              new StructuredProperties(envelopedStructuredProps.getValue().data()),
+              entityUrn));
+    }
+
+    final EnvelopedAspect envelopedStatus = aspects.get(Constants.STATUS_ASPECT_NAME);
+    if (envelopedStatus != null) {
+      final Status status = new Status(envelopedStatus.getValue().data());
+      result.setStatus(StatusMapper.map(context, status));
+      result.setExists(!status.isRemoved());
+    }
+
+    final EnvelopedAspect envelopedDeprecation = aspects.get(Constants.DEPRECATION_ASPECT_NAME);
+    if (envelopedDeprecation != null) {
+      result.setDeprecation(
+          DeprecationMapper.map(context, new Deprecation(envelopedDeprecation.getValue().data())));
+    }
+
+    final EnvelopedAspect envelopedDataPlatformInstance =
+        aspects.get(Constants.DATA_PLATFORM_INSTANCE_ASPECT_NAME);
+    if (envelopedDataPlatformInstance != null) {
+      result.setDataPlatformInstance(
+          DataPlatformInstanceAspectMapper.map(
+              context, new DataPlatformInstance(envelopedDataPlatformInstance.getValue().data())));
+    }
+
+    final EnvelopedAspect envelopedSubTypes = aspects.get(Constants.SUB_TYPES_ASPECT_NAME);
+    if (envelopedSubTypes != null) {
+      result.setSubTypes(
+          SubTypesMapper.map(context, new SubTypes(envelopedSubTypes.getValue().data())));
+    }
+
+    final EnvelopedAspect envelopedDocumentation = aspects.get(Constants.DOCUMENTATION_ASPECT_NAME);
+    if (envelopedDocumentation != null) {
+      result.setDocumentation(
+          DocumentationMapper.map(
+              context, new Documentation(envelopedDocumentation.getValue().data())));
+    }
+
+    final EnvelopedAspect envelopedBrowsePathsV2 =
+        aspects.get(Constants.BROWSE_PATHS_V2_ASPECT_NAME);
+    if (envelopedBrowsePathsV2 != null) {
+      result.setBrowsePathV2(
+          BrowsePathsV2Mapper.map(
+              context, new BrowsePathsV2(envelopedBrowsePathsV2.getValue().data())));
+    }
+
+    if (context != null && !canView(context.getOperationContext(), entityUrn)) {
+      return com.linkedin.datahub.graphql.authorization.AuthorizationUtils.restrictEntity(
+          result, Metric.class);
+    }
+    return result;
+  }
+
+  private static MetricInfo mapMetricInfo(final com.linkedin.metric.MetricInfo pdl) {
+    final MetricInfo result = new MetricInfo();
+    result.setName(pdl.getName());
+    if (pdl.hasDescription() && pdl.getDescription() != null) {
+      result.setDescription(pdl.getDescription());
+    }
+    if (pdl.hasCreated() && pdl.getCreated() != null) {
+      result.setCreated(MapperUtils.createResolvedAuditStamp(pdl.getCreated()));
+    }
+    if (pdl.hasLastModified() && pdl.getLastModified() != null) {
+      result.setLastModified(MapperUtils.createResolvedAuditStamp(pdl.getLastModified()));
+    }
+    if (pdl.hasExpression() && pdl.getExpression() != null) {
+      result.setExpression(MetricExpressionMapper.map(pdl.getExpression()));
+    }
+    if (pdl.hasAiContext() && pdl.getAiContext() != null) {
+      result.setAiContext(AiContextMapper.map(pdl.getAiContext()));
+    }
+    return result;
+  }
+
+  private static com.linkedin.datahub.graphql.generated.MetricRelationships mapMetricRelationships(
+      @Nullable QueryContext context, final com.linkedin.metric.MetricRelationships pdl) {
+    final com.linkedin.datahub.graphql.generated.MetricRelationships result =
+        new com.linkedin.datahub.graphql.generated.MetricRelationships();
+
+    if (pdl.hasParentMetric() && pdl.getParentMetric() != null) {
+      result.setParentMetric((Metric) UrnToEntityMapper.map(context, pdl.getParentMetric()));
+    }
+
+    final List<EntityEdge> derivedFrom;
+    if (pdl.hasDerivedFrom() && pdl.getDerivedFrom() != null) {
+      derivedFrom =
+          EdgeMapper.mapList(
+              context,
+              pdl.getDerivedFrom().stream()
+                  .map(d -> new com.linkedin.common.Edge(d.data()))
+                  .collect(Collectors.toList()));
+    } else {
+      derivedFrom = Collections.emptyList();
+    }
+    result.setDerivedFrom(derivedFrom);
+
+    final List<EntityEdge> relatedMetrics;
+    if (pdl.hasRelatedMetrics() && pdl.getRelatedMetrics() != null) {
+      relatedMetrics = EdgeMapper.mapList(context, new ArrayList<>(pdl.getRelatedMetrics()));
+    } else {
+      relatedMetrics = Collections.emptyList();
+    }
+    result.setRelatedMetrics(relatedMetrics);
+
+    return result;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricUpstreamsMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricUpstreamsMapper.java
@@ -1,0 +1,43 @@
+package com.linkedin.datahub.graphql.types.metric.mappers;
+
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.MetricUpstreams;
+import com.linkedin.datahub.graphql.types.common.mappers.EdgeMapper;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Maps {@link com.linkedin.metric.MetricUpstreams} Pegasus records to the generated GraphQL {@link
+ * MetricUpstreams}.
+ */
+public class MetricUpstreamsMapper {
+
+  private MetricUpstreamsMapper() {}
+
+  @Nullable
+  public static MetricUpstreams map(
+      @Nullable QueryContext context, @Nullable com.linkedin.metric.MetricUpstreams pdl) {
+    if (pdl == null) {
+      return null;
+    }
+
+    MetricUpstreams result = new MetricUpstreams();
+
+    if (pdl.hasDatasetUpstreams() && pdl.getDatasetUpstreams() != null) {
+      result.setDatasetUpstreams(EdgeMapper.mapList(context, pdl.getDatasetUpstreams()));
+    }
+
+    if (pdl.hasFieldUpstreams() && pdl.getFieldUpstreams() != null) {
+      result.setFieldUpstreams(EdgeMapper.mapList(context, pdl.getFieldUpstreams()));
+    }
+
+    return result;
+  }
+
+  @Nonnull
+  public static MetricUpstreams mapNonNull(
+      @Nonnull QueryContext context, @Nonnull com.linkedin.metric.MetricUpstreams pdl) {
+    MetricUpstreams result = map(context, pdl);
+    return result != null ? result : new MetricUpstreams();
+  }
+}

--- a/datahub-graphql-core/src/main/resources/metrics.graphql
+++ b/datahub-graphql-core/src/main/resources/metrics.graphql
@@ -102,7 +102,7 @@ type Metric implements Entity {
   """
   Parent metrics in the metric hierarchy.
   """
-  parentMetrics: ParentMetricsResult
+  parentMetrics: [Metric!]!
 
   """
   Child metrics in the metric hierarchy.
@@ -487,13 +487,6 @@ type AiContext {
   instructions: String
   examples: [String!]
   customInstructions: String
-}
-
-"""
-The ordered chain of ancestor metrics from direct parent up to the root.
-"""
-type ParentMetricsResult {
-  metrics: [Metric!]!
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/metric/mappers/AiContextMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/metric/mappers/AiContextMapperTest.java
@@ -1,0 +1,64 @@
+package com.linkedin.datahub.graphql.types.metric.mappers;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import com.linkedin.data.template.StringArray;
+import com.linkedin.metric.AiContext;
+import org.testng.annotations.Test;
+
+public class AiContextMapperTest {
+
+  @Test
+  public void testMapNull() {
+    assertNull(AiContextMapper.map(null));
+  }
+
+  @Test
+  public void testMapAllFields() {
+    AiContext pdl = new AiContext();
+    pdl.setSynonyms(new StringArray("rev", "revenue_total"));
+    pdl.setInstructions("Use this metric for financial reporting.");
+    pdl.setExamples(new StringArray("Q1 revenue = 1000000"));
+    pdl.setCustomInstructions("Always filter by fiscal year.");
+
+    com.linkedin.datahub.graphql.generated.AiContext result = AiContextMapper.map(pdl);
+
+    assertNotNull(result);
+    assertEquals(result.getSynonyms().size(), 2);
+    assertEquals(result.getSynonyms().get(0), "rev");
+    assertEquals(result.getSynonyms().get(1), "revenue_total");
+    assertEquals(result.getInstructions(), "Use this metric for financial reporting.");
+    assertEquals(result.getExamples().size(), 1);
+    assertEquals(result.getExamples().get(0), "Q1 revenue = 1000000");
+    assertEquals(result.getCustomInstructions(), "Always filter by fiscal year.");
+  }
+
+  @Test
+  public void testMapPartialFields() {
+    AiContext pdl = new AiContext();
+    pdl.setInstructions("Some guidance.");
+
+    com.linkedin.datahub.graphql.generated.AiContext result = AiContextMapper.map(pdl);
+
+    assertNotNull(result);
+    assertNull(result.getSynonyms());
+    assertEquals(result.getInstructions(), "Some guidance.");
+    assertNull(result.getExamples());
+    assertNull(result.getCustomInstructions());
+  }
+
+  @Test
+  public void testMapEmpty() {
+    AiContext pdl = new AiContext();
+
+    com.linkedin.datahub.graphql.generated.AiContext result = AiContextMapper.map(pdl);
+
+    assertNotNull(result);
+    assertNull(result.getSynonyms());
+    assertNull(result.getInstructions());
+    assertNull(result.getExamples());
+    assertNull(result.getCustomInstructions());
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricExpressionMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricExpressionMapperTest.java
@@ -1,0 +1,56 @@
+package com.linkedin.datahub.graphql.types.metric.mappers;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.metric.DialectExpression;
+import com.linkedin.metric.DialectExpressionArray;
+import com.linkedin.metric.MetricExpression;
+import org.testng.annotations.Test;
+
+public class MetricExpressionMapperTest {
+
+  @Test
+  public void testMapNull() {
+    assertNull(MetricExpressionMapper.map(null));
+  }
+
+  @Test
+  public void testMapNoDialects() {
+    MetricExpression pdl = new MetricExpression();
+    pdl.setDialects(new DialectExpressionArray());
+
+    com.linkedin.datahub.graphql.generated.MetricExpression result =
+        MetricExpressionMapper.map(pdl);
+
+    assertNotNull(result);
+    assertNotNull(result.getDialects());
+    assertTrue(result.getDialects().isEmpty());
+  }
+
+  @Test
+  public void testMapAllDialectEnumValues() {
+    for (com.linkedin.metric.Dialect pdlDialect : com.linkedin.metric.Dialect.values()) {
+      // $UNKNOWN is a Rest.li synthetic sentinel, not a real dialect — it maps to OTHER
+      if (pdlDialect.name().startsWith("$")) {
+        continue;
+      }
+
+      DialectExpression de = new DialectExpression();
+      de.setDialect(pdlDialect);
+      de.setExpression("expr");
+
+      MetricExpression pdl = new MetricExpression();
+      pdl.setDialects(new DialectExpressionArray(de));
+
+      com.linkedin.datahub.graphql.generated.MetricExpression result =
+          MetricExpressionMapper.map(pdl);
+
+      assertNotNull(result);
+      assertEquals(result.getDialects().size(), 1);
+      assertEquals(result.getDialects().get(0).getDialect().name(), pdlDialect.name());
+    }
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricMapperTest.java
@@ -1,0 +1,254 @@
+package com.linkedin.datahub.graphql.types.metric.mappers;
+
+import static com.linkedin.metadata.Constants.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.data.template.StringMap;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.Metric;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.metadata.key.MetricKey;
+import com.linkedin.metric.DerivedMetricInput;
+import com.linkedin.metric.DerivedMetricInputArray;
+import com.linkedin.metric.MetricInfo;
+import com.linkedin.metric.MetricRelationships;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+import org.mockito.MockedStatic;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class MetricMapperTest {
+
+  private static final String PLATFORM_URN = "urn:li:dataPlatform:dbt";
+  private static final String METRIC_URN =
+      "urn:li:metric:(urn:li:dataPlatform:dbt,analytics.orders_model,revenue)";
+  private static final String SEMANTIC_MODEL_URN =
+      "urn:li:semanticModel:(urn:li:dataPlatform:dbt,analytics.orders_model,my_model)";
+  private static final String ACTOR_URN = "urn:li:corpuser:testuser";
+  private static final String PARENT_METRIC_URN =
+      "urn:li:metric:(urn:li:dataPlatform:dbt,analytics.orders_model,gross_revenue)";
+  private static final String DERIVED_METRIC_URN_1 =
+      "urn:li:metric:(urn:li:dataPlatform:dbt,analytics.orders_model,subtotal)";
+  private static final String DERIVED_METRIC_URN_2 =
+      "urn:li:metric:(urn:li:dataPlatform:dbt,analytics.orders_model,tax)";
+  private static final Long TEST_TIMESTAMP = 1640995200000L;
+
+  private Urn metricUrn;
+  private QueryContext mockQueryContext;
+
+  @BeforeMethod
+  public void setup() throws URISyntaxException {
+    metricUrn = Urn.createFromString(METRIC_URN);
+    mockQueryContext = mock(QueryContext.class);
+  }
+
+  @Test
+  public void testMapKeyOnly() {
+    EntityResponse entityResponse = createBaseEntityResponse();
+
+    try (MockedStatic<AuthorizationUtils> authMock = mockStatic(AuthorizationUtils.class)) {
+      authMock.when(() -> AuthorizationUtils.canView(any(), eq(metricUrn))).thenReturn(true);
+
+      Metric result = MetricMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result);
+      assertEquals(result.getUrn(), METRIC_URN);
+      assertEquals(result.getType(), EntityType.METRIC);
+      assertNotNull(result.getPlatform());
+      assertEquals(result.getPlatform().getUrn(), PLATFORM_URN);
+      assertEquals(result.getPath(), "analytics.orders_model");
+      assertEquals(result.getId(), "revenue");
+    }
+  }
+
+  @Test
+  public void testMapMetricInfoAuditStamps() throws URISyntaxException {
+    EntityResponse entityResponse = createBaseEntityResponse();
+
+    Urn actorUrn = Urn.createFromString(ACTOR_URN);
+    AuditStamp createdStamp = new AuditStamp().setTime(TEST_TIMESTAMP).setActor(actorUrn);
+    AuditStamp lastModifiedStamp =
+        new AuditStamp().setTime(TEST_TIMESTAMP + 1000L).setActor(actorUrn);
+
+    MetricInfo info = new MetricInfo().setName("Revenue");
+    info.setCreated(createdStamp);
+    info.setLastModified(lastModifiedStamp);
+    addAspect(entityResponse, METRIC_INFO_ASPECT_NAME, info);
+
+    try (MockedStatic<AuthorizationUtils> authMock = mockStatic(AuthorizationUtils.class)) {
+      authMock.when(() -> AuthorizationUtils.canView(any(), eq(metricUrn))).thenReturn(true);
+
+      Metric result = MetricMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result.getInfo());
+      assertEquals(result.getInfo().getName(), "Revenue");
+      assertNotNull(result.getInfo().getCreated());
+      assertEquals(result.getInfo().getCreated().getTime(), TEST_TIMESTAMP);
+      assertEquals(result.getInfo().getCreated().getActor().getUrn(), ACTOR_URN);
+      assertNotNull(result.getInfo().getLastModified());
+      assertEquals(result.getInfo().getLastModified().getTime(), TEST_TIMESTAMP + 1000L);
+    }
+  }
+
+  @Test
+  public void testMapMetricInfoSemanticModelStub() throws URISyntaxException {
+    EntityResponse entityResponse = createBaseEntityResponse();
+
+    MetricInfo info =
+        new MetricInfo()
+            .setName("Revenue")
+            .setSemanticModel(Urn.createFromString(SEMANTIC_MODEL_URN));
+    addAspect(entityResponse, METRIC_INFO_ASPECT_NAME, info);
+
+    try (MockedStatic<AuthorizationUtils> authMock = mockStatic(AuthorizationUtils.class)) {
+      authMock.when(() -> AuthorizationUtils.canView(any(), eq(metricUrn))).thenReturn(true);
+
+      Metric result = MetricMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result.getSemanticModel());
+      assertEquals(result.getSemanticModel().getUrn(), SEMANTIC_MODEL_URN);
+      assertEquals(result.getSemanticModel().getType(), EntityType.SEMANTIC_MODEL);
+    }
+  }
+
+  @Test
+  public void testMapMetricRelationshipsParentMetric() throws URISyntaxException {
+    EntityResponse entityResponse = createBaseEntityResponse();
+
+    MetricRelationships rels =
+        new MetricRelationships().setParentMetric(Urn.createFromString(PARENT_METRIC_URN));
+    addAspect(entityResponse, METRIC_RELATIONSHIPS_ASPECT_NAME, rels);
+
+    try (MockedStatic<AuthorizationUtils> authMock = mockStatic(AuthorizationUtils.class)) {
+      authMock.when(() -> AuthorizationUtils.canView(any(), any())).thenReturn(true);
+
+      Metric result = MetricMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result.getMetricRelationships());
+      assertNotNull(result.getMetricRelationships().getParentMetric());
+      assertEquals(result.getMetricRelationships().getParentMetric().getUrn(), PARENT_METRIC_URN);
+      assertEquals(result.getMetricRelationships().getParentMetric().getType(), EntityType.METRIC);
+    }
+  }
+
+  @Test
+  public void testMapMetricRelationshipsDerivedFrom() throws URISyntaxException {
+    EntityResponse entityResponse = createBaseEntityResponse();
+
+    Urn actorUrn = Urn.createFromString(ACTOR_URN);
+    AuditStamp createdStamp = new AuditStamp().setTime(TEST_TIMESTAMP).setActor(actorUrn);
+
+    StringMap props1 = new StringMap();
+    props1.put("weight", "0.7");
+
+    DerivedMetricInput input1 =
+        new DerivedMetricInput()
+            .setDestinationUrn(Urn.createFromString(DERIVED_METRIC_URN_1))
+            .setCreated(createdStamp)
+            .setProperties(props1);
+
+    DerivedMetricInput input2 =
+        new DerivedMetricInput().setDestinationUrn(Urn.createFromString(DERIVED_METRIC_URN_2));
+
+    MetricRelationships rels =
+        new MetricRelationships().setDerivedFrom(new DerivedMetricInputArray(input1, input2));
+    addAspect(entityResponse, METRIC_RELATIONSHIPS_ASPECT_NAME, rels);
+
+    try (MockedStatic<AuthorizationUtils> authMock = mockStatic(AuthorizationUtils.class)) {
+      authMock.when(() -> AuthorizationUtils.canView(any(), any())).thenReturn(true);
+
+      Metric result = MetricMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result.getMetricRelationships());
+      assertEquals(result.getMetricRelationships().getDerivedFrom().size(), 2);
+      assertEquals(
+          result.getMetricRelationships().getDerivedFrom().get(0).getDestination().getUrn(),
+          DERIVED_METRIC_URN_1);
+      assertNotNull(result.getMetricRelationships().getDerivedFrom().get(0).getCreated());
+      assertEquals(
+          result.getMetricRelationships().getDerivedFrom().get(0).getCreated().getTime(),
+          TEST_TIMESTAMP);
+      assertNotNull(result.getMetricRelationships().getDerivedFrom().get(0).getProperties());
+      assertEquals(
+          result.getMetricRelationships().getDerivedFrom().get(0).getProperties().get(0).getKey(),
+          "weight");
+      assertEquals(
+          result.getMetricRelationships().getDerivedFrom().get(0).getProperties().get(0).getValue(),
+          "0.7");
+      assertEquals(
+          result.getMetricRelationships().getDerivedFrom().get(1).getDestination().getUrn(),
+          DERIVED_METRIC_URN_2);
+    }
+  }
+
+  @Test
+  public void testMapMetricRelationshipsRelatedMetricsDefaultEmpty() throws URISyntaxException {
+    EntityResponse entityResponse = createBaseEntityResponse();
+
+    MetricRelationships rels = new MetricRelationships();
+    addAspect(entityResponse, METRIC_RELATIONSHIPS_ASPECT_NAME, rels);
+
+    try (MockedStatic<AuthorizationUtils> authMock = mockStatic(AuthorizationUtils.class)) {
+      authMock.when(() -> AuthorizationUtils.canView(any(), eq(metricUrn))).thenReturn(true);
+
+      Metric result = MetricMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result.getMetricRelationships());
+      assertNotNull(result.getMetricRelationships().getRelatedMetrics());
+      assertTrue(result.getMetricRelationships().getRelatedMetrics().isEmpty());
+    }
+  }
+
+  @Test
+  public void testMapAbsentMetricUpstreams() {
+    EntityResponse entityResponse = createBaseEntityResponse();
+
+    try (MockedStatic<AuthorizationUtils> authMock = mockStatic(AuthorizationUtils.class)) {
+      authMock.when(() -> AuthorizationUtils.canView(any(), eq(metricUrn))).thenReturn(true);
+
+      Metric result = MetricMapper.map(mockQueryContext, entityResponse);
+
+      assertNull(result.getMetricUpstreams());
+    }
+  }
+
+  private EntityResponse createBaseEntityResponse() {
+    EntityResponse entityResponse = new EntityResponse();
+    entityResponse.setUrn(metricUrn);
+
+    try {
+      MetricKey key = new MetricKey();
+      key.setPlatform(Urn.createFromString(PLATFORM_URN));
+      key.setPath("analytics.orders_model");
+      key.setId("revenue");
+
+      EnvelopedAspect keyAspect = new EnvelopedAspect();
+      keyAspect.setValue(new Aspect(key.data()));
+
+      Map<String, EnvelopedAspect> aspects = new HashMap<>();
+      aspects.put(METRIC_KEY_ASPECT_NAME, keyAspect);
+      entityResponse.setAspects(new EnvelopedAspectMap(aspects));
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+    return entityResponse;
+  }
+
+  private void addAspect(
+      EntityResponse entityResponse, String aspectName, RecordTemplate aspectData) {
+    EnvelopedAspect aspect = new EnvelopedAspect();
+    aspect.setValue(new Aspect(aspectData.data()));
+    entityResponse.getAspects().put(aspectName, aspect);
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricUpstreamsMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricUpstreamsMapperTest.java
@@ -1,0 +1,119 @@
+package com.linkedin.datahub.graphql.types.metric.mappers;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.Edge;
+import com.linkedin.common.EdgeArray;
+import com.linkedin.common.urn.Urn;
+import java.net.URISyntaxException;
+import org.testng.annotations.Test;
+
+public class MetricUpstreamsMapperTest {
+
+  private static final String DATASET_URN =
+      "urn:li:dataset:(urn:li:dataPlatform:dbt,analytics.orders,PROD)";
+  private static final String SCHEMA_FIELD_URN =
+      "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,analytics.orders,PROD),revenue)";
+
+  @Test
+  public void testMapNull() {
+    assertNull(MetricUpstreamsMapper.map(null, null));
+  }
+
+  @Test
+  public void testMapEmpty() {
+    com.linkedin.metric.MetricUpstreams pdl = new com.linkedin.metric.MetricUpstreams();
+
+    com.linkedin.datahub.graphql.generated.MetricUpstreams result =
+        MetricUpstreamsMapper.map(null, pdl);
+
+    assertNotNull(result);
+    assertNull(result.getDatasetUpstreams());
+    assertNull(result.getFieldUpstreams());
+  }
+
+  @Test
+  public void testMapDatasetUpstreams() throws URISyntaxException {
+    Edge edge = new Edge().setDestinationUrn(Urn.createFromString(DATASET_URN));
+    com.linkedin.metric.MetricUpstreams pdl = new com.linkedin.metric.MetricUpstreams();
+    pdl.setDatasetUpstreams(new EdgeArray(edge));
+
+    com.linkedin.datahub.graphql.generated.MetricUpstreams result =
+        MetricUpstreamsMapper.map(null, pdl);
+
+    assertNotNull(result);
+    assertNotNull(result.getDatasetUpstreams());
+    assertEquals(result.getDatasetUpstreams().size(), 1);
+    assertEquals(result.getDatasetUpstreams().get(0).getDestination().getUrn(), DATASET_URN);
+    assertNull(result.getFieldUpstreams());
+  }
+
+  @Test
+  public void testMapFieldUpstreams() throws URISyntaxException {
+    Edge edge = new Edge().setDestinationUrn(Urn.createFromString(SCHEMA_FIELD_URN));
+    com.linkedin.metric.MetricUpstreams pdl = new com.linkedin.metric.MetricUpstreams();
+    pdl.setFieldUpstreams(new EdgeArray(edge));
+
+    com.linkedin.datahub.graphql.generated.MetricUpstreams result =
+        MetricUpstreamsMapper.map(null, pdl);
+
+    assertNotNull(result);
+    assertNull(result.getDatasetUpstreams());
+    assertNotNull(result.getFieldUpstreams());
+    assertEquals(result.getFieldUpstreams().size(), 1);
+    assertEquals(result.getFieldUpstreams().get(0).getDestination().getUrn(), SCHEMA_FIELD_URN);
+  }
+
+  @Test
+  public void testMapBothUpstreams() throws URISyntaxException {
+    Edge datasetEdge = new Edge().setDestinationUrn(Urn.createFromString(DATASET_URN));
+    Edge fieldEdge = new Edge().setDestinationUrn(Urn.createFromString(SCHEMA_FIELD_URN));
+
+    com.linkedin.metric.MetricUpstreams pdl = new com.linkedin.metric.MetricUpstreams();
+    pdl.setDatasetUpstreams(new EdgeArray(datasetEdge));
+    pdl.setFieldUpstreams(new EdgeArray(fieldEdge));
+
+    com.linkedin.datahub.graphql.generated.MetricUpstreams result =
+        MetricUpstreamsMapper.map(null, pdl);
+
+    assertNotNull(result);
+    assertEquals(result.getDatasetUpstreams().size(), 1);
+    assertEquals(result.getFieldUpstreams().size(), 1);
+  }
+
+  @Test
+  public void testMapUnresolvableEdgeIsDropped() throws URISyntaxException {
+    Edge goodEdge = new Edge().setDestinationUrn(Urn.createFromString(DATASET_URN));
+    Edge badEdge = new Edge().setDestinationUrn(Urn.createFromString("urn:li:unknownEntity:foo"));
+
+    com.linkedin.metric.MetricUpstreams pdl = new com.linkedin.metric.MetricUpstreams();
+    pdl.setDatasetUpstreams(new EdgeArray(goodEdge, badEdge));
+
+    com.linkedin.datahub.graphql.generated.MetricUpstreams result =
+        MetricUpstreamsMapper.map(null, pdl);
+
+    assertNotNull(result);
+    // Bad edge is silently dropped by EdgeMapper
+    assertEquals(result.getDatasetUpstreams().size(), 1);
+    assertEquals(result.getDatasetUpstreams().get(0).getDestination().getUrn(), DATASET_URN);
+  }
+
+  @Test
+  public void testMapEmptyEdgeArraysYieldEmptyLists() {
+    com.linkedin.metric.MetricUpstreams pdl = new com.linkedin.metric.MetricUpstreams();
+    pdl.setDatasetUpstreams(new EdgeArray());
+    pdl.setFieldUpstreams(new EdgeArray());
+
+    com.linkedin.datahub.graphql.generated.MetricUpstreams result =
+        MetricUpstreamsMapper.map(null, pdl);
+
+    assertNotNull(result);
+    assertNotNull(result.getDatasetUpstreams());
+    assertTrue(result.getDatasetUpstreams().isEmpty());
+    assertNotNull(result.getFieldUpstreams());
+    assertTrue(result.getFieldUpstreams().isEmpty());
+  }
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
@@ -11,9 +11,7 @@ import com.linkedin.schema.SchemaField
 record SemanticField {
 
   /**
-   * Inline SchemaField describing this field's schema and identity.
-   * Its `fieldPath` composes into `urn:li:schemaField:(<parentSemanticModelUrn>,<fieldPath>)`,
-   * which serves as the endpoint for column-level lineage edges and as the anchor for
+   * Inline SchemaField describing this field's schema and identity for column-level lineage edges and as the anchor for
    * column-level governance (tags, glossary terms, description).
    */
   schemaField: SchemaField

--- a/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
@@ -11,7 +11,9 @@ import com.linkedin.schema.SchemaField
 record SemanticField {
 
   /**
-   * Inline SchemaField describing this field's schema and identity for column-level lineage edges and as the anchor for
+   * Inline SchemaField describing this field's schema and identity.
+   * Its `fieldPath` composes into `urn:li:schemaField:(<parentSemanticModelUrn>,<fieldPath>)`,
+   * which serves as the endpoint for column-level lineage edges and as the anchor for
    * column-level governance (tags, glossary terms, description).
    */
   schemaField: SchemaField


### PR DESCRIPTION
## Summary
- Adds `MetricType`, the `LoadableType`/`SearchableEntityType` implementation that batch-loads `Metric` entities from GMS via `batchGetV2` and delegates mapping to `MetricMapper`.
- Adds `MetricMapper`, mapping the `metricKey`, `metricInfo`, `metricRelationships`, and `metricUpstreams` aspects plus the standard governance aspects (ownership, tags, glossary terms, domain, institutional memory, structured properties, status/deprecation, data platform instance, sub types, documentation, browse paths) onto the generated GraphQL `Metric` type.
- Adds supporting mappers: `MetricExpressionMapper` (dialect expressions, using `PdlEnumMapper` for safe enum conversion), `AiContextMapper`, and `MetricUpstreamsMapper` (dataset/field upstream edges via the shared `EdgeMapper`).
