### PR TITLE
fix(zdu): do not delete semantic search index during orphan cleanup

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
@@ -17,6 +17,7 @@ import com.linkedin.metadata.search.utils.ESUtils;
 import com.linkedin.metadata.search.utils.RetryConfigUtils;
 import com.linkedin.metadata.search.utils.SizeUtils;
 import com.linkedin.metadata.timeseries.BatchWriteOperationsOptions;
+import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import com.linkedin.metadata.utils.elasticsearch.responses.GetIndexResponse;
 import com.linkedin.metadata.utils.elasticsearch.responses.RawResponse;
@@ -2554,6 +2555,7 @@ public class ESIndexBuilder {
       @Nonnull Set<String> excludePhysicalIndices) {
     List<String> orphanedIndices = new ArrayList<>();
     RequestOptions requestOptions = buildRequestOptionsLong(esConfig);
+    final IndexConvention indexConvention = opContext.getSearchContext().getIndexConvention();
     try {
       Date retentionDate =
           Date.from(
@@ -2570,6 +2572,23 @@ public class ESIndexBuilder {
       for (String index : response.getIndices()) {
         if (excludePhysicalIndices.contains(index)) {
           log.info("Skipping protected index {} referenced by incremental reindex state", index);
+          continue;
+        }
+
+        // The base entity clean pattern (e.g. "datasetindex_v2_*") also matches the semantic index
+        // "datasetindex_v2_semantic". That is the live semantic search index itself (where the
+        // embeddings live), addressed directly by its physical name - not an orphaned backing index
+        // of the base entity index. The original semantic index has no alias, so this orphan sweep
+        // (alias-less + past retention) would otherwise delete live data. The bare index is only
+        // meant to be removed when a reindex converts it to an alias - renameReindexedIndices
+        // deletes it and points the alias at the new "<base>_semantic_<ts>" backing; those backings
+        // are then cleaned normally (they don't match isSemanticEntityIndex). So never delete the
+        // bare name here.
+        if (indexConvention.isSemanticEntityIndex(index)) {
+          log.info(
+              "Skipping semantic index {} matched by base clean pattern {}",
+              index,
+              indexState.indexCleanPattern());
           continue;
         }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ESIndexBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ESIndexBuilderTest.java
@@ -21,6 +21,7 @@ import com.linkedin.metadata.search.elasticsearch.indexbuilder.ESIndexBuilder;
 import com.linkedin.metadata.search.elasticsearch.indexbuilder.ReindexConfig;
 import com.linkedin.metadata.search.elasticsearch.indexbuilder.ReindexResult;
 import com.linkedin.metadata.search.elasticsearch.indexbuilder.exceptions.ReplicaHealthException;
+import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import com.linkedin.metadata.utils.elasticsearch.responses.GetIndexResponse;
 import com.linkedin.metadata.utils.elasticsearch.responses.RawResponse;
@@ -800,6 +801,79 @@ public class ESIndexBuilderTest {
             any(OperationContext.class), deleteCaptor.capture(), any(RequestOptions.class));
     assertEquals(deleteCaptor.getAllValues().size(), 1);
     assertEquals(deleteCaptor.getValue().indices()[0], deletableOrphan);
+  }
+
+  @Test
+  void testCleanIndex_DoesNotDeleteSemanticSiblingIndex() throws Exception {
+    // The base entity config's clean pattern (e.g. datasetindex_v2_*) also matches the live
+    // semantic index (datasetindex_v2_semantic). The bare semantic index is alias-less and old, so
+    // it otherwise satisfies the orphan condition, but it must NOT be deleted as an orphan of the
+    // base entity config. Its own backing indices (datasetindex_v2_semantic_<ts>) are NOT semantic
+    // per isSemanticEntityIndex (they end in a timestamp), so a stale, alias-less one must still be
+    // deleted - the guard protects only the bare name, not the semantic index's backing churn.
+    // Names are derived from the context's IndexConvention so the semantic suffix (and any
+    // configured prefix) match what isSemanticEntityIndex expects.
+    IndexConvention indexConvention = opContext.getSearchContext().getIndexConvention();
+    String baseName = indexConvention.getEntityIndexName("dataset");
+    String semanticSibling = indexConvention.getEntityIndexNameSemantic("dataset");
+    String baseBackingOrphan = baseName + "_1700000000000";
+    String semanticBackingOrphan = semanticSibling + "_1700000000000";
+
+    ReindexConfig baseConfig = mock(ReindexConfig.class);
+    when(baseConfig.name()).thenReturn(baseName);
+    when(baseConfig.indexPattern()).thenReturn(baseName + "*");
+    when(baseConfig.indexCleanPattern()).thenReturn(baseName + "_*");
+
+    long tenDaysAgo = System.currentTimeMillis() - 10L * 24 * 60 * 60 * 1000;
+
+    GetIndexResponse getIndexResponse = mock(GetIndexResponse.class);
+    when(getIndexResponse.getIndices())
+        .thenReturn(new String[] {baseBackingOrphan, semanticSibling, semanticBackingOrphan});
+    when(getIndexResponse.getSetting(anyString(), eq("index.creation_date")))
+        .thenReturn(String.valueOf(tenDaysAgo));
+    // All alias-less: the two backing indices are genuine orphans; the bare semantic index is live
+    // but addressed by physical name (no alias).
+    when(getIndexResponse.getAliases())
+        .thenReturn(
+            Map.of(
+                baseBackingOrphan,
+                List.of(),
+                semanticSibling,
+                List.of(),
+                semanticBackingOrphan,
+                List.of()));
+
+    when(searchClient.getIndex(
+            any(OperationFingerprint.class), any(GetIndexRequest.class), any(RequestOptions.class)))
+        .thenReturn(getIndexResponse);
+    when(searchClient.indexExists(
+            any(OperationFingerprint.class), any(GetIndexRequest.class), any(RequestOptions.class)))
+        .thenReturn(true);
+
+    AcknowledgedResponse deleteResponse = mock(AcknowledgedResponse.class);
+    when(deleteResponse.isAcknowledged()).thenReturn(true);
+    when(searchClient.deleteIndex(
+            any(OperationFingerprint.class),
+            any(DeleteIndexRequest.class),
+            any(RequestOptions.class)))
+        .thenReturn(deleteResponse);
+
+    ESIndexBuilder.cleanOrphanedIndices(
+        searchClient, opContext, elasticSearchConfiguration, baseConfig, Set.of());
+
+    ArgumentCaptor<DeleteIndexRequest> deleteCaptor =
+        ArgumentCaptor.forClass(DeleteIndexRequest.class);
+    verify(searchClient, times(2))
+        .deleteIndex(
+            any(OperationContext.class), deleteCaptor.capture(), any(RequestOptions.class));
+    Set<String> deleted = new HashSet<>();
+    for (DeleteIndexRequest request : deleteCaptor.getAllValues()) {
+      deleted.add(request.indices()[0]);
+    }
+    assertTrue(deleted.contains(baseBackingOrphan), "Base backing orphan should be deleted");
+    assertTrue(
+        deleted.contains(semanticBackingOrphan), "Stale semantic backing orphan should be deleted");
+    assertFalse(deleted.contains(semanticSibling), "Live bare semantic index must not be deleted");
   }
 
   @Test

--- a/metadata-utils/src/test/java/com/linkedin/metadata/utils/elasticsearch/IndexConventionImplTest.java
+++ b/metadata-utils/src/test/java/com/linkedin/metadata/utils/elasticsearch/IndexConventionImplTest.java
@@ -415,4 +415,23 @@ public class IndexConventionImplTest {
         allPatterns.contains("*index_v3"),
         "getAllEntityIndicesPatterns should not include v3 when disabled");
   }
+
+  @Test
+  public void testIsSemanticEntityIndex() {
+    EntityIndexConfiguration entityIndexConfiguration = new EntityIndexConfiguration();
+    IndexConvention indexConvention = IndexConventionImpl.noPrefix("MD5", entityIndexConfiguration);
+
+    assertTrue(
+        indexConvention.isSemanticEntityIndex("datasetindex_v2_semantic"),
+        "Should identify semantic entity index");
+
+    assertFalse(
+        indexConvention.isSemanticEntityIndex("datasetindex_v2"),
+        "Should not identify v2 index as semantic");
+    // A versioned semantic backing index must NOT be treated as the bare semantic index, so
+    // orphan cleanup still reclaims stale semantic backing indices.
+    assertFalse(
+        indexConvention.isSemanticEntityIndex("datasetindex_v2_semantic_1700000000000"),
+        "Should not identify a versioned semantic backing index");
+  }
 }


### PR DESCRIPTION
## Summary

During a zero-downtime `datahub-upgrade`, the `CleanIndices` step removes alias-less orphaned backing indices left behind by reindex/alias-swaps. For each managed `ReindexConfig` it deletes indices matching `<name>_*` that are alias-less and older than the build-indices retention window (default 60 days).

The base entity index config `datasetindex_v2` cleans with pattern `datasetindex_v2_*`, which **also matches the live semantic search index `datasetindex_v2_semantic`**. That index is the semantic index itself (where embeddings live), addressed directly by physical name with **no alias**. So once it ages past retention it satisfies the orphan condition (matched pattern + alias-less + older than retention) and gets deleted as if it were an orphaned backing index of the base entity index.

Because the runtime dual-write to the semantic index (`UpdateIndicesV2Strategy`) is gated on the index existing, deleting it also **silently stops the dual-write**, and the one-shot bootstrap copy (`CopyDocumentsToSemanticIndexStep`) never repopulates it — so semantic search stays broken until a manual re-bootstrap.

The base index `datasetindex_v2` is safe from its own pattern (no trailing `_<x>`); it's the `_semantic` suffix that makes the semantic index look like a base backing index.

## Fix

Skip any index recognized by `IndexConvention.isSemanticEntityIndex(...)` in `ESIndexBuilder.getOrphanedIndices`, before the retention/alias checks. The guard is **intrinsic** — derived from the context `IndexConvention` — so it protects every caller of the orphan sweep rather than depending on callers threading extra state.

- Matches only the bare `<base>index_v2_semantic` name (ends-with check).
- Backing indices (`..._v2_<ts>`, `..._semantic_<ts>`) do **not** match, so genuine orphans are still cleaned normally, including the semantic index's own backing-index churn via its `<base>_semantic_*` config.
- The bare semantic index is removed only by the reindex alias-swap (`renameReindexedIndices`, which deletes the concrete index and points the alias at the new backing) or by an intentional teardown — never by retention-based orphan cleanup.

## Testing

- New `ESIndexBuilderTest.testCleanIndex_DoesNotDeleteSemanticSiblingIndex`: the base config's clean pattern returns both a genuine backing orphan and the live semantic index (both alias-less + old); asserts only the backing orphan is deleted. Index names derived from the context `IndexConvention` so the suffix/prefix match `isSemanticEntityIndex`.
- `./gradlew :metadata-io:test --tests "*ESIndexBuilderTest"` → 57 passing.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added
- [ ] Docs (n/a)
- [ ] Breaking changes (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)