### PR TITLE
fix(ui): keep Select dropdown scrollbar visible when options overflow

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Select/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/components.ts
@@ -109,6 +109,15 @@ export const DropdownContainer = styled.div<{ ignoreMaxHeight?: boolean }>(({ ig
     overflow: 'auto',
     width: '100%',
     maxHeight: ignoreMaxHeight ? undefined : '360px',
+    // Force a persistent scrollbar so overflowing options (e.g. the language list)
+    // are discoverable; WebKit overlay scrollbars otherwise auto-hide on macOS.
+    '&::-webkit-scrollbar': {
+        width: '8px',
+    },
+    '&::-webkit-scrollbar-thumb': {
+        background: theme?.colors?.border,
+        borderRadius: radius.lg,
+    },
 }));
 
 // Styled components for SelectValue (Selected value display)

--- a/datahub-web-react/src/alchemy-components/components/Select/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/components.ts
@@ -112,10 +112,11 @@ export const DropdownContainer = styled.div<{ ignoreMaxHeight?: boolean }>(({ ig
     // Force a persistent scrollbar so overflowing options (e.g. the language list)
     // are discoverable; WebKit overlay scrollbars otherwise auto-hide on macOS.
     '&::-webkit-scrollbar': {
-        width: '8px',
+        width: '6px',
+        background: theme?.colors?.scrollbarTrack,
     },
     '&::-webkit-scrollbar-thumb': {
-        background: theme?.colors?.border,
+        background: theme?.colors?.scrollbarThumb,
         borderRadius: radius.lg,
     },
 }));


### PR DESCRIPTION
## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing/#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests added/updated (if applicable) — n/a, CSS-only styling change
- [ ] Docs added/updated (if applicable)

## What & why

The UI language dropdown in **Settings → Appearance** (and any other long `Select` dropdown) shows enough options to overflow its 360px max-height, but on macOS the WebKit **overlay scrollbar auto-hides** until the user actively scrolls. That gives no visual cue that more options exist below the fold — languages 8, 9, … are effectively undiscoverable.

## Fix

Define an explicit `::-webkit-scrollbar` with a styled thumb on the shared `DropdownContainer` styled-component. Providing explicit scrollbar rules switches WebKit from an auto-hiding overlay scrollbar to a persistent one, and since the container is already `overflow: auto`, it only appears when the options actually overflow.

```ts
'&::-webkit-scrollbar': { width: '6px', background: theme?.colors?.scrollbarTrack },
'&::-webkit-scrollbar-thumb': { background: theme?.colors?.scrollbarThumb, borderRadius: radius.lg },
```

## Scope & consistency

This is the **shared** `Select` dropdown container, so the persistent-when-scrollable scrollbar now applies to every overflowing `Select` dropdown, not just the language picker. That breadth is intentional — a couple of findings from surveying the codebase:

- **A persistent scrollbar is the app's dominant convention, not a new idea.** ~17 scrollable surfaces (sidebars, popovers such as `MoveDocumentPopover`/`DocumentPopoverBase`, entity lists, the entity sidebar) already render a styled `::-webkit-scrollbar` + thumb. The alchemy `Select` family was in the *minority* that relied on the raw browser overlay scrollbar. This change moves `Select` **toward** the established pattern, so it improves cross-app consistency rather than introducing a one-off.
- **It reuses the house scrollbar tokens.** The theme already defines `scrollbarTrack` / `scrollbarThumb` (light + dark). Using them keeps the scrollbar dark-mode correct and visually identical to the other surfaces. The `6px` width matches the most common width used elsewhere (6px is used by 7 components; 5px/8px are the next most common).

**Alternatives considered and rejected:**
- *Scope to only the language dropdown* — the dropdown renders through antd's `dropdownRender` into a portal, so targeting a single instance would require a fragile global selector hack. The shared fix is cleaner and, per the point above, more consistent.
- *Leave the overlay (pre-existing) behavior* — that is precisely the reported problem (auto-hide hides discoverability), and it would keep `Select` in the minority unstyled camp.

Flagging the shared-component scope for a designer's eye, since it touches the most-reused dropdown surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)