### PR TITLE
test(playwright): add support of .ant-notification to toast component

### DIFF
--- a/e2e-test/ui/playwright/pages/common/toast-component.ts
+++ b/e2e-test/ui/playwright/pages/common/toast-component.ts
@@ -5,14 +5,15 @@ import { type Locator, type Page, expect } from '@playwright/test';
  *
  * The app is mid-migration from antd's global `message.*` API (rendered in `.ant-message`)
  * to the alchemy `toast.*` API (rendered in a portal with `data-testid="toast-notification-container"`).
- * Match either container so this helper works regardless of which API a given surface uses.
+ * Some surfaces (e.g. subscriptions) still use antd's `notification.*` API, rendered in `.ant-notification`.
+ * Match any of these containers so this helper works regardless of which API a given surface uses.
  */
 export class ToastComponent {
   private readonly container: Locator;
 
   constructor(page: Page) {
-    // eslint-disable-next-line playwright/no-raw-locators -- antd's global message container has no data-testid or ARIA role; the union covers both toast systems during migration.
-    this.container = page.locator('.ant-message, [data-testid="toast-notification-container"]');
+    // eslint-disable-next-line playwright/no-raw-locators -- antd's global message/notification containers have no data-testid or ARIA role; the union covers all three toast systems during migration.
+    this.container = page.locator('.ant-message, .ant-notification, [data-testid="toast-notification-container"]');
   }
 
   getToast(text: string | RegExp): Locator {


### PR DESCRIPTION
This PR bring fix in ToastComponent to OSS

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
