### PR TITLE
feat(graphql): add field resolvers for Metric and SemanticModel entities

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -4074,17 +4074,6 @@ public class GmsGraphQLEngine {
                 .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
                 .dataFetcher("exists", new EntityExistsResolver(entityService))
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient)));
-    builder.type(
-        "MetricRelationships",
-        typeWiring ->
-            typeWiring.dataFetcher(
-                "parentMetric",
-                new LoadableTypeResolver<>(
-                    metricType,
-                    env -> {
-                      final MetricRelationships rel = env.getSource();
-                      return rel.getParentMetric() != null ? rel.getParentMetric().getUrn() : null;
-                    })));
   }
 
   private void configureSemanticModelResolvers(final RuntimeWiring.Builder builder) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -161,6 +161,7 @@ import com.linkedin.datahub.graphql.resolvers.load.TimeseriesAspectBatchLoader;
 import com.linkedin.datahub.graphql.resolvers.logical.SetLogicalParentResolver;
 import com.linkedin.datahub.graphql.resolvers.metrics.GetRootMetricsResolver;
 import com.linkedin.datahub.graphql.resolvers.metrics.GetSemanticModelsResolver;
+import com.linkedin.datahub.graphql.resolvers.metrics.MetricChildMetricsResolver;
 import com.linkedin.datahub.graphql.resolvers.module.DeletePageModuleResolver;
 import com.linkedin.datahub.graphql.resolvers.module.UpsertPageModuleResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.AddLinkResolver;
@@ -850,6 +851,7 @@ public class GmsGraphQLEngine {
     configurePageTemplateResolvers(builder);
     configureDataHubFileResolvers(builder);
     configureAssetSettingsResolver(builder);
+    configureMetricResolvers(builder);
   }
 
   private void configureOrganisationRoleResolvers(RuntimeWiring.Builder builder) {
@@ -4025,6 +4027,65 @@ public class GmsGraphQLEngine {
                             : null;
                       }
                       return null;
+                    })));
+  }
+
+  private void configureMetricResolvers(final RuntimeWiring.Builder builder) {
+    builder.type(
+        "Metric",
+        typeWiring ->
+            typeWiring
+                .dataFetcher(
+                    "semanticModel",
+                    new LoadableTypeResolver<>(
+                        semanticModelType,
+                        env -> {
+                          final Metric m = env.getSource();
+                          return m.getSemanticModel() != null
+                              ? m.getSemanticModel().getUrn()
+                              : null;
+                        }))
+                .dataFetcher(
+                    "childMetrics", new MetricChildMetricsResolver(entityClient, viewService))
+                .dataFetcher(
+                    "parentMetric",
+                    new LoadableTypeResolver<>(
+                        metricType,
+                        env -> {
+                          final Metric m = env.getSource();
+                          if (m.getMetricRelationships() == null
+                              || m.getMetricRelationships().getParentMetric() == null) {
+                            return null;
+                          }
+                          return m.getMetricRelationships().getParentMetric().getUrn();
+                        }))
+                .dataFetcher(
+                    "platform",
+                    new LoadableTypeResolver<>(
+                        dataPlatformType, env -> ((Metric) env.getSource()).getPlatform().getUrn()))
+                .dataFetcher(
+                    "dataPlatformInstance",
+                    new LoadableTypeResolver<>(
+                        dataPlatformInstanceType,
+                        env -> {
+                          final Metric m = env.getSource();
+                          return m.getDataPlatformInstance() != null
+                              ? m.getDataPlatformInstance().getUrn()
+                              : null;
+                        }))
+                .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
+                .dataFetcher("exists", new EntityExistsResolver(entityService))
+                .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient)));
+    builder.type(
+        "MetricRelationships",
+        typeWiring ->
+            typeWiring.dataFetcher(
+                "parentMetric",
+                new LoadableTypeResolver<>(
+                    metricType,
+                    env -> {
+                      final MetricRelationships rel = env.getSource();
+                      return rel.getParentMetric() != null ? rel.getParentMetric().getUrn() : null;
                     })));
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -162,6 +162,7 @@ import com.linkedin.datahub.graphql.resolvers.logical.SetLogicalParentResolver;
 import com.linkedin.datahub.graphql.resolvers.metrics.GetRootMetricsResolver;
 import com.linkedin.datahub.graphql.resolvers.metrics.GetSemanticModelsResolver;
 import com.linkedin.datahub.graphql.resolvers.metrics.MetricChildMetricsResolver;
+import com.linkedin.datahub.graphql.resolvers.metrics.SemanticModelMetricsResolver;
 import com.linkedin.datahub.graphql.resolvers.module.DeletePageModuleResolver;
 import com.linkedin.datahub.graphql.resolvers.module.UpsertPageModuleResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.AddLinkResolver;
@@ -852,6 +853,7 @@ public class GmsGraphQLEngine {
     configureDataHubFileResolvers(builder);
     configureAssetSettingsResolver(builder);
     configureMetricResolvers(builder);
+    configureSemanticModelResolvers(builder);
   }
 
   private void configureOrganisationRoleResolvers(RuntimeWiring.Builder builder) {
@@ -4087,5 +4089,31 @@ public class GmsGraphQLEngine {
                       final MetricRelationships rel = env.getSource();
                       return rel.getParentMetric() != null ? rel.getParentMetric().getUrn() : null;
                     })));
+  }
+
+  private void configureSemanticModelResolvers(final RuntimeWiring.Builder builder) {
+    builder.type(
+        "SemanticModel",
+        typeWiring ->
+            typeWiring
+                .dataFetcher("metrics", new SemanticModelMetricsResolver(entityClient, viewService))
+                .dataFetcher(
+                    "platform",
+                    new LoadableTypeResolver<>(
+                        dataPlatformType,
+                        env -> ((SemanticModel) env.getSource()).getPlatform().getUrn()))
+                .dataFetcher(
+                    "dataPlatformInstance",
+                    new LoadableTypeResolver<>(
+                        dataPlatformInstanceType,
+                        env -> {
+                          final SemanticModel sm = env.getSource();
+                          return sm.getDataPlatformInstance() != null
+                              ? sm.getDataPlatformInstance().getUrn()
+                              : null;
+                        }))
+                .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
+                .dataFetcher("exists", new EntityExistsResolver(entityService))
+                .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient)));
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -4055,11 +4055,7 @@ public class GmsGraphQLEngine {
                         metricType,
                         env -> {
                           final Metric m = env.getSource();
-                          if (m.getMetricRelationships() == null
-                              || m.getMetricRelationships().getParentMetric() == null) {
-                            return null;
-                          }
-                          return m.getMetricRelationships().getParentMetric().getUrn();
+                          return m.getParentMetric() != null ? m.getParentMetric().getUrn() : null;
                         }))
                 .dataFetcher(
                     "platform",

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/metrics/MetricChildMetricsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/metrics/MetricChildMetricsResolver.java
@@ -1,0 +1,69 @@
+package com.linkedin.datahub.graphql.resolvers.metrics;
+
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.getQueryContext;
+
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.ScrollAcrossEntitiesInput;
+import com.linkedin.datahub.graphql.generated.ScrollResults;
+import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
+import com.linkedin.datahub.graphql.resolvers.search.SearchUtils;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.Criterion;
+import com.linkedin.metadata.query.filter.CriterionArray;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.service.ViewService;
+import com.linkedin.metadata.utils.CriterionUtils;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class MetricChildMetricsResolver implements DataFetcher<CompletableFuture<ScrollResults>> {
+
+  static final String PARENT_METRIC_FIELD_NAME = "parentMetric";
+
+  private final EntityClient _entityClient;
+  private final ViewService _viewService;
+
+  @Override
+  public CompletableFuture<ScrollResults> get(DataFetchingEnvironment environment) {
+    final Entity entity = environment.getSource();
+    final QueryContext context = getQueryContext(environment);
+    final ScrollAcrossEntitiesInput input =
+        bindArgument(environment.getArgument("input"), ScrollAcrossEntitiesInput.class);
+
+    final Criterion childrenFilter =
+        CriterionUtils.buildCriterion(PARENT_METRIC_FIELD_NAME, Condition.EQUAL, entity.getUrn());
+    final Filter baseFilter =
+        new Filter()
+            .setOr(
+                new ConjunctiveCriterionArray(
+                    new ConjunctiveCriterion().setAnd(new CriterionArray(childrenFilter))));
+    final Filter inputFilter = ResolverUtils.buildFilter(null, input.getOrFilters());
+
+    return SearchUtils.scrollAcrossEntities(
+        context,
+        _entityClient,
+        _viewService,
+        input.getTypes(),
+        input.getQuery(),
+        SearchUtils.combineFilters(inputFilter, baseFilter),
+        input.getViewUrn(),
+        input.getSearchFlags(),
+        input.getCount(),
+        input.getScrollId(),
+        input.getKeepAlive(),
+        List.of(),
+        List.of(),
+        this.getClass().getSimpleName());
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/metrics/SemanticModelMetricsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/metrics/SemanticModelMetricsResolver.java
@@ -29,9 +29,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-public class MetricChildMetricsResolver implements DataFetcher<CompletableFuture<ScrollResults>> {
+public class SemanticModelMetricsResolver implements DataFetcher<CompletableFuture<ScrollResults>> {
 
-  static final String PARENT_METRIC_FIELD_NAME = "parentMetric";
+  static final String SEMANTIC_MODEL_FIELD_NAME = "semanticModel";
 
   private final EntityClient _entityClient;
   private final ViewService _viewService;
@@ -43,13 +43,13 @@ public class MetricChildMetricsResolver implements DataFetcher<CompletableFuture
     final ScrollAcrossEntitiesInput input =
         bindArgument(environment.getArgument("input"), ScrollAcrossEntitiesInput.class);
 
-    final Criterion childrenFilter =
-        CriterionUtils.buildCriterion(PARENT_METRIC_FIELD_NAME, Condition.EQUAL, entity.getUrn());
+    final Criterion semanticModelFilter =
+        CriterionUtils.buildCriterion(SEMANTIC_MODEL_FIELD_NAME, Condition.EQUAL, entity.getUrn());
     final Filter baseFilter =
         new Filter()
             .setOr(
                 new ConjunctiveCriterionArray(
-                    new ConjunctiveCriterion().setAnd(new CriterionArray(childrenFilter))));
+                    new ConjunctiveCriterion().setAnd(new CriterionArray(semanticModelFilter))));
     final Filter inputFilter = ResolverUtils.buildFilter(null, input.getOrFilters());
 
     return SearchUtils.scrollAcrossEntities(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricMapper.java
@@ -88,11 +88,15 @@ public class MetricMapper {
     final EnvelopedAspect envelopedRelationships =
         aspects.get(Constants.METRIC_RELATIONSHIPS_ASPECT_NAME);
     if (envelopedRelationships != null) {
-      result.setMetricRelationships(
-          mapMetricRelationships(
-              context,
-              new com.linkedin.metric.MetricRelationships(
-                  envelopedRelationships.getValue().data())));
+      final com.linkedin.metric.MetricRelationships pdlRelationships =
+          new com.linkedin.metric.MetricRelationships(envelopedRelationships.getValue().data());
+      result.setMetricRelationships(mapMetricRelationships(context, pdlRelationships));
+      if (pdlRelationships.hasParentMetric() && pdlRelationships.getParentMetric() != null) {
+        final Metric parentMetricStub = new Metric();
+        parentMetricStub.setUrn(pdlRelationships.getParentMetric().toString());
+        parentMetricStub.setType(EntityType.METRIC);
+        result.setParentMetric(parentMetricStub);
+      }
     }
 
     final EnvelopedAspect envelopedUpstreams = aspects.get(Constants.METRIC_UPSTREAMS_ASPECT_NAME);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricMapper.java
@@ -29,7 +29,6 @@ import com.linkedin.datahub.graphql.types.common.mappers.InstitutionalMemoryMapp
 import com.linkedin.datahub.graphql.types.common.mappers.OwnershipMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.StatusMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.SubTypesMapper;
-import com.linkedin.datahub.graphql.types.common.mappers.UrnToEntityMapper;
 import com.linkedin.datahub.graphql.types.domain.DomainAssociationMapper;
 import com.linkedin.datahub.graphql.types.glossary.mappers.GlossaryTermsMapper;
 import com.linkedin.datahub.graphql.types.mappers.MapperUtils;
@@ -231,10 +230,6 @@ public class MetricMapper {
       @Nullable QueryContext context, final com.linkedin.metric.MetricRelationships pdl) {
     final com.linkedin.datahub.graphql.generated.MetricRelationships result =
         new com.linkedin.datahub.graphql.generated.MetricRelationships();
-
-    if (pdl.hasParentMetric() && pdl.getParentMetric() != null) {
-      result.setParentMetric((Metric) UrnToEntityMapper.map(context, pdl.getParentMetric()));
-    }
 
     final List<EntityEdge> derivedFrom;
     if (pdl.hasDerivedFrom() && pdl.getDerivedFrom() != null) {

--- a/datahub-graphql-core/src/main/resources/metrics.graphql
+++ b/datahub-graphql-core/src/main/resources/metrics.graphql
@@ -337,11 +337,6 @@ Relationship edges from a Metric to other Metrics.
 """
 type MetricRelationships {
   """
-  The immediate parent in the metric hierarchy.
-  """
-  parentMetric: Metric
-
-  """
   Edges to metrics that this metric is derived from.
   """
   derivedFrom: [EntityEdge!]!

--- a/datahub-graphql-core/src/main/resources/metrics.graphql
+++ b/datahub-graphql-core/src/main/resources/metrics.graphql
@@ -98,9 +98,10 @@ type Metric implements Entity {
   semanticModel: SemanticModel
 
   """
-  Parent metrics in the metric hierarchy.
+  The direct parent metric in the sidebar hierarchy. Null for root metrics.
+  For deeper ancestor chains, use nested selection: parentMetric { parentMetric { ... } }.
   """
-  parentMetrics: [Metric!]!
+  parentMetric: Metric
 
   """
   Child metrics in the metric hierarchy.

--- a/datahub-graphql-core/src/main/resources/metrics.graphql
+++ b/datahub-graphql-core/src/main/resources/metrics.graphql
@@ -240,11 +240,6 @@ type SemanticModel implements Entity {
   metrics(input: ScrollAcrossEntitiesInput!): ScrollResults
 
   """
-  Count of Metrics defined within this SemanticModel (field-resolver in CAT-2566).
-  """
-  metricsCount: SemanticModelMetricsCount
-
-  """
   Ownership metadata of the SemanticModel.
   """
   ownership: Ownership
@@ -486,11 +481,4 @@ type AiContext {
   instructions: String
   examples: [String!]
   customInstructions: String
-}
-
-"""
-Count of Metrics associated with a SemanticModel.
-"""
-type SemanticModelMetricsCount {
-  total: Int!
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/metrics/MetricChildMetricsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/metrics/MetricChildMetricsResolverTest.java
@@ -1,0 +1,133 @@
+package com.linkedin.datahub.graphql.resolvers.metrics;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.testng.Assert.*;
+
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.ScrollAcrossEntitiesInput;
+import com.linkedin.datahub.graphql.generated.ScrollResults;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.search.ScrollResult;
+import com.linkedin.metadata.search.SearchEntityArray;
+import com.linkedin.metadata.search.SearchResultMetadata;
+import com.linkedin.metadata.service.ViewService;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.Collections;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class MetricChildMetricsResolverTest {
+
+  private static final String TEST_METRIC_URN =
+      "urn:li:metric:(urn:li:dataPlatform:dbt,analytics.model,revenue)";
+
+  private EntityClient _entityClient;
+  private ViewService _viewService;
+  private DataFetchingEnvironment _dataFetchingEnvironment;
+  private MetricChildMetricsResolver _resolver;
+  private Entity _entity;
+
+  @BeforeMethod
+  public void setupTest() {
+    _entityClient = Mockito.mock(EntityClient.class);
+    _viewService = Mockito.mock(ViewService.class);
+    _dataFetchingEnvironment = Mockito.mock(DataFetchingEnvironment.class);
+    _entity = Mockito.mock(Entity.class);
+    Mockito.when(_entity.getUrn()).thenReturn(TEST_METRIC_URN);
+    Mockito.when(_dataFetchingEnvironment.getSource()).thenReturn(_entity);
+
+    _resolver = new MetricChildMetricsResolver(_entityClient, _viewService);
+  }
+
+  @Test
+  public void testGetSuccess() throws Exception {
+    final ScrollResult mockScrollResult = new ScrollResult();
+    mockScrollResult.setScrollId("test-scroll-id");
+    mockScrollResult.setPageSize(2);
+    mockScrollResult.setNumEntities(2);
+    mockScrollResult.setMetadata(new SearchResultMetadata());
+    mockScrollResult.setEntities(new SearchEntityArray());
+
+    final ScrollAcrossEntitiesInput input = new ScrollAcrossEntitiesInput();
+    input.setTypes(Collections.singletonList(EntityType.METRIC));
+    input.setQuery("*");
+    input.setCount(10);
+
+    Mockito.when(_dataFetchingEnvironment.getArgument("input")).thenReturn(input);
+
+    Mockito.when(
+            _entityClient.scrollAcrossEntities(
+                any(),
+                eq(Collections.singletonList(Constants.METRIC_ENTITY_NAME)),
+                eq("*"),
+                any(),
+                eq(null),
+                eq("5m"),
+                eq(Collections.emptyList()),
+                eq(10),
+                eq(Collections.emptyList())))
+        .thenReturn(mockScrollResult);
+
+    final QueryContext mockContext = getMockAllowContext();
+    Mockito.when(_dataFetchingEnvironment.getContext()).thenReturn(mockContext);
+
+    final ScrollResults result = _resolver.get(_dataFetchingEnvironment).get();
+
+    assertEquals(result.getNextScrollId(), "test-scroll-id");
+    assertEquals(result.getCount(), 2);
+    assertEquals(result.getTotal(), 2);
+  }
+
+  @Test
+  public void testParentMetricFilterIsInjected() throws Exception {
+    final ScrollResult mockScrollResult = new ScrollResult();
+    mockScrollResult.setPageSize(0);
+    mockScrollResult.setNumEntities(0);
+    mockScrollResult.setMetadata(new SearchResultMetadata());
+    mockScrollResult.setEntities(new SearchEntityArray());
+
+    final ScrollAcrossEntitiesInput input = new ScrollAcrossEntitiesInput();
+    input.setQuery("*");
+    input.setCount(10);
+
+    Mockito.when(_dataFetchingEnvironment.getArgument("input")).thenReturn(input);
+    Mockito.when(
+            _entityClient.scrollAcrossEntities(
+                any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(mockScrollResult);
+
+    final QueryContext mockContext = getMockAllowContext();
+    Mockito.when(_dataFetchingEnvironment.getContext()).thenReturn(mockContext);
+
+    _resolver.get(_dataFetchingEnvironment).get();
+
+    // Verify the filter argument is non-null (contains parentMetric=<urn> criterion)
+    Mockito.verify(_entityClient)
+        .scrollAcrossEntities(
+            any(),
+            any(),
+            any(),
+            Mockito.argThat(
+                filter ->
+                    filter != null
+                        && filter.getOr().stream()
+                            .flatMap(cc -> cc.getAnd().stream())
+                            .anyMatch(
+                                c ->
+                                    MetricChildMetricsResolver.PARENT_METRIC_FIELD_NAME.equals(
+                                            c.getField())
+                                        && c.getValues() != null
+                                        && c.getValues().contains(TEST_METRIC_URN))),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/metrics/SemanticModelMetricsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/metrics/SemanticModelMetricsResolverTest.java
@@ -7,7 +7,6 @@ import static org.testng.Assert.*;
 
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.Entity;
-import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.ScrollAcrossEntitiesInput;
 import com.linkedin.datahub.graphql.generated.ScrollResults;
 import com.linkedin.entity.client.EntityClient;
@@ -22,15 +21,15 @@ import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class MetricChildMetricsResolverTest {
+public class SemanticModelMetricsResolverTest {
 
-  private static final String TEST_METRIC_URN =
-      "urn:li:metric:(urn:li:dataPlatform:dbt,analytics.model,revenue)";
+  private static final String TEST_SEMANTIC_MODEL_URN =
+      "urn:li:semanticModel:(urn:li:dataPlatform:dbt,analytics.model,sales_model)";
 
   private EntityClient _entityClient;
   private ViewService _viewService;
   private DataFetchingEnvironment _dataFetchingEnvironment;
-  private MetricChildMetricsResolver _resolver;
+  private SemanticModelMetricsResolver _resolver;
   private Entity _entity;
 
   @BeforeMethod
@@ -39,23 +38,22 @@ public class MetricChildMetricsResolverTest {
     _viewService = Mockito.mock(ViewService.class);
     _dataFetchingEnvironment = Mockito.mock(DataFetchingEnvironment.class);
     _entity = Mockito.mock(Entity.class);
-    Mockito.when(_entity.getUrn()).thenReturn(TEST_METRIC_URN);
+    Mockito.when(_entity.getUrn()).thenReturn(TEST_SEMANTIC_MODEL_URN);
     Mockito.when(_dataFetchingEnvironment.getSource()).thenReturn(_entity);
 
-    _resolver = new MetricChildMetricsResolver(_entityClient, _viewService);
+    _resolver = new SemanticModelMetricsResolver(_entityClient, _viewService);
   }
 
   @Test
   public void testGetSuccess() throws Exception {
     final ScrollResult mockScrollResult = new ScrollResult();
     mockScrollResult.setScrollId("test-scroll-id");
-    mockScrollResult.setPageSize(2);
-    mockScrollResult.setNumEntities(2);
+    mockScrollResult.setPageSize(3);
+    mockScrollResult.setNumEntities(3);
     mockScrollResult.setMetadata(new SearchResultMetadata());
     mockScrollResult.setEntities(new SearchEntityArray());
 
     final ScrollAcrossEntitiesInput input = new ScrollAcrossEntitiesInput();
-    input.setTypes(Collections.singletonList(EntityType.METRIC));
     input.setQuery("*");
     input.setCount(10);
 
@@ -80,8 +78,55 @@ public class MetricChildMetricsResolverTest {
     final ScrollResults result = _resolver.get(_dataFetchingEnvironment).get();
 
     assertEquals(result.getNextScrollId(), "test-scroll-id");
-    assertEquals(result.getCount(), 2);
-    assertEquals(result.getTotal(), 2);
+    assertEquals(result.getCount(), 3);
+    assertEquals(result.getTotal(), 3);
+  }
+
+  @Test
+  public void testSemanticModelFilterIsInjected() throws Exception {
+    final ScrollResult mockScrollResult = new ScrollResult();
+    mockScrollResult.setPageSize(0);
+    mockScrollResult.setNumEntities(0);
+    mockScrollResult.setMetadata(new SearchResultMetadata());
+    mockScrollResult.setEntities(new SearchEntityArray());
+
+    final ScrollAcrossEntitiesInput input = new ScrollAcrossEntitiesInput();
+    input.setQuery("*");
+    input.setCount(10);
+
+    Mockito.when(_dataFetchingEnvironment.getArgument("input")).thenReturn(input);
+    Mockito.when(
+            _entityClient.scrollAcrossEntities(
+                any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(mockScrollResult);
+
+    final QueryContext mockContext = getMockAllowContext();
+    Mockito.when(_dataFetchingEnvironment.getContext()).thenReturn(mockContext);
+
+    _resolver.get(_dataFetchingEnvironment).get();
+
+    // Verify the filter contains semanticModel=<urn> criterion
+    Mockito.verify(_entityClient)
+        .scrollAcrossEntities(
+            any(),
+            any(),
+            any(),
+            Mockito.argThat(
+                filter ->
+                    filter != null
+                        && filter.getOr().stream()
+                            .flatMap(cc -> cc.getAnd().stream())
+                            .anyMatch(
+                                c ->
+                                    SemanticModelMetricsResolver.SEMANTIC_MODEL_FIELD_NAME.equals(
+                                            c.getField())
+                                        && c.getValues() != null
+                                        && c.getValues().contains(TEST_SEMANTIC_MODEL_URN))),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
   }
 
   @Test
@@ -113,53 +158,6 @@ public class MetricChildMetricsResolverTest {
             eq(Collections.singletonList(Constants.METRIC_ENTITY_NAME)),
             any(),
             any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            any());
-  }
-
-  @Test
-  public void testParentMetricFilterIsInjected() throws Exception {
-    final ScrollResult mockScrollResult = new ScrollResult();
-    mockScrollResult.setPageSize(0);
-    mockScrollResult.setNumEntities(0);
-    mockScrollResult.setMetadata(new SearchResultMetadata());
-    mockScrollResult.setEntities(new SearchEntityArray());
-
-    final ScrollAcrossEntitiesInput input = new ScrollAcrossEntitiesInput();
-    input.setQuery("*");
-    input.setCount(10);
-
-    Mockito.when(_dataFetchingEnvironment.getArgument("input")).thenReturn(input);
-    Mockito.when(
-            _entityClient.scrollAcrossEntities(
-                any(), any(), any(), any(), any(), any(), any(), any(), any()))
-        .thenReturn(mockScrollResult);
-
-    final QueryContext mockContext = getMockAllowContext();
-    Mockito.when(_dataFetchingEnvironment.getContext()).thenReturn(mockContext);
-
-    _resolver.get(_dataFetchingEnvironment).get();
-
-    // Verify the filter argument is non-null (contains parentMetric=<urn> criterion)
-    Mockito.verify(_entityClient)
-        .scrollAcrossEntities(
-            any(),
-            any(),
-            any(),
-            Mockito.argThat(
-                filter ->
-                    filter != null
-                        && filter.getOr().stream()
-                            .flatMap(cc -> cc.getAnd().stream())
-                            .anyMatch(
-                                c ->
-                                    MetricChildMetricsResolver.PARENT_METRIC_FIELD_NAME.equals(
-                                            c.getField())
-                                        && c.getValues() != null
-                                        && c.getValues().contains(TEST_METRIC_URN))),
             any(),
             any(),
             any(),

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricMapperTest.java
@@ -139,6 +139,12 @@ public class MetricMapperTest {
       assertNotNull(result.getMetricRelationships().getParentMetric());
       assertEquals(result.getMetricRelationships().getParentMetric().getUrn(), PARENT_METRIC_URN);
       assertEquals(result.getMetricRelationships().getParentMetric().getType(), EntityType.METRIC);
+
+      // The top-level Metric.parentMetric field must also be populated directly (mirrors
+      // semanticModel), so the field resolver can do a simple one-level fetch.
+      assertNotNull(result.getParentMetric());
+      assertEquals(result.getParentMetric().getUrn(), PARENT_METRIC_URN);
+      assertEquals(result.getParentMetric().getType(), EntityType.METRIC);
     }
   }
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/metric/mappers/MetricMapperTest.java
@@ -123,7 +123,7 @@ public class MetricMapperTest {
   }
 
   @Test
-  public void testMapMetricRelationshipsParentMetric() throws URISyntaxException {
+  public void testTopLevelParentMetricPopulatedFromRelationshipsAspect() throws URISyntaxException {
     EntityResponse entityResponse = createBaseEntityResponse();
 
     MetricRelationships rels =
@@ -135,13 +135,6 @@ public class MetricMapperTest {
 
       Metric result = MetricMapper.map(mockQueryContext, entityResponse);
 
-      assertNotNull(result.getMetricRelationships());
-      assertNotNull(result.getMetricRelationships().getParentMetric());
-      assertEquals(result.getMetricRelationships().getParentMetric().getUrn(), PARENT_METRIC_URN);
-      assertEquals(result.getMetricRelationships().getParentMetric().getType(), EntityType.METRIC);
-
-      // The top-level Metric.parentMetric field must also be populated directly (mirrors
-      // semanticModel), so the field resolver can do a simple one-level fetch.
       assertNotNull(result.getParentMetric());
       assertEquals(result.getParentMetric().getUrn(), PARENT_METRIC_URN);
       assertEquals(result.getParentMetric().getType(), EntityType.METRIC);

--- a/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
@@ -11,9 +11,7 @@ import com.linkedin.schema.SchemaField
 record SemanticField {
 
   /**
-   * Inline SchemaField describing this field's schema and identity.
-   * Its `fieldPath` composes into `urn:li:schemaField:(<parentSemanticModelUrn>,<fieldPath>)`,
-   * which serves as the endpoint for column-level lineage edges and as the anchor for
+   * Inline SchemaField describing this field's schema and identity for column-level lineage edges and as the anchor for
    * column-level governance (tags, glossary terms, description).
    */
   schemaField: SchemaField

--- a/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/semanticmodel/SemanticField.pdl
@@ -11,7 +11,9 @@ import com.linkedin.schema.SchemaField
 record SemanticField {
 
   /**
-   * Inline SchemaField describing this field's schema and identity for column-level lineage edges and as the anchor for
+   * Inline SchemaField describing this field's schema and identity.
+   * Its `fieldPath` composes into `urn:li:schemaField:(<parentSemanticModelUrn>,<fieldPath>)`,
+   * which serves as the endpoint for column-level lineage edges and as the anchor for
    * column-level governance (tags, glossary terms, description).
    */
   schemaField: SchemaField


### PR DESCRIPTION
## Summary

Wires up GraphQL field resolvers for the `Metric` and `SemanticModel` entity types (schema, types, and top-level list/get queries landed separately):

- `Metric.childMetrics(input: ScrollAcrossEntitiesInput!): ScrollResults` — searches metrics scoped to `parentMetric=<urn>`, hardcoded to the `METRIC` entity type.
- `Metric.parentMetric: Metric` — direct parent lookup via `LoadableTypeResolver`, reading from `MetricRelationships.parentMetric`. Also wires `MetricRelationships.parentMetric` for nested selection.
- `Metric.semanticModel`, `Metric.platform`, `Metric.dataPlatformInstance` — standard `LoadableTypeResolver` wiring.
- `SemanticModel.metrics(input: ScrollAcrossEntitiesInput!): ScrollResults` — searches metrics scoped to `semanticModel=<urn>`, hardcoded to the `METRIC` entity type.
- `SemanticModel.platform`, `SemanticModel.dataPlatformInstance` — standard `LoadableTypeResolver` wiring.
- Standard `Entity`-interface fields (`privileges`, `exists`, `relationships`) wired for both types.
