### PR TITLE
feat(usage): add report-driven MCP Tier B metering path

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/identity/UsageActorClassResolver.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/identity/UsageActorClassResolver.java
@@ -18,7 +18,7 @@ import javax.annotation.Nullable;
 public class UsageActorClassResolver {
 
   private static final Set<String> KNOWN_SYSTEM_ACTOR_URNS =
-      Set.of(Constants.SYSTEM_ACTOR, Constants.UNKNOWN_ACTOR, Constants.ANONYMOUS_ACTOR);
+      Set.of(Constants.SYSTEM_ACTOR, Constants.ANONYMOUS_ACTOR);
 
   private final CorpUserFlagsProvider corpUserFlagsProvider;
 
@@ -54,8 +54,17 @@ public class UsageActorClassResolver {
     if (usageIdentity != null && KNOWN_SYSTEM_ACTOR_URNS.contains(usageIdentity)) {
       return UsageActorClass.SYSTEM;
     }
+    // System credentials may write attributed usage (ReportedUsage). Classify the
+    // attributed identity when it differs from the system session actor — metering is not access
+    // control.
     if (isSystemAuthentication(authentication)) {
-      return UsageActorClass.SYSTEM;
+      String sessionUrn =
+          authentication.getActor() != null ? authentication.getActor().toUrnStr() : null;
+      boolean attributedIsSystemSession =
+          usageIdentity == null || usageIdentity.isBlank() || usageIdentity.equals(sessionUrn);
+      if (attributedIsSystemSession) {
+        return UsageActorClass.SYSTEM;
+      }
     }
 
     String corpUserUrn = resolveCorpUserUrn(usageIdentity, actorUrn);

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/registry/metrics/UsageMetricIncrementResolver.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/registry/metrics/UsageMetricIncrementResolver.java
@@ -19,8 +19,7 @@ public final class UsageMetricIncrementResolver {
 
   /**
    * Returns true when the metric's {@code (emit_when, value_unit)} pair is recognized. Distinct
-   * metrics and explicit no-op rules ({@link UsageMetricRegistry.EmitWhen#INTEGRATIONS_MCP_REPORT})
-   * are always supported.
+   * metrics and report-driven ({@link UsageMetricRegistry.EmitWhen#REPORTED}) rules are supported.
    */
   public static boolean isSupported(@Nonnull UsageMetricRegistry.MetricDefinition metric) {
     if (metric.mergeKind() == UsageMetricRegistry.MergeKind.DISTINCT) {
@@ -30,8 +29,14 @@ public final class UsageMetricIncrementResolver {
       };
     }
     return resolveRequestPhaseIncrement(metric, null, null) >= 0
-        || metric.emitWhen() == UsageMetricRegistry.EmitWhen.INTEGRATIONS_MCP_REPORT
+        || isReportDrivenMetric(metric)
         || isResponsePhaseMetric(metric);
+  }
+
+  /** Additive metrics incremented only via {@code recordReportedUsage}. */
+  public static boolean isReportDrivenMetric(@Nonnull UsageMetricRegistry.MetricDefinition metric) {
+    return metric.mergeKind() == UsageMetricRegistry.MergeKind.ADDITIVE
+        && metric.emitWhen().isReportDriven();
   }
 
   /** True for additive metrics incremented during {@code recordResponse}. */
@@ -69,7 +74,7 @@ public final class UsageMetricIncrementResolver {
           metric.valueUnit(), operationEntry, requestContext);
       case COST_PROFILE -> resolveCostProfileIncrement(
           metric.valueUnit(), operationEntry, usageQuantity);
-      case INTEGRATIONS_MCP_REPORT -> 0L;
+      case REPORTED -> 0L;
       default -> -1;
     };
   }
@@ -92,7 +97,11 @@ public final class UsageMetricIncrementResolver {
     if ("billed_bytes".equals(metric.metricName())) {
       return Optional.of(BILLED_BYTES_METRIC);
     }
-    if (metric.metronomeBatch()) {
+    if (isReportDrivenMetric(metric)) {
+      // Do not share DATAHUB_REQUEST_COUNT with api_calls; export under the registry name.
+      if (metric.valueUnit() == ValueUnit.COUNT) {
+        return Optional.of("datahub.usage." + metric.metricName());
+      }
       return Optional.empty();
     }
     return switch (metric.valueUnit()) {
@@ -129,7 +138,7 @@ public final class UsageMetricIncrementResolver {
           || metric.valueUnit() == ValueUnit.INPUT_BYTES;
       case INGESTION_REQUEST -> metric.valueUnit() == ValueUnit.INPUT_BYTES;
       case COST_PROFILE -> metric.valueUnit() == ValueUnit.COST_UNITS;
-      case INTEGRATIONS_MCP_REPORT -> true;
+      case REPORTED -> true;
       default -> false;
     };
   }

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/registry/metrics/UsageMetricRegistry.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/registry/metrics/UsageMetricRegistry.java
@@ -73,7 +73,17 @@ public class UsageMetricRegistry {
     WRITER_ACTIVITY_ALLOWLIST,
     INGESTION_REQUEST,
     COST_PROFILE,
-    INTEGRATIONS_MCP_REPORT;
+    /**
+     * Additive metrics recorded only via {@link
+     * com.linkedin.metadata.usage.store.UsageAggregationStore#recordReportedUsage} (not
+     * request-path {@code recordRequest}).
+     */
+    REPORTED;
+
+    /** True when the metric is incremented only from report-driven usage. */
+    public boolean isReportDriven() {
+      return this == REPORTED;
+    }
 
     static EmitWhen fromYaml(String raw) {
       return switch (raw.toLowerCase()) {
@@ -83,7 +93,7 @@ public class UsageMetricRegistry {
         case "writer_activity_allowlist" -> WRITER_ACTIVITY_ALLOWLIST;
         case "ingestion_request" -> INGESTION_REQUEST;
         case "cost_profile" -> COST_PROFILE;
-        case "integrations_mcp_report" -> INTEGRATIONS_MCP_REPORT;
+        case "reported" -> REPORTED;
         default -> throw new IllegalArgumentException("Unknown emit_when: " + raw);
       };
     }
@@ -94,7 +104,6 @@ public class UsageMetricRegistry {
       MergeKind mergeKind,
       String distinctKey,
       ValueUnit valueUnit,
-      boolean metronomeBatch,
       EmitWhen emitWhen) {
 
     public static MetricDefinition fromYamlDefinition(
@@ -104,7 +113,6 @@ public class UsageMetricRegistry {
           MergeKind.fromYaml(def.getMergeKind()),
           def.getDistinctKey(),
           ValueUnit.fromYaml(def.getValueUnit()),
-          def.isMetronomeBatch(),
           EmitWhen.fromYaml(def.getEmitWhen()));
     }
   }

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/registry/operations/UsageOperationsRegistry.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/registry/operations/UsageOperationsRegistry.java
@@ -100,6 +100,7 @@ public class UsageOperationsRegistry {
       case "openapi" -> RequestContext.RequestAPI.OPENAPI;
       case "restli" -> RequestContext.RequestAPI.RESTLI;
       case "messaging" -> RequestContext.RequestAPI.MESSAGING;
+      case "mcp" -> RequestContext.RequestAPI.MCP;
       default -> throw new IllegalArgumentException("Unknown request_api in manifest: " + raw);
     };
   }

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/report/ReportedUsage.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/report/ReportedUsage.java
@@ -1,0 +1,153 @@
+package com.linkedin.metadata.usage.report;
+
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.usage.UsageDimensions;
+import com.linkedin.metadata.usage.store.UsageAggregationStore;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.RequestContext;
+import io.datahubproject.metadata.context.usage.AuthChannel;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Records externally reported usage into {@link UsageAggregationStore} using the same dimension
+ * vocabulary as HTTP usage tracking.
+ *
+ * <p>Taxonomy and API allowlisting are enforced via {@code usage_operations.yaml} when the store
+ * resolves the operation. Which metrics increment is controlled by {@code emit_when: reported} in
+ * the metric registry — not by billing event-type allowlists.
+ *
+ * <p>This is metering, not access control: builds an attributed {@link RequestContext} and records
+ * via {@link UsageAggregationStore#recordReportedUsage}. Reports are never rejected because an
+ * attributed actor is missing, removed, or suspended.
+ */
+@Slf4j
+public final class ReportedUsage {
+
+  /** Report-payload keys (not rollup dimensions — see {@link UsageDimensions}). */
+  public static final String PROP_ACTOR_URN = "actor_urn";
+
+  public static final String PROP_USAGE_IDENTITY = "usage_identity";
+  public static final String PROP_USER_AGENT = "user_agent";
+
+  private ReportedUsage() {}
+
+  /**
+   * Records {@code quantity} for a report-driven event. Builds an attributed {@link RequestContext}
+   * from {@code properties}. Requires {@link UsageDimensions#USAGE_OPERATION} and {@link
+   * UsageDimensions#REQUEST_API}; the store rejects unknown operations or API mismatches against
+   * {@code usage_operations.yaml}.
+   *
+   * @return false when required props are missing, quantity is non-positive, or the store rejects
+   *     the report
+   */
+  public static boolean record(
+      @Nonnull UsageAggregationStore usageAggregationStore,
+      @Nonnull OperationContext systemOperationContext,
+      long quantity,
+      @Nonnull Map<String, Object> properties) {
+    if (quantity <= 0) {
+      return false;
+    }
+
+    String usageOperation = stringProp(properties, UsageDimensions.USAGE_OPERATION);
+    if (usageOperation == null || usageOperation.isBlank()) {
+      return false;
+    }
+
+    RequestContext.RequestAPI requestApi =
+        parseRequestApi(stringProp(properties, UsageDimensions.REQUEST_API));
+    if (requestApi == null) {
+      return false;
+    }
+
+    String actorUrn = firstNonBlank(properties, PROP_ACTOR_URN, PROP_USAGE_IDENTITY);
+    if (actorUrn == null || actorUrn.isBlank()) {
+      // Stable unknown — UsageActorClassResolver classifies as regular (not system session).
+      actorUrn = Constants.UNKNOWN_ACTOR;
+    }
+    String usageIdentity = firstNonBlank(properties, PROP_USAGE_IDENTITY, PROP_ACTOR_URN);
+    if (usageIdentity == null || usageIdentity.isBlank()) {
+      usageIdentity = actorUrn;
+    }
+
+    String userAgent = stringProp(properties, PROP_USER_AGENT);
+    if (userAgent == null) {
+      userAgent = "";
+    }
+    AuthChannel authChannel =
+        parseAuthChannel(stringProp(properties, UsageDimensions.AUTH_CHANNEL));
+
+    // Omit metricUtils: RequestContext construction would otherwise emit request-count Micrometer.
+    RequestContext requestContext =
+        RequestContext.builder()
+            .actorUrn(actorUrn)
+            .sourceIP("0.0.0.0")
+            .requestAPI(requestApi)
+            .requestID("reported_usage:" + usageOperation)
+            .userAgent(userAgent)
+            .usageOperation(usageOperation)
+            .usageIdentity(usageIdentity)
+            .authChannel(authChannel)
+            .build();
+
+    boolean recorded =
+        usageAggregationStore.recordReportedUsage(systemOperationContext, requestContext, quantity);
+    if (recorded) {
+      log.debug(
+          "Recorded reported usage quantity={} operation={} requestApi={}",
+          quantity,
+          usageOperation,
+          requestApi);
+    }
+    return recorded;
+  }
+
+  @Nullable
+  private static RequestContext.RequestAPI parseRequestApi(@Nullable String raw) {
+    if (raw == null || raw.isBlank()) {
+      return null;
+    }
+    try {
+      return RequestContext.RequestAPI.valueOf(raw.trim().toUpperCase());
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  @Nonnull
+  private static AuthChannel parseAuthChannel(@Nullable String raw) {
+    if (raw == null || raw.isBlank()) {
+      return AuthChannel.UNKNOWN;
+    }
+    try {
+      return AuthChannel.valueOf(raw.trim().toUpperCase());
+    } catch (IllegalArgumentException e) {
+      return AuthChannel.UNKNOWN;
+    }
+  }
+
+  @Nullable
+  private static String firstNonBlank(
+      @Nonnull Map<String, Object> properties, @Nonnull String... keys) {
+    for (String key : keys) {
+      String value = stringProp(properties, key);
+      if (value != null && !value.isBlank()) {
+        return value;
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  private static String stringProp(@Nonnull Map<String, Object> properties, @Nonnull String key) {
+    Object value = properties.get(key);
+    if (value == null) {
+      return null;
+    }
+    String asString = String.valueOf(value).trim();
+    return asString.isEmpty() ? null : asString;
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/report/ReportedUsage.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/report/ReportedUsage.java
@@ -17,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
  *
  * <p>Taxonomy and API allowlisting are enforced via {@code usage_operations.yaml} when the store
  * resolves the operation. Which metrics increment is controlled by {@code emit_when: reported} in
- * the metric registry — not by billing event-type allowlists.
+ * the metric registry.
  *
  * <p>This is metering, not access control: builds an attributed {@link RequestContext} and records
  * via {@link UsageAggregationStore#recordReportedUsage}. Reports are never rejected because an

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/store/InMemoryUsageAggregationStore.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/store/InMemoryUsageAggregationStore.java
@@ -39,9 +39,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * In-memory {@link UsageAggregationStore} for GMS API request/response usage metrics.
  *
- * <p>Renamed from {@code InMemoryUsageRollupStore} to avoid colliding with the legacy product-usage
- * rollup type in {@code com.linkedin.metadata.billing.rollup}.
- *
  * <p>Recorders hold a shared read lock while writing to the active window; drain swaps windows
  * under an exclusive write lock (brief) then builds and publishes Micrometer batches outside any
  * lock.
@@ -212,6 +209,74 @@ public class InMemoryUsageAggregationStore implements UsageAggregationStore {
     }
     tryTriggerDrain();
     return true;
+  }
+
+  @Override
+  public boolean recordReportedUsage(
+      @Nonnull OperationContext systemOperationContext,
+      @Nonnull RequestContext requestContext,
+      long quantity) {
+    if (quantity <= 0) {
+      return false;
+    }
+    UsageOperationsRegistry.UsageOperationEntry operationEntry =
+        resolveAllowedOperation(requestContext);
+    if (operationEntry == null) {
+      return false;
+    }
+    UsageActorClass actorClass =
+        actorClassResolver.resolve(
+            systemOperationContext,
+            requestContext,
+            systemOperationContext.getSessionAuthentication());
+    String usageIdentity =
+        requestContext.getUsageIdentity() != null
+            ? requestContext.getUsageIdentity()
+            : requestContext.getActorUrn();
+    AttributionType attribution = UsageDimensions.resolveAttribution(requestContext);
+    ActivitySnapshot activitySnapshot =
+        ActivitySnapshot.fromActivityClass(operationEntry.activityClass());
+
+    Map<String, String> resolvedDimensions =
+        new HashMap<>(
+            UsageDimensions.fromRequestContext(
+                requestContext, requestContext.getUsageOperation(), null));
+    resolvedDimensions.putIfAbsent(UsageDimensions.ACTOR_CLASS, actorClass.dimensionValue());
+    Map<String, String> dimKey = Map.copyOf(resolvedDimensions);
+
+    boolean recorded = false;
+    windowLock.readLock().lock();
+    try {
+      ActiveWindow window = activeWindow;
+      String windowId = window.windowId();
+      for (UsageMetricRegistry.MetricDefinition metric :
+          metricRegistry.apiUsageMetrics().values()) {
+        if (metric.mergeKind() == UsageMetricRegistry.MergeKind.DISTINCT) {
+          if (!UsageMetricIncrementResolver.shouldEmitDistinct(
+              metric, activitySnapshot, operationEntry)) {
+            continue;
+          }
+          DistinctRollupKey key =
+              new DistinctRollupKey(windowId, metric.metricName(), actorClass.dimensionValue());
+          recordDistinctIdentity(window, key, usageIdentity, attribution);
+          recorded = true;
+          continue;
+        }
+        if (!UsageMetricIncrementResolver.isReportDrivenMetric(metric)) {
+          continue;
+        }
+        AdditiveRollupKey key =
+            new AdditiveRollupKey(windowId, metric.metricName(), actorClass, dimKey);
+        recordAdditive(window, key, quantity);
+        recorded = true;
+      }
+    } finally {
+      windowLock.readLock().unlock();
+    }
+    if (recorded) {
+      tryTriggerDrain();
+    }
+    return recorded;
   }
 
   @Override

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/store/UsageAggregationStore.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/store/UsageAggregationStore.java
@@ -28,10 +28,11 @@ public interface UsageAggregationStore {
    *
    * <p>Pass the system {@link OperationContext} for actor-class aspect reads and an attributed
    * {@link RequestContext} built by the reporter. Does not invoke {@code SessionContextEnricher} /
-   * request-path {@code api_calls}. Increments only metrics with {@code emit_when: reported}.
-   * Default no-op when a deployment does not implement the hook.
+   * request-path {@code api_calls}. Increments additive metrics with {@code emit_when: reported}
+   * and applies the same distinct-metric allowlists as {@link #recordRequest}. Default no-op when a
+   * deployment does not implement the hook.
    *
-   * @return true when at least one report-driven metric was recorded
+   * @return true when at least one metric bucket was updated
    */
   default boolean recordReportedUsage(
       @Nonnull OperationContext systemOperationContext,

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/store/UsageAggregationStore.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/store/UsageAggregationStore.java
@@ -1,15 +1,12 @@
 package com.linkedin.metadata.usage.store;
 
 import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.RequestContext;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * In-memory store for GMS API usage aggregation (operational Micrometer + optional commercial flush
- * sinks).
- *
- * <p>Not to be confused with {@link com.linkedin.metadata.billing.rollup.UsageRollupStore}, the
- * legacy product-usage rollup for integrations events (MCP, ingest proposals, etc.).
+ * In-memory store for GMS API usage aggregation (operational Micrometer + optional flush sinks).
  *
  * @see InMemoryUsageAggregationStore
  */
@@ -25,4 +22,21 @@ public interface UsageAggregationStore {
   void recordResponse(@Nonnull OperationContext opContext, @Nullable Long outputBytes);
 
   void flush(@Nonnull com.linkedin.metadata.usage.flush.FlushTrigger trigger);
+
+  /**
+   * Report-driven usage from trusted reporters (not HTTP request-path {@link #recordRequest}).
+   *
+   * <p>Pass the system {@link OperationContext} for actor-class aspect reads and an attributed
+   * {@link RequestContext} built by the reporter. Does not invoke {@code SessionContextEnricher} /
+   * request-path {@code api_calls}. Increments only metrics with {@code emit_when: reported}.
+   * Default no-op when a deployment does not implement the hook.
+   *
+   * @return true when at least one report-driven metric was recorded
+   */
+  default boolean recordReportedUsage(
+      @Nonnull OperationContext systemOperationContext,
+      @Nonnull RequestContext requestContext,
+      long quantity) {
+    return false;
+  }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/UsageMetricRegistryTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/UsageMetricRegistryTest.java
@@ -18,6 +18,8 @@ public class UsageMetricRegistryTest {
     UsageMetricRegistry registry = UsageMetricRegistry.loadBundled(loader, java.util.List.of());
     Assert.assertFalse(registry.apiUsageMetrics().isEmpty());
     Assert.assertTrue(registry.apiUsageMetrics().containsKey("api_calls"));
+    Assert.assertTrue(registry.apiUsageMetrics().containsKey("mcp_queries"));
+    Assert.assertTrue(registry.apiUsageMetrics().get("mcp_queries").emitWhen().isReportDriven());
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/UsageRollupSystemsBoundaryTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/UsageRollupSystemsBoundaryTest.java
@@ -9,24 +9,33 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.testng.annotations.Test;
 
-/** Ensures billing rollup and API usage aggregation remain separate packages. */
+/**
+ * Ensures the legacy product-usage rollup package and API usage aggregation remain separate.
+ * Package directory names under {@code metadata/billing} are commercial overlays.
+ */
 public class UsageRollupSystemsBoundaryTest {
 
   private static final Path METADATA_IO_SRC = Path.of("src/main/java/com/linkedin/metadata");
 
   @Test
-  public void usagePackagesDoNotImportBillingRollup() throws IOException {
+  public void ossUsagePackagesDoNotImportProductUsageRollup() throws IOException {
     Path usageRoot = METADATA_IO_SRC.resolve("usage");
     try (Stream<Path> paths = Files.walk(usageRoot)) {
       paths
           .filter(path -> path.toString().endsWith(".java"))
+          // Commercial overlay under usage/billing may integrate with product rollup packages.
+          .filter(path -> !path.toString().contains("/usage/billing/"))
           .forEach(
               path -> {
                 try {
                   for (String line : Files.readAllLines(path)) {
                     if (line.startsWith("import ")
                         && line.contains("com.linkedin.metadata.billing.rollup.")) {
-                      fail("usage package must not import billing.rollup: " + path + " -> " + line);
+                      fail(
+                          "OSS usage package must not import product-usage rollup: "
+                              + path
+                              + " -> "
+                              + line);
                     }
                   }
                 } catch (IOException e) {
@@ -37,19 +46,18 @@ public class UsageRollupSystemsBoundaryTest {
   }
 
   @Test
-  public void billingRollupDoesNotImportUsageStore() throws IOException {
+  public void productUsageRollupDoesNotImportUsageStore() throws IOException {
     Path rollupRoot = METADATA_IO_SRC.resolve("billing/rollup");
     Path rollupStore = rollupRoot.resolve("InMemoryUsageRollupStore.java");
     if (!Files.exists(rollupStore)) {
-      return; // OSS deployments without billing rollup skip this boundary check.
+      return; // Deployments without the product-usage rollup package skip this check.
     }
     List<String> lines = Files.readAllLines(rollupStore);
     for (String line : lines) {
       if (line.startsWith("import ") && line.contains("com.linkedin.metadata.usage.store.")) {
-        fail("billing.rollup must not import usage.store: " + line);
+        fail("product-usage rollup must not import usage.store: " + line);
       }
     }
-    // Javadoc @see links are allowed; verify no compile-time imports across all rollup sources.
     try (Stream<Path> paths = Files.walk(rollupRoot)) {
       paths
           .filter(path -> path.toString().endsWith(".java"))
@@ -59,7 +67,7 @@ public class UsageRollupSystemsBoundaryTest {
                   for (String line : Files.readAllLines(path)) {
                     if (line.startsWith("import ")
                         && line.contains("com.linkedin.metadata.usage.")) {
-                      fail("billing.rollup must not import usage.*: " + path + " -> " + line);
+                      fail("product-usage rollup must not import usage.*: " + path + " -> " + line);
                     }
                   }
                 } catch (IOException e) {

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/identity/UsageActorClassResolverTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/identity/UsageActorClassResolverTest.java
@@ -122,6 +122,17 @@ public class UsageActorClassResolverTest {
   }
 
   @Test
+  public void testUnknownUsageIdentityIsRegular() throws Exception {
+    // Stable unknown principal (unparsed JWT subject, etc.) — regular, not system.
+    Assert.assertEquals(
+        defaultResolver.resolve(
+            context(Constants.UNKNOWN_ACTOR),
+            request(Constants.UNKNOWN_ACTOR),
+            userAuth(Constants.SYSTEM_ACTOR)),
+        UsageActorClass.REGULAR);
+  }
+
+  @Test
   public void testResolvesCorpUserFromActorUrnWhenUsageIdentityMissing() throws Exception {
     UsageActorClassResolver resolver =
         new UsageActorClassResolver(new FixedCorpUserFlagsProvider(false, true));
@@ -166,6 +177,32 @@ public class UsageActorClassResolverTest {
     org.mockito.Mockito.when(auth.getActor()).thenReturn(null);
     Assert.assertEquals(
         defaultResolver.resolve(opContext, requestContext, auth), UsageActorClass.REGULAR);
+  }
+
+  @Test
+  public void testSystemAuthWithAttributedCorpUserClassifiesAttributedIdentity() throws Exception {
+    UsageActorClassResolver resolver =
+        new UsageActorClassResolver(new FixedCorpUserFlagsProvider(false, true));
+    RequestContext requestContext = request(UsageTestFixtures.REGULAR_CORP_USER_URN);
+    OperationContext opContext =
+        TestOperationContexts.systemContextNoValidate().toBuilder()
+            .requestContext(requestContext)
+            .build(TestOperationContexts.systemContextNoValidate().getSessionActorContext(), false);
+    Assert.assertEquals(
+        resolver.resolve(opContext, requestContext, userAuth(Constants.SYSTEM_ACTOR)),
+        UsageActorClass.SUPPORT);
+  }
+
+  @Test
+  public void testSystemAuthWithoutAttributedIdentityRemainsSystem() throws Exception {
+    RequestContext requestContext = request(Constants.SYSTEM_ACTOR);
+    OperationContext opContext =
+        TestOperationContexts.systemContextNoValidate().toBuilder()
+            .requestContext(requestContext)
+            .build(TestOperationContexts.systemContextNoValidate().getSessionActorContext(), false);
+    Assert.assertEquals(
+        defaultResolver.resolve(opContext, requestContext, userAuth(Constants.SYSTEM_ACTOR)),
+        UsageActorClass.SYSTEM);
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/registry/UsageMetricIncrementResolverTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/registry/UsageMetricIncrementResolverTest.java
@@ -43,6 +43,19 @@ public class UsageMetricIncrementResolverTest {
   }
 
   @Test
+  public void testReportedMcpQueriesExportsDedicatedMicrometerName() {
+    UsageMetricRegistry.MetricDefinition metric =
+        ossRegistry().apiUsageMetrics().get("mcp_queries");
+    Assert.assertTrue(UsageMetricIncrementResolver.isReportDrivenMetric(metric));
+    Assert.assertEquals(
+        UsageMetricIncrementResolver.micrometerCounterName(metric),
+        Optional.of("datahub.usage.mcp_queries"));
+    Assert.assertNotEquals(
+        UsageMetricIncrementResolver.micrometerCounterName(metric),
+        Optional.of(MetricUtils.DATAHUB_REQUEST_COUNT));
+  }
+
+  @Test
   public void testApiCallsIncrementForNonIngest() {
     UsageMetricRegistry.MetricDefinition metric = ossRegistry().apiUsageMetrics().get("api_calls");
     UsageOperationsRegistry.UsageOperationEntry entry =
@@ -140,7 +153,6 @@ public class UsageMetricIncrementResolverTest {
             UsageMetricRegistry.MergeKind.ADDITIVE,
             null,
             com.linkedin.metadata.usage.registry.metrics.ValueUnit.COST_UNITS,
-            false,
             UsageMetricRegistry.EmitWhen.COST_PROFILE);
     UsageOperationsRegistry ossOps =
         UsageOperationsRegistry.loadOssOnly(new UsageOperationsLoader(yamlMapper()));
@@ -158,7 +170,6 @@ public class UsageMetricIncrementResolverTest {
             UsageMetricRegistry.MergeKind.ADDITIVE,
             null,
             com.linkedin.metadata.usage.registry.metrics.ValueUnit.OUTPUT_BYTES,
-            false,
             UsageMetricRegistry.EmitWhen.ALWAYS);
     Assert.assertEquals(
         UsageMetricIncrementResolver.micrometerCounterName(metric),
@@ -173,7 +184,6 @@ public class UsageMetricIncrementResolverTest {
             UsageMetricRegistry.MergeKind.DISTINCT,
             "usage_identity",
             com.linkedin.metadata.usage.registry.metrics.ValueUnit.COUNT,
-            false,
             UsageMetricRegistry.EmitWhen.ALWAYS);
     Assert.assertFalse(UsageMetricIncrementResolver.isSupported(metric));
   }
@@ -187,20 +197,6 @@ public class UsageMetricIncrementResolverTest {
   }
 
   @Test
-  public void testMetronomeBatchMetricHasNoMicrometerCounter() {
-    UsageMetricRegistry.MetricDefinition metric =
-        new UsageMetricRegistry.MetricDefinition(
-            "metronome_only",
-            UsageMetricRegistry.MergeKind.ADDITIVE,
-            null,
-            com.linkedin.metadata.usage.registry.metrics.ValueUnit.COUNT,
-            true,
-            UsageMetricRegistry.EmitWhen.ALWAYS);
-    Assert.assertEquals(
-        UsageMetricIncrementResolver.micrometerCounterName(metric), Optional.empty());
-  }
-
-  @Test
   public void testIngestionRequestInputBytesRequiresIngestionEndpoint() {
     UsageMetricRegistry.MetricDefinition metric =
         new UsageMetricRegistry.MetricDefinition(
@@ -208,7 +204,6 @@ public class UsageMetricIncrementResolverTest {
             UsageMetricRegistry.MergeKind.ADDITIVE,
             null,
             com.linkedin.metadata.usage.registry.metrics.ValueUnit.INPUT_BYTES,
-            false,
             UsageMetricRegistry.EmitWhen.INGESTION_REQUEST);
     UsageOperationsRegistry ossOps =
         UsageOperationsRegistry.loadOssOnly(new UsageOperationsLoader(yamlMapper()));

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/registry/UsageOperationsRegistryTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/registry/UsageOperationsRegistryTest.java
@@ -106,6 +106,13 @@ public class UsageOperationsRegistryTest {
   }
 
   @Test
+  public void testMcpQueryAllowsMcpApiOnly() {
+    UsageOperationsRegistry.UsageOperationEntry entry = ossRegistry().require("mcp_query");
+    Assert.assertTrue(ossRegistry().isAllowedForApi(entry, RequestContext.RequestAPI.MCP));
+    Assert.assertFalse(ossRegistry().isAllowedForApi(entry, RequestContext.RequestAPI.OPENAPI));
+  }
+
+  @Test
   public void testIsAllowedForApiWhenRestricted() {
     UsageOperationsRegistry.UsageOperationEntry entry = ossRegistry().require("metadata_read");
     Assert.assertTrue(ossRegistry().isAllowedForApi(entry, RequestContext.RequestAPI.RESTLI));

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/report/ReportedUsageTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/report/ReportedUsageTest.java
@@ -5,10 +5,10 @@ import com.datahub.authentication.ActorType;
 import com.datahub.authentication.Authentication;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.config.usage.loader.UsageMetricRegistryLoader;
 import com.linkedin.metadata.config.usage.loader.UsageOperationsLoader;
 import com.linkedin.metadata.usage.UsageDimensions;
+import com.linkedin.metadata.usage.UsageTestFixtures;
 import com.linkedin.metadata.usage.flush.AdditiveUsageRow;
 import com.linkedin.metadata.usage.flush.FlushTrigger;
 import com.linkedin.metadata.usage.flush.RecordingUsageFlushSink;
@@ -43,9 +43,9 @@ public class ReportedUsageTest {
                 UsageDimensions.USAGE_OPERATION,
                 "mcp_query",
                 ReportedUsage.PROP_ACTOR_URN,
-                Constants.METATDATA_TEST_ACTOR,
+                UsageTestFixtures.REGULAR_CORP_USER_URN,
                 ReportedUsage.PROP_USAGE_IDENTITY,
-                Constants.METATDATA_TEST_ACTOR,
+                UsageTestFixtures.REGULAR_CORP_USER_URN,
                 ReportedUsage.PROP_USER_AGENT,
                 "python-requests/2.31.0",
                 UsageDimensions.AUTH_CHANNEL,
@@ -60,7 +60,7 @@ public class ReportedUsageTest {
                 "datahub"));
     Assert.assertTrue(recorded);
 
-    store.recordRequest(httpSession(Constants.METATDATA_TEST_ACTOR, "metadata_ingest"));
+    store.recordRequest(httpSession(UsageTestFixtures.REGULAR_CORP_USER_URN, "metadata_ingest"));
     store.flush(FlushTrigger.SCHEDULED);
 
     var batch = recordingSink.batches().get(0);

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/report/ReportedUsageTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/report/ReportedUsageTest.java
@@ -1,0 +1,238 @@
+package com.linkedin.metadata.usage.report;
+
+import com.datahub.authentication.Actor;
+import com.datahub.authentication.ActorType;
+import com.datahub.authentication.Authentication;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.config.usage.loader.UsageMetricRegistryLoader;
+import com.linkedin.metadata.config.usage.loader.UsageOperationsLoader;
+import com.linkedin.metadata.usage.UsageDimensions;
+import com.linkedin.metadata.usage.flush.AdditiveUsageRow;
+import com.linkedin.metadata.usage.flush.FlushTrigger;
+import com.linkedin.metadata.usage.flush.RecordingUsageFlushSink;
+import com.linkedin.metadata.usage.identity.AspectCorpUserFlagsProvider;
+import com.linkedin.metadata.usage.identity.UsageActorClassResolver;
+import com.linkedin.metadata.usage.registry.metrics.UsageMetricRegistry;
+import com.linkedin.metadata.usage.registry.operations.UsageOperationsRegistry;
+import com.linkedin.metadata.usage.store.InMemoryUsageAggregationStore;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.RequestContext;
+import io.datahubproject.metadata.context.usage.AuthChannel;
+import io.datahubproject.metadata.context.usage.UsageActorClass;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ReportedUsageTest {
+
+  @Test
+  public void record_mcpQuery_incrementsMcpQueriesWithoutApiCalls() {
+    RecordingUsageFlushSink recordingSink = new RecordingUsageFlushSink();
+    InMemoryUsageAggregationStore store = newStore(recordingSink);
+    OperationContext systemContext = TestOperationContexts.systemContextNoValidate();
+
+    boolean recorded =
+        ReportedUsage.record(
+            store,
+            systemContext,
+            3L,
+            Map.of(
+                UsageDimensions.USAGE_OPERATION,
+                "mcp_query",
+                ReportedUsage.PROP_ACTOR_URN,
+                Constants.METATDATA_TEST_ACTOR,
+                ReportedUsage.PROP_USAGE_IDENTITY,
+                Constants.METATDATA_TEST_ACTOR,
+                ReportedUsage.PROP_USER_AGENT,
+                "python-requests/2.31.0",
+                UsageDimensions.AUTH_CHANNEL,
+                "pat",
+                UsageDimensions.REQUEST_API,
+                "mcp",
+                "operation",
+                "tools/call",
+                "tool_name",
+                "search",
+                "mcp_server",
+                "datahub"));
+    Assert.assertTrue(recorded);
+
+    store.recordRequest(httpSession(Constants.METATDATA_TEST_ACTOR, "metadata_ingest"));
+    store.flush(FlushTrigger.SCHEDULED);
+
+    var batch = recordingSink.batches().get(0);
+    long mcpQueries =
+        batch.additiveRows().stream()
+            .filter(row -> row.metricName().equals("mcp_queries"))
+            .mapToLong(AdditiveUsageRow::valueSum)
+            .sum();
+    long apiCalls =
+        batch.additiveRows().stream()
+            .filter(row -> row.metricName().equals("api_calls"))
+            .mapToLong(AdditiveUsageRow::valueSum)
+            .sum();
+    Assert.assertEquals(mcpQueries, 3L);
+    Assert.assertEquals(apiCalls, 1L);
+
+    AdditiveUsageRow mcpRow =
+        batch.additiveRows().stream()
+            .filter(row -> row.metricName().equals("mcp_queries"))
+            .findFirst()
+            .orElseThrow();
+    Assert.assertEquals(mcpRow.dimensions().get(UsageDimensions.USAGE_OPERATION), "mcp_query");
+    Assert.assertEquals(mcpRow.dimensions().get(UsageDimensions.REQUEST_API), "mcp");
+    Assert.assertEquals(mcpRow.dimensions().get(UsageDimensions.AUTH_CHANNEL), "pat");
+    Assert.assertNotNull(mcpRow.dimensions().get(UsageDimensions.AGENT_CLASS));
+    Assert.assertNotNull(mcpRow.dimensions().get(UsageDimensions.ACTOR_CLASS));
+  }
+
+  @Test
+  public void record_rejectsZeroQuantityAndMissingTaxonomyProps() {
+    RecordingUsageFlushSink recordingSink = new RecordingUsageFlushSink();
+    InMemoryUsageAggregationStore store = newStore(recordingSink);
+    OperationContext systemContext = TestOperationContexts.systemContextNoValidate();
+    Assert.assertFalse(
+        ReportedUsage.record(
+            store,
+            systemContext,
+            0L,
+            Map.of(
+                UsageDimensions.USAGE_OPERATION, "mcp_query", UsageDimensions.REQUEST_API, "mcp")));
+    Assert.assertFalse(ReportedUsage.record(store, systemContext, 1L, Map.of()));
+    Assert.assertFalse(
+        ReportedUsage.record(
+            store, systemContext, 1L, Map.of(UsageDimensions.USAGE_OPERATION, "mcp_query")));
+  }
+
+  @Test
+  public void record_rejectsUnknownUsageOperation() {
+    RecordingUsageFlushSink recordingSink = new RecordingUsageFlushSink();
+    InMemoryUsageAggregationStore store = newStore(recordingSink);
+    OperationContext systemContext = TestOperationContexts.systemContextNoValidate();
+    Assert.assertFalse(
+        ReportedUsage.record(
+            store,
+            systemContext,
+            1L,
+            Map.of(
+                UsageDimensions.USAGE_OPERATION,
+                "not_a_real_operation",
+                UsageDimensions.REQUEST_API,
+                "mcp")));
+  }
+
+  @Test
+  public void record_rejectsRequestApiNotAllowedForOperation() {
+    RecordingUsageFlushSink recordingSink = new RecordingUsageFlushSink();
+    InMemoryUsageAggregationStore store = newStore(recordingSink);
+    OperationContext systemContext = TestOperationContexts.systemContextNoValidate();
+    // mcp_query only allows request_apis: [mcp]
+    Assert.assertFalse(
+        ReportedUsage.record(
+            store,
+            systemContext,
+            1L,
+            Map.of(
+                UsageDimensions.USAGE_OPERATION,
+                "mcp_query",
+                UsageDimensions.REQUEST_API,
+                "openapi")));
+  }
+
+  @Test
+  public void record_acceptsUnprovisionedActorWithoutAccessChecks() {
+    RecordingUsageFlushSink recordingSink = new RecordingUsageFlushSink();
+    InMemoryUsageAggregationStore store = newStore(recordingSink);
+    OperationContext systemContext = TestOperationContexts.systemContextNoValidate();
+
+    boolean recorded =
+        ReportedUsage.record(
+            store,
+            systemContext,
+            2L,
+            Map.of(
+                UsageDimensions.USAGE_OPERATION,
+                "mcp_query",
+                ReportedUsage.PROP_ACTOR_URN,
+                "urn:li:corpuser:never-provisioned-metering-actor",
+                UsageDimensions.REQUEST_API,
+                "mcp"));
+    Assert.assertTrue(recorded);
+
+    store.flush(FlushTrigger.SCHEDULED);
+    long mcpQueries =
+        recordingSink.batches().get(0).additiveRows().stream()
+            .filter(row -> row.metricName().equals("mcp_queries"))
+            .mapToLong(AdditiveUsageRow::valueSum)
+            .sum();
+    Assert.assertEquals(mcpQueries, 2L);
+  }
+
+  @Test
+  public void record_missingActorFallsBackToUnknownNotSystem() {
+    RecordingUsageFlushSink recordingSink = new RecordingUsageFlushSink();
+    InMemoryUsageAggregationStore store = newStore(recordingSink);
+    OperationContext systemContext = TestOperationContexts.systemContextNoValidate();
+
+    Assert.assertTrue(
+        ReportedUsage.record(
+            store,
+            systemContext,
+            1L,
+            Map.of(
+                UsageDimensions.USAGE_OPERATION, "mcp_query", UsageDimensions.REQUEST_API, "mcp")));
+
+    store.flush(FlushTrigger.SCHEDULED);
+    AdditiveUsageRow mcpRow =
+        recordingSink.batches().get(0).additiveRows().stream()
+            .filter(row -> row.metricName().equals("mcp_queries"))
+            .findFirst()
+            .orElseThrow();
+    Assert.assertEquals(
+        mcpRow.dimensions().get(UsageDimensions.ACTOR_CLASS),
+        UsageActorClass.REGULAR.dimensionValue());
+  }
+
+  private static InMemoryUsageAggregationStore newStore(RecordingUsageFlushSink recordingSink) {
+    YAMLMapper yamlMapper = new YAMLMapper();
+    yamlMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    UsageOperationsRegistry usageRegistry =
+        UsageOperationsRegistry.loadOssOnly(new UsageOperationsLoader(yamlMapper));
+    UsageMetricRegistry metricRegistry =
+        UsageMetricRegistry.loadBundled(
+            new UsageMetricRegistryLoader(yamlMapper), java.util.List.of());
+    return new InMemoryUsageAggregationStore(
+        usageRegistry,
+        metricRegistry,
+        new UsageActorClassResolver(new AspectCorpUserFlagsProvider()),
+        recordingSink,
+        10_000,
+        300);
+  }
+
+  private static OperationContext httpSession(String actorUrn, String usageOperation) {
+    RequestContext requestContext =
+        RequestContext.builder()
+            .actorUrn(actorUrn)
+            .sourceIP("127.0.0.1")
+            .requestAPI(RequestContext.RequestAPI.OPENAPI)
+            .requestID("testAction")
+            .userAgent("test-agent")
+            .usageOperation(usageOperation)
+            .usageIdentity(actorUrn)
+            .authChannel(AuthChannel.PAT)
+            .build();
+    Authentication authentication =
+        new Authentication(new Actor(ActorType.USER, actorUrn), "Basic test");
+    try {
+      return TestOperationContexts.systemContextNoValidate().toBuilder()
+          .requestContext(requestContext)
+          .build(authentication, true);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/store/InMemoryUsageAggregationStoreTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/store/InMemoryUsageAggregationStoreTest.java
@@ -32,6 +32,7 @@ import java.util.Comparator;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
@@ -598,15 +599,11 @@ public class InMemoryUsageAggregationStoreTest {
 
   @Test
   public void testTryDrainSkipsWhenDrainInProgress() throws Exception {
-    sink = new RecordingUsageFlushSink();
     UsageOperationsRegistry usageRegistry =
         UsageOperationsRegistry.loadOssOnly(new UsageOperationsLoader(yamlMapper()));
     UsageMetricRegistry metricRegistry =
         UsageMetricRegistry.loadBundled(
             new UsageMetricRegistryLoader(yamlMapper()), java.util.List.of());
-    InMemoryUsageAggregationStore lowCardinalityStore =
-        new InMemoryUsageAggregationStore(
-            usageRegistry, metricRegistry, deterministicActorClassResolver(), sink, 2, 300);
 
     CountDownLatch flushStarted = new CountDownLatch(1);
     CountDownLatch releaseFlush = new CountDownLatch(1);
@@ -623,23 +620,34 @@ public class InMemoryUsageAggregationStoreTest {
             super.publish(batch);
           }
         };
-    lowCardinalityStore =
+    // High cardinality limit: a single metadata_read already creates more than a few rollup
+    // keys. A tiny maxCardinality would auto-drain into this blocking sink on the first
+    // recordRequest and race with the scheduled flush below.
+    InMemoryUsageAggregationStore blockingStore =
         new InMemoryUsageAggregationStore(
-            usageRegistry, metricRegistry, deterministicActorClassResolver(), slowSink, 2, 300);
-    final InMemoryUsageAggregationStore blockingStore = lowCardinalityStore;
+            usageRegistry,
+            metricRegistry,
+            deterministicActorClassResolver(),
+            slowSink,
+            10_000,
+            300);
 
-    blockingStore.recordRequest(
-        session(UsageTestFixtures.REGULAR_CORP_USER_URN, "metadata_read", null));
+    Assert.assertTrue(
+        blockingStore.recordRequest(
+            session(UsageTestFixtures.REGULAR_CORP_USER_URN, "metadata_read", null)));
 
     ExecutorService executor = Executors.newSingleThreadExecutor();
     try {
-      executor.submit(() -> blockingStore.flush(FlushTrigger.SCHEDULED));
+      Future<?> flushFuture = executor.submit(() -> blockingStore.flush(FlushTrigger.SCHEDULED));
       Assert.assertTrue(flushStarted.await(10, TimeUnit.SECONDS));
 
-      blockingStore.recordRequest(session("urn:li:corpuser:other", "metadata_read", null));
+      Assert.assertTrue(
+          blockingStore.recordRequest(session("urn:li:corpuser:other", "metadata_read", null)));
 
       releaseFlush.countDown();
+      flushFuture.get(30, TimeUnit.SECONDS);
     } finally {
+      releaseFlush.countDown();
       executor.shutdownNow();
     }
 

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/RequestContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/RequestContext.java
@@ -693,8 +693,16 @@ public class RequestContext implements ContextInterface {
     RESTLI,
     OPENAPI,
     GRAPHQL,
-    /** Kafka / pgQueue MCP consumption (MCE consumer), not HTTP. */
-    MESSAGING;
+    /**
+     * MetadataChangeProposal queue consumption (Kafka / pgQueue on the MCE consumer). Distinct from
+     * {@link #MCP} (Model Context Protocol server traffic).
+     */
+    MESSAGING,
+    /**
+     * Model Context Protocol server traffic (report-driven metering). Distinct from {@link
+     * #MESSAGING} (MetadataChangeProposal ingest).
+     */
+    MCP;
 
     @Nonnull
     public String toMetricLabel() {

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/usage/UsageYamlMapper.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/usage/UsageYamlMapper.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import javax.annotation.Nonnull;
 
-/** Shared snake_case YAML mapper for usage and billing manifest loaders. */
+/** Shared snake_case YAML mapper for usage registry / operations loaders. */
 public final class UsageYamlMapper {
 
   private UsageYamlMapper() {}

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/usage/manifest/UsageMetricRegistryManifest.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/usage/manifest/UsageMetricRegistryManifest.java
@@ -15,7 +15,6 @@ public class UsageMetricRegistryManifest {
     private String mergeKind;
     private String distinctKey;
     private String valueUnit;
-    private boolean metronomeBatch;
     private String emitWhen;
   }
 }

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/usage/metric/MetricRegistryYamlDefinition.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/usage/metric/MetricRegistryYamlDefinition.java
@@ -2,10 +2,7 @@ package com.linkedin.metadata.config.usage.metric;
 
 import javax.annotation.Nullable;
 
-/**
- * Shared YAML shape for metric registry entries. Implemented by OSS and commercial overlay manifest
- * types.
- */
+/** Shared YAML shape for metric registry entries. */
 public interface MetricRegistryYamlDefinition {
 
   @Nullable
@@ -16,8 +13,6 @@ public interface MetricRegistryYamlDefinition {
 
   @Nullable
   String getValueUnit();
-
-  boolean isMetronomeBatch();
 
   @Nullable
   String getEmitWhen();

--- a/metadata-service/configuration/src/main/resources/usage_metric_registry.yaml
+++ b/metadata-service/configuration/src/main/resources/usage_metric_registry.yaml
@@ -4,33 +4,32 @@ metric_registry:
     api_calls:
       merge_kind: additive
       value_unit: count
-      metronome_batch: false
       emit_when: always
+    # Report-driven (recordReportedUsage); not request-path api_calls.
+    mcp_queries:
+      merge_kind: additive
+      value_unit: count
+      emit_when: reported
     input_bytes:
       merge_kind: additive
       value_unit: input_bytes
-      metronome_batch: false
       emit_when: always
     output_bytes:
       merge_kind: additive
       value_unit: output_bytes
-      metronome_batch: false
       emit_when: always
     active_users:
       merge_kind: distinct
       distinct_key: usage_identity
       value_unit: count
-      metronome_batch: false
       emit_when: activity_allowlist
     active_readers:
       merge_kind: distinct
       distinct_key: usage_identity
       value_unit: count
-      metronome_batch: false
       emit_when: reader_activity_allowlist
     active_writers:
       merge_kind: distinct
       distinct_key: usage_identity
       value_unit: count
-      metronome_batch: false
       emit_when: writer_activity_allowlist

--- a/metadata-service/configuration/src/main/resources/usage_operations.yaml
+++ b/metadata-service/configuration/src/main/resources/usage_operations.yaml
@@ -11,7 +11,7 @@ usage_operations:
     description: >
       Entity, aspect, relationship, and Iceberg catalog reads — single/batch get,
       exists, versioned batch get, single-aspect GET, relationship graph reads,
-      Iceberg namespace/table/view GET (including /iceberg and billable
+      Iceberg namespace/table/view GET (including /iceberg and
       /public-iceberg/v1 public read), dataHubFile download (GET /openapi/v1/files,
       presigned redirect), and async-write trace polling (POST
       /openapi/v1/trace/write/{traceId}) (OpenAPI, Rest.li, GraphQL).
@@ -160,8 +160,8 @@ usage_operations:
     description: >
       Zero-cost reads — entity/lineage registry, schema registry GET/HEAD,
       auth session introspection (POST /auth/getSsoSettings, POST
-      /auth/verifyNativeUserCredentials), OAuth client GET (/auth/oauth2/clients), usage
-      credits query, system info / configuration introspection, rate limit
+      /auth/verifyNativeUserCredentials), OAuth client GET (/auth/oauth2/clients),
+      system info / configuration introspection, rate limit
       status, identity debug (GET /openapi/operations/identity/user/urn), internal
       messaging queue lag/transport GETs (/openapi/operations/messaging), ingestion
       run list/describe (Rest.li BatchIngestionRunResource), Kubernetes GET
@@ -195,8 +195,8 @@ usage_operations:
       /auth/signUp, /auth/resetNativeUserCredentials, /auth/generateSessionTokenForUser),
       OAuth client POST/DELETE and DCR registration
       token (/auth/oauth2/clients, /auth/oauth2/registration-token), product analytics
-      tracking (POST /openapi/v1/tracking/track and POST /auth/track), internal usage
-      fan-in endpoint, Elasticsearch index config mutations (POST
+      tracking (POST /openapi/v1/tracking/track and POST /auth/track), Elasticsearch index
+      config mutations (POST
       /openapi/operations/elasticSearch/incrementalReindex/*/dualWrite/disable), AI
       conversation create/update/delete and streaming chat (OpenAPI
       DataHubAiConversationController, GraphQL ai.graphql; bytes omitted v1), and GraphQL
@@ -260,7 +260,11 @@ usage_operations:
         - revokeAccessToken
 
   mcp_query:
-    description: MCP request reported by integrations-service usage fan-in API.
+    description: >
+      Model Context Protocol server request (RequestAPI.MCP), reported into usage
+      aggregation via recordReportedUsage. Distinct from metadata_ingest /
+      RequestAPI.MESSAGING (MetadataChangeProposal queue consumption).
+    request_apis: [mcp]
     activity_class: read
     default_cost_units: 1
     ingestion_endpoint: false

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/usage/cigate/graphql/GraphqlUsageCoverageClassifier.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/usage/cigate/graphql/GraphqlUsageCoverageClassifier.java
@@ -1,9 +1,6 @@
 package com.linkedin.metadata.config.usage.cigate.graphql;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.linkedin.metadata.config.usage.UsageYamlMapper;
 import com.linkedin.metadata.config.usage.loader.UsageOperationsLoader;
-import com.linkedin.metadata.config.usage.overlay.UsageConfigurationOverlay;
 import com.linkedin.metadata.usage.registry.graphql.GraphqlUsageClassificationRegistryBuilder;
 import io.datahubproject.metadata.context.graphql.GraphQLOperationKind;
 import io.datahubproject.metadata.context.graphql.GraphqlPatternRule;
@@ -19,42 +16,18 @@ import javax.annotation.Nullable;
 
 public final class GraphqlUsageCoverageClassifier {
 
-  private static final String OPTIONAL_OVERLAY_LOADER =
-      "com.linkedin.metadata.config.billing.BillingUsageOverridesLoader";
-
   private final GraphqlUsageClassificationRegistry registry;
 
   GraphqlUsageCoverageClassifier(@Nonnull GraphqlUsageClassificationRegistry registry) {
     this.registry = registry;
   }
 
-  /**
-   * Builds a classifier from OSS {@code usage_operations.yaml} merged with an optional classpath
-   * overlay when present (empty overlay otherwise).
-   */
+  /** Builds a classifier from OSS {@code usage_operations.yaml}. */
   @Nonnull
   public static GraphqlUsageCoverageClassifier fromBundledYaml(
       @Nonnull UsageOperationsLoader loader) {
-    var usageManifest = loader.loadBundled();
     return new GraphqlUsageCoverageClassifier(
-        GraphqlUsageClassificationRegistryBuilder.fromManifest(
-            usageManifest, loadOptionalOverlay(UsageYamlMapper.create())));
-  }
-
-  @Nonnull
-  private static UsageConfigurationOverlay loadOptionalOverlay(@Nonnull ObjectMapper yamlMapper) {
-    try {
-      // Reflect so this OSS test helper does not hard-depend on the commercial overlay loader.
-      Class<?> loaderClass = Class.forName(OPTIONAL_OVERLAY_LOADER);
-      Object loaderInstance =
-          loaderClass.getConstructor(ObjectMapper.class).newInstance(yamlMapper);
-      Object manifest = loaderClass.getMethod("loadBundled").invoke(loaderInstance);
-      return (UsageConfigurationOverlay) manifest;
-    } catch (ClassNotFoundException e) {
-      return UsageConfigurationOverlay.empty();
-    } catch (ReflectiveOperationException e) {
-      throw new IllegalStateException("Failed to load optional usage configuration overlay", e);
-    }
+        GraphqlUsageClassificationRegistryBuilder.fromManifest(loader.loadBundled()));
   }
 
   @Nonnull

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/usage/cigate/graphql/GraphqlUsageCoverageClassifier.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/usage/cigate/graphql/GraphqlUsageCoverageClassifier.java
@@ -1,6 +1,9 @@
 package com.linkedin.metadata.config.usage.cigate.graphql;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.metadata.config.usage.UsageYamlMapper;
 import com.linkedin.metadata.config.usage.loader.UsageOperationsLoader;
+import com.linkedin.metadata.config.usage.overlay.UsageConfigurationOverlay;
 import com.linkedin.metadata.usage.registry.graphql.GraphqlUsageClassificationRegistryBuilder;
 import io.datahubproject.metadata.context.graphql.GraphQLOperationKind;
 import io.datahubproject.metadata.context.graphql.GraphqlPatternRule;
@@ -16,17 +19,42 @@ import javax.annotation.Nullable;
 
 public final class GraphqlUsageCoverageClassifier {
 
+  private static final String OPTIONAL_OVERLAY_LOADER =
+      "com.linkedin.metadata.config.billing.BillingUsageOverridesLoader";
+
   private final GraphqlUsageClassificationRegistry registry;
 
   GraphqlUsageCoverageClassifier(@Nonnull GraphqlUsageClassificationRegistry registry) {
     this.registry = registry;
   }
 
+  /**
+   * Builds a classifier from OSS {@code usage_operations.yaml} merged with an optional classpath
+   * overlay when present (empty overlay otherwise).
+   */
   @Nonnull
   public static GraphqlUsageCoverageClassifier fromBundledYaml(
       @Nonnull UsageOperationsLoader loader) {
+    var usageManifest = loader.loadBundled();
     return new GraphqlUsageCoverageClassifier(
-        GraphqlUsageClassificationRegistryBuilder.fromManifest(loader.loadBundled()));
+        GraphqlUsageClassificationRegistryBuilder.fromManifest(
+            usageManifest, loadOptionalOverlay(UsageYamlMapper.create())));
+  }
+
+  @Nonnull
+  private static UsageConfigurationOverlay loadOptionalOverlay(@Nonnull ObjectMapper yamlMapper) {
+    try {
+      // Reflect so this OSS test helper does not hard-depend on the commercial overlay loader.
+      Class<?> loaderClass = Class.forName(OPTIONAL_OVERLAY_LOADER);
+      Object loaderInstance =
+          loaderClass.getConstructor(ObjectMapper.class).newInstance(yamlMapper);
+      Object manifest = loaderClass.getMethod("loadBundled").invoke(loaderInstance);
+      return (UsageConfigurationOverlay) manifest;
+    } catch (ClassNotFoundException e) {
+      return UsageConfigurationOverlay.empty();
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Failed to load optional usage configuration overlay", e);
+    }
   }
 
   @Nonnull

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/usage/UsageAggregationFactoryPlacementTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/usage/UsageAggregationFactoryPlacementTest.java
@@ -30,6 +30,15 @@ public class UsageAggregationFactoryPlacementTest {
   }
 
   @Test
+  public void reportedUsageLivesUnderOssReportPackage() throws Exception {
+    Class<?> reportedUsage = Class.forName("com.linkedin.metadata.usage.report.ReportedUsage");
+    assertEquals(
+        reportedUsage.getPackageName(),
+        "com.linkedin.metadata.usage.report",
+        "Reported usage must live under OSS com.linkedin.metadata.usage.report");
+  }
+
+  @Test
   public void billingExtensionFactoryLivesUnderBillingPackage() throws Exception {
     if (!Files.exists(BILLING_FACTORY)) {
       return; // SaaS billing overlay not present in OSS.


### PR DESCRIPTION
## Summary
- Add OSS `ReportedUsage` + `UsageAggregationStore.recordReportedUsage` so trusted reporters can land MCP usage into the in-memory aggregation store without request-path `api_calls`
- Introduce `RequestAPI.MCP`, `emit_when: reported` / `mcp_queries`, and `mcp_query` taxonomy allowlisting (`request_apis: [mcp]`)
- Classify attributed identities correctly when recording under system credentials (metering is not access control); drop OSS `metronome_batch` from the shared metric definition

## Test plan
- [ ] `./gradlew :metadata-io:test --tests '*ReportedUsageTest*'`
- [ ] `./gradlew :metadata-io:test --tests '*UsageActorClassResolverTest*' --tests '*UsageMetricIncrementResolverTest*' --tests '*UsageOperationsRegistryTest*' --tests '*UsageMetricRegistryTest*'`
- [ ] Confirm report path increments `mcp_queries` by quantity and does not increment `api_calls`
- [ ] Confirm `mcp_query` + `request_api=openapi` is rejected; missing actor falls back to `UNKNOWN` / `REGULAR`
- [ ] Coordinate SaaS overlays that previously used `metronome_batch` / `integrations_mcp_report`


Made with [Cursor](https://cursor.com)