### PR TITLE
chore(schema-registry): reserve schema id 23 to avoid conflicts

### DIFF
--- a/metadata-events/mxe-utils-avro/src/main/java/com/linkedin/metadata/EventSchemaConstants.java
+++ b/metadata-events/mxe-utils-avro/src/main/java/com/linkedin/metadata/EventSchemaConstants.java
@@ -140,6 +140,9 @@ public final class EventSchemaConstants {
     Set<SchemaIdOrdinal> missingOrdinals = new HashSet<>();
 
     for (SchemaIdOrdinal ordinal : SchemaIdOrdinal.values()) {
+      if (ordinal.isReserved()) {
+        continue;
+      }
       if (!map.containsKey(ordinal)) {
         missingOrdinals.add(ordinal);
       }

--- a/metadata-events/mxe-utils-avro/src/main/java/com/linkedin/metadata/SchemaIdOrdinal.java
+++ b/metadata-events/mxe-utils-avro/src/main/java/com/linkedin/metadata/SchemaIdOrdinal.java
@@ -34,7 +34,14 @@ public enum SchemaIdOrdinal {
   METADATA_CHANGE_LOG_TIMESERIES(19),
   METADATA_CHANGE_EVENT(20),
   FAILED_METADATA_CHANGE_EVENT(21),
-  METADATA_AUDIT_EVENT(22);
+  METADATA_AUDIT_EVENT(22),
+
+  /**
+   * Reserved placeholder schema id. Do not assign this id to a new OSS event schema. Kept occupied
+   * so forks / external deployments that already emit wire-format schema id 23 do not collide when
+   * OSS later allocates new ordinals.
+   */
+  RESERVED_23(23);
 
   private final int schemaId;
 
@@ -49,6 +56,11 @@ public enum SchemaIdOrdinal {
    */
   public int getSchemaId() {
     return schemaId;
+  }
+
+  /** Whether this ordinal is a reservation placeholder (no published event schema). */
+  public boolean isReserved() {
+    return this == RESERVED_23;
   }
 
   /**

--- a/metadata-events/mxe-utils-avro/src/test/java/com/linkedin/metadata/EventSchemaConstantsTest.java
+++ b/metadata-events/mxe-utils-avro/src/test/java/com/linkedin/metadata/EventSchemaConstantsTest.java
@@ -137,6 +137,7 @@ public class EventSchemaConstantsTest {
     assertEquals(SchemaIdOrdinal.METADATA_CHANGE_EVENT.getSchemaId(), 20);
     assertEquals(SchemaIdOrdinal.FAILED_METADATA_CHANGE_EVENT.getSchemaId(), 21);
     assertEquals(SchemaIdOrdinal.METADATA_AUDIT_EVENT.getSchemaId(), 22);
+    assertEquals(SchemaIdOrdinal.RESERVED_23.getSchemaId(), 23);
   }
 
   @Test

--- a/metadata-events/mxe-utils-avro/src/test/java/com/linkedin/metadata/EventSchemaDataTest.java
+++ b/metadata-events/mxe-utils-avro/src/test/java/com/linkedin/metadata/EventSchemaDataTest.java
@@ -131,6 +131,9 @@ public class EventSchemaDataTest {
     try {
       // This should not throw any exceptions because all ordinals should be mapped
       for (SchemaIdOrdinal ordinal : SchemaIdOrdinal.values()) {
+        if (ordinal.isReserved()) {
+          continue;
+        }
         org.apache.avro.Schema schema = EventSchemaConstants.SCHEMA_ID_TO_SCHEMA_MAP.get(ordinal);
         assertNotNull(schema, "Schema mapping should exist for ordinal: " + ordinal);
       }

--- a/metadata-events/mxe-utils-avro/src/test/java/com/linkedin/metadata/SchemaIdOrdinalTest.java
+++ b/metadata-events/mxe-utils-avro/src/test/java/com/linkedin/metadata/SchemaIdOrdinalTest.java
@@ -36,6 +36,7 @@ public class SchemaIdOrdinalTest {
     assertEquals(SchemaIdOrdinal.METADATA_CHANGE_EVENT.getSchemaId(), 20);
     assertEquals(SchemaIdOrdinal.FAILED_METADATA_CHANGE_EVENT.getSchemaId(), 21);
     assertEquals(SchemaIdOrdinal.METADATA_AUDIT_EVENT.getSchemaId(), 22);
+    assertEquals(SchemaIdOrdinal.RESERVED_23.getSchemaId(), 23);
   }
 
   @Test
@@ -81,13 +82,14 @@ public class SchemaIdOrdinalTest {
     assertEquals(SchemaIdOrdinal.fromSchemaId(20), SchemaIdOrdinal.METADATA_CHANGE_EVENT);
     assertEquals(SchemaIdOrdinal.fromSchemaId(21), SchemaIdOrdinal.FAILED_METADATA_CHANGE_EVENT);
     assertEquals(SchemaIdOrdinal.fromSchemaId(22), SchemaIdOrdinal.METADATA_AUDIT_EVENT);
+    assertEquals(SchemaIdOrdinal.fromSchemaId(23), SchemaIdOrdinal.RESERVED_23);
   }
 
   @Test
   public void testFromSchemaIdWithInvalidId() {
     // Test that fromSchemaId() returns null for invalid schema IDs
     assertNull(SchemaIdOrdinal.fromSchemaId(-1));
-    assertNull(SchemaIdOrdinal.fromSchemaId(23));
+    assertNull(SchemaIdOrdinal.fromSchemaId(24));
     assertNull(SchemaIdOrdinal.fromSchemaId(999));
     assertNull(SchemaIdOrdinal.fromSchemaId(Integer.MAX_VALUE));
     assertNull(SchemaIdOrdinal.fromSchemaId(Integer.MIN_VALUE));
@@ -119,10 +121,11 @@ public class SchemaIdOrdinalTest {
     assertTrue(SchemaIdOrdinal.isValidSchemaId(20));
     assertTrue(SchemaIdOrdinal.isValidSchemaId(21));
     assertTrue(SchemaIdOrdinal.isValidSchemaId(22));
+    assertTrue(SchemaIdOrdinal.isValidSchemaId(23));
 
     // Test that isValidSchemaId() returns false for invalid schema IDs
     assertFalse(SchemaIdOrdinal.isValidSchemaId(-1));
-    assertFalse(SchemaIdOrdinal.isValidSchemaId(23));
+    assertFalse(SchemaIdOrdinal.isValidSchemaId(24));
     assertFalse(SchemaIdOrdinal.isValidSchemaId(999));
     assertFalse(SchemaIdOrdinal.isValidSchemaId(Integer.MAX_VALUE));
     assertFalse(SchemaIdOrdinal.isValidSchemaId(Integer.MIN_VALUE));
@@ -173,7 +176,7 @@ public class SchemaIdOrdinalTest {
     SchemaIdOrdinal[] ordinals = SchemaIdOrdinal.values();
 
     assertNotNull(ordinals);
-    assertEquals(ordinals.length, 23, "Should have exactly 23 schema ID ordinals");
+    assertEquals(ordinals.length, 24, "Should have exactly 24 schema ID ordinals");
 
     // Verify all expected ordinals are present
     assertTrue(contains(ordinals, SchemaIdOrdinal.METADATA_CHANGE_PROPOSAL_V1));
@@ -199,6 +202,7 @@ public class SchemaIdOrdinalTest {
     assertTrue(contains(ordinals, SchemaIdOrdinal.FAILED_METADATA_CHANGE_EVENT_V1_FIX));
     assertTrue(contains(ordinals, SchemaIdOrdinal.METADATA_AUDIT_EVENT_V1_FIX));
     assertTrue(contains(ordinals, SchemaIdOrdinal.METADATA_AUDIT_EVENT));
+    assertTrue(contains(ordinals, SchemaIdOrdinal.RESERVED_23));
   }
 
   @Test
@@ -357,6 +361,8 @@ public class SchemaIdOrdinalTest {
         return 21;
       case METADATA_AUDIT_EVENT:
         return 22;
+      case RESERVED_23:
+        return 23;
       default:
         throw new IllegalArgumentException("Unknown ordinal: " + ordinal);
     }


### PR DESCRIPTION
## Summary
- Reserve wire-format schema id `23` as `SchemaIdOrdinal.RESERVED_23` so OSS does not later assign it to a real event schema
- Skip reserved ordinals in `EventSchemaConstants` schema-map validation (no published event schema for the placeholder)
- Update unit tests for the new ordinal and `isReserved()` behavior

## Test plan
- [x] Spotless Java formatting/lint
- [ ] `./gradlew :metadata-events:mxe-utils-avro:test`


Made with [Cursor](https://cursor.com)