### PR TITLE
fix(object-storage): create local storage root directory on init

### DIFF
--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/objectstorage/LocalObjectStorageClient.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/objectstorage/LocalObjectStorageClient.java
@@ -14,6 +14,20 @@ public class LocalObjectStorageClient implements ObjectStorageClient {
 
   public LocalObjectStorageClient(@Nullable String rootPath) {
     this.rootPath = rootPath;
+    if (isConfigured()) {
+      ensureRootExists();
+    }
+  }
+
+  private void ensureRootExists() {
+    Path root = Path.of(rootPath);
+    try {
+      Files.createDirectories(root);
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Failed to create local object storage root directory '" + root + "': " + e.getMessage(),
+          e);
+    }
   }
 
   @Override

--- a/metadata-utils/src/test/java/com/linkedin/metadata/utils/objectstorage/LocalObjectStorageClientTest.java
+++ b/metadata-utils/src/test/java/com/linkedin/metadata/utils/objectstorage/LocalObjectStorageClientTest.java
@@ -57,10 +57,49 @@ public class LocalObjectStorageClientTest {
   }
 
   @Test
-  public void testIsConfigured() {
+  public void testIsConfigured() throws Exception {
     assertFalse(new LocalObjectStorageClient(null).isConfigured());
     assertFalse(new LocalObjectStorageClient("").isConfigured());
-    assertTrue(new LocalObjectStorageClient("/tmp/datahub-object-storage").isConfigured());
+    Path root = Files.createTempDirectory("object-storage-configured");
+    assertTrue(new LocalObjectStorageClient(root.toString()).isConfigured());
+  }
+
+  @Test
+  public void testConstructorCreatesMissingRoot() throws Exception {
+    Path base = Files.createTempDirectory("object-storage-base");
+    Path root = base.resolve("missing").resolve("nested").resolve("root");
+    assertFalse(Files.exists(root));
+
+    LocalObjectStorageClient client = new LocalObjectStorageClient(root.toString());
+
+    assertTrue(Files.isDirectory(root));
+    assertTrue(client.isConfigured());
+  }
+
+  @Test
+  public void testConstructorToleratesExistingRoot() throws Exception {
+    Path root = Files.createTempDirectory("object-storage-existing");
+    assertTrue(Files.isDirectory(root));
+
+    LocalObjectStorageClient client = new LocalObjectStorageClient(root.toString());
+
+    assertTrue(Files.isDirectory(root));
+    assertTrue(client.isConfigured());
+  }
+
+  @Test
+  public void testConstructorToleratesPartialExistingPath() throws Exception {
+    Path base = Files.createTempDirectory("object-storage-partial");
+    Path existingParent = base.resolve("already-there");
+    Files.createDirectories(existingParent);
+    Path root = existingParent.resolve("child").resolve("root");
+    assertTrue(Files.isDirectory(existingParent));
+    assertFalse(Files.exists(root));
+
+    LocalObjectStorageClient client = new LocalObjectStorageClient(root.toString());
+
+    assertTrue(Files.isDirectory(root));
+    assertTrue(client.isConfigured());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Create the configured local object-storage root on `LocalObjectStorageClient` construction via `Files.createDirectories` (tolerant of missing and partially existing paths)
- Add unit coverage for missing root, existing root, and partial path cases

## Test plan
- [x] `./gradlew :metadata-utils:test --tests com.linkedin.metadata.utils.objectstorage.LocalObjectStorageClientTest`
- [x] `./gradlew :metadata-service:factories:test --tests com.linkedin.gms.factory.objectstorage.ObjectStorageClientFactoryTest`
- [ ] Configure `DATAHUB_OBJECT_STORAGE_URI=file:///tmp/datahub-object-storage` (or nested missing path) on GMS and confirm the root is created at startup


Made with [Cursor](https://cursor.com)