### PR TITLE
fix(web): substitute @basePath in index.html for the Vite dev server

### DIFF
--- a/datahub-web-react/vite.config.ts
+++ b/datahub-web-react/vite.config.ts
@@ -63,6 +63,21 @@ function assertLazyIconsGenerated(): PluginOption {
     };
 }
 
+// In production the datahub-frontend Play server substitutes @basePath in index.html
+// at serve time. The Vite dev server serves the template verbatim, leaving a broken
+// relative <base href="@basePath">, so relative asset URLs (e.g. platform logos at
+// assets/platforms/*) resolve against the current route instead of the site root and
+// 404 on deep routes. Substitute it to '/' for dev, matching what Play does.
+function substituteBasePathForDev(): PluginOption {
+    return {
+        name: 'substitute-base-path-dev',
+        apply: 'serve',
+        transformIndexHtml(html) {
+            return html.replace('@basePath', '/');
+        },
+    };
+}
+
 // https://vitejs.dev/config/
 export default defineConfig(async ({ mode }) => {
     const { viteStaticCopy } = await import('vite-plugin-static-copy');
@@ -140,6 +155,7 @@ export default defineConfig(async ({ mode }) => {
         appType: 'spa',
         base: './', // Always use root - runtime base path detection handles deployment paths
         plugins: [
+            substituteBasePathForDev(),
             assertLazyIconsGenerated(),
             ...devPlugins,
             react(),


### PR DESCRIPTION
In production the datahub-frontend Play server substitutes @basePath in index.html at serve time. The Vite dev server served the template verbatim, leaving a broken relative `<base href="@basePath">`, so relative asset URLs (e.g. platform logos) resolved against the current route and 404'd on deep routes. Add a serve-only (i.e. dev only) plugin that substitutes it to '/', matching Play.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
