### PR TITLE
feat(looker): emit per-explore usage statistics

### DIFF
--- a/metadata-ingestion/docs/sources/looker/looker_post.md
+++ b/metadata-ingestion/docs/sources/looker/looker_post.md
@@ -2,6 +2,21 @@
 
 Use the **Important Capabilities** table above as the source of truth for supported features and whether additional configuration is required.
 
+#### Usage Statistics
+
+When `extract_usage_history` is enabled, the `looker` module extracts usage from Looker's [System Activity](https://cloud.google.com/looker/docs/system-activity) `history` explore and attaches it to the corresponding DataHub entities:
+
+- **Dashboards** and **Looks / Charts** — view counts and per-user usage.
+- **Explores** — query counts and per-user usage, emitted as dataset usage statistics on the explore's dataset URN.
+
+Usage is aggregated per day over the window set by `extract_usage_history_for_interval`.
+
+:::note
+
+Explore usage is attached only to explores that were actually ingested in the same run. Unlike dashboards and looks, Looker exposes no absolute usage snapshot for an explore, so only the per-day time-series (with per-user counts) is emitted for explores. View-level (LookML view) usage is not derivable at the explore-query grain in System Activity.
+
+:::
+
 ### Limitations
 
 Module behavior is constrained by source APIs, permissions, and metadata exposed by the platform. Refer to capability notes for unsupported or conditional features.

--- a/metadata-ingestion/src/datahub/ingestion/autogenerated/connector_registry/datahub.json
+++ b/metadata-ingestion/src/datahub/ingestion/autogenerated/connector_registry/datahub.json
@@ -2349,7 +2349,7 @@
         },
         {
           "capability": "USAGE_STATS",
-          "description": "Enabled by default, configured using `extract_usage_history`",
+          "description": "Dashboard, chart, and explore usage. Enabled by default, configured using `extract_usage_history`",
           "subtype_modifier": null,
           "supported": true
         },

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
@@ -1659,7 +1659,10 @@ class LookerDashboardSourceReport(StaleEntityRemovalSourceReport):
     filtered_looks: LossyList[str] = dataclasses_field(default_factory=LossyList)
     dashboards_scanned_for_usage: int = 0
     charts_scanned_for_usage: int = 0
+    explores_scanned_for_usage: int = 0
     charts_with_activity: LossySet[str] = dataclasses_field(default_factory=LossySet)
+    # Explores that had usage activity, keyed by "<model>::<explore>"
+    explores_with_activity: LossySet[str] = dataclasses_field(default_factory=LossySet)
     accessed_dashboards: int = 0
     dashboards_with_activity: LossySet[str] = dataclasses_field(
         default_factory=LossySet
@@ -1670,6 +1673,9 @@ class LookerDashboardSourceReport(StaleEntityRemovalSourceReport):
         default_factory=LossySet
     )
     charts_skipped_for_usage: LossySet[str] = dataclasses_field(
+        default_factory=LossySet
+    )
+    explores_skipped_for_usage: LossySet[str] = dataclasses_field(
         default_factory=LossySet
     )
 
@@ -1710,6 +1716,9 @@ class LookerDashboardSourceReport(StaleEntityRemovalSourceReport):
 
     def report_charts_scanned_for_usage(self, num_charts: int) -> None:
         self.charts_scanned_for_usage += num_charts
+
+    def report_explores_scanned_for_usage(self, num_explores: int) -> None:
+        self.explores_scanned_for_usage += num_explores
 
     def report_upstream_latency(
         self, start_time: datetime.datetime, end_time: datetime.datetime

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_query_model.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_query_model.py
@@ -18,6 +18,10 @@ class LookerView(StrEnum):
     HISTORY = "history"
     USER = "user"
     LOOK = "look"
+    # The `query` view in System Activity describes what an execution ran
+    # against, including the model and the explore (Looker calls the explore
+    # the query's `view`).
+    QUERY = "query"
 
 
 class LookerField(StrEnum):
@@ -27,6 +31,8 @@ class LookerField(StrEnum):
     ID = "id"
     DASHBOARD_USER = "dashboard_user"
     COUNT = "count"
+    MODEL = "model"
+    VIEW = "view"
 
 
 class ViewField(StrEnum):
@@ -53,6 +59,13 @@ class UserViewField(ViewField):
 
 class LookViewField(ViewField):
     LOOK_ID = f"{LookerView.LOOK}.{LookerField.ID}"
+
+
+class QueryViewField(ViewField):
+    # `query.view` is the explore the query ran against (Looker's naming, not a
+    # LookML view). Together with `query.model` it identifies the explore.
+    QUERY_MODEL = f"{LookerView.QUERY}.{LookerField.MODEL}"
+    QUERY_VIEW = f"{LookerView.QUERY}.{LookerField.VIEW}"
 
 
 @dataclass

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
@@ -1414,8 +1414,6 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
             filtered_looks,
         )
 
-        # Explores map to the L2 layer of the Looker-derived semantic model; their
-        # usage is the signal used to prioritize generated models.
         explore_usage_generator = looker_usage.create_explore_stat_generator(
             stat_generator_config,
             self.reporter,

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
@@ -177,6 +177,9 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
         # Keep track of ingested chart urns, to omit usage for non-ingested entities
         self.chart_urns: Set[str] = set()
 
+        # Explores we actually emitted, so we only attach usage stats to them
+        self.explores_for_usage: List[looker_usage.LookerExploreForUsage] = []
+
     @staticmethod
     def test_connection(config_dict: dict) -> TestConnectionReport:
         test_report = TestConnectionReport()
@@ -913,6 +916,14 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
                 self.source_config.external_base_url or self.source_config.base_url,
                 self.source_config.extract_embed_urls,
             )
+            if explore_dataset_entity is not None:
+                # list.append is atomic under the GIL, so this is safe to call
+                # from the BackpressureAwareExecutor worker threads.
+                self.explores_for_usage.append(
+                    looker_usage.LookerExploreForUsage(
+                        id=None, model_name=model, name=explore
+                    )
+                )
 
         return (
             explore_dataset_entity,
@@ -1403,8 +1414,21 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
             filtered_looks,
         )
 
+        # Explores map to the L2 layer of the Looker-derived semantic model; their
+        # usage is the signal used to prioritize generated models.
+        explore_usage_generator = looker_usage.create_explore_stat_generator(
+            stat_generator_config,
+            self.reporter,
+            self.source_config,
+            self.explores_for_usage,
+        )
+
         mcps: List[MetadataChangeProposalWrapper] = []
-        for usage_stat_generator in [dashboard_usage_generator, chart_usage_generator]:
+        for usage_stat_generator in [
+            dashboard_usage_generator,
+            chart_usage_generator,
+            explore_usage_generator,
+        ]:
             for mcp in usage_stat_generator.generate_usage_stat_mcps():
                 mcps.append(mcp)
 

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
@@ -124,7 +124,7 @@ class DashboardProcessingResult:
 )
 @capability(
     SourceCapability.USAGE_STATS,
-    "Enabled by default, configured using `extract_usage_history`",
+    "Dashboard, chart, and explore usage. Enabled by default, configured using `extract_usage_history`",
 )
 @capability(SourceCapability.TEST_CONNECTION, "Enabled by default")
 @capability(

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
@@ -683,11 +683,9 @@ class LookStatGenerator(BaseStatGenerator):
 class ExploreStatGenerator(BaseStatGenerator):
     """Emits per-explore usage from Looker's System Activity `history` explore.
 
-    Explores map to the L2 layer of the Looker-derived semantic model, so their
-    query/user counts are the signal used to prioritize which generated models
-    are surfaced. Unlike dashboards and looks, Looker exposes no absolute usage
-    snapshot for an explore, so this generator emits only the per-day timeseries
-    stats (entity + per-user).
+    Unlike dashboards and looks, Looker exposes no absolute usage snapshot for an
+    explore, so this generator emits only the per-day timeseries stats (entity +
+    per-user).
     """
 
     def __init__(

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
@@ -29,6 +29,7 @@ from datahub.ingestion.source.looker.looker_query_model import (
     LookerModel,
     LookerQuery,
     LookViewField,
+    QueryViewField,
     StrEnum,
     UserViewField,
     ViewField,
@@ -39,6 +40,8 @@ from datahub.metadata.schema_classes import (
     ChartUserUsageCountsClass,
     DashboardUsageStatisticsClass,
     DashboardUserUsageCountsClass,
+    DatasetUsageStatisticsClass,
+    DatasetUserUsageCountsClass,
     TimeWindowSizeClass,
     _Aspect as AspectAbstract,
 )
@@ -92,6 +95,14 @@ class LookerDashboardForUsage(ModelForUsage):
 
 
 @dataclass
+class LookerExploreForUsage(ModelForUsage):
+    # An explore is identified in System Activity by (model, name); `id` holds
+    # the composite key so the base generator's id/urn plumbing works unchanged.
+    model_name: str
+    name: str
+
+
+@dataclass
 class StatGeneratorConfig:
     looker_api_wrapper: LookerAPI
     looker_user_registry: LookerUserRegistry
@@ -106,6 +117,8 @@ class QueryId(StrEnum):
     DASHBOARD_PER_USER_PER_DAY_USAGE_STAT = "counts_per_day_per_user_per_dashboard"
     LOOK_PER_DAY_USAGE_STAT = "counts_per_day_per_look"
     LOOK_PER_USER_PER_DAY_USAGE_STAT = "counts_per_day_per_user_per_look"
+    EXPLORE_PER_DAY_USAGE_STAT = "counts_per_day_per_explore"
+    EXPLORE_PER_USER_PER_DAY_USAGE_STAT = "counts_per_day_per_user_per_explore"
 
 
 query_collection: Dict[QueryId, LookerQuery] = {
@@ -152,6 +165,33 @@ query_collection: Dict[QueryId, LookerQuery] = {
         ],
         filters={
             LookViewField.LOOK_ID: "NOT NULL",
+        },
+    ),
+    QueryId.EXPLORE_PER_DAY_USAGE_STAT: LookerQuery(
+        model=LookerModel.SYSTEM_ACTIVITY,
+        explore=LookerExplore.HISTORY,
+        fields=[
+            HistoryViewField.HISTORY_CREATED_DATE,
+            HistoryViewField.HISTORY_COUNT,
+            QueryViewField.QUERY_MODEL,
+            QueryViewField.QUERY_VIEW,
+        ],
+        filters={
+            QueryViewField.QUERY_VIEW: "NOT NULL",
+        },
+    ),
+    QueryId.EXPLORE_PER_USER_PER_DAY_USAGE_STAT: LookerQuery(
+        model=LookerModel.SYSTEM_ACTIVITY,
+        explore=LookerExplore.HISTORY,
+        fields=[
+            HistoryViewField.HISTORY_CREATED_DATE,
+            HistoryViewField.HISTORY_COUNT,
+            QueryViewField.QUERY_MODEL,
+            QueryViewField.QUERY_VIEW,
+            UserViewField.USER_ID,
+        ],
+        filters={
+            QueryViewField.QUERY_VIEW: "NOT NULL",
         },
     ),
 }
@@ -368,15 +408,26 @@ class BaseStatGenerator(ABC):
             query.filters.update(self.get_filter())
         return query
 
+    def emits_absolute_stats(self) -> bool:
+        """Whether the source exposes an absolute usage snapshot for this entity.
+
+        Dashboards and looks expose absolute counters (view/favorite counts) in
+        Looker; explores do not (System Activity has no per-explore absolute
+        snapshot). Generators for such entities override this to emit only the
+        per-day timeseries + per-user stats.
+        """
+        return True
+
     def generate_usage_stat_mcps(self) -> Iterable[MetadataChangeProposalWrapper]:
         # No looker entities available to process stat generation
         if len(self.looker_models) == 0:
             return
 
         # yield absolute stat for looker entities
-        for looker_object in self.looker_models:
-            aspect = self.to_entity_absolute_stat_aspect(looker_object)
-            yield self.create_mcp(looker_object, aspect)
+        if self.emits_absolute_stats():
+            for looker_object in self.looker_models:
+                aspect = self.to_entity_absolute_stat_aspect(looker_object)
+                yield self.create_mcp(looker_object, aspect)
 
         # Execute query and process the raw json which contains stat information
         entity_query_with_filters: LookerQuery = self._append_filters(
@@ -629,6 +680,134 @@ class LookStatGenerator(BaseStatGenerator):
         )
 
 
+class ExploreStatGenerator(BaseStatGenerator):
+    """Emits per-explore usage from Looker's System Activity `history` explore.
+
+    Explores map to the L2 layer of the Looker-derived semantic model, so their
+    query/user counts are the signal used to prioritize which generated models
+    are surfaced. Unlike dashboards and looks, Looker exposes no absolute usage
+    snapshot for an explore, so this generator emits only the per-day timeseries
+    stats (entity + per-user).
+    """
+
+    def __init__(
+        self,
+        config: StatGeneratorConfig,
+        looker_explores: Sequence[LookerExploreForUsage],
+        report: LookerDashboardSourceReport,
+        source_config: looker_common.LookerCommonConfig,
+    ):
+        super().__init__(
+            config,
+            looker_models=looker_explores,
+            report=report,
+        )
+        self.source_config = source_config
+        report.report_explores_scanned_for_usage(len(looker_explores))
+
+    @staticmethod
+    def _stat_key(model: str, explore: str) -> str:
+        return f"{model}::{explore}"
+
+    def get_stats_generator_name(self) -> str:
+        return "ExploreStats"
+
+    def report_skip_set(self) -> LossySet[str]:
+        return self.report.explores_skipped_for_usage
+
+    def get_filter(self) -> Dict[ViewField, str]:
+        return {
+            QueryViewField.QUERY_VIEW: ",".join(
+                sorted(
+                    {
+                        explore.name
+                        for explore in cast(
+                            Sequence[LookerExploreForUsage], self.looker_models
+                        )
+                    }
+                )
+            )
+        }
+
+    def get_id(self, looker_object: ModelForUsage) -> str:
+        explore = cast(LookerExploreForUsage, looker_object)
+        return self._stat_key(explore.model_name, explore.name)
+
+    def get_id_from_row(self, row: dict) -> str:
+        return self._stat_key(
+            str(row[QueryViewField.QUERY_MODEL]),
+            str(row[QueryViewField.QUERY_VIEW]),
+        )
+
+    def get_entity_stat_key(self, row: Dict) -> Tuple[str, str]:
+        return (
+            self.get_id_from_row(row),
+            row[HistoryViewField.HISTORY_CREATED_DATE],
+        )
+
+    def _get_urn(self, model: ModelForUsage) -> str:
+        explore = cast(LookerExploreForUsage, model)
+        return looker_common.LookerExplore(
+            name=explore.name, model_name=explore.model_name
+        ).get_explore_urn(self.source_config)
+
+    def emits_absolute_stats(self) -> bool:
+        # Looker has no absolute usage snapshot for an explore (only the per-day
+        # timeseries from System Activity), so skip the absolute-stat MCP.
+        return False
+
+    def to_entity_absolute_stat_aspect(
+        self, looker_object: ModelForUsage
+    ) -> DatasetUsageStatisticsClass:
+        # Unreachable: emits_absolute_stats() is False, so the base template
+        # never requests an absolute-stat aspect for explores.
+        raise NotImplementedError
+
+    def get_entity_timeseries_query(self) -> LookerQuery:
+        return query_collection[QueryId.EXPLORE_PER_DAY_USAGE_STAT]
+
+    def get_entity_user_timeseries_query(self) -> LookerQuery:
+        return query_collection[QueryId.EXPLORE_PER_USER_PER_DAY_USAGE_STAT]
+
+    def to_entity_timeseries_stat_aspect(
+        self, row: dict
+    ) -> DatasetUsageStatisticsClass:
+        self.report.explores_with_activity.add(self.get_id_from_row(row))
+        return DatasetUsageStatisticsClass(
+            timestampMillis=self._round_time(
+                row[HistoryViewField.HISTORY_CREATED_DATE]
+            ),
+            eventGranularity=TimeWindowSizeClass(unit=CalendarIntervalClass.DAY),
+            totalSqlQueries=row[HistoryViewField.HISTORY_COUNT],
+            uniqueUserCount=0,
+            userCounts=[],
+        )
+
+    def append_user_stat(
+        self, entity_stat_aspect: Aspect, user: LookerUser, row: Dict
+    ) -> None:
+        explore_stat_aspect: DatasetUsageStatisticsClass = cast(
+            DatasetUsageStatisticsClass, entity_stat_aspect
+        )
+
+        if explore_stat_aspect.userCounts is None:
+            explore_stat_aspect.userCounts = []
+
+        user_urn: Optional[str] = user.get_urn(self.config.strip_user_ids_from_email)
+        if user_urn is None:
+            logger.warning(f"user_urn not found for the user {user}")
+            return
+
+        explore_stat_aspect.userCounts.append(
+            DatasetUserUsageCountsClass(
+                user=user_urn,
+                count=row[HistoryViewField.HISTORY_COUNT],
+                userEmail=user.email,
+            )
+        )
+        explore_stat_aspect.uniqueUserCount = len(explore_stat_aspect.userCounts)
+
+
 def create_dashboard_stat_generator(
     config: StatGeneratorConfig,
     report: LookerDashboardSourceReport,
@@ -659,4 +838,23 @@ def create_chart_stat_generator(
     )
     return LookStatGenerator(
         config=config, looker_looks=looker_looks, report=report, urn_builder=urn_builder
+    )
+
+
+def create_explore_stat_generator(
+    config: StatGeneratorConfig,
+    report: LookerDashboardSourceReport,
+    source_config: looker_common.LookerCommonConfig,
+    looker_explores: Sequence[LookerExploreForUsage],
+) -> ExploreStatGenerator:
+    logger.debug(
+        "Number of explores received for stat processing = {}".format(
+            len(looker_explores)
+        )
+    )
+    return ExploreStatGenerator(
+        config=config,
+        looker_explores=looker_explores,
+        report=report,
+        source_config=source_config,
     )

--- a/metadata-ingestion/tests/integration/looker/test_looker.py
+++ b/metadata-ingestion/tests/integration/looker/test_looker.py
@@ -690,6 +690,10 @@ def side_effect_query_inline(
                 },
             ]
         ),
+        # Explore-level usage is unit-tested in tests/unit/looker/test_looker_usage.py;
+        # here we just return empty so the dashboard/look goldens are unaffected.
+        looker_usage.QueryId.EXPLORE_PER_DAY_USAGE_STAT: json.dumps([]),
+        looker_usage.QueryId.EXPLORE_PER_USER_PER_DAY_USAGE_STAT: json.dumps([]),
     }
 
     if query_id_vs_response.get(query_type) is None:

--- a/metadata-ingestion/tests/unit/looker/test_looker_usage.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_usage.py
@@ -1,0 +1,255 @@
+from unittest import mock
+
+from datahub.ingestion.source.looker import looker_usage
+from datahub.ingestion.source.looker.looker_common import (
+    LookerCommonConfig,
+    LookerDashboardSourceReport,
+)
+from datahub.ingestion.source.looker.looker_query_model import (
+    HistoryViewField,
+    LookerModel,
+    QueryViewField,
+    UserViewField,
+)
+from datahub.metadata.schema_classes import DatasetUsageStatisticsClass
+
+
+def _stat_config() -> looker_usage.StatGeneratorConfig:
+    return looker_usage.StatGeneratorConfig(
+        looker_api_wrapper=mock.MagicMock(),
+        looker_user_registry=mock.MagicMock(),
+        strip_user_ids_from_email=False,
+        interval="2022-07-01 to 2022-07-08",
+        max_threads=1,
+    )
+
+
+def test_explore_usage_queries_target_system_activity_query_view():
+    per_day = looker_usage.query_collection[
+        looker_usage.QueryId.EXPLORE_PER_DAY_USAGE_STAT
+    ]
+    per_user = looker_usage.query_collection[
+        looker_usage.QueryId.EXPLORE_PER_USER_PER_DAY_USAGE_STAT
+    ]
+
+    for query in (per_day, per_user):
+        assert query.model == LookerModel.SYSTEM_ACTIVITY
+        # An explore is identified by (query.model, query.view) in System Activity.
+        assert QueryViewField.QUERY_MODEL in query.fields
+        assert QueryViewField.QUERY_VIEW in query.fields
+        assert HistoryViewField.HISTORY_COUNT in query.fields
+
+    # Only the per-user variant carries the user dimension.
+    assert UserViewField.USER_ID not in per_day.fields
+    assert UserViewField.USER_ID in per_user.fields
+
+
+def test_explore_stat_generator_builds_explore_dataset_urn():
+    generator = looker_usage.create_explore_stat_generator(
+        config=_stat_config(),
+        report=LookerDashboardSourceReport(),
+        source_config=LookerCommonConfig(),
+        looker_explores=[
+            looker_usage.LookerExploreForUsage(
+                id=None, model_name="sales", name="orders"
+            )
+        ],
+    )
+
+    urn = generator._get_urn(
+        looker_usage.LookerExploreForUsage(id=None, model_name="sales", name="orders")
+    )
+    assert urn.startswith("urn:li:dataset:(urn:li:dataPlatform:looker,")
+    # Default explore_naming_pattern is "{model}.explore.{name}".
+    assert "sales.explore.orders" in urn
+
+
+def test_explore_stat_generator_emits_usage_stats():
+    entity_rows = [
+        {
+            QueryViewField.QUERY_MODEL: "sales",
+            QueryViewField.QUERY_VIEW: "orders",
+            HistoryViewField.HISTORY_CREATED_DATE: "2022-07-05",
+            HistoryViewField.HISTORY_COUNT: 30,
+        }
+    ]
+    user_rows = [
+        {
+            QueryViewField.QUERY_MODEL: "sales",
+            QueryViewField.QUERY_VIEW: "orders",
+            HistoryViewField.HISTORY_CREATED_DATE: "2022-07-05",
+            UserViewField.USER_ID: 1,
+            HistoryViewField.HISTORY_COUNT: 20,
+        },
+        {
+            QueryViewField.QUERY_MODEL: "sales",
+            QueryViewField.QUERY_VIEW: "orders",
+            HistoryViewField.HISTORY_CREATED_DATE: "2022-07-05",
+            UserViewField.USER_ID: 2,
+            HistoryViewField.HISTORY_COUNT: 10,
+        },
+    ]
+
+    config = _stat_config()
+    # entity query is executed first, then the per-user query.
+    config.looker_api_wrapper.execute_query.side_effect = [entity_rows, user_rows]
+
+    def fake_user(user_id: int):
+        user = mock.MagicMock()
+        user.get_urn.return_value = f"urn:li:corpuser:user{user_id}"
+        user.email = f"user{user_id}@example.com"
+        return user
+
+    config.looker_user_registry.get_by_id.side_effect = fake_user
+
+    generator = looker_usage.create_explore_stat_generator(
+        config=config,
+        report=LookerDashboardSourceReport(),
+        source_config=LookerCommonConfig(),
+        looker_explores=[
+            looker_usage.LookerExploreForUsage(
+                id=None, model_name="sales", name="orders"
+            )
+        ],
+    )
+
+    mcps = list(generator.generate_usage_stat_mcps())
+
+    assert len(mcps) == 1
+    aspect = mcps[0].aspect
+    assert isinstance(aspect, DatasetUsageStatisticsClass)
+    assert aspect.totalSqlQueries == 30
+    assert aspect.uniqueUserCount == 2
+    assert aspect.userCounts is not None
+    assert {uc.count for uc in aspect.userCounts} == {20, 10}
+    assert "sales.explore.orders" in mcps[0].entityUrn
+
+
+def test_explore_stat_key_round_trips_between_model_and_row():
+    # The generator keys ingested explores by get_id() and matches System
+    # Activity rows back by get_id_from_row(). If these diverge, the >100-explore
+    # post_filter path silently drops every row, so lock the contract here.
+    generator = looker_usage.create_explore_stat_generator(
+        config=_stat_config(),
+        report=LookerDashboardSourceReport(),
+        source_config=LookerCommonConfig(),
+        looker_explores=[
+            looker_usage.LookerExploreForUsage(
+                id=None, model_name="sales", name="orders"
+            )
+        ],
+    )
+
+    explore = looker_usage.LookerExploreForUsage(
+        id=None, model_name="sales", name="orders"
+    )
+    row = {
+        QueryViewField.QUERY_MODEL: "sales",
+        QueryViewField.QUERY_VIEW: "orders",
+    }
+    assert generator.get_id(explore) == generator.get_id_from_row(row)
+
+
+def test_explore_stat_generator_skips_unresolved_users():
+    entity_rows = [
+        {
+            QueryViewField.QUERY_MODEL: "sales",
+            QueryViewField.QUERY_VIEW: "orders",
+            HistoryViewField.HISTORY_CREATED_DATE: "2022-07-05",
+            HistoryViewField.HISTORY_COUNT: 30,
+        }
+    ]
+    user_rows = [
+        {
+            QueryViewField.QUERY_MODEL: "sales",
+            QueryViewField.QUERY_VIEW: "orders",
+            HistoryViewField.HISTORY_CREATED_DATE: "2022-07-05",
+            UserViewField.USER_ID: 1,
+            HistoryViewField.HISTORY_COUNT: 20,
+        },
+        {
+            QueryViewField.QUERY_MODEL: "sales",
+            QueryViewField.QUERY_VIEW: "orders",
+            HistoryViewField.HISTORY_CREATED_DATE: "2022-07-05",
+            UserViewField.USER_ID: 2,
+            HistoryViewField.HISTORY_COUNT: 10,
+        },
+    ]
+
+    config = _stat_config()
+    config.looker_api_wrapper.execute_query.side_effect = [entity_rows, user_rows]
+
+    def fake_user(user_id: int):
+        user = mock.MagicMock()
+        # User 2 has no resolvable urn (e.g. a deleted Looker user).
+        user.get_urn.return_value = (
+            f"urn:li:corpuser:user{user_id}" if user_id == 1 else None
+        )
+        user.email = f"user{user_id}@example.com"
+        return user
+
+    config.looker_user_registry.get_by_id.side_effect = fake_user
+
+    generator = looker_usage.create_explore_stat_generator(
+        config=config,
+        report=LookerDashboardSourceReport(),
+        source_config=LookerCommonConfig(),
+        looker_explores=[
+            looker_usage.LookerExploreForUsage(
+                id=None, model_name="sales", name="orders"
+            )
+        ],
+    )
+
+    mcps = list(generator.generate_usage_stat_mcps())
+
+    assert len(mcps) == 1
+    aspect = mcps[0].aspect
+    assert isinstance(aspect, DatasetUsageStatisticsClass)
+    # Entity-level totals are unaffected by the unresolved user.
+    assert aspect.totalSqlQueries == 30
+    # Only the resolvable user contributes to per-user counts.
+    assert aspect.uniqueUserCount == 1
+    assert aspect.userCounts is not None
+    assert {uc.count for uc in aspect.userCounts} == {20}
+
+
+def test_explore_stat_generator_reports_non_ingested_explore_as_skipped():
+    # System Activity returns usage for an explore we never ingested; it should
+    # not be emitted and should be recorded in the skip set for observability.
+    entity_rows = [
+        {
+            QueryViewField.QUERY_MODEL: "sales",
+            QueryViewField.QUERY_VIEW: "orders",
+            HistoryViewField.HISTORY_CREATED_DATE: "2022-07-05",
+            HistoryViewField.HISTORY_COUNT: 30,
+        },
+        {
+            QueryViewField.QUERY_MODEL: "sales",
+            QueryViewField.QUERY_VIEW: "returns",
+            HistoryViewField.HISTORY_CREATED_DATE: "2022-07-05",
+            HistoryViewField.HISTORY_COUNT: 5,
+        },
+    ]
+
+    config = _stat_config()
+    config.looker_api_wrapper.execute_query.side_effect = [entity_rows, []]
+
+    report = LookerDashboardSourceReport()
+    generator = looker_usage.create_explore_stat_generator(
+        config=config,
+        report=report,
+        source_config=LookerCommonConfig(),
+        looker_explores=[
+            looker_usage.LookerExploreForUsage(
+                id=None, model_name="sales", name="orders"
+            )
+        ],
+    )
+
+    mcps = list(generator.generate_usage_stat_mcps())
+
+    emitted_urns = [mcp.entityUrn for mcp in mcps]
+    assert any("sales.explore.orders" in urn for urn in emitted_urns)
+    assert not any("sales.explore.returns" in urn for urn in emitted_urns)
+    assert "sales::returns" in report.explores_skipped_for_usage

--- a/metadata-ingestion/tests/unit/looker/test_looker_usage.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_usage.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from unittest import mock
 
 from datahub.ingestion.source.looker import looker_usage
@@ -14,10 +15,13 @@ from datahub.ingestion.source.looker.looker_query_model import (
 from datahub.metadata.schema_classes import DatasetUsageStatisticsClass
 
 
-def _stat_config() -> looker_usage.StatGeneratorConfig:
+def _stat_config(
+    api: Optional[mock.MagicMock] = None,
+    user_registry: Optional[mock.MagicMock] = None,
+) -> looker_usage.StatGeneratorConfig:
     return looker_usage.StatGeneratorConfig(
-        looker_api_wrapper=mock.MagicMock(),
-        looker_user_registry=mock.MagicMock(),
+        looker_api_wrapper=api or mock.MagicMock(),
+        looker_user_registry=user_registry or mock.MagicMock(),
         strip_user_ids_from_email=False,
         interval="2022-07-01 to 2022-07-08",
         max_threads=1,
@@ -90,20 +94,21 @@ def test_explore_stat_generator_emits_usage_stats():
         },
     ]
 
-    config = _stat_config()
+    mock_api = mock.MagicMock()
     # entity query is executed first, then the per-user query.
-    config.looker_api_wrapper.execute_query.side_effect = [entity_rows, user_rows]
+    mock_api.execute_query.side_effect = [entity_rows, user_rows]
 
-    def fake_user(user_id: int):
+    def fake_user(user_id: int) -> mock.MagicMock:
         user = mock.MagicMock()
         user.get_urn.return_value = f"urn:li:corpuser:user{user_id}"
         user.email = f"user{user_id}@example.com"
         return user
 
-    config.looker_user_registry.get_by_id.side_effect = fake_user
+    mock_registry = mock.MagicMock()
+    mock_registry.get_by_id.side_effect = fake_user
 
     generator = looker_usage.create_explore_stat_generator(
-        config=config,
+        config=_stat_config(api=mock_api, user_registry=mock_registry),
         report=LookerDashboardSourceReport(),
         source_config=LookerCommonConfig(),
         looker_explores=[
@@ -122,7 +127,8 @@ def test_explore_stat_generator_emits_usage_stats():
     assert aspect.uniqueUserCount == 2
     assert aspect.userCounts is not None
     assert {uc.count for uc in aspect.userCounts} == {20, 10}
-    assert "sales.explore.orders" in mcps[0].entityUrn
+    entity_urn = mcps[0].entityUrn
+    assert entity_urn is not None and "sales.explore.orders" in entity_urn
 
 
 def test_explore_stat_key_round_trips_between_model_and_row():
@@ -176,10 +182,10 @@ def test_explore_stat_generator_skips_unresolved_users():
         },
     ]
 
-    config = _stat_config()
-    config.looker_api_wrapper.execute_query.side_effect = [entity_rows, user_rows]
+    mock_api = mock.MagicMock()
+    mock_api.execute_query.side_effect = [entity_rows, user_rows]
 
-    def fake_user(user_id: int):
+    def fake_user(user_id: int) -> mock.MagicMock:
         user = mock.MagicMock()
         # User 2 has no resolvable urn (e.g. a deleted Looker user).
         user.get_urn.return_value = (
@@ -188,10 +194,11 @@ def test_explore_stat_generator_skips_unresolved_users():
         user.email = f"user{user_id}@example.com"
         return user
 
-    config.looker_user_registry.get_by_id.side_effect = fake_user
+    mock_registry = mock.MagicMock()
+    mock_registry.get_by_id.side_effect = fake_user
 
     generator = looker_usage.create_explore_stat_generator(
-        config=config,
+        config=_stat_config(api=mock_api, user_registry=mock_registry),
         report=LookerDashboardSourceReport(),
         source_config=LookerCommonConfig(),
         looker_explores=[
@@ -232,12 +239,12 @@ def test_explore_stat_generator_reports_non_ingested_explore_as_skipped():
         },
     ]
 
-    config = _stat_config()
-    config.looker_api_wrapper.execute_query.side_effect = [entity_rows, []]
+    mock_api = mock.MagicMock()
+    mock_api.execute_query.side_effect = [entity_rows, []]
 
     report = LookerDashboardSourceReport()
     generator = looker_usage.create_explore_stat_generator(
-        config=config,
+        config=_stat_config(api=mock_api),
         report=report,
         source_config=LookerCommonConfig(),
         looker_explores=[
@@ -249,7 +256,7 @@ def test_explore_stat_generator_reports_non_ingested_explore_as_skipped():
 
     mcps = list(generator.generate_usage_stat_mcps())
 
-    emitted_urns = [mcp.entityUrn for mcp in mcps]
+    emitted_urns = [mcp.entityUrn or "" for mcp in mcps]
     assert any("sales.explore.orders" in urn for urn in emitted_urns)
     assert not any("sales.explore.returns" in urn for urn in emitted_urns)
     assert "sales::returns" in report.explores_skipped_for_usage


### PR DESCRIPTION
## 📋 Summary

Emit per-explore usage statistics from the Looker ingestion source.

## 🎯 Motivation

The Looker connector already emits usage for **dashboards** and **looks/charts**, but never for **explores**. Explores are ingested as datasets, yet they carried no usage signal — query volume and unique-user counts for explores were invisible in DataHub. This PR closes that gap so explore usage is collected alongside dashboard and look usage.

## 🔧 Changes Overview

**New Features:**

- Per-explore usage extraction from Looker's **System Activity** `history` explore, aggregated by `(query.model, query.view)` — Looker identifies an explore by its model + view.
- Emits `DatasetUsageStatistics` (`totalSqlQueries`, `uniqueUserCount`, per-user `userCounts`) on the explore's dataset URN, mirroring the existing dashboard/look stat generators.
- New report counters for observability: explores scanned for usage, explores with activity, and explores skipped.

**Modifications:**

- Usage extraction now runs a third stat generator (`ExploreStatGenerator`) alongside the dashboard and look generators.
- The source tracks the explores it actually emitted (`explores_for_usage`) so usage attaches only to ingested explores.
- Added an `emits_absolute_stats()` hook to the shared `BaseStatGenerator` template so generators that have no absolute usage snapshot (explores) can opt out cleanly instead of duplicating the generation algorithm. The default is `True`, preserving existing dashboard/look behavior exactly.

**Config:** No new configuration. Gated entirely by the existing `extract_usage_history` flag.

## 🏗️ Architecture / Design Notes

- Reuses the existing template-method pattern (`BaseStatGenerator`). Explores have no absolute usage snapshot in Looker (unlike dashboards/looks), so only per-day timeseries + per-user stats are emitted; the new `emits_absolute_stats()` hook expresses this without overriding the whole algorithm.
- Explores are matched back to System Activity rows via a stable `"{model}::{explore}"` key (`get_id` / `get_id_from_row`), which also drives the >100-entity server-side-vs-post-filter code path.
- `DatasetUsageStatistics` is a timeseries (append-only) aspect, so there is no PATCH-vs-UPSERT / user-curated-metadata overwrite concern.

## 🧪 Testing

- New unit tests in `tests/unit/looker/test_looker_usage.py`:
  - query definitions target System Activity with the correct model/view/user fields;
  - explore dataset URN construction;
  - full timeseries + per-user aggregation;
  - **key round-trip contract** (`get_id` ↔ `get_id_from_row`) — guards the >100-explore silent-drop path;
  - unresolved-user handling (entity totals unaffected, user skipped);
  - non-ingested-explore reporting via the skip set.
- Existing dashboard/look golden integration tests are unaffected — the two new explore queries are stubbed empty in the integration test.
- Verified locally: `ruff` format + lint clean, `mypy` clean, all Looker unit tests pass, and the dashboard/look usage goldens pass.

**Live end-to-end validation** (against a real Looker instance, file sink only — nothing published):

- Per-explore `datasetUsageStatistics` MCPs were emitted on explore dataset URNs (e.g. `...,<model>.explore.<name>,PROD)`), each with `totalSqlQueries` and `uniqueUserCount` populated from System Activity.
- The new report counters worked as intended: `explores_scanned_for_usage`, `explores_with_activity`, and `explores_skipped_for_usage` (an explore with usage that wasn't ingested was correctly recorded in the skip set rather than silently dropped — exercising the `get_id`/`get_id_from_row` key round-trip against real data).
- A narrow historical interval yielded zero explore-usage rows and the generator degraded cleanly to no MCPs (no error); widening `extract_usage_history_for_interval` surfaced real activity.

## 📊 Impact Assessment

- **Affected Components:** Looker ingestion source only (`metadata-ingestion`).
- **Breaking Changes:** None.
- **Performance:** Two additional System Activity queries per ingestion run when `extract_usage_history` is enabled.
- **Risk Level:** Low — additive, flag-gated, no schema/model changes, timeseries aspect only.

## 🚀 Deployment Notes

- No migration and no new config. Only active when `extract_usage_history` is enabled.
- Rollback is safe: revert the change, no data migration involved.

## 🔗 Follow-ups

- Golden / end-to-end integration coverage that asserts an explore usage MCP is emitted through the full source pipeline.
- View-level (L1) usage is not derivable at the explore-query grain in System Activity and is left as a follow-up.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing/#commit-message-format))
- [x] Tests added / updated
- [x] Docs added / updated (Looker connector docs: new "Usage Statistics" section + `USAGE_STATS` capability description)
