### PR TITLE
feat(lineage): add a redraw control to the lineage graph

### DIFF
--- a/datahub-web-react/src/app/lineageV3/LineageDisplay.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageDisplay.tsx
@@ -83,12 +83,16 @@ export default function LineageDisplay({
             return [
                 ...oldNodes
                     .filter((n) => newNodeMap.has(n.id))
-                    .map((n) => ({
-                        ...n,
-                        position: (!n.data.dragged && newNodeMap.get(n.id)?.position) || n.position,
-                        data: newNodeMap.get(n.id)?.data ?? n.data,
-                        selectable: newNodeMap.get(n.id)?.selectable ?? n.selectable,
-                    })),
+                    .map((n) => {
+                        const newNode = newNodeMap.get(n.id);
+                        return {
+                            ...n,
+                            position: (!n.data.dragged && newNode?.position) || n.position,
+                            // Preserve dragged data so dragged nodes don't reset position
+                            data: { ...(newNode?.data ?? n.data), dragged: n.data.dragged },
+                            selectable: newNode?.selectable ?? n.selectable,
+                        };
+                    }),
                 ...nodesToAdd.map((n) => ({ ...n, data: { ...n.data, dragged: false } })),
             ].sort((a, b) => getNodePriority(b) - getNodePriority(a));
         });

--- a/datahub-web-react/src/app/lineageV3/controls/LineageControls.tsx
+++ b/datahub-web-react/src/app/lineageV3/controls/LineageControls.tsx
@@ -1,10 +1,11 @@
+import { ArrowCounterClockwise } from '@phosphor-icons/react/dist/csr/ArrowCounterClockwise';
 import { ArrowsIn } from '@phosphor-icons/react/dist/csr/ArrowsIn';
 import { ArrowsOut } from '@phosphor-icons/react/dist/csr/ArrowsOut';
 import { CalendarBlank } from '@phosphor-icons/react/dist/csr/CalendarBlank';
 import { Funnel } from '@phosphor-icons/react/dist/csr/Funnel';
 import { House } from '@phosphor-icons/react/dist/csr/House';
 import { SidebarSimple } from '@phosphor-icons/react/dist/csr/SidebarSimple';
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Panel, useReactFlow } from 'reactflow';
 import styled from 'styled-components';
@@ -47,11 +48,18 @@ type PanelType = 'filters' | 'timeRange';
 
 export default function LineageControls() {
     const { t } = useTranslation('lineage');
-    const { rootUrn, hideTransformations, showDataProcessInstances, showGhostEntities } =
+    const { rootUrn, hideTransformations, showDataProcessInstances, showGhostEntities, setDisplayVersion } =
         useContext(LineageNodesContext);
     const { isTabFullsize, setTabFullsize } = useContext(TabFullsizedContext);
     const { isDefault: isLineageTimeUnchanged } = useGetLineageTimeParams();
-    const { fitView } = useReactFlow();
+    const { fitView, setNodes } = useReactFlow();
+
+    // Clear manual drag flags so the recompute re-lays-out every node from scratch, then bump the
+    // display version to trigger that recompute.
+    const onRedraw = useCallback(() => {
+        setNodes((nodes) => nodes.map((n) => ({ ...n, data: { ...n.data, dragged: false } })));
+        setDisplayVersion(([version, urns]) => [version + 1, urns]);
+    }, [setNodes, setDisplayVersion]);
 
     const [isExpanded, setIsExpanded] = useState(false);
     const [visiblePanel, setVisiblePanel] = useState<PanelType | null>(null);
@@ -88,6 +96,10 @@ export default function LineageControls() {
                     >
                         <LineageControlIcon icon={House} color="icon" />
                         {showExpandedText ? t('controls.focusOnHome.label') : null}
+                    </StyledPanelButton>
+                    <StyledPanelButton $showText={isExpanded} onClick={onRedraw}>
+                        <LineageControlIcon icon={ArrowCounterClockwise} color="icon" />
+                        {showExpandedText ? t('controls.redraw.label') : null}
                     </StyledPanelButton>
                     <StyledDivider />
                     <StyledPanelButton

--- a/datahub-web-react/src/i18n/locales/en/lineage.json
+++ b/datahub-web-react/src/i18n/locales/en/lineage.json
@@ -30,6 +30,7 @@
     "controls.filters.title": "Filters",
     "controls.focusOnHome.label": "Focus on Home",
     "controls.hideMenu.label": "Hide Menu",
+    "controls.redraw.label": "Redraw",
     "controls.screenshotButton.label": "Screenshot",
     "controls.search.placeholder": "Search Graph",
     "controls.showColumns": "Show Columns",


### PR DESCRIPTION
Adds a "Redraw" button to the lineage controls panel that clears manual drag flags on every node and bumps the display version, forcing a full re-layout from scratch. To go along with this, LineageDisplay now preserves each node's `dragged` flag when merging recomputed nodes, so dragged nodes keep their position across recomputes until the user explicitly redraws.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
