### PR TITLE
feat(ui/lineage): Add showLineageFilterNodes flag, moving capabilities to contract button; refactoring

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -272,6 +272,7 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
             .setShowIntroducePage(_featureFlags.isShowIntroducePage())
             .setShowIngestionPageRedesign(_featureFlags.isShowIngestionPageRedesign())
             .setShowLineageExpandMore(_featureFlags.isShowLineageExpandMore())
+            .setShowLineageFilterNodes(_featureFlags.isShowLineageFilterNodes())
             .setShowStatsTabRedesign(_featureFlags.isShowStatsTabRedesign())
             .setShowDefaultExternalLinks(_featureFlags.isShowDefaultExternalLinks())
             .setShowHomePageRedesign(_featureFlags.isShowHomePageRedesign())

--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -805,6 +805,12 @@ type FeatureFlagsConfig {
   showStatsTabRedesign: Boolean!
 
   """
+  If enabled, render lineage filter nodes ("N shown of M" cards) in the lineage graph.
+  If disabled, pagination and search controls live on the expand/contract buttons instead.
+  """
+  showLineageFilterNodes: Boolean!
+
+  """
   If turned on, show the re-designed home page
   """
   showHomePageRedesign: Boolean!

--- a/datahub-web-react/src/alchemy-components/components/Input/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/Input/components.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import {
     INPUT_MAX_HEIGHT,
@@ -27,29 +27,41 @@ export const InputWrapper = styled.div({
     width: '100%',
 });
 
+export const inputContainerStyles = css<{
+    isSuccess?: boolean;
+    warning?: string;
+    isDisabled?: boolean;
+    isInvalid?: boolean;
+}>`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    flex: 1;
+    max-height: ${INPUT_MAX_HEIGHT};
+    padding-right: ${spacing.md};
+    overflow: hidden;
+    border-radius: ${radius.md};
+    border: ${({ isSuccess, warning, isInvalid, theme }) =>
+        `${borders['1px']} ${getStatusColors(isSuccess, warning, isInvalid, theme.colors)}`};
+    background-color: ${({ isDisabled, theme }) => (isDisabled ? theme.colors.bgInputDisabled : theme.colors.bg)};
+    color: ${({ theme }) => theme.colors.icon};
+    box-shadow: ${({ theme }) => theme.colors.shadowXs};
+
+    &:focus-within {
+        border-color: ${({ theme }) => theme.colors.borderBrandFocused};
+        outline: ${({ theme }) => `${borders['1px']} ${theme.colors.borderBrandFocused}`};
+    }
+`;
+
 export const InputContainer = styled.div<{
     isSuccess?: boolean;
     warning?: string;
     isDisabled?: boolean;
     isInvalid?: boolean;
-}>(({ isSuccess, warning, isDisabled, isInvalid, theme }) => ({
-    border: `${borders['1px']} ${getStatusColors(isSuccess, warning, isInvalid, theme.colors)}`,
-    backgroundColor: isDisabled ? theme.colors.bgInputDisabled : theme.colors.bg,
-    paddingRight: spacing.md,
-    ...defaultFlexStyles,
-    width: '100%',
-    maxHeight: INPUT_MAX_HEIGHT,
-    overflow: 'hidden' as const,
-    borderRadius: radius.md,
-    flex: 1,
-    color: theme.colors.icon,
-    boxShadow: theme.colors.shadowXs,
-
-    '&:focus-within': {
-        borderColor: theme.colors.borderBrandFocused,
-        outline: `${borders['1px']} ${theme.colors.borderBrandFocused}`,
-    },
-}));
+}>`
+    ${inputContainerStyles}
+`;
 
 export const InputField = styled.input(({ theme }) => ({
     padding: `${spacing.sm} ${spacing.md}`,

--- a/datahub-web-react/src/app/lineageV3/LineageBoundingBoxNode/LineageBoundingBoxNode.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageBoundingBoxNode/LineageBoundingBoxNode.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { NodeProps, NodeResizer } from 'reactflow';
 import styled from 'styled-components';
 
+import { IconStyleType } from '@app/entityV2/Entity';
 import HomePill from '@app/lineageV3/LineageEntityNode/HomePill';
 import LineageVisualizationContext from '@app/lineageV3/LineageVisualizationContext';
 import NodeWrapper from '@app/lineageV3/NodeWrapper';
@@ -15,6 +16,7 @@ import {
 } from '@app/lineageV3/common';
 import LineageCard from '@app/lineageV3/components/LineageCard';
 import usePrevious from '@app/shared/usePrevious';
+import { useEntityRegistry } from '@app/useEntityRegistry';
 
 export const LINEAGE_BOUNDING_BOX_NODE_NAME = 'lineage-bounding-box';
 export const BOUNDING_BOX_PADDING = 50;
@@ -56,6 +58,7 @@ export default function LineageBoundingBoxNode(props: NodeProps<LineageBoundingB
     const { data, selected, dragging } = props;
     const { urn, type, entity } = data;
 
+    const entityRegistry = useEntityRegistry();
     const { rootUrn } = useContext(LineageNodesContext);
     const { searchedEntity, setIsDraggingBoundingBox } = useContext(LineageVisualizationContext);
     const ignoreSchemaFieldStatus = useIgnoreSchemaFieldStatus();
@@ -121,6 +124,7 @@ export default function LineageBoundingBoxNode(props: NodeProps<LineageBoundingB
                         loading={!entity}
                         name={entity?.name || urn}
                         properties={entity?.genericEntityProperties}
+                        typeIcon={entityRegistry.getIcon(type, 16, IconStyleType.ACCENT)}
                         platformIcons={entity?.icon ? [entity.icon] : []}
                         childrenOpen={false}
                     />

--- a/datahub-web-react/src/app/lineageV3/LineageBoundingBoxNode/LineageBoundingBoxNode.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageBoundingBoxNode/LineageBoundingBoxNode.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { NodeProps, NodeResizer } from 'reactflow';
 import styled from 'styled-components';
 
+import { IconStyleType } from '@app/entityV2/Entity';
 import HomePill from '@app/lineageV3/LineageEntityNode/HomePill';
 import LineageVisualizationContext from '@app/lineageV3/LineageVisualizationContext';
 import NodeWrapper from '@app/lineageV3/NodeWrapper';
@@ -15,6 +16,7 @@ import {
 } from '@app/lineageV3/common';
 import LineageCard from '@app/lineageV3/components/LineageCard';
 import usePrevious from '@app/shared/usePrevious';
+import { useEntityRegistry } from '@app/useEntityRegistry';
 
 export const LINEAGE_BOUNDING_BOX_NODE_NAME = 'lineage-bounding-box';
 export const BOUNDING_BOX_PADDING = 50;
@@ -56,6 +58,7 @@ export default function LineageBoundingBoxNode(props: NodeProps<LineageBoundingB
     const { data, selected, dragging } = props;
     const { urn, type, entity } = data;
 
+    const entityRegistry = useEntityRegistry();
     const { rootUrn } = useContext(LineageNodesContext);
     const { searchedEntity, setIsDraggingBoundingBox } = useContext(LineageVisualizationContext);
     const ignoreSchemaFieldStatus = useIgnoreSchemaFieldStatus();
@@ -121,6 +124,7 @@ export default function LineageBoundingBoxNode(props: NodeProps<LineageBoundingB
                         loading={!entity}
                         name={entity?.name || urn}
                         properties={entity?.genericEntityProperties}
+                        leadingIcon={entityRegistry.getIcon(type, 16, IconStyleType.ACCENT)}
                         platformIcons={entity?.icon ? [entity.icon] : []}
                         childrenOpen={false}
                     />

--- a/datahub-web-react/src/app/lineageV3/LineageBoundingBoxNode/LineageBoundingBoxNode.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageBoundingBoxNode/LineageBoundingBoxNode.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { NodeProps, NodeResizer } from 'reactflow';
 import styled from 'styled-components';
 
-import { IconStyleType } from '@app/entityV2/Entity';
 import HomePill from '@app/lineageV3/LineageEntityNode/HomePill';
 import LineageVisualizationContext from '@app/lineageV3/LineageVisualizationContext';
 import NodeWrapper from '@app/lineageV3/NodeWrapper';
@@ -16,7 +15,6 @@ import {
 } from '@app/lineageV3/common';
 import LineageCard from '@app/lineageV3/components/LineageCard';
 import usePrevious from '@app/shared/usePrevious';
-import { useEntityRegistry } from '@app/useEntityRegistry';
 
 export const LINEAGE_BOUNDING_BOX_NODE_NAME = 'lineage-bounding-box';
 export const BOUNDING_BOX_PADDING = 50;
@@ -58,7 +56,6 @@ export default function LineageBoundingBoxNode(props: NodeProps<LineageBoundingB
     const { data, selected, dragging } = props;
     const { urn, type, entity } = data;
 
-    const entityRegistry = useEntityRegistry();
     const { rootUrn } = useContext(LineageNodesContext);
     const { searchedEntity, setIsDraggingBoundingBox } = useContext(LineageVisualizationContext);
     const ignoreSchemaFieldStatus = useIgnoreSchemaFieldStatus();
@@ -124,7 +121,6 @@ export default function LineageBoundingBoxNode(props: NodeProps<LineageBoundingB
                         loading={!entity}
                         name={entity?.name || urn}
                         properties={entity?.genericEntityProperties}
-                        leadingIcon={entityRegistry.getIcon(type, 16, IconStyleType.ACCENT)}
                         platformIcons={entity?.icon ? [entity.icon] : []}
                         childrenOpen={false}
                     />

--- a/datahub-web-react/src/app/lineageV3/LineageDisplay.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageDisplay.tsx
@@ -32,7 +32,16 @@ export default function LineageDisplay({
     const [hoveredNode, setHoveredNode] = useState<string | null>(null);
     const [displayedMenuNode, setDisplayedMenuNode] = useState<string | null>(null);
 
-    const { fineGrainedLineage, flowNodes, flowEdges, resetPositions, levelsInfo, levelsMap } = useComputeGraph();
+    const {
+        fineGrainedLineage,
+        flowNodes,
+        flowEdges,
+        resetPositions,
+        levelsInfo,
+        levelsMap,
+        lineageFilters,
+        adjacencyList: displayedAdjacencyList,
+    } = useComputeGraph();
 
     const addAnnotationNodes = useAddAnnotationNodes();
 
@@ -44,7 +53,7 @@ export default function LineageDisplay({
     );
     const refetchUrn = useBulkEntityLineage(shownUrns);
 
-    const { highlightedNodes, highlightedEdges } = useNodeHighlighting(hoveredNode);
+    const { highlightedNodes, highlightedEdges } = useNodeHighlighting(hoveredNode, displayedAdjacencyList);
     const { cllHighlightedNodes, highlightedColumns } = useColumnHighlighting(
         selectedColumn,
         hoveredColumn,
@@ -107,6 +116,7 @@ export default function LineageDisplay({
             value={{
                 hoveredNode,
                 setHoveredNode,
+                lineageFilters,
                 displayedMenuNode,
                 setDisplayedMenuNode,
                 selectedColumn,

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/ContractLineageControl.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/ContractLineageControl.tsx
@@ -1,0 +1,195 @@
+import { Icon } from '@components';
+import { CaretLeft } from '@phosphor-icons/react/dist/csr/CaretLeft';
+import { CaretRight } from '@phosphor-icons/react/dist/csr/CaretRight';
+import React, { useContext, useState } from 'react';
+import { Trans } from 'react-i18next';
+import styled from 'styled-components';
+
+import analytics, { EventType } from '@app/analytics';
+import { ContractLineageButton } from '@app/lineageV3/LineageEntityNode/ContractLineageButton';
+import { Button } from '@app/lineageV3/LineageEntityNode/components';
+import LineageFilterSearch from '@app/lineageV3/LineageFilterNode/LineageFilterSearch';
+import LineageFilterSummary from '@app/lineageV3/LineageFilterNode/LineageFilterSummary';
+import { ShowMoreButton } from '@app/lineageV3/LineageFilterNode/ShowMoreButton';
+import useFetchFilterNodeContents from '@app/lineageV3/LineageFilterNode/useFetchFilterNodeContents';
+import {
+    LineageDisplayContext,
+    LineageFilter,
+    LineageNodesContext,
+    createLineageFilterNodeId,
+    onClickPreventSelect,
+} from '@app/lineageV3/common';
+
+import { LineageDirection } from '@types';
+
+const ControlWrapper = styled.div<{ direction: LineageDirection }>`
+    position: absolute;
+    ${({ direction }) =>
+        direction === LineageDirection.Upstream ? 'right: calc(100% + 10px);' : 'left: calc(100% + 10px);'}
+    transform: translateY(-50%);
+
+    background-color: ${(props) => props.theme.colors.bg};
+    border-radius: 4px;
+    box-shadow: ${(props) => props.theme.colors.shadowXs};
+    color: ${(props) => props.theme.colors.iconBrand};
+    cursor: pointer;
+    font-size: 18px;
+
+    display: flex;
+    align-items: center;
+`;
+
+const CountText = styled.span`
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+`;
+
+const Panel = styled.div<{ direction: LineageDirection; visible: boolean }>`
+    position: absolute;
+    bottom: calc(100% + 6px);
+    ${({ direction }) => (direction === LineageDirection.Upstream ? 'right: 0;' : 'left: 0;')}
+
+    background-color: ${(props) => props.theme.colors.bg};
+    border: 1px solid ${(props) => props.theme.colors.border};
+    border-radius: 8px;
+    box-shadow: ${(props) => props.theme.colors.shadowXs};
+    color: ${(props) => props.theme.colors.text};
+    cursor: default;
+    font-size: 12px;
+    line-height: 16px;
+
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px;
+    width: 250px;
+
+    opacity: ${({ visible }) => (visible ? 1 : 0)};
+    pointer-events: ${({ visible }) => (visible ? 'all' : 'none')};
+    transform: translateY(${({ visible }) => (visible ? '0' : '6px')});
+    transition:
+        opacity 0.2s ease-in-out,
+        transform 0.2s ease-in-out;
+
+    /* Invisible bridge over the gap to the button, so the panel stays open while crossing it */
+    ::after {
+        content: '';
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        height: 12px;
+    }
+`;
+
+const PanelHeader = styled.div`
+    align-items: center;
+    display: flex;
+    gap: 8px;
+    justify-content: space-between;
+`;
+
+const TitleCount = styled.span`
+    font-weight: 600;
+`;
+
+interface Props {
+    urn: string;
+    direction: LineageDirection;
+}
+
+/**
+ * Contract button for an expanded node. If some of the node's children are not displayed
+ * (`lineageFilters` has an entry for this node and direction), makes that clear by showing how
+ * many children are shown, and expands on hover into a control to contract, search, and paginate
+ * children. Used in place of lineage filter nodes when those are not rendered.
+ */
+export function ContractLineageControl({ urn, direction }: Props) {
+    const { lineageFilters } = useContext(LineageDisplayContext);
+    const filter = lineageFilters.get(createLineageFilterNodeId(urn, direction));
+
+    if (!filter) {
+        return <ContractLineageButton urn={urn} direction={direction} />;
+    }
+    return <FilteredChildrenControl urn={urn} direction={direction} filter={filter} />;
+}
+
+function FilteredChildrenControl({ urn, direction, filter }: Props & { filter: LineageFilter }) {
+    const { nodes, setDisplayVersion, showGhostEntities } = useContext(LineageNodesContext);
+    const [isHovered, setIsHovered] = useState(false);
+    // Panel contents are mounted on first hover and kept mounted, so search state persists
+    const [hasHovered, setHasHovered] = useState(false);
+    const [numMatches, setNumMatches] = useState(0);
+
+    const { total, platforms, subtypes } = useFetchFilterNodeContents(urn, direction, !hasHovered);
+    const denominator = showGhostEntities ? filter.allChildren.size : (total ?? filter.allChildren.size);
+    const shown = Math.min(filter.shown.size, denominator);
+
+    const contractLineage = (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {
+        e.stopPropagation();
+        const node = nodes.get(urn);
+        if (node) {
+            node.isExpanded = { ...node.isExpanded, [direction]: false };
+            // Keeping the previous zoom node list leaves the viewport in place
+            setDisplayVersion(([version, n]) => [version + 1, n]);
+            analytics.event({
+                type: EventType.ContractLineageEvent,
+                direction,
+                entityUrn: urn,
+                entityType: node.type,
+            });
+        }
+    };
+
+    const contractIcon = direction === LineageDirection.Upstream ? CaretRight : CaretLeft;
+    return (
+        <ControlWrapper
+            className="nodrag"
+            direction={direction}
+            data-testid={`contract-lineage-control-${urn}-${direction}`}
+            onMouseEnter={(e) => {
+                e.stopPropagation();
+                setIsHovered(true);
+                setHasHovered(true);
+            }}
+            onMouseLeave={(e) => {
+                e.stopPropagation();
+                setIsHovered(false);
+            }}
+        >
+            <Panel visible={isHovered} direction={direction} onClick={onClickPreventSelect}>
+                {hasHovered && (
+                    <>
+                        <PanelHeader>
+                            <span>
+                                <Trans
+                                    i18nKey="lineage:filter.shownOfTotal"
+                                    values={{ shown, total: denominator, plus: showGhostEntities ? '+' : '' }}
+                                    components={{ shown: <TitleCount />, total: <TitleCount /> }}
+                                />
+                            </span>
+                            <ShowMoreButton data={filter} numMatches={numMatches} />
+                        </PanelHeader>
+                        <LineageFilterSearch
+                            data={filter}
+                            numMatches={numMatches}
+                            setNumMatches={setNumMatches}
+                            zoomToNode={false}
+                        />
+                        <LineageFilterSummary platforms={platforms} subtypes={subtypes} />
+                    </>
+                )}
+            </Panel>
+            <Button
+                onClick={(e) => onClickPreventSelect(e) && contractLineage(e)}
+                data-testid={`contract-${urn}-button`}
+            >
+                <CountText data-testid={`children-shown-${urn}-${direction}`}>
+                    {shown}/{denominator}
+                </CountText>
+                <Icon icon={contractIcon} size="lg" />
+            </Button>
+        </ControlWrapper>
+    );
+}

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/NodeContents.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/NodeContents.tsx
@@ -13,7 +13,7 @@ import { LastRunIcon } from '@app/entityV2/dataJob/tabs/RunsTab';
 import StructuredPropertyBadge from '@app/entityV2/shared/containers/profile/header/StructuredPropertyBadge';
 import VersioningBadge from '@app/entityV2/shared/versioning/VersioningBadge';
 import Columns from '@app/lineageV3/LineageEntityNode/Columns';
-import { ContractLineageButton } from '@app/lineageV3/LineageEntityNode/ContractLineageButton';
+import { ContractLineageControl } from '@app/lineageV3/LineageEntityNode/ContractLineageControl';
 import { ExpandLineageButton } from '@app/lineageV3/LineageEntityNode/ExpandLineageButton';
 import HomePill from '@app/lineageV3/LineageEntityNode/HomePill';
 import ManageLineageMenu from '@app/lineageV3/LineageEntityNode/ManageLineageMenu';
@@ -418,12 +418,12 @@ function NodeContents(props: Props & LineageEntity & DisplayedColumns) {
                             {fetchStatus[LineageDirection.Upstream] === FetchStatus.COMPLETE &&
                                 isExpandedUpstream &&
                                 hasUpstreamChildren && (
-                                    <ContractLineageButton urn={urn} direction={LineageDirection.Upstream} />
+                                    <ContractLineageControl urn={urn} direction={LineageDirection.Upstream} />
                                 )}
                             {fetchStatus[LineageDirection.Downstream] === FetchStatus.COMPLETE &&
                                 isExpandedDownstream &&
                                 hasDownstreamChildren && (
-                                    <ContractLineageButton urn={urn} direction={LineageDirection.Downstream} />
+                                    <ContractLineageControl urn={urn} direction={LineageDirection.Downstream} />
                                 )}
                             {fetchStatus[LineageDirection.Upstream] === FetchStatus.LOADING && (
                                 <LoadingWrapper className="nodrag" style={{ left: -30 }}>

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/components.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/components.tsx
@@ -40,6 +40,7 @@ export const DownstreamWrapper = styled(ExpandContractButton)`
 export const Button = styled.span`
     display: flex;
     align-items: center;
+    cursor: pointer;
     font-size: 12px;
 
     line-height: 0;

--- a/datahub-web-react/src/app/lineageV3/LineageFilterNode/LineageFilterNodeBasic.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageFilterNode/LineageFilterNodeBasic.tsx
@@ -5,20 +5,15 @@ import styled from 'styled-components';
 
 import { useAvoidIntersectionsOften } from '@app/lineageV3/LineageEntityNode/useAvoidIntersections';
 import LineageFilterSearch from '@app/lineageV3/LineageFilterNode/LineageFilterSearch';
+import LineageFilterSummary from '@app/lineageV3/LineageFilterNode/LineageFilterSummary';
 import { ShowMoreButton } from '@app/lineageV3/LineageFilterNode/ShowMoreButton';
-import useFetchFilterNodeContents, {
-    PlatformAggregate,
-    SubtypeAggregate,
-} from '@app/lineageV3/LineageFilterNode/useFetchFilterNodeContents';
+import useFetchFilterNodeContents from '@app/lineageV3/LineageFilterNode/useFetchFilterNodeContents';
 import {
     LINEAGE_NODE_WIDTH,
     LineageFilter,
     LineageNodesContext,
     useIgnoreSchemaFieldStatus,
 } from '@app/lineageV3/common';
-import { getFilterIconAndLabel } from '@app/searchV2/filters/utils';
-import { ENTITY_SUB_TYPE_FILTER_NAME, PLATFORM_FILTER_NAME } from '@app/searchV2/utils/constants';
-import { useEntityRegistryV2 } from '@app/useEntityRegistry';
 
 import { EntityType } from '@types';
 
@@ -74,18 +69,6 @@ const CustomHandle = styled(Handle)<{ position: Position }>`
     ${({ position }) => (position === Position.Left ? 'left: 0px; top: 50%;' : 'right: 0; top: 50%;')}
 `;
 
-const PillsWrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    margin-top: 6px;
-`;
-
-const PillColumn = styled.div`
-    color: ${(props) => props.theme.colors.textSecondary};
-    display: flex;
-    flex-direction: row;
-`;
-
 export default function LineageFilterNode(props: NodeProps<LineageFilter>) {
     const { id, data } = props;
     const { parent, direction, shown, allChildren, numShown } = data;
@@ -129,62 +112,7 @@ export default function LineageFilterNode(props: NodeProps<LineageFilter>) {
                 <ShowMoreButton data={data} numMatches={numMatches} />
             </TitleWrapper>
             <LineageFilterSearch data={data} numMatches={numMatches} setNumMatches={setNumMatches} />
-            <PillsWrapper>
-                <PillColumn>
-                    {platforms?.map((agg, index) => <PlatformEntry agg={agg} key={agg[0]} index={index} />)}
-                </PillColumn>
-                <PillColumn>
-                    {subtypes
-                        ?.filter(([filterValue]) => !filterValue.toLocaleLowerCase().endsWith('query'))
-                        .map((agg, index) => <SubtypeEntry agg={agg} key={agg[0]} index={index} />)}
-                </PillColumn>
-            </PillsWrapper>
+            <LineageFilterSummary platforms={platforms} subtypes={subtypes} />
         </NodeWrapper>
-    );
-}
-
-interface EntryProps<T> {
-    agg: T;
-    index: number;
-}
-
-function PlatformEntry({ agg, index }: EntryProps<PlatformAggregate>) {
-    return LineageFilterEntry(PLATFORM_FILTER_NAME, agg, index, 'platform');
-}
-
-function SubtypeEntry({ agg, index }: EntryProps<SubtypeAggregate>) {
-    return LineageFilterEntry(ENTITY_SUB_TYPE_FILTER_NAME, agg, index, 'subtype');
-}
-
-const EntryWrapper = styled.span<{ includeBefore: boolean }>`
-    align-items: center;
-    display: flex;
-
-    ${({ includeBefore }) =>
-        includeBefore &&
-        `::before {
-             content: ',';
-             margin-right: 4px;
-         }`})
-`;
-
-const CountWrapper = styled.span`
-    margin-left: 4px;
-`;
-
-function LineageFilterEntry(
-    filterName: string,
-    [filterValue, count, entity]: PlatformAggregate | SubtypeAggregate,
-    index: number,
-    dataTestIdPrefix: string,
-) {
-    const entityRegistry = useEntityRegistryV2();
-    const { icon, label } = getFilterIconAndLabel(filterName, filterValue, entityRegistry, entity || null, 12);
-
-    return (
-        <EntryWrapper title={label} includeBefore={index > 0}>
-            {icon}
-            <CountWrapper data-testid={`filter-counter-${dataTestIdPrefix}-${label}`}>{count}</CountWrapper>
-        </EntryWrapper>
     );
 }

--- a/datahub-web-react/src/app/lineageV3/LineageFilterNode/LineageFilterSearch.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageFilterNode/LineageFilterSearch.tsx
@@ -41,9 +41,12 @@ interface Props {
     data: LineageFilter;
     numMatches: number;
     setNumMatches: (numMatches: number) => void;
+    /** If false, keeps the current viewport in place when search results change,
+     * rather than zooming to the filter node. Defaults to true. */
+    zoomToNode?: boolean;
 }
 
-export default function LineageFilterSearch({ data, numMatches, setNumMatches }: Props) {
+export default function LineageFilterSearch({ data, numMatches, setNumMatches, zoomToNode = true }: Props) {
     const { t } = useTranslation('lineage');
     const { id, direction, parent, limit } = data;
 
@@ -61,9 +64,9 @@ export default function LineageFilterSearch({ data, numMatches, setNumMatches }:
         if (filters && searchQuery.length < 3 && oldSearchQuery?.length >= 3) {
             filters.searchUrns = undefined;
             setNumMatches(0);
-            setDisplayVersion(([prev]) => [prev + 1, [id]]);
+            setDisplayVersion(([prev, n]) => [prev + 1, zoomToNode ? [id] : n]);
         }
-    }, [searchQuery, oldSearchQuery, id, parent, direction, nodes, setNumMatches, setDisplayVersion]);
+    }, [searchQuery, oldSearchQuery, id, parent, direction, nodes, setNumMatches, setDisplayVersion, zoomToNode]);
 
     const orFilters = computeOrFilters([{ field: DEGREE_FILTER_NAME, values: ['1'] }]);
     const { loading } = useSearchAcrossLineageNamesQuery({
@@ -99,7 +102,8 @@ export default function LineageFilterSearch({ data, numMatches, setNumMatches }:
                 filters.searchUrns = new Set(
                     queryData.searchAcrossLineage?.searchResults?.map((result) => result.entity.urn),
                 );
-                setDisplayVersion(([prev]) => [prev + 1, [id]]);
+                // Keeping the previous zoom node list leaves the viewport in place
+                setDisplayVersion(([prev, n]) => [prev + 1, zoomToNode ? [id] : n]);
             }
         },
     });

--- a/datahub-web-react/src/app/lineageV3/LineageFilterNode/LineageFilterSummary.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageFilterNode/LineageFilterSummary.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { PlatformAggregate, SubtypeAggregate } from '@app/lineageV3/LineageFilterNode/useFetchFilterNodeContents';
+import { getFilterIconAndLabel } from '@app/searchV2/filters/utils';
+import { ENTITY_SUB_TYPE_FILTER_NAME, PLATFORM_FILTER_NAME } from '@app/searchV2/utils/constants';
+import { useAppConfig } from '@app/useAppConfig';
+import { useEntityRegistryV2 } from '@app/useEntityRegistry';
+
+const PillsWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    margin-top: 6px;
+`;
+
+const PillColumn = styled.div`
+    color: ${(props) => props.theme.colors.textSecondary};
+    display: flex;
+    flex-direction: row;
+`;
+
+interface Props {
+    platforms?: PlatformAggregate[];
+    subtypes?: SubtypeAggregate[];
+}
+
+/** Summary of a node's filtered children: their platforms and subtypes, with counts. */
+export default function LineageFilterSummary({ platforms, subtypes }: Props) {
+    const appConfig = useAppConfig();
+    const { showLineageFilterNodes } = appConfig.config.featureFlags;
+
+    return (
+        <PillsWrapper>
+            <PillColumn>
+                {platforms?.map((agg, index) => <PlatformEntry agg={agg} key={agg[0]} index={index} />)}
+            </PillColumn>
+            {showLineageFilterNodes && (
+                <PillColumn>
+                    {subtypes
+                        ?.filter(([filterValue]) => !filterValue.toLocaleLowerCase().endsWith('query'))
+                        .map((agg, index) => <SubtypeEntry agg={agg} key={agg[0]} index={index} />)}
+                </PillColumn>
+            )}
+        </PillsWrapper>
+    );
+}
+
+interface EntryProps<T> {
+    agg: T;
+    index: number;
+}
+
+function PlatformEntry({ agg, index }: EntryProps<PlatformAggregate>) {
+    return LineageFilterEntry(PLATFORM_FILTER_NAME, agg, index, 'platform');
+}
+
+function SubtypeEntry({ agg, index }: EntryProps<SubtypeAggregate>) {
+    return LineageFilterEntry(ENTITY_SUB_TYPE_FILTER_NAME, agg, index, 'subtype');
+}
+
+const EntryWrapper = styled.span<{ includeBefore: boolean }>`
+    align-items: center;
+    display: flex;
+
+    ${({ includeBefore }) =>
+        includeBefore &&
+        `::before {
+             content: ',';
+             margin-right: 4px;
+         }`})
+`;
+
+const CountWrapper = styled.span`
+    margin-left: 4px;
+`;
+
+function LineageFilterEntry(
+    filterName: string,
+    [filterValue, count, entity]: PlatformAggregate | SubtypeAggregate,
+    index: number,
+    dataTestIdPrefix: string,
+) {
+    const entityRegistry = useEntityRegistryV2();
+    const { icon, label } = getFilterIconAndLabel(filterName, filterValue, entityRegistry, entity || null, 12);
+
+    return (
+        <EntryWrapper title={label} includeBefore={index > 0}>
+            {icon}
+            <CountWrapper data-testid={`filter-counter-${dataTestIdPrefix}-${label}`}>{count}</CountWrapper>
+        </EntryWrapper>
+    );
+}

--- a/datahub-web-react/src/app/lineageV3/LineageFilterNode/ShowMoreButton.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageFilterNode/ShowMoreButton.tsx
@@ -16,6 +16,7 @@ const ExtraButtons = styled.div`
     flex-direction: column;
     align-items: end;
     background-color: ${(props) => props.theme.colors.bg};
+    z-index: 2;
 `;
 
 const Wrapper = styled.div`

--- a/datahub-web-react/src/app/lineageV3/LineageVisualization.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageVisualization.tsx
@@ -39,6 +39,12 @@ const StyledReactFlow = styled(ReactFlow)<{ isDraggingBoundingBox: boolean; $edg
         `.react-flow__node-lineage-entity:not(.dragging) {
             transition: transform ${TRANSITION_DURATION_MS}ms ease-in-out;
         }`}
+
+    /* Hovered nodes render above their neighbors, so overlays like the expand/contract
+       controls are not hidden behind other nodes. Overrides React Flow's inline z-index. */
+    .react-flow__node-lineage-entity:hover {
+        z-index: 1000 !important;
+    }
 `;
 
 // TODO: Bring back after figuring out how to no overlap expand / contract actions

--- a/datahub-web-react/src/app/lineageV3/common.ts
+++ b/datahub-web-react/src/app/lineageV3/common.ts
@@ -320,6 +320,26 @@ export function removeFromAdjacencyList(
     adjacencyList[reverseDirection(direction)].get(child)?.delete(parent);
 }
 
+/** Restricts an adjacency list to the given node ids, on both sides of each edge. */
+export function filterAdjacencyList(
+    adjacencyList: NodeContext['adjacencyList'],
+    keepIds: Set<Urn>,
+): NodeContext['adjacencyList'] {
+    const filterMap = (neighborMap: NeighborMap): NeighborMap => {
+        const result: NeighborMap = new Map();
+        neighborMap.forEach((neighbors, urn) => {
+            if (!keepIds.has(urn)) return;
+            const keptNeighbors = new Set(Array.from(neighbors).filter((neighbor) => keepIds.has(neighbor)));
+            if (keptNeighbors.size) result.set(urn, keptNeighbors);
+        });
+        return result;
+    };
+    return {
+        [LineageDirection.Upstream]: filterMap(adjacencyList[LineageDirection.Upstream]),
+        [LineageDirection.Downstream]: filterMap(adjacencyList[LineageDirection.Downstream]),
+    };
+}
+
 // Mapping fromRef -> toRef -> operationRef represents a column-level edge (fromRef -> toRef)
 // with an operationRef attached if this is an edge to that operation's query node
 export type FineGrainedLineageMap = Map<ColumnRef, Map<ColumnRef, FineGrainedOperationRef | null>>;
@@ -330,6 +350,10 @@ interface DisplayContext {
     // Params
     hoveredNode: Urn | null;
     setHoveredNode: Dispatch<SetStateAction<Urn | null>>;
+    /** Pagination state for each node and direction with filtered-out children, keyed by
+     * `createLineageFilterNodeId`. Used by the expand/contract controls when lineage filter
+     * nodes are not displayed. */
+    lineageFilters: Map<string, LineageFilter>;
     displayedMenuNode: Urn | null;
     setDisplayedMenuNode: Dispatch<SetStateAction<Urn | null>>;
     hoveredColumn: ColumnRef | null;
@@ -350,6 +374,7 @@ interface DisplayContext {
 export const LineageDisplayContext = React.createContext<DisplayContext>({
     hoveredNode: null,
     setHoveredNode: () => {},
+    lineageFilters: new Map(),
     displayedMenuNode: null,
     setDisplayedMenuNode: () => {},
     hoveredColumn: null,

--- a/datahub-web-react/src/app/lineageV3/components/LineageCard.tsx
+++ b/datahub-web-react/src/app/lineageV3/components/LineageCard.tsx
@@ -159,6 +159,8 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
     name: string;
     nameExtra?: React.ReactNode;
     nameHighlight?: { text: string; color: string };
+    // Rendered in the left icon column, before any platform icons
+    leadingIcon?: React.ReactNode;
     platformIcons: string[];
     menuActions?: React.ReactNode[];
 
@@ -185,6 +187,7 @@ function LineageCard(
         name,
         nameExtra,
         nameHighlight,
+        leadingIcon,
         platformIcons,
         menuActions,
         extraDetails,
@@ -204,6 +207,7 @@ function LineageCard(
             ) : (
                 <CardWrapper {...props} ref={ref}>
                     <PlatformIconsWrapper>
+                        {leadingIcon}
                         {platformIcons.map((icon) => (
                             /* eslint-disable-next-line i18next/no-literal-string -- (untranslated-text) internal alt fallback, not user-facing */
                             <PlatformIcon key={icon} src={icon} alt="Platform" />

--- a/datahub-web-react/src/app/lineageV3/components/LineageCard.tsx
+++ b/datahub-web-react/src/app/lineageV3/components/LineageCard.tsx
@@ -159,6 +159,9 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
     name: string;
     nameExtra?: React.ReactNode;
     nameHighlight?: { text: string; color: string };
+
+    // Rendered when there are no platform icons
+    typeIcon?: React.ReactNode;
     platformIcons: string[];
     menuActions?: React.ReactNode[];
 
@@ -185,6 +188,7 @@ function LineageCard(
         name,
         nameExtra,
         nameHighlight,
+        typeIcon,
         platformIcons,
         menuActions,
         extraDetails,
@@ -204,6 +208,7 @@ function LineageCard(
             ) : (
                 <CardWrapper {...props} ref={ref}>
                     <PlatformIconsWrapper>
+                        {platformIcons.length === 0 && typeIcon}
                         {platformIcons.map((icon) => (
                             /* eslint-disable-next-line i18next/no-literal-string -- (untranslated-text) internal alt fallback, not user-facing */
                             <PlatformIcon key={icon} src={icon} alt="Platform" />

--- a/datahub-web-react/src/app/lineageV3/components/LineageCard.tsx
+++ b/datahub-web-react/src/app/lineageV3/components/LineageCard.tsx
@@ -159,8 +159,6 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
     name: string;
     nameExtra?: React.ReactNode;
     nameHighlight?: { text: string; color: string };
-    // Rendered in the left icon column, before any platform icons
-    leadingIcon?: React.ReactNode;
     platformIcons: string[];
     menuActions?: React.ReactNode[];
 
@@ -187,7 +185,6 @@ function LineageCard(
         name,
         nameExtra,
         nameHighlight,
-        leadingIcon,
         platformIcons,
         menuActions,
         extraDetails,
@@ -207,7 +204,6 @@ function LineageCard(
             ) : (
                 <CardWrapper {...props} ref={ref}>
                     <PlatformIconsWrapper>
-                        {leadingIcon}
                         {platformIcons.map((icon) => (
                             /* eslint-disable-next-line i18next/no-literal-string -- (untranslated-text) internal alt fallback, not user-facing */
                             <PlatformIcon key={icon} src={icon} alt="Platform" />

--- a/datahub-web-react/src/app/lineageV3/controls/SearchControl.tsx
+++ b/datahub-web-react/src/app/lineageV3/controls/SearchControl.tsx
@@ -3,17 +3,15 @@ import { CaretDown } from '@phosphor-icons/react/dist/csr/CaretDown';
 import { CaretUp } from '@phosphor-icons/react/dist/csr/CaretUp';
 import { MagnifyingGlass } from '@phosphor-icons/react/dist/csr/MagnifyingGlass';
 import { X } from '@phosphor-icons/react/dist/csr/X';
+import { Input, InputRef } from 'antd';
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDebounce } from 'react-use';
 import { Panel } from 'reactflow';
 import styled from 'styled-components';
 
-import { InputContainer, InputField } from '@components/components/Input/components';
+import { inputContainerStyles } from '@components/components/Input/components';
 
-import LineageControlIcon from '@app/lineage/controls/LineageControlIcon';
-import { LINEAGE_CONTROL_ICON_WEIGHT } from '@app/lineage/controls/constants';
-import { getWrappedIndex } from '@app/lineage/controls/lineageControlsUtils';
 import LineageVisualizationContext from '@app/lineageV3/LineageVisualizationContext';
 import { LineageDisplayContext, LineageNodesContext } from '@app/lineageV3/common';
 
@@ -21,56 +19,54 @@ const StyledPanel = styled(Panel)`
     margin-top: 20px;
 `;
 
-const SearchRow = styled.div<{ $width: number }>`
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    width: ${({ $width }) => $width}px;
-`;
-
-const SearchBox = styled(InputContainer)<{ $isOpen: boolean }>`
+const StyledInput = styled(Input)<{ width: number }>`
+    ${inputContainerStyles};
     min-width: 50px;
     min-height: 50px;
-    height: 50px;
-    width: ${({ $isOpen }) => ($isOpen ? 'auto' : '50px')};
-    flex: ${({ $isOpen }) => ($isOpen ? '1' : '0 0 50px')};
-    padding: ${({ $isOpen }) => ($isOpen ? '0 12px' : '0')};
-    cursor: text;
-    justify-content: ${({ $isOpen }) => ($isOpen ? 'flex-start' : 'center')};
+    width: ${({ width }) => width}px;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    font-size: 14px;
+
+    border-color: ${(props) => props.theme.colors.border} !important;
+    box-shadow: none !important;
 `;
 
-const SearchInputField = styled(InputField)<{ $isOpen: boolean }>`
-    width: ${({ $isOpen }) => ($isOpen ? '100%' : '0')};
-    min-width: 0;
-    padding: ${({ $isOpen }) => ($isOpen ? undefined : '0')};
-    opacity: ${({ $isOpen }) => ($isOpen ? 1 : 0)};
-    pointer-events: ${({ $isOpen }) => ($isOpen ? 'auto' : 'none')};
+const ClosedSearchIcon = styled(MagnifyingGlass)`
+    margin-left: 8px;
+    font-size: 16px;
 `;
 
-const VerticalDivider = styled.div<{ $margin: number }>`
+const OpenSearchIcon = styled(MagnifyingGlass)``;
+
+const VerticalDivider = styled.hr<{ margin: number }>`
     align-self: stretch;
-    width: 0.5px;
-    margin: 0 ${({ $margin }) => $margin}px;
-    background-color: ${(props) => props.theme.colors.border};
+    height: auto;
+    margin: 0 ${({ margin }) => margin}px;
+    border: 0.5px solid ${(props) => props.theme.colors.border};
+    vertical-align: text-top;
 `;
 
 export default function SearchControl() {
     const { t } = useTranslation('lineage');
     const { searchQuery, setSearchQuery, setSearchedEntity } = useContext(LineageVisualizationContext);
     const [isFocused, setIsFocused] = useState(false);
-    const inputRef = useRef<HTMLInputElement>(null);
 
+    const inputRef = useRef<InputRef>(null);
     useCaptureKeyboardSearch(inputRef, setIsFocused);
 
     const matchedNodes = useComputeMatchedNodes();
     const searchIndex = useAssignSearchedEntity(matchedNodes);
 
     const prev = useCallback(
-        () => setSearchedEntity(matchedNodes[getWrappedIndex(searchIndex, -1, matchedNodes.length)]),
+        () => setSearchedEntity(matchedNodes[(searchIndex - 1 + matchedNodes.length) % matchedNodes.length]),
         [matchedNodes, searchIndex, setSearchedEntity],
     );
     const next = useCallback(
-        () => setSearchedEntity(matchedNodes[getWrappedIndex(searchIndex, 1, matchedNodes.length)]),
+        () => setSearchedEntity(matchedNodes[(searchIndex + 1) % matchedNodes.length]),
         [matchedNodes, searchIndex, setSearchedEntity],
     );
 
@@ -82,67 +78,44 @@ export default function SearchControl() {
     }, [setSearchQuery]);
     useCaptureEscape(isOpen, close);
 
-    const openSearch = useCallback(() => {
-        setIsFocused(true);
-        setTimeout(() => inputRef.current?.focus(), 0);
-    }, []);
+    const [isOpenDelayed, setIsOpenDelayed] = useState(isOpen);
+    useEffect(() => {
+        const timeout = setTimeout(() => setIsOpenDelayed(isOpen), 200);
+        return () => clearTimeout(timeout);
+    }, [isOpen]);
 
     return (
         <StyledPanel position="top-left">
-            <SearchRow
-                $width={isOpen ? 330 : 50}
-                onFocusCapture={() => setIsFocused(true)}
-                onBlurCapture={(e) => {
-                    if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
-                        setIsFocused(false);
-                    }
+            <StyledInput
+                ref={inputRef}
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onPressEnter={(e) => {
+                    if (e.shiftKey) prev();
+                    else next();
                 }}
-            >
-                <SearchBox $isOpen={isOpen} onClick={() => !isOpen && openSearch()}>
-                    <LineageControlIcon icon={MagnifyingGlass} color={isOpen ? 'textPlaceholder' : 'icon'} />
-                    <SearchInputField
-                        ref={inputRef}
-                        $isOpen={isOpen}
-                        value={searchQuery}
-                        onChange={(e) => setSearchQuery(e.target.value)}
-                        placeholder={isOpen ? t('controls.search.placeholder') : ''}
-                        onKeyDown={(e) => {
-                            if (e.key === 'Enter') {
-                                if (e.shiftKey) prev();
-                                else next();
-                            }
-                        }}
-                    />
-                </SearchBox>
-                {isOpen && searchQuery && (
-                    <>
-                        {/* eslint-disable i18next/no-literal-string -- (untranslated-text) numeric match-position separator (e.g. "3 / 10"), not translatable */}
-                        <span>
-                            {matchedNodes.length ? searchIndex + 1 : 0} / {matchedNodes.length}
-                        </span>
-                        {/* eslint-enable i18next/no-literal-string */}
-                        <VerticalDivider $margin={8} />
-                        <Button
-                            icon={{ icon: CaretUp, weight: LINEAGE_CONTROL_ICON_WEIGHT }}
-                            variant="outline"
-                            size="sm"
-                            onClick={prev}
-                        />
-                        <Button
-                            icon={{ icon: CaretDown, weight: LINEAGE_CONTROL_ICON_WEIGHT }}
-                            variant="outline"
-                            size="sm"
-                            onClick={next}
-                        />
-                        <Button
-                            icon={{ icon: X, weight: LINEAGE_CONTROL_ICON_WEIGHT }}
-                            variant="outline"
-                            size="sm"
-                            onClick={close}
-                        />
-                    </>
-                )}
-            </SearchRow>
+                placeholder={isOpen ? t('controls.search.placeholder') : undefined}
+                width={isOpen || isOpenDelayed ? 250 : 40}
+                prefix={isOpen ? <OpenSearchIcon /> : <ClosedSearchIcon />}
+                suffix={
+                    isOpen &&
+                    searchQuery && (
+                        <>
+                            {/* eslint-disable i18next/no-literal-string -- (untranslated-text) numeric match-position separator (e.g. "3 / 10"), not translatable */}
+                            <span>
+                                {matchedNodes.length ? searchIndex + 1 : 0} / {matchedNodes.length}
+                            </span>
+                            {/* eslint-enable i18next/no-literal-string */}
+                            <VerticalDivider margin={8} />
+                            <Button icon={{ icon: CaretUp }} variant="outline" size="sm" onClick={prev} />
+                            <Button icon={{ icon: CaretDown }} variant="outline" size="sm" onClick={next} />
+                            <Button icon={{ icon: X }} variant="outline" size="sm" onClick={close} />
+                        </>
+                    )
+                }
+                onBlur={() => setIsFocused(false)}
+                onFocus={() => setIsFocused(true)}
+            />
         </StyledPanel>
     );
 }
@@ -170,25 +143,30 @@ function useAssignSearchedEntity(matchedNodes: string[]) {
 
     const [searchIndex, newSearchedEntity] = useMemo(() => {
         if (!searchedEntity) {
+            // No previously selected entity, default to first matched node
             return [0, matchedNodes.length ? matchedNodes[0] : null];
         }
         const index = matchedNodes.indexOf(searchedEntity);
         if (index === -1) {
+            // Previously selected entity no longer in search list, default to first matched node
             return [0, matchedNodes[0]];
         }
+        // Previously selected entity still in search list, keep it selected and recalculate index
         return [index, searchedEntity];
     }, [searchedEntity, matchedNodes]);
 
+    // Add debounce so graph doesn't jump around while user is typing
     useDebounce(() => setSearchedEntity(newSearchedEntity), 300, [searchQuery]);
 
     return searchIndex;
 }
 
-function useCaptureKeyboardSearch(inputRef: React.RefObject<HTMLInputElement>, setIsFocused: (value: boolean) => void) {
+function useCaptureKeyboardSearch(inputRef: React.RefObject<InputRef>, setIsFocused: (value: boolean) => void) {
     const { isFocused } = useContext(LineageVisualizationContext);
 
     const handleKeyPress = useCallback(
         (e: KeyboardEvent) => {
+            // Capture ctrl-f or cmd-f
             if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
                 e.preventDefault();
                 inputRef.current?.focus();

--- a/datahub-web-react/src/app/lineageV3/controls/SearchControl.tsx
+++ b/datahub-web-react/src/app/lineageV3/controls/SearchControl.tsx
@@ -1,26 +1,21 @@
-import { Button, SearchBar } from '@components';
+import { Button } from '@components';
 import { CaretDown } from '@phosphor-icons/react/dist/csr/CaretDown';
 import { CaretUp } from '@phosphor-icons/react/dist/csr/CaretUp';
 import { MagnifyingGlass } from '@phosphor-icons/react/dist/csr/MagnifyingGlass';
 import { X } from '@phosphor-icons/react/dist/csr/X';
-import { InputRef } from 'antd';
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDebounce } from 'react-use';
 import { Panel } from 'reactflow';
 import styled from 'styled-components';
 
-import { InputContainer } from '@components/components/Input/components';
+import { InputContainer, InputField } from '@components/components/Input/components';
 
 import LineageControlIcon from '@app/lineage/controls/LineageControlIcon';
 import { LINEAGE_CONTROL_ICON_WEIGHT } from '@app/lineage/controls/constants';
 import { getWrappedIndex } from '@app/lineage/controls/lineageControlsUtils';
 import LineageVisualizationContext from '@app/lineageV3/LineageVisualizationContext';
 import { LineageDisplayContext, LineageNodesContext } from '@app/lineageV3/common';
-
-const COLLAPSED_SIZE = 36;
-const OPEN_WIDTH = 300;
-const SEARCH_BAR_HEIGHT = '24px';
 
 const StyledPanel = styled(Panel)`
     margin-top: 20px;
@@ -33,19 +28,23 @@ const SearchRow = styled.div<{ $width: number }>`
     width: ${({ $width }) => $width}px;
 `;
 
-const CollapsedSearch = styled(InputContainer)`
-    min-width: ${COLLAPSED_SIZE}px;
-    min-height: ${COLLAPSED_SIZE}px;
-    height: ${COLLAPSED_SIZE}px;
-    width: ${COLLAPSED_SIZE}px;
-    padding: 0;
-    justify-content: center;
+const SearchBox = styled(InputContainer)<{ $isOpen: boolean }>`
+    min-width: 50px;
+    min-height: 50px;
+    height: 50px;
+    width: ${({ $isOpen }) => ($isOpen ? 'auto' : '50px')};
+    flex: ${({ $isOpen }) => ($isOpen ? '1' : '0 0 50px')};
+    padding: ${({ $isOpen }) => ($isOpen ? '0 12px' : '0')};
     cursor: text;
+    justify-content: ${({ $isOpen }) => ($isOpen ? 'flex-start' : 'center')};
 `;
 
-const StyledSearchBar = styled(SearchBar)`
-    flex: 1;
+const SearchInputField = styled(InputField)<{ $isOpen: boolean }>`
+    width: ${({ $isOpen }) => ($isOpen ? '100%' : '0')};
     min-width: 0;
+    padding: ${({ $isOpen }) => ($isOpen ? undefined : '0')};
+    opacity: ${({ $isOpen }) => ($isOpen ? 1 : 0)};
+    pointer-events: ${({ $isOpen }) => ($isOpen ? 'auto' : 'none')};
 `;
 
 const VerticalDivider = styled.div<{ $margin: number }>`
@@ -59,7 +58,7 @@ export default function SearchControl() {
     const { t } = useTranslation('lineage');
     const { searchQuery, setSearchQuery, setSearchedEntity } = useContext(LineageVisualizationContext);
     const [isFocused, setIsFocused] = useState(false);
-    const inputRef = useRef<InputRef>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
 
     useCaptureKeyboardSearch(inputRef, setIsFocused);
 
@@ -91,7 +90,7 @@ export default function SearchControl() {
     return (
         <StyledPanel position="top-left">
             <SearchRow
-                $width={isOpen ? OPEN_WIDTH : COLLAPSED_SIZE}
+                $width={isOpen ? 330 : 50}
                 onFocusCapture={() => setIsFocused(true)}
                 onBlurCapture={(e) => {
                     if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
@@ -99,14 +98,14 @@ export default function SearchControl() {
                     }
                 }}
             >
-                {isOpen ? (
-                    <StyledSearchBar
+                <SearchBox $isOpen={isOpen} onClick={() => !isOpen && openSearch()}>
+                    <LineageControlIcon icon={MagnifyingGlass} color={isOpen ? 'textPlaceholder' : 'icon'} />
+                    <SearchInputField
                         ref={inputRef}
+                        $isOpen={isOpen}
                         value={searchQuery}
-                        onChange={(value) => setSearchQuery(value)}
-                        placeholder={t('controls.search.placeholder')}
-                        height={SEARCH_BAR_HEIGHT}
-                        allowClear={false}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        placeholder={isOpen ? t('controls.search.placeholder') : ''}
                         onKeyDown={(e) => {
                             if (e.key === 'Enter') {
                                 if (e.shiftKey) prev();
@@ -114,11 +113,7 @@ export default function SearchControl() {
                             }
                         }}
                     />
-                ) : (
-                    <CollapsedSearch onClick={openSearch}>
-                        <LineageControlIcon icon={MagnifyingGlass} color="icon" />
-                    </CollapsedSearch>
-                )}
+                </SearchBox>
                 {isOpen && searchQuery && (
                     <>
                         {/* eslint-disable i18next/no-literal-string -- (untranslated-text) numeric match-position separator (e.g. "3 / 10"), not translatable */}
@@ -189,7 +184,7 @@ function useAssignSearchedEntity(matchedNodes: string[]) {
     return searchIndex;
 }
 
-function useCaptureKeyboardSearch(inputRef: React.RefObject<InputRef>, setIsFocused: (value: boolean) => void) {
+function useCaptureKeyboardSearch(inputRef: React.RefObject<HTMLInputElement>, setIsFocused: (value: boolean) => void) {
     const { isFocused } = useContext(LineageVisualizationContext);
 
     const handleKeyPress = useCallback(

--- a/datahub-web-react/src/app/lineageV3/controls/SearchControl.tsx
+++ b/datahub-web-react/src/app/lineageV3/controls/SearchControl.tsx
@@ -1,21 +1,26 @@
-import { Button } from '@components';
+import { Button, SearchBar } from '@components';
 import { CaretDown } from '@phosphor-icons/react/dist/csr/CaretDown';
 import { CaretUp } from '@phosphor-icons/react/dist/csr/CaretUp';
 import { MagnifyingGlass } from '@phosphor-icons/react/dist/csr/MagnifyingGlass';
 import { X } from '@phosphor-icons/react/dist/csr/X';
+import { InputRef } from 'antd';
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDebounce } from 'react-use';
 import { Panel } from 'reactflow';
 import styled from 'styled-components';
 
-import { InputContainer, InputField } from '@components/components/Input/components';
+import { InputContainer } from '@components/components/Input/components';
 
 import LineageControlIcon from '@app/lineage/controls/LineageControlIcon';
 import { LINEAGE_CONTROL_ICON_WEIGHT } from '@app/lineage/controls/constants';
 import { getWrappedIndex } from '@app/lineage/controls/lineageControlsUtils';
 import LineageVisualizationContext from '@app/lineageV3/LineageVisualizationContext';
 import { LineageDisplayContext, LineageNodesContext } from '@app/lineageV3/common';
+
+const COLLAPSED_SIZE = 36;
+const OPEN_WIDTH = 300;
+const SEARCH_BAR_HEIGHT = '24px';
 
 const StyledPanel = styled(Panel)`
     margin-top: 20px;
@@ -28,23 +33,19 @@ const SearchRow = styled.div<{ $width: number }>`
     width: ${({ $width }) => $width}px;
 `;
 
-const SearchBox = styled(InputContainer)<{ $isOpen: boolean }>`
-    min-width: 50px;
-    min-height: 50px;
-    height: 50px;
-    width: ${({ $isOpen }) => ($isOpen ? 'auto' : '50px')};
-    flex: ${({ $isOpen }) => ($isOpen ? '1' : '0 0 50px')};
-    padding: ${({ $isOpen }) => ($isOpen ? '0 12px' : '0')};
+const CollapsedSearch = styled(InputContainer)`
+    min-width: ${COLLAPSED_SIZE}px;
+    min-height: ${COLLAPSED_SIZE}px;
+    height: ${COLLAPSED_SIZE}px;
+    width: ${COLLAPSED_SIZE}px;
+    padding: 0;
+    justify-content: center;
     cursor: text;
-    justify-content: ${({ $isOpen }) => ($isOpen ? 'flex-start' : 'center')};
 `;
 
-const SearchInputField = styled(InputField)<{ $isOpen: boolean }>`
-    width: ${({ $isOpen }) => ($isOpen ? '100%' : '0')};
+const StyledSearchBar = styled(SearchBar)`
+    flex: 1;
     min-width: 0;
-    padding: ${({ $isOpen }) => ($isOpen ? undefined : '0')};
-    opacity: ${({ $isOpen }) => ($isOpen ? 1 : 0)};
-    pointer-events: ${({ $isOpen }) => ($isOpen ? 'auto' : 'none')};
 `;
 
 const VerticalDivider = styled.div<{ $margin: number }>`
@@ -58,7 +59,7 @@ export default function SearchControl() {
     const { t } = useTranslation('lineage');
     const { searchQuery, setSearchQuery, setSearchedEntity } = useContext(LineageVisualizationContext);
     const [isFocused, setIsFocused] = useState(false);
-    const inputRef = useRef<HTMLInputElement>(null);
+    const inputRef = useRef<InputRef>(null);
 
     useCaptureKeyboardSearch(inputRef, setIsFocused);
 
@@ -90,7 +91,7 @@ export default function SearchControl() {
     return (
         <StyledPanel position="top-left">
             <SearchRow
-                $width={isOpen ? 330 : 50}
+                $width={isOpen ? OPEN_WIDTH : COLLAPSED_SIZE}
                 onFocusCapture={() => setIsFocused(true)}
                 onBlurCapture={(e) => {
                     if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
@@ -98,14 +99,14 @@ export default function SearchControl() {
                     }
                 }}
             >
-                <SearchBox $isOpen={isOpen} onClick={() => !isOpen && openSearch()}>
-                    <LineageControlIcon icon={MagnifyingGlass} color={isOpen ? 'textPlaceholder' : 'icon'} />
-                    <SearchInputField
+                {isOpen ? (
+                    <StyledSearchBar
                         ref={inputRef}
-                        $isOpen={isOpen}
                         value={searchQuery}
-                        onChange={(e) => setSearchQuery(e.target.value)}
-                        placeholder={isOpen ? t('controls.search.placeholder') : ''}
+                        onChange={(value) => setSearchQuery(value)}
+                        placeholder={t('controls.search.placeholder')}
+                        height={SEARCH_BAR_HEIGHT}
+                        allowClear={false}
                         onKeyDown={(e) => {
                             if (e.key === 'Enter') {
                                 if (e.shiftKey) prev();
@@ -113,7 +114,11 @@ export default function SearchControl() {
                             }
                         }}
                     />
-                </SearchBox>
+                ) : (
+                    <CollapsedSearch onClick={openSearch}>
+                        <LineageControlIcon icon={MagnifyingGlass} color="icon" />
+                    </CollapsedSearch>
+                )}
                 {isOpen && searchQuery && (
                     <>
                         {/* eslint-disable i18next/no-literal-string -- (untranslated-text) numeric match-position separator (e.g. "3 / 10"), not translatable */}
@@ -184,7 +189,7 @@ function useAssignSearchedEntity(matchedNodes: string[]) {
     return searchIndex;
 }
 
-function useCaptureKeyboardSearch(inputRef: React.RefObject<HTMLInputElement>, setIsFocused: (value: boolean) => void) {
+function useCaptureKeyboardSearch(inputRef: React.RefObject<InputRef>, setIsFocused: (value: boolean) => void) {
     const { isFocused } = useContext(LineageVisualizationContext);
 
     const handleKeyPress = useCallback(

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/NodeBuilder.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/NodeBuilder.ts
@@ -36,11 +36,11 @@ import { LINEAGE_ARROW_MARKER } from '@app/lineageV3/lineageSVGs';
 
 import { EntityType, LineageDirection } from '@types';
 
-const MAIN_X_SEP_RATIO = 0.5;
-const MAIN_TO_MINI_X_SEP_RATIO = 0.25;
-const MINI_X_SEP_RATIO = 0.125;
-const MAIN_Y_SEP_RATIO = 0.5;
-const MINI_Y_SEP_RATIO = MAIN_Y_SEP_RATIO / 2;
+export const MAIN_X_SEP_RATIO = 0.5;
+export const MAIN_TO_MINI_X_SEP_RATIO = 0.25;
+export const MINI_X_SEP_RATIO = 0.125;
+export const MAIN_Y_SEP_RATIO = 0.5;
+export const MINI_Y_SEP_RATIO = MAIN_Y_SEP_RATIO / 2;
 const TRANSFORMATIONAL_LEAF_OFFSET = 25;
 
 export type LineageVisualizationNode = Node<LineageEntity | LineageFilter | LineageBoundingBox | LineageAnnotationNode>;
@@ -119,6 +119,10 @@ export default class NodeBuilder {
 
     isHorizontal: boolean;
 
+    // If set, layers are computed from the provided `parents` map (requires nodes in topological
+    // order, as in the data flow DAG visualization), rather than via shortest path from the home node
+    useProvidedParents: boolean;
+
     // Must set node layers in rough topological order
     // A node must be preceded by all its min-parents, the parents along the shortest paths from the home node to it
     // TODO: Memoize this min-parent calculation?
@@ -147,12 +151,14 @@ export default class NodeBuilder {
         nodes: LineageNode[],
         parents: Map<string, Set<string>>,
         isHorizontal = true,
+        useProvidedParents = !isHorizontal,
     ) {
         this.homeUrn = rootUrn;
         this.homeType = rootType;
         this.roots = new Set(roots.map((node) => node.urn));
         this.parents = parents;
         this.isHorizontal = isHorizontal;
+        this.useProvidedParents = useProvidedParents;
         this.nodeHeight = rootType === EntityType.DataFlow ? LINEAGE_NODE_WIDTH : LINEAGE_NODE_HEIGHT;
         this.nodeWidth = rootType === EntityType.DataFlow ? LINEAGE_NODE_HEIGHT - 10 : LINEAGE_NODE_WIDTH;
 
@@ -331,13 +337,14 @@ export default class NodeBuilder {
             // Exemptions for lineage filter node and queries because they aren't fully in the adjacency list
             // As well as the data flow graph, in which nodes have no direction
             // TODO: Unify into single function + figure out why this.parents doesn't work
-            const parents = this.isHorizontal
-                ? getParents(node, adjacencyList)
-                : Array.from(this.parents.get(node.id) || []);
+            const parents = this.useProvidedParents
+                ? Array.from(this.parents.get(node.id) || [])
+                : getParents(node, adjacencyList);
             const minParentLayer = parents
                 .map<NodeInformation | undefined>((parent) => this.nodeInformation[parent])
                 .filter(
                     (parent) =>
+                        this.useProvidedParents ||
                         this.homeType === EntityType.DataFlow ||
                         node.type === LINEAGE_FILTER_TYPE ||
                         (node.type === EntityType.Query && [node.direction, undefined].includes(parent?.direction)) ||
@@ -376,8 +383,12 @@ export default class NodeBuilder {
         const nextLayerMap = this.#computeLayerPositions();
         this.transformations.forEach((node) => {
             const nextLayer = nextLayerMap.get(this.nodeInformation[node.id].layer || '');
-            if (node.direction) {
-                const children = Array.from(adjacencyList[node.direction].get(node.urn) || []).filter(
+            // The home node has children in both directions and is always placed at y=0, so it
+            // doesn't need its children for positioning
+            if (node.urn !== this.homeUrn) {
+                // Direction-less nodes (e.g. in the data flow DAG or box interiors) flow downstream
+                const direction = node.direction ?? LineageDirection.Downstream;
+                const children = Array.from(adjacencyList[direction].get(node.urn) || []).filter(
                     (child) => !nextLayer || this.nodeInformation[child]?.layer === nextLayer,
                 );
                 this.transformationChildren.set(node.urn, new Set(children));
@@ -475,7 +486,9 @@ export default class NodeBuilder {
                 return;
             }
 
-            const sortedNodes = Array.from(nodes).sort((idA, idB) => goalY[idA] - goalY[idB] || idA.localeCompare(idB));
+            // Stable sort: nodes with the same goal position keep their display (priority) order,
+            // so paginating in more children adds them below their existing siblings
+            const sortedNodes = Array.from(nodes).sort((idA, idB) => goalY[idA] - goalY[idB]);
             const getY = (idx: number): number => {
                 const id = sortedNodes[idx];
                 const val = this.nodeInformation[id].y;

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/computeLineageGraph.test.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/computeLineageGraph.test.ts
@@ -1,0 +1,184 @@
+import {
+    FetchStatus,
+    GraphStoreFields,
+    LINEAGE_FILTER_TYPE,
+    LineageEdge,
+    LineageEntity,
+    LineageToggles,
+    NodeContext,
+    createLineageFilterNodeId,
+} from '@app/lineageV3/common';
+import computeLineageGraph from '@app/lineageV3/useComputeGraph/computeLineageGraph';
+
+import { EntityType, LineageDirection } from '@types';
+
+type GraphContext = Pick<NodeContext, GraphStoreFields | LineageToggles | 'rootType'>;
+
+function createNode(urn: string, type: EntityType = EntityType.Dataset, limit?: number): LineageEntity {
+    return {
+        id: urn,
+        urn,
+        type,
+        isExpanded: { [LineageDirection.Upstream]: true, [LineageDirection.Downstream]: true },
+        fetchStatus: {
+            [LineageDirection.Upstream]: FetchStatus.COMPLETE,
+            [LineageDirection.Downstream]: FetchStatus.COMPLETE,
+        },
+        filters: {
+            [LineageDirection.Upstream]: { facetFilters: new Map() },
+            [LineageDirection.Downstream]: { facetFilters: new Map(), limit },
+        },
+    };
+}
+
+const createEdge = (isDisplayed = true): LineageEdge => ({ isDisplayed, isManual: false });
+
+const TOGGLES: Pick<NodeContext, LineageToggles> = {
+    hideTransformations: false,
+    showDataProcessInstances: false,
+    showGhostEntities: false,
+};
+
+/**
+ * Builds a simple graph: `upstream -> root -> downstream`.
+ */
+function buildLinearContext(overrides: Partial<Pick<NodeContext, LineageToggles>> = {}): GraphContext {
+    const nodes = new Map<string, LineageEntity>([
+        ['root', createNode('root')],
+        ['upstream', createNode('upstream')],
+        ['downstream', createNode('downstream')],
+    ]);
+    const edges = new Map<string, LineageEdge>([
+        ['upstream-:-root', createEdge()],
+        ['root-:-downstream', createEdge()],
+    ]);
+    const adjacencyList = {
+        [LineageDirection.Upstream]: new Map([
+            ['root', new Set(['upstream'])],
+            ['downstream', new Set(['root'])],
+        ]),
+        [LineageDirection.Downstream]: new Map([
+            ['root', new Set(['downstream'])],
+            ['upstream', new Set(['root'])],
+        ]),
+    };
+    return { nodes, edges, adjacencyList, rootType: EntityType.Dataset, ...TOGGLES, ...overrides };
+}
+
+describe('computeLineageGraph', () => {
+    it('returns the root and displays nodes in both directions', () => {
+        const { roots, displayedNodes } = computeLineageGraph('root', buildLinearContext(), false);
+
+        expect(roots.map((n) => n.urn)).toEqual(['root']);
+        const displayedUrns = displayedNodes.map((n) => n.id).sort();
+        expect(displayedUrns).toEqual(['downstream', 'root', 'upstream']);
+    });
+
+    it('signs order indices by direction, with the root at zero', () => {
+        const { orderIndices } = computeLineageGraph('root', buildLinearContext(), false);
+
+        expect(orderIndices.root).toBe(0);
+        expect(orderIndices.downstream).toBeGreaterThan(0);
+        expect(orderIndices.upstream).toBeLessThan(0);
+    });
+
+    it('returns no roots and no displayed nodes when the root is absent from the graph', () => {
+        const { roots, displayedNodes } = computeLineageGraph('missing', buildLinearContext(), false);
+
+        expect(roots).toEqual([]);
+        expect(displayedNodes).toEqual([]);
+    });
+
+    it('removes nodes matched by nodeFilter before display', () => {
+        const { displayedNodes, newGraphStore } = computeLineageGraph('root', buildLinearContext(), false, {
+            nodeFilter: (node) => node.urn !== 'downstream',
+        });
+
+        expect(newGraphStore.nodes.has('downstream')).toBe(false);
+        expect(displayedNodes.some((n) => n.id === 'downstream')).toBe(false);
+        expect(displayedNodes.some((n) => n.id === 'upstream')).toBe(true);
+    });
+
+    it('applies transformDisplayedNodes to the returned nodes', () => {
+        const { displayedNodes } = computeLineageGraph('root', buildLinearContext(), false, {
+            transformDisplayedNodes: (displayed) => displayed.filter((n) => n.id === 'root'),
+        });
+
+        expect(displayedNodes.map((n) => n.id)).toEqual(['root']);
+    });
+
+    it('hides transformational nodes from the graph store when hideTransformations is set', () => {
+        const nodes = new Map<string, LineageEntity>([
+            ['root', createNode('root')],
+            ['transform', createNode('transform', EntityType.DataJob)],
+            ['downstream', createNode('downstream')],
+        ]);
+        const edges = new Map<string, LineageEdge>([
+            ['root-:-transform', createEdge()],
+            ['transform-:-downstream', createEdge()],
+        ]);
+        const adjacencyList = {
+            [LineageDirection.Upstream]: new Map([
+                ['transform', new Set(['root'])],
+                ['downstream', new Set(['transform'])],
+            ]),
+            [LineageDirection.Downstream]: new Map([
+                ['root', new Set(['transform'])],
+                ['transform', new Set(['downstream'])],
+            ]),
+        };
+        const context: GraphContext = {
+            nodes,
+            edges,
+            adjacencyList,
+            rootType: EntityType.Dataset,
+            ...TOGGLES,
+            hideTransformations: true,
+        };
+
+        const { newGraphStore, displayedNodes } = computeLineageGraph('root', context, false);
+
+        expect(newGraphStore.nodes.has('transform')).toBe(false);
+        expect(displayedNodes.some((n) => n.id === 'transform')).toBe(false);
+        expect(displayedNodes.some((n) => n.id === 'downstream')).toBe(true);
+    });
+
+    describe('with more children than the pagination limit', () => {
+        const CHILDREN = ['c0', 'c1', 'c2', 'c3', 'c4', 'c5'];
+
+        function buildFanOutContext(): GraphContext {
+            const nodes = new Map<string, LineageEntity>([['root', createNode('root')]]);
+            CHILDREN.forEach((urn) => nodes.set(urn, createNode(urn)));
+            // hideNodes rebuilds the adjacency list from edges, so each child needs a backing edge
+            const edges = new Map<string, LineageEdge>(CHILDREN.map((urn) => [`root-:-${urn}`, createEdge()]));
+            return {
+                nodes,
+                edges,
+                rootType: EntityType.Dataset,
+                ...TOGGLES,
+                adjacencyList: {
+                    [LineageDirection.Downstream]: new Map([['root', new Set(CHILDREN)]]),
+                    [LineageDirection.Upstream]: new Map(CHILDREN.map((urn) => [urn, new Set(['root'])])),
+                },
+            };
+        }
+
+        const filterId = createLineageFilterNodeId('root', LineageDirection.Downstream);
+
+        it('includes a filter node by default and records pagination state', () => {
+            const { displayedNodes, lineageFilters } = computeLineageGraph('root', buildFanOutContext(), false);
+
+            expect(displayedNodes.some((n) => n.type === LINEAGE_FILTER_TYPE)).toBe(true);
+            expect(lineageFilters.get(filterId)?.contents).toEqual(CHILDREN);
+        });
+
+        it('omits the filter node but keeps its state when createFilterNodes is false', () => {
+            const { displayedNodes, lineageFilters } = computeLineageGraph('root', buildFanOutContext(), false, {
+                createFilterNodes: false,
+            });
+
+            expect(displayedNodes.some((n) => n.type === LINEAGE_FILTER_TYPE)).toBe(false);
+            expect(lineageFilters.get(filterId)).toBeDefined();
+        });
+    });
+});

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getDisplayedNodes.test.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getDisplayedNodes.test.ts
@@ -1,0 +1,87 @@
+import {
+    FetchStatus,
+    LINEAGE_FILTER_TYPE,
+    LineageEntity,
+    NodeContext,
+    createLineageFilterNodeId,
+} from '@app/lineageV3/common';
+import getDisplayedNodes from '@app/lineageV3/useComputeGraph/getDisplayedNodes';
+
+import { EntityType, LineageDirection } from '@types';
+
+const ROOT = 'root';
+// More than LINEAGE_FILTER_PAGINATION (4), so a lineage filter is created for the root's children
+const CHILDREN = ['c0', 'c1', 'c2', 'c3', 'c4', 'c5'];
+const LIMIT = 2;
+
+function createNode(urn: string, limit?: number): LineageEntity {
+    return {
+        id: urn,
+        urn,
+        type: EntityType.Dataset,
+        isExpanded: { [LineageDirection.Upstream]: true, [LineageDirection.Downstream]: true },
+        fetchStatus: {
+            [LineageDirection.Upstream]: FetchStatus.COMPLETE,
+            [LineageDirection.Downstream]: FetchStatus.COMPLETE,
+        },
+        filters: {
+            [LineageDirection.Upstream]: { facetFilters: new Map() },
+            [LineageDirection.Downstream]: { facetFilters: new Map(), limit },
+        },
+    };
+}
+
+function buildContext(): Pick<NodeContext, 'adjacencyList' | 'nodes' | 'edges' | 'rootType'> {
+    const nodes = new Map<string, LineageEntity>([[ROOT, createNode(ROOT, LIMIT)]]);
+    CHILDREN.forEach((urn) => nodes.set(urn, createNode(urn)));
+    return {
+        nodes,
+        edges: new Map(),
+        rootType: EntityType.Dataset,
+        adjacencyList: {
+            [LineageDirection.Downstream]: new Map([[ROOT, new Set(CHILDREN)]]),
+            [LineageDirection.Upstream]: new Map(CHILDREN.map((urn) => [urn, new Set([ROOT])])),
+        },
+    };
+}
+
+// Children in priority order; pagination should keep the first `limit`
+const orderedNodes = () => {
+    const context = buildContext();
+    return {
+        [LineageDirection.Downstream]: CHILDREN.map((urn) => context.nodes.get(urn) as LineageEntity),
+        [LineageDirection.Upstream]: [],
+    };
+};
+
+describe('getDisplayedNodes pagination and filter nodes', () => {
+    const filterId = createLineageFilterNodeId(ROOT, LineageDirection.Downstream);
+
+    it('keeps the first `limit` children and records full pagination state', () => {
+        const { displayedNodes, lineageFilters } = getDisplayedNodes(ROOT, orderedNodes(), buildContext());
+
+        const shownChildren = displayedNodes.filter((n) => CHILDREN.includes(n.id)).map((n) => n.id);
+        expect(shownChildren).toEqual(['c0', 'c1']);
+
+        const filter = lineageFilters.get(filterId);
+        expect(filter).toBeDefined();
+        expect(filter?.contents).toEqual(CHILDREN);
+        expect(filter?.shown).toEqual(new Set(['c0', 'c1']));
+    });
+
+    it('renders a filter node by default', () => {
+        const { displayedNodes } = getDisplayedNodes(ROOT, orderedNodes(), buildContext());
+        expect(displayedNodes.some((n) => n.type === LINEAGE_FILTER_TYPE)).toBe(true);
+    });
+
+    it('omits the filter node but still returns its state when createFilterNodes is false', () => {
+        const { displayedNodes, lineageFilters } = getDisplayedNodes(ROOT, orderedNodes(), buildContext(), {
+            createFilterNodes: false,
+        });
+
+        expect(displayedNodes.some((n) => n.type === LINEAGE_FILTER_TYPE)).toBe(false);
+        // Children are still shown; only the filter card is suppressed
+        expect(displayedNodes.filter((n) => CHILDREN.includes(n.id)).map((n) => n.id)).toEqual(['c0', 'c1']);
+        expect(lineageFilters.get(filterId)?.shown).toEqual(new Set(['c0', 'c1']));
+    });
+});

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getDisplayedNodes.test.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getDisplayedNodes.test.ts
@@ -1,87 +1,325 @@
 import {
     FetchStatus,
+    Filters,
     LINEAGE_FILTER_TYPE,
     LineageEntity,
     NodeContext,
     createLineageFilterNodeId,
 } from '@app/lineageV3/common';
 import getDisplayedNodes from '@app/lineageV3/useComputeGraph/getDisplayedNodes';
+import { ENTITY_SUB_TYPE_FILTER_NAME, FILTER_DELIMITER, PLATFORM_FILTER_NAME } from '@app/searchV2/utils/constants';
 
 import { EntityType, LineageDirection } from '@types';
 
-const ROOT = 'root';
-// More than LINEAGE_FILTER_PAGINATION (4), so a lineage filter is created for the root's children
-const CHILDREN = ['c0', 'c1', 'c2', 'c3', 'c4', 'c5'];
-const LIMIT = 2;
+type Context = Pick<NodeContext, 'adjacencyList' | 'nodes' | 'edges' | 'rootType'>;
 
-function createNode(urn: string, limit?: number): LineageEntity {
+interface NodeOpts {
+    type?: EntityType;
+    entity?: any;
+    inCycle?: boolean;
+    expanded?: boolean;
+    /** Direction of the node relative to the root; drives `getParents` traversal. */
+    direction?: LineageDirection;
+    downstream?: Partial<Filters>;
+    upstream?: Partial<Filters>;
+}
+
+function createNode(urn: string, opts: NodeOpts = {}): LineageEntity {
+    const { type = EntityType.Dataset, entity, inCycle, expanded = true, direction, downstream, upstream } = opts;
     return {
         id: urn,
         urn,
-        type: EntityType.Dataset,
-        isExpanded: { [LineageDirection.Upstream]: true, [LineageDirection.Downstream]: true },
+        type,
+        entity,
+        inCycle,
+        direction,
+        isExpanded: { [LineageDirection.Upstream]: expanded, [LineageDirection.Downstream]: expanded },
         fetchStatus: {
             [LineageDirection.Upstream]: FetchStatus.COMPLETE,
             [LineageDirection.Downstream]: FetchStatus.COMPLETE,
         },
         filters: {
-            [LineageDirection.Upstream]: { facetFilters: new Map() },
-            [LineageDirection.Downstream]: { facetFilters: new Map(), limit },
+            [LineageDirection.Upstream]: { facetFilters: new Map(), ...upstream },
+            [LineageDirection.Downstream]: { facetFilters: new Map(), ...downstream },
         },
     };
 }
 
-function buildContext(): Pick<NodeContext, 'adjacencyList' | 'nodes' | 'edges' | 'rootType'> {
-    const nodes = new Map<string, LineageEntity>([[ROOT, createNode(ROOT, LIMIT)]]);
-    CHILDREN.forEach((urn) => nodes.set(urn, createNode(urn)));
+const emptyAdjacencyList = () => ({
+    [LineageDirection.Upstream]: new Map<string, Set<string>>(),
+    [LineageDirection.Downstream]: new Map<string, Set<string>>(),
+});
+
+/** Links `parent -> child` in the downstream direction (and the reverse upstream). */
+function addEdge(adjacencyList: NodeContext['adjacencyList'], parent: string, child: string): void {
+    if (!adjacencyList[LineageDirection.Downstream].has(parent)) {
+        adjacencyList[LineageDirection.Downstream].set(parent, new Set());
+    }
+    adjacencyList[LineageDirection.Downstream].get(parent)?.add(child);
+    if (!adjacencyList[LineageDirection.Upstream].has(child)) {
+        adjacencyList[LineageDirection.Upstream].set(child, new Set());
+    }
+    adjacencyList[LineageDirection.Upstream].get(child)?.add(parent);
+}
+
+/** Builds a context from a node list and a set of downstream edges `[parent, child]`. */
+function buildContext(nodeList: LineageEntity[], downstreamEdges: [string, string][] = []): Context {
+    const nodes = new Map(nodeList.map((n) => [n.urn, n]));
+    const adjacencyList = emptyAdjacencyList();
+    downstreamEdges.forEach(([parent, child]) => addEdge(adjacencyList, parent, child));
+    return { nodes, edges: new Map(), rootType: EntityType.Dataset, adjacencyList };
+}
+
+/** BFS-ordered node lists per direction, as `orderNodes` would produce. */
+function ordered(
+    context: Context,
+    downstreamUrns: string[],
+    upstreamUrns: string[] = [],
+): Record<LineageDirection, LineageEntity[]> {
+    const lookup = (urn: string) => context.nodes.get(urn) as LineageEntity;
     return {
-        nodes,
-        edges: new Map(),
-        rootType: EntityType.Dataset,
-        adjacencyList: {
-            [LineageDirection.Downstream]: new Map([[ROOT, new Set(CHILDREN)]]),
-            [LineageDirection.Upstream]: new Map(CHILDREN.map((urn) => [urn, new Set([ROOT])])),
-        },
+        [LineageDirection.Downstream]: downstreamUrns.map(lookup),
+        [LineageDirection.Upstream]: upstreamUrns.map(lookup),
     };
 }
 
-// Children in priority order; pagination should keep the first `limit`
-const orderedNodes = () => {
-    const context = buildContext();
-    return {
-        [LineageDirection.Downstream]: CHILDREN.map((urn) => context.nodes.get(urn) as LineageEntity),
-        [LineageDirection.Upstream]: [],
-    };
-};
+const childUrns = (displayed: LineageEntity[], all: string[]) =>
+    displayed.filter((n) => all.includes(n.id)).map((n) => n.id);
 
-describe('getDisplayedNodes pagination and filter nodes', () => {
-    const filterId = createLineageFilterNodeId(ROOT, LineageDirection.Downstream);
+describe('getDisplayedNodes', () => {
+    describe('pagination and filter nodes', () => {
+        const ROOT = 'root';
+        // More than LINEAGE_FILTER_PAGINATION (4), so a lineage filter is created for the root's children
+        const CHILDREN = ['c0', 'c1', 'c2', 'c3', 'c4', 'c5'];
+        const LIMIT = 2;
+        const filterId = createLineageFilterNodeId(ROOT, LineageDirection.Downstream);
 
-    it('keeps the first `limit` children and records full pagination state', () => {
-        const { displayedNodes, lineageFilters } = getDisplayedNodes(ROOT, orderedNodes(), buildContext());
+        function build(): Context {
+            const nodes = [
+                createNode(ROOT, { downstream: { limit: LIMIT } }),
+                ...CHILDREN.map((urn) => createNode(urn)),
+            ];
+            return buildContext(
+                nodes,
+                CHILDREN.map((urn) => [ROOT, urn]),
+            );
+        }
 
-        const shownChildren = displayedNodes.filter((n) => CHILDREN.includes(n.id)).map((n) => n.id);
-        expect(shownChildren).toEqual(['c0', 'c1']);
+        it('keeps the first `limit` children and records full pagination state', () => {
+            const context = build();
+            const { displayedNodes, lineageFilters } = getDisplayedNodes(ROOT, ordered(context, CHILDREN), context);
 
-        const filter = lineageFilters.get(filterId);
-        expect(filter).toBeDefined();
-        expect(filter?.contents).toEqual(CHILDREN);
-        expect(filter?.shown).toEqual(new Set(['c0', 'c1']));
-    });
+            expect(childUrns(displayedNodes, CHILDREN)).toEqual(['c0', 'c1']);
 
-    it('renders a filter node by default', () => {
-        const { displayedNodes } = getDisplayedNodes(ROOT, orderedNodes(), buildContext());
-        expect(displayedNodes.some((n) => n.type === LINEAGE_FILTER_TYPE)).toBe(true);
-    });
-
-    it('omits the filter node but still returns its state when createFilterNodes is false', () => {
-        const { displayedNodes, lineageFilters } = getDisplayedNodes(ROOT, orderedNodes(), buildContext(), {
-            createFilterNodes: false,
+            const filter = lineageFilters.get(filterId);
+            expect(filter?.contents).toEqual(CHILDREN);
+            expect(filter?.shown).toEqual(new Set(['c0', 'c1']));
         });
 
-        expect(displayedNodes.some((n) => n.type === LINEAGE_FILTER_TYPE)).toBe(false);
-        // Children are still shown; only the filter card is suppressed
-        expect(displayedNodes.filter((n) => CHILDREN.includes(n.id)).map((n) => n.id)).toEqual(['c0', 'c1']);
-        expect(lineageFilters.get(filterId)?.shown).toEqual(new Set(['c0', 'c1']));
+        it('renders a filter node by default', () => {
+            const context = build();
+            const { displayedNodes } = getDisplayedNodes(ROOT, ordered(context, CHILDREN), context);
+            expect(displayedNodes.some((n) => n.type === LINEAGE_FILTER_TYPE)).toBe(true);
+        });
+
+        it('omits the filter node but still returns its state when createFilterNodes is false', () => {
+            const context = build();
+            const { displayedNodes, lineageFilters } = getDisplayedNodes(ROOT, ordered(context, CHILDREN), context, {
+                createFilterNodes: false,
+            });
+
+            expect(displayedNodes.some((n) => n.type === LINEAGE_FILTER_TYPE)).toBe(false);
+            expect(childUrns(displayedNodes, CHILDREN)).toEqual(['c0', 'c1']);
+            expect(lineageFilters.get(filterId)?.shown).toEqual(new Set(['c0', 'c1']));
+        });
+    });
+
+    describe('search filtering', () => {
+        const CHILDREN = ['c0', 'c1', 'c2'];
+
+        it('shows only children whose urn is in searchUrns', () => {
+            const context = buildContext(
+                [
+                    createNode('root', { downstream: { searchUrns: new Set(['c1']) } }),
+                    ...CHILDREN.map((u) => createNode(u)),
+                ],
+                CHILDREN.map((u) => ['root', u] as [string, string]),
+            );
+
+            const { displayedNodes } = getDisplayedNodes('root', ordered(context, CHILDREN), context);
+            expect(childUrns(displayedNodes, CHILDREN)).toEqual(['c1']);
+        });
+
+        it('matches a schema field child via its parent urn in searchUrns', () => {
+            // Search results reference the parent dataset, not the schema field itself
+            const field = createNode('field', {
+                type: EntityType.SchemaField,
+                entity: { parent: { urn: 'parentDataset' } },
+            });
+            const context = buildContext(
+                [createNode('root', { downstream: { searchUrns: new Set(['parentDataset']) } }), field],
+                [['root', 'field']],
+            );
+
+            const { displayedNodes } = getDisplayedNodes('root', ordered(context, ['field']), context);
+            expect(displayedNodes.some((n) => n.id === 'field')).toBe(true);
+        });
+    });
+
+    describe('facet filtering', () => {
+        it('filters children by platform', () => {
+            const mysql = 'urn:li:dataPlatform:mysql';
+            const snowflake = 'urn:li:dataPlatform:snowflake';
+            const context = buildContext(
+                [
+                    createNode('root', {
+                        downstream: { facetFilters: new Map([[PLATFORM_FILTER_NAME, new Set([mysql])]]) },
+                    }),
+                    createNode('c0', { entity: { platform: { urn: mysql } } }),
+                    createNode('c1', { entity: { platform: { urn: snowflake } } }),
+                ],
+                [
+                    ['root', 'c0'],
+                    ['root', 'c1'],
+                ],
+            );
+
+            const { displayedNodes } = getDisplayedNodes('root', ordered(context, ['c0', 'c1']), context);
+            expect(childUrns(displayedNodes, ['c0', 'c1'])).toEqual(['c0']);
+        });
+
+        it('filters children by entity subtype', () => {
+            const facetValue = `${EntityType.Dataset}${FILTER_DELIMITER}View`;
+            const context = buildContext(
+                [
+                    createNode('root', {
+                        downstream: { facetFilters: new Map([[ENTITY_SUB_TYPE_FILTER_NAME, new Set([facetValue])]]) },
+                    }),
+                    createNode('c0', { entity: { subtype: 'View' } }),
+                    createNode('c1', { entity: { subtype: 'Table' } }),
+                ],
+                [
+                    ['root', 'c0'],
+                    ['root', 'c1'],
+                ],
+            );
+
+            const { displayedNodes } = getDisplayedNodes('root', ordered(context, ['c0', 'c1']), context);
+            expect(childUrns(displayedNodes, ['c0', 'c1'])).toEqual(['c0']);
+        });
+    });
+
+    describe('reachability', () => {
+        it('only displays nodes reachable from the root urn', () => {
+            // Two disconnected components; only root -> reachable should be traversed
+            const context = buildContext(
+                [createNode('root'), createNode('reachable'), createNode('island0'), createNode('island1')],
+                [
+                    ['root', 'reachable'],
+                    ['island0', 'island1'],
+                ],
+            );
+
+            // island nodes are ordered but unreachable from root
+            const { displayedNodes } = getDisplayedNodes(
+                'root',
+                ordered(context, ['reachable', 'island0', 'island1']),
+                context,
+            );
+
+            expect(displayedNodes.map((n) => n.id).sort()).toEqual(['reachable', 'root']);
+        });
+
+        it('does not traverse past a node whose filters set display to false', () => {
+            const context = buildContext(
+                [createNode('root'), createNode('a', { downstream: { display: false } }), createNode('b')],
+                [
+                    ['root', 'a'],
+                    ['a', 'b'],
+                ],
+            );
+
+            const { displayedNodes } = getDisplayedNodes('root', ordered(context, ['a', 'b']), context);
+            expect(displayedNodes.map((n) => n.id).sort()).toEqual(['a', 'root']);
+        });
+    });
+
+    describe('ordering', () => {
+        it('returns children in the priority order given by orderedNodes', () => {
+            const context = buildContext(
+                [createNode('root'), createNode('c0'), createNode('c1'), createNode('c2')],
+                // Adjacency insertion order differs from the intended priority order
+                [
+                    ['root', 'c2'],
+                    ['root', 'c0'],
+                    ['root', 'c1'],
+                ],
+            );
+
+            const { displayedNodes } = getDisplayedNodes('root', ordered(context, ['c0', 'c1', 'c2']), context);
+            expect(childUrns(displayedNodes, ['c0', 'c1', 'c2'])).toEqual(['c0', 'c1', 'c2']);
+        });
+
+        it('returns the root first, then upstream nodes, then downstream nodes', () => {
+            const context = buildContext(
+                [createNode('root'), createNode('up'), createNode('down')],
+                [
+                    ['root', 'down'],
+                    ['up', 'root'],
+                ],
+            );
+
+            const { displayedNodes } = getDisplayedNodes('root', ordered(context, ['down'], ['up']), context);
+            expect(displayedNodes.map((n) => n.id)).toEqual(['root', 'up', 'down']);
+        });
+    });
+
+    describe('transformational nodes', () => {
+        // root -> t (DataJob, transformational) -> c0, c1
+        function build(rootOpts: NodeOpts = {}): Context {
+            return buildContext(
+                [
+                    createNode('root', rootOpts),
+                    createNode('t', { type: EntityType.DataJob, direction: LineageDirection.Downstream }),
+                    createNode('c0', { direction: LineageDirection.Downstream }),
+                    createNode('c1', { direction: LineageDirection.Downstream }),
+                ],
+                [
+                    ['root', 't'],
+                    ['t', 'c0'],
+                    ['t', 'c1'],
+                ],
+            );
+        }
+
+        it('filters the non-transformational children, then adds the transformational node back', () => {
+            const context = build();
+            const { displayedNodes } = getDisplayedNodes('root', ordered(context, ['c0', 'c1']), context);
+
+            // Transformational `t` is not itself filterable, but is re-inserted on the path to its leaves
+            expect(displayedNodes.map((n) => n.id)).toEqual(['root', 't', 'c0', 'c1']);
+        });
+
+        it('keeps the transformational node when at least one leaf survives filtering', () => {
+            const context = build({ downstream: { searchUrns: new Set(['c0']) } });
+            const { displayedNodes } = getDisplayedNodes('root', ordered(context, ['c0', 'c1']), context);
+
+            expect(displayedNodes.map((n) => n.id)).toEqual(['root', 't', 'c0']);
+        });
+
+        it('drops the transformational node when all of its leaves are filtered out', () => {
+            const context = build({ downstream: { searchUrns: new Set(['no-match']) } });
+            const { displayedNodes } = getDisplayedNodes('root', ordered(context, ['c0', 'c1']), context);
+
+            expect(displayedNodes.map((n) => n.id)).toEqual(['root']);
+        });
+
+        it('records the transformational leaves as parents of the shown children', () => {
+            const context = build();
+            const { parents } = getDisplayedNodes('root', ordered(context, ['c0', 'c1']), context);
+
+            expect(parents.get('c0')).toEqual(new Set(['root']));
+            expect(parents.get('c1')).toEqual(new Set(['root']));
+        });
     });
 });

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getDisplayedNodes.test.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getDisplayedNodes.test.ts
@@ -3,6 +3,7 @@ import {
     Filters,
     LINEAGE_FILTER_TYPE,
     LineageEntity,
+    LineageNode,
     NodeContext,
     createLineageFilterNodeId,
 } from '@app/lineageV3/common';
@@ -83,7 +84,7 @@ function ordered(
     };
 }
 
-const childUrns = (displayed: LineageEntity[], all: string[]) =>
+const childUrns = (displayed: LineageNode[], all: string[]) =>
     displayed.filter((n) => all.includes(n.id)).map((n) => n.id);
 
 describe('getDisplayedNodes', () => {

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/computeDataFlowGraph.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/computeDataFlowGraph.ts
@@ -13,10 +13,12 @@ import {
     LINEAGE_NODE_WIDTH,
     LineageBoundingBox,
     LineageEdgeData,
+    LineageFilter,
     LineageTableEdgeData,
     LineageToggles,
     NodeContext,
     VERTICAL_HANDLE,
+    filterAdjacencyList,
 } from '@app/lineageV3/common';
 import NodeBuilder, { LineageVisualizationNode } from '@app/lineageV3/useComputeGraph/NodeBuilder';
 import computeConnectedComponents from '@app/lineageV3/useComputeGraph/computeConnectedComponents';
@@ -47,7 +49,9 @@ export default function computeDataFlowGraph(
     type: EntityType,
     context: Pick<NodeContext, GraphStoreFields | LineageToggles | 'rootType'>,
     ignoreSchemaFieldStatus: boolean,
+    showFilterNodes = true,
 ) {
+    const lineageFilters = new Map<string, LineageFilter>();
     const { nodes, edges, adjacencyList, rootType, showDataProcessInstances, showGhostEntities } = context;
     const graphStore = { nodes, edges, adjacencyList };
     console.debug(graphStore);
@@ -136,7 +140,11 @@ export default function computeDataFlowGraph(
             );
 
             if (node.isExpanded.UPSTREAM || node.isExpanded.DOWNSTREAM) {
-                const { flowNodes: newFlowNodes, flowEdges: newFlowEdges } = computeImpactAnalysisGraph(
+                const {
+                    flowNodes: newFlowNodes,
+                    flowEdges: newFlowEdges,
+                    lineageFilters: newLineageFilters,
+                } = computeImpactAnalysisGraph(
                     node.urn,
                     node.type,
                     context,
@@ -144,7 +152,10 @@ export default function computeDataFlowGraph(
                     undefined,
                     offsets,
                     (n) => n.urn === node.urn || n.parentDataJob !== urn,
+                    undefined,
+                    showFilterNodes,
                 );
+                newLineageFilters.forEach((filter, id) => lineageFilters.set(id, filter));
                 flowNodes.push(
                     ...newFlowNodes.filter((n) => n.id !== node.urn && nodes.get(n.id)?.parentDataJob !== urn),
                 );
@@ -224,7 +235,15 @@ export default function computeDataFlowGraph(
                 .filter((e) => !e.data?.hide),
         );
     }
-    return { flowNodes, flowEdges, resetPositions: false };
+    // Note: `newGraphStore` is scoped to this flow's jobs, so the full adjacency is restricted to
+    // shown nodes for highlighting instead
+    return {
+        flowNodes,
+        flowEdges,
+        resetPositions: false,
+        lineageFilters,
+        adjacencyList: filterAdjacencyList(adjacencyList, new Set(flowNodes.map((node) => node.id))),
+    };
 }
 
 function addBoundingBoxDataFlow(

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/computeImpactAnalysisGraph.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/computeImpactAnalysisGraph.ts
@@ -1,21 +1,23 @@
-import { GraphStoreFields, LineageEntity, LineageToggles, NodeContext } from '@app/lineageV3/common';
+import {
+    GraphStoreFields,
+    LineageEntity,
+    LineageNode,
+    LineageToggles,
+    NodeContext,
+    filterAdjacencyList,
+} from '@app/lineageV3/common';
 import NodeBuilder from '@app/lineageV3/useComputeGraph/NodeBuilder';
-import hideNodes, { HideNodesConfig } from '@app/lineageV3/useComputeGraph/filterNodes';
-import getDisplayedNodes from '@app/lineageV3/useComputeGraph/getDisplayedNodes';
+import computeLineageGraph from '@app/lineageV3/useComputeGraph/computeLineageGraph';
 import { limitNodesPerLevel } from '@app/lineageV3/useComputeGraph/limitNodes/limitNodesPerLevel';
-import orderNodes from '@app/lineageV3/useComputeGraph/orderNodes';
+import { LevelsInfo } from '@app/lineageV3/useComputeGraph/limitNodes/limitNodesUtils';
 
 import { EntityType, LineageDirection } from '@types';
 
 /**
  * Computes an "impact analysis" graph, which shows the upstream and downstream entities of a given entity.
  *
- * Traverses the graph from the home node, upstream and downstream, deciding whether to continue based on each node's
- * properties like filters, fetchStatus, isExpanded. If nodes are filtered out, a LineageFilterNode is instantiated
- * in their place.
- *
- * Supports removing nodes from the graph, either truncating the graph or connecting the graph through the removed nodes,
- * as specified by the `LineageToggles`. Also supports removing edges from the graph, via the edge's `isDisplayed` property.
+ * Delegates the graph computation to `computeLineageGraph`, positioning nodes with the standard
+ * NodeBuilder, and limiting entity nodes per level in module view.
  *
  * @param urn The focused or "home" entity's urn
  * @param type The type of the home entity
@@ -25,10 +27,13 @@ import { EntityType, LineageDirection } from '@types';
  * @param offsets Map of offsets for each direction, used to position nodes in the graph when called to render a subgraph
  * @param nodeFilter Optional filter function to apply to nodes before processing them.
  * @param isModuleView Optional boolean parameter if it is module view
+ * @param showFilterNodes Whether to render lineage filter nodes; if false, their pagination state
+ *        is only returned via `lineageFilters`
  * @returns An object containing:
  *   flowNodes: Nodes for React Flow to render
  *   flowEdges: Edges for React Flow to render
  *   resetPositions: Whether the positions of existing nodes should be reset
+ *   lineageFilters: Pagination state of each node with filtered-out children
  */
 export default function computeImpactAnalysisGraph(
     urn: string,
@@ -39,63 +44,48 @@ export default function computeImpactAnalysisGraph(
     offsets: Map<LineageDirection, [number, number]> = new Map(),
     nodeFilter?: (node: LineageEntity) => boolean,
     isModuleView?: boolean,
+    showFilterNodes = true,
 ) {
-    const { nodes, edges, adjacencyList, rootType, hideTransformations, showDataProcessInstances, showGhostEntities } =
-        context;
-    const graphStore: Pick<NodeContext, GraphStoreFields | 'rootType'> = { nodes, edges, adjacencyList, rootType };
-    console.debug(graphStore);
+    const { adjacencyList, rootType, hideTransformations } = context;
 
-    // Computed before nodes are hidden by `hideNodes`, to keep node order consistent.
-    // Includes nodes that will be hidden, but they'll be filtered out by `getDisplayedNodes`.
-    const orderedNodes = {
-        [LineageDirection.Upstream]: orderNodes(urn, LineageDirection.Upstream, graphStore),
-        [LineageDirection.Downstream]: orderNodes(urn, LineageDirection.Downstream, graphStore),
-    };
-
-    const config: HideNodesConfig = {
-        hideTransformations,
-        hideDataProcessInstances: !showDataProcessInstances,
-        hideGhostEntities: !showGhostEntities,
-        ignoreSchemaFieldStatus,
-    };
-    const newGraphStore = { ...hideNodes(urn, rootType, config, graphStore, nodeFilter), rootType };
-    console.debug(newGraphStore);
-
-    const { displayedNodes, parents } = getDisplayedNodes(urn, orderedNodes, newGraphStore);
-    const rootNode = nodes.get(urn);
-
-    let limitedNodes = displayedNodes;
-    let levelsInfo = {};
+    let levelsInfo: LevelsInfo = {};
     let levelsMap = new Map<string, number>();
-
     // Limit entity nodes per level in module view
-    if (isModuleView) {
-        const result = limitNodesPerLevel({
-            nodes: displayedNodes,
-            rootUrn: urn,
-            rootType,
-            adjacencyList,
-            maxPerLevel: 2,
-        });
-        limitedNodes = result.limitedNodes;
-        levelsInfo = result.levelsInfo;
-        levelsMap = result.levelsMap;
-    }
+    const transformDisplayedNodes = isModuleView
+        ? (displayedNodes: LineageNode[]) => {
+              const result = limitNodesPerLevel({
+                  nodes: displayedNodes,
+                  rootUrn: urn,
+                  rootType,
+                  adjacencyList,
+                  maxPerLevel: 2,
+              });
+              levelsInfo = result.levelsInfo;
+              levelsMap = result.levelsMap;
+              return result.limitedNodes;
+          }
+        : undefined;
 
-    const nodeBuilder = new NodeBuilder(urn, type, rootNode ? [rootNode] : [], limitedNodes, parents);
+    const { newGraphStore, orderIndices, roots, displayedNodes, parents, lineageFilters } = computeLineageGraph(
+        urn,
+        context,
+        ignoreSchemaFieldStatus,
+        { nodeFilter, transformDisplayedNodes, createFilterNodes: showFilterNodes },
+    );
 
-    const orderIndices = {
-        [urn]: 0,
-        ...Object.fromEntries(orderedNodes[LineageDirection.Downstream].map((e, idx) => [e.id, idx + 1])),
-        ...Object.fromEntries(orderedNodes[LineageDirection.Upstream].map((e, idx) => [e.id, -idx - 1])),
-    };
+    const builder = new NodeBuilder(urn, type, roots, displayedNodes, parents);
+    const flowNodes = builder
+        .createNodes(newGraphStore, ignoreSchemaFieldStatus, offsets)
+        .sort((a, b) => (orderIndices[a.id] || 0) - (orderIndices[b.id] || 0));
+
     return {
-        flowNodes: nodeBuilder
-            .createNodes(newGraphStore, ignoreSchemaFieldStatus, offsets)
-            .sort((a, b) => (orderIndices[a.id] || 0) - (orderIndices[b.id] || 0)),
-        flowEdges: nodeBuilder.createEdges(newGraphStore.edges),
+        flowNodes,
+        flowEdges: builder.createEdges(newGraphStore.edges),
         resetPositions: prevHideTransformations !== undefined && prevHideTransformations !== hideTransformations,
         levelsInfo,
         levelsMap,
+        lineageFilters,
+        // For node highlighting: only shown nodes, with edges connected through toggle-hidden nodes
+        adjacencyList: filterAdjacencyList(newGraphStore.adjacencyList, new Set(displayedNodes.map((n) => n.id))),
     };
 }

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/computeLineageGraph.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/computeLineageGraph.ts
@@ -1,0 +1,106 @@
+import {
+    GraphStoreFields,
+    LineageEntity,
+    LineageFilter,
+    LineageNode,
+    LineageToggles,
+    NodeContext,
+} from '@app/lineageV3/common';
+import hideNodes, { HideNodesConfig } from '@app/lineageV3/useComputeGraph/filterNodes';
+import getDisplayedNodes from '@app/lineageV3/useComputeGraph/getDisplayedNodes';
+import orderNodes from '@app/lineageV3/useComputeGraph/orderNodes';
+
+import { LineageDirection } from '@types';
+
+interface Options {
+    /** Removes nodes from the graph entirely, before display rules are applied. */
+    nodeFilter?: (node: LineageEntity) => boolean;
+    /** Transforms the displayed nodes before they are returned, e.g. to limit nodes per level. */
+    transformDisplayedNodes?: (displayedNodes: LineageNode[]) => LineageNode[];
+    /** Overrides the default ordering of a node's children. Order determines priority:
+     * pagination keeps the first children when there are too many to show. */
+    compareNodes?: (a: string, b: string) => number;
+    /** If false, lineage filter nodes are not included in the displayed nodes;
+     * their state is still returned via `lineageFilters`. Defaults to true. */
+    createFilterNodes?: boolean;
+}
+
+export interface LineageGraph {
+    /** Graph store with hidden nodes removed, edges connected through them. */
+    newGraphStore: Pick<NodeContext, GraphStoreFields | 'rootType'>;
+    /** BFS order of each node from the root: positive downstream, negative upstream, 0 at the root. */
+    orderIndices: Record<string, number>;
+    /** The root node, if present in the graph. */
+    roots: LineageEntity[];
+    /** Nodes to display, including lineage filter nodes for filtered-out sections. */
+    displayedNodes: LineageNode[];
+    /** Each displayed node's non-transformational parents. */
+    parents: Map<string, Set<string>>;
+    /** Pagination state for each node and direction with filtered-out children, keyed by
+     * `createLineageFilterNodeId`. Populated whether or not filter nodes are displayed. */
+    lineageFilters: Map<string, LineageFilter>;
+}
+
+/**
+ * Computes the nodes and edges to render for the lineage graph around a given entity:
+ * 1. Orders nodes in BFS order from the root (`orderNodes`)
+ * 2. Removes nodes hidden by the `LineageToggles`, connecting edges through them (`hideNodes`)
+ * 3. Selects nodes to display based on each node's filters, fetchStatus, and isExpanded state,
+ *    instantiating lineage filter nodes for filtered-out sections (`getDisplayedNodes`)
+ *
+ * Positioning is left to the caller, via a NodeBuilder over the returned graph.
+ *
+ * @param urn The focused or "home" entity's urn
+ * @param context LineageNodesContext that represents the current state of the graph
+ * @param ignoreSchemaFieldStatus Whether to ignore schema field status when computing the graph
+ * @param options Optional node filter and displayed node transformation
+ * @returns The graph store post-hiding, node order indices, and the root, displayed nodes, and
+ *          parents with which to construct a NodeBuilder
+ */
+export default function computeLineageGraph(
+    urn: string,
+    context: Pick<NodeContext, GraphStoreFields | LineageToggles | 'rootType'>,
+    ignoreSchemaFieldStatus: boolean,
+    { nodeFilter, transformDisplayedNodes, compareNodes, createFilterNodes }: Options = {},
+): LineageGraph {
+    const { nodes, edges, adjacencyList, rootType, hideTransformations, showDataProcessInstances, showGhostEntities } =
+        context;
+    const graphStore: Pick<NodeContext, GraphStoreFields | 'rootType'> = { nodes, edges, adjacencyList, rootType };
+
+    // Computed before nodes are hidden by `hideNodes`, to keep node order consistent.
+    // Includes nodes that will be hidden, but they'll be filtered out by `getDisplayedNodes`.
+    const orderNodesOptions = { compareNodes };
+    const orderedNodes = {
+        [LineageDirection.Upstream]: orderNodes(urn, LineageDirection.Upstream, graphStore, orderNodesOptions),
+        [LineageDirection.Downstream]: orderNodes(urn, LineageDirection.Downstream, graphStore, orderNodesOptions),
+    };
+
+    const config: HideNodesConfig = {
+        hideTransformations,
+        hideDataProcessInstances: !showDataProcessInstances,
+        hideGhostEntities: !showGhostEntities,
+        ignoreSchemaFieldStatus,
+    };
+    const newGraphStore = { ...hideNodes(urn, rootType, config, graphStore, nodeFilter), rootType };
+    console.debug(newGraphStore);
+
+    const { displayedNodes, parents, lineageFilters } = getDisplayedNodes(urn, orderedNodes, newGraphStore, {
+        createFilterNodes,
+    });
+    const rootNode = nodes.get(urn);
+    const finalDisplayedNodes = transformDisplayedNodes ? transformDisplayedNodes(displayedNodes) : displayedNodes;
+
+    const orderIndices = {
+        [urn]: 0,
+        ...Object.fromEntries(orderedNodes[LineageDirection.Downstream].map((e, idx) => [e.id, idx + 1])),
+        ...Object.fromEntries(orderedNodes[LineageDirection.Upstream].map((e, idx) => [e.id, -idx - 1])),
+    };
+    return {
+        newGraphStore,
+        orderIndices,
+        roots: rootNode ? [rootNode] : [],
+        displayedNodes: finalDisplayedNodes,
+        parents,
+        lineageFilters,
+    };
+}

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/getDisplayedNodes.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/getDisplayedNodes.ts
@@ -21,6 +21,16 @@ import { LineageDirection } from '@types';
 interface Output {
     displayedNodes: LineageNode[];
     parents: Map<string, Set<string>>;
+    /** Pagination state for each node and direction with filtered-out children, keyed by
+     * `createLineageFilterNodeId`. Populated whether or not filter nodes are displayed, so
+     * pagination controls can render elsewhere (e.g. on the expand/contract buttons). */
+    lineageFilters: Map<string, LineageFilter>;
+}
+
+interface Options {
+    /** If false, lineage filter nodes are not included in the displayed nodes;
+     * their state is still returned via `lineageFilters`. Defaults to true. */
+    createFilterNodes?: boolean;
 }
 
 /**
@@ -28,20 +38,24 @@ interface Output {
  * @param urn The urn of the root node.
  * @param orderedNodes Nodes ordered by `orderNodes`, in BFS order.
  * @param context Lineage node context.
+ * @param options Optional filter node toggle.
  * @returns A list of nodes to display in rough topological order,
- *          and a map of nodes to their non-transformational parents.
+ *          a map of nodes to their non-transformational parents,
+ *          and the pagination state of each node with filtered-out children.
  */
 export default function getDisplayedNodes(
     urn: string,
     orderedNodes: Record<LineageDirection, LineageEntity[]>,
     context: Pick<NodeContext, 'adjacencyList' | 'nodes' | 'edges' | 'rootType'>,
+    options: Options = {},
 ): Output {
     const parents = new Map<string, Set<string>>();
+    const lineageFilters = new Map<string, LineageFilter>();
 
     const { nodes, rootType } = context;
     const rootNode = nodes.get(urn);
     if (!rootNode) {
-        return { displayedNodes: [], parents };
+        return { displayedNodes: [], parents, lineageFilters };
     }
 
     const displayedNodes: LineageNode[] = [rootNode];
@@ -53,9 +67,18 @@ export default function getDisplayedNodes(
         }
         const seenNodes = new Set<string>([urn]);
         const queue = [urn]; // Note: uses array for queue, slow for large graphs
+
         while (queue.length > 0) {
             const current = queue.shift() as string; // Just checked length
-            const filteredChildren = applyFilters(current, direction, orderedNodes[direction], parents, context);
+            const filteredChildren = applyFilters(
+                current,
+                direction,
+                orderedNodes[direction],
+                parents,
+                lineageFilters,
+                options.createFilterNodes ?? true,
+                context,
+            );
             filteredChildren.forEach((child) => {
                 if (!seenNodes.has(child.id)) {
                     seenNodes.add(child.id);
@@ -81,7 +104,7 @@ export default function getDisplayedNodes(
     traverseTree(LineageDirection.Upstream);
     traverseTree(LineageDirection.Downstream);
 
-    return { displayedNodes, parents };
+    return { displayedNodes, parents, lineageFilters };
 }
 
 function applyFilters(
@@ -89,6 +112,8 @@ function applyFilters(
     direction: LineageDirection,
     orderedNodes: LineageEntity[],
     parents: Map<string, Set<string>>,
+    lineageFilters: Map<string, LineageFilter>,
+    createFilterNodes: boolean,
     context: Pick<NodeContext, 'adjacencyList' | 'nodes' | 'edges' | 'rootType'>,
 ): LineageNode[] {
     const { adjacencyList, nodes } = context;
@@ -131,7 +156,8 @@ function applyFilters(
     });
 
     const limit = filters?.limit || filteredChildren.length;
-    const shownNodes = filteredChildren.slice(Math.max(0, filteredChildren.length - limit));
+    // Children are ordered highest priority first, so pagination keeps the first `limit`
+    const shownNodes = filteredChildren.slice(0, limit);
     const allShownNodes = [...getTransformationalNodes(node, shownNodes, direction, context), ...shownNodes];
 
     // Build parent map
@@ -154,7 +180,10 @@ function applyFilters(
             contents: contents.map((n) => n.urn),
             shown: new Set(allShownNodes.map((n) => n.urn)),
         };
-        result.push(filterNode);
+        lineageFilters.set(filterNode.id, filterNode);
+        if (createFilterNodes) {
+            result.push(filterNode);
+        }
     }
     if (node) {
         result.push(...allShownNodes);

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/orderNodes.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/orderNodes.ts
@@ -11,7 +11,6 @@ export interface OrderNodesOptions {
 /**
  * Orders nodes in BFS order, starting from the root node.
  * Within a single node, children are ordered transformations last, then alphabetically.
- * Note: Transformations should be put first once show more is put at the bottom.
  * @param urn Root node urn.
  * @param direction Direction in which to perform BFS.
  * @param context Lineage node context.

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/orderNodes.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/orderNodes.ts
@@ -2,6 +2,12 @@ import { LineageEntity, NodeContext, isUrnTransformational } from '@app/lineageV
 
 import { EntityType, LineageDirection } from '@types';
 
+export interface OrderNodesOptions {
+    /** Overrides the default ordering of a node's children. Order determines priority: pagination
+     * keeps the first children when there are too many to show. */
+    compareNodes?: (a: string, b: string) => number;
+}
+
 /**
  * Orders nodes in BFS order, starting from the root node.
  * Within a single node, children are ordered transformations last, then alphabetically.
@@ -9,31 +15,35 @@ import { EntityType, LineageDirection } from '@types';
  * @param urn Root node urn.
  * @param direction Direction in which to perform BFS.
  * @param context Lineage node context.
+ * @param options Optional child comparator.
  */
 export default function orderNodes(
     urn: string,
     direction: LineageDirection,
     { nodes, adjacencyList, rootType }: Pick<NodeContext, 'adjacencyList' | 'nodes' | 'rootType'>,
+    options: OrderNodesOptions = {},
 ): LineageEntity[] {
-    const compareNodes = generateCompareNodesFunction(rootType);
+    const compareNodes = options.compareNodes ?? generateCompareNodesFunction(rootType);
     const orderedNodes: string[] = [];
     const seenNodes = new Set<string>([urn]);
     const queue = [urn]; // Note: uses array for queue, slow for large graphs
+    const visit = (child: string) => {
+        if (!seenNodes.has(child)) {
+            queue.push(child);
+            seenNodes.add(child);
+            orderedNodes.push(child);
+        }
+    };
     while (queue.length > 0) {
         const current = queue.shift() as string; // Just checked length
-        const children = Array.from(adjacencyList[direction].get(current) || []).sort(compareNodes);
-        children?.forEach((child) => {
-            if (!seenNodes.has(child)) {
-                queue.push(child);
-                seenNodes.add(child);
-                orderedNodes.push(child);
-            }
-        });
+        Array.from(adjacencyList[direction].get(current) || [])
+            .sort(compareNodes)
+            .forEach(visit);
     }
     return orderedNodes.map((id) => nodes.get(id)).filter((node): node is LineageEntity => !!node);
 }
 
-function generateCompareNodesFunction(rootType: EntityType) {
+export function generateCompareNodesFunction(rootType: EntityType) {
     return function compareNodes(a: string, b: string): number {
         const isATransformation = isUrnTransformational(a, rootType);
         const isBTransformation = isUrnTransformational(b, rootType);

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/useComputeGraph.tsx
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/useComputeGraph.tsx
@@ -2,12 +2,13 @@ import { useContext, useMemo } from 'react';
 import { Edge } from 'reactflow';
 
 import LineageGraphContext from '@app/lineageV3/LineageGraphContext';
-import { LineageNodesContext, useIgnoreSchemaFieldStatus } from '@app/lineageV3/common';
+import { LineageFilter, LineageNodesContext, NodeContext, useIgnoreSchemaFieldStatus } from '@app/lineageV3/common';
 import { LineageVisualizationNode } from '@app/lineageV3/useComputeGraph/NodeBuilder';
 import computeDataFlowGraph from '@app/lineageV3/useComputeGraph/computeDataFlowGraph';
 import computeImpactAnalysisGraph from '@app/lineageV3/useComputeGraph/computeImpactAnalysisGraph';
 import getFineGrainedLineage, { FineGrainedLineageData } from '@app/lineageV3/useComputeGraph/getFineGrainedLineage';
 import { LevelsInfo } from '@app/lineageV3/useComputeGraph/limitNodes/limitNodesUtils';
+import { useAppConfig } from '@app/useAppConfig';
 
 import { EntityType } from '@types';
 
@@ -18,6 +19,12 @@ interface ProcessedData {
     resetPositions: boolean;
     levelsInfo: LevelsInfo;
     levelsMap?: Map<string, number>;
+    /** Pagination state for each node and direction with filtered-out children,
+     * keyed by `createLineageFilterNodeId`. */
+    lineageFilters: Map<string, LineageFilter>;
+    /** Adjacency list of the computed graph, e.g. with edges connected through hidden nodes.
+     * Used to compute node highlighting. */
+    adjacencyList: NodeContext['adjacencyList'];
 }
 
 /**
@@ -26,6 +33,8 @@ interface ProcessedData {
  */
 export default function useComputeGraph(): ProcessedData {
     const ignoreSchemaFieldStatus = useIgnoreSchemaFieldStatus();
+    const appConfig = useAppConfig();
+    const { showLineageFilterNodes } = appConfig.config.featureFlags;
     const {
         rootUrn,
         rootType,
@@ -51,7 +60,15 @@ export default function useComputeGraph(): ProcessedData {
         [nodes, edges, rootType, dataVersion],
     );
 
-    const { flowNodes, flowEdges, resetPositions, levelsInfo, levelsMap } = useMemo(
+    const {
+        flowNodes,
+        flowEdges,
+        resetPositions,
+        levelsInfo,
+        levelsMap,
+        lineageFilters,
+        adjacencyList: displayedAdjacencyList,
+    } = useMemo(
         () => {
             const context = {
                 rootType,
@@ -64,7 +81,13 @@ export default function useComputeGraph(): ProcessedData {
             };
 
             if (rootType === EntityType.DataFlow) {
-                const result = computeDataFlowGraph(rootUrn, rootType, context, ignoreSchemaFieldStatus);
+                const result = computeDataFlowGraph(
+                    rootUrn,
+                    rootType,
+                    context,
+                    ignoreSchemaFieldStatus,
+                    showLineageFilterNodes,
+                );
                 return {
                     ...result,
                     levelsInfo: {},
@@ -81,6 +104,7 @@ export default function useComputeGraph(): ProcessedData {
                 new Map(),
                 undefined,
                 isModuleView,
+                showLineageFilterNodes,
             );
         }, // eslint-disable-next-line react-hooks/exhaustive-deps
         [
@@ -97,8 +121,18 @@ export default function useComputeGraph(): ProcessedData {
             ignoreSchemaFieldStatus,
             dataVersion,
             isModuleView,
+            showLineageFilterNodes,
         ],
     );
 
-    return { flowNodes, flowEdges, fineGrainedLineage, resetPositions, levelsInfo, levelsMap };
+    return {
+        flowNodes,
+        flowEdges,
+        fineGrainedLineage,
+        resetPositions,
+        levelsInfo,
+        levelsMap,
+        lineageFilters,
+        adjacencyList: displayedAdjacencyList,
+    };
 }

--- a/datahub-web-react/src/app/lineageV3/useNodeHighlighting.ts
+++ b/datahub-web-react/src/app/lineageV3/useNodeHighlighting.ts
@@ -1,27 +1,37 @@
-import { useContext, useMemo } from 'react';
-import { Node, useReactFlow } from 'reactflow';
+import { useMemo } from 'react';
 
-import { LineageNode, LineageNodesContext, NodeContext, createEdgeId } from '@app/lineageV3/common';
+import { NodeContext, createEdgeId } from '@app/lineageV3/common';
 
 import { LineageDirection } from '@types';
 
-export default function useNodeHighlighting(hoveredNode: string | null): {
+/**
+ * Computes the nodes and edges to highlight when hovering a node: everything reachable from the
+ * hovered entity, in each direction.
+ * @param hoveredNode The hovered entity's urn.
+ * @param adjacencyList Adjacency list of the computed graph: only shown nodes, with edges
+ *        connected through toggle-hidden nodes.
+ */
+export default function useNodeHighlighting(
+    hoveredNode: string | null,
+    adjacencyList: NodeContext['adjacencyList'],
+): {
     highlightedNodes: Set<string>;
     highlightedEdges: Set<string>;
 } {
-    const { adjacencyList } = useContext(LineageNodesContext);
-    const { getNode } = useReactFlow<LineageNode>();
-    const { highlightedNodes, highlightedEdges } = useMemo(() => {
-        const node = hoveredNode ? getNode(hoveredNode) : null;
-        return computeHighlights(node, adjacencyList);
-    }, [hoveredNode, adjacencyList, getNode]);
+    const { highlightedNodes, highlightedEdges } = useMemo(
+        // Note: hover state stores the entity urn, which for data product members differs from
+        // their node id. Traversal is at the entity level, so start from the urn directly;
+        // member edges still highlight, matching on their entity-level `originalId`.
+        () => computeHighlights(hoveredNode, adjacencyList),
+        [hoveredNode, adjacencyList],
+    );
 
     return { highlightedNodes, highlightedEdges };
 }
 
 /** Compute highlighted nodes and table->table edges. */
 function computeHighlights(
-    node: Node<LineageNode> | undefined | null,
+    hoveredUrn: string | null,
     adjacencyList: NodeContext['adjacencyList'],
 ): {
     highlightedNodes: Set<string>;
@@ -29,12 +39,12 @@ function computeHighlights(
 } {
     const highlightedNodes = new Set<string>();
     const highlightedEdges = new Set<string>();
-    if (!node) {
+    if (!hoveredUrn) {
         return { highlightedNodes, highlightedEdges };
     }
     Object.entries(adjacencyList).forEach(([direction, neighborMap]) => {
         const seen = new Set<string>();
-        const toVisit = [node.id];
+        const toVisit = [hoveredUrn];
         while (toVisit.length) {
             const urn = toVisit.pop();
             if (urn === undefined) {

--- a/datahub-web-react/src/appConfigContext.tsx
+++ b/datahub-web-react/src/appConfigContext.tsx
@@ -89,6 +89,7 @@ export const DEFAULT_APP_CONFIG = {
         showIngestionPageRedesign: false,
         ingestionOnboardingRedesignV1: false,
         showLineageExpandMore: false,
+        showLineageFilterNodes: false,
         showDefaultExternalLinks: true,
         showStatsTabRedesign: false,
         showHomePageRedesign: false,

--- a/datahub-web-react/src/graphql/app.graphql
+++ b/datahub-web-react/src/graphql/app.graphql
@@ -109,6 +109,7 @@ query appConfig {
             showIntroducePage
             showIngestionPageRedesign
             showLineageExpandMore
+            showLineageFilterNodes
             showStatsTabRedesign
             showHomePageRedesign
             showDefaultExternalLinks

--- a/e2e-test/ui/playwright/pages/lineage-v3.page.ts
+++ b/e2e-test/ui/playwright/pages/lineage-v3.page.ts
@@ -345,6 +345,21 @@ export class LineageV3Page extends LineageV2Page {
     await this.getContractControl(nodeUrn, direction).getByTestId('show-more').click();
   }
 
+  // show-less and show-all are revealed only while the show-more button is hovered.
+  async contractControlShowLess(nodeUrn: string, direction: 'up' | 'down'): Promise<void> {
+    await this.openContractControlPanel(nodeUrn, direction);
+    const control = this.getContractControl(nodeUrn, direction);
+    await control.getByTestId('show-max-wrapper').hover();
+    await control.getByTestId('show-less').click();
+  }
+
+  async contractControlShowAll(nodeUrn: string, direction: 'up' | 'down'): Promise<void> {
+    await this.openContractControlPanel(nodeUrn, direction);
+    const control = this.getContractControl(nodeUrn, direction);
+    await control.getByTestId('show-max-wrapper').hover();
+    await control.getByTestId('show-all').click();
+  }
+
   // ── Result and Text Utilities ──────────────────────────────────────────────
 
   /**

--- a/e2e-test/ui/playwright/pages/lineage-v3.page.ts
+++ b/e2e-test/ui/playwright/pages/lineage-v3.page.ts
@@ -281,6 +281,70 @@ export class LineageV3Page extends LineageV2Page {
     await this.columnSelectVirtualList.getByText(columnName, { exact: true }).click({ timeout: TIMEOUTS.MEDIUM });
   }
 
+  // ── Contract lineage control (shown when the filter-node flag is off) ───────
+  // Pagination/search lives on the expand/contract button, revealed as a panel on hover.
+
+  private static directionEnum(direction: 'up' | 'down'): 'UPSTREAM' | 'DOWNSTREAM' {
+    return direction === 'up' ? 'UPSTREAM' : 'DOWNSTREAM';
+  }
+
+  getContractControl(nodeUrn: string, direction: 'up' | 'down'): Locator {
+    return this.page.getByTestId(`contract-lineage-control-${nodeUrn}-${LineageV3Page.directionEnum(direction)}`);
+  }
+
+  async checkContractControlExists(nodeUrn: string, direction: 'up' | 'down'): Promise<void> {
+    await expect(this.getContractControl(nodeUrn, direction)).toBeAttached({ timeout: TIMEOUTS.LONG });
+  }
+
+  /** Assert the "shown/total" count rendered on the contract button, e.g. "4/6". */
+  async checkChildrenShown(nodeUrn: string, direction: 'up' | 'down', text: string): Promise<void> {
+    const dir = LineageV3Page.directionEnum(direction);
+    await expect(
+      this.getContractControl(nodeUrn, direction).getByTestId(`children-shown-${nodeUrn}-${dir}`),
+    ).toHaveText(text, { timeout: TIMEOUTS.LONG });
+  }
+
+  /** Hover the contract control to reveal its search/pagination panel. */
+  async openContractControlPanel(nodeUrn: string, direction: 'up' | 'down'): Promise<void> {
+    await this.getContractControl(nodeUrn, direction).hover();
+  }
+
+  /** Type into the contract control's child search box (opens the panel first). */
+  async filterContractControlChildren(nodeUrn: string, direction: 'up' | 'down', query: string): Promise<void> {
+    await this.openContractControlPanel(nodeUrn, direction);
+    const input = this.getContractControl(nodeUrn, direction).getByTestId('search-input');
+    await input.clear();
+    await input.fill(query);
+  }
+
+  async clearContractControlFilter(nodeUrn: string, direction: 'up' | 'down'): Promise<void> {
+    await this.openContractControlPanel(nodeUrn, direction);
+    await this.getContractControl(nodeUrn, direction).getByTestId('search-input').clear();
+  }
+
+  async checkContractControlMatches(nodeUrn: string, direction: 'up' | 'down', matchesNumber: string): Promise<void> {
+    const label = matchesNumber === '1' ? '1 match' : `${matchesNumber} matches`;
+    await expect(this.getContractControl(nodeUrn, direction).getByTestId('matches')).toHaveText(label, {
+      timeout: TIMEOUTS.MEDIUM,
+    });
+  }
+
+  async checkContractControlPlatformCounter(
+    nodeUrn: string,
+    direction: 'up' | 'down',
+    platformLabel: string,
+    value: string,
+  ): Promise<void> {
+    await expect(
+      this.getContractControl(nodeUrn, direction).getByTestId(`filter-counter-platform-${platformLabel}`),
+    ).toHaveText(value, { timeout: TIMEOUTS.MEDIUM });
+  }
+
+  async contractControlShowMore(nodeUrn: string, direction: 'up' | 'down'): Promise<void> {
+    await this.openContractControlPanel(nodeUrn, direction);
+    await this.getContractControl(nodeUrn, direction).getByTestId('show-more').click();
+  }
+
   // ── Result and Text Utilities ──────────────────────────────────────────────
 
   /**

--- a/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-graph.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-graph.spec.ts
@@ -940,9 +940,21 @@ test.describe('lineage v3 — lineage graph', () => {
     await lineagePage.checkNodeExists(FILTERING_NODE1_URN);
     await lineagePage.checkNodeExists(FILTERING_NODE2_URN);
 
-    // ── Downstream control renders its own independent count ────────────────
+    // ── Downstream: show more / less / all (13 children) ────────────────────
     await lineagePage.checkContractControlExists(FILTERING_NODE7_URN, 'down');
     await lineagePage.checkChildrenShown(FILTERING_NODE7_URN, 'down', '4/13');
+    await lineagePage.checkNodeNotExists(FILTERING_NODE8_URN);
+
+    await lineagePage.contractControlShowMore(FILTERING_NODE7_URN, 'down');
+    await lineagePage.checkChildrenShown(FILTERING_NODE7_URN, 'down', '8/13');
+
+    // show less and show all are only reachable by hovering the show-more button
+    await lineagePage.contractControlShowLess(FILTERING_NODE7_URN, 'down');
+    await lineagePage.checkChildrenShown(FILTERING_NODE7_URN, 'down', '4/13');
+
+    await lineagePage.contractControlShowAll(FILTERING_NODE7_URN, 'down');
+    await lineagePage.checkChildrenShown(FILTERING_NODE7_URN, 'down', '13/13');
+    await lineagePage.checkNodeExists(FILTERING_NODE8_URN);
   });
 
   test('can switch direction between upstream and downstream in compact mode', async () => {

--- a/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-graph.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-graph.spec.ts
@@ -224,6 +224,14 @@ const SEARCH_TERMS = {
   HEALTH_TEST: 'playwright_health_test',
 } as const;
 
+// showLineageFilterNodes is omitted so most tests run on the backend default; only the filter test overrides it.
+const BASE_FEATURE_FLAGS = {
+  lineageGraphV3: true,
+  themeV2Enabled: true,
+  themeV2Default: true,
+  showNavBarRedesign: true,
+};
+
 // ── Test Suite ───────────────────────────────────────────────────────────────
 
 test.describe('lineage v3 — lineage graph', () => {
@@ -249,12 +257,7 @@ test.describe('lineage v3 — lineage graph', () => {
   test.beforeEach(async ({ page, logger, logDir, apiMock }) => {
     lineagePage = new LineageV3Page(page, logger, logDir);
 
-    await apiMock.setFeatureFlags({
-      lineageGraphV3: true,
-      themeV2Enabled: true,
-      themeV2Default: true,
-      showNavBarRedesign: true,
-    });
+    await apiMock.setFeatureFlags(BASE_FEATURE_FLAGS);
   });
 
   test('can see full history', async () => {
@@ -545,7 +548,10 @@ test.describe('lineage v3 — lineage graph', () => {
     await lineagePage.checkEdgeExists(NODE7_DATAJOB_URN, NODE8_DATASET_URN);
   });
 
-  test('should allow to expand and filter children', async () => {
+  test('should allow to expand and filter children', async ({ apiMock }) => {
+    // The dedicated filter-node UI asserted below only renders when showLineageFilterNodes is on.
+    await apiMock.setFeatureFlags({ ...BASE_FEATURE_FLAGS, showLineageFilterNodes: true });
+
     await lineagePage.goToLineageGraph(DATASET_ENTITY_TYPE, FILTERING_NODE7_URN);
 
     await lineagePage.checkNodeExists(FILTERING_NODE7_URN);
@@ -877,6 +883,66 @@ test.describe('lineage v3 — lineage graph', () => {
     await lineagePage.checkNodeExists(FILTERING_NODE18_URN);
     await lineagePage.checkNodeExists(FILTERING_NODE19_URN);
     await lineagePage.checkNodeExists(FILTERING_NODE20_URN);
+  });
+
+  test('paginates and filters children via the contract button', async ({ apiMock }) => {
+    // Filter nodes off: pagination/search lives on the contract button (ContractLineageControl).
+    await apiMock.setFeatureFlags({ ...BASE_FEATURE_FLAGS, showLineageFilterNodes: false });
+
+    await lineagePage.goToLineageGraph(DATASET_ENTITY_TYPE, FILTERING_NODE7_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE7_URN);
+
+    // No dedicated filter node is rendered in this mode.
+    await expect(lineagePage.getFilterNode(FILTERING_NODE7_URN, 'up')).not.toBeAttached({ timeout: TIMEOUTS.MEDIUM });
+
+    // ── Upstream: initial paginated state ───────────────────────────────────
+    await lineagePage.checkContractControlExists(FILTERING_NODE7_URN, 'up');
+    await lineagePage.checkChildrenShown(FILTERING_NODE7_URN, 'up', '4/6');
+
+    await lineagePage.checkNodeNotExists(FILTERING_NODE1_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE2_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE3_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE4_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE5_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE6_URN);
+
+    // Hover reveals the platform breakdown panel.
+    await lineagePage.openContractControlPanel(FILTERING_NODE7_URN, 'up');
+    await lineagePage.checkContractControlPlatformCounter(FILTERING_NODE7_URN, 'up', 'PostgreSQL', '3');
+    await lineagePage.checkContractControlPlatformCounter(FILTERING_NODE7_URN, 'up', 'Snowflake', '3');
+
+    // ── Search by node name: single match ───────────────────────────────────
+    await lineagePage.filterContractControlChildren(FILTERING_NODE7_URN, 'up', 'node6');
+    await lineagePage.checkChildrenShown(FILTERING_NODE7_URN, 'up', '1/6');
+    await lineagePage.checkContractControlMatches(FILTERING_NODE7_URN, 'up', '1');
+    await lineagePage.checkNodeNotExists(FILTERING_NODE1_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE3_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE6_URN);
+
+    // ── Search by platform: three matches ───────────────────────────────────
+    await lineagePage.filterContractControlChildren(FILTERING_NODE7_URN, 'up', 'postgres');
+    await lineagePage.checkChildrenShown(FILTERING_NODE7_URN, 'up', '3/6');
+    await lineagePage.checkContractControlMatches(FILTERING_NODE7_URN, 'up', '3');
+    await lineagePage.checkNodeExists(FILTERING_NODE1_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE2_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE3_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE4_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE5_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE6_URN);
+
+    // ── Clear search: back to the initial paginated view ────────────────────
+    await lineagePage.clearContractControlFilter(FILTERING_NODE7_URN, 'up');
+    await lineagePage.checkChildrenShown(FILTERING_NODE7_URN, 'up', '4/6');
+
+    // ── Show more: reveal all 6 upstream children ───────────────────────────
+    await lineagePage.contractControlShowMore(FILTERING_NODE7_URN, 'up');
+    await lineagePage.checkChildrenShown(FILTERING_NODE7_URN, 'up', '6/6');
+    await lineagePage.checkNodeExists(FILTERING_NODE1_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE2_URN);
+
+    // ── Downstream control renders its own independent count ────────────────
+    await lineagePage.checkContractControlExists(FILTERING_NODE7_URN, 'down');
+    await lineagePage.checkChildrenShown(FILTERING_NODE7_URN, 'down', '4/13');
   });
 
   test('can switch direction between upstream and downstream in compact mode', async () => {

--- a/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-graph.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-graph.spec.ts
@@ -562,13 +562,14 @@ test.describe('lineage v3 — lineage graph', () => {
     await lineagePage.checkFilterCounter(FILTERING_NODE7_URN, 'up', 'platform', 'PostgreSQL', '3');
     await lineagePage.checkFilterCounter(FILTERING_NODE7_URN, 'up', 'platform', 'Snowflake', '3');
 
-    // Verify initial node visibility
-    await lineagePage.checkNodeNotExists(FILTERING_NODE1_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE2_URN);
+    // Verify initial node visibility: pagination keeps the first `limit` children in priority
+    // order (postgres node1-3, then snowflake node4), so node5/node6 are hidden.
+    await lineagePage.checkNodeExists(FILTERING_NODE1_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE2_URN);
     await lineagePage.checkNodeExists(FILTERING_NODE3_URN);
     await lineagePage.checkNodeExists(FILTERING_NODE4_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE5_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE6_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE5_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE6_URN);
 
     // Show more upstream
     await lineagePage.showMore(FILTERING_NODE7_URN, 'up');
@@ -649,52 +650,54 @@ test.describe('lineage v3 — lineage graph', () => {
     await lineagePage.checkFilterCounter(FILTERING_NODE7_URN, 'down', 'platform', 'PostgreSQL', '3');
     await lineagePage.checkFilterCounter(FILTERING_NODE7_URN, 'down', 'platform', 'Snowflake', '10');
 
-    // Verify initial downstream node visibility
-    await lineagePage.checkNodeNotExists(FILTERING_NODE8_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE9_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE10_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE11_URN);
+    // Verify initial downstream node visibility: first `limit` children in priority order are
+    // postgres node8-10, then snowflake node11; node12-20 are hidden.
+    await lineagePage.checkNodeExists(FILTERING_NODE8_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE9_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE10_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE11_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE12_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE13_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE14_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE15_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE16_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE17_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE18_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE19_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE20_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE17_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE18_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE19_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE20_URN);
 
-    // Show more downstream
+    // Show more downstream: limit grows to 8, revealing the next four in priority order
+    // (node12-15); node16-20 remain hidden.
     await lineagePage.showMore(FILTERING_NODE7_URN, 'down');
-    await lineagePage.checkNodeNotExists(FILTERING_NODE8_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE9_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE10_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE11_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE12_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE8_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE9_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE10_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE11_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE12_URN);
     await lineagePage.checkNodeExists(FILTERING_NODE13_URN);
     await lineagePage.checkNodeExists(FILTERING_NODE14_URN);
     await lineagePage.checkNodeExists(FILTERING_NODE15_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE16_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE17_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE18_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE19_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE20_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE16_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE17_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE18_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE19_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE20_URN);
 
-    // Show less downstream
+    // Show less downstream: back to the first four (node8-11)
     await lineagePage.showLess(FILTERING_NODE7_URN, 'down');
-    await lineagePage.checkNodeNotExists(FILTERING_NODE8_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE9_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE10_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE11_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE8_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE9_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE10_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE11_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE12_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE13_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE14_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE15_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE16_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE17_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE18_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE19_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE20_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE17_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE18_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE19_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE20_URN);
 
     // Show all downstream
     await lineagePage.showAll(FILTERING_NODE7_URN, 'down');
@@ -831,20 +834,20 @@ test.describe('lineage v3 — lineage graph', () => {
     await lineagePage.checkFilterCounter(FILTERING_NODE7_URN, 'down', 'platform', 'PostgreSQL', '3');
     await lineagePage.checkFilterCounter(FILTERING_NODE7_URN, 'down', 'platform', 'Snowflake', '10');
 
-    // Verify node visibility
-    await lineagePage.checkNodeNotExists(FILTERING_NODE8_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE9_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE10_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE11_URN);
+    // Verify node visibility: first four in priority order (node8-11)
+    await lineagePage.checkNodeExists(FILTERING_NODE8_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE9_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE10_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE11_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE12_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE13_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE14_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE15_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE16_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE17_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE18_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE19_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE20_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE17_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE18_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE19_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE20_URN);
 
     // Filter with no matches (filtering node should still exist)
     await lineagePage.filterNodes(FILTERING_NODE7_URN, 'down', 'unknown');
@@ -870,19 +873,19 @@ test.describe('lineage v3 — lineage graph', () => {
     await lineagePage.ensureFilterNodeTitleHasText(FILTERING_NODE7_URN, 'down', '4 of 13 shown');
     await lineagePage.checkFilterCounter(FILTERING_NODE7_URN, 'down', 'platform', 'PostgreSQL', '3');
     await lineagePage.checkFilterCounter(FILTERING_NODE7_URN, 'down', 'platform', 'Snowflake', '10');
-    await lineagePage.checkNodeNotExists(FILTERING_NODE8_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE9_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE10_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE11_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE8_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE9_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE10_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE11_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE12_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE13_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE14_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE15_URN);
     await lineagePage.checkNodeNotExists(FILTERING_NODE16_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE17_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE18_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE19_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE20_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE17_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE18_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE19_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE20_URN);
   });
 
   test('paginates and filters children via the contract button', async ({ apiMock }) => {
@@ -899,12 +902,13 @@ test.describe('lineage v3 — lineage graph', () => {
     await lineagePage.checkContractControlExists(FILTERING_NODE7_URN, 'up');
     await lineagePage.checkChildrenShown(FILTERING_NODE7_URN, 'up', '4/6');
 
-    await lineagePage.checkNodeNotExists(FILTERING_NODE1_URN);
-    await lineagePage.checkNodeNotExists(FILTERING_NODE2_URN);
+    // Pagination keeps the first `limit` children in priority order (node1-4); node5/6 are hidden.
+    await lineagePage.checkNodeExists(FILTERING_NODE1_URN);
+    await lineagePage.checkNodeExists(FILTERING_NODE2_URN);
     await lineagePage.checkNodeExists(FILTERING_NODE3_URN);
     await lineagePage.checkNodeExists(FILTERING_NODE4_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE5_URN);
-    await lineagePage.checkNodeExists(FILTERING_NODE6_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE5_URN);
+    await lineagePage.checkNodeNotExists(FILTERING_NODE6_URN);
 
     // Hover reveals the platform breakdown panel.
     await lineagePage.openContractControlPanel(FILTERING_NODE7_URN, 'up');
@@ -943,7 +947,8 @@ test.describe('lineage v3 — lineage graph', () => {
     // ── Downstream: show more / less / all (13 children) ────────────────────
     await lineagePage.checkContractControlExists(FILTERING_NODE7_URN, 'down');
     await lineagePage.checkChildrenShown(FILTERING_NODE7_URN, 'down', '4/13');
-    await lineagePage.checkNodeNotExists(FILTERING_NODE8_URN);
+    // node8 is now among the first `limit` children shown (priority order node8-11).
+    await lineagePage.checkNodeExists(FILTERING_NODE8_URN);
 
     await lineagePage.contractControlShowMore(FILTERING_NODE7_URN, 'down');
     await lineagePage.checkChildrenShown(FILTERING_NODE7_URN, 'down', '8/13');

--- a/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
@@ -43,6 +43,7 @@ public class FeatureFlags {
   private boolean showIngestionPageRedesign = false;
   private boolean ingestionOnboardingRedesignV1 = false;
   private boolean showLineageExpandMore = true;
+  private boolean showLineageFilterNodes = false;
   private boolean showStatsTabRedesign = false;
   private boolean showHomePageRedesign = false;
   private boolean lineageGraphV3 = true;

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -1498,6 +1498,7 @@ featureFlags:
   showIngestionPageRedesign: ${SHOW_INGESTION_PAGE_REDESIGN:true} # If turned on, show the re-designed Ingestion page
   ingestionOnboardingRedesignV1: ${INGESTION_ONBOARDING_REDESIGN_V1:false} # If turned on, show the redesigned ingestion onboarding experience
   showLineageExpandMore: ${SHOW_LINEAGE_EXPAND_MORE:true} # If turned on, show the expand more button (>>) in the lineage graph
+  showLineageFilterNodes: ${SHOW_LINEAGE_FILTER_NODES:false} # If turned on, render lineage filter nodes ("N shown of M" cards) in the lineage graph; if off, pagination and search live on the expand/contract buttons
   showStatsTabRedesign: ${SHOW_STATS_TAB_REDESIGN:true} # If turned on, show the re-designed Stats tab on the entity page
   showHomePageRedesign: ${SHOW_HOME_PAGE_REDESIGN:true} # If turned on, show the re-designed home page
   lineageGraphV3: ${LINEAGE_GRAPH_V3:true} # Enables the redesign of the lineage v2 graph


### PR DESCRIPTION
  ## Summary

  Adds a `showLineageFilterNodes` feature flag (default `false`) controlling how a node's filtered-out lineage children are surfaced:

  - **Flag off (default):** pagination + search move onto the node's expand/contract button, which expands into a panel on hover (new `ContractLineageControl`).
  - **Flag on:** the existing dedicated filter-node UI ("N of M shown" cards) is rendered.

  ## Changes

  **Graph-computation refactor**
  - Extracted the shared graph-computation core into `computeLineageGraph` (orderNodes → hideNodes → getDisplayedNodes → NodeBuilder), and reworked `computeImpactAnalysisGraph` to use it.
  - `getDisplayedNodes` now takes a `createFilterNodes` option and **always** returns the per-node pagination state (`lineageFilters`) whether or not filter nodes are rendered, so the controls can live elsewhere (e.g. the contract button).
    * Pagination now slices from the start rather than the end; NodeBuilder now orders nodes based on the same global order than than alphabetical. Confirmed via testing that this results in a behavior that makes sense
  - Updates `useNodeHighlighting` to compute this only based on displayed nodes and edges, rather than all known nodes and edges

  **Component reuse**
  - Extracted `LineageFilterSummary` (platform/subtype breakdown) and parameterized `LineageFilterSearch` with `zoomToNode`, so both the filter node and the new `ContractLineageControl` reuse the same search/summary/pagination pieces without forcing a viewport zoom.

  **Flag plumbing**
  - `FeatureFlags.java`, `AppConfigResolver.java`, `app.graphql`, `application.yaml`, and the frontend `appConfigContext` default.

  ## Testing

  - Unit: `getDisplayedNodes.test.ts` covers the `createFilterNodes` toggle (filter node omitted but pagination state still returned).
  - E2E (`v3-lineage-graph.spec.ts`): the filter-node UI with the flag on, and the contract-button UI with the flag off — count display, hover panel, name/platform search, and show more / less / all.


<img width="274" height="85" alt="Screenshot 2026-07-11 at 9 07 49 PM" src="https://github.com/user-attachments/assets/675f5973-e4b1-4c70-8870-03f7c378b1ac" />
<img width="394" height="171" alt="Screenshot 2026-07-11 at 9 07 51 PM" src="https://github.com/user-attachments/assets/372ba094-fe30-4ea8-a525-a0ef5f7f9224" />
<img width="567" height="164" alt="Screenshot 2026-07-11 at 9 08 05 PM" src="https://github.com/user-attachments/assets/105d5243-076c-4e6a-a007-e97f80440f38" />
