### PR TITLE
perf(mce-consumer): stream MCP conversion to bound consumer memory

### DIFF
--- a/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/batch/BatchMetadataChangeProposalsProcessor.java
+++ b/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/batch/BatchMetadataChangeProposalsProcessor.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.kafka.batch;
 import static com.linkedin.metadata.utils.metrics.MetricUtils.BATCH_SIZE_ATTR;
 import static com.linkedin.mxe.ConsumerGroups.MCP_CONSUMER_GROUP_ID_VALUE;
 
+import com.linkedin.data.template.StringMap;
 import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.gms.factory.entityclient.RestliEntityClientFactory;
@@ -18,13 +19,16 @@ import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.mxe.Topics;
 import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +47,17 @@ import org.springframework.stereotype.Component;
 @Conditional(BatchMetadataChangeProposalProcessorCondition.class)
 @RequiredArgsConstructor
 public class BatchMetadataChangeProposalsProcessor {
+
+  private static final String AVRO_SYSTEM_METADATA_FIELD = "systemMetadata";
+  private static final String AVRO_PROPERTIES_FIELD = "properties";
+
+  private static final Set<String> TELEMETRY_PROPERTY_KEYS =
+      Set.of(
+          SystemTelemetryContext.TELEMETRY_TRACE_KEY,
+          SystemTelemetryContext.TELEMETRY_QUEUE_SPAN_KEY,
+          SystemTelemetryContext.TELEMETRY_LOG_KEY,
+          SystemTelemetryContext.TELEMETRY_ENQUEUED_AT);
+
   private final OperationContext systemOperationContext;
   private final SystemEntityClient entityClient;
   private final EventProducer kafkaProducer;
@@ -118,8 +133,8 @@ public class BatchMetadataChangeProposalsProcessor {
       final List<ConsumerRecord<String, GenericRecord>> consumerRecords,
       @Nullable final List<InboundRecordProperties> inboundProperties) {
 
-    List<MetadataChangeProposal> allMCPs = new ArrayList<>(consumerRecords.size());
     String topicName = null;
+    List<SystemMetadata> tracingSystemMetadataList = new ArrayList<>();
 
     for (int i = 0; i < consumerRecords.size(); i++) {
       ConsumerRecord<String, GenericRecord> consumerRecord = consumerRecords.get(i);
@@ -154,53 +169,62 @@ public class BatchMetadataChangeProposalsProcessor {
           consumerRecord.serializedValueSize(),
           consumerRecord.timestamp());
 
-      try {
-        MetadataChangeProposal mcp = EventUtils.avroToPegasusMCP(record);
-        allMCPs.add(mcp);
-      } catch (IOException e) {
-        log.error(
-            "Unrecoverable message deserialization error. Cannot forward to failure topic.", e);
+      SystemMetadata traceMetadata = getTelemetryTraceMetadata(record);
+      if (traceMetadata != null) {
+        tracingSystemMetadataList.add(traceMetadata);
       }
     }
 
-    // Create the span tracking for all records, even if allMCPs is empty
-    List<SystemMetadata> systemMetadataList =
-        allMCPs.stream().map(MetadataChangeProposal::getSystemMetadata).toList();
-
+    final String spanTopicName = topicName;
     sliceContext.withQueueSpan(
         "consume",
-        systemMetadataList,
-        topicName,
+        tracingSystemMetadataList,
+        spanTopicName,
         () -> {
-          if (!allMCPs.isEmpty()) {
-            // Now partition and process within the span
-            processInBatches(sliceContext, allMCPs);
-          } else {
-            log.info("No valid MCPs to process after deserialization");
+          if (consumerRecords.isEmpty()) {
+            log.info("No MCPs to process after deserialization");
+            return;
           }
+          processInBatches(sliceContext, consumerRecords);
         },
         BATCH_SIZE_ATTR,
-        String.valueOf(allMCPs.size()),
+        String.valueOf(consumerRecords.size()),
         MetricUtils.DROPWIZARD_NAME,
         MetricUtils.name(this.getClass(), "consume"));
   }
 
   /**
-   * Process MCPs in batches within the established span
+   * Stream-convert and sub-batch the poll's MCPs within the established span.
+   *
+   * <p>Each avro record is converted to a Pegasus MCP lazily and accumulated into a byte-budgeted
+   * sub-batch; when the budget is exceeded the sub-batch is ingested and released, so only one
+   * sub-batch of Pegasus MCPs is resident at a time (rather than the full poll).
    *
    * @param sliceContext slice-level OperationContext used for downstream ingest + FMCP emission
-   * @param allMCPs All MCPs to process
+   * @param consumerRecords the avro records for this consume call
    */
   private void processInBatches(
-      @Nonnull OperationContext sliceContext, List<MetadataChangeProposal> allMCPs) {
+      @Nonnull OperationContext sliceContext,
+      List<ConsumerRecord<String, GenericRecord>> consumerRecords) {
     List<MetadataChangeProposal> currentBatch = new ArrayList<>();
     long currentBatchSize = 0;
     int totalProcessed = 0;
 
-    for (MetadataChangeProposal mcp : allMCPs) {
+    for (ConsumerRecord<String, GenericRecord> consumerRecord : consumerRecords) {
+      final GenericRecord record = consumerRecord.value();
+      final MetadataChangeProposal mcp;
+      try {
+        mcp = EventUtils.avroToPegasusMCP(record);
+      } catch (IOException e) {
+        log.error(
+            "Unrecoverable message deserialization error. Cannot forward to failure topic.", e);
+        continue;
+      }
       long mcpSize = calculateMCPSize(mcp);
 
-      // If adding this MCP would exceed the batch size limit, process the current batch first
+      // If adding this MCP would exceed the batch size limit, process the current batch first.
+      // The limit is read only once currentBatch is non-empty, so a poll whose records all fail
+      // deserialization never touches the config provider (matching the pre-streaming behaviour).
       if (!currentBatch.isEmpty()
           && currentBatchSize + mcpSize
               > provider.getMetadataChangeProposal().getConsumer().getBatch().getSize()) {
@@ -210,7 +234,7 @@ public class BatchMetadataChangeProposalsProcessor {
             "Processed batch of {} MCPs, total processed so far: {}/{}",
             currentBatch.size(),
             totalProcessed,
-            allMCPs.size());
+            consumerRecords.size());
 
         // Reset for the next batch
         currentBatch = new ArrayList<>();
@@ -230,7 +254,7 @@ public class BatchMetadataChangeProposalsProcessor {
           "Processed final batch of {} MCPs, total processed: {}/{}",
           currentBatch.size(),
           totalProcessed,
-          allMCPs.size());
+          consumerRecords.size());
     }
   }
 
@@ -267,6 +291,48 @@ public class BatchMetadataChangeProposalsProcessor {
 
       kafkaProducer.produceFailedMetadataChangeProposal(sliceContext, batch, throwable);
     }
+  }
+
+  /**
+   * Read the telemetry trace properties off an avro MCP's {@code systemMetadata.properties} map
+   * into a lightweight, properties-only {@link SystemMetadata} — without converting the
+   * (potentially large) aspect via {@link EventUtils#avroToPegasusMCP}. Returns {@code null} unless
+   * the record carries both {@link SystemTelemetryContext#TELEMETRY_TRACE_KEY} and {@link
+   * SystemTelemetryContext#TELEMETRY_QUEUE_SPAN_KEY}, mirroring the filter {@link
+   * SystemTelemetryContext#withQueueSpan} applies.
+   *
+   * <p>{@code withQueueSpan}/{@code closeQueueSpan} only read {@code properties} (the trace id,
+   * queue span id, log-tracing flag, and enqueued-at timestamp) off each entry, so this trimmed
+   * SystemMetadata is all they need to link the consume span to the upstream trace and record queue
+   * latency on the receive span.
+   */
+  @Nullable
+  private SystemMetadata getTelemetryTraceMetadata(@Nullable GenericRecord record) {
+    if (record == null
+        || !(record.get(AVRO_SYSTEM_METADATA_FIELD) instanceof GenericRecord systemMetadataRecord)
+        || !(systemMetadataRecord.get(AVRO_PROPERTIES_FIELD) instanceof Map<?, ?> avroProperties)) {
+      return null;
+    }
+
+    // Avro deserializes map keys as Utf8, which never equals a String, so we can't look them up by
+    // key — iterate and stringify, copying only the telemetry entries into a Pegasus StringMap.
+    StringMap telemetryProps = new StringMap();
+    for (Map.Entry<?, ?> entry : avroProperties.entrySet()) {
+      String key = entry.getKey().toString();
+      if (entry.getValue() != null && TELEMETRY_PROPERTY_KEYS.contains(key)) {
+        telemetryProps.put(key, entry.getValue().toString());
+      }
+    }
+
+    // Both ids are required for withQueueSpan to link the consume span to the upstream trace.
+    if (!telemetryProps.containsKey(SystemTelemetryContext.TELEMETRY_TRACE_KEY)
+        || !telemetryProps.containsKey(SystemTelemetryContext.TELEMETRY_QUEUE_SPAN_KEY)) {
+      return null;
+    }
+
+    SystemMetadata systemMetadata = new SystemMetadata();
+    systemMetadata.setProperties(telemetryProps);
+    return systemMetadata;
   }
 
   /**

--- a/metadata-jobs/mce-consumer/src/test/java/com/linkedin/metadata/kafka/batch/BatchMetadataChangeProposalsProcessorTest.java
+++ b/metadata-jobs/mce-consumer/src/test/java/com/linkedin/metadata/kafka/batch/BatchMetadataChangeProposalsProcessorTest.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertTrue;
 import com.codahale.metrics.Histogram;
 import com.linkedin.common.Status;
 import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.StringMap;
 import com.linkedin.dataset.DatasetProperties;
 import com.linkedin.entity.client.EntityClientConfig;
 import com.linkedin.entity.client.SystemEntityClient;
@@ -49,6 +50,7 @@ import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.mxe.Topics;
 import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -56,7 +58,9 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.generic.GenericRecord;
@@ -903,6 +907,107 @@ public class BatchMetadataChangeProposalsProcessorTest {
 
     // Execute - should not throw exception
     processorNoRegistry.consume(List.of(mockConsumerRecord1));
+  }
+
+  @Test
+  public void testStreamingSingleConversionPerRecord() throws Exception {
+    // The streaming refactor must convert each avro record to a Pegasus MCP exactly
+    // once in the common (non-trace-enabled) path: the pre-pass only peeks
+    // systemMetadata.properties for trace ids and must NOT convert, and the span
+    // pass converts once for ingestion. Use the real OperationContext (like the
+    // ingestion tests) so withQueueSpan actually runs the processing runnable.
+    setupBasicConfiguration();
+
+    MetadataChangeProposal mcp1 = createSimpleMCP();
+    MetadataChangeProposal mcp2 = createSimpleMCP();
+    MetadataChangeProposal mcp3 = createSimpleMCP();
+    eventUtilsMock.when(() -> EventUtils.avroToPegasusMCP(mockRecord1)).thenReturn(mcp1);
+    eventUtilsMock.when(() -> EventUtils.avroToPegasusMCP(mockRecord2)).thenReturn(mcp2);
+    eventUtilsMock.when(() -> EventUtils.avroToPegasusMCP(mockRecord3)).thenReturn(mcp3);
+
+    processor.consume(List.of(mockConsumerRecord1, mockConsumerRecord2, mockConsumerRecord3));
+
+    // One conversion per record — no double conversion from a pre-pass.
+    eventUtilsMock.verify(() -> EventUtils.avroToPegasusMCP(mockRecord1), times(1));
+    eventUtilsMock.verify(() -> EventUtils.avroToPegasusMCP(mockRecord2), times(1));
+    eventUtilsMock.verify(() -> EventUtils.avroToPegasusMCP(mockRecord3), times(1));
+
+    // All three still ingested together (MAX_VALUE batch limit).
+    verify(mockEntityService, times(1)).ingestProposal(any(), any(), eq(false));
+  }
+
+  @Test
+  public void testTracedRecordSystemMetadataExtractedPrePass() throws Exception {
+    // A trace-carrying record must have its telemetry props read from the avro
+    // systemMetadata.properties map WITHOUT a full avro->Pegasus conversion, and the trimmed
+    // SystemMetadata handed to withQueueSpan must carry every property the receive span needs:
+    // trace id, queue span id, AND the enqueued-at timestamp used for queue-latency attributes.
+    // The record itself is still converted exactly once, inside the span, for ingestion.
+    setupBasicConfiguration();
+
+    // Capture the SystemMetadata list the pre-pass passes to withQueueSpan, and run the runnable.
+    // Explicit matchers per vararg (BATCH_SIZE_ATTR + value, DROPWIZARD_NAME + name) — a single
+    // any() does not match the 4-element varargs.
+    OperationContext tracingContext = spy(opContext);
+    List<List<SystemMetadata>> capturedTracing = new ArrayList<>();
+    doAnswer(
+            invocation -> {
+              capturedTracing.add(invocation.getArgument(1));
+              ((Runnable) invocation.getArgument(3)).run();
+              return null;
+            })
+        .when(tracingContext)
+        .withQueueSpan(
+            anyString(),
+            anyList(),
+            anyString(),
+            any(Runnable.class),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString());
+
+    BatchMetadataChangeProposalsProcessor tracingProcessor =
+        new BatchMetadataChangeProposalsProcessor(
+            tracingContext,
+            entityClient,
+            mockKafkaProducer,
+            mockKafkaThrottle,
+            mockProvider,
+            mockConsumerPauseSupport);
+    setProcessorFields(tracingProcessor);
+
+    // Wire mockRecord1's avro systemMetadata.properties with the trace keys plus enqueued-at
+    // (valid W3C hex ids so a real closeQueueSpan could build a remote SpanContext).
+    GenericRecord sysMetaAvro = mock(GenericRecord.class);
+    Map<String, String> props = new HashMap<>();
+    props.put(SystemTelemetryContext.TELEMETRY_TRACE_KEY, "0123456789abcdef0123456789abcdef");
+    props.put(SystemTelemetryContext.TELEMETRY_QUEUE_SPAN_KEY, "0123456789abcdef");
+    props.put(SystemTelemetryContext.TELEMETRY_ENQUEUED_AT, "1700000000000");
+    when(mockRecord1.get("systemMetadata")).thenReturn(sysMetaAvro);
+    when(sysMetaAvro.get("properties")).thenReturn(props);
+
+    MetadataChangeProposal mcp = createSimpleMCP();
+    eventUtilsMock.when(() -> EventUtils.avroToPegasusMCP(mockRecord1)).thenReturn(mcp);
+
+    tracingProcessor.consume(List.of(mockConsumerRecord1));
+
+    // Single conversion: the pre-pass reads properties off the avro map; only the span (ingest)
+    // pass converts.
+    eventUtilsMock.verify(() -> EventUtils.avroToPegasusMCP(mockRecord1), times(1));
+    verify(mockEntityService, times(1)).ingestProposal(any(), any(), eq(false));
+
+    // Regression guard: the trimmed SystemMetadata carries the trace keys AND the enqueued-at
+    // timestamp, so closeQueueSpan can still set queue-latency attributes on the receive span.
+    assertEquals(capturedTracing.size(), 1);
+    assertEquals(capturedTracing.get(0).size(), 1);
+    StringMap tracedProps = capturedTracing.get(0).get(0).getProperties();
+    assertEquals(
+        tracedProps.get(SystemTelemetryContext.TELEMETRY_TRACE_KEY),
+        "0123456789abcdef0123456789abcdef");
+    assertEquals(
+        tracedProps.get(SystemTelemetryContext.TELEMETRY_QUEUE_SPAN_KEY), "0123456789abcdef");
+    assertEquals(tracedProps.get(SystemTelemetryContext.TELEMETRY_ENQUEUED_AT), "1700000000000");
   }
 
   // Helper methods to reduce duplication


### PR DESCRIPTION
## Summary

The batch MCP consumer materialized the entire Kafka poll as Pegasus
`MetadataChangeProposal`s before processing (`allMCPs`). With individual MCPs
up to ~15MB and `fetch.max.bytes` permitting ~50MB polls, peak heap scaled
with the whole poll, driving the mce-consumer toward OOM under large-message
load.

This PR reworks `BatchMetadataChangeProposalsProcessor` to a **streaming**
path: records are deserialized lazily inside `processInBatches` and
accumulated into byte-budgeted sub-batches (bounded by
`metadataChangeProposal.consumer.batch.size`). Each sub-batch is ingested and
released before the next is assembled, so only **one sub-batch of Pegasus
MCPs is resident at a time** instead of the full poll.

## Details

- **Streaming conversion.** `processInBatches` now takes the raw
  `ConsumerRecord`s and calls `EventUtils.avroToPegasusMCP` per record as it
  fills each sub-batch, keeping resident memory bounded regardless of poll size.
- **Trace linking preserved, single conversion per record.** Because full
  sampling stamps trace ids onto essentially every MCP, a naive "convert up
  front to collect `SystemMetadata`" pre-pass would deserialize every record
  twice. Instead, `getTelemetryTraceMetadata` reads the telemetry keys directly
  off the avro `systemMetadata.properties` map and builds a properties-only
  `SystemMetadata`. It carries the trace id, queue span id, log flag, and
  enqueued-at timestamp — everything `withQueueSpan`/`closeQueueSpan` read to
  link the consume span upstream and record queue latency on the receive span —
  so each record is converted exactly once (in `processInBatches`).
- **No behavior change** to ingestion, batching semantics, config, or APIs.

## Testing

- `testStreamingSingleConversionPerRecord` — verifies each record is converted
  exactly once on the common path and all records still ingest in one batch
  under the default byte budget.
- `testTracedRecordSystemMetadataExtractedPrePass` — verifies a trace-carrying
  record has its telemetry properties read from avro (no extra conversion),
  that the trimmed `SystemMetadata` handed to `withQueueSpan` carries the trace
  id, queue span id, **and** enqueued-at timestamp, and that it is then ingested.
- Full `BatchMetadataChangeProposalsProcessorTest` suite passing (16 tests).

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated
- [ ] Docs added/updated — n/a (no user-facing config or API change)
- [ ] Breaking change entry in `updating-datahub.md` — n/a (no breaking change)
