### PR TITLE
feat(graphql): add GraphQL type and mappers for SemanticModel entity

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/semanticmodel/SemanticModelType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/semanticmodel/SemanticModelType.java
@@ -1,0 +1,148 @@
+package com.linkedin.datahub.graphql.types.semanticmodel;
+
+import static com.linkedin.datahub.graphql.authorization.AuthorizationUtils.canView;
+
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.AutoCompleteResults;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.FacetFilterInput;
+import com.linkedin.datahub.graphql.generated.SearchResults;
+import com.linkedin.datahub.graphql.generated.SemanticModel;
+import com.linkedin.datahub.graphql.types.SearchableEntityType;
+import com.linkedin.datahub.graphql.types.mappers.AutoCompleteResultsMapper;
+import com.linkedin.datahub.graphql.types.semanticmodel.mappers.SemanticModelMapper;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
+import graphql.execution.DataFetcherResult;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.NotImplementedException;
+
+public class SemanticModelType implements SearchableEntityType<SemanticModel, String> {
+
+  public static final Set<String> ASPECTS_TO_FETCH =
+      ImmutableSet.of(
+          Constants.SEMANTIC_MODEL_KEY_ASPECT_NAME,
+          Constants.SEMANTIC_MODEL_INFO_ASPECT_NAME,
+          Constants.UPSTREAM_LINEAGE_ASPECT_NAME,
+          Constants.OWNERSHIP_ASPECT_NAME,
+          Constants.DOMAINS_ASPECT_NAME,
+          Constants.GLOBAL_TAGS_ASPECT_NAME,
+          Constants.GLOSSARY_TERMS_ASPECT_NAME,
+          Constants.INSTITUTIONAL_MEMORY_ASPECT_NAME,
+          Constants.STRUCTURED_PROPERTIES_ASPECT_NAME,
+          Constants.STATUS_ASPECT_NAME,
+          Constants.DEPRECATION_ASPECT_NAME,
+          Constants.DATA_PLATFORM_INSTANCE_ASPECT_NAME,
+          Constants.SUB_TYPES_ASPECT_NAME,
+          Constants.DOCUMENTATION_ASPECT_NAME,
+          Constants.BROWSE_PATHS_V2_ASPECT_NAME,
+          Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME);
+
+  private final EntityClient _entityClient;
+
+  public SemanticModelType(final EntityClient entityClient) {
+    _entityClient = entityClient;
+  }
+
+  @Override
+  public EntityType type() {
+    return EntityType.SEMANTIC_MODEL;
+  }
+
+  @Override
+  public Function<Entity, String> getKeyProvider() {
+    return Entity::getUrn;
+  }
+
+  @Override
+  public Class<SemanticModel> objectClass() {
+    return SemanticModel.class;
+  }
+
+  @Override
+  public List<DataFetcherResult<SemanticModel>> batchLoad(
+      @Nonnull List<String> urns, @Nonnull QueryContext context) throws Exception {
+    final List<Urn> semanticModelUrns =
+        urns.stream().map(this::getUrn).collect(Collectors.toList());
+
+    try {
+      final Map<Urn, EntityResponse> entities =
+          _entityClient.batchGetV2(
+              context.getOperationContext(),
+              Constants.SEMANTIC_MODEL_ENTITY_NAME,
+              semanticModelUrns.stream()
+                  .filter(urn -> canView(context.getOperationContext(), urn))
+                  .collect(Collectors.toSet()),
+              ASPECTS_TO_FETCH,
+              true);
+
+      final List<EntityResponse> gmsResults = new ArrayList<>(urns.size());
+      for (Urn urn : semanticModelUrns) {
+        gmsResults.add(entities.getOrDefault(urn, null));
+      }
+      return gmsResults.stream()
+          .map(
+              gmsResult ->
+                  gmsResult == null
+                      ? null
+                      : DataFetcherResult.<SemanticModel>newResult()
+                          .data(SemanticModelMapper.map(context, gmsResult))
+                          .build())
+          .collect(Collectors.toList());
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to batch load SemanticModels", e);
+    }
+  }
+
+  @Override
+  public SearchResults search(
+      @Nonnull String query,
+      @Nullable List<FacetFilterInput> filters,
+      int start,
+      @Nullable Integer count,
+      @Nonnull final QueryContext context)
+      throws Exception {
+    throw new NotImplementedException(
+        "Searchable type (deprecated) not implemented on SemanticModel entity type. Use searchAcrossEntities instead.");
+  }
+
+  @Override
+  public AutoCompleteResults autoComplete(
+      @Nonnull String query,
+      @Nullable String field,
+      @Nullable Filter filters,
+      @Nullable Integer limit,
+      @Nonnull final QueryContext context)
+      throws Exception {
+    final AutoCompleteResult result =
+        _entityClient.autoComplete(
+            context.getOperationContext(),
+            Constants.SEMANTIC_MODEL_ENTITY_NAME,
+            query,
+            filters,
+            limit);
+    return AutoCompleteResultsMapper.map(context, result);
+  }
+
+  private Urn getUrn(final String urnStr) {
+    try {
+      return Urn.createFromString(urnStr);
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(String.format("Failed to convert urn string %s into Urn", urnStr));
+    }
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/semanticmodel/mappers/SemanticFieldMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/semanticmodel/mappers/SemanticFieldMapper.java
@@ -1,0 +1,69 @@
+package com.linkedin.datahub.graphql.types.semanticmodel.mappers;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.Dimension;
+import com.linkedin.datahub.graphql.generated.SemanticField;
+import com.linkedin.datahub.graphql.generated.SemanticFieldType;
+import com.linkedin.datahub.graphql.types.dataset.mappers.SchemaFieldMapper;
+import com.linkedin.datahub.graphql.types.mappers.PdlEnumMapper;
+import com.linkedin.datahub.graphql.types.metric.mappers.AiContextMapper;
+import com.linkedin.datahub.graphql.types.metric.mappers.MetricExpressionMapper;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Maps {@link com.linkedin.semanticmodel.SemanticField} Pegasus records to the generated GraphQL
+ * {@link SemanticField}.
+ *
+ * <p>The {@code semanticModelUrn} parameter is threaded from the enclosing SemanticModel so that
+ * the inline {@code schemaField}'s {@code SchemaFieldEntity.urn} is constructed as {@code
+ * urn:li:schemaField:(<semanticModelUrn>,<fieldPath>)}.
+ */
+public class SemanticFieldMapper {
+
+  private SemanticFieldMapper() {}
+
+  @Nullable
+  public static SemanticField map(
+      @Nullable QueryContext context,
+      @Nonnull com.linkedin.semanticmodel.SemanticField pdl,
+      @Nonnull Urn semanticModelUrn) {
+    final SemanticField result = new SemanticField();
+
+    if (pdl.hasSchemaField() && pdl.getSchemaField() != null) {
+      result.setSchemaField(SchemaFieldMapper.map(context, pdl.getSchemaField(), semanticModelUrn));
+    }
+
+    if (pdl.hasType() && pdl.getType() != null) {
+      result.setType(mapSemanticFieldType(pdl.getType()));
+    } else {
+      result.setType(SemanticFieldType.OTHER);
+    }
+
+    if (pdl.hasExpression() && pdl.getExpression() != null) {
+      result.setExpression(MetricExpressionMapper.map(pdl.getExpression()));
+    }
+
+    if (pdl.hasDimension() && pdl.getDimension() != null) {
+      result.setDimension(mapDimension(pdl.getDimension()));
+    }
+
+    if (pdl.hasAiContext() && pdl.getAiContext() != null) {
+      result.setAiContext(AiContextMapper.map(pdl.getAiContext()));
+    }
+
+    return result;
+  }
+
+  private static SemanticFieldType mapSemanticFieldType(
+      @Nonnull com.linkedin.semanticmodel.SemanticFieldType pdlType) {
+    return PdlEnumMapper.map(SemanticFieldType.class, pdlType, SemanticFieldType.OTHER);
+  }
+
+  private static Dimension mapDimension(@Nonnull com.linkedin.semanticmodel.Dimension pdl) {
+    final Dimension result = new Dimension();
+    result.setIsTime(pdl.isIsTime());
+    return result;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/semanticmodel/mappers/SemanticModelMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/semanticmodel/mappers/SemanticModelMapper.java
@@ -1,0 +1,294 @@
+package com.linkedin.datahub.graphql.types.semanticmodel.mappers;
+
+import static com.linkedin.datahub.graphql.authorization.AuthorizationUtils.canView;
+
+import com.linkedin.common.BrowsePathsV2;
+import com.linkedin.common.DataPlatformInstance;
+import com.linkedin.common.Deprecation;
+import com.linkedin.common.Documentation;
+import com.linkedin.common.GlobalTags;
+import com.linkedin.common.GlossaryTerms;
+import com.linkedin.common.InstitutionalMemory;
+import com.linkedin.common.Ownership;
+import com.linkedin.common.Status;
+import com.linkedin.common.SubTypes;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.DataPlatform;
+import com.linkedin.datahub.graphql.generated.ERModelRelationshipCardinality;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.ModelDataset;
+import com.linkedin.datahub.graphql.generated.SemanticField;
+import com.linkedin.datahub.graphql.generated.SemanticModel;
+import com.linkedin.datahub.graphql.generated.SemanticModelInfo;
+import com.linkedin.datahub.graphql.generated.SemanticModelRelationship;
+import com.linkedin.datahub.graphql.types.common.mappers.BrowsePathsV2Mapper;
+import com.linkedin.datahub.graphql.types.common.mappers.DataPlatformInstanceAspectMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.DeprecationMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.DocumentationMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.FineGrainedLineagesMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.InstitutionalMemoryMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.OwnershipMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.StatusMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.SubTypesMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.UrnToEntityMapper;
+import com.linkedin.datahub.graphql.types.domain.DomainAssociationMapper;
+import com.linkedin.datahub.graphql.types.glossary.mappers.GlossaryTermsMapper;
+import com.linkedin.datahub.graphql.types.mappers.MapperUtils;
+import com.linkedin.datahub.graphql.types.mappers.PdlEnumMapper;
+import com.linkedin.datahub.graphql.types.structuredproperty.StructuredPropertiesMapper;
+import com.linkedin.datahub.graphql.types.tag.mappers.GlobalTagsMapper;
+import com.linkedin.dataset.UpstreamLineage;
+import com.linkedin.domain.Domains;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.key.SemanticModelKey;
+import com.linkedin.structured.StructuredProperties;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+public class SemanticModelMapper {
+
+  private SemanticModelMapper() {}
+
+  public static SemanticModel map(
+      @Nullable QueryContext context, final EntityResponse entityResponse) {
+    final SemanticModel result = new SemanticModel();
+    final Urn entityUrn = entityResponse.getUrn();
+    final EnvelopedAspectMap aspects = entityResponse.getAspects();
+
+    result.setUrn(entityUrn.toString());
+    result.setType(EntityType.SEMANTIC_MODEL);
+
+    final EnvelopedAspect envelopedKey = aspects.get(Constants.SEMANTIC_MODEL_KEY_ASPECT_NAME);
+    if (envelopedKey != null) {
+      final SemanticModelKey key = new SemanticModelKey(envelopedKey.getValue().data());
+      result.setPlatform(
+          DataPlatform.builder()
+              .setType(EntityType.DATA_PLATFORM)
+              .setUrn(key.getPlatform().toString())
+              .build());
+      result.setPath(key.getPath());
+      result.setId(key.getId());
+    }
+
+    final EnvelopedAspect envelopedInfo = aspects.get(Constants.SEMANTIC_MODEL_INFO_ASPECT_NAME);
+    if (envelopedInfo != null) {
+      final com.linkedin.semanticmodel.SemanticModelInfo pdlInfo =
+          new com.linkedin.semanticmodel.SemanticModelInfo(envelopedInfo.getValue().data());
+      result.setInfo(mapSemanticModelInfo(context, pdlInfo, entityUrn));
+    }
+
+    final EnvelopedAspect envelopedUpstreamLineage =
+        aspects.get(Constants.UPSTREAM_LINEAGE_ASPECT_NAME);
+    if (envelopedUpstreamLineage != null) {
+      final UpstreamLineage upstreamLineage =
+          new UpstreamLineage(envelopedUpstreamLineage.getValue().data());
+      if (upstreamLineage.hasFineGrainedLineages()
+          && upstreamLineage.getFineGrainedLineages() != null) {
+        result.setFineGrainedLineages(
+            FineGrainedLineagesMapper.map(upstreamLineage.getFineGrainedLineages()));
+      }
+    }
+
+    final EnvelopedAspect envelopedOwnership = aspects.get(Constants.OWNERSHIP_ASPECT_NAME);
+    if (envelopedOwnership != null) {
+      result.setOwnership(
+          OwnershipMapper.map(
+              context, new Ownership(envelopedOwnership.getValue().data()), entityUrn));
+    }
+
+    final EnvelopedAspect envelopedGlobalTags = aspects.get(Constants.GLOBAL_TAGS_ASPECT_NAME);
+    if (envelopedGlobalTags != null) {
+      result.setTags(
+          GlobalTagsMapper.map(
+              context, new GlobalTags(envelopedGlobalTags.getValue().data()), entityUrn));
+    }
+
+    final EnvelopedAspect envelopedGlossaryTerms =
+        aspects.get(Constants.GLOSSARY_TERMS_ASPECT_NAME);
+    if (envelopedGlossaryTerms != null) {
+      result.setGlossaryTerms(
+          GlossaryTermsMapper.map(
+              context, new GlossaryTerms(envelopedGlossaryTerms.getValue().data()), entityUrn));
+    }
+
+    final EnvelopedAspect envelopedDomains = aspects.get(Constants.DOMAINS_ASPECT_NAME);
+    if (envelopedDomains != null) {
+      final Domains domains = new Domains(envelopedDomains.getValue().data());
+      if (domains.hasDomains() && !domains.getDomains().isEmpty()) {
+        result.setDomain(DomainAssociationMapper.map(context, domains, entityUrn.toString()));
+      }
+    }
+
+    final EnvelopedAspect envelopedInstitutionalMemory =
+        aspects.get(Constants.INSTITUTIONAL_MEMORY_ASPECT_NAME);
+    if (envelopedInstitutionalMemory != null) {
+      result.setInstitutionalMemory(
+          InstitutionalMemoryMapper.map(
+              context,
+              new InstitutionalMemory(envelopedInstitutionalMemory.getValue().data()),
+              entityUrn));
+    }
+
+    final EnvelopedAspect envelopedStructuredProps =
+        aspects.get(Constants.STRUCTURED_PROPERTIES_ASPECT_NAME);
+    if (envelopedStructuredProps != null) {
+      result.setStructuredProperties(
+          StructuredPropertiesMapper.map(
+              context,
+              new StructuredProperties(envelopedStructuredProps.getValue().data()),
+              entityUrn));
+    }
+
+    final EnvelopedAspect envelopedStatus = aspects.get(Constants.STATUS_ASPECT_NAME);
+    if (envelopedStatus != null) {
+      final Status status = new Status(envelopedStatus.getValue().data());
+      result.setStatus(StatusMapper.map(context, status));
+      result.setExists(!status.isRemoved());
+    }
+
+    final EnvelopedAspect envelopedDeprecation = aspects.get(Constants.DEPRECATION_ASPECT_NAME);
+    if (envelopedDeprecation != null) {
+      result.setDeprecation(
+          DeprecationMapper.map(context, new Deprecation(envelopedDeprecation.getValue().data())));
+    }
+
+    final EnvelopedAspect envelopedDataPlatformInstance =
+        aspects.get(Constants.DATA_PLATFORM_INSTANCE_ASPECT_NAME);
+    if (envelopedDataPlatformInstance != null) {
+      result.setDataPlatformInstance(
+          DataPlatformInstanceAspectMapper.map(
+              context, new DataPlatformInstance(envelopedDataPlatformInstance.getValue().data())));
+    }
+
+    final EnvelopedAspect envelopedSubTypes = aspects.get(Constants.SUB_TYPES_ASPECT_NAME);
+    if (envelopedSubTypes != null) {
+      result.setSubTypes(
+          SubTypesMapper.map(context, new SubTypes(envelopedSubTypes.getValue().data())));
+    }
+
+    final EnvelopedAspect envelopedDocumentation = aspects.get(Constants.DOCUMENTATION_ASPECT_NAME);
+    if (envelopedDocumentation != null) {
+      result.setDocumentation(
+          DocumentationMapper.map(
+              context, new Documentation(envelopedDocumentation.getValue().data())));
+    }
+
+    final EnvelopedAspect envelopedBrowsePathsV2 =
+        aspects.get(Constants.BROWSE_PATHS_V2_ASPECT_NAME);
+    if (envelopedBrowsePathsV2 != null) {
+      result.setBrowsePathV2(
+          BrowsePathsV2Mapper.map(
+              context, new BrowsePathsV2(envelopedBrowsePathsV2.getValue().data())));
+    }
+
+    if (context != null && !canView(context.getOperationContext(), entityUrn)) {
+      return com.linkedin.datahub.graphql.authorization.AuthorizationUtils.restrictEntity(
+          result, SemanticModel.class);
+    }
+    return result;
+  }
+
+  private static SemanticModelInfo mapSemanticModelInfo(
+      @Nullable QueryContext context,
+      final com.linkedin.semanticmodel.SemanticModelInfo pdl,
+      final Urn semanticModelUrn) {
+    final SemanticModelInfo result = new SemanticModelInfo();
+    result.setName(pdl.getName());
+
+    if (pdl.hasDescription() && pdl.getDescription() != null) {
+      result.setDescription(pdl.getDescription());
+    }
+    if (pdl.hasCreated() && pdl.getCreated() != null) {
+      result.setCreated(MapperUtils.createResolvedAuditStamp(pdl.getCreated()));
+    }
+    if (pdl.hasLastModified() && pdl.getLastModified() != null) {
+      result.setLastModified(MapperUtils.createResolvedAuditStamp(pdl.getLastModified()));
+    }
+    if (pdl.hasNativeDefinition() && pdl.getNativeDefinition() != null) {
+      result.setNativeDefinition(pdl.getNativeDefinition());
+    }
+    if (pdl.hasAiContext() && pdl.getAiContext() != null) {
+      result.setAiContext(
+          com.linkedin.datahub.graphql.types.metric.mappers.AiContextMapper.map(
+              pdl.getAiContext()));
+    }
+
+    final List<ModelDataset> datasets;
+    if (pdl.hasDatasets() && pdl.getDatasets() != null) {
+      datasets =
+          pdl.getDatasets().stream()
+              .map(md -> mapModelDataset(context, md, semanticModelUrn))
+              .collect(Collectors.toList());
+    } else {
+      datasets = Collections.emptyList();
+    }
+    result.setDatasets(datasets);
+
+    if (pdl.hasRelationships() && pdl.getRelationships() != null) {
+      result.setRelationships(
+          pdl.getRelationships().stream()
+              .map(SemanticModelMapper::mapSemanticModelRelationship)
+              .collect(Collectors.toList()));
+    }
+
+    return result;
+  }
+
+  private static ModelDataset mapModelDataset(
+      @Nullable QueryContext context,
+      final com.linkedin.semanticmodel.ModelDataset pdl,
+      final Urn semanticModelUrn) {
+    final ModelDataset result = new ModelDataset();
+    result.setName(pdl.getName());
+
+    if (pdl.hasSource() && pdl.getSource() != null) {
+      result.setSource(UrnToEntityMapper.map(context, pdl.getSource()));
+    }
+
+    if (pdl.hasFields() && pdl.getFields() != null) {
+      final List<SemanticField> fields = new ArrayList<>();
+      for (com.linkedin.semanticmodel.SemanticField field : pdl.getFields()) {
+        final SemanticField mapped = SemanticFieldMapper.map(context, field, semanticModelUrn);
+        if (mapped != null) {
+          fields.add(mapped);
+        }
+      }
+      result.setFields(fields);
+    }
+
+    return result;
+  }
+
+  private static SemanticModelRelationship mapSemanticModelRelationship(
+      final com.linkedin.semanticmodel.SemanticModelRelationship pdl) {
+    final SemanticModelRelationship result = new SemanticModelRelationship();
+
+    if (pdl.hasName() && pdl.getName() != null) {
+      result.setName(pdl.getName());
+    }
+    result.setFrom(pdl.getFrom());
+    result.setFromColumns(new ArrayList<>(pdl.getFromColumns()));
+    result.setTo(pdl.getTo());
+    result.setToColumns(new ArrayList<>(pdl.getToColumns()));
+
+    if (pdl.hasCardinality() && pdl.getCardinality() != null) {
+      result.setCardinality(
+          PdlEnumMapper.mapDefaultNull(ERModelRelationshipCardinality.class, pdl.getCardinality()));
+    }
+
+    if (pdl.hasAiContext() && pdl.getAiContext() != null) {
+      result.setAiContext(
+          com.linkedin.datahub.graphql.types.metric.mappers.AiContextMapper.map(
+              pdl.getAiContext()));
+    }
+
+    return result;
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/semanticmodel/mappers/SemanticFieldMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/semanticmodel/mappers/SemanticFieldMapperTest.java
@@ -1,0 +1,99 @@
+package com.linkedin.datahub.graphql.types.semanticmodel.mappers;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.generated.SemanticField;
+import com.linkedin.datahub.graphql.generated.SemanticFieldType;
+import com.linkedin.metric.AiContext;
+import com.linkedin.metric.DialectExpression;
+import com.linkedin.metric.DialectExpressionArray;
+import com.linkedin.metric.MetricExpression;
+import com.linkedin.schema.SchemaField;
+import com.linkedin.schema.SchemaFieldDataType;
+import com.linkedin.schema.StringType;
+import com.linkedin.semanticmodel.Dimension;
+import java.net.URISyntaxException;
+import org.testng.annotations.Test;
+
+public class SemanticFieldMapperTest {
+
+  private static final String SEMANTIC_MODEL_URN =
+      "urn:li:semanticModel:(urn:li:dataPlatform:dbt,analytics.orders_model,my_model)";
+
+  @Test
+  public void testMapFullyPopulated() throws URISyntaxException {
+    Urn semanticModelUrn = Urn.createFromString(SEMANTIC_MODEL_URN);
+
+    com.linkedin.semanticmodel.SemanticField pdl =
+        new com.linkedin.semanticmodel.SemanticField()
+            .setSchemaField(buildSchemaField("revenue"))
+            .setType(com.linkedin.semanticmodel.SemanticFieldType.MEASURE)
+            .setExpression(buildExpression())
+            .setDimension(new Dimension().setIsTime(true))
+            .setAiContext(new AiContext().setInstructions("Sum of order revenue."));
+
+    SemanticField result = SemanticFieldMapper.map(null, pdl, semanticModelUrn);
+
+    assertNotNull(result);
+    assertNotNull(result.getSchemaField());
+    assertEquals(result.getSchemaField().getFieldPath(), "revenue");
+    assertNotNull(result.getSchemaField().getSchemaFieldEntity());
+    assertEquals(
+        result.getSchemaField().getSchemaFieldEntity().getUrn(),
+        "urn:li:schemaField:(" + SEMANTIC_MODEL_URN + ",revenue)");
+    assertEquals(result.getType(), SemanticFieldType.MEASURE);
+    assertNotNull(result.getExpression());
+    assertEquals(result.getExpression().getDialects().size(), 1);
+    assertNotNull(result.getDimension());
+    assertTrue(result.getDimension().getIsTime());
+    assertNotNull(result.getAiContext());
+    assertEquals(result.getAiContext().getInstructions(), "Sum of order revenue.");
+  }
+
+  @Test
+  public void testMapMissingTypeDefaultsToOther() throws URISyntaxException {
+    Urn semanticModelUrn = Urn.createFromString(SEMANTIC_MODEL_URN);
+
+    com.linkedin.semanticmodel.SemanticField pdl =
+        new com.linkedin.semanticmodel.SemanticField().setSchemaField(buildSchemaField("field"));
+
+    SemanticField result = SemanticFieldMapper.map(null, pdl, semanticModelUrn);
+
+    assertEquals(result.getType(), SemanticFieldType.OTHER);
+  }
+
+  @Test
+  public void testMapMissingSchemaFieldIsNull() throws URISyntaxException {
+    Urn semanticModelUrn = Urn.createFromString(SEMANTIC_MODEL_URN);
+
+    com.linkedin.semanticmodel.SemanticField pdl =
+        new com.linkedin.semanticmodel.SemanticField()
+            .setType(com.linkedin.semanticmodel.SemanticFieldType.FILTER);
+
+    SemanticField result = SemanticFieldMapper.map(null, pdl, semanticModelUrn);
+
+    assertNull(result.getSchemaField());
+    assertEquals(result.getType(), SemanticFieldType.FILTER);
+  }
+
+  private static SchemaField buildSchemaField(String fieldPath) {
+    return new SchemaField()
+        .setFieldPath(fieldPath)
+        .setNativeDataType("string")
+        .setType(
+            new SchemaFieldDataType().setType(SchemaFieldDataType.Type.create(new StringType())));
+  }
+
+  private static MetricExpression buildExpression() {
+    return new MetricExpression()
+        .setDialects(
+            new DialectExpressionArray(
+                new DialectExpression()
+                    .setDialect(com.linkedin.metric.Dialect.ANSI_SQL)
+                    .setExpression("SUM(revenue)")));
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/semanticmodel/mappers/SemanticModelMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/semanticmodel/mappers/SemanticModelMapperTest.java
@@ -1,0 +1,431 @@
+package com.linkedin.datahub.graphql.types.semanticmodel.mappers;
+
+import static com.linkedin.metadata.Constants.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.DataMap;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
+import com.linkedin.datahub.graphql.generated.ERModelRelationshipCardinality;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.SemanticModel;
+import com.linkedin.dataset.FineGrainedLineage;
+import com.linkedin.dataset.FineGrainedLineageArray;
+import com.linkedin.dataset.FineGrainedLineageDownstreamType;
+import com.linkedin.dataset.FineGrainedLineageUpstreamType;
+import com.linkedin.dataset.UpstreamLineage;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.metadata.key.SemanticModelKey;
+import com.linkedin.metric.DialectExpression;
+import com.linkedin.metric.DialectExpressionArray;
+import com.linkedin.metric.MetricExpression;
+import com.linkedin.schema.SchemaField;
+import com.linkedin.schema.SchemaFieldDataType;
+import com.linkedin.schema.StringType;
+import com.linkedin.semanticmodel.Dimension;
+import com.linkedin.semanticmodel.ModelDataset;
+import com.linkedin.semanticmodel.ModelDatasetArray;
+import com.linkedin.semanticmodel.SemanticField;
+import com.linkedin.semanticmodel.SemanticFieldArray;
+import com.linkedin.semanticmodel.SemanticModelInfo;
+import com.linkedin.semanticmodel.SemanticModelRelationship;
+import com.linkedin.semanticmodel.SemanticModelRelationshipArray;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+import org.mockito.MockedStatic;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class SemanticModelMapperTest {
+
+  private static final String PLATFORM_URN = "urn:li:dataPlatform:dbt";
+  private static final String SEMANTIC_MODEL_URN =
+      "urn:li:semanticModel:(urn:li:dataPlatform:dbt,analytics.orders_model,my_model)";
+  private static final String DATASET_URN =
+      "urn:li:dataset:(urn:li:dataPlatform:dbt,my_db.my_schema.my_table,PROD)";
+  private static final String QUERY_URN = "urn:li:query:abc123";
+  private static final String ACTOR_URN = "urn:li:corpuser:testuser";
+  private static final Long TEST_TIMESTAMP = 1640995200000L;
+
+  private Urn semanticModelUrn;
+  private QueryContext mockQueryContext;
+
+  @BeforeMethod
+  public void setup() throws URISyntaxException {
+    semanticModelUrn = Urn.createFromString(SEMANTIC_MODEL_URN);
+    mockQueryContext = mock(QueryContext.class);
+  }
+
+  @Test
+  public void testMapKeyOnly() {
+    EntityResponse entityResponse = createBaseEntityResponse();
+
+    try (MockedStatic<AuthorizationUtils> authMock = mockStatic(AuthorizationUtils.class)) {
+      authMock.when(() -> AuthorizationUtils.canView(any(), eq(semanticModelUrn))).thenReturn(true);
+
+      SemanticModel result = SemanticModelMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result);
+      assertEquals(result.getUrn(), SEMANTIC_MODEL_URN);
+      assertEquals(result.getType(), EntityType.SEMANTIC_MODEL);
+      assertNotNull(result.getPlatform());
+      assertEquals(result.getPlatform().getUrn(), PLATFORM_URN);
+      assertEquals(result.getPath(), "analytics.orders_model");
+      assertEquals(result.getId(), "my_model");
+    }
+  }
+
+  @Test
+  public void testMapSemanticModelInfoAuditStamps() throws URISyntaxException {
+    EntityResponse entityResponse = createBaseEntityResponse();
+
+    Urn actorUrn = Urn.createFromString(ACTOR_URN);
+    AuditStamp createdStamp = new AuditStamp().setTime(TEST_TIMESTAMP).setActor(actorUrn);
+    AuditStamp lastModifiedStamp =
+        new AuditStamp().setTime(TEST_TIMESTAMP + 1000L).setActor(actorUrn);
+
+    SemanticModelInfo info = new SemanticModelInfo().setName("My Semantic Model");
+    info.setCreated(createdStamp);
+    info.setLastModified(lastModifiedStamp);
+    addAspect(entityResponse, SEMANTIC_MODEL_INFO_ASPECT_NAME, info);
+
+    try (MockedStatic<AuthorizationUtils> authMock = mockStatic(AuthorizationUtils.class)) {
+      authMock.when(() -> AuthorizationUtils.canView(any(), eq(semanticModelUrn))).thenReturn(true);
+
+      SemanticModel result = SemanticModelMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result.getInfo());
+      assertEquals(result.getInfo().getName(), "My Semantic Model");
+      assertNotNull(result.getInfo().getCreated());
+      assertEquals(result.getInfo().getCreated().getTime(), TEST_TIMESTAMP);
+      assertEquals(result.getInfo().getCreated().getActor().getUrn(), ACTOR_URN);
+      assertNotNull(result.getInfo().getLastModified());
+      assertEquals(result.getInfo().getLastModified().getTime(), TEST_TIMESTAMP + 1000L);
+    }
+  }
+
+  @Test
+  public void testMapDatasetsSourceDataset() throws URISyntaxException {
+    EntityResponse entityResponse = createBaseEntityResponse();
+
+    ModelDataset modelDataset =
+        new ModelDataset().setName("orders_ds").setSource(Urn.createFromString(DATASET_URN));
+    SemanticModelInfo info =
+        new SemanticModelInfo()
+            .setName("My Model")
+            .setDatasets(new ModelDatasetArray(modelDataset));
+    addAspect(entityResponse, SEMANTIC_MODEL_INFO_ASPECT_NAME, info);
+
+    try (MockedStatic<AuthorizationUtils> authMock = mockStatic(AuthorizationUtils.class)) {
+      authMock.when(() -> AuthorizationUtils.canView(any(), any())).thenReturn(true);
+
+      SemanticModel result = SemanticModelMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result.getInfo());
+      assertNotNull(result.getInfo().getDatasets());
+      assertEquals(result.getInfo().getDatasets().size(), 1);
+      assertEquals(result.getInfo().getDatasets().get(0).getName(), "orders_ds");
+      assertNotNull(result.getInfo().getDatasets().get(0).getSource());
+      assertEquals(result.getInfo().getDatasets().get(0).getSource().getUrn(), DATASET_URN);
+      assertEquals(result.getInfo().getDatasets().get(0).getSource().getType(), EntityType.DATASET);
+    }
+  }
+
+  @Test
+  public void testMapDatasetsSourceQuery() throws URISyntaxException {
+    EntityResponse entityResponse = createBaseEntityResponse();
+
+    ModelDataset modelDataset =
+        new ModelDataset().setName("inline_query_ds").setSource(Urn.createFromString(QUERY_URN));
+    SemanticModelInfo info =
+        new SemanticModelInfo()
+            .setName("My Model")
+            .setDatasets(new ModelDatasetArray(modelDataset));
+    addAspect(entityResponse, SEMANTIC_MODEL_INFO_ASPECT_NAME, info);
+
+    try (MockedStatic<AuthorizationUtils> authMock = mockStatic(AuthorizationUtils.class)) {
+      authMock.when(() -> AuthorizationUtils.canView(any(), any())).thenReturn(true);
+
+      SemanticModel result = SemanticModelMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result.getInfo().getDatasets().get(0).getSource());
+      assertEquals(result.getInfo().getDatasets().get(0).getSource().getUrn(), QUERY_URN);
+      assertEquals(result.getInfo().getDatasets().get(0).getSource().getType(), EntityType.QUERY);
+    }
+  }
+
+  @Test
+  public void testMapSemanticFieldSchemaFieldAndUrn() throws URISyntaxException {
+    EntityResponse entityResponse = createBaseEntityResponse();
+
+    SchemaField schemaField =
+        new SchemaField()
+            .setFieldPath("revenue")
+            .setNativeDataType("NUMERIC")
+            .setType(
+                new SchemaFieldDataType()
+                    .setType(SchemaFieldDataType.Type.create(new StringType())))
+            .setDescription("Revenue dimension");
+
+    MetricExpression expression =
+        new MetricExpression()
+            .setDialects(
+                new DialectExpressionArray(
+                    new DialectExpression()
+                        .setDialect(com.linkedin.metric.Dialect.ANSI_SQL)
+                        .setExpression("SUM(revenue)")));
+
+    SemanticField semanticField =
+        new SemanticField()
+            .setSchemaField(schemaField)
+            .setType(com.linkedin.semanticmodel.SemanticFieldType.MEASURE)
+            .setExpression(expression);
+
+    ModelDataset modelDataset =
+        new ModelDataset()
+            .setName("orders_ds")
+            .setSource(Urn.createFromString(DATASET_URN))
+            .setFields(new SemanticFieldArray(semanticField));
+    SemanticModelInfo info =
+        new SemanticModelInfo()
+            .setName("My Model")
+            .setDatasets(new ModelDatasetArray(modelDataset));
+    addAspect(entityResponse, SEMANTIC_MODEL_INFO_ASPECT_NAME, info);
+
+    try (MockedStatic<AuthorizationUtils> authMock = mockStatic(AuthorizationUtils.class)) {
+      authMock.when(() -> AuthorizationUtils.canView(any(), any())).thenReturn(true);
+
+      SemanticModel result = SemanticModelMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result.getInfo().getDatasets().get(0).getFields());
+      assertEquals(result.getInfo().getDatasets().get(0).getFields().size(), 1);
+
+      com.linkedin.datahub.graphql.generated.SemanticField field =
+          result.getInfo().getDatasets().get(0).getFields().get(0);
+      assertNotNull(field.getSchemaField());
+      assertEquals(field.getSchemaField().getFieldPath(), "revenue");
+      assertEquals(field.getSchemaField().getDescription(), "Revenue dimension");
+      assertEquals(
+          field.getSchemaField().getType(),
+          com.linkedin.datahub.graphql.generated.SchemaFieldDataType.STRING);
+      assertNotNull(field.getSchemaField().getSchemaFieldEntity());
+      String expectedSchemaFieldUrn = "urn:li:schemaField:(" + SEMANTIC_MODEL_URN + ",revenue)";
+      assertEquals(field.getSchemaField().getSchemaFieldEntity().getUrn(), expectedSchemaFieldUrn);
+      assertEquals(
+          field.getType(), com.linkedin.datahub.graphql.generated.SemanticFieldType.MEASURE);
+    }
+  }
+
+  @Test
+  public void testMapSemanticFieldTypeDiscriminatorAllValues() throws URISyntaxException {
+    EntityResponse entityResponse = createBaseEntityResponse();
+
+    MetricExpression expr =
+        new MetricExpression()
+            .setDialects(
+                new DialectExpressionArray(
+                    new DialectExpression()
+                        .setDialect(com.linkedin.metric.Dialect.ANSI_SQL)
+                        .setExpression("1")));
+
+    SemanticField dimensionField =
+        new SemanticField()
+            .setSchemaField(buildSchemaField("dim_field"))
+            .setType(com.linkedin.semanticmodel.SemanticFieldType.DIMENSION)
+            .setExpression(expr)
+            .setDimension(new Dimension().setIsTime(true));
+
+    SemanticField measureField =
+        new SemanticField()
+            .setSchemaField(buildSchemaField("measure_field"))
+            .setType(com.linkedin.semanticmodel.SemanticFieldType.MEASURE)
+            .setExpression(expr);
+
+    SemanticField filterField =
+        new SemanticField()
+            .setSchemaField(buildSchemaField("filter_field"))
+            .setType(com.linkedin.semanticmodel.SemanticFieldType.FILTER)
+            .setExpression(expr);
+
+    SemanticField otherField =
+        new SemanticField()
+            .setSchemaField(buildSchemaField("other_field"))
+            .setType(com.linkedin.semanticmodel.SemanticFieldType.OTHER)
+            .setExpression(expr);
+
+    ModelDataset modelDataset =
+        new ModelDataset()
+            .setName("ds")
+            .setSource(Urn.createFromString(DATASET_URN))
+            .setFields(
+                new SemanticFieldArray(dimensionField, measureField, filterField, otherField));
+    addAspect(
+        entityResponse,
+        SEMANTIC_MODEL_INFO_ASPECT_NAME,
+        new SemanticModelInfo().setName("M").setDatasets(new ModelDatasetArray(modelDataset)));
+
+    try (MockedStatic<AuthorizationUtils> authMock = mockStatic(AuthorizationUtils.class)) {
+      authMock.when(() -> AuthorizationUtils.canView(any(), any())).thenReturn(true);
+
+      SemanticModel result = SemanticModelMapper.map(mockQueryContext, entityResponse);
+      java.util.List<com.linkedin.datahub.graphql.generated.SemanticField> fields =
+          result.getInfo().getDatasets().get(0).getFields();
+
+      assertEquals(
+          fields.get(0).getType(),
+          com.linkedin.datahub.graphql.generated.SemanticFieldType.DIMENSION);
+      assertNotNull(fields.get(0).getDimension());
+      assertTrue(fields.get(0).getDimension().getIsTime());
+
+      assertEquals(
+          fields.get(1).getType(),
+          com.linkedin.datahub.graphql.generated.SemanticFieldType.MEASURE);
+      assertNull(fields.get(1).getDimension());
+
+      assertEquals(
+          fields.get(2).getType(), com.linkedin.datahub.graphql.generated.SemanticFieldType.FILTER);
+      assertNull(fields.get(2).getDimension());
+
+      assertEquals(
+          fields.get(3).getType(), com.linkedin.datahub.graphql.generated.SemanticFieldType.OTHER);
+      assertNull(fields.get(3).getDimension());
+    }
+  }
+
+  @Test
+  public void testMapRelationshipsCardinality() throws URISyntaxException {
+    EntityResponse entityResponse = createBaseEntityResponse();
+
+    SemanticModelRelationship rel =
+        new SemanticModelRelationship()
+            .setName("orders_to_customers")
+            .setFrom("orders_ds")
+            .setFromColumns(new com.linkedin.data.template.StringArray("order_id"))
+            .setTo("customers_ds")
+            .setToColumns(new com.linkedin.data.template.StringArray("customer_id"))
+            .setCardinality(com.linkedin.ermodelrelation.ERModelRelationshipCardinality.N_ONE);
+
+    SemanticModelRelationship relNoCardinality =
+        new SemanticModelRelationship()
+            .setFrom("a")
+            .setFromColumns(new com.linkedin.data.template.StringArray("x"))
+            .setTo("b")
+            .setToColumns(new com.linkedin.data.template.StringArray("y"));
+
+    SemanticModelInfo info =
+        new SemanticModelInfo()
+            .setName("M")
+            .setRelationships(new SemanticModelRelationshipArray(rel, relNoCardinality));
+    addAspect(entityResponse, SEMANTIC_MODEL_INFO_ASPECT_NAME, info);
+
+    try (MockedStatic<AuthorizationUtils> authMock = mockStatic(AuthorizationUtils.class)) {
+      authMock.when(() -> AuthorizationUtils.canView(any(), eq(semanticModelUrn))).thenReturn(true);
+
+      SemanticModel result = SemanticModelMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result.getInfo().getRelationships());
+      assertEquals(result.getInfo().getRelationships().size(), 2);
+
+      com.linkedin.datahub.graphql.generated.SemanticModelRelationship mapped0 =
+          result.getInfo().getRelationships().get(0);
+      assertEquals(mapped0.getName(), "orders_to_customers");
+      assertEquals(mapped0.getFrom(), "orders_ds");
+      assertEquals(mapped0.getFromColumns().get(0), "order_id");
+      assertEquals(mapped0.getTo(), "customers_ds");
+      assertEquals(mapped0.getToColumns().get(0), "customer_id");
+      assertEquals(mapped0.getCardinality(), ERModelRelationshipCardinality.N_ONE);
+
+      assertNull(result.getInfo().getRelationships().get(1).getCardinality());
+    }
+  }
+
+  @Test
+  public void testMapFineGrainedLineages() throws URISyntaxException {
+    EntityResponse entityResponse = createBaseEntityResponse();
+
+    Urn upstreamFieldUrn = Urn.createFromString("urn:li:schemaField:(" + DATASET_URN + ",revenue)");
+    Urn downstreamFieldUrn =
+        Urn.createFromString("urn:li:schemaField:(" + SEMANTIC_MODEL_URN + ",total_revenue)");
+
+    UrnArray upstreamUrns = new UrnArray(upstreamFieldUrn);
+    UrnArray downstreamUrns = new UrnArray(downstreamFieldUrn);
+
+    FineGrainedLineage fgl = new FineGrainedLineage(new DataMap());
+    fgl.setUpstreams(upstreamUrns);
+    fgl.setDownstreams(downstreamUrns);
+    fgl.setUpstreamType(FineGrainedLineageUpstreamType.FIELD_SET);
+    fgl.setDownstreamType(FineGrainedLineageDownstreamType.FIELD);
+
+    UpstreamLineage upstreamLineage =
+        new UpstreamLineage().setFineGrainedLineages(new FineGrainedLineageArray(fgl));
+    addAspect(entityResponse, UPSTREAM_LINEAGE_ASPECT_NAME, upstreamLineage);
+
+    try (MockedStatic<AuthorizationUtils> authMock = mockStatic(AuthorizationUtils.class)) {
+      authMock.when(() -> AuthorizationUtils.canView(any(), eq(semanticModelUrn))).thenReturn(true);
+
+      SemanticModel result = SemanticModelMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result.getFineGrainedLineages());
+      assertEquals(result.getFineGrainedLineages().size(), 1);
+    }
+  }
+
+  @Test
+  public void testMapAbsentUpstreamLineage() {
+    EntityResponse entityResponse = createBaseEntityResponse();
+
+    try (MockedStatic<AuthorizationUtils> authMock = mockStatic(AuthorizationUtils.class)) {
+      authMock.when(() -> AuthorizationUtils.canView(any(), eq(semanticModelUrn))).thenReturn(true);
+
+      SemanticModel result = SemanticModelMapper.map(mockQueryContext, entityResponse);
+
+      assertNull(result.getFineGrainedLineages());
+    }
+  }
+
+  private EntityResponse createBaseEntityResponse() {
+    EntityResponse entityResponse = new EntityResponse();
+    entityResponse.setUrn(semanticModelUrn);
+
+    try {
+      SemanticModelKey key = new SemanticModelKey();
+      key.setPlatform(Urn.createFromString(PLATFORM_URN));
+      key.setPath("analytics.orders_model");
+      key.setId("my_model");
+
+      EnvelopedAspect keyAspect = new EnvelopedAspect();
+      keyAspect.setValue(new Aspect(key.data()));
+
+      Map<String, EnvelopedAspect> aspects = new HashMap<>();
+      aspects.put(SEMANTIC_MODEL_KEY_ASPECT_NAME, keyAspect);
+      entityResponse.setAspects(new EnvelopedAspectMap(aspects));
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+    return entityResponse;
+  }
+
+  private void addAspect(
+      EntityResponse entityResponse, String aspectName, RecordTemplate aspectData) {
+    EnvelopedAspect aspect = new EnvelopedAspect();
+    aspect.setValue(new Aspect(aspectData.data()));
+    entityResponse.getAspects().put(aspectName, aspect);
+  }
+
+  private SchemaField buildSchemaField(String fieldPath) {
+    return new SchemaField()
+        .setFieldPath(fieldPath)
+        .setNativeDataType("string")
+        .setType(
+            new SchemaFieldDataType().setType(SchemaFieldDataType.Type.create(new StringType())));
+  }
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
@@ -11,9 +11,7 @@ import com.linkedin.schema.SchemaField
 record SemanticField {
 
   /**
-   * Inline SchemaField describing this field's schema and identity.
-   * Its `fieldPath` composes into `urn:li:schemaField:(<parentSemanticModelUrn>,<fieldPath>)`,
-   * which serves as the endpoint for column-level lineage edges and as the anchor for
+   * Inline SchemaField describing this field's schema and identity for column-level lineage edges and as the anchor for
    * column-level governance (tags, glossary terms, description).
    */
   schemaField: SchemaField

--- a/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
@@ -11,7 +11,9 @@ import com.linkedin.schema.SchemaField
 record SemanticField {
 
   /**
-   * Inline SchemaField describing this field's schema and identity for column-level lineage edges and as the anchor for
+   * Inline SchemaField describing this field's schema and identity.
+   * Its `fieldPath` composes into `urn:li:schemaField:(<parentSemanticModelUrn>,<fieldPath>)`,
+   * which serves as the endpoint for column-level lineage edges and as the anchor for
    * column-level governance (tags, glossary terms, description).
    */
   schemaField: SchemaField


### PR DESCRIPTION
## Summary
- Adds `SemanticModelType` (batch-load entity type) and `SemanticModelMapper`/`SemanticFieldMapper` under `types/semanticmodel/`, following the same pattern established for the `Metric` entity in #18377.
- `SemanticModelMapper` maps the three-part key (`platform`/`path`/`id`), `semanticModelInfo` (name, description, `nativeDefinition`, audit stamps, `aiContext`, `datasets`, `relationships`), the `upstreamLineage` aspect's `fineGrainedLineages`, and all standard governance aspects.
- `SemanticFieldMapper` maps each dataset's inline `SchemaField` (via the existing `SchemaFieldMapper`, threading the enclosing semantic-model URN through so `schemaFieldEntity.urn` composes correctly), the `SemanticFieldType` discriminator (via `PdlEnumMapper` for forward-compatible enum handling), `expression`, and the `dimension` sub-record.
- `SemanticModelRelationship.cardinality` is mapped from the shared `ERModelRelationshipCardinality` enum, also via `PdlEnumMapper`.
- Adds `SemanticModelMapperTest` covering key parsing, audit stamps, dataset `source` resolving to both `dataset` and `query` stubs, `SemanticField`/`SchemaField` mapping (including the composed `schemaFieldEntity.urn`), all `SemanticFieldType` values, relationship field round-trip with/without cardinality, and `fineGrainedLineages` presence/absence.