### PR TITLE
fix(ingest/powerbi): stop logging the PowerBI access token

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/config.py
@@ -39,7 +39,6 @@ class Constant:
     keys used in powerbi plugin
     """
 
-    PBIAccessToken = "PBIAccessToken"
     DASHBOARD_LIST = "DASHBOARD_LIST"
     TILE_LIST = "TILE_LIST"
     REPORT_LIST = "REPORT_LIST"

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/rest_api_wrapper/data_resolver.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/rest_api_wrapper/data_resolver.py
@@ -227,8 +227,6 @@ class DataResolverBase(ABC):
             )
         )
 
-        logger.debug(f"{Constant.PBIAccessToken}={self._access_token}")
-
         return self._access_token
 
     def _is_access_token_expired(self) -> bool:


### PR DESCRIPTION
## Summary

The PowerBI resolver logged the full `Bearer <token>` access token at debug level every time a token was acquired:

```python
logger.debug(f"{Constant.PBIAccessToken}={self._access_token}")
```

With `--debug` enabled this writes a live, valid PowerBI credential into the ingestion logs (and anywhere those logs are shipped/stored), which is a security risk with no real diagnostic value.

## Changes

- Remove the debug log line that printed the access token. The existing `logger.info("Generated PowerBi access token")` message already provides the useful signal (that a token was successfully obtained) without exposing the secret.
- Drop the now-unused `Constant.PBIAccessToken` key.

## Testing

- `./gradlew :metadata-ingestion:lint` (ruff + format + mypy) is clean.
- Existing PowerBI integration tests pass, including `test_access_token_expiry_with_long_expiry`.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing/#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)