### PR TITLE
fix(ebean): sort aspect keys before FOR UPDATE to prevent MySQL deadlocks

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
@@ -7,6 +7,7 @@ import static com.linkedin.metadata.Constants.READ_ONLY_LOG;
 import com.codahale.metrics.MetricRegistry;
 import com.datahub.util.exception.ModelConversionException;
 import com.datahub.util.exception.RetryLimitReached;
+import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
@@ -55,7 +56,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -201,7 +201,7 @@ public class EbeanAspectDao implements AspectDao, AspectMigrationsDao {
       boolean forUpdate) {
     validateConnection();
 
-    List<EbeanAspectV2.PrimaryKey> keys =
+    Set<EbeanAspectV2.PrimaryKey> keys =
         urnAspects.entrySet().stream()
             .flatMap(
                 entry ->
@@ -210,16 +210,12 @@ public class EbeanAspectDao implements AspectDao, AspectMigrationsDao {
                             aspect ->
                                 new EbeanAspectV2.PrimaryKey(
                                     entry.getKey(), aspect, ASPECT_LATEST_VERSION)))
-            .sorted(
-                Comparator.comparing(EbeanAspectV2.PrimaryKey::getUrn)
-                    .thenComparing(EbeanAspectV2.PrimaryKey::getAspect)
-                    .thenComparing(EbeanAspectV2.PrimaryKey::getVersion))
-            .collect(Collectors.toList());
+            .collect(Collectors.toSet());
 
     // Use batchGet to chunk large IN clauses and avoid optimizer memory exhaustion
     // (range_optimizer_max_mem_size)
     final List<EbeanAspectV2> results =
-        batchGet(opContext, new HashSet<>(keys), queryKeysCount, forUpdate && canWrite);
+        batchGet(opContext, keys, queryKeysCount, forUpdate && canWrite);
     return toUrnAspectMap(opContext.getEntityRegistry(), results, opContext);
   }
 
@@ -369,7 +365,14 @@ public class EbeanAspectDao implements AspectDao, AspectMigrationsDao {
 
     int position = 0;
 
+    // Sort by primary key so that all transactions acquire row locks in the same order.
+    // Unordered keys under FOR UPDATE cause lock-order deadlocks between concurrent writers
+    // ("Deadlock found when trying to get lock").
     List<EbeanAspectV2.PrimaryKey> keyList = new ArrayList<>(keys);
+    keyList.sort(
+        Comparator.comparing(EbeanAspectV2.PrimaryKey::getUrn)
+            .thenComparing(EbeanAspectV2.PrimaryKey::getAspect)
+            .thenComparing(EbeanAspectV2.PrimaryKey::getVersion));
     final int totalPageCount = QueryUtils.getTotalPageCount(keys.size(), keysCount);
     final List<EbeanAspectV2> finalResult =
         batchGetSelectString(opContext, keyList, keysCount, position, forUpdate);
@@ -412,8 +415,9 @@ public class EbeanAspectDao implements AspectDao, AspectMigrationsDao {
     }
   }
 
+  @VisibleForTesting
   @Nonnull
-  private List<EbeanAspectV2> batchGetSelectString(
+  protected List<EbeanAspectV2> batchGetSelectString(
       @Nonnull OperationContext opContext,
       @Nonnull final List<EbeanAspectV2.PrimaryKey> keys,
       final int keysCount,

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
@@ -365,14 +365,17 @@ public class EbeanAspectDao implements AspectDao, AspectMigrationsDao {
 
     int position = 0;
 
-    // Sort by primary key so that all transactions acquire row locks in the same order.
-    // Unordered keys under FOR UPDATE cause lock-order deadlocks between concurrent writers
-    // ("Deadlock found when trying to get lock").
     List<EbeanAspectV2.PrimaryKey> keyList = new ArrayList<>(keys);
-    keyList.sort(
-        Comparator.comparing(EbeanAspectV2.PrimaryKey::getUrn)
-            .thenComparing(EbeanAspectV2.PrimaryKey::getAspect)
-            .thenComparing(EbeanAspectV2.PrimaryKey::getVersion));
+    // Only when we actually take row locks: sort by primary key so all transactions acquire locks
+    // in the same (urn, aspect, version) order. Unordered keys under FOR UPDATE cause lock-order
+    // deadlocks between concurrent writers ("Deadlock found when trying to get lock"). Non-locking
+    // reads take no row locks, so sorting them would be wasted work.
+    if (forUpdate && canWrite) {
+      keyList.sort(
+          Comparator.comparing(EbeanAspectV2.PrimaryKey::getUrn)
+              .thenComparing(EbeanAspectV2.PrimaryKey::getAspect)
+              .thenComparing(EbeanAspectV2.PrimaryKey::getVersion));
+    }
     final int totalPageCount = QueryUtils.getTotalPageCount(keys.size(), keysCount);
     final List<EbeanAspectV2> finalResult =
         batchGetSelectString(opContext, keyList, keysCount, position, forUpdate);

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EbeanAspectDaoTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EbeanAspectDaoTest.java
@@ -5,8 +5,11 @@ import static com.linkedin.metadata.Constants.CORP_USER_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.DATA_PLATFORM_INSTANCE_ASPECT_NAME;
 import static com.linkedin.metadata.Constants.STATUS_ASPECT_NAME;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -40,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.mockito.ArgumentCaptor;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -213,6 +217,50 @@ public class EbeanAspectDaoTest {
       assertFalse(
           sql.get(0).contains("FOR UPDATE;"), String.format("Found `for update` in %s ", sql));
     }
+  }
+
+  @Test
+  public void testGetLatestAspectsPassesSortedKeysToQuery() {
+    // Regression test for a deadlock introduced in #17206: keys were routed through a HashSet
+    // before the FOR UPDATE query, dropping their sort order. Concurrent writers with overlapping
+    // key sets then acquired row locks in inconsistent orders, producing
+    // "Deadlock found when trying to get lock". batchGet must hand the query builder keys in
+    // (urn, aspect, version) order regardless of the caller's input iteration order.
+    EbeanAspectDao spyDao = org.mockito.Mockito.spy(testDao);
+    // Stub the query builder so no real DB round-trip happens; we only assert on the keys it
+    // receives. HashMap/Set.of iteration order is not sorted, so only the sort inside batchGet can
+    // produce the asserted order.
+    // Return a mutable list: batchGet may addAll into the first page's result during pagination.
+    org.mockito.Mockito.doReturn(new java.util.ArrayList<EbeanAspectV2>())
+        .when(spyDao)
+        .batchGetSelectString(
+            any(), org.mockito.ArgumentMatchers.anyList(), anyInt(), anyInt(), anyBoolean());
+
+    Map<String, Set<String>> urnAspects = new HashMap<>();
+    urnAspects.put("urn:li:corpuser:c", Set.of(STATUS_ASPECT_NAME));
+    urnAspects.put("urn:li:corpuser:a", Set.of(STATUS_ASPECT_NAME, "ownership"));
+    urnAspects.put("urn:li:corpuser:b", Set.of(STATUS_ASPECT_NAME));
+
+    spyDao.getLatestAspects(opContext, urnAspects, true);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<EbeanAspectV2.PrimaryKey>> captor = ArgumentCaptor.forClass(List.class);
+    verify(spyDao).batchGetSelectString(any(), captor.capture(), anyInt(), anyInt(), anyBoolean());
+
+    // Compare on (urn, aspect, version) tuples: PrimaryKey.equals ignores version, so it cannot
+    // detect a wrong version tie-break on its own.
+    List<String> actual = captor.getValue().stream().map(EbeanAspectDaoTest::keyTuple).toList();
+    List<String> expected =
+        List.of(
+            "urn:li:corpuser:a|ownership|0",
+            "urn:li:corpuser:a|status|0",
+            "urn:li:corpuser:b|status|0",
+            "urn:li:corpuser:c|status|0");
+    assertEquals(actual, expected);
+  }
+
+  private static String keyTuple(EbeanAspectV2.PrimaryKey key) {
+    return key.getUrn() + "|" + key.getAspect() + "|" + key.getVersion();
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EbeanAspectDaoTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EbeanAspectDaoTest.java
@@ -7,8 +7,11 @@ import static com.linkedin.metadata.Constants.STATUS_ASPECT_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -38,11 +41,13 @@ import io.datahubproject.test.metadata.context.TestOperationContexts;
 import io.ebean.Database;
 import io.ebean.test.LoggedSql;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -221,42 +226,65 @@ public class EbeanAspectDaoTest {
 
   @Test
   public void testGetLatestAspectsPassesSortedKeysToQuery() {
-    // Regression test for a deadlock introduced in #17206: keys were routed through a HashSet
-    // before the FOR UPDATE query, dropping their sort order. Concurrent writers with overlapping
-    // key sets then acquired row locks in inconsistent orders, producing
-    // "Deadlock found when trying to get lock". batchGet must hand the query builder keys in
-    // (urn, aspect, version) order regardless of the caller's input iteration order.
-    EbeanAspectDao spyDao = org.mockito.Mockito.spy(testDao);
-    // Stub the query builder so no real DB round-trip happens; we only assert on the keys it
-    // receives. HashMap/Set.of iteration order is not sorted, so only the sort inside batchGet can
-    // produce the asserted order.
-    // Return a mutable list: batchGet may addAll into the first page's result during pagination.
-    org.mockito.Mockito.doReturn(new java.util.ArrayList<EbeanAspectV2>())
-        .when(spyDao)
-        .batchGetSelectString(
-            any(), org.mockito.ArgumentMatchers.anyList(), anyInt(), anyInt(), anyBoolean());
-
+    // Regression guard (#17206): batchGet must deliver keys in (urn, aspect, version) order
+    // regardless of input order, so concurrent FOR UPDATE writers avoid lock-order deadlocks.
     Map<String, Set<String>> urnAspects = new HashMap<>();
     urnAspects.put("urn:li:corpuser:c", Set.of(STATUS_ASPECT_NAME));
     urnAspects.put("urn:li:corpuser:a", Set.of(STATUS_ASPECT_NAME, "ownership"));
     urnAspects.put("urn:li:corpuser:b", Set.of(STATUS_ASPECT_NAME));
 
-    spyDao.getLatestAspects(opContext, urnAspects, true);
+    List<String> actual =
+        captureKeysHandedToQuery(dao -> dao.getLatestAspects(opContext, urnAspects, true));
 
-    @SuppressWarnings("unchecked")
-    ArgumentCaptor<List<EbeanAspectV2.PrimaryKey>> captor = ArgumentCaptor.forClass(List.class);
-    verify(spyDao).batchGetSelectString(any(), captor.capture(), anyInt(), anyInt(), anyBoolean());
-
-    // Compare on (urn, aspect, version) tuples: PrimaryKey.equals ignores version, so it cannot
-    // detect a wrong version tie-break on its own.
-    List<String> actual = captor.getValue().stream().map(EbeanAspectDaoTest::keyTuple).toList();
-    List<String> expected =
+    assertEquals(
+        actual,
         List.of(
             "urn:li:corpuser:a|ownership|0",
             "urn:li:corpuser:a|status|0",
             "urn:li:corpuser:b|status|0",
-            "urn:li:corpuser:c|status|0");
-    assertEquals(actual, expected);
+            "urn:li:corpuser:c|status|0"));
+  }
+
+  @Test
+  public void testBatchGetPassesSortedKeysToQuery() {
+    // The public batchGet(Set, forUpdate) path takes an unordered Set and must also lock in sorted
+    // order (it was never sorted, even before #17206).
+    Set<EntityAspectIdentifier> ids =
+        Set.of(
+            new EntityAspectIdentifier(
+                "urn:li:corpuser:c", STATUS_ASPECT_NAME, ASPECT_LATEST_VERSION),
+            new EntityAspectIdentifier(
+                "urn:li:corpuser:a", STATUS_ASPECT_NAME, ASPECT_LATEST_VERSION),
+            new EntityAspectIdentifier(
+                "urn:li:corpuser:b", STATUS_ASPECT_NAME, ASPECT_LATEST_VERSION));
+
+    List<String> actual = captureKeysHandedToQuery(dao -> dao.batchGet(opContext, ids, true));
+
+    assertEquals(
+        actual,
+        List.of(
+            "urn:li:corpuser:a|status|0",
+            "urn:li:corpuser:b|status|0",
+            "urn:li:corpuser:c|status|0"));
+  }
+
+  /**
+   * Spies the DAO, stubs the query builder so no real DB round-trip happens, runs the given locking
+   * read, and returns the (urn, aspect, version) tuples in the order they reached the query
+   * builder.
+   */
+  private List<String> captureKeysHandedToQuery(Consumer<EbeanAspectDao> lockingRead) {
+    EbeanAspectDao spyDao = spy(testDao);
+    // Mutable list: batchGet may addAll into the first page's result during pagination.
+    doReturn(new ArrayList<EbeanAspectV2>())
+        .when(spyDao)
+        .batchGetSelectString(any(), anyList(), anyInt(), anyInt(), anyBoolean());
+
+    lockingRead.accept(spyDao);
+
+    ArgumentCaptor<List<EbeanAspectV2.PrimaryKey>> captor = ArgumentCaptor.captor();
+    verify(spyDao).batchGetSelectString(any(), captor.capture(), anyInt(), anyInt(), anyBoolean());
+    return captor.getValue().stream().map(EbeanAspectDaoTest::keyTuple).toList();
   }
 
   private static String keyTuple(EbeanAspectV2.PrimaryKey key) {


### PR DESCRIPTION
## Summary

Restores deterministic lock ordering for batched `FOR UPDATE` aspect reads, fixing a
regression that produced a spike in `Deadlock found when trying to get lock` errors
(surfaced as `Retryable PersistenceException` / "Deadlock detected and retry" warnings).

## Root cause

Concurrent transactions that lock overlapping sets of rows with `SELECT ... FOR UPDATE`
must acquire those row locks in the same order, or InnoDB detects a lock cycle and aborts
one transaction with a deadlock.

Prior to #17206, `getLatestAspects` sorted its keys by `(urn, aspect, version)` and issued a
single `idIn(keys).forUpdate()` statement, so lock acquisition order was consistent across
transactions.

#17206 replaced that single statement with a chunked `batchGet` (a good change on its own —
it avoids optimizer memory exhaustion on large `IN` lists). But it passed the keys through
`new HashSet<>(keys)` on the way in. `HashSet` has no defined iteration order, so the sort was
silently discarded and the keys were read back out in hash order. Two effects combined to
cause the deadlocks:

1. **Chunking** moved lock-order responsibility from InnoDB's single-statement index-order
   access to the application (which chunk a key lands in, and its order within a chunk).
2. **`HashSet`** then made that application ordering inconsistent between transactions with
   overlapping-but-different key sets.

The public `batchGet(Set, forUpdate)` path (called from `EntityServiceImpl` with
`forUpdate=true`) took an unordered `Set` and was never sorted at all — so the fix also closes
a pre-existing gap on that path.

## Fix

Sort the key list by `(urn, aspect, version)` inside the private `batchGet`, before chunking,
guarded by `forUpdate && canWrite` — i.e. only when a `FOR UPDATE` clause is actually emitted.
This is the single choke point every batched read funnels through, so all locking paths
(`getLatestAspects` and the public `batchGet` callers) now acquire locks in a consistent
global order, while non-locking reads skip the sort entirely. Sorting before chunking also
keeps lock order consistent across chunks within one transaction. The chunking behavior from
#17206 is retained.