### PR TITLE
fix(settings): add collapsed state to settings sidebar

### DIFF
--- a/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarMenu.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarMenu.tsx
@@ -40,7 +40,7 @@ export default function NavBarMenu({ menu, selectedKey, isCollapsed, iconSize, s
         if (item.type === NavBarMenuItemTypes.Group && item.items?.filter((candidate) => !candidate.isHidden)?.length) {
             const groupTitle = item.renderTitle ? item.renderTitle() : !isCollapsed && item.title;
             return (
-                <NavBarMenuItemGroup title={groupTitle} key={item.key}>
+                <NavBarMenuItemGroup title={groupTitle} key={item.key} $isCollapsed={isCollapsed}>
                     {item.items?.map((subItem) => renderMenuItem(subItem))}
                 </NavBarMenuItemGroup>
             );

--- a/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarMenuItem.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarMenuItem.tsx
@@ -10,7 +10,13 @@ import analytics, { EventType } from '@src/app/analytics';
 const StyledMenuItem = styled(Menu.Item)<{ isCollapsed?: boolean }>`
     &&& {
         position: relative;
-        padding: 4px 8px;
+        padding: ${(props) => (props.isCollapsed ? '4px 0 !important' : '4px 8px')};
+        ${(props) =>
+            props.isCollapsed &&
+            `
+            padding-left: 0 !important;
+            padding-right: 0 !important;
+        `}
         margin: 4px 0;
         margin-bottom: 0;
         height: 36px;
@@ -19,7 +25,12 @@ const StyledMenuItem = styled(Menu.Item)<{ isCollapsed?: boolean }>`
         border: 0;
         display: flex;
         align-items: center;
-        ${(props) => props.isCollapsed && 'width: 36px;'}
+        ${(props) =>
+            props.isCollapsed &&
+            `
+            width: 100%;
+            justify-content: center;
+        `}
         @media (max-height: 970px) {
             margin: 2px 0;
         }
@@ -47,6 +58,13 @@ const StyledMenuItem = styled(Menu.Item)<{ isCollapsed?: boolean }>`
         align-items: center;
         height: 36px;
         line-height: 24px;
+        ${(props) =>
+            props.isCollapsed &&
+            `
+            justify-content: center;
+            gap: 0;
+            width: auto;
+        `}
     }
 
     &:hover,
@@ -64,6 +82,7 @@ const StyledMenuItem = styled(Menu.Item)<{ isCollapsed?: boolean }>`
 const Icon = styled.div<{ $isSelected?: boolean; $size?: number }>`
     width: ${(props) => props.$size ?? 20}px;
     height: ${(props) => props.$size ?? 20}px;
+    flex: 0 0 auto;
 
     && svg {
         ${(props) =>

--- a/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarMenuItemGroup.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarMenuItemGroup.tsx
@@ -1,40 +1,41 @@
 import { Menu } from 'antd';
 import styled from 'styled-components';
 
-const NavBarMenuItemGroup = styled(Menu.ItemGroup)`
+const NavBarMenuItemGroup = styled(Menu.ItemGroup)<{ $isCollapsed?: boolean }>`
     .ant-menu-item-group-title {
-        margin-top: 8px;
-        padding: 8px 0;
+        display: ${(props) => (props.$isCollapsed ? 'none' : 'block')};
+        margin-top: ${(props) => (props.$isCollapsed ? '0' : '4px')};
+        padding: ${(props) => (props.$isCollapsed ? '0' : '4px 0')};
+        min-height: ${(props) => (props.$isCollapsed ? '0' : '28px')};
         color: ${(props) => props.theme.colors.textTertiary};
         font-family: Mulish;
         font-size: 14px;
         font-style: normal;
         font-weight: 700;
         line-height: normal;
-        min-height: 38px;
 
         @media (max-height: 970px) {
-            margin-top: 2px;
+            margin-top: ${(props) => (props.$isCollapsed ? '0' : '2px')};
         }
         @media (max-height: 890px) {
             margin-top: 0px;
         }
         @media (max-height: 835px) {
-            min-height: 34px;
+            min-height: ${(props) => (props.$isCollapsed ? '0' : '24px')};
         }
         @media (max-height: 800px) {
-            min-height: 24px;
+            min-height: ${(props) => (props.$isCollapsed ? '0' : '20px')};
         }
         @media (max-height: 775px) {
-            min-height: 14px;
+            min-height: ${(props) => (props.$isCollapsed ? '0' : '12px')};
         }
         @media (max-height: 750px) {
-            min-height: 0px;
-            padding: 4px 0;
+            min-height: ${(props) => (props.$isCollapsed ? '0' : '0px')};
+            padding: ${(props) => (props.$isCollapsed ? '0' : '2px 0')};
         }
         @media (max-height: 730px) {
-            min-height: 0px;
-            padding: 0;
+            min-height: ${(props) => (props.$isCollapsed ? '0' : '0px')};
+            padding: ${(props) => (props.$isCollapsed ? '0' : '0')};
         }
     }
 `;

--- a/datahub-web-react/src/app/settingsV2/SettingsPage.tsx
+++ b/datahub-web-react/src/app/settingsV2/SettingsPage.tsx
@@ -1,3 +1,5 @@
+import { ArrowLineLeft } from '@phosphor-icons/react/dist/csr/ArrowLineLeft';
+import { ArrowLineRight } from '@phosphor-icons/react/dist/csr/ArrowLineRight';
 import { Bank } from '@phosphor-icons/react/dist/csr/Bank';
 import { Bell } from '@phosphor-icons/react/dist/csr/Bell';
 import { Funnel } from '@phosphor-icons/react/dist/csr/Funnel';
@@ -8,7 +10,7 @@ import { ToggleRight } from '@phosphor-icons/react/dist/csr/ToggleRight';
 import { Users } from '@phosphor-icons/react/dist/csr/Users';
 import { UsersThree } from '@phosphor-icons/react/dist/csr/UsersThree';
 import { Wrench } from '@phosphor-icons/react/dist/csr/Wrench';
-import React, { Suspense } from 'react';
+import React, { Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Redirect, Route, Switch, useHistory, useLocation, useRouteMatch } from 'react-router';
 import styled from 'styled-components';
@@ -23,6 +25,8 @@ import { useAppConfig } from '@app/useAppConfig';
 import { useShowNavBarRedesign } from '@app/useShowNavBarRedesign';
 import { Button } from '@src/alchemy-components';
 
+const COLLAPSED_NAV_WIDTH = 72;
+
 const PageContainer = styled.div`
     display: flex;
     overflow: auto;
@@ -32,17 +36,22 @@ const PageContainer = styled.div`
     padding: 5px;
 `;
 
-const NavBarContainer = styled.div`
-    padding: 20px 20px;
+const NavBarContainer = styled.div<{ $isCollapsed: boolean }>`
+    box-sizing: border-box;
+    padding: ${(props) => (props.$isCollapsed ? '16px 12px' : '20px 20px')};
     background-color: ${(props) => props.theme.colors.bg};
     display: flex;
     flex-direction: column;
     border-radius: ${(props) => props.theme.styles['border-radius-navbar-redesign']};
     box-shadow: ${(props) => props.theme.colors.shadowSm};
-    align-items: start;
+    align-items: ${(props) => (props.$isCollapsed ? 'center' : 'start')};
     overflow: auto;
-    width: 20%;
-    min-width: 180px;
+    width: ${(props) => (props.$isCollapsed ? `${COLLAPSED_NAV_WIDTH}px` : '20%')};
+    min-width: ${(props) => (props.$isCollapsed ? `${COLLAPSED_NAV_WIDTH}px` : '180px')};
+    transition:
+        width 180ms ease-out,
+        min-width 180ms ease-out,
+        padding 180ms ease-out;
 `;
 
 const NavBarHeader = styled.div`
@@ -53,10 +62,16 @@ const NavBarHeader = styled.div`
     justify-content: space-between;
 `;
 
+const NavBarHeaderMain = styled.div<{ $isCollapsed: boolean }>`
+    display: ${(props) => (props.$isCollapsed ? 'none' : 'flex')};
+    flex-direction: column;
+`;
+
 const NavBarTitle = styled.div`
     font-size: 16px;
     font-weight: 700;
-    margin-bottom: 4px;
+    color: ${(props) => props.theme.colors.text};
+    margin-bottom: 0;
 `;
 
 const NavBarSubTitle = styled.div`
@@ -65,8 +80,23 @@ const NavBarSubTitle = styled.div`
     margin-bottom: 8px;
 `;
 
-const NavBarMenuContainer = styled.div`
-    padding-bottom: 8px; // Adds space below nav bar items on overflow.
+const NavBarHeaderActions = styled.div<{ $isCollapsed: boolean }>`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: ${(props) => (props.$isCollapsed ? '100%' : 'auto')};
+    justify-content: ${(props) => (props.$isCollapsed ? 'center' : 'flex-end')};
+`;
+
+const NavBarDivider = styled.div`
+    width: 100%;
+    height: 1px;
+    margin: 4px 0 12px 0;
+    background-color: ${(props) => props.theme.colors.border};
+`;
+
+const NavBarMenuContainer = styled.div<{ $isCollapsed: boolean }>`
+    padding-bottom: ${(props) => (props.$isCollapsed ? '0' : '8px')}; // Adds space below nav bar items on overflow.
     width: 100%;
 `;
 
@@ -79,11 +109,14 @@ const ContentContainer = styled.div`
     box-shadow: ${(props) => props.theme.colors.shadowSm};
 `;
 
+const fillIcon = (icon: React.ReactElement) => React.cloneElement(icon, { weight: 'fill' });
+
 const SettingsPageContent = () => {
     const { t } = useTranslation('settings.page');
     const { path, url } = useRouteMatch();
     const { pathname } = useLocation();
     const history = useHistory();
+    const [isCollapsed, setIsCollapsed] = useState(false);
     const subscriptionsEnabled = false;
     const me = useUserContext();
     const isShowNavBarRedesign = useShowNavBarRedesign();
@@ -125,6 +158,7 @@ const SettingsPageContent = () => {
                         link: `${url}/views`,
                         isHidden: !showViews,
                         icon: <Funnel />,
+                        selectedIcon: fillIcon(<Funnel />),
                     },
                     {
                         type: NavBarMenuItemTypes.Item,
@@ -133,6 +167,7 @@ const SettingsPageContent = () => {
                         link: `${url}/personal-notifications`,
                         isHidden: !subscriptionsEnabled,
                         icon: <Bell />,
+                        selectedIcon: fillIcon(<Bell />),
                     },
                     {
                         type: NavBarMenuItemTypes.Item,
@@ -141,6 +176,7 @@ const SettingsPageContent = () => {
                         link: `${url}/personal-subscriptions`,
                         isHidden: !subscriptionsEnabled,
                         icon: <Star />,
+                        selectedIcon: fillIcon(<Star />),
                     },
                 ],
             },
@@ -157,6 +193,7 @@ const SettingsPageContent = () => {
                         link: `${url}/tokens`,
                         isHidden: !showAccessTokens,
                         icon: <ShieldCheck />,
+                        selectedIcon: fillIcon(<ShieldCheck />),
                     },
                 ],
             },
@@ -173,6 +210,7 @@ const SettingsPageContent = () => {
                         link: `${url}/identities`,
                         isHidden: !showUsersGroups,
                         icon: <UsersThree />,
+                        selectedIcon: fillIcon(<UsersThree />),
                     },
                     {
                         type: NavBarMenuItemTypes.Item,
@@ -181,6 +219,7 @@ const SettingsPageContent = () => {
                         link: `${url}/permissions`,
                         isHidden: !showPolicies,
                         icon: <Bank />,
+                        selectedIcon: fillIcon(<Bank />),
                     },
                 ],
             },
@@ -197,6 +236,7 @@ const SettingsPageContent = () => {
                         link: `${url}/features`,
                         isHidden: !showFeatures,
                         icon: <ToggleRight />,
+                        selectedIcon: fillIcon(<ToggleRight />),
                     },
                     {
                         type: NavBarMenuItemTypes.Item,
@@ -205,6 +245,7 @@ const SettingsPageContent = () => {
                         link: `${url}/posts`,
                         isHidden: !showHomePagePosts,
                         icon: <House />,
+                        selectedIcon: fillIcon(<House />),
                     },
                     {
                         type: NavBarMenuItemTypes.Item,
@@ -213,6 +254,7 @@ const SettingsPageContent = () => {
                         link: `${url}/ownership`,
                         isHidden: !showOwnershipTypes,
                         icon: <Users />,
+                        selectedIcon: fillIcon(<Users />),
                     },
                 ],
             },
@@ -228,6 +270,7 @@ const SettingsPageContent = () => {
                         key: 'preferences',
                         link: `${url}/preferences`,
                         icon: <Wrench />,
+                        selectedIcon: fillIcon(<Wrench />),
                     },
                 ],
             },
@@ -235,32 +278,50 @@ const SettingsPageContent = () => {
     };
 
     const handleLogout = useGetLogoutHandler();
+    const handleToggleCollapse = () => {
+        setIsCollapsed((current) => !current);
+    };
+    const toggleSidebarLabel = isCollapsed ? t('nav.expandSidebar') : t('nav.collapseSidebar');
 
     return (
         <PageContainer>
             {/* Sidebar with NavBarMenu */}
-            <NavBarContainer>
+            <NavBarContainer $isCollapsed={isCollapsed}>
                 <NavBarHeader>
-                    <div>
+                    <NavBarHeaderMain $isCollapsed={isCollapsed}>
                         <NavBarTitle>{t('title')}</NavBarTitle>
                         <NavBarSubTitle>{t('subTitle')}</NavBarSubTitle>
-                    </div>
-                    {!isShowNavBarRedesign && (
-                        <a href="/logOut">
-                            <Button
-                                variant="outline"
-                                color="red"
-                                onClick={handleLogout}
-                                data-testid="log-out-menu-item"
-                            >
-                                {t('logOut')}
-                            </Button>
-                        </a>
-                    )}
+                    </NavBarHeaderMain>
+                    <NavBarHeaderActions $isCollapsed={isCollapsed}>
+                        {!isShowNavBarRedesign && !isCollapsed && (
+                            <a href="/logOut">
+                                <Button
+                                    variant="outline"
+                                    color="red"
+                                    onClick={handleLogout}
+                                    data-testid="log-out-menu-item"
+                                >
+                                    {t('logOut')}
+                                </Button>
+                            </a>
+                        )}
+                        <Button
+                            variant="text"
+                            color="gray"
+                            size="lg"
+                            isCircle
+                            type="button"
+                            onClick={handleToggleCollapse}
+                            aria-label={toggleSidebarLabel}
+                            title={toggleSidebarLabel}
+                            icon={{ icon: isCollapsed ? ArrowLineRight : ArrowLineLeft }}
+                        />
+                    </NavBarHeaderActions>
                 </NavBarHeader>
-                <NavBarMenuContainer>
+                <NavBarDivider />
+                <NavBarMenuContainer $isCollapsed={isCollapsed}>
                     <NavBarMenu
-                        isCollapsed={false}
+                        isCollapsed={isCollapsed}
                         selectedKey={activePath}
                         menu={menuItems}
                         iconSize={16}

--- a/datahub-web-react/src/i18n/locales/de/settings.page.json
+++ b/datahub-web-react/src/i18n/locales/de/settings.page.json
@@ -13,6 +13,8 @@
     "nav.permissions": "Berechtigungen",
     "nav.personal": "Persönlich",
     "nav.preferences": "Präferenzen",
+    "nav.collapseSidebar": "Einstellungen einklappen",
+    "nav.expandSidebar": "Einstellungen ausklappen",
     "nav.usersGroups": "Benutzer & Gruppen",
     "nav.views": "Ansichten",
     "subTitle": "Deine Einstellungen verwalten",

--- a/datahub-web-react/src/i18n/locales/en/settings.page.json
+++ b/datahub-web-react/src/i18n/locales/en/settings.page.json
@@ -15,6 +15,8 @@
     "nav.preferences": "Preferences",
     "nav.usersGroups": "Users & Groups",
     "nav.views": "Views",
+    "nav.collapseSidebar": "Collapse settings sidebar",
+    "nav.expandSidebar": "Expand settings sidebar",
     "subTitle": "Manage your settings",
     "title": "Settings"
 }

--- a/datahub-web-react/src/i18n/locales/es/settings.page.json
+++ b/datahub-web-react/src/i18n/locales/es/settings.page.json
@@ -13,6 +13,8 @@
     "nav.permissions": "Permisos",
     "nav.personal": "Personal",
     "nav.preferences": "Preferencias",
+    "nav.collapseSidebar": "Contraer panel de configuración",
+    "nav.expandSidebar": "Expandir panel de configuración",
     "nav.usersGroups": "Usuarios y grupos",
     "nav.views": "Vistas",
     "subTitle": "Gestione su configuración",

--- a/datahub-web-react/src/i18n/locales/fr/settings.page.json
+++ b/datahub-web-react/src/i18n/locales/fr/settings.page.json
@@ -13,6 +13,8 @@
     "nav.permissions": "Autorisations",
     "nav.personal": "Personnel",
     "nav.preferences": "Préférences",
+    "nav.collapseSidebar": "Réduire la barre latérale des paramètres",
+    "nav.expandSidebar": "Développer la barre latérale des paramètres",
     "nav.usersGroups": "Utilisateurs et groupes",
     "nav.views": "Vues",
     "subTitle": "Gérez vos paramètres",

--- a/datahub-web-react/src/i18n/locales/hu/settings.page.json
+++ b/datahub-web-react/src/i18n/locales/hu/settings.page.json
@@ -13,6 +13,8 @@
     "nav.permissions": "Jogosultságok",
     "nav.personal": "Személyes",
     "nav.preferences": "Preferenciák",
+    "nav.collapseSidebar": "Beállítások oldalsáv összecsukása",
+    "nav.expandSidebar": "Beállítások oldalsáv kinyitása",
     "nav.usersGroups": "Felhasználók és csoportok",
     "nav.views": "Nézetek",
     "subTitle": "Beállítások kezelése",

--- a/datahub-web-react/src/i18n/locales/it/settings.page.json
+++ b/datahub-web-react/src/i18n/locales/it/settings.page.json
@@ -13,6 +13,8 @@
     "nav.permissions": "Autorizzazioni",
     "nav.personal": "Personale",
     "nav.preferences": "Preferenze",
+    "nav.collapseSidebar": "Comprimi barra laterale impostazioni",
+    "nav.expandSidebar": "Espandi barra laterale impostazioni",
     "nav.usersGroups": "Utenti e gruppi",
     "nav.views": "Viste",
     "subTitle": "Gestisci le impostazioni",

--- a/datahub-web-react/src/i18n/locales/nb/settings.page.json
+++ b/datahub-web-react/src/i18n/locales/nb/settings.page.json
@@ -13,6 +13,8 @@
     "nav.permissions": "Tillatelser",
     "nav.personal": "Personlig",
     "nav.preferences": "Preferanser",
+    "nav.collapseSidebar": "Skjul innstillingssidefelt",
+    "nav.expandSidebar": "Vis innstillingssidefelt",
     "nav.usersGroups": "Brukere og grupper",
     "nav.views": "Visninger",
     "subTitle": "Administrer innstillingene dine",

--- a/datahub-web-react/src/i18n/locales/pt-BR/settings.page.json
+++ b/datahub-web-react/src/i18n/locales/pt-BR/settings.page.json
@@ -13,6 +13,8 @@
     "nav.permissions": "Permissões",
     "nav.personal": "Pessoal",
     "nav.preferences": "Preferências",
+    "nav.collapseSidebar": "Recolher barra lateral de configurações",
+    "nav.expandSidebar": "Expandir barra lateral de configurações",
     "nav.usersGroups": "Usuários e Grupos",
     "nav.views": "Visualizações",
     "subTitle": "Gerencie suas configurações",

--- a/datahub-web-react/src/i18n/locales/sv/settings.page.json
+++ b/datahub-web-react/src/i18n/locales/sv/settings.page.json
@@ -13,6 +13,8 @@
     "nav.permissions": "Behörigheter",
     "nav.personal": "Personligt",
     "nav.preferences": "Preferenser",
+    "nav.collapseSidebar": "Fäll ihop inställningssidofältet",
+    "nav.expandSidebar": "Expandera inställningssidofältet",
     "nav.usersGroups": "Användare och grupper",
     "nav.views": "Vyer",
     "subTitle": "Hantera dina inställningar",


### PR DESCRIPTION
Adding a collapse / expand to the settings sidebar to leave more room 

<img width="1840" height="1196" alt="Screenshot 2026-07-14 at 1 36 52 PM" src="https://github.com/user-attachments/assets/82668027-b855-4a4f-b226-af5489433aa9" />
<img width="1840" height="1196" alt="Screenshot 2026-07-14 at 1 36 43 PM" src="https://github.com/user-attachments/assets/b72133a8-2de3-489d-93f6-ce5480f2dd1d" />
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
