### PR TITLE
fix(graphql): Fix hidden documents showing up in search UI counts & bring back Saas Docs changes

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/chart/BrowseV2Resolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/chart/BrowseV2Resolver.java
@@ -14,6 +14,7 @@ import com.linkedin.datahub.graphql.generated.BrowseResultsV2;
 import com.linkedin.datahub.graphql.generated.BrowseV2Input;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
+import com.linkedin.datahub.graphql.resolvers.search.DefaultEntityFiltersUtil;
 import com.linkedin.datahub.graphql.resolvers.search.SearchUtils;
 import com.linkedin.datahub.graphql.types.common.mappers.UrnToEntityMapper;
 import com.linkedin.datahub.graphql.types.entitytype.EntityTypeMapper;
@@ -76,15 +77,23 @@ public class BrowseV2Resolver implements DataFetcher<CompletableFuture<BrowseRes
                     : "";
             final Filter inputFilter = ResolverUtils.buildFilter(null, input.getOrFilters());
 
+            Filter effectiveFilter =
+                maybeResolvedView != null
+                    ? SearchUtils.combineFilters(
+                        inputFilter, maybeResolvedView.getDefinition().getFilter())
+                    : inputFilter;
+
+            // Add default entity filters (e.g. showInGlobalContext for documents)
+            effectiveFilter =
+                DefaultEntityFiltersUtil.applyDefaultEntityFilters(
+                    effectiveFilter, entityNames, searchFlags, context);
+
             BrowseResultV2 browseResults =
                 _entityClient.browseV2(
                     context.getOperationContext().withSearchFlags(flags -> searchFlags),
                     entityNames,
                     pathStr,
-                    maybeResolvedView != null
-                        ? SearchUtils.combineFilters(
-                            inputFilter, maybeResolvedView.getDefinition().getFilter())
-                        : inputFilter,
+                    effectiveFilter,
                     sanitizedQuery,
                     start,
                     count);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentSearchFilterUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentSearchFilterUtils.java
@@ -15,77 +15,106 @@ import javax.annotation.Nonnull;
 /**
  * Utility class for building document search filters with ownership constraints. Shared logic for
  * SearchDocumentsResolver, RelatedDocumentsResolver, and ContextDocumentsResolver.
+ *
+ * <p>Visibility is determined by two fields with a priority rule:
+ *
+ * <ul>
+ *   <li><b>lifecycleStage</b> (on the {@code status} aspect) — preferred, new field
+ *   <li><b>state</b> (on {@code documentInfo.status}) — legacy, used as fallback
+ * </ul>
+ *
+ * When {@code lifecycleStage} is present it takes precedence: PUBLISHED URN → visible to all,
+ * UNPUBLISHED/IN_REVIEW/etc URN → visible only to owners, DRAFT URN → never visible (even to
+ * owners). When absent, the legacy {@code state} field is used with the same semantics.
  */
 public class DocumentSearchFilterUtils {
+
+  static final String PUBLISHED_LIFECYCLE_STAGE_URN = "urn:li:lifecycleStageType:PUBLISHED";
+  static final String DRAFT_LIFECYCLE_STAGE_URN = "urn:li:lifecycleStageType:DRAFT";
 
   private DocumentSearchFilterUtils() {
     // Utility class - prevent instantiation
   }
 
   /**
-   * Builds a combined filter with ownership constraints that excludes documents explicitly hidden
-   * from global context.
-   *
-   * <p>This is the default for global document searches (sidebar, search popovers). Only documents
-   * with showInGlobalContext explicitly set to false are excluded; documents without the
-   * documentSettings aspect are shown by default.
+   * Builds a combined filter with ownership constraints, optional showInGlobalContext filter, and
+   * optional privilege-based bypass of ownership restrictions.
    *
    * @param baseCriteria The base user criteria (without state filtering)
    * @param userAndGroupUrns List of URNs for the current user and their groups
-   * @return The combined filter excluding showInGlobalContext=false documents
-   */
-  @Nonnull
-  public static Filter buildCombinedFilter(
-      @Nonnull List<Criterion> baseCriteria, @Nonnull List<String> userAndGroupUrns) {
-    return buildCombinedFilter(baseCriteria, userAndGroupUrns, true);
-  }
-
-  /**
-   * Builds a combined filter with ownership constraints and optional showInGlobalContext filter.
-   *
-   * <p>The filter structure is: - With showInGlobalContext: (user-filters AND PUBLISHED AND
-   * showInGlobalContext!=false) OR (user-filters AND UNPUBLISHED AND owned-by-user-or-groups AND
-   * showInGlobalContext!=false)
-   *
-   * <p>- Without showInGlobalContext: (user-filters AND PUBLISHED) OR (user-filters AND UNPUBLISHED
-   * AND owned-by-user-or-groups)
-   *
-   * <p>Uses negated EQUAL (field != "false") instead of positive EQUAL (field == "true") so that
-   * documents without an explicit documentSettings aspect are included by default. Only documents
-   * that explicitly set showInGlobalContext=false are excluded.
-   *
-   * @param baseCriteria The base user criteria (without state filtering)
-   * @param userAndGroupUrns List of URNs for the current user and their groups
-   * @param applyShowInGlobalContext Whether to exclude showInGlobalContext=false documents (set to
-   *     false for related documents queries where context-only docs should be visible)
+   * @param applyShowInGlobalContext Whether to exclude showInGlobalContext=false documents
+   * @param canManageDocuments When true, unpublished documents are visible without ownership
+   *     constraints (for users with MANAGE_DOCUMENTS privilege). DRAFT documents remain excluded
+   *     regardless.
    * @return The combined filter
    */
   @Nonnull
   public static Filter buildCombinedFilter(
       @Nonnull List<Criterion> baseCriteria,
       @Nonnull List<String> userAndGroupUrns,
-      boolean applyShowInGlobalContext) {
+      boolean applyShowInGlobalContext,
+      boolean canManageDocuments) {
 
     List<ConjunctiveCriterion> orClauses = new ArrayList<>();
 
-    // Clause 1: Published documents (with user filters)
-    List<Criterion> publishedCriteria = new ArrayList<>(baseCriteria);
-    publishedCriteria.add(CriterionUtils.buildCriterion("state", Condition.EQUAL, "PUBLISHED"));
-    if (applyShowInGlobalContext) {
-      publishedCriteria.add(buildNegatedCriterion("showInGlobalContext", "false"));
-    }
-    orClauses.add(new ConjunctiveCriterion().setAnd(new CriterionArray(publishedCriteria)));
+    // --- New lifecycleStage-based clauses (take priority when field is present) ---
 
-    // Clause 2: Unpublished documents owned by user or their groups (with user filters)
-    List<Criterion> unpublishedOwnedCriteria = new ArrayList<>(baseCriteria);
-    unpublishedOwnedCriteria.add(
-        CriterionUtils.buildCriterion("state", Condition.EQUAL, "UNPUBLISHED"));
-    unpublishedOwnedCriteria.add(
-        CriterionUtils.buildCriterion("owners", Condition.EQUAL, userAndGroupUrns));
+    // Clause 1: lifecycleStage = PUBLISHED → visible to all
+    List<Criterion> lifecyclePublishedCriteria = new ArrayList<>(baseCriteria);
+    lifecyclePublishedCriteria.add(
+        CriterionUtils.buildCriterion(
+            "lifecycleStage", Condition.EQUAL, PUBLISHED_LIFECYCLE_STAGE_URN));
     if (applyShowInGlobalContext) {
-      unpublishedOwnedCriteria.add(buildNegatedCriterion("showInGlobalContext", "false"));
+      lifecyclePublishedCriteria.add(buildNegatedCriterion("showInGlobalContext", "false"));
     }
-    orClauses.add(new ConjunctiveCriterion().setAnd(new CriterionArray(unpublishedOwnedCriteria)));
+    orClauses.add(
+        new ConjunctiveCriterion().setAnd(new CriterionArray(lifecyclePublishedCriteria)));
+
+    // Clause 2: lifecycleStage != PUBLISHED AND lifecycleStage != DRAFT AND lifecycleStage EXISTS
+    // AND (owned OR canManageDocuments) → non-published, non-draft stages (UNPUBLISHED, IN_REVIEW,
+    // REJECTED, etc.) visible to owners or users with MANAGE_DOCUMENTS privilege.
+    // DRAFT is excluded entirely — it is never surfaced in the UI.
+    List<Criterion> lifecycleNonPublishedCriteria = new ArrayList<>(baseCriteria);
+    lifecycleNonPublishedCriteria.add(
+        buildNegatedCriterion("lifecycleStage", PUBLISHED_LIFECYCLE_STAGE_URN));
+    lifecycleNonPublishedCriteria.add(
+        buildNegatedCriterion("lifecycleStage", DRAFT_LIFECYCLE_STAGE_URN));
+    lifecycleNonPublishedCriteria.add(buildExistsCriterion("lifecycleStage"));
+    if (!canManageDocuments) {
+      lifecycleNonPublishedCriteria.add(
+          CriterionUtils.buildCriterion("owners", Condition.EQUAL, userAndGroupUrns));
+    }
+    if (applyShowInGlobalContext) {
+      lifecycleNonPublishedCriteria.add(buildNegatedCriterion("showInGlobalContext", "false"));
+    }
+    orClauses.add(
+        new ConjunctiveCriterion().setAnd(new CriterionArray(lifecycleNonPublishedCriteria)));
+
+    // --- Legacy state-based clauses (fallback when lifecycleStage is not set) ---
+
+    // Clause 3: lifecycleStage IS_NULL AND state = PUBLISHED → visible to all
+    List<Criterion> legacyPublishedCriteria = new ArrayList<>(baseCriteria);
+    legacyPublishedCriteria.add(buildIsNullCriterion("lifecycleStage"));
+    legacyPublishedCriteria.add(
+        CriterionUtils.buildCriterion("state", Condition.EQUAL, "PUBLISHED"));
+    if (applyShowInGlobalContext) {
+      legacyPublishedCriteria.add(buildNegatedCriterion("showInGlobalContext", "false"));
+    }
+    orClauses.add(new ConjunctiveCriterion().setAnd(new CriterionArray(legacyPublishedCriteria)));
+
+    // Clause 4: lifecycleStage IS_NULL AND state = UNPUBLISHED AND (owned OR canManageDocuments)
+    List<Criterion> legacyUnpublishedCriteria = new ArrayList<>(baseCriteria);
+    legacyUnpublishedCriteria.add(buildIsNullCriterion("lifecycleStage"));
+    legacyUnpublishedCriteria.add(
+        CriterionUtils.buildCriterion("state", Condition.EQUAL, "UNPUBLISHED"));
+    if (!canManageDocuments) {
+      legacyUnpublishedCriteria.add(
+          CriterionUtils.buildCriterion("owners", Condition.EQUAL, userAndGroupUrns));
+    }
+    if (applyShowInGlobalContext) {
+      legacyUnpublishedCriteria.add(buildNegatedCriterion("showInGlobalContext", "false"));
+    }
+    orClauses.add(new ConjunctiveCriterion().setAnd(new CriterionArray(legacyUnpublishedCriteria)));
 
     return new Filter().setOr(new ConjunctiveCriterionArray(orClauses));
   }
@@ -101,6 +130,22 @@ public class DocumentSearchFilterUtils {
     criterion.setValues(
         new com.linkedin.data.template.StringArray(Collections.singletonList(value)));
     criterion.setNegated(true);
+    return criterion;
+  }
+
+  /** Builds an EXISTS criterion — matches documents where the field is present / not null. */
+  private static Criterion buildExistsCriterion(String field) {
+    Criterion criterion = new Criterion();
+    criterion.setField(field);
+    criterion.setCondition(Condition.EXISTS);
+    return criterion;
+  }
+
+  /** Builds an IS_NULL criterion — matches documents where the field is absent / not set. */
+  private static Criterion buildIsNullCriterion(String field) {
+    Criterion criterion = new Criterion();
+    criterion.setField(field);
+    criterion.setCondition(Condition.IS_NULL);
     return criterion;
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/RelatedDocumentsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/RelatedDocumentsResolver.java
@@ -4,6 +4,7 @@ import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
 
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.generated.Document;
 import com.linkedin.datahub.graphql.generated.Entity;
@@ -94,9 +95,10 @@ public class RelatedDocumentsResolver
             // Note: applyShowInGlobalContext=false because related documents should show
             // all context documents (those are meant to be discovered through their related
             // entities)
+            final boolean canManageDocuments = AuthorizationUtils.canManageDocuments(context);
             Filter filter =
                 DocumentSearchFilterUtils.buildCombinedFilter(
-                    baseUserCriteria, userAndGroupUrns, false);
+                    baseUserCriteria, userAndGroupUrns, false, canManageDocuments);
 
             // Step 1: Search using service to get URNs
             // Sort by lastModifiedAt descending to show most recently updated documents first

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/SearchDocumentsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/SearchDocumentsResolver.java
@@ -7,6 +7,7 @@ import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.resolveV
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.generated.Document;
 import com.linkedin.datahub.graphql.generated.SearchDocumentsInput;
@@ -84,8 +85,11 @@ public class SearchDocumentsResolver
             // Build filter that combines user filters with ownership constraints
             // Filter logic: (PUBLISHED) OR (UNPUBLISHED AND owned-by-user-or-groups)
             List<Criterion> baseUserCriteria = buildBaseUserCriteria(input);
+            // Users with MANAGE_DOCUMENTS privilege can see all unpublished documents
+            final boolean canManageDocuments = AuthorizationUtils.canManageDocuments(context);
             Filter filter =
-                DocumentSearchFilterUtils.buildCombinedFilter(baseUserCriteria, userAndGroupUrns);
+                DocumentSearchFilterUtils.buildCombinedFilter(
+                    baseUserCriteria, userAndGroupUrns, true, canManageDocuments);
 
             // Scope results to the active View, if one is provided. We combine the View's filter
             // (domains, ownership, etc.) with the document filter so the Documents overview and

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/AggregateAcrossEntitiesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/AggregateAcrossEntitiesResolver.java
@@ -87,16 +87,24 @@ public class AggregateAcrossEntitiesResolver
           }
 
           try {
+            Filter effectiveFilter =
+                maybeResolvedView != null
+                    ? SearchUtils.combineFilters(
+                        inputFilter, maybeResolvedView.getDefinition().getFilter())
+                    : inputFilter;
+
+            // Add default entity filters (e.g. showInGlobalContext for documents)
+            effectiveFilter =
+                DefaultEntityFiltersUtil.applyDefaultEntityFilters(
+                    effectiveFilter, finalEntities, searchFlags, context);
+
             return mapAggregateResults(
                 context,
                 _entityClient.searchAcrossEntities(
                     context.getOperationContext().withSearchFlags(flags -> searchFlags),
                     finalEntities,
                     sanitizedQuery,
-                    maybeResolvedView != null
-                        ? SearchUtils.combineFilters(
-                            inputFilter, maybeResolvedView.getDefinition().getFilter())
-                        : inputFilter,
+                    effectiveFilter,
                     0,
                     0, // 0 entity count because we don't want resolved entities
                     Collections.emptyList(),

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/DefaultEntityFiltersUtil.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/DefaultEntityFiltersUtil.java
@@ -2,8 +2,10 @@ package com.linkedin.datahub.graphql.resolvers.search;
 
 import static com.linkedin.metadata.Constants.DOCUMENT_ENTITY_NAME;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
+import com.linkedin.metadata.query.SearchFlags;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
@@ -30,8 +32,14 @@ import javax.annotation.Nullable;
  * entity types may have default filters that should be applied. This utility ensures those filters
  * only affect the target entity types without excluding other entities from search results.
  *
- * <p>Currently supports default filters for: - DOCUMENT: Filters out unpublished documents and
- * optionally filters out documents not meant for global visibility
+ * <p>Currently supports default filters for: - DOCUMENT: Shows only published documents using a
+ * two-clause OR filter consistent with the MCP tool's anchor filter pattern:
+ *
+ * <ol>
+ *   <li>lifecycleStage = PUBLISHED (new field present and published)
+ *   <li>lifecycleStage IS_NULL AND state != UNPUBLISHED (legacy fallback; non-document entities
+ *       also pass through this clause)
+ * </ol>
  */
 public class DefaultEntityFiltersUtil {
 
@@ -40,7 +48,9 @@ public class DefaultEntityFiltersUtil {
    * aggregation results since they are system/hidden filters that shouldn't be shown to users.
    */
   public static final Set<String> DEFAULT_FILTER_FIELDS =
-      ImmutableSet.of("state", "showInGlobalContext");
+      ImmutableSet.of("state", "lifecycleStage", "showInGlobalContext");
+
+  static final String PUBLISHED_LIFECYCLE_STAGE_URN = "urn:li:lifecycleStageType:PUBLISHED";
 
   private DefaultEntityFiltersUtil() {
     // Utility class - prevent instantiation
@@ -109,23 +119,21 @@ public class DefaultEntityFiltersUtil {
   }
 
   /**
-   * Adds default entity-specific filters to the base filter for cross-entity searches.
-   *
-   * <p>The filters use negated EQUAL conditions which naturally pass through for entities that
-   * don't have the filtered fields. For example, `state != UNPUBLISHED` (negated EQUAL) passes for
-   * datasets (which don't have a state field) because the field doesn't exist with the excluded
-   * value.
+   * Adds default entity-specific filters with optional privilege-based bypass.
    *
    * @param baseFilter The existing filter to combine with default filters (can be null)
    * @param entityTypes List of entity type names being searched
    * @param applyShowInGlobalContext Whether to filter out showInGlobalContext=false documents
+   * @param canManageDocuments When true, unpublished documents are not filtered out (for users with
+   *     MANAGE_DOCUMENTS privilege). DRAFT documents remain excluded regardless.
    * @return The combined filter with default entity filters applied
    */
   @Nullable
   public static Filter addDefaultEntityFilters(
       @Nullable Filter baseFilter,
       @Nonnull List<String> entityTypes,
-      boolean applyShowInGlobalContext) {
+      boolean applyShowInGlobalContext,
+      boolean canManageDocuments) {
 
     // Check if any entity types require default filters
     if (!entityTypes.contains(DOCUMENT_ENTITY_NAME)) {
@@ -133,7 +141,8 @@ public class DefaultEntityFiltersUtil {
     }
 
     // Build default filter for documents (uses negated conditions so non-documents pass through)
-    Filter documentDefaults = buildDocumentDefaultFilter(applyShowInGlobalContext);
+    Filter documentDefaults =
+        buildDocumentDefaultFilter(applyShowInGlobalContext, canManageDocuments);
 
     if (baseFilter == null || !baseFilter.hasOr() || baseFilter.getOr().isEmpty()) {
       return documentDefaults;
@@ -143,36 +152,90 @@ public class DefaultEntityFiltersUtil {
   }
 
   /**
-   * Builds default filter for documents using negated EQUAL conditions.
+   * Applies default entity filters (e.g. PUBLISHED-only, showInGlobalContext for documents) to the
+   * given filter, respecting search flags and user privileges. Skips filtering only when the caller
+   * explicitly requests hidden lifecycle stages.
    *
-   * <p>Using negated conditions allows non-document entities to naturally pass through:
+   * <p>This is the single entry point that all cross-entity search resolvers (search, scroll,
+   * aggregate, browse) should use to ensure consistent document visibility filtering.
    *
-   * <ul>
-   *   <li>`state != UNPUBLISHED` (negated) - passes for non-documents (field doesn't exist) and
-   *       published documents
-   *   <li>`showInGlobalContext != false` (negated) - passes for non-documents and documents meant
-   *       for global visibility
-   * </ul>
+   * @param baseFilter The existing filter to combine with default filters (can be null)
+   * @param entityTypes List of entity type names being searched
+   * @param searchFlags The search flags from the request (can be null)
+   * @param context The query context for authorization checks
+   * @return The combined filter with default entity filters applied
+   */
+  @Nullable
+  public static Filter applyDefaultEntityFilters(
+      @Nullable Filter baseFilter,
+      @Nonnull List<String> entityTypes,
+      @Nullable SearchFlags searchFlags,
+      @Nonnull QueryContext context) {
+    if (searchFlags != null && Boolean.TRUE.equals(searchFlags.isIncludeHiddenLifecycleStages())) {
+      return baseFilter;
+    }
+    boolean canManageDocs =
+        entityTypes.contains(DOCUMENT_ENTITY_NAME)
+            && AuthorizationUtils.canManageDocuments(context);
+    return addDefaultEntityFilters(baseFilter, entityTypes, true, canManageDocs);
+  }
+
+  /**
+   * Builds default filter for documents in cross-entity search. Mirrors the MCP tool's anchor
+   * filter pattern: {@code lifecycleStage = PUBLISHED OR (lifecycleStage IS NULL AND state !=
+   * UNPUBLISHED)}.
+   *
+   * <p>Clause 1 matches documents with the new lifecycleStage field set to PUBLISHED. Clause 2
+   * handles legacy documents (no lifecycleStage) and non-document entities (both fields absent —
+   * negated EQUAL and IS_NULL both succeed when the field does not exist).
    *
    * @param applyShowInGlobalContext Whether to filter out showInGlobalContext=false documents
-   * @return Filter with document defaults using negated conditions
+   * @return Filter with document defaults
    */
-  private static Filter buildDocumentDefaultFilter(boolean applyShowInGlobalContext) {
-    List<Criterion> criteria = new ArrayList<>();
+  private static Filter buildDocumentDefaultFilter(
+      boolean applyShowInGlobalContext, boolean canManageDocuments) {
+    List<ConjunctiveCriterion> orClauses = new ArrayList<>();
 
-    // Exclude unpublished documents (non-documents pass through since they don't have this field)
-    // Using negated EQUAL instead of NOT_EQUAL
-    criteria.add(buildNegatedCriterion("state", "UNPUBLISHED"));
-
-    // Optionally exclude documents not meant for global context
+    // Clause 1: lifecycleStage = PUBLISHED
+    List<Criterion> publishedCriteria = new ArrayList<>();
+    publishedCriteria.add(buildEqualCriterion("lifecycleStage", PUBLISHED_LIFECYCLE_STAGE_URN));
     if (applyShowInGlobalContext) {
-      criteria.add(buildNegatedCriterion("showInGlobalContext", "false"));
+      publishedCriteria.add(buildNegatedCriterion("showInGlobalContext", "false"));
     }
+    orClauses.add(new ConjunctiveCriterion().setAnd(new CriterionArray(publishedCriteria)));
 
-    return new Filter()
-        .setOr(
-            new ConjunctiveCriterionArray(
-                ImmutableList.of(new ConjunctiveCriterion().setAnd(new CriterionArray(criteria)))));
+    // Clause 2: lifecycleStage IS_NULL AND state != UNPUBLISHED (legacy fallback).
+    // Non-document entities also match this clause (both fields absent).
+    // When canManageDocuments is true, skip the state != UNPUBLISHED filter so
+    // privileged users can see unpublished documents.
+    List<Criterion> legacyCriteria = new ArrayList<>();
+    legacyCriteria.add(buildIsNullCriterion("lifecycleStage"));
+    if (!canManageDocuments) {
+      legacyCriteria.add(buildNegatedCriterion("state", "UNPUBLISHED"));
+    }
+    if (applyShowInGlobalContext) {
+      legacyCriteria.add(buildNegatedCriterion("showInGlobalContext", "false"));
+    }
+    orClauses.add(new ConjunctiveCriterion().setAnd(new CriterionArray(legacyCriteria)));
+
+    return new Filter().setOr(new ConjunctiveCriterionArray(orClauses));
+  }
+
+  private static Criterion buildEqualCriterion(String field, String value) {
+    Criterion criterion = new Criterion();
+    criterion.setField(field);
+    criterion.setCondition(Condition.EQUAL);
+    criterion.setValues(
+        new com.linkedin.data.template.StringArray(Collections.singletonList(value)));
+    return criterion;
+  }
+
+  /** Builds an IS_NULL criterion — matches documents where the field is absent / not set. */
+  private static Criterion buildIsNullCriterion(String field) {
+    Criterion criterion = new Criterion();
+    criterion.setField(field);
+    criterion.setCondition(Condition.IS_NULL);
+    return criterion;
   }
 
   /**

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossEntitiesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossEntitiesResolver.java
@@ -3,11 +3,9 @@ package com.linkedin.datahub.graphql.resolvers.search;
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.getQueryContext;
 import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.*;
-import static com.linkedin.metadata.Constants.DOCUMENT_ENTITY_NAME;
 
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.ScrollAcrossEntitiesInput;
@@ -110,16 +108,10 @@ public class ScrollAcrossEntitiesResolver implements DataFetcher<CompletableFutu
                         baseFilter, maybeResolvedView.getDefinition().getFilter())
                     : baseFilter;
 
-            boolean canBypassDocumentDefaults =
-                searchFlags != null
-                    && Boolean.TRUE.equals(searchFlags.isIncludeHiddenLifecycleStages())
-                    && finalEntities.contains(DOCUMENT_ENTITY_NAME)
-                    && AuthorizationUtils.canManageDocuments(context);
-            if (!canBypassDocumentDefaults) {
-              combinedFilter =
-                  DefaultEntityFiltersUtil.addDefaultEntityFilters(
-                      combinedFilter, finalEntities, true);
-            }
+            // Add default entity filters (e.g. showInGlobalContext for documents).
+            combinedFilter =
+                DefaultEntityFiltersUtil.applyDefaultEntityFilters(
+                    combinedFilter, finalEntities, searchFlags, context);
 
             // Execute scroll and remove default filter fields from aggregations
             com.linkedin.metadata.search.ScrollResult scrollResult =

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossEntitiesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossEntitiesResolver.java
@@ -101,10 +101,10 @@ public class SearchAcrossEntitiesResolver implements DataFetcher<CompletableFutu
                         baseFilter, maybeResolvedView.getDefinition().getFilter())
                     : baseFilter;
 
-            // Add default entity filters that should be applied to all queries
+            // Add default entity filters (e.g. showInGlobalContext for documents).
             combinedFilter =
-                DefaultEntityFiltersUtil.addDefaultEntityFilters(
-                    combinedFilter, finalEntities, true);
+                DefaultEntityFiltersUtil.applyDefaultEntityFilters(
+                    combinedFilter, finalEntities, searchFlags, context);
 
             boolean shouldIncludeStructuredPropertyFacets =
                 input.getSearchFlags() != null

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/browse/BrowseV2ResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/browse/BrowseV2ResolverTest.java
@@ -1,8 +1,10 @@
 package com.linkedin.datahub.graphql.resolvers.browse;
 
 import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
+import static com.linkedin.datahub.graphql.TestUtils.getMockDenyContext;
 import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.AuditStamp;
@@ -19,6 +21,7 @@ import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
 import com.linkedin.datahub.graphql.resolvers.chart.BrowseV2Resolver;
 import com.linkedin.datahub.graphql.types.entitytype.EntityTypeMapper;
 import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.browse.BrowseResultGroupV2;
 import com.linkedin.metadata.browse.BrowseResultGroupV2Array;
 import com.linkedin.metadata.browse.BrowseResultMetadata;
@@ -35,7 +38,9 @@ import com.linkedin.view.DataHubViewInfo;
 import com.linkedin.view.DataHubViewType;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -294,6 +299,63 @@ public class BrowseV2ResolverTest {
     info.setDefinition(
         new DataHubViewDefinition().setEntityTypes(entityNames).setFilter(viewFilter));
     return info;
+  }
+
+  @Test
+  public static void testDocumentTypeAppliesDefaultFilters() throws Exception {
+    // When browsing DOCUMENT entities, default document filters (showInGlobalContext) should be
+    // applied so bridge documents don't inflate browse counts.
+    FormService mockFormService = Mockito.mock(FormService.class);
+    ViewService mockService = Mockito.mock(ViewService.class);
+
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.when(
+            mockClient.browseV2(
+                any(),
+                Mockito.anyList(),
+                Mockito.anyString(),
+                Mockito.any(Filter.class),
+                Mockito.anyString(),
+                Mockito.anyInt(),
+                Mockito.anyInt()))
+        .thenReturn(
+            new BrowseResultV2()
+                .setNumGroups(0)
+                .setGroups(new BrowseResultGroupV2Array())
+                .setMetadata(new BrowseResultMetadata().setPath("").setTotalNumEntities(0))
+                .setFrom(0)
+                .setPageSize(10));
+
+    final BrowseV2Resolver resolver =
+        new BrowseV2Resolver(mockClient, mockService, mockFormService);
+
+    BrowseV2Input input = new BrowseV2Input();
+    input.setPath(new ArrayList<>());
+    input.setType(EntityType.DOCUMENT);
+
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockDenyContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    resolver.get(mockEnv).get();
+
+    ArgumentCaptor<Filter> filterCaptor = ArgumentCaptor.forClass(Filter.class);
+    Mockito.verify(mockClient)
+        .browseV2(
+            any(),
+            eq(Collections.singletonList(Constants.DOCUMENT_ENTITY_NAME)),
+            eq(""),
+            filterCaptor.capture(),
+            eq("*"),
+            eq(0),
+            eq(10));
+    Filter appliedFilter = filterCaptor.getValue();
+    Assert.assertNotNull(appliedFilter);
+    Assert.assertTrue(
+        appliedFilter.getOr().stream()
+            .flatMap(clause -> clause.getAnd().stream())
+            .anyMatch(c -> "showInGlobalContext".equals(c.getField())));
   }
 
   @Test

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentSearchFilterUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/DocumentSearchFilterUtilsTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.datahub.graphql.resolvers.knowledge;
 
+import static com.linkedin.datahub.graphql.resolvers.knowledge.DocumentSearchFilterUtils.*;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -10,6 +11,7 @@ import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.utils.CriterionUtils;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.testng.annotations.Test;
 
 public class DocumentSearchFilterUtilsTest {
@@ -17,250 +19,195 @@ public class DocumentSearchFilterUtilsTest {
   private static final String TEST_USER_URN = "urn:li:corpuser:test";
   private static final String TEST_GROUP_URN = "urn:li:corpGroup:testGroup";
 
-  @Test
-  public void testBuildCombinedFilterWithEmptyBaseCriteria() {
-    List<Criterion> baseCriteria = new ArrayList<>();
-    List<String> userAndGroupUrns = ImmutableList.of(TEST_USER_URN, TEST_GROUP_URN);
+  // ---- helpers ----
 
-    Filter filter = DocumentSearchFilterUtils.buildCombinedFilter(baseCriteria, userAndGroupUrns);
+  private static Criterion findCriterion(ConjunctiveCriterion clause, String field) {
+    return clause.getAnd().stream()
+        .filter(c -> field.equals(c.getField()))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static void assertShowInGlobalContextNegated(ConjunctiveCriterion clause) {
+    Criterion c = findCriterion(clause, "showInGlobalContext");
+    assertNotNull(c, "showInGlobalContext criterion missing");
+    assertEquals(c.getCondition(), Condition.EQUAL);
+    assertEquals(c.getValues().get(0), "false");
+    assertTrue(c.isNegated());
+  }
+
+  // ---- tests ----
+
+  @Test
+  public void testBuildCombinedFilterProducesFourClauses() {
+    List<Criterion> baseCriteria = new ArrayList<>();
+    List<String> urns = ImmutableList.of(TEST_USER_URN, TEST_GROUP_URN);
+
+    Filter filter = DocumentSearchFilterUtils.buildCombinedFilter(baseCriteria, urns, true, false);
 
     assertNotNull(filter);
     assertNotNull(filter.getOr());
-    assertEquals(filter.getOr().size(), 2); // PUBLISHED OR UNPUBLISHED owned
-
-    // Check first clause: PUBLISHED AND showInGlobalContext!=false
-    ConjunctiveCriterion publishedClause = filter.getOr().get(0);
-    assertNotNull(publishedClause.getAnd());
-    assertEquals(publishedClause.getAnd().size(), 2); // state + showInGlobalContext
-    Criterion stateCriterion = publishedClause.getAnd().get(0);
-    assertEquals(stateCriterion.getField(), "state");
-    assertEquals(stateCriterion.getCondition(), Condition.EQUAL);
-    assertEquals(stateCriterion.getValues().get(0), "PUBLISHED");
-    // Verify showInGlobalContext uses negated filter (exclude false, not require true)
-    Criterion showInGlobalContextCriterion = publishedClause.getAnd().get(1);
-    assertEquals(showInGlobalContextCriterion.getField(), "showInGlobalContext");
-    assertEquals(showInGlobalContextCriterion.getCondition(), Condition.EQUAL);
-    assertEquals(showInGlobalContextCriterion.getValues().get(0), "false");
-    assertTrue(showInGlobalContextCriterion.isNegated());
-
-    // Check second clause: UNPUBLISHED AND owned AND showInGlobalContext!=false
-    ConjunctiveCriterion unpublishedClause = filter.getOr().get(1);
-    assertNotNull(unpublishedClause.getAnd());
-    assertEquals(unpublishedClause.getAnd().size(), 3); // State + owners + showInGlobalContext
-    Criterion unpublishedStateCriterion = unpublishedClause.getAnd().get(0);
-    assertEquals(unpublishedStateCriterion.getField(), "state");
-    assertEquals(unpublishedStateCriterion.getCondition(), Condition.EQUAL);
-    assertEquals(unpublishedStateCriterion.getValues().get(0), "UNPUBLISHED");
-    Criterion ownersCriterion = unpublishedClause.getAnd().get(1);
-    assertEquals(ownersCriterion.getField(), "owners");
-    assertEquals(ownersCriterion.getCondition(), Condition.EQUAL);
-    assertTrue(ownersCriterion.getValues().contains(TEST_USER_URN));
-    assertTrue(ownersCriterion.getValues().contains(TEST_GROUP_URN));
-    // Verify showInGlobalContext uses negated filter in unpublished clause
-    Criterion unpublishedShowInGlobalContextCriterion = unpublishedClause.getAnd().get(2);
-    assertEquals(unpublishedShowInGlobalContextCriterion.getField(), "showInGlobalContext");
-    assertEquals(unpublishedShowInGlobalContextCriterion.getCondition(), Condition.EQUAL);
-    assertEquals(unpublishedShowInGlobalContextCriterion.getValues().get(0), "false");
-    assertTrue(unpublishedShowInGlobalContextCriterion.isNegated());
+    assertEquals(filter.getOr().size(), 4);
   }
 
   @Test
-  public void testBuildCombinedFilterWithBaseCriteria() {
+  public void testClause1_LifecyclePublished() {
+    List<String> urns = ImmutableList.of(TEST_USER_URN);
+    Filter filter =
+        DocumentSearchFilterUtils.buildCombinedFilter(new ArrayList<>(), urns, true, false);
+
+    // Clause 1: lifecycleStage = PUBLISHED_URN + showInGlobalContext!=false
+    ConjunctiveCriterion clause = filter.getOr().get(0);
+    assertEquals(clause.getAnd().size(), 2);
+
+    Criterion lifecycle = findCriterion(clause, "lifecycleStage");
+    assertNotNull(lifecycle);
+    assertEquals(lifecycle.getCondition(), Condition.EQUAL);
+    assertEquals(lifecycle.getValues().get(0), PUBLISHED_LIFECYCLE_STAGE_URN);
+
+    assertShowInGlobalContextNegated(clause);
+    // No owners filter required
+    assertNull(findCriterion(clause, "owners"));
+  }
+
+  @Test
+  public void testClause2_LifecycleNonPublishedOwned() {
+    List<String> urns = ImmutableList.of(TEST_USER_URN, TEST_GROUP_URN);
+    Filter filter =
+        DocumentSearchFilterUtils.buildCombinedFilter(new ArrayList<>(), urns, true, false);
+
+    // Clause 2: lifecycleStage != PUBLISHED + lifecycleStage != DRAFT + lifecycleStage EXISTS +
+    // owners + showInGlobalContext!=false
+    ConjunctiveCriterion clause = filter.getOr().get(1);
+    assertEquals(clause.getAnd().size(), 5);
+
+    // Collect negated lifecycleStage criteria and the EXISTS criterion
+    List<Criterion> negatedLifecycleCriteria = new ArrayList<>();
+    Criterion existsLifecycle = null;
+    for (Criterion c : clause.getAnd()) {
+      if ("lifecycleStage".equals(c.getField())) {
+        if (c.getCondition() == Condition.EXISTS) {
+          existsLifecycle = c;
+        } else if (c.isNegated()) {
+          negatedLifecycleCriteria.add(c);
+        }
+      }
+    }
+
+    // Must exclude both PUBLISHED and DRAFT
+    assertEquals(negatedLifecycleCriteria.size(), 2);
+    List<String> negatedValues =
+        negatedLifecycleCriteria.stream()
+            .flatMap(c -> c.getValues().stream())
+            .collect(Collectors.toList());
+    assertTrue(negatedValues.contains(PUBLISHED_LIFECYCLE_STAGE_URN));
+    assertTrue(negatedValues.contains(DRAFT_LIFECYCLE_STAGE_URN));
+    assertNotNull(existsLifecycle);
+
+    Criterion owners = findCriterion(clause, "owners");
+    assertNotNull(owners);
+    assertTrue(owners.getValues().contains(TEST_USER_URN));
+    assertTrue(owners.getValues().contains(TEST_GROUP_URN));
+
+    assertShowInGlobalContextNegated(clause);
+  }
+
+  @Test
+  public void testClause3_LegacyPublished() {
+    List<String> urns = ImmutableList.of(TEST_USER_URN);
+    Filter filter =
+        DocumentSearchFilterUtils.buildCombinedFilter(new ArrayList<>(), urns, true, false);
+
+    // Clause 3: lifecycleStage IS_NULL + state = PUBLISHED + showInGlobalContext!=false
+    ConjunctiveCriterion clause = filter.getOr().get(2);
+    assertEquals(clause.getAnd().size(), 3);
+
+    Criterion lifecycle = findCriterion(clause, "lifecycleStage");
+    assertNotNull(lifecycle);
+    assertEquals(lifecycle.getCondition(), Condition.IS_NULL);
+
+    Criterion state = findCriterion(clause, "state");
+    assertNotNull(state);
+    assertEquals(state.getCondition(), Condition.EQUAL);
+    assertEquals(state.getValues().get(0), "PUBLISHED");
+
+    assertShowInGlobalContextNegated(clause);
+    assertNull(findCriterion(clause, "owners"));
+  }
+
+  @Test
+  public void testClause4_LegacyUnpublishedOwned() {
+    List<String> urns = ImmutableList.of(TEST_USER_URN, TEST_GROUP_URN);
+    Filter filter =
+        DocumentSearchFilterUtils.buildCombinedFilter(new ArrayList<>(), urns, true, false);
+
+    // Clause 4: lifecycleStage IS_NULL + state = UNPUBLISHED + owners + showInGlobalContext!=false
+    ConjunctiveCriterion clause = filter.getOr().get(3);
+    assertEquals(clause.getAnd().size(), 4);
+
+    Criterion lifecycle = findCriterion(clause, "lifecycleStage");
+    assertNotNull(lifecycle);
+    assertEquals(lifecycle.getCondition(), Condition.IS_NULL);
+
+    Criterion state = findCriterion(clause, "state");
+    assertNotNull(state);
+    assertEquals(state.getValues().get(0), "UNPUBLISHED");
+
+    Criterion owners = findCriterion(clause, "owners");
+    assertNotNull(owners);
+    assertTrue(owners.getValues().contains(TEST_USER_URN));
+    assertTrue(owners.getValues().contains(TEST_GROUP_URN));
+
+    assertShowInGlobalContextNegated(clause);
+  }
+
+  @Test
+  public void testCanManageDocuments_SkipsOwnershipConstraints() {
+    List<String> urns = ImmutableList.of(TEST_USER_URN);
+    Filter filter =
+        DocumentSearchFilterUtils.buildCombinedFilter(new ArrayList<>(), urns, true, true);
+
+    assertEquals(filter.getOr().size(), 4);
+
+    // Clause 2: no owners filter when canManageDocuments=true
+    ConjunctiveCriterion clause2 = filter.getOr().get(1);
+    assertNull(findCriterion(clause2, "owners"));
+
+    // Clause 4: no owners filter when canManageDocuments=true
+    ConjunctiveCriterion clause4 = filter.getOr().get(3);
+    assertNull(findCriterion(clause4, "owners"));
+  }
+
+  @Test
+  public void testWithoutShowInGlobalContext() {
+    List<String> urns = ImmutableList.of(TEST_USER_URN);
+    Filter filter =
+        DocumentSearchFilterUtils.buildCombinedFilter(new ArrayList<>(), urns, false, false);
+
+    assertEquals(filter.getOr().size(), 4);
+
+    // No showInGlobalContext in any clause
+    for (ConjunctiveCriterion clause : filter.getOr()) {
+      assertNull(
+          findCriterion(clause, "showInGlobalContext"),
+          "showInGlobalContext should not be present when applyShowInGlobalContext=false");
+    }
+  }
+
+  @Test
+  public void testBaseCriteriaIncludedInAllClauses() {
     List<Criterion> baseCriteria = new ArrayList<>();
     baseCriteria.add(
         CriterionUtils.buildCriterion("types", Condition.EQUAL, ImmutableList.of("tutorial")));
-    baseCriteria.add(
-        CriterionUtils.buildCriterion(
-            "domains", Condition.EQUAL, ImmutableList.of("urn:li:domain:test")));
 
-    List<String> userAndGroupUrns = ImmutableList.of(TEST_USER_URN);
+    List<String> urns = ImmutableList.of(TEST_USER_URN);
+    Filter filter = DocumentSearchFilterUtils.buildCombinedFilter(baseCriteria, urns, true, false);
 
-    Filter filter = DocumentSearchFilterUtils.buildCombinedFilter(baseCriteria, userAndGroupUrns);
+    assertEquals(filter.getOr().size(), 4);
 
-    assertNotNull(filter);
-    assertNotNull(filter.getOr());
-    assertEquals(filter.getOr().size(), 2);
-
-    // Check first clause: base criteria AND PUBLISHED AND showInGlobalContext!=false
-    ConjunctiveCriterion publishedClause = filter.getOr().get(0);
-    assertNotNull(publishedClause.getAnd());
-    assertEquals(
-        publishedClause.getAnd().size(), 4); // types + domains + state + showInGlobalContext
-
-    // Check second clause: base criteria AND UNPUBLISHED AND owned AND showInGlobalContext!=false
-    ConjunctiveCriterion unpublishedClause = filter.getOr().get(1);
-    assertNotNull(unpublishedClause.getAnd());
-    assertEquals(
-        unpublishedClause.getAnd().size(),
-        5); // types + domains + state + owners + showInGlobalContext
-
-    // Verify base criteria and showInGlobalContext are in both clauses
-    boolean foundTypesInPublished = false;
-    boolean foundDomainsInPublished = false;
-    boolean foundTypesInUnpublished = false;
-    boolean foundDomainsInUnpublished = false;
-    boolean foundShowInGlobalContextInPublished = false;
-    boolean foundShowInGlobalContextInUnpublished = false;
-
-    for (Criterion criterion : publishedClause.getAnd()) {
-      if ("types".equals(criterion.getField())) {
-        foundTypesInPublished = true;
-      }
-      if ("domains".equals(criterion.getField())) {
-        foundDomainsInPublished = true;
-      }
-      if ("showInGlobalContext".equals(criterion.getField())) {
-        foundShowInGlobalContextInPublished = true;
-        assertTrue(criterion.isNegated(), "showInGlobalContext should use negated filter");
-      }
+    // Every clause should include the base criteria
+    for (ConjunctiveCriterion clause : filter.getOr()) {
+      assertNotNull(findCriterion(clause, "types"), "Base criteria should be in every clause");
     }
-
-    for (Criterion criterion : unpublishedClause.getAnd()) {
-      if ("types".equals(criterion.getField())) {
-        foundTypesInUnpublished = true;
-      }
-      if ("domains".equals(criterion.getField())) {
-        foundDomainsInUnpublished = true;
-      }
-      if ("showInGlobalContext".equals(criterion.getField())) {
-        foundShowInGlobalContextInUnpublished = true;
-        assertTrue(criterion.isNegated(), "showInGlobalContext should use negated filter");
-      }
-    }
-
-    assertTrue(foundTypesInPublished, "Types filter should be in published clause");
-    assertTrue(foundDomainsInPublished, "Domains filter should be in published clause");
-    assertTrue(
-        foundShowInGlobalContextInPublished,
-        "showInGlobalContext filter should be in published clause");
-    assertTrue(foundTypesInUnpublished, "Types filter should be in unpublished clause");
-    assertTrue(foundDomainsInUnpublished, "Domains filter should be in unpublished clause");
-    assertTrue(
-        foundShowInGlobalContextInUnpublished,
-        "showInGlobalContext filter should be in unpublished clause");
-  }
-
-  @Test
-  public void testBuildCombinedFilterWithSingleUser() {
-    List<Criterion> baseCriteria = new ArrayList<>();
-    List<String> userAndGroupUrns = ImmutableList.of(TEST_USER_URN);
-
-    Filter filter = DocumentSearchFilterUtils.buildCombinedFilter(baseCriteria, userAndGroupUrns);
-
-    assertNotNull(filter);
-    assertNotNull(filter.getOr());
-    assertEquals(filter.getOr().size(), 2);
-
-    // Check owners filter in unpublished clause (state, owners, showInGlobalContext)
-    ConjunctiveCriterion unpublishedClause = filter.getOr().get(1);
-    assertEquals(unpublishedClause.getAnd().size(), 3); // state + owners + showInGlobalContext
-    Criterion ownersCriterion = unpublishedClause.getAnd().get(1);
-    assertEquals(ownersCriterion.getField(), "owners");
-    assertEquals(ownersCriterion.getValues().size(), 1);
-    assertEquals(ownersCriterion.getValues().get(0), TEST_USER_URN);
-  }
-
-  @Test
-  public void testBuildCombinedFilterWithMultipleGroups() {
-    List<Criterion> baseCriteria = new ArrayList<>();
-    List<String> userAndGroupUrns =
-        ImmutableList.of(TEST_USER_URN, TEST_GROUP_URN, "urn:li:corpGroup:anotherGroup");
-
-    Filter filter = DocumentSearchFilterUtils.buildCombinedFilter(baseCriteria, userAndGroupUrns);
-
-    assertNotNull(filter);
-    assertNotNull(filter.getOr());
-    assertEquals(filter.getOr().size(), 2);
-
-    // Check owners filter includes all URNs (state, owners, showInGlobalContext)
-    ConjunctiveCriterion unpublishedClause = filter.getOr().get(1);
-    assertEquals(unpublishedClause.getAnd().size(), 3); // state + owners + showInGlobalContext
-    Criterion ownersCriterion = unpublishedClause.getAnd().get(1);
-    assertEquals(ownersCriterion.getField(), "owners");
-    assertEquals(ownersCriterion.getValues().size(), 3);
-    assertTrue(ownersCriterion.getValues().contains(TEST_USER_URN));
-    assertTrue(ownersCriterion.getValues().contains(TEST_GROUP_URN));
-    assertTrue(ownersCriterion.getValues().contains("urn:li:corpGroup:anotherGroup"));
-  }
-
-  @Test
-  public void testBuildCombinedFilterStructure() {
-    // Verify the filter structure: (base AND PUBLISHED AND showInGlobalContext!=false)
-    // OR (base AND UNPUBLISHED AND owners AND showInGlobalContext!=false)
-    List<Criterion> baseCriteria = new ArrayList<>();
-    baseCriteria.add(
-        CriterionUtils.buildCriterion(
-            "relatedAssets", Condition.EQUAL, ImmutableList.of("urn:li:dataset:test")));
-
-    List<String> userAndGroupUrns = ImmutableList.of(TEST_USER_URN);
-
-    Filter filter = DocumentSearchFilterUtils.buildCombinedFilter(baseCriteria, userAndGroupUrns);
-
-    assertNotNull(filter);
-    assertNotNull(filter.getOr());
-    assertEquals(filter.getOr().size(), 2);
-
-    // Published clause should have: relatedAssets + state + showInGlobalContext
-    ConjunctiveCriterion publishedClause = filter.getOr().get(0);
-    assertEquals(publishedClause.getAnd().size(), 3);
-    assertEquals(publishedClause.getAnd().get(1).getField(), "state");
-    assertEquals(publishedClause.getAnd().get(1).getValues().get(0), "PUBLISHED");
-    assertEquals(publishedClause.getAnd().get(2).getField(), "showInGlobalContext");
-    assertEquals(publishedClause.getAnd().get(2).getValues().get(0), "false");
-    assertTrue(publishedClause.getAnd().get(2).isNegated());
-
-    // Unpublished clause should have: relatedAssets + state + owners + showInGlobalContext
-    ConjunctiveCriterion unpublishedClause = filter.getOr().get(1);
-    assertEquals(unpublishedClause.getAnd().size(), 4);
-    assertEquals(unpublishedClause.getAnd().get(1).getField(), "state");
-    assertEquals(unpublishedClause.getAnd().get(1).getValues().get(0), "UNPUBLISHED");
-    assertEquals(unpublishedClause.getAnd().get(2).getField(), "owners");
-    assertEquals(unpublishedClause.getAnd().get(3).getField(), "showInGlobalContext");
-    assertEquals(unpublishedClause.getAnd().get(3).getValues().get(0), "false");
-    assertTrue(unpublishedClause.getAnd().get(3).isNegated());
-  }
-
-  @Test
-  public void testBuildCombinedFilterExcludesExplicitlyHidden() {
-    // Verify that showInGlobalContext!=false is used in both published and unpublished clauses.
-    // This excludes only documents that explicitly set showInGlobalContext=false;
-    // documents without a documentSettings aspect are included by default.
-    List<Criterion> baseCriteria = new ArrayList<>();
-    List<String> userAndGroupUrns = ImmutableList.of(TEST_USER_URN);
-
-    Filter filter = DocumentSearchFilterUtils.buildCombinedFilter(baseCriteria, userAndGroupUrns);
-
-    assertNotNull(filter);
-    assertNotNull(filter.getOr());
-    assertEquals(filter.getOr().size(), 2);
-
-    // Both clauses should have negated showInGlobalContext=false criterion
-    boolean foundNegatedInPublished = false;
-    boolean foundNegatedInUnpublished = false;
-
-    ConjunctiveCriterion publishedClause = filter.getOr().get(0);
-    for (Criterion criterion : publishedClause.getAnd()) {
-      if ("showInGlobalContext".equals(criterion.getField())
-          && criterion.getCondition() == Condition.EQUAL
-          && criterion.getValues().contains("false")
-          && criterion.isNegated()) {
-        foundNegatedInPublished = true;
-      }
-    }
-
-    ConjunctiveCriterion unpublishedClause = filter.getOr().get(1);
-    for (Criterion criterion : unpublishedClause.getAnd()) {
-      if ("showInGlobalContext".equals(criterion.getField())
-          && criterion.getCondition() == Condition.EQUAL
-          && criterion.getValues().contains("false")
-          && criterion.isNegated()) {
-        foundNegatedInUnpublished = true;
-      }
-    }
-
-    assertTrue(
-        foundNegatedInPublished, "Published clause should exclude showInGlobalContext=false");
-    assertTrue(
-        foundNegatedInUnpublished, "Unpublished clause should exclude showInGlobalContext=false");
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/RelatedDocumentsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/RelatedDocumentsResolverTest.java
@@ -218,7 +218,9 @@ public class RelatedDocumentsResolverTest {
     Filter capturedFilter = filterCaptor.getValue();
     assertNotNull(capturedFilter);
     assertNotNull(capturedFilter.getOr());
-    assertEquals(capturedFilter.getOr().size(), 2); // PUBLISHED OR UNPUBLISHED owned
+    // 4 clauses: lifecycle published, lifecycle non-published owned, legacy published, legacy
+    // unpublished owned
+    assertEquals(capturedFilter.getOr().size(), 4);
 
     // Check that relatedAssets filter is in both clauses
     boolean foundRelatedAssetsFilter = false;

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/AggregateAcrossEntitiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/AggregateAcrossEntitiesResolverTest.java
@@ -1,9 +1,12 @@
 package com.linkedin.datahub.graphql.resolvers.search;
 
 import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
+import static com.linkedin.datahub.graphql.TestUtils.getMockDenyContext;
 import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.SEARCHABLE_ENTITY_TYPES;
 import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.AuditStamp;
@@ -22,6 +25,7 @@ import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.Criterion;
 import com.linkedin.metadata.query.filter.CriterionArray;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchEntityArray;
@@ -38,6 +42,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -270,6 +275,7 @@ public class AggregateAcrossEntitiesResolverTest {
   @Test
   public static void testApplyViewViewDoesNotExist() throws Exception {
     // When a view does not exist, the endpoint should WARN and not apply the view.
+    // Since DOCUMENT is in SEARCHABLE_ENTITY_TYPES, document default filters are applied.
 
     FormService mockFormService = Mockito.mock(FormService.class);
     ViewService mockService = initMockViewService(TEST_VIEW_URN, null);
@@ -279,11 +285,13 @@ public class AggregateAcrossEntitiesResolverTest {
             .map(EntityTypeMapper::getName)
             .collect(Collectors.toList());
 
+    Filter expectedDocumentFilter = buildDocumentDefaultFilter();
+
     EntityClient mockClient =
         initMockEntityClient(
             searchEntityTypes,
             "",
-            null,
+            expectedDocumentFilter,
             0,
             0,
             null,
@@ -306,7 +314,7 @@ public class AggregateAcrossEntitiesResolverTest {
 
     resolver.get(mockEnv).get();
 
-    verifyMockEntityClient(mockClient, searchEntityTypes, "", null, 0, 0, null);
+    verifyMockEntityClient(mockClient, searchEntityTypes, "", expectedDocumentFilter, 0, 0, null);
   }
 
   @Test
@@ -338,6 +346,220 @@ public class AggregateAcrossEntitiesResolverTest {
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     Assert.assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+  }
+
+  @Test
+  public static void testDocumentTypeAppliesDefaultFilters() throws Exception {
+    // When DOCUMENT is in the entity types, default document filters (lifecycleStage,
+    // showInGlobalContext) should be applied — this is the bug fix for bridge documents
+    // inflating sidebar counts.
+    FormService mockFormService = Mockito.mock(FormService.class);
+    ViewService mockService = Mockito.mock(ViewService.class);
+
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.when(
+            mockClient.searchAcrossEntities(
+                any(),
+                Mockito.anyList(),
+                Mockito.anyString(),
+                Mockito.any(),
+                Mockito.anyInt(),
+                Mockito.anyInt(),
+                Mockito.eq(Collections.emptyList()),
+                Mockito.eq(null)))
+        .thenReturn(
+            new SearchResult()
+                .setEntities(new SearchEntityArray())
+                .setNumEntities(0)
+                .setFrom(0)
+                .setPageSize(0)
+                .setMetadata(new SearchResultMetadata()));
+
+    final AggregateAcrossEntitiesResolver resolver =
+        new AggregateAcrossEntitiesResolver(mockClient, mockService, mockFormService);
+
+    final AggregateAcrossEntitiesInput testInput =
+        new AggregateAcrossEntitiesInput(
+            ImmutableList.of(EntityType.DOCUMENT), "", null, null, null, null);
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    resolver.get(mockEnv).get();
+
+    ArgumentCaptor<Filter> filterCaptor = ArgumentCaptor.forClass(Filter.class);
+    Mockito.verify(mockClient)
+        .searchAcrossEntities(
+            any(),
+            eq(Collections.singletonList(Constants.DOCUMENT_ENTITY_NAME)),
+            eq(""),
+            filterCaptor.capture(),
+            eq(0),
+            eq(0),
+            eq(Collections.emptyList()),
+            Mockito.eq(null));
+    Filter appliedFilter = filterCaptor.getValue();
+    assertNotNull(appliedFilter);
+    assertTrue(filterContainsField(appliedFilter, "lifecycleStage"));
+    assertTrue(filterContainsField(appliedFilter, "showInGlobalContext"));
+  }
+
+  @Test
+  public static void testNonDocumentTypeDoesNotAddDefaultFilters() throws Exception {
+    FormService mockFormService = Mockito.mock(FormService.class);
+    ViewService mockService = Mockito.mock(ViewService.class);
+
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.when(
+            mockClient.searchAcrossEntities(
+                any(),
+                Mockito.anyList(),
+                Mockito.anyString(),
+                Mockito.any(),
+                Mockito.anyInt(),
+                Mockito.anyInt(),
+                Mockito.eq(Collections.emptyList()),
+                Mockito.eq(null)))
+        .thenReturn(
+            new SearchResult()
+                .setEntities(new SearchEntityArray())
+                .setNumEntities(0)
+                .setFrom(0)
+                .setPageSize(0)
+                .setMetadata(new SearchResultMetadata()));
+
+    final AggregateAcrossEntitiesResolver resolver =
+        new AggregateAcrossEntitiesResolver(mockClient, mockService, mockFormService);
+
+    final AggregateAcrossEntitiesInput testInput =
+        new AggregateAcrossEntitiesInput(
+            ImmutableList.of(EntityType.DATASET), "", null, null, null, null);
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    resolver.get(mockEnv).get();
+
+    ArgumentCaptor<Filter> filterCaptor = ArgumentCaptor.forClass(Filter.class);
+    Mockito.verify(mockClient)
+        .searchAcrossEntities(
+            any(),
+            eq(Collections.singletonList(Constants.DATASET_ENTITY_NAME)),
+            eq(""),
+            filterCaptor.capture(),
+            eq(0),
+            eq(0),
+            eq(Collections.emptyList()),
+            Mockito.eq(null));
+    assertNull(filterCaptor.getValue());
+  }
+
+  @Test
+  public static void testIncludeHiddenLifecycleStagesBypassesDocumentDefaultFilters()
+      throws Exception {
+    FormService mockFormService = Mockito.mock(FormService.class);
+    ViewService mockService = Mockito.mock(ViewService.class);
+
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.when(
+            mockClient.searchAcrossEntities(
+                any(),
+                Mockito.anyList(),
+                Mockito.anyString(),
+                Mockito.any(),
+                Mockito.anyInt(),
+                Mockito.anyInt(),
+                Mockito.eq(Collections.emptyList()),
+                Mockito.eq(null)))
+        .thenReturn(
+            new SearchResult()
+                .setEntities(new SearchEntityArray())
+                .setNumEntities(0)
+                .setFrom(0)
+                .setPageSize(0)
+                .setMetadata(new SearchResultMetadata()));
+
+    final AggregateAcrossEntitiesResolver resolver =
+        new AggregateAcrossEntitiesResolver(mockClient, mockService, mockFormService);
+
+    com.linkedin.datahub.graphql.generated.SearchFlags gqlFlags =
+        new com.linkedin.datahub.graphql.generated.SearchFlags();
+    gqlFlags.setIncludeHiddenLifecycleStages(true);
+
+    final AggregateAcrossEntitiesInput testInput =
+        new AggregateAcrossEntitiesInput(
+            ImmutableList.of(EntityType.DOCUMENT), "", null, null, null, gqlFlags);
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockDenyContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    resolver.get(mockEnv).get();
+
+    ArgumentCaptor<Filter> filterCaptor = ArgumentCaptor.forClass(Filter.class);
+    Mockito.verify(mockClient)
+        .searchAcrossEntities(
+            any(),
+            eq(Collections.singletonList(Constants.DOCUMENT_ENTITY_NAME)),
+            eq(""),
+            filterCaptor.capture(),
+            eq(0),
+            eq(0),
+            eq(Collections.emptyList()),
+            Mockito.eq(null));
+    assertNull(filterCaptor.getValue());
+  }
+
+  private static boolean filterContainsField(Filter filter, String fieldName) {
+    if (filter == null || !filter.hasOr()) return false;
+    return filter.getOr().stream()
+        .flatMap(clause -> clause.getAnd().stream())
+        .anyMatch(criterion -> fieldName.equals(criterion.getField()));
+  }
+
+  /**
+   * Builds the default document filter applied when DOCUMENT is in entity types. Since
+   * getMockAllowContext allows all privileges (canManageDocuments=true), the legacy clause omits
+   * the state != UNPUBLISHED filter.
+   */
+  private static Filter buildDocumentDefaultFilter() {
+    Criterion lifecycleCriterion = new Criterion();
+    lifecycleCriterion.setField("lifecycleStage");
+    lifecycleCriterion.setCondition(Condition.EQUAL);
+    lifecycleCriterion.setValues(
+        new com.linkedin.data.template.StringArray(
+            Collections.singletonList("urn:li:lifecycleStageType:PUBLISHED")));
+
+    ConjunctiveCriterion publishedClause =
+        new ConjunctiveCriterion()
+            .setAnd(
+                new CriterionArray(
+                    ImmutableList.of(lifecycleCriterion, buildShowInGlobalContextCriterion())));
+
+    Criterion isNullCriterion = new Criterion();
+    isNullCriterion.setField("lifecycleStage");
+    isNullCriterion.setCondition(Condition.IS_NULL);
+
+    ConjunctiveCriterion legacyClause =
+        new ConjunctiveCriterion()
+            .setAnd(
+                new CriterionArray(
+                    ImmutableList.of(isNullCriterion, buildShowInGlobalContextCriterion())));
+
+    return new Filter()
+        .setOr(new ConjunctiveCriterionArray(ImmutableList.of(publishedClause, legacyClause)));
+  }
+
+  private static Criterion buildShowInGlobalContextCriterion() {
+    Criterion criterion = new Criterion();
+    criterion.setField("showInGlobalContext");
+    criterion.setCondition(Condition.EQUAL);
+    criterion.setValues(
+        new com.linkedin.data.template.StringArray(Collections.singletonList("false")));
+    criterion.setNegated(true);
+    return criterion;
   }
 
   private static Filter createFilter(String field, String value) {

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/DefaultEntityFiltersUtilTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/DefaultEntityFiltersUtilTest.java
@@ -26,7 +26,8 @@ public class DefaultEntityFiltersUtilTest {
     // When DOCUMENT is not in the entity types, no filters should be added
     List<String> entityTypes = ImmutableList.of(DATASET_ENTITY_NAME);
 
-    Filter result = DefaultEntityFiltersUtil.addDefaultEntityFilters(null, entityTypes, true);
+    Filter result =
+        DefaultEntityFiltersUtil.addDefaultEntityFilters(null, entityTypes, true, false);
 
     assertNull(result);
   }
@@ -37,48 +38,60 @@ public class DefaultEntityFiltersUtilTest {
     List<String> entityTypes = ImmutableList.of(DATASET_ENTITY_NAME);
     Filter baseFilter = new Filter();
 
-    Filter result = DefaultEntityFiltersUtil.addDefaultEntityFilters(baseFilter, entityTypes, true);
+    Filter result =
+        DefaultEntityFiltersUtil.addDefaultEntityFilters(baseFilter, entityTypes, true, false);
 
     assertSame(result, baseFilter);
   }
 
   @Test
   public void testAddDefaultEntityFilters_WithDocumentAndShowInGlobalContext() {
-    // When DOCUMENT is in entity types with showInGlobalContext=true,
-    // should add document filters using negated EQUAL for cross-entity compatibility
+    // Should produce two OR clauses: lifecycleStage = PUBLISHED, legacy fallback
     List<String> entityTypes = ImmutableList.of(DATASET_ENTITY_NAME, DOCUMENT_ENTITY_NAME);
 
-    Filter result = DefaultEntityFiltersUtil.addDefaultEntityFilters(null, entityTypes, true);
+    Filter result =
+        DefaultEntityFiltersUtil.addDefaultEntityFilters(null, entityTypes, true, false);
 
     assertNotNull(result);
     assertNotNull(result.getOr());
-    assertEquals(result.getOr().size(), 1); // Single AND clause with negated conditions
+    assertEquals(result.getOr().size(), 2);
 
-    ConjunctiveCriterion clause = result.getOr().get(0);
-    assertEquals(clause.getAnd().size(), 2); // state, showInGlobalContext
+    // Clause 1: lifecycleStage = PUBLISHED AND showInGlobalContext != false
+    ConjunctiveCriterion publishedClause = result.getOr().get(0);
+    assertEquals(publishedClause.getAnd().size(), 2);
+    assertTrue(hasFieldWithCondition(publishedClause, "lifecycleStage", Condition.EQUAL));
+    assertTrue(
+        hasNegatedFieldWithCondition(publishedClause, "showInGlobalContext", Condition.EQUAL));
 
-    // Verify negated EQUAL conditions (these pass for non-documents since field doesn't exist)
-    assertTrue(hasNegatedFieldWithCondition(clause, "state", Condition.EQUAL));
-    assertTrue(hasNegatedFieldWithCondition(clause, "showInGlobalContext", Condition.EQUAL));
+    // Clause 2: lifecycleStage IS_NULL AND state != UNPUBLISHED AND showInGlobalContext != false
+    ConjunctiveCriterion legacyClause = result.getOr().get(1);
+    assertEquals(legacyClause.getAnd().size(), 3);
+    assertTrue(hasFieldWithCondition(legacyClause, "lifecycleStage", Condition.IS_NULL));
+    assertTrue(hasNegatedFieldWithCondition(legacyClause, "state", Condition.EQUAL));
+    assertTrue(hasNegatedFieldWithCondition(legacyClause, "showInGlobalContext", Condition.EQUAL));
   }
 
   @Test
   public void testAddDefaultEntityFilters_WithDocumentWithoutShowInGlobalContext() {
-    // When DOCUMENT is in entity types with showInGlobalContext=false,
-    // should add document filters without showInGlobalContext criterion
+    // Without showInGlobalContext, clauses should omit that criterion
     List<String> entityTypes = ImmutableList.of(DOCUMENT_ENTITY_NAME);
 
-    Filter result = DefaultEntityFiltersUtil.addDefaultEntityFilters(null, entityTypes, false);
+    Filter result =
+        DefaultEntityFiltersUtil.addDefaultEntityFilters(null, entityTypes, false, false);
 
     assertNotNull(result);
     assertNotNull(result.getOr());
-    assertEquals(result.getOr().size(), 1); // Single AND clause
+    assertEquals(result.getOr().size(), 2);
 
-    ConjunctiveCriterion clause = result.getOr().get(0);
-    assertEquals(clause.getAnd().size(), 1); // state only (no showInGlobalContext)
+    // Clause 1: lifecycleStage = PUBLISHED (no showInGlobalContext)
+    ConjunctiveCriterion publishedClause = result.getOr().get(0);
+    assertEquals(publishedClause.getAnd().size(), 1);
+    assertFalse(hasField(publishedClause, "showInGlobalContext"));
 
-    assertTrue(hasNegatedFieldWithCondition(clause, "state", Condition.EQUAL));
-    assertFalse(hasField(clause, "showInGlobalContext"));
+    // Clause 2: lifecycleStage IS_NULL AND state != UNPUBLISHED (no showInGlobalContext)
+    ConjunctiveCriterion legacyClause = result.getOr().get(1);
+    assertEquals(legacyClause.getAnd().size(), 2);
+    assertFalse(hasField(legacyClause, "showInGlobalContext"));
   }
 
   @Test
@@ -86,10 +99,11 @@ public class DefaultEntityFiltersUtilTest {
     // When only DOCUMENT is being searched
     List<String> entityTypes = ImmutableList.of(DOCUMENT_ENTITY_NAME);
 
-    Filter result = DefaultEntityFiltersUtil.addDefaultEntityFilters(null, entityTypes, true);
+    Filter result =
+        DefaultEntityFiltersUtil.addDefaultEntityFilters(null, entityTypes, true, false);
 
     assertNotNull(result);
-    assertEquals(result.getOr().size(), 1); // Single AND clause
+    assertEquals(result.getOr().size(), 2);
   }
 
   @Test
@@ -97,23 +111,57 @@ public class DefaultEntityFiltersUtilTest {
     // Verify the actual filter values are correct
     List<String> entityTypes = ImmutableList.of(DOCUMENT_ENTITY_NAME);
 
-    Filter result = DefaultEntityFiltersUtil.addDefaultEntityFilters(null, entityTypes, true);
+    Filter result =
+        DefaultEntityFiltersUtil.addDefaultEntityFilters(null, entityTypes, true, false);
 
-    ConjunctiveCriterion clause = result.getOr().get(0);
+    // Clause 1: lifecycleStage = PUBLISHED
+    ConjunctiveCriterion publishedClause = result.getOr().get(0);
+    Criterion lifecycleCriterion =
+        findCriterionByCondition(publishedClause, "lifecycleStage", Condition.EQUAL);
+    assertNotNull(lifecycleCriterion);
+    assertFalse(lifecycleCriterion.isNegated());
+    assertTrue(lifecycleCriterion.getValues().contains("urn:li:lifecycleStageType:PUBLISHED"));
 
-    // Verify state != UNPUBLISHED (negated EQUAL)
-    Criterion stateCriterion = findCriterion(clause, "state");
+    Criterion showCtx1 = findNegatedCriterion(publishedClause, "showInGlobalContext");
+    assertNotNull(showCtx1);
+    assertTrue(showCtx1.getValues().contains("false"));
+
+    // Clause 2: lifecycleStage IS_NULL AND state != UNPUBLISHED
+    ConjunctiveCriterion legacyClause = result.getOr().get(1);
+    Criterion isNullCriterion =
+        findCriterionByCondition(legacyClause, "lifecycleStage", Condition.IS_NULL);
+    assertNotNull(isNullCriterion);
+
+    Criterion stateCriterion = findNegatedCriterion(legacyClause, "state");
     assertNotNull(stateCriterion);
-    assertEquals(stateCriterion.getCondition(), Condition.EQUAL);
-    assertTrue(stateCriterion.isNegated());
     assertTrue(stateCriterion.getValues().contains("UNPUBLISHED"));
 
-    // Verify showInGlobalContext != false (negated EQUAL)
-    Criterion showInGlobalContextCriterion = findCriterion(clause, "showInGlobalContext");
-    assertNotNull(showInGlobalContextCriterion);
-    assertEquals(showInGlobalContextCriterion.getCondition(), Condition.EQUAL);
-    assertTrue(showInGlobalContextCriterion.isNegated());
-    assertTrue(showInGlobalContextCriterion.getValues().contains("false"));
+    Criterion showCtx2 = findNegatedCriterion(legacyClause, "showInGlobalContext");
+    assertNotNull(showCtx2);
+    assertTrue(showCtx2.getValues().contains("false"));
+  }
+
+  @Test
+  public void testAddDefaultEntityFilters_CanManageDocumentsProducesTwoClauses() {
+    List<String> entityTypes = ImmutableList.of(DOCUMENT_ENTITY_NAME);
+
+    Filter result = DefaultEntityFiltersUtil.addDefaultEntityFilters(null, entityTypes, true, true);
+
+    assertNotNull(result);
+    // 2 clauses: published, legacy (no state filter). ES-level hideInSearch handles hidden stages.
+    assertEquals(result.getOr().size(), 2);
+  }
+
+  @Test
+  public void testAddDefaultEntityFilters_CanManageDocumentsLegacyClauseNoStateFilter() {
+    List<String> entityTypes = ImmutableList.of(DOCUMENT_ENTITY_NAME);
+
+    Filter result = DefaultEntityFiltersUtil.addDefaultEntityFilters(null, entityTypes, true, true);
+
+    // Clause 2 (legacy): lifecycleStage IS_NULL, no state != UNPUBLISHED filter
+    ConjunctiveCriterion legacyClause = result.getOr().get(1);
+    assertTrue(hasFieldWithCondition(legacyClause, "lifecycleStage", Condition.IS_NULL));
+    assertNull(findNegatedCriterion(legacyClause, "state"));
   }
 
   private static boolean hasField(ConjunctiveCriterion clause, String field) {
@@ -122,21 +170,38 @@ public class DefaultEntityFiltersUtilTest {
 
   private static boolean hasFieldWithCondition(
       ConjunctiveCriterion clause, String field, Condition condition) {
-    Criterion criterion = findCriterion(clause, field);
-    return criterion != null
-        && condition.equals(criterion.getCondition())
-        && !criterion.isNegated();
+    Criterion criterion = findCriterionByCondition(clause, field, condition);
+    return criterion != null && !criterion.isNegated();
   }
 
   private static boolean hasNegatedFieldWithCondition(
       ConjunctiveCriterion clause, String field, Condition condition) {
-    Criterion criterion = findCriterion(clause, field);
-    return criterion != null && condition.equals(criterion.getCondition()) && criterion.isNegated();
+    Criterion criterion = findCriterionByCondition(clause, field, condition);
+    return criterion != null && criterion.isNegated();
   }
 
   private static Criterion findCriterion(ConjunctiveCriterion clause, String field) {
     for (Criterion criterion : clause.getAnd()) {
       if (field.equals(criterion.getField())) {
+        return criterion;
+      }
+    }
+    return null;
+  }
+
+  private static Criterion findCriterionByCondition(
+      ConjunctiveCriterion clause, String field, Condition condition) {
+    for (Criterion criterion : clause.getAnd()) {
+      if (field.equals(criterion.getField()) && condition.equals(criterion.getCondition())) {
+        return criterion;
+      }
+    }
+    return null;
+  }
+
+  private static Criterion findNegatedCriterion(ConjunctiveCriterion clause, String field) {
+    for (Criterion criterion : clause.getAnd()) {
+      if (field.equals(criterion.getField()) && criterion.isNegated()) {
         return criterion;
       }
     }
@@ -299,8 +364,9 @@ public class DefaultEntityFiltersUtilTest {
   public void testDefaultFilterFieldsConstant() {
     // Verify the expected fields are in the constant
     assertTrue(DefaultEntityFiltersUtil.DEFAULT_FILTER_FIELDS.contains("state"));
+    assertTrue(DefaultEntityFiltersUtil.DEFAULT_FILTER_FIELDS.contains("lifecycleStage"));
     assertTrue(DefaultEntityFiltersUtil.DEFAULT_FILTER_FIELDS.contains("showInGlobalContext"));
-    assertEquals(DefaultEntityFiltersUtil.DEFAULT_FILTER_FIELDS.size(), 2);
+    assertEquals(DefaultEntityFiltersUtil.DEFAULT_FILTER_FIELDS.size(), 3);
   }
 
   // ============================================================================

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossEntitiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossEntitiesResolverTest.java
@@ -164,7 +164,7 @@ public class ScrollAcrossEntitiesResolverTest {
   }
 
   @Test
-  public void testIncludeHiddenLifecycleStagesKeepsDocumentDefaultFiltersWithoutManageDocuments()
+  public void testIncludeHiddenLifecycleStagesBypassesDocumentDefaultFiltersWithoutManageDocuments()
       throws Exception {
     ScrollResult mockResult = new ScrollResult();
     mockResult.setPageSize(0);
@@ -172,6 +172,9 @@ public class ScrollAcrossEntitiesResolverTest {
     mockResult.setMetadata(new SearchResultMetadata());
     mockResult.setEntities(new SearchEntityArray());
 
+    // includeHiddenLifecycleStages alone is sufficient to bypass default document filters —
+    // internal callers (agent dashboards, eval tooling) set this flag and already have
+    // system-level access, so the canManageDocuments privilege check is unnecessary.
     SearchFlags searchFlags = new SearchFlags();
     searchFlags.setIncludeHiddenLifecycleStages(true);
 
@@ -204,8 +207,8 @@ public class ScrollAcrossEntitiesResolverTest {
             eq("5m"),
             eq(Collections.emptyList()),
             eq(10));
-    assertTrue(filterContainsField(filterCaptor.getValue(), "state"));
-    assertTrue(filterContainsField(filterCaptor.getValue(), "showInGlobalContext"));
+    // includeHiddenLifecycleStages alone is sufficient to bypass default document filters
+    assertNull(filterCaptor.getValue());
   }
 
   @Test
@@ -250,7 +253,9 @@ public class ScrollAcrossEntitiesResolverTest {
             eq("5m"),
             eq(Collections.emptyList()),
             eq(10));
-    assertTrue(filterContainsField(filterCaptor.getValue(), "state"));
+    // With canManageDocuments=true (mock allows all), the state field is omitted from
+    // unpublished clauses and replaced by a lifecycleStage EXISTS + lifecycleStage != DRAFT clause.
+    assertTrue(filterContainsField(filterCaptor.getValue(), "lifecycleStage"));
     assertTrue(filterContainsField(filterCaptor.getValue(), "showInGlobalContext"));
   }
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossEntitiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossEntitiesResolverTest.java
@@ -40,7 +40,6 @@ import com.linkedin.view.DataHubViewDefinition;
 import com.linkedin.view.DataHubViewInfo;
 import com.linkedin.view.DataHubViewType;
 import graphql.schema.DataFetchingEnvironment;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletionException;
@@ -565,36 +564,46 @@ public class SearchAcrossEntitiesResolverTest {
   }
 
   /**
-   * Builds the default document filter that is applied when DOCUMENT is in the search entity types.
-   * Uses negated EQUAL conditions which naturally pass through for non-document entities:
-   *
-   * <p>state != UNPUBLISHED (negated) AND showInGlobalContext != false (negated)
+   * Builds the default document filter applied when DOCUMENT is in entity types. Since
+   * getMockAllowContext allows all privileges (canManageDocuments=true), the legacy clause omits
+   * the state != UNPUBLISHED filter.
    */
   private static Filter buildDocumentDefaultFilter() {
-    List<Criterion> criteria = new ArrayList<>();
+    Criterion lifecycleCriterion = new Criterion();
+    lifecycleCriterion.setField("lifecycleStage");
+    lifecycleCriterion.setCondition(Condition.EQUAL);
+    lifecycleCriterion.setValues(
+        new com.linkedin.data.template.StringArray(
+            Collections.singletonList("urn:li:lifecycleStageType:PUBLISHED")));
 
-    // Exclude unpublished documents (non-documents pass through) - negated EQUAL
-    Criterion stateCriterion = new Criterion();
-    stateCriterion.setField("state");
-    stateCriterion.setCondition(Condition.EQUAL);
-    stateCriterion.setValues(
-        new com.linkedin.data.template.StringArray(Collections.singletonList("UNPUBLISHED")));
-    stateCriterion.setNegated(true);
-    criteria.add(stateCriterion);
+    ConjunctiveCriterion publishedClause =
+        new ConjunctiveCriterion()
+            .setAnd(
+                new CriterionArray(
+                    ImmutableList.of(lifecycleCriterion, buildShowInGlobalContextCriterion())));
 
-    // Exclude documents not meant for global context (non-documents pass through) - negated EQUAL
-    Criterion showInGlobalContextCriterion = new Criterion();
-    showInGlobalContextCriterion.setField("showInGlobalContext");
-    showInGlobalContextCriterion.setCondition(Condition.EQUAL);
-    showInGlobalContextCriterion.setValues(
-        new com.linkedin.data.template.StringArray(Collections.singletonList("false")));
-    showInGlobalContextCriterion.setNegated(true);
-    criteria.add(showInGlobalContextCriterion);
+    Criterion isNullCriterion = new Criterion();
+    isNullCriterion.setField("lifecycleStage");
+    isNullCriterion.setCondition(Condition.IS_NULL);
+
+    ConjunctiveCriterion legacyClause =
+        new ConjunctiveCriterion()
+            .setAnd(
+                new CriterionArray(
+                    ImmutableList.of(isNullCriterion, buildShowInGlobalContextCriterion())));
 
     return new Filter()
-        .setOr(
-            new ConjunctiveCriterionArray(
-                ImmutableList.of(new ConjunctiveCriterion().setAnd(new CriterionArray(criteria)))));
+        .setOr(new ConjunctiveCriterionArray(ImmutableList.of(publishedClause, legacyClause)));
+  }
+
+  private static Criterion buildShowInGlobalContextCriterion() {
+    Criterion criterion = new Criterion();
+    criterion.setField("showInGlobalContext");
+    criterion.setCondition(Condition.EQUAL);
+    criterion.setValues(
+        new com.linkedin.data.template.StringArray(Collections.singletonList("false")));
+    criterion.setNegated(true);
+    return criterion;
   }
 
   @Test

--- a/smoke-test/tests/status/test_lifecycle_state.py
+++ b/smoke-test/tests/status/test_lifecycle_state.py
@@ -433,10 +433,20 @@ class TestLifecycleStageAPIs:
 
         Note: searchDocuments uses document-specific filter logic that matches
         on well-known lifecycle stage URNs (PUBLISHED, UNPUBLISHED, DRAFT),
-        not the generic hideInSearch flag. We use the bootstrapped PUBLISHED
-        stage to verify that a visible stage keeps the document searchable.
+        not the generic hideInSearch flag. We use the PUBLISHED stage to verify
+        that a visible stage keeps the document searchable.
         """
-        stage_urn = "urn:li:lifecycleStageType:PUBLISHED"
+        # Ensure the well-known PUBLISHED stage type entity exists (it may not
+        # be bootstrapped in all environments).
+        stage_urn = _ingest_lifecycle_stage(
+            auth_session,
+            "PUBLISHED",
+            "Published",
+            hide_in_search=False,
+            entity_types=["dataset", "document"],
+        )
+        self.created_stage_urns.append(stage_urn)
+        wait_for_writes_to_sync()
 
         title = f"Lifecycle Visible Test {_unique_id()}"
         doc_id = _unique_id("lc-vis")
@@ -478,7 +488,17 @@ class TestLifecycleStageAPIs:
         from Clause 2 (the owner-visible non-published clause) so that DRAFT
         documents match no clause and are filtered out entirely.
         """
-        draft_stage_urn = "urn:li:lifecycleStageType:DRAFT"
+        # Ensure the well-known DRAFT stage type entity exists (it may not
+        # be bootstrapped in all environments).
+        draft_stage_urn = _ingest_lifecycle_stage(
+            auth_session,
+            "DRAFT",
+            "Draft",
+            hide_in_search=True,
+            entity_types=["dataset", "document"],
+        )
+        self.created_stage_urns.append(draft_stage_urn)
+        wait_for_writes_to_sync()
 
         title = f"Lifecycle Draft Test {_unique_id()}"
         doc_id = _unique_id("lc-draft")

--- a/smoke-test/tests/status/test_lifecycle_state.py
+++ b/smoke-test/tests/status/test_lifecycle_state.py
@@ -112,6 +112,15 @@ SEARCH_DOCUMENTS_QUERY = """
     }
 """
 
+SEARCH_ACROSS_ENTITIES_QUERY = """
+    query SearchAcross($input: SearchAcrossEntitiesInput!) {
+        searchAcrossEntities(input: $input) {
+            count
+            searchResults { entity { urn } }
+        }
+    }
+"""
+
 SET_LIFECYCLE_STAGE_MUTATION = """
     mutation SetStage($urn: String!, $lifecycleStageUrn: String) {
         setLifecycleStage(urn: $urn, lifecycleStageUrn: $lifecycleStageUrn)
@@ -173,6 +182,7 @@ def _set_lifecycle_stage_via_rest(
 
 
 def _search_documents(auth_session, query: str) -> List[str]:
+    """Search via the document-specific search (docs home page). Ownership-aware."""
     result = execute_graphql(
         auth_session,
         SEARCH_DOCUMENTS_QUERY,
@@ -181,6 +191,28 @@ def _search_documents(auth_session, query: str) -> List[str]:
     assert "errors" not in result, f"searchDocuments errors: {result.get('errors')}"
     docs = result["data"]["searchDocuments"]["documents"]
     return [d["urn"] for d in docs]
+
+
+def _search_across_entities(auth_session, query: str) -> List[str]:
+    """Search via cross-entity search (global search bar). No ownership context."""
+    result = execute_graphql(
+        auth_session,
+        SEARCH_ACROSS_ENTITIES_QUERY,
+        {
+            "input": {
+                "query": query,
+                "types": ["DOCUMENT"],
+                "count": 50,
+            }
+        },
+    )
+    assert "errors" not in result, (
+        f"searchAcrossEntities errors: {result.get('errors')}"
+    )
+    return [
+        r["entity"]["urn"]
+        for r in result["data"]["searchAcrossEntities"]["searchResults"]
+    ]
 
 
 def _get_status(auth_session, urn: str) -> Dict[str, Any]:
@@ -315,10 +347,10 @@ class TestLifecycleStageAPIs:
         assert status.get("lifecycleStage") is None
         logger.info("setLifecycleStage mutation set and cleared stage")
 
-    def test_hidden_stage_excludes_from_search(self, auth_session):
+    def test_hidden_stage_excludes_from_cross_entity_search(self, auth_session):
         """
-        Entities in a hideInSearch=true stage are excluded from default search.
-        Clearing the stage restores visibility.
+        Entities in a hideInSearch=true stage are excluded from cross-entity
+        search (global search bar). Clearing the stage restores visibility.
         """
         stage_urn = self._ingest_stage("HiddenStage", hide_in_search=True)
         wait_for_writes_to_sync()
@@ -331,39 +363,80 @@ class TestLifecycleStageAPIs:
 
         @with_test_retry(max_attempts=12)
         def _assert_visible():
-            urns = _search_documents(auth_session, title)
-            assert urn in urns, f"Expected {urn} in search, got: {urns}"
+            urns = _search_across_entities(auth_session, title)
+            assert urn in urns, f"Expected {urn} in cross-entity search, got: {urns}"
 
         _assert_visible()
 
         _set_lifecycle_stage_via_rest(auth_session, urn, stage_urn)
         wait_for_writes_to_sync()
 
-        @with_test_retry(max_attempts=30)
+        @with_test_retry(max_attempts=12)
         def _assert_hidden():
-            urns = _search_documents(auth_session, title)
-            assert urn not in urns, "Entity in hidden stage should not appear in search"
+            urns = _search_across_entities(auth_session, title)
+            assert urn not in urns, (
+                "Entity in hidden stage should not appear in cross-entity search"
+            )
 
         _assert_hidden()
-        logger.info("Hidden stage excludes entity from search")
+        logger.info("Hidden stage excludes entity from cross-entity search")
 
         _set_lifecycle_stage_via_rest(auth_session, urn, None)
         wait_for_writes_to_sync()
 
         @with_test_retry(max_attempts=12)
         def _assert_visible_again():
-            urns = _search_documents(auth_session, title)
+            urns = _search_across_entities(auth_session, title)
             assert urn in urns, f"Cleared entity should be visible: {urns}"
 
         _assert_visible_again()
-        logger.info("Cleared stage restores search visibility")
+        logger.info("Cleared stage restores cross-entity search visibility")
+
+    def test_hidden_stage_visible_to_owner_in_doc_search(self, auth_session):
+        """
+        Owners can still see their documents in the docs home page search
+        (searchDocuments) even when the doc is in a hideInSearch=true stage.
+        """
+        stage_urn = self._ingest_stage("HiddenOwnerStage", hide_in_search=True)
+        wait_for_writes_to_sync()
+
+        title = f"Lifecycle Owner Test {_unique_id()}"
+        doc_id = _unique_id("lc-owner")
+        urn = _create_document(auth_session, doc_id, title)
+        self.created_urns.append(urn)
+        wait_for_writes_to_sync()
+
+        @with_test_retry(max_attempts=12)
+        def _assert_visible_before():
+            urns = _search_documents(auth_session, title)
+            assert urn in urns, f"Expected {urn} in doc search, got: {urns}"
+
+        _assert_visible_before()
+
+        _set_lifecycle_stage_via_rest(auth_session, urn, stage_urn)
+        wait_for_writes_to_sync()
+
+        @with_test_retry(max_attempts=12)
+        def _assert_still_visible_to_owner():
+            urns = _search_documents(auth_session, title)
+            assert urn in urns, (
+                "Owner should still see doc in hidden stage via doc search"
+            )
+
+        _assert_still_visible_to_owner()
+        logger.info("Owner can see hidden-stage doc in document search")
 
     def test_visible_stage_remains_in_search(self, auth_session):
         """
-        Entities in a hideInSearch=false stage remain visible in default search.
+        Entities in the well-known PUBLISHED lifecycle stage remain visible in
+        default document search.
+
+        Note: searchDocuments uses document-specific filter logic that matches
+        on well-known lifecycle stage URNs (PUBLISHED, UNPUBLISHED, DRAFT),
+        not the generic hideInSearch flag. We use the bootstrapped PUBLISHED
+        stage to verify that a visible stage keeps the document searchable.
         """
-        stage_urn = self._ingest_stage("VisibleStage", hide_in_search=False)
-        wait_for_writes_to_sync()
+        stage_urn = "urn:li:lifecycleStageType:PUBLISHED"
 
         title = f"Lifecycle Visible Test {_unique_id()}"
         doc_id = _unique_id("lc-vis")
@@ -393,3 +466,43 @@ class TestLifecycleStageAPIs:
         status = _get_status(auth_session, urn)
         assert status.get("lifecycleStage") == stage_urn
         logger.info("Visible stage keeps entity in search results")
+
+    def test_draft_stage_hidden_from_owner_in_doc_search(self, auth_session):
+        """
+        Documents in the well-known DRAFT lifecycle stage must not appear in
+        document search (searchDocuments) even for the owning user.
+
+        Unlike generic hidden stages (which are still visible to owners),
+        DRAFT is treated as a staging state that is never surfaced in the UI
+        regardless of ownership. DocumentSearchFilterUtils excludes DRAFT
+        from Clause 2 (the owner-visible non-published clause) so that DRAFT
+        documents match no clause and are filtered out entirely.
+        """
+        draft_stage_urn = "urn:li:lifecycleStageType:DRAFT"
+
+        title = f"Lifecycle Draft Test {_unique_id()}"
+        doc_id = _unique_id("lc-draft")
+        urn = _create_document(auth_session, doc_id, title)
+        self.created_urns.append(urn)
+        wait_for_writes_to_sync()
+
+        @with_test_retry(max_attempts=12)
+        def _assert_visible_before():
+            urns = _search_documents(auth_session, title)
+            assert urn in urns, f"Expected {urn} in doc search, got: {urns}"
+
+        _assert_visible_before()
+
+        _set_lifecycle_stage_via_rest(auth_session, urn, draft_stage_urn)
+        wait_for_writes_to_sync()
+
+        @with_test_retry(max_attempts=12)
+        def _assert_hidden_from_owner():
+            urns = _search_documents(auth_session, title)
+            assert urn not in urns, (
+                "Owner should NOT see a DRAFT document in doc search "
+                f"(found in results): {urns}"
+            )
+
+        _assert_hidden_from_owner()
+        logger.info("DRAFT stage hides document from owner in document search")


### PR DESCRIPTION
The main point of this PR is to bring a fix to OSS where we were showing counts of documents in the UI where we shouldn't:
After digging into a reported issue that after an upgrade, asset counts have nearly doubled for most platforms, I discovered that for almost every dataset in an instance, we created some corresponding `document` entity (a Bridge document type). These documents were showing up in counts in the main search UI in some places but not all, resulting in buggy-ness where counts appear incorrect.

These documents are created with a flag `showInGlobalContext = false` so they should be hidden from the UI. Well, in the `aggregateAcrossEntities` endpoint and the `browseV2` endpoint we weren't applying the same default filters to filter these documents out.

In the future i think this is fixed because we start always hiding these docs setting them in DRAFT lifecycle stage, but we should still be applying the same filters in these endpoints as we do in our main search and scroll endpoints.

**Also:**
Since that fix required some changes that should be in OSS that were not, I decided to bring them all back where they belong here - these are the changes for applying default filters for documents in search and in the documents page. 


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
