### PR TITLE
feat(graphql): Add bulkEntityDataProducts resolver

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/Constants.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/Constants.java
@@ -44,6 +44,7 @@ public class Constants {
   public static final String MODULE_SCHEMA_FILE = "module.graphql";
   public static final String PATCH_SCHEMA_FILE = "patch.graphql";
   public static final String LIFECYCLE_SCHEMA_FILE = "lifecycle.graphql";
+  public static final String DATA_PRODUCT_SCHEMA_FILE = "dataProduct.graphql";
   public static final String BROWSE_PATH_DELIMITER = "/";
   public static final String BROWSE_PATH_V2_DELIMITER = "␟";
   public static final String VERSION_STAMP_FIELD_NAME = "versionStamp";

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -71,6 +71,7 @@ import com.linkedin.datahub.graphql.resolvers.datacontract.UpsertDataContractRes
 import com.linkedin.datahub.graphql.resolvers.dataproduct.BatchAddToDataProductsResolver;
 import com.linkedin.datahub.graphql.resolvers.dataproduct.BatchRemoveFromDataProductsResolver;
 import com.linkedin.datahub.graphql.resolvers.dataproduct.BatchSetDataProductResolver;
+import com.linkedin.datahub.graphql.resolvers.dataproduct.BulkEntityDataProductsResolver;
 import com.linkedin.datahub.graphql.resolvers.dataproduct.CreateDataProductResolver;
 import com.linkedin.datahub.graphql.resolvers.dataproduct.DeleteDataProductResolver;
 import com.linkedin.datahub.graphql.resolvers.dataproduct.ListDataProductAssetsResolver;
@@ -1184,6 +1185,8 @@ public class GmsGraphQLEngine {
                     "getQuickFilters",
                     new GetQuickFiltersResolver(this.entityClient, this.viewService))
                 .dataFetcher("dataProduct", getResolver(dataProductType))
+                .dataFetcher(
+                    "bulkEntityDataProducts", new BulkEntityDataProductsResolver(this.entityClient))
                 .dataFetcher("application", getResolver(applicationType))
                 .dataFetcher(
                     "listDataProductAssets", new ListDataProductAssetsResolver(this.entityClient))
@@ -1720,6 +1723,18 @@ public class GmsGraphQLEngine {
                                   ? relationship.getUpdatedActor()
                                   : null;
                             })))
+        .type(
+            "EntityDataProducts",
+            typeWiring ->
+                typeWiring.dataFetcher(
+                    "dataProducts",
+                    new LoadableTypeBatchResolver<>(
+                        dataProductType,
+                        (env) ->
+                            ((EntityDataProducts) env.getSource())
+                                .getDataProducts().stream()
+                                    .map(DataProduct::getUrn)
+                                    .collect(Collectors.toList()))))
         .type(
             "ListDomainsResult",
             typeWiring ->
@@ -3236,6 +3251,11 @@ public class GmsGraphQLEngine {
                 .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
                 .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
+                .dataFetcher(
+                    "lineage",
+                    new EntityLineageResultResolver(
+                        siblingGraphService, restrictedService, this.authorizationConfiguration))
+                .dataFetcher("exists", new EntityExistsResolver(entityService))
                 .dataFetcher(
                     "relatedDocuments",
                     new com.linkedin.datahub.graphql.resolvers.knowledge.RelatedDocumentsResolver(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -3251,10 +3251,6 @@ public class GmsGraphQLEngine {
                 .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
                 .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
-                .dataFetcher(
-                    "lineage",
-                    new EntityLineageResultResolver(
-                        siblingGraphService, restrictedService, this.authorizationConfiguration))
                 .dataFetcher("exists", new EntityExistsResolver(entityService))
                 .dataFetcher(
                     "relatedDocuments",

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -908,7 +908,8 @@ public class GmsGraphQLEngine {
         .addSchema(fileBasedSchema(FILES_SCHEMA_FILE))
         .addSchema(fileBasedSchema(DOCUMENTS_SCHEMA_FILE))
         .addSchema(fileBasedSchema(RUNS_SCHEMA_FILE))
-        .addSchema(fileBasedSchema(LIFECYCLE_SCHEMA_FILE));
+        .addSchema(fileBasedSchema(LIFECYCLE_SCHEMA_FILE))
+        .addSchema(fileBasedSchema(DATA_PRODUCT_SCHEMA_FILE));
 
     for (GmsGraphQLPlugin plugin : this.graphQLPlugins) {
       List<String> pluginSchemaFiles = plugin.getSchemaFiles();
@@ -1724,17 +1725,16 @@ public class GmsGraphQLEngine {
                                   : null;
                             })))
         .type(
-            "EntityDataProducts",
+            "EntityDataProductAssociation",
             typeWiring ->
                 typeWiring.dataFetcher(
-                    "dataProducts",
-                    new LoadableTypeBatchResolver<>(
+                    "dataProduct",
+                    new LoadableTypeResolver<>(
                         dataProductType,
                         (env) ->
-                            ((EntityDataProducts) env.getSource())
-                                .getDataProducts().stream()
-                                    .map(DataProduct::getUrn)
-                                    .collect(Collectors.toList()))))
+                            ((EntityDataProductAssociation) env.getSource())
+                                .getDataProduct()
+                                .getUrn())))
         .type(
             "ListDomainsResult",
             typeWiring ->

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BulkEntityDataProductsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BulkEntityDataProductsResolver.java
@@ -57,6 +57,9 @@ public class BulkEntityDataProductsResolver
 
   private static final String DATA_PRODUCT_CONTAINS_RELATIONSHIP = "DataProductContains";
   private static final int MAX_URNS = 100;
+  // Safety net for the sibling-expanded set that drives the relationship scroll's urn filter. Set
+  // well above MAX_URNS since each input entity may contribute several siblings.
+  private static final int MAX_URNS_WITH_SIBLINGS = 1000;
   // Page size for scrolling the DataProductContains relationship. An entity is typically in at most
   // one data product, so a single page comfortably covers the input batch and their siblings.
   private static final int RELATIONSHIP_SCROLL_COUNT = 1000;
@@ -79,16 +82,26 @@ public class BulkEntityDataProductsResolver
       throw new IllegalArgumentException(
           String.format("Cannot fetch data products for more than %s entities at once", MAX_URNS));
     }
+    // Parse up front so a malformed urn fails fast, synchronously, as a client error rather than
+    // escaping from the async supplier below.
+    final List<Urn> parsedUrns =
+        inputUrns.stream().map(UrnUtils::getUrn).collect(Collectors.toList());
 
     return GraphQLConcurrencyUtils.supplyAsync(
         () -> {
           // 1. Read each input entity's siblings in one batched aspect read.
-          final Map<String, Set<String>> siblingsByEntity = getSiblings(opContext, inputUrns);
+          final Map<String, Set<String>> siblingsByEntity = getSiblings(opContext, parsedUrns);
 
           // 2. Every entity plus its siblings, since a sibling's data product membership counts
-          // too.
+          // too. Bounded well above MAX_URNS as a safety net on the set that drives the scroll.
           final Set<String> allUrns = new HashSet<>(inputUrns);
           siblingsByEntity.values().forEach(allUrns::addAll);
+          if (allUrns.size() > MAX_URNS_WITH_SIBLINGS) {
+            throw new IllegalStateException(
+                String.format(
+                    "Resolved %s entities including siblings, exceeding the limit of %s",
+                    allUrns.size(), MAX_URNS_WITH_SIBLINGS));
+          }
 
           // 3. Resolve data product membership for all of them in a single relationship scroll.
           final Map<String, Set<String>> dataProductsByEntity =
@@ -119,15 +132,11 @@ public class BulkEntityDataProductsResolver
 
   /** Reads the siblings of each urn via batched aspect reads, grouped by entity type. */
   private Map<String, Set<String>> getSiblings(
-      @Nonnull final OperationContext opContext, @Nonnull final List<String> urns) {
+      @Nonnull final OperationContext opContext, @Nonnull final List<Urn> urns) {
     final Map<String, Set<Urn>> urnsByEntityType = new HashMap<>();
     urns.forEach(
-        urn -> {
-          final Urn parsed = UrnUtils.getUrn(urn);
-          urnsByEntityType
-              .computeIfAbsent(parsed.getEntityType(), k -> new HashSet<>())
-              .add(parsed);
-        });
+        urn ->
+            urnsByEntityType.computeIfAbsent(urn.getEntityType(), k -> new HashSet<>()).add(urn));
 
     final Map<String, Set<String>> result = new HashMap<>();
     urnsByEntityType.forEach(
@@ -179,6 +188,9 @@ public class BulkEntityDataProductsResolver
     }
 
     final GraphRetriever graphRetriever = opContext.getRetrieverContext().getGraphRetriever();
+    // A data product typically contains many of the input entities, so cache the view check to
+    // avoid re-authorizing the same data product for every edge and scroll page.
+    final Map<String, Boolean> viewableByDataProduct = new HashMap<>();
     String scrollId = null;
     do {
       final RelatedEntitiesScrollResult scroll =
@@ -198,7 +210,10 @@ public class BulkEntityDataProductsResolver
       for (RelatedEntities related : scroll.getEntities()) {
         // Incoming DataProductContains: source is the data product, destination is the entity.
         final String dataProductUrn = related.getSourceUrn();
-        if (canView(opContext, UrnUtils.getUrn(dataProductUrn))) {
+        final boolean viewable =
+            viewableByDataProduct.computeIfAbsent(
+                dataProductUrn, urn -> canView(opContext, UrnUtils.getUrn(urn)));
+        if (viewable) {
           result
               .computeIfAbsent(related.getDestinationUrn(), k -> new HashSet<>())
               .add(dataProductUrn);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BulkEntityDataProductsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BulkEntityDataProductsResolver.java
@@ -11,7 +11,9 @@ import com.linkedin.data.DataMap;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.generated.BulkEntityDataProductsInput;
+import com.linkedin.datahub.graphql.generated.BulkEntityDataProductsResult;
 import com.linkedin.datahub.graphql.generated.DataProduct;
+import com.linkedin.datahub.graphql.generated.EntityDataProductAssociation;
 import com.linkedin.datahub.graphql.generated.EntityDataProducts;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.dataproduct.DataProductAssociation;
@@ -53,7 +55,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class BulkEntityDataProductsResolver
-    implements DataFetcher<CompletableFuture<List<EntityDataProducts>>> {
+    implements DataFetcher<CompletableFuture<BulkEntityDataProductsResult>> {
 
   private static final String DATA_PRODUCT_CONTAINS_RELATIONSHIP = "DataProductContains";
   private static final int MAX_URNS = 100;
@@ -71,7 +73,7 @@ public class BulkEntityDataProductsResolver
   }
 
   @Override
-  public CompletableFuture<List<EntityDataProducts>> get(DataFetchingEnvironment environment) {
+  public CompletableFuture<BulkEntityDataProductsResult> get(DataFetchingEnvironment environment) {
     final QueryContext context = environment.getContext();
     final OperationContext opContext = context.getOperationContext();
     final BulkEntityDataProductsInput input =
@@ -116,15 +118,19 @@ public class BulkEntityDataProductsResolver
               getOutputPortsByDataProduct(opContext, allDataProductUrns);
 
           // 5. Assemble results, folding in siblings' memberships and output-port status.
-          return inputUrns.stream()
-              .map(
-                  urn ->
-                      buildEntityDataProducts(
-                          urn,
-                          siblingsByEntity.getOrDefault(urn, Collections.emptySet()),
-                          dataProductsByEntity,
-                          outputPortsByDataProduct))
-              .collect(Collectors.toList());
+          final List<EntityDataProducts> entities =
+              inputUrns.stream()
+                  .map(
+                      urn ->
+                          buildEntityDataProducts(
+                              urn,
+                              siblingsByEntity.getOrDefault(urn, Collections.emptySet()),
+                              dataProductsByEntity,
+                              outputPortsByDataProduct))
+                  .collect(Collectors.toList());
+          final BulkEntityDataProductsResult result = new BulkEntityDataProductsResult();
+          result.setEntities(entities);
+          return result;
         },
         this.getClass().getSimpleName(),
         "get");
@@ -210,6 +216,16 @@ public class BulkEntityDataProductsResolver
       for (RelatedEntities related : scroll.getEntities()) {
         // Incoming DataProductContains: source is the data product, destination is the entity.
         final String dataProductUrn = related.getSourceUrn();
+        // Guard against a malformed edge whose source is not actually a data product; skip rather
+        // than surface a non-data-product urn as a member.
+        if (!Constants.DATA_PRODUCT_ENTITY_NAME.equals(
+            UrnUtils.getUrn(dataProductUrn).getEntityType())) {
+          log.warn(
+              "Skipping non-data-product source urn {} on {} relationship",
+              dataProductUrn,
+              DATA_PRODUCT_CONTAINS_RELATIONSHIP);
+          continue;
+        }
         final boolean viewable =
             viewableByDataProduct.computeIfAbsent(
                 dataProductUrn, urn -> canView(opContext, UrnUtils.getUrn(urn)));
@@ -292,26 +308,25 @@ public class BulkEntityDataProductsResolver
 
     final EntityDataProducts result = new EntityDataProducts();
     result.setUrn(urn);
-    result.setDataProducts(
+    result.setDataProductAssociations(
         dataProductUrns.stream()
             .map(
                 dataProductUrn -> {
                   final DataProduct dataProduct = new DataProduct();
                   dataProduct.setUrn(dataProductUrn);
                   dataProduct.setType(EntityType.DATA_PRODUCT);
-                  return dataProduct;
-                })
-            .collect(Collectors.toList()));
 
-    // A data product is an output port for this entity if it marks the entity, or any of its
-    // siblings, as an output port.
-    result.setOutputPortInDataProducts(
-        dataProductUrns.stream()
-            .filter(
-                dataProductUrn -> {
+                  // The entity is an output port of the data product if the data product marks the
+                  // entity, or any of its siblings, as an output port.
                   final Set<String> outputPorts =
                       outputPortsByDataProduct.getOrDefault(dataProductUrn, Collections.emptySet());
-                  return entityGroup.stream().anyMatch(outputPorts::contains);
+                  final boolean isOutputPort = entityGroup.stream().anyMatch(outputPorts::contains);
+
+                  final EntityDataProductAssociation association =
+                      new EntityDataProductAssociation();
+                  association.setDataProduct(dataProduct);
+                  association.setIsOutputPort(isOutputPort);
+                  return association;
                 })
             .collect(Collectors.toList()));
     return result;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BulkEntityDataProductsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BulkEntityDataProductsResolver.java
@@ -1,0 +1,304 @@
+package com.linkedin.datahub.graphql.resolvers.dataproduct;
+
+import static com.linkedin.datahub.graphql.authorization.AuthorizationUtils.canView;
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
+import static com.linkedin.metadata.search.utils.QueryUtils.EMPTY_FILTER;
+
+import com.linkedin.common.Siblings;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.DataMap;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
+import com.linkedin.datahub.graphql.generated.BulkEntityDataProductsInput;
+import com.linkedin.datahub.graphql.generated.DataProduct;
+import com.linkedin.datahub.graphql.generated.EntityDataProducts;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.dataproduct.DataProductAssociation;
+import com.linkedin.dataproduct.DataProductProperties;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.aspect.GraphRetriever;
+import com.linkedin.metadata.aspect.models.graph.RelatedEntities;
+import com.linkedin.metadata.aspect.models.graph.RelatedEntitiesScrollResult;
+import com.linkedin.metadata.query.filter.RelationshipDirection;
+import com.linkedin.metadata.search.utils.QueryUtils;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Resolver used to fetch the Data Products that directly contain each of a set of entities, in a
+ * single request. Used by the data product lineage visualization, which must know the data product
+ * membership of every node in the graph, without fetching relationships for each entity as part of
+ * the standard lineage queries.
+ *
+ * <p>Membership is resolved in bulk rather than per entity: siblings are read in one batch, then a
+ * single scroll over the {@code DataProductContains} graph relationship resolves the data products
+ * for every entity and sibling at once. An entity is reported as belonging to (and being an output
+ * port of) any data product that contains it <i>or one of its siblings</i>.
+ */
+@Slf4j
+public class BulkEntityDataProductsResolver
+    implements DataFetcher<CompletableFuture<List<EntityDataProducts>>> {
+
+  private static final String DATA_PRODUCT_CONTAINS_RELATIONSHIP = "DataProductContains";
+  private static final int MAX_URNS = 100;
+  // Page size for scrolling the DataProductContains relationship. An entity is typically in at most
+  // one data product, so a single page comfortably covers the input batch and their siblings.
+  private static final int RELATIONSHIP_SCROLL_COUNT = 1000;
+
+  private final EntityClient _entityClient;
+
+  public BulkEntityDataProductsResolver(final EntityClient entityClient) {
+    _entityClient = entityClient;
+  }
+
+  @Override
+  public CompletableFuture<List<EntityDataProducts>> get(DataFetchingEnvironment environment) {
+    final QueryContext context = environment.getContext();
+    final OperationContext opContext = context.getOperationContext();
+    final BulkEntityDataProductsInput input =
+        bindArgument(environment.getArgument("input"), BulkEntityDataProductsInput.class);
+
+    final List<String> inputUrns = input.getUrns();
+    if (inputUrns.size() > MAX_URNS) {
+      throw new IllegalArgumentException(
+          String.format("Cannot fetch data products for more than %s entities at once", MAX_URNS));
+    }
+
+    return GraphQLConcurrencyUtils.supplyAsync(
+        () -> {
+          // 1. Read each input entity's siblings in one batched aspect read.
+          final Map<String, Set<String>> siblingsByEntity = getSiblings(opContext, inputUrns);
+
+          // 2. Every entity plus its siblings, since a sibling's data product membership counts
+          // too.
+          final Set<String> allUrns = new HashSet<>(inputUrns);
+          siblingsByEntity.values().forEach(allUrns::addAll);
+
+          // 3. Resolve data product membership for all of them in a single relationship scroll.
+          final Map<String, Set<String>> dataProductsByEntity =
+              getDataProductsByEntity(opContext, allUrns);
+
+          // 4. Load each referenced data product's output-port assets in one batch.
+          final Set<String> allDataProductUrns =
+              dataProductsByEntity.values().stream()
+                  .flatMap(Set::stream)
+                  .collect(Collectors.toSet());
+          final Map<String, Set<String>> outputPortsByDataProduct =
+              getOutputPortsByDataProduct(opContext, allDataProductUrns);
+
+          // 5. Assemble results, folding in siblings' memberships and output-port status.
+          return inputUrns.stream()
+              .map(
+                  urn ->
+                      buildEntityDataProducts(
+                          urn,
+                          siblingsByEntity.getOrDefault(urn, Collections.emptySet()),
+                          dataProductsByEntity,
+                          outputPortsByDataProduct))
+              .collect(Collectors.toList());
+        },
+        this.getClass().getSimpleName(),
+        "get");
+  }
+
+  /** Reads the siblings of each urn via batched aspect reads, grouped by entity type. */
+  private Map<String, Set<String>> getSiblings(
+      @Nonnull final OperationContext opContext, @Nonnull final List<String> urns) {
+    final Map<String, Set<Urn>> urnsByEntityType = new HashMap<>();
+    urns.forEach(
+        urn -> {
+          final Urn parsed = UrnUtils.getUrn(urn);
+          urnsByEntityType
+              .computeIfAbsent(parsed.getEntityType(), k -> new HashSet<>())
+              .add(parsed);
+        });
+
+    final Map<String, Set<String>> result = new HashMap<>();
+    urnsByEntityType.forEach(
+        (entityType, typedUrns) -> {
+          try {
+            final Map<Urn, EntityResponse> responses =
+                _entityClient.batchGetV2(
+                    opContext,
+                    entityType,
+                    typedUrns,
+                    Collections.singleton(Constants.SIBLINGS_ASPECT_NAME));
+            responses.forEach(
+                (urn, response) -> {
+                  final Set<String> siblings = extractSiblings(response);
+                  if (!siblings.isEmpty()) {
+                    result.put(urn.toString(), siblings);
+                  }
+                });
+          } catch (Exception e) {
+            // Best-effort: without siblings we simply report direct membership only.
+            log.error("Failed to resolve siblings for entities of type {}", entityType, e);
+          }
+        });
+    return result;
+  }
+
+  private Set<String> extractSiblings(final EntityResponse response) {
+    if (response == null || !response.getAspects().containsKey(Constants.SIBLINGS_ASPECT_NAME)) {
+      return Collections.emptySet();
+    }
+    final DataMap data =
+        response.getAspects().get(Constants.SIBLINGS_ASPECT_NAME).getValue().data();
+    final Siblings siblings = new Siblings(data);
+    if (!siblings.hasSiblings()) {
+      return Collections.emptySet();
+    }
+    return siblings.getSiblings().stream().map(Urn::toString).collect(Collectors.toSet());
+  }
+
+  /**
+   * Maps each entity urn to the data products that directly contain it, resolved in a single scroll
+   * over the {@code DataProductContains} relationship (incoming to the entity).
+   */
+  private Map<String, Set<String>> getDataProductsByEntity(
+      @Nonnull final OperationContext opContext, @Nonnull final Set<String> entityUrns) {
+    final Map<String, Set<String>> result = new HashMap<>();
+    if (entityUrns.isEmpty()) {
+      return result;
+    }
+
+    final GraphRetriever graphRetriever = opContext.getRetrieverContext().getGraphRetriever();
+    String scrollId = null;
+    do {
+      final RelatedEntitiesScrollResult scroll =
+          graphRetriever.scrollRelatedEntities(
+              null,
+              QueryUtils.newFilter(QueryUtils.newCriterion("urn", new ArrayList<>(entityUrns))),
+              null,
+              EMPTY_FILTER,
+              Set.of(DATA_PRODUCT_CONTAINS_RELATIONSHIP),
+              QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING),
+              Collections.emptyList(),
+              scrollId,
+              RELATIONSHIP_SCROLL_COUNT,
+              null,
+              null);
+
+      for (RelatedEntities related : scroll.getEntities()) {
+        // Incoming DataProductContains: source is the data product, destination is the entity.
+        final String dataProductUrn = related.getSourceUrn();
+        if (canView(opContext, UrnUtils.getUrn(dataProductUrn))) {
+          result
+              .computeIfAbsent(related.getDestinationUrn(), k -> new HashSet<>())
+              .add(dataProductUrn);
+        }
+      }
+
+      scrollId = scroll.getEntities().isEmpty() ? null : scroll.getScrollId();
+    } while (scrollId != null);
+
+    return result;
+  }
+
+  /** Maps each data product urn to the set of asset urns it marks as output ports. */
+  private Map<String, Set<String>> getOutputPortsByDataProduct(
+      @Nonnull final OperationContext opContext, @Nonnull final Set<String> dataProductUrns) {
+    if (dataProductUrns.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    try {
+      final Map<Urn, EntityResponse> responses =
+          _entityClient.batchGetV2(
+              opContext,
+              Constants.DATA_PRODUCT_ENTITY_NAME,
+              dataProductUrns.stream().map(UrnUtils::getUrn).collect(Collectors.toSet()),
+              Collections.singleton(Constants.DATA_PRODUCT_PROPERTIES_ASPECT_NAME));
+
+      final Map<String, Set<String>> result = new HashMap<>();
+      responses.forEach(
+          (dataProductUrn, response) -> {
+            if (response == null
+                || !response
+                    .getAspects()
+                    .containsKey(Constants.DATA_PRODUCT_PROPERTIES_ASPECT_NAME)) {
+              return;
+            }
+            final DataMap data =
+                response
+                    .getAspects()
+                    .get(Constants.DATA_PRODUCT_PROPERTIES_ASPECT_NAME)
+                    .getValue()
+                    .data();
+            final DataProductProperties properties = new DataProductProperties(data);
+            if (!properties.hasAssets()) {
+              return;
+            }
+            result.put(
+                dataProductUrn.toString(),
+                properties.getAssets().stream()
+                    .filter(DataProductAssociation::isOutputPort)
+                    .map(association -> association.getDestinationUrn().toString())
+                    .collect(Collectors.toSet()));
+          });
+      return result;
+    } catch (Exception e) {
+      // Output-port badges are best-effort; membership is still returned if this fails.
+      log.error("Failed to resolve output ports for data products {}", dataProductUrns, e);
+      return Collections.emptyMap();
+    }
+  }
+
+  // Package-private for unit testing of the sibling-folding and output-port assembly logic.
+  EntityDataProducts buildEntityDataProducts(
+      @Nonnull final String urn,
+      @Nonnull final Set<String> siblings,
+      @Nonnull final Map<String, Set<String>> dataProductsByEntity,
+      @Nonnull final Map<String, Set<String>> outputPortsByDataProduct) {
+    // The entity and its siblings are interchangeable for data product membership.
+    final Set<String> entityGroup = new HashSet<>(siblings);
+    entityGroup.add(urn);
+
+    final Set<String> dataProductUrns = new LinkedHashSet<>();
+    entityGroup.forEach(
+        member ->
+            dataProductUrns.addAll(
+                dataProductsByEntity.getOrDefault(member, Collections.emptySet())));
+
+    final EntityDataProducts result = new EntityDataProducts();
+    result.setUrn(urn);
+    result.setDataProducts(
+        dataProductUrns.stream()
+            .map(
+                dataProductUrn -> {
+                  final DataProduct dataProduct = new DataProduct();
+                  dataProduct.setUrn(dataProductUrn);
+                  dataProduct.setType(EntityType.DATA_PRODUCT);
+                  return dataProduct;
+                })
+            .collect(Collectors.toList()));
+
+    // A data product is an output port for this entity if it marks the entity, or any of its
+    // siblings, as an output port.
+    result.setOutputPortInDataProducts(
+        dataProductUrns.stream()
+            .filter(
+                dataProductUrn -> {
+                  final Set<String> outputPorts =
+                      outputPortsByDataProduct.getOrDefault(dataProductUrn, Collections.emptySet());
+                  return entityGroup.stream().anyMatch(outputPorts::contains);
+                })
+            .collect(Collectors.toList()));
+    return result;
+  }
+}

--- a/datahub-graphql-core/src/main/resources/dataProduct.graphql
+++ b/datahub-graphql-core/src/main/resources/dataProduct.graphql
@@ -1,0 +1,58 @@
+extend type Query {
+  """
+  Fetch the Data Products that directly contain each of the given entities, in bulk
+  """
+  bulkEntityDataProducts(
+    input: BulkEntityDataProductsInput!
+  ): BulkEntityDataProductsResult!
+}
+
+"""
+Input for fetching the Data Products containing a set of entities
+"""
+input BulkEntityDataProductsInput {
+  """
+  The urns of the entities to fetch Data Products for
+  """
+  urns: [String!]!
+}
+
+"""
+Result for fetching the Data Products containing a set of entities
+"""
+type BulkEntityDataProductsResult {
+  """
+  The Data Products for each requested entity, one entry per requested urn
+  """
+  entities: [EntityDataProducts!]!
+}
+
+"""
+The Data Products containing a single entity
+"""
+type EntityDataProducts {
+  """
+  The urn of the entity
+  """
+  urn: String!
+
+  """
+  The Data Products that directly contain the entity, and whether the entity is an output port of each
+  """
+  dataProductAssociations: [EntityDataProductAssociation!]!
+}
+
+"""
+A Data Product that contains an entity, along with the entity's relationship to it
+"""
+type EntityDataProductAssociation {
+  """
+  The Data Product that contains the entity
+  """
+  dataProduct: DataProduct!
+
+  """
+  Whether the entity is an output port of the Data Product
+  """
+  isOutputPort: Boolean!
+}

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -13553,11 +13553,6 @@ type DataProduct implements Entity {
   privileges: EntityPrivileges
 
   """
-  Lineage information for the Data Product (upstream and downstream entities)
-  """
-  lineage(input: LineageInput!): EntityLineageResult
-
-  """
   Whether the Data Product exists in DataHub
   """
   exists: Boolean

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -253,13 +253,6 @@ type Query {
   dataProduct(urn: String!): DataProduct
 
   """
-  Fetch the Data Products that directly contain each of the given entities, in bulk
-  """
-  bulkEntityDataProducts(
-    input: BulkEntityDataProductsInput!
-  ): [EntityDataProducts!]!
-
-  """
   List Custom Ownership Types
   """
   listOwnershipTypes(
@@ -14536,34 +14529,4 @@ type PolicyEvaluationDetail {
   The reason for deny for this policy
   """
   reason: String!
-}
-
-"""
-Input for fetching the Data Products containing a set of entities
-"""
-input BulkEntityDataProductsInput {
-  """
-  The urns of the entities to fetch Data Products for
-  """
-  urns: [String!]!
-}
-
-"""
-The Data Products containing a single entity
-"""
-type EntityDataProducts {
-  """
-  The urn of the entity
-  """
-  urn: String!
-
-  """
-  The Data Products that directly contain the entity
-  """
-  dataProducts: [DataProduct!]!
-
-  """
-  The urns of the Data Products (a subset of dataProducts) for which this entity is an output port.
-  """
-  outputPortInDataProducts: [String!]!
 }

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -253,6 +253,13 @@ type Query {
   dataProduct(urn: String!): DataProduct
 
   """
+  Fetch the Data Products that directly contain each of the given entities, in bulk
+  """
+  bulkEntityDataProducts(
+    input: BulkEntityDataProductsInput!
+  ): [EntityDataProducts!]!
+
+  """
   List Custom Ownership Types
   """
   listOwnershipTypes(
@@ -13544,6 +13551,16 @@ type DataProduct implements Entity {
   Privileges given to a user relevant to this entity
   """
   privileges: EntityPrivileges
+
+  """
+  Lineage information for the Data Product (upstream and downstream entities)
+  """
+  lineage(input: LineageInput!): EntityLineageResult
+
+  """
+  Whether the Data Product exists in DataHub
+  """
+  exists: Boolean
 }
 
 """
@@ -14524,4 +14541,34 @@ type PolicyEvaluationDetail {
   The reason for deny for this policy
   """
   reason: String!
+}
+
+"""
+Input for fetching the Data Products containing a set of entities
+"""
+input BulkEntityDataProductsInput {
+  """
+  The urns of the entities to fetch Data Products for
+  """
+  urns: [String!]!
+}
+
+"""
+The Data Products containing a single entity
+"""
+type EntityDataProducts {
+  """
+  The urn of the entity
+  """
+  urn: String!
+
+  """
+  The Data Products that directly contain the entity
+  """
+  dataProducts: [DataProduct!]!
+
+  """
+  The urns of the Data Products (a subset of dataProducts) for which this entity is an output port.
+  """
+  outputPortInDataProducts: [String!]!
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BulkEntityDataProductsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BulkEntityDataProductsResolverTest.java
@@ -22,8 +22,9 @@ import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 /**
- * Focuses on {@link BulkEntityDataProductsResolver#buildEntityDataProducts}, which folds an entity
- * together with its siblings when determining data product membership and output-port status.
+ * Covers {@link BulkEntityDataProductsResolver#buildEntityDataProducts} — folding an entity with
+ * its siblings when determining data product membership and output-port status — and the input-size
+ * guard in {@link BulkEntityDataProductsResolver#get}.
  */
 public class BulkEntityDataProductsResolverTest {
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BulkEntityDataProductsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BulkEntityDataProductsResolverTest.java
@@ -1,0 +1,129 @@
+package com.linkedin.datahub.graphql.resolvers.dataproduct;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.BulkEntityDataProductsInput;
+import com.linkedin.datahub.graphql.generated.DataProduct;
+import com.linkedin.datahub.graphql.generated.EntityDataProducts;
+import com.linkedin.entity.client.EntityClient;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+/**
+ * Focuses on {@link BulkEntityDataProductsResolver#buildEntityDataProducts}, which folds an entity
+ * together with its siblings when determining data product membership and output-port status.
+ */
+public class BulkEntityDataProductsResolverTest {
+
+  private static final String ENTITY = "urn:li:dataset:(urn:li:dataPlatform:mysql,db.t1,PROD)";
+  private static final String SIBLING = "urn:li:dataset:(urn:li:dataPlatform:dbt,db.t1,PROD)";
+  private static final String DP_1 = "urn:li:dataProduct:dp1";
+  private static final String DP_2 = "urn:li:dataProduct:dp2";
+
+  private static BulkEntityDataProductsResolver newResolver() {
+    return new BulkEntityDataProductsResolver(Mockito.mock(EntityClient.class));
+  }
+
+  private static Set<String> dataProductUrns(final EntityDataProducts result) {
+    return result.getDataProducts().stream().map(DataProduct::getUrn).collect(Collectors.toSet());
+  }
+
+  @Test
+  public void testDirectMembershipAndOutputPort() {
+    EntityDataProducts result =
+        newResolver()
+            .buildEntityDataProducts(
+                ENTITY,
+                Collections.emptySet(),
+                ImmutableMap.of(ENTITY, ImmutableSet.of(DP_1)),
+                ImmutableMap.of(DP_1, ImmutableSet.of(ENTITY)));
+
+    assertEquals(result.getUrn(), ENTITY);
+    assertEquals(dataProductUrns(result), ImmutableSet.of(DP_1));
+    assertEquals(result.getOutputPortInDataProducts(), List.of(DP_1));
+  }
+
+  @Test
+  public void testMemberButNotOutputPort() {
+    EntityDataProducts result =
+        newResolver()
+            .buildEntityDataProducts(
+                ENTITY,
+                Collections.emptySet(),
+                ImmutableMap.of(ENTITY, ImmutableSet.of(DP_1)),
+                // DP_1 marks some other asset, not this entity, as an output port
+                ImmutableMap.of(DP_1, ImmutableSet.of("urn:li:dataset:(other)")));
+
+    assertEquals(dataProductUrns(result), ImmutableSet.of(DP_1));
+    assertTrue(result.getOutputPortInDataProducts().isEmpty());
+  }
+
+  @Test
+  public void testSiblingMembershipAndOutputPortFoldedIn() {
+    // The entity itself is in no data product; its sibling is in DP_2 and is an output port there.
+    EntityDataProducts result =
+        newResolver()
+            .buildEntityDataProducts(
+                ENTITY,
+                ImmutableSet.of(SIBLING),
+                ImmutableMap.of(SIBLING, ImmutableSet.of(DP_2)),
+                ImmutableMap.of(DP_2, ImmutableSet.of(SIBLING)));
+
+    assertEquals(dataProductUrns(result), ImmutableSet.of(DP_2));
+    assertEquals(result.getOutputPortInDataProducts(), List.of(DP_2));
+  }
+
+  @Test
+  public void testEntityAndSiblingMembershipsAreUnioned() {
+    EntityDataProducts result =
+        newResolver()
+            .buildEntityDataProducts(
+                ENTITY,
+                ImmutableSet.of(SIBLING),
+                ImmutableMap.of(
+                    ENTITY, ImmutableSet.of(DP_1),
+                    SIBLING, ImmutableSet.of(DP_2)),
+                Map.of());
+
+    assertEquals(dataProductUrns(result), ImmutableSet.of(DP_1, DP_2));
+    assertTrue(result.getOutputPortInDataProducts().isEmpty());
+  }
+
+  @Test
+  public void testNoMemberships() {
+    EntityDataProducts result =
+        newResolver().buildEntityDataProducts(ENTITY, Collections.emptySet(), Map.of(), Map.of());
+
+    assertTrue(result.getDataProducts().isEmpty());
+    assertTrue(result.getOutputPortInDataProducts().isEmpty());
+  }
+
+  @Test
+  public void testGetRejectsTooManyUrns() {
+    final BulkEntityDataProductsInput input = new BulkEntityDataProductsInput();
+    // One past the 100-urn batch limit enforced by the resolver.
+    input.setUrns(
+        IntStream.rangeClosed(1, 101)
+            .mapToObj(
+                i -> String.format("urn:li:dataset:(urn:li:dataPlatform:mysql,db.t%d,PROD)", i))
+            .collect(Collectors.toList()));
+
+    final DataFetchingEnvironment environment = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(environment.getContext()).thenReturn(Mockito.mock(QueryContext.class));
+    Mockito.when(environment.getArgument("input")).thenReturn(input);
+
+    assertThrows(IllegalArgumentException.class, () -> newResolver().get(environment));
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BulkEntityDataProductsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BulkEntityDataProductsResolverTest.java
@@ -1,18 +1,46 @@
 package com.linkedin.datahub.graphql.resolvers.dataproduct;
 
+import static com.linkedin.metadata.Constants.DATA_PRODUCT_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.DATA_PRODUCT_PROPERTIES_ASPECT_NAME;
+import static com.linkedin.metadata.Constants.SIBLINGS_ASPECT_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.Siblings;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.data.template.SetMode;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.BulkEntityDataProductsInput;
-import com.linkedin.datahub.graphql.generated.DataProduct;
+import com.linkedin.datahub.graphql.generated.BulkEntityDataProductsResult;
+import com.linkedin.datahub.graphql.generated.EntityDataProductAssociation;
 import com.linkedin.datahub.graphql.generated.EntityDataProducts;
+import com.linkedin.dataproduct.DataProductAssociation;
+import com.linkedin.dataproduct.DataProductAssociationArray;
+import com.linkedin.dataproduct.DataProductProperties;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
 import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.aspect.CachingAspectRetriever;
+import com.linkedin.metadata.aspect.GraphRetriever;
+import com.linkedin.metadata.aspect.models.graph.RelatedEntities;
+import com.linkedin.metadata.aspect.models.graph.RelatedEntitiesScrollResult;
+import com.linkedin.metadata.entity.SearchRetriever;
+import com.linkedin.metadata.query.filter.RelationshipDirection;
 import graphql.schema.DataFetchingEnvironment;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.RetrieverContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -23,8 +51,8 @@ import org.testng.annotations.Test;
 
 /**
  * Covers {@link BulkEntityDataProductsResolver#buildEntityDataProducts} — folding an entity with
- * its siblings when determining data product membership and output-port status — and the input-size
- * guard in {@link BulkEntityDataProductsResolver#get}.
+ * its siblings when determining data product membership and output-port status — the input-size
+ * guard in {@link BulkEntityDataProductsResolver#get}, and the end-to-end resolution flow.
  */
 public class BulkEntityDataProductsResolverTest {
 
@@ -38,7 +66,16 @@ public class BulkEntityDataProductsResolverTest {
   }
 
   private static Set<String> dataProductUrns(final EntityDataProducts result) {
-    return result.getDataProducts().stream().map(DataProduct::getUrn).collect(Collectors.toSet());
+    return result.getDataProductAssociations().stream()
+        .map(association -> association.getDataProduct().getUrn())
+        .collect(Collectors.toSet());
+  }
+
+  private static Set<String> outputPortDataProductUrns(final EntityDataProducts result) {
+    return result.getDataProductAssociations().stream()
+        .filter(EntityDataProductAssociation::getIsOutputPort)
+        .map(association -> association.getDataProduct().getUrn())
+        .collect(Collectors.toSet());
   }
 
   @Test
@@ -53,7 +90,7 @@ public class BulkEntityDataProductsResolverTest {
 
     assertEquals(result.getUrn(), ENTITY);
     assertEquals(dataProductUrns(result), ImmutableSet.of(DP_1));
-    assertEquals(result.getOutputPortInDataProducts(), List.of(DP_1));
+    assertEquals(outputPortDataProductUrns(result), ImmutableSet.of(DP_1));
   }
 
   @Test
@@ -68,7 +105,7 @@ public class BulkEntityDataProductsResolverTest {
                 ImmutableMap.of(DP_1, ImmutableSet.of("urn:li:dataset:(other)")));
 
     assertEquals(dataProductUrns(result), ImmutableSet.of(DP_1));
-    assertTrue(result.getOutputPortInDataProducts().isEmpty());
+    assertTrue(outputPortDataProductUrns(result).isEmpty());
   }
 
   @Test
@@ -83,7 +120,7 @@ public class BulkEntityDataProductsResolverTest {
                 ImmutableMap.of(DP_2, ImmutableSet.of(SIBLING)));
 
     assertEquals(dataProductUrns(result), ImmutableSet.of(DP_2));
-    assertEquals(result.getOutputPortInDataProducts(), List.of(DP_2));
+    assertEquals(outputPortDataProductUrns(result), ImmutableSet.of(DP_2));
   }
 
   @Test
@@ -99,7 +136,7 @@ public class BulkEntityDataProductsResolverTest {
                 Map.of());
 
     assertEquals(dataProductUrns(result), ImmutableSet.of(DP_1, DP_2));
-    assertTrue(result.getOutputPortInDataProducts().isEmpty());
+    assertTrue(outputPortDataProductUrns(result).isEmpty());
   }
 
   @Test
@@ -107,8 +144,7 @@ public class BulkEntityDataProductsResolverTest {
     EntityDataProducts result =
         newResolver().buildEntityDataProducts(ENTITY, Collections.emptySet(), Map.of(), Map.of());
 
-    assertTrue(result.getDataProducts().isEmpty());
-    assertTrue(result.getOutputPortInDataProducts().isEmpty());
+    assertTrue(result.getDataProductAssociations().isEmpty());
   }
 
   @Test
@@ -126,5 +162,165 @@ public class BulkEntityDataProductsResolverTest {
     Mockito.when(environment.getArgument("input")).thenReturn(input);
 
     assertThrows(IllegalArgumentException.class, () -> newResolver().get(environment));
+  }
+
+  /**
+   * End-to-end resolution where the requested entity and its sibling each belong to a different
+   * data product. Both memberships must surface on the single requested entity, with output-port
+   * status folded across the sibling group.
+   */
+  @Test
+  public void testGetReturnsBothDataProductsAcrossSiblings() throws Exception {
+    final EntityClient entityClient = Mockito.mock(EntityClient.class);
+
+    // ENTITY has SIBLING; siblings are read for the input urns only.
+    Mockito.when(
+            entityClient.batchGetV2(
+                any(), eq("dataset"), any(), eq(Collections.singleton(SIBLINGS_ASPECT_NAME))))
+        .thenReturn(Map.of(UrnUtils.getUrn(ENTITY), siblingsResponse(ENTITY, SIBLING)));
+
+    // DP_1 marks ENTITY as an output port; DP_2 marks nothing.
+    Mockito.when(
+            entityClient.batchGetV2(
+                any(),
+                eq(DATA_PRODUCT_ENTITY_NAME),
+                any(),
+                eq(Collections.singleton(DATA_PRODUCT_PROPERTIES_ASPECT_NAME))))
+        .thenReturn(
+            Map.of(
+                UrnUtils.getUrn(DP_1), dataProductResponse(ENTITY),
+                UrnUtils.getUrn(DP_2), dataProductResponse()));
+
+    // DataProductContains edges: DP_1 -> ENTITY, DP_2 -> SIBLING (incoming to the entities).
+    final GraphRetriever graphRetriever = Mockito.mock(GraphRetriever.class);
+    Mockito.when(
+            graphRetriever.scrollRelatedEntities(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(
+            new RelatedEntitiesScrollResult(
+                2, 2, null, List.of(relatedEntity(DP_1, ENTITY), relatedEntity(DP_2, SIBLING))));
+
+    final BulkEntityDataProductsInput input = new BulkEntityDataProductsInput();
+    input.setUrns(List.of(ENTITY));
+
+    final QueryContext queryContext = queryContext(graphRetriever);
+    final DataFetchingEnvironment environment = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(environment.getContext()).thenReturn(queryContext);
+    Mockito.when(environment.getArgument("input")).thenReturn(input);
+
+    final BulkEntityDataProductsResult result =
+        new BulkEntityDataProductsResolver(entityClient).get(environment).get();
+
+    assertEquals(result.getEntities().size(), 1);
+    final EntityDataProducts entity = result.getEntities().get(0);
+    assertEquals(entity.getUrn(), ENTITY);
+    assertEquals(dataProductUrns(entity), ImmutableSet.of(DP_1, DP_2));
+    // ENTITY is an output port of DP_1 only.
+    assertEquals(outputPortDataProductUrns(entity), ImmutableSet.of(DP_1));
+  }
+
+  /**
+   * End-to-end happy path: a single entity with no siblings that belongs to one data product and is
+   * an output port of it.
+   */
+  @Test
+  public void testGetHappyPath() throws Exception {
+    final EntityClient entityClient = Mockito.mock(EntityClient.class);
+
+    // No siblings for the requested entity.
+    Mockito.when(
+            entityClient.batchGetV2(
+                any(), eq("dataset"), any(), eq(Collections.singleton(SIBLINGS_ASPECT_NAME))))
+        .thenReturn(Map.of());
+
+    // DP_1 contains ENTITY and marks it as an output port.
+    Mockito.when(
+            entityClient.batchGetV2(
+                any(),
+                eq(DATA_PRODUCT_ENTITY_NAME),
+                any(),
+                eq(Collections.singleton(DATA_PRODUCT_PROPERTIES_ASPECT_NAME))))
+        .thenReturn(Map.of(UrnUtils.getUrn(DP_1), dataProductResponse(ENTITY)));
+
+    final GraphRetriever graphRetriever = Mockito.mock(GraphRetriever.class);
+    Mockito.when(
+            graphRetriever.scrollRelatedEntities(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(
+            new RelatedEntitiesScrollResult(1, 1, null, List.of(relatedEntity(DP_1, ENTITY))));
+
+    final BulkEntityDataProductsInput input = new BulkEntityDataProductsInput();
+    input.setUrns(List.of(ENTITY));
+
+    final QueryContext queryContext = queryContext(graphRetriever);
+    final DataFetchingEnvironment environment = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(environment.getContext()).thenReturn(queryContext);
+    Mockito.when(environment.getArgument("input")).thenReturn(input);
+
+    final BulkEntityDataProductsResult result =
+        new BulkEntityDataProductsResolver(entityClient).get(environment).get();
+
+    assertEquals(result.getEntities().size(), 1);
+    final EntityDataProducts entity = result.getEntities().get(0);
+    assertEquals(entity.getUrn(), ENTITY);
+    assertEquals(entity.getDataProductAssociations().size(), 1);
+    final EntityDataProductAssociation association = entity.getDataProductAssociations().get(0);
+    assertEquals(association.getDataProduct().getUrn(), DP_1);
+    assertTrue(association.getIsOutputPort());
+  }
+
+  private static QueryContext queryContext(final GraphRetriever graphRetriever) {
+    // System context makes canView permissive, so the resolver returns every resolved membership.
+    final OperationContext base = TestOperationContexts.systemContextNoSearchAuthorization();
+    final RetrieverContext retrieverContext =
+        RetrieverContext.builder()
+            .graphRetriever(graphRetriever)
+            .searchRetriever(SearchRetriever.EMPTY)
+            .cachingAspectRetriever(CachingAspectRetriever.EMPTY)
+            .build();
+    final OperationContext opContext =
+        base.toBuilder()
+            .retrieverContext(retrieverContext)
+            .build(base.getSessionAuthentication(), false);
+    final QueryContext queryContext = Mockito.mock(QueryContext.class);
+    Mockito.when(queryContext.getOperationContext()).thenReturn(opContext);
+    return queryContext;
+  }
+
+  private static RelatedEntities relatedEntity(
+      final String dataProductUrn, final String entityUrn) {
+    return new RelatedEntities(
+        "DataProductContains", dataProductUrn, entityUrn, RelationshipDirection.INCOMING, null);
+  }
+
+  private static EntityResponse siblingsResponse(final String urn, final String sibling)
+      throws Exception {
+    final Siblings siblings =
+        new Siblings().setSiblings(new com.linkedin.common.UrnArray(Urn.createFromString(sibling)));
+    return entityResponse(urn, SIBLINGS_ASPECT_NAME, siblings);
+  }
+
+  private static EntityResponse dataProductResponse(final String... outputPortUrns) {
+    final DataProductAssociationArray assets = new DataProductAssociationArray();
+    for (String outputPortUrn : outputPortUrns) {
+      assets.add(
+          new DataProductAssociation()
+              .setDestinationUrn(UrnUtils.getUrn(outputPortUrn))
+              .setOutputPort(true));
+    }
+    final DataProductProperties properties =
+        new DataProductProperties().setAssets(assets, SetMode.IGNORE_NULL);
+    return entityResponse(DP_1, DATA_PRODUCT_PROPERTIES_ASPECT_NAME, properties);
+  }
+
+  private static EntityResponse entityResponse(
+      final String urn, final String aspectName, final RecordTemplate aspect) {
+    final EnvelopedAspect envelopedAspect =
+        new EnvelopedAspect().setValue(new Aspect(aspect.data()));
+    final Map<String, EnvelopedAspect> aspects = new HashMap<>();
+    aspects.put(aspectName, envelopedAspect);
+    return new EntityResponse()
+        .setUrn(UrnUtils.getUrn(urn))
+        .setAspects(new EnvelopedAspectMap(aspects));
   }
 }


### PR DESCRIPTION
Adds a resolver to fetch, in bulk, the Data Products that directly contain each of a set of entities, along with which of those an entity is an output port of. Membership is resolved in one batched siblings read plus a single scroll over the DataProductContains relationship; an entity inherits the membership and output-port status of its siblings.

Also exposes `exists` on the DataProduct GraphQL type.

These back the data product lineage visualization, which must know the data product membership of every node in the graph.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
