### PR TITLE
fix(ingest/transformer): dedupe owners in container ownership rollup to avoid oversized patches

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_ownership.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_ownership.py
@@ -6,7 +6,7 @@ variants in ``add_dataset_ownership.py`` delegate to these with
 """
 
 import logging
-from typing import Callable, Dict, List, Optional, Union, cast
+from typing import Callable, Dict, List, Optional, Set, Tuple, Union, cast
 
 import datahub.emitter.mce_builder as builder
 from datahub.configuration.common import (
@@ -165,11 +165,36 @@ class AddOwnership(OwnershipTransformer):
 
         for urn, owners in ownership_container_mapping.items():
             patch_builder = DashboardPatchBuilder(urn)
-            for owner in owners:
+            for owner in self._dedupe_owners(owners):
                 patch_builder.add_owner(owner)
             mcps.extend(list(patch_builder.build()))
 
         return mcps
+
+    @staticmethod
+    def _dedupe_owners(owners: List[OwnerClass]) -> List[OwnerClass]:
+        # Container rollup concatenates owners from every child. Without
+        # dedup, large folders emit one identical add_owner op per child
+        # and can exceed GMS's payload limit. Key matches HasOwnershipPatch.
+        seen: Set[Tuple[str, str, str, str]] = set()
+        deduped: List[OwnerClass] = []
+        for owner in owners:
+            source = (
+                owner.attribution.source
+                if (owner.attribution and owner.attribution.source)
+                else ""
+            )
+            key = (
+                owner.owner,
+                str(owner.type) if owner.type else "",
+                str(owner.typeUrn) if owner.typeUrn else "",
+                source,
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(owner)
+        return deduped
 
     def transform_aspect(
         self, entity_urn: str, aspect_name: str, aspect: Optional[Aspect]

--- a/metadata-ingestion/tests/unit/test_transform_ownership_universal.py
+++ b/metadata-ingestion/tests/unit/test_transform_ownership_universal.py
@@ -5,11 +5,18 @@ PatternAddOwnership, AddOwnership) work on all supported entity types,
 while the legacy *Dataset* variants preserve their original entity type set.
 """
 
+import json
 from unittest import mock
 
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import EndOfStream, PipelineContext, RecordEnvelope
-from datahub.metadata.schema_classes import OwnerClass, OwnershipClass
+from datahub.metadata.schema_classes import (
+    BrowsePathEntryClass,
+    BrowsePathsV2Class,
+    MetadataChangeProposalClass,
+    OwnerClass,
+    OwnershipClass,
+)
 
 
 class TestCallbackBasedOwnershipTransformers:
@@ -52,6 +59,56 @@ class TestCallbackBasedOwnershipTransformers:
                     if any(o.owner == owner_urn for o in envelope.record.aspect.owners):
                         owner_found = True
         assert owner_found, "Owner should be added to container"
+
+    def test_container_rollup_dedupes_owners(self) -> None:
+        """Container ownership rollup must emit one op per unique owner."""
+        from datahub.ingestion.transformer.add_ownership import PatternAddOwnership
+
+        owner_urn = "urn:li:corpGroup:shared"
+
+        graph = mock.MagicMock()
+        graph.get_aspect.return_value = BrowsePathsV2Class(
+            path=[BrowsePathEntryClass(id=self.CONTAINER_URN, urn=self.CONTAINER_URN)]
+        )
+        pipeline_context = PipelineContext(run_id="test_container_rollup_dedupe")
+        pipeline_context.graph = graph
+
+        transformer = PatternAddOwnership.create(
+            {
+                "owner_pattern": {"rules": {".*": [owner_urn]}},
+                "ownership_type": "TECHNICAL_OWNER",
+                "is_container": True,
+            },
+            pipeline_context,
+        )
+
+        records = [
+            RecordEnvelope(r, metadata={})
+            for r in [
+                *[
+                    MetadataChangeProposalWrapper(
+                        entityUrn=f"urn:li:dataset:(urn:li:dataPlatform:looker,explore.{i},PROD)",
+                        aspect=OwnershipClass(owners=[]),
+                    )
+                    for i in range(50)
+                ],
+                EndOfStream(),
+            ]
+        ]
+
+        outputs = list(transformer.transform(records))
+
+        container_patch = next(
+            env.record
+            for env in outputs
+            if isinstance(env.record, MetadataChangeProposalClass)
+            and env.record.entityUrn == self.CONTAINER_URN
+            and env.record.aspectName == "ownership"
+        )
+        assert container_patch.aspect is not None
+        envelope = json.loads(container_patch.aspect.value)
+        assert len(envelope["patch"]) == 1
+        assert envelope["patch"][0]["value"]["owner"] == owner_urn
 
 
 class TestOwnershipEntityTypesConfigRestriction:


### PR DESCRIPTION
## Summary

Ownership transformers with `is_container: true` aggregate each child asset's owners onto its parent container. The rollup concatenated owners across all children **without de-duplication**, so when many children share the same owner (common with a universal `.*` owner rule), the container's ownership PATCH contained one identical `add_owner` op **per child asset**.

For containers with a large number of children this pushed the PATCH past the GMS request-size limit (`ingestProposalBatch`), which failed the whole batch with:

`400 Client Error: Bad Request ... Cannot parse request entity`

Because it's a batch endpoint, the single oversized MCP also took down the other container-ownership MCPs sharing that batch, so many containers silently ended up with no owner even though the container entities themselves ingested fine.

## What changed

- Added `AddOwnership._dedupe_owners(...)` and applied it in `handle_end_of_stream` before building the container ownership patch.
- Owners are de-duplicated on the same compound key the patch builder keys on: `(owner, type, typeUrn, attribution.source)`, so genuinely distinct owners are preserved while exact duplicates collapse.
- The container ownership update is now constant-size regardless of child count (one op per unique owner).

This is a client-side (ingestion) change only — no GMS/server changes and no recipe changes required.
