### PR TITLE
refactor(lineage): Extract shared graph-reset logic into useResetLineageGraph

### DIFF
--- a/datahub-web-react/src/app/lineageV3/initialize/DataFlowGraphInitializer.tsx
+++ b/datahub-web-react/src/app/lineageV3/initialize/DataFlowGraphInitializer.tsx
@@ -1,10 +1,10 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext } from 'react';
 import { ReactFlowProvider } from 'reactflow';
 
-import { useGetLineageTimeParams } from '@app/lineage/utils/useGetLineageTimeParams';
 import LineageDisplay from '@app/lineageV3/LineageDisplay';
-import { FetchStatus, LineageEntity, LineageNodesContext, useIgnoreSchemaFieldStatus } from '@app/lineageV3/common';
+import { FetchStatus, LineageEntity, LineageNodesContext } from '@app/lineageV3/common';
 import useFetchChildDataJobs from '@app/lineageV3/initialize/useFetchChildDataJobs';
+import useResetLineageGraph from '@app/lineageV3/initialize/useResetLineageGraph';
 
 import { EntityType, LineageDirection } from '@types';
 
@@ -29,35 +29,7 @@ export default function ImpactAnalysisNodeInitializer(props: Props) {
  */
 function useInitializeNodes(urn: string, type: EntityType): boolean {
     const context = useContext(LineageNodesContext);
-
-    const { startTimeMillis, endTimeMillis } = useGetLineageTimeParams();
-    const { nodes, adjacencyList, edges, setNodeVersion, setDisplayVersion, showGhostEntities } = context;
-    const ignoreSchemaFieldStatus = useIgnoreSchemaFieldStatus();
-
-    useEffect(() => {
-        // Reset graph if home node or time range changes
-        nodes.clear();
-        adjacencyList[LineageDirection.Upstream].clear();
-        adjacencyList[LineageDirection.Downstream].clear();
-        edges.clear();
-        nodes.set(urn, makeInitialNode(urn, type));
-        setNodeVersion(0);
-        setDisplayVersion([0, []]);
-    }, [urn, type, startTimeMillis, endTimeMillis, nodes, adjacencyList, edges, setNodeVersion, setDisplayVersion]);
-
-    useEffect(() => {
-        // Reset edges if showGhostEntities changes. Not necessary if on schema field page and ignoring status
-        if (!(type === EntityType.SchemaField && ignoreSchemaFieldStatus)) {
-            adjacencyList[LineageDirection.Upstream].clear();
-            adjacencyList[LineageDirection.Downstream].clear();
-            edges.clear();
-            nodes.forEach((node) => {
-                // eslint-disable-next-line no-param-reassign
-                node.entity = undefined;
-            });
-            setDisplayVersion([0, []]);
-        }
-    }, [showGhostEntities, ignoreSchemaFieldStatus, type, nodes, adjacencyList, edges, setDisplayVersion]);
+    useResetLineageGraph(context, urn, type, () => makeInitialNode(urn, type));
 
     return useFetchChildDataJobs();
 }

--- a/datahub-web-react/src/app/lineageV3/initialize/DataFlowGraphInitializer.tsx
+++ b/datahub-web-react/src/app/lineageV3/initialize/DataFlowGraphInitializer.tsx
@@ -13,7 +13,7 @@ interface Props {
     type: EntityType;
 }
 
-export default function ImpactAnalysisNodeInitializer(props: Props) {
+export default function DataFlowGraphInitializer(props: Props) {
     const { urn, type } = props;
     const initialized = useInitializeNodes(urn, type);
 

--- a/datahub-web-react/src/app/lineageV3/initialize/ImpactAnalysisNodeInitializer.tsx
+++ b/datahub-web-react/src/app/lineageV3/initialize/ImpactAnalysisNodeInitializer.tsx
@@ -1,15 +1,9 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext } from 'react';
 import { ReactFlowProvider } from 'reactflow';
 
-import { useGetLineageTimeParams } from '@app/lineage/utils/useGetLineageTimeParams';
 import LineageDisplay from '@app/lineageV3/LineageDisplay';
-import {
-    FetchStatus,
-    LINEAGE_FILTER_PAGINATION,
-    LineageEntity,
-    LineageNodesContext,
-    useIgnoreSchemaFieldStatus,
-} from '@app/lineageV3/common';
+import { FetchStatus, LINEAGE_FILTER_PAGINATION, LineageEntity, LineageNodesContext } from '@app/lineageV3/common';
+import useResetLineageGraph from '@app/lineageV3/initialize/useResetLineageGraph';
 import useSearchAcrossLineage from '@app/lineageV3/queries/useSearchAcrossLineage';
 
 import { EntityType, LineageDirection } from '@types';
@@ -35,35 +29,7 @@ export default function ImpactAnalysisNodeInitializer(props: Props) {
  */
 function useInitializeNodes(urn: string, type: EntityType): boolean {
     const context = useContext(LineageNodesContext);
-
-    const { startTimeMillis, endTimeMillis } = useGetLineageTimeParams();
-    const { nodes, adjacencyList, edges, setNodeVersion, setDisplayVersion, showGhostEntities } = context;
-    const ignoreSchemaFieldStatus = useIgnoreSchemaFieldStatus();
-
-    useEffect(() => {
-        // Reset graph if home node or time range changes
-        nodes.clear();
-        adjacencyList[LineageDirection.Upstream].clear();
-        adjacencyList[LineageDirection.Downstream].clear();
-        edges.clear();
-        nodes.set(urn, makeInitialNode(urn, type));
-        setNodeVersion(0);
-        setDisplayVersion([0, []]);
-    }, [urn, type, startTimeMillis, endTimeMillis, nodes, adjacencyList, edges, setNodeVersion, setDisplayVersion]);
-
-    useEffect(() => {
-        // Reset edges if showGhostEntities changes. Not necessary if on schema field page and ignoring status
-        if (!(type === EntityType.SchemaField && ignoreSchemaFieldStatus)) {
-            adjacencyList[LineageDirection.Upstream].clear();
-            adjacencyList[LineageDirection.Downstream].clear();
-            edges.clear();
-            nodes.forEach((node) => {
-                // eslint-disable-next-line no-param-reassign
-                node.entity = undefined;
-            });
-            setDisplayVersion([0, []]);
-        }
-    }, [showGhostEntities, ignoreSchemaFieldStatus, type, nodes, adjacencyList, edges, setDisplayVersion]);
+    useResetLineageGraph(context, urn, type, () => makeInitialNode(urn, type));
 
     const { processed: upstreamProcessed } = useSearchAcrossLineage(urn, type, context, LineageDirection.Upstream);
     const { processed: downstreamProcessed } = useSearchAcrossLineage(urn, type, context, LineageDirection.Downstream);

--- a/datahub-web-react/src/app/lineageV3/initialize/__tests__/useResetLineageGraph.test.ts
+++ b/datahub-web-react/src/app/lineageV3/initialize/__tests__/useResetLineageGraph.test.ts
@@ -1,0 +1,54 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LineageEntity, NodeContext } from '@app/lineageV3/common';
+import useResetLineageGraph from '@app/lineageV3/initialize/useResetLineageGraph';
+
+import { EntityType, LineageDirection } from '@types';
+
+vi.mock('@app/lineage/utils/useGetLineageTimeParams', () => ({
+    useGetLineageTimeParams: () => ({ startTimeMillis: undefined, endTimeMillis: undefined }),
+}));
+
+vi.mock('@app/lineageV3/common', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@app/lineageV3/common')>()),
+    useIgnoreSchemaFieldStatus: () => false,
+}));
+
+const URN = 'urn:li:dataset:(urn:li:dataPlatform:mysql,db.t,PROD)';
+
+function makeContext(): NodeContext {
+    return {
+        nodes: new Map(),
+        edges: new Map(),
+        adjacencyList: {
+            [LineageDirection.Upstream]: new Map(),
+            [LineageDirection.Downstream]: new Map(),
+        },
+        setNodeVersion: vi.fn(),
+        setDisplayVersion: vi.fn(),
+        showGhostEntities: false,
+    } as unknown as NodeContext;
+}
+
+const makeInitialNode = () => ({ id: URN, urn: URN, type: EntityType.Dataset }) as LineageEntity;
+
+describe('useResetLineageGraph', () => {
+    it('clears stale graph state, seeds the home node, and resets versions on mount', () => {
+        const context = makeContext();
+        // Pre-populate to verify the reset actually clears everything
+        context.nodes.set('stale-urn', makeInitialNode());
+        context.edges.set('stale-edge', {} as never);
+        context.adjacencyList[LineageDirection.Upstream].set('a', new Set(['b']));
+        context.adjacencyList[LineageDirection.Downstream].set('b', new Set(['a']));
+
+        renderHook(() => useResetLineageGraph(context, URN, EntityType.Dataset, makeInitialNode));
+
+        expect(Array.from(context.nodes.keys())).toEqual([URN]);
+        expect(context.edges.size).toBe(0);
+        expect(context.adjacencyList[LineageDirection.Upstream].size).toBe(0);
+        expect(context.adjacencyList[LineageDirection.Downstream].size).toBe(0);
+        expect(context.setNodeVersion).toHaveBeenCalledWith(0);
+        expect(context.setDisplayVersion).toHaveBeenCalledWith([0, []]);
+    });
+});

--- a/datahub-web-react/src/app/lineageV3/initialize/__tests__/useResetLineageGraph.test.ts
+++ b/datahub-web-react/src/app/lineageV3/initialize/__tests__/useResetLineageGraph.test.ts
@@ -1,10 +1,12 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { LineageEntity, NodeContext } from '@app/lineageV3/common';
 import useResetLineageGraph from '@app/lineageV3/initialize/useResetLineageGraph';
 
 import { EntityType, LineageDirection } from '@types';
+
+const mocks = vi.hoisted(() => ({ ignoreSchemaFieldStatus: false }));
 
 vi.mock('@app/lineage/utils/useGetLineageTimeParams', () => ({
     useGetLineageTimeParams: () => ({ startTimeMillis: undefined, endTimeMillis: undefined }),
@@ -12,7 +14,7 @@ vi.mock('@app/lineage/utils/useGetLineageTimeParams', () => ({
 
 vi.mock('@app/lineageV3/common', async (importOriginal) => ({
     ...(await importOriginal<typeof import('@app/lineageV3/common')>()),
-    useIgnoreSchemaFieldStatus: () => false,
+    useIgnoreSchemaFieldStatus: () => mocks.ignoreSchemaFieldStatus,
 }));
 
 const URN = 'urn:li:dataset:(urn:li:dataPlatform:mysql,db.t,PROD)';
@@ -34,6 +36,10 @@ function makeContext(): NodeContext {
 const makeInitialNode = () => ({ id: URN, urn: URN, type: EntityType.Dataset }) as LineageEntity;
 
 describe('useResetLineageGraph', () => {
+    beforeEach(() => {
+        mocks.ignoreSchemaFieldStatus = false;
+    });
+
     it('clears stale graph state, seeds the home node, and resets versions on mount', () => {
         const context = makeContext();
         // Pre-populate to verify the reset actually clears everything
@@ -50,5 +56,44 @@ describe('useResetLineageGraph', () => {
         expect(context.adjacencyList[LineageDirection.Downstream].size).toBe(0);
         expect(context.setNodeVersion).toHaveBeenCalledWith(0);
         expect(context.setDisplayVersion).toHaveBeenCalledWith([0, []]);
+    });
+
+    it('clears fetched edges and node entities when showGhostEntities changes', () => {
+        const context = makeContext();
+        const { rerender } = renderHook(
+            ({ ctx }) => useResetLineageGraph(ctx, URN, EntityType.Dataset, makeInitialNode),
+            { initialProps: { ctx: context } },
+        );
+
+        // Simulate fetched state that toggling ghost entities should invalidate.
+        const homeNode = context.nodes.get(URN) as LineageEntity;
+        homeNode.entity = {} as never;
+        context.edges.set('e', {} as never);
+        context.adjacencyList[LineageDirection.Upstream].set('a', new Set(['b']));
+
+        rerender({ ctx: { ...context, showGhostEntities: true } });
+
+        expect(context.edges.size).toBe(0);
+        expect(context.adjacencyList[LineageDirection.Upstream].size).toBe(0);
+        expect(homeNode.entity).toBeUndefined();
+    });
+
+    it('leaves fetched state intact on showGhostEntities change for schema fields when ignoring status', () => {
+        mocks.ignoreSchemaFieldStatus = true;
+        const context = makeContext();
+        const { rerender } = renderHook(
+            ({ ctx }) => useResetLineageGraph(ctx, URN, EntityType.SchemaField, makeInitialNode),
+            { initialProps: { ctx: context } },
+        );
+
+        const homeNode = context.nodes.get(URN) as LineageEntity;
+        homeNode.entity = {} as never;
+        context.edges.set('e', {} as never);
+
+        rerender({ ctx: { ...context, showGhostEntities: true } });
+
+        // The ghost-entity reset is guarded out for schema fields when ignoring status.
+        expect(context.edges.size).toBe(1);
+        expect(homeNode.entity).not.toBeUndefined();
     });
 });

--- a/datahub-web-react/src/app/lineageV3/initialize/useResetLineageGraph.ts
+++ b/datahub-web-react/src/app/lineageV3/initialize/useResetLineageGraph.ts
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+
+import { useGetLineageTimeParams } from '@app/lineage/utils/useGetLineageTimeParams';
+import { LineageEntity, NodeContext, useIgnoreSchemaFieldStatus } from '@app/lineageV3/common';
+
+import { EntityType, LineageDirection } from '@types';
+
+/**
+ * Resets the lineage node context whenever the home node or selected time range changes, and
+ * clears fetched edges whenever `showGhostEntities` changes, since ghost entities affect which
+ * edges are considered fetched.
+ */
+export default function useResetLineageGraph(
+    context: NodeContext,
+    urn: string,
+    type: EntityType,
+    makeInitialNode: () => LineageEntity,
+) {
+    const { nodes, adjacencyList, edges, setNodeVersion, setDisplayVersion, showGhostEntities } = context;
+    const ignoreSchemaFieldStatus = useIgnoreSchemaFieldStatus();
+    const { startTimeMillis, endTimeMillis } = useGetLineageTimeParams();
+
+    useEffect(() => {
+        nodes.clear();
+        adjacencyList[LineageDirection.Upstream].clear();
+        adjacencyList[LineageDirection.Downstream].clear();
+        edges.clear();
+        nodes.set(urn, makeInitialNode());
+        setNodeVersion(0);
+        setDisplayVersion([0, []]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [urn, type, startTimeMillis, endTimeMillis, nodes, adjacencyList, edges, setNodeVersion, setDisplayVersion]);
+
+    useEffect(() => {
+        // Not necessary if on schema field page and ignoring status
+        if (!(type === EntityType.SchemaField && ignoreSchemaFieldStatus)) {
+            adjacencyList[LineageDirection.Upstream].clear();
+            adjacencyList[LineageDirection.Downstream].clear();
+            edges.clear();
+            nodes.forEach((node) => {
+                // eslint-disable-next-line no-param-reassign
+                node.entity = undefined;
+            });
+            setDisplayVersion([0, []]);
+        }
+    }, [showGhostEntities, ignoreSchemaFieldStatus, type, nodes, adjacencyList, edges, setDisplayVersion]);
+}


### PR DESCRIPTION
Simple refactor to pull shared logic into a reusable hook

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
