### PR TITLE
feat(metrics): schema registration, rename getSemanticModels, and top-level list query resolvers

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/Constants.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/Constants.java
@@ -37,6 +37,7 @@ public class Constants {
   public static final String SETTINGS_SCHEMA_FILE = "settings.graphql";
   public static final String FILES_SCHEMA_FILE = "files.graphql";
   public static final String DOCUMENTS_SCHEMA_FILE = "documents.graphql";
+  public static final String METRICS_SCHEMA_FILE = "metrics.graphql";
   public static final String RUNS_SCHEMA_FILE = "runs.graphql";
 
   public static final String QUERY_SCHEMA_FILE = "query.graphql";

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -159,6 +159,8 @@ import com.linkedin.datahub.graphql.resolvers.load.OwnerTypeResolver;
 import com.linkedin.datahub.graphql.resolvers.load.TimeSeriesAspectResolver;
 import com.linkedin.datahub.graphql.resolvers.load.TimeseriesAspectBatchLoader;
 import com.linkedin.datahub.graphql.resolvers.logical.SetLogicalParentResolver;
+import com.linkedin.datahub.graphql.resolvers.metrics.GetRootMetricsResolver;
+import com.linkedin.datahub.graphql.resolvers.metrics.GetSemanticModelsResolver;
 import com.linkedin.datahub.graphql.resolvers.module.DeletePageModuleResolver;
 import com.linkedin.datahub.graphql.resolvers.module.UpsertPageModuleResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.AddLinkResolver;
@@ -317,6 +319,7 @@ import com.linkedin.datahub.graphql.types.incident.IncidentType;
 import com.linkedin.datahub.graphql.types.ingestion.ExecutionRequestType;
 import com.linkedin.datahub.graphql.types.ingestion.IngestionSourceType;
 import com.linkedin.datahub.graphql.types.knowledge.DocumentType;
+import com.linkedin.datahub.graphql.types.metric.MetricType;
 import com.linkedin.datahub.graphql.types.mlmodel.MLFeatureTableType;
 import com.linkedin.datahub.graphql.types.mlmodel.MLFeatureType;
 import com.linkedin.datahub.graphql.types.mlmodel.MLModelGroupType;
@@ -332,6 +335,7 @@ import com.linkedin.datahub.graphql.types.restricted.RestrictedType;
 import com.linkedin.datahub.graphql.types.role.DataHubRoleType;
 import com.linkedin.datahub.graphql.types.rolemetadata.RoleType;
 import com.linkedin.datahub.graphql.types.schemafield.SchemaFieldType;
+import com.linkedin.datahub.graphql.types.semanticmodel.SemanticModelType;
 import com.linkedin.datahub.graphql.types.structuredproperty.StructuredPropertyType;
 import com.linkedin.datahub.graphql.types.tag.TagType;
 import com.linkedin.datahub.graphql.types.template.PageTemplateType;
@@ -496,6 +500,8 @@ public class GmsGraphQLEngine {
   private final ContainerType containerType;
   private final DomainType domainType;
   private final DocumentType documentType;
+  private final MetricType metricType;
+  private final SemanticModelType semanticModelType;
   private final NotebookType notebookType;
   private final AssertionType assertionType;
   private final VersionedDatasetType versionedDatasetType;
@@ -641,6 +647,8 @@ public class GmsGraphQLEngine {
     this.containerType = new ContainerType(entityClient);
     this.domainType = new DomainType(entityClient);
     this.documentType = new DocumentType(entityClient);
+    this.metricType = new MetricType(entityClient);
+    this.semanticModelType = new SemanticModelType(entityClient);
     this.notebookType = new NotebookType(entityClient);
     this.assertionType = new AssertionType(entityClient);
     this.versionedDatasetType = new VersionedDatasetType(entityClient);
@@ -701,6 +709,8 @@ public class GmsGraphQLEngine {
                 notebookType,
                 domainType,
                 documentType,
+                metricType,
+                semanticModelType,
                 assertionType,
                 versionedDatasetType,
                 dataPlatformInstanceType,
@@ -906,6 +916,7 @@ public class GmsGraphQLEngine {
         .addSchema(fileBasedSchema(SETTINGS_SCHEMA_FILE))
         .addSchema(fileBasedSchema(FILES_SCHEMA_FILE))
         .addSchema(fileBasedSchema(DOCUMENTS_SCHEMA_FILE))
+        .addSchema(fileBasedSchema(METRICS_SCHEMA_FILE))
         .addSchema(fileBasedSchema(RUNS_SCHEMA_FILE))
         .addSchema(fileBasedSchema(LIFECYCLE_SCHEMA_FILE));
 
@@ -1167,6 +1178,10 @@ public class GmsGraphQLEngine {
                     "getRootGlossaryTerms", new GetRootGlossaryTermsResolver(this.entityClient))
                 .dataFetcher(
                     "getRootGlossaryNodes", new GetRootGlossaryNodesResolver(this.entityClient))
+                .dataFetcher("metric", getResolver(metricType))
+                .dataFetcher("semanticModel", getResolver(semanticModelType))
+                .dataFetcher("getRootMetrics", new GetRootMetricsResolver(this.entityClient))
+                .dataFetcher("getSemanticModels", new GetSemanticModelsResolver(this.entityClient))
                 .dataFetcher("entityExists", new EntityExistsResolver(this.entityService))
                 .dataFetcher("entity", getEntityResolver())
                 .dataFetcher("entities", getEntitiesResolver())
@@ -1755,6 +1770,30 @@ public class GmsGraphQLEngine {
                             ((GetRootGlossaryNodesResult) env.getSource())
                                 .getNodes().stream()
                                     .map(GlossaryNode::getUrn)
+                                    .collect(Collectors.toList()))))
+        .type(
+            "GetRootMetricsResult",
+            typeWiring ->
+                typeWiring.dataFetcher(
+                    "metrics",
+                    new LoadableTypeBatchResolver<>(
+                        metricType,
+                        (env) ->
+                            ((GetRootMetricsResult) env.getSource())
+                                .getMetrics().stream()
+                                    .map(Metric::getUrn)
+                                    .collect(Collectors.toList()))))
+        .type(
+            "GetSemanticModelsResult",
+            typeWiring ->
+                typeWiring.dataFetcher(
+                    "semanticModels",
+                    new LoadableTypeBatchResolver<>(
+                        semanticModelType,
+                        (env) ->
+                            ((GetSemanticModelsResult) env.getSource())
+                                .getSemanticModels().stream()
+                                    .map(SemanticModel::getUrn)
                                     .collect(Collectors.toList()))))
         .type(
             "AutoCompleteResults",

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/metrics/GetRootMetricsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/metrics/GetRootMetricsResolver.java
@@ -68,7 +68,7 @@ public class GetRootMetricsResolver
                     query,
                     filter,
                     Collections.singletonList(
-                        new SortCriterion().setField("id").setOrder(SortOrder.ASCENDING)),
+                        new SortCriterion().setField("name").setOrder(SortOrder.ASCENDING)),
                     start,
                     count);
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/metrics/GetRootMetricsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/metrics/GetRootMetricsResolver.java
@@ -1,0 +1,114 @@
+package com.linkedin.datahub.graphql.resolvers.metrics;
+
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.getQueryContext;
+import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.GetRootEntitiesInput;
+import com.linkedin.datahub.graphql.generated.GetRootMetricsResult;
+import com.linkedin.datahub.graphql.generated.Metric;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.CriterionArray;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.query.filter.SortCriterion;
+import com.linkedin.metadata.query.filter.SortOrder;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.r2.RemoteInvocationException;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class GetRootMetricsResolver
+    implements DataFetcher<CompletableFuture<GetRootMetricsResult>> {
+
+  static final String HAS_PARENT_METRIC_FIELD_NAME = "hasParentMetric";
+  private static final String DEFAULT_QUERY = "*";
+
+  private final EntityClient _entityClient;
+
+  public GetRootMetricsResolver(final EntityClient entityClient) {
+    _entityClient = entityClient;
+  }
+
+  @Override
+  public CompletableFuture<GetRootMetricsResult> get(final DataFetchingEnvironment environment)
+      throws Exception {
+    final QueryContext context = getQueryContext(environment);
+    return GraphQLConcurrencyUtils.supplyAsync(
+        () -> {
+          final GetRootEntitiesInput input =
+              bindArgument(environment.getArgument("input"), GetRootEntitiesInput.class);
+          final Integer start = input.getStart() == null ? 0 : input.getStart();
+          final Integer count = input.getCount() == null ? 25 : input.getCount();
+          final String query =
+              input.getQuery() == null || input.getQuery().isEmpty()
+                  ? DEFAULT_QUERY
+                  : input.getQuery();
+          final Filter filter = buildRootMetricsFilter();
+
+          try {
+            final SearchResult gmsResult =
+                _entityClient.search(
+                    context.getOperationContext().withSearchFlags(flags -> flags.setFulltext(true)),
+                    Constants.METRIC_ENTITY_NAME,
+                    query,
+                    filter,
+                    Collections.singletonList(
+                        new SortCriterion().setField("id").setOrder(SortOrder.ASCENDING)),
+                    start,
+                    count);
+
+            final GetRootMetricsResult result = new GetRootMetricsResult();
+            result.setStart(gmsResult.getFrom());
+            result.setCount(gmsResult.getPageSize());
+            result.setTotal(gmsResult.getNumEntities());
+            result.setMetrics(
+                mapUnresolvedMetrics(
+                    gmsResult.getEntities().stream()
+                        .map(SearchEntity::getEntity)
+                        .collect(Collectors.toList())));
+            return result;
+          } catch (RemoteInvocationException e) {
+            throw new RuntimeException("Failed to retrieve root metrics from GMS", e);
+          }
+        },
+        this.getClass().getSimpleName(),
+        "get");
+  }
+
+  private Filter buildRootMetricsFilter() {
+    final CriterionArray array =
+        new CriterionArray(
+            ImmutableList.of(
+                buildCriterion(HAS_PARENT_METRIC_FIELD_NAME, Condition.EQUAL, "false")));
+    final Filter filter = new Filter();
+    filter.setOr(
+        new ConjunctiveCriterionArray(ImmutableList.of(new ConjunctiveCriterion().setAnd(array))));
+    return filter;
+  }
+
+  private List<Metric> mapUnresolvedMetrics(final List<Urn> entityUrns) {
+    final List<Metric> results = new ArrayList<>();
+    for (final Urn urn : entityUrns) {
+      final Metric stub = new Metric();
+      stub.setUrn(urn.toString());
+      stub.setType(EntityType.METRIC);
+      results.add(stub);
+    }
+    return results;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/metrics/GetSemanticModelsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/metrics/GetSemanticModelsResolver.java
@@ -59,7 +59,7 @@ public class GetSemanticModelsResolver
                     query,
                     null,
                     Collections.singletonList(
-                        new SortCriterion().setField("id").setOrder(SortOrder.ASCENDING)),
+                        new SortCriterion().setField("name").setOrder(SortOrder.ASCENDING)),
                     start,
                     count);
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/metrics/GetSemanticModelsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/metrics/GetSemanticModelsResolver.java
@@ -1,0 +1,94 @@
+package com.linkedin.datahub.graphql.resolvers.metrics;
+
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.getQueryContext;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.GetRootEntitiesInput;
+import com.linkedin.datahub.graphql.generated.GetSemanticModelsResult;
+import com.linkedin.datahub.graphql.generated.SemanticModel;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.query.filter.SortCriterion;
+import com.linkedin.metadata.query.filter.SortOrder;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.r2.RemoteInvocationException;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class GetSemanticModelsResolver
+    implements DataFetcher<CompletableFuture<GetSemanticModelsResult>> {
+
+  private static final String DEFAULT_QUERY = "*";
+
+  private final EntityClient _entityClient;
+
+  public GetSemanticModelsResolver(final EntityClient entityClient) {
+    _entityClient = entityClient;
+  }
+
+  @Override
+  public CompletableFuture<GetSemanticModelsResult> get(final DataFetchingEnvironment environment)
+      throws Exception {
+    final QueryContext context = getQueryContext(environment);
+    return GraphQLConcurrencyUtils.supplyAsync(
+        () -> {
+          final GetRootEntitiesInput input =
+              bindArgument(environment.getArgument("input"), GetRootEntitiesInput.class);
+          final Integer start = input.getStart() == null ? 0 : input.getStart();
+          final Integer count = input.getCount() == null ? 25 : input.getCount();
+          final String query =
+              input.getQuery() == null || input.getQuery().isEmpty()
+                  ? DEFAULT_QUERY
+                  : input.getQuery();
+
+          try {
+            final SearchResult gmsResult =
+                _entityClient.search(
+                    context.getOperationContext().withSearchFlags(flags -> flags.setFulltext(true)),
+                    Constants.SEMANTIC_MODEL_ENTITY_NAME,
+                    query,
+                    null,
+                    Collections.singletonList(
+                        new SortCriterion().setField("id").setOrder(SortOrder.ASCENDING)),
+                    start,
+                    count);
+
+            final GetSemanticModelsResult result = new GetSemanticModelsResult();
+            result.setStart(gmsResult.getFrom());
+            result.setCount(gmsResult.getPageSize());
+            result.setTotal(gmsResult.getNumEntities());
+            result.setSemanticModels(
+                mapUnresolvedSemanticModels(
+                    gmsResult.getEntities().stream()
+                        .map(SearchEntity::getEntity)
+                        .collect(Collectors.toList())));
+            return result;
+          } catch (RemoteInvocationException e) {
+            throw new RuntimeException("Failed to retrieve semantic models from GMS", e);
+          }
+        },
+        this.getClass().getSimpleName(),
+        "get");
+  }
+
+  private List<SemanticModel> mapUnresolvedSemanticModels(final List<Urn> entityUrns) {
+    final List<SemanticModel> results = new ArrayList<>();
+    for (final Urn urn : entityUrns) {
+      final SemanticModel stub = new SemanticModel();
+      stub.setUrn(urn.toString());
+      stub.setType(EntityType.SEMANTIC_MODEL);
+      results.add(stub);
+    }
+    return results;
+  }
+}

--- a/datahub-graphql-core/src/main/resources/metrics.graphql
+++ b/datahub-graphql-core/src/main/resources/metrics.graphql
@@ -15,11 +15,9 @@ extend type Query {
   getRootMetrics(input: GetRootEntitiesInput!): GetRootMetricsResult
 
   """
-  List root-level SemanticModels (paginated).
+  List SemanticModels (paginated).
   """
-  getRootSemanticModels(
-    input: GetRootEntitiesInput!
-  ): GetRootSemanticModelsResult
+  getSemanticModels(input: GetRootEntitiesInput!): GetSemanticModelsResult
 }
 
 """
@@ -38,7 +36,7 @@ type GetRootMetricsResult {
   total: Int!
 }
 
-type GetRootSemanticModelsResult {
+type GetSemanticModelsResult {
   semanticModels: [SemanticModel!]!
   start: Int!
   count: Int!

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/metrics/GetRootMetricsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/metrics/GetRootMetricsResolverTest.java
@@ -1,0 +1,171 @@
+package com.linkedin.datahub.graphql.resolvers.metrics;
+
+import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.testng.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.GetRootEntitiesInput;
+import com.linkedin.datahub.graphql.generated.GetRootMetricsResult;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.CriterionArray;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.search.SearchEntityArray;
+import com.linkedin.metadata.search.SearchResult;
+import graphql.schema.DataFetchingEnvironment;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.Collections;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+public class GetRootMetricsResolverTest {
+
+  private static final String METRIC_URN_1 =
+      "urn:li:metric:(urn:li:dataPlatform:dbt,analytics.model,revenue)";
+  private static final String METRIC_URN_2 =
+      "urn:li:metric:(urn:li:dataPlatform:dbt,analytics.model,cost)";
+
+  @Test
+  public void testGetSuccess() throws Exception {
+    final EntityClient mockClient = Mockito.mock(EntityClient.class);
+    final QueryContext mockContext = Mockito.mock(QueryContext.class);
+    final OperationContext mockOpContext = Mockito.mock(OperationContext.class);
+    Mockito.when(mockContext.getOperationContext()).thenReturn(mockOpContext);
+    Mockito.when(mockOpContext.withSearchFlags(any())).thenReturn(mockOpContext);
+
+    final DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Mockito.when(mockEnv.getArgument("input")).thenReturn(new GetRootEntitiesInput(0, 10, "*"));
+
+    Mockito.when(
+            mockClient.search(
+                any(),
+                eq(Constants.METRIC_ENTITY_NAME),
+                eq("*"),
+                eq(buildRootMetricsFilter()),
+                any(),
+                eq(0),
+                eq(10)))
+        .thenReturn(
+            new SearchResult()
+                .setEntities(
+                    new SearchEntityArray(
+                        ImmutableList.of(
+                            new SearchEntity().setEntity(Urn.createFromString(METRIC_URN_1)),
+                            new SearchEntity().setEntity(Urn.createFromString(METRIC_URN_2)))))
+                .setFrom(0)
+                .setPageSize(2)
+                .setNumEntities(2));
+
+    final GetRootMetricsResolver resolver = new GetRootMetricsResolver(mockClient);
+    final GetRootMetricsResult result = resolver.get(mockEnv).get();
+
+    assertEquals(result.getStart(), 0);
+    assertEquals(result.getCount(), 2);
+    assertEquals(result.getTotal(), 2);
+    assertEquals(result.getMetrics().get(0).getUrn(), METRIC_URN_1);
+    assertEquals(result.getMetrics().get(1).getUrn(), METRIC_URN_2);
+  }
+
+  @Test
+  public void testPaginationFlowsThrough() throws Exception {
+    final EntityClient mockClient = Mockito.mock(EntityClient.class);
+    final QueryContext mockContext = Mockito.mock(QueryContext.class);
+    final OperationContext mockOpContext = Mockito.mock(OperationContext.class);
+    Mockito.when(mockContext.getOperationContext()).thenReturn(mockOpContext);
+    Mockito.when(mockOpContext.withSearchFlags(any())).thenReturn(mockOpContext);
+
+    final DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Mockito.when(mockEnv.getArgument("input")).thenReturn(new GetRootEntitiesInput(5, 25, "*"));
+
+    Mockito.when(
+            mockClient.search(
+                any(),
+                eq(Constants.METRIC_ENTITY_NAME),
+                eq("*"),
+                eq(buildRootMetricsFilter()),
+                any(),
+                eq(5),
+                eq(25)))
+        .thenReturn(
+            new SearchResult()
+                .setEntities(new SearchEntityArray(Collections.emptyList()))
+                .setFrom(5)
+                .setPageSize(0)
+                .setNumEntities(5));
+
+    final GetRootMetricsResolver resolver = new GetRootMetricsResolver(mockClient);
+    final GetRootMetricsResult result = resolver.get(mockEnv).get();
+
+    assertEquals(result.getStart(), 5);
+    assertEquals(result.getTotal(), 5);
+    Mockito.verify(mockClient)
+        .search(any(), eq(Constants.METRIC_ENTITY_NAME), eq("*"), any(), any(), eq(5), eq(25));
+  }
+
+  @Test
+  public void testHasParentMetricFilterIsApplied() throws Exception {
+    final EntityClient mockClient = Mockito.mock(EntityClient.class);
+    final QueryContext mockContext = Mockito.mock(QueryContext.class);
+    final OperationContext mockOpContext = Mockito.mock(OperationContext.class);
+    Mockito.when(mockContext.getOperationContext()).thenReturn(mockOpContext);
+    Mockito.when(mockOpContext.withSearchFlags(any())).thenReturn(mockOpContext);
+
+    final DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Mockito.when(mockEnv.getArgument("input")).thenReturn(new GetRootEntitiesInput(0, 10, "*"));
+
+    Mockito.when(
+            mockClient.search(
+                any(),
+                eq(Constants.METRIC_ENTITY_NAME),
+                any(),
+                eq(buildRootMetricsFilter()),
+                any(),
+                eq(0),
+                eq(10)))
+        .thenReturn(
+            new SearchResult()
+                .setEntities(new SearchEntityArray(Collections.emptyList()))
+                .setFrom(0)
+                .setPageSize(0)
+                .setNumEntities(0));
+
+    final GetRootMetricsResolver resolver = new GetRootMetricsResolver(mockClient);
+    resolver.get(mockEnv).get();
+
+    Mockito.verify(mockClient)
+        .search(
+            any(),
+            eq(Constants.METRIC_ENTITY_NAME),
+            any(),
+            eq(buildRootMetricsFilter()),
+            any(),
+            anyInt(),
+            anyInt());
+  }
+
+  private Filter buildRootMetricsFilter() {
+    final CriterionArray array =
+        new CriterionArray(
+            ImmutableList.of(
+                buildCriterion(
+                    GetRootMetricsResolver.HAS_PARENT_METRIC_FIELD_NAME,
+                    Condition.EQUAL,
+                    "false")));
+    final Filter filter = new Filter();
+    filter.setOr(
+        new ConjunctiveCriterionArray(ImmutableList.of(new ConjunctiveCriterion().setAnd(array))));
+    return filter;
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/metrics/GetSemanticModelsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/metrics/GetSemanticModelsResolverTest.java
@@ -1,0 +1,164 @@
+package com.linkedin.datahub.graphql.resolvers.metrics;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.testng.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.GetRootEntitiesInput;
+import com.linkedin.datahub.graphql.generated.GetSemanticModelsResult;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.search.SearchEntityArray;
+import com.linkedin.metadata.search.SearchResult;
+import graphql.schema.DataFetchingEnvironment;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.Collections;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+public class GetSemanticModelsResolverTest {
+
+  private static final String SEMANTIC_MODEL_URN_1 =
+      "urn:li:semanticModel:(urn:li:dataPlatform:dbt,analytics.model,sales_model)";
+  private static final String SEMANTIC_MODEL_URN_2 =
+      "urn:li:semanticModel:(urn:li:dataPlatform:dbt,analytics.model,finance_model)";
+
+  @Test
+  public void testGetSuccess() throws Exception {
+    final EntityClient mockClient = Mockito.mock(EntityClient.class);
+    final QueryContext mockContext = Mockito.mock(QueryContext.class);
+    final OperationContext mockOpContext = Mockito.mock(OperationContext.class);
+    Mockito.when(mockContext.getOperationContext()).thenReturn(mockOpContext);
+    Mockito.when(mockOpContext.withSearchFlags(any())).thenReturn(mockOpContext);
+
+    final DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Mockito.when(mockEnv.getArgument("input")).thenReturn(new GetRootEntitiesInput(0, 10, "*"));
+
+    Mockito.when(
+            mockClient.search(
+                any(),
+                eq(Constants.SEMANTIC_MODEL_ENTITY_NAME),
+                eq("*"),
+                isNull(),
+                any(),
+                eq(0),
+                eq(10)))
+        .thenReturn(
+            new SearchResult()
+                .setEntities(
+                    new SearchEntityArray(
+                        ImmutableList.of(
+                            new SearchEntity()
+                                .setEntity(Urn.createFromString(SEMANTIC_MODEL_URN_1)),
+                            new SearchEntity()
+                                .setEntity(Urn.createFromString(SEMANTIC_MODEL_URN_2)))))
+                .setFrom(0)
+                .setPageSize(2)
+                .setNumEntities(2));
+
+    final GetSemanticModelsResolver resolver = new GetSemanticModelsResolver(mockClient);
+    final GetSemanticModelsResult result = resolver.get(mockEnv).get();
+
+    assertEquals(result.getStart(), 0);
+    assertEquals(result.getCount(), 2);
+    assertEquals(result.getTotal(), 2);
+    assertEquals(result.getSemanticModels().get(0).getUrn(), SEMANTIC_MODEL_URN_1);
+    assertEquals(result.getSemanticModels().get(1).getUrn(), SEMANTIC_MODEL_URN_2);
+  }
+
+  @Test
+  public void testPaginationFlowsThrough() throws Exception {
+    final EntityClient mockClient = Mockito.mock(EntityClient.class);
+    final QueryContext mockContext = Mockito.mock(QueryContext.class);
+    final OperationContext mockOpContext = Mockito.mock(OperationContext.class);
+    Mockito.when(mockContext.getOperationContext()).thenReturn(mockOpContext);
+    Mockito.when(mockOpContext.withSearchFlags(any())).thenReturn(mockOpContext);
+
+    final DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Mockito.when(mockEnv.getArgument("input"))
+        .thenReturn(new GetRootEntitiesInput(10, 50, "my-model"));
+
+    Mockito.when(
+            mockClient.search(
+                any(),
+                eq(Constants.SEMANTIC_MODEL_ENTITY_NAME),
+                eq("my-model"),
+                isNull(),
+                any(),
+                eq(10),
+                eq(50)))
+        .thenReturn(
+            new SearchResult()
+                .setEntities(new SearchEntityArray(Collections.emptyList()))
+                .setFrom(10)
+                .setPageSize(0)
+                .setNumEntities(10));
+
+    final GetSemanticModelsResolver resolver = new GetSemanticModelsResolver(mockClient);
+    final GetSemanticModelsResult result = resolver.get(mockEnv).get();
+
+    assertEquals(result.getStart(), 10);
+    assertEquals(result.getTotal(), 10);
+    Mockito.verify(mockClient)
+        .search(
+            any(),
+            eq(Constants.SEMANTIC_MODEL_ENTITY_NAME),
+            eq("my-model"),
+            isNull(),
+            any(),
+            eq(10),
+            eq(50));
+  }
+
+  @Test
+  public void testNoFilterApplied() throws Exception {
+    final EntityClient mockClient = Mockito.mock(EntityClient.class);
+    final QueryContext mockContext = Mockito.mock(QueryContext.class);
+    final OperationContext mockOpContext = Mockito.mock(OperationContext.class);
+    Mockito.when(mockContext.getOperationContext()).thenReturn(mockOpContext);
+    Mockito.when(mockOpContext.withSearchFlags(any())).thenReturn(mockOpContext);
+
+    final DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Mockito.when(mockEnv.getArgument("input")).thenReturn(new GetRootEntitiesInput(0, 10, "*"));
+
+    Mockito.when(
+            mockClient.search(
+                any(),
+                eq(Constants.SEMANTIC_MODEL_ENTITY_NAME),
+                any(),
+                isNull(),
+                any(),
+                anyInt(),
+                any()))
+        .thenReturn(
+            new SearchResult()
+                .setEntities(new SearchEntityArray(Collections.emptyList()))
+                .setFrom(0)
+                .setPageSize(0)
+                .setNumEntities(0));
+
+    final GetSemanticModelsResolver resolver = new GetSemanticModelsResolver(mockClient);
+    resolver.get(mockEnv).get();
+
+    // No filter (null) should be passed — unlike GetRootMetricsResolver which filters by
+    // hasParentMetric
+    Mockito.verify(mockClient)
+        .search(
+            any(),
+            eq(Constants.SEMANTIC_MODEL_ENTITY_NAME),
+            any(),
+            isNull(),
+            any(),
+            anyInt(),
+            any());
+  }
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
@@ -11,9 +11,7 @@ import com.linkedin.schema.SchemaField
 record SemanticField {
 
   /**
-   * Inline SchemaField describing this field's schema and identity.
-   * Its `fieldPath` composes into `urn:li:schemaField:(<parentSemanticModelUrn>,<fieldPath>)`,
-   * which serves as the endpoint for column-level lineage edges and as the anchor for
+   * Inline SchemaField describing this field's schema and identity for column-level lineage edges and as the anchor for
    * column-level governance (tags, glossary terms, description).
    */
   schemaField: SchemaField

--- a/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
@@ -11,7 +11,9 @@ import com.linkedin.schema.SchemaField
 record SemanticField {
 
   /**
-   * Inline SchemaField describing this field's schema and identity for column-level lineage edges and as the anchor for
+   * Inline SchemaField describing this field's schema and identity.
+   * Its `fieldPath` composes into `urn:li:schemaField:(<parentSemanticModelUrn>,<fieldPath>)`,
+   * which serves as the endpoint for column-level lineage edges and as the anchor for
    * column-level governance (tags, glossary terms, description).
    */
   schemaField: SchemaField


### PR DESCRIPTION
## Summary

- Renames `getRootSemanticModels` → `getSemanticModels` (and `GetRootSemanticModelsResult` → `GetSemanticModelsResult`) in `metrics.graphql`; semantic models are flat so the "root" prefix was misleading
- Adds `metrics.graphql` to the runtime schema merge in `GmsGraphQLEngine` via a new `METRICS_SCHEMA_FILE` constant
- Registers `MetricType` and `SemanticModelType` as engine fields and in `entityTypes` so DataLoaders, batch loading, and `EntityInterfaceTypeResolver` work automatically
- Implements `GetRootMetricsResolver` (filters `hasParentMetric=false`) and `GetSemanticModelsResolver` (no filter) with unit tests
- Wires `metric`, `semanticModel`, `getRootMetrics`, `getSemanticModels` query fetchers in `configureQueryResolvers`, plus `LoadableTypeBatchResolver` for `GetRootMetricsResult.metrics` and `GetSemanticModelsResult.semanticModels`
