### PR TITLE
fix(timeline): resolve ownership type name in Change History; fix raw diff serialization

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/history/__tests__/changeEventToString.test.ts
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/history/__tests__/changeEventToString.test.ts
@@ -422,6 +422,26 @@ describe('getChangeEventString', () => {
             expect(result).toBe('Added owner "jane_doe" (Business Owner).');
         });
 
+        it('should resolve a custom ownership type URN to its display name via the name map', () => {
+            // Custom types have opaque UUID slugs; without name resolution the label would show the
+            // UUID ("Custom Uuid 123") instead of the type's real name.
+            const changeEvent: ChangeEvent = {
+                urn: 'urn:test',
+                category: ChangeCategoryType.Ownership,
+                operation: ChangeOperationType.Add,
+                parameters: [
+                    { key: 'ownerUrn', value: 'urn:li:corpuser:jane_doe' },
+                    { key: 'ownerType', value: 'NONE' },
+                    { key: 'ownerTypeUrn', value: 'urn:li:ownershipType:custom-uuid-123' },
+                ],
+                description: "'jane_doe' added as owner.",
+            };
+
+            const nameMap = new Map([['urn:li:ownershipType:custom-uuid-123', 'Data Owner']]);
+            const result = getChangeEventString(changeEvent, nameMap);
+            expect(result).toBe('Added owner "jane_doe" (Data Owner).');
+        });
+
         it('should suppress NONE owner type', () => {
             const changeEvent: ChangeEvent = {
                 urn: 'urn:test',

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/history/changeEventToString.ts
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/history/changeEventToString.ts
@@ -219,7 +219,10 @@ export function getChangeEventString(changeEvent: ChangeEvent, nameMap?: Map<str
         const ownerTypeUrn = getParameter(changeEvent.parameters, PARAM_OWNER_TYPE_URN);
         let ownerTypeSuffix = '';
         if (ownerTypeUrn) {
-            ownerTypeSuffix = ` (${formatOwnerTypeUrn(ownerTypeUrn)})`;
+            // Prefer the ownership type's resolved display name — custom types have opaque URN slugs
+            // (a UUID), so humanizing the slug would show the UUID instead of the type's real name.
+            // Fall back to slug humanization when the type can't be resolved (e.g. it was deleted).
+            ownerTypeSuffix = ` (${nameMap?.get(ownerTypeUrn) ?? formatOwnerTypeUrn(ownerTypeUrn)})`;
         } else if (rawOwnerType && !UNINFORMATIVE_OWNER_TYPES.has(rawOwnerType)) {
             ownerTypeSuffix = ` (${formatOwnerType(rawOwnerType)})`;
         }

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/timeline/data/ChangeTransaction.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/timeline/data/ChangeTransaction.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.timeline.data;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.json.JsonPatch;
@@ -19,7 +20,11 @@ public class ChangeTransaction {
   SemanticChangeType semVerChange;
   @Setter List<ChangeEvent> changeEvents;
 
+  // JsonPatch (parsson JsonPatchImpl) is not a Jackson bean, so serializing it directly throws
+  // "No serializer found" and fails the whole /timeline response when raw=true. Emit its RFC-6902
+  // JSON array form instead.
   @ArraySchema(schema = @Schema(implementation = PatchOperation.class))
+  @JsonSerialize(using = JsonPatchSerializer.class)
   JsonPatch rawDiff;
 
   @Setter String versionStamp;

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/timeline/data/JsonPatchSerializer.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/timeline/data/JsonPatchSerializer.java
@@ -1,0 +1,21 @@
+package com.linkedin.metadata.timeline.data;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import jakarta.json.JsonPatch;
+import java.io.IOException;
+
+/**
+ * Serializes a {@link JsonPatch} as its RFC-6902 JSON array form. The default parsson
+ * implementation ({@code org.eclipse.parsson.JsonPatchImpl}) is not a Jackson bean, so Jackson
+ * would otherwise throw "No serializer found" and fail the entire timeline response when {@code
+ * raw=true} is requested.
+ */
+public class JsonPatchSerializer extends JsonSerializer<JsonPatch> {
+  @Override
+  public void serialize(JsonPatch value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    gen.writeRawValue(value.toJsonArray().toString());
+  }
+}

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/timeline/data/ChangeTransactionSerializationTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/timeline/data/ChangeTransactionSerializationTest.java
@@ -1,0 +1,25 @@
+package com.linkedin.metadata.timeline.data;
+
+import static org.testng.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.Json;
+import jakarta.json.JsonPatch;
+import org.testng.annotations.Test;
+
+public class ChangeTransactionSerializationTest {
+
+  // A populated rawDiff (raw=true) previously threw "No serializer found for
+  // org.eclipse.parsson.JsonPatchImpl" and failed the whole /timeline response. It must now
+  // serialize as its RFC-6902 JSON array.
+  @Test
+  public void testRawDiffSerializesAsJsonArray() throws Exception {
+    JsonPatch patch = Json.createPatchBuilder().add("/foo", "bar").build();
+    ChangeTransaction txn = ChangeTransaction.builder().timestamp(1L).rawDiff(patch).build();
+
+    String json = new ObjectMapper().writeValueAsString(txn);
+
+    assertTrue(json.contains("\"rawDiff\":["), json);
+    assertTrue(json.contains("\"op\":\"add\""), json);
+  }
+}


### PR DESCRIPTION
## Summary

Two small, independent fixes on the Change History / Timeline surface.

### 1. Change History shows the ownership type's display name (frontend)

The Change History entry for an ownership change rendered the type by humanizing its
URN slug (`formatOwnerTypeUrn`), so it did **not** match the name shown elsewhere in
the UI (ownership sidebar, remove-owner dialog), which resolve the ownership-type
entity's live `info.name`. Effects:

- **Custom ownership types** (opaque UUID URNs) rendered the UUID instead of the name.
- **Renamed built-in types** rendered the default slug (e.g. `__system__data_steward`
  → "Data Steward") even after the type was renamed, so the same owner showed a
  different type label in Change History vs. the ownership panel.

The name resolver (`useResolveEntityNames`) already batch-resolves every URN-valued
parameter — including `ownerTypeUrn` — into `nameMap`, and the query fragment already
selects `OwnershipTypeEntity { info { name } }`. This change just consults it, falling
back to slug humanization only when the type can't be resolved (e.g. it was deleted).

Note: this resolves the type's **current** display name (consistent with the rest of
the UI). Showing the name as it was at the time of each event would require capturing
the name with the event and is intentionally out of scope.

### 2. `/timeline` OpenAPI endpoint fails when `raw=true` (backend)

`ChangeTransaction.rawDiff` is a `jakarta.json.JsonPatch` (parsson `JsonPatchImpl`),
which is not a Jackson-serializable bean — serializing it threw
`No serializer found for org.eclipse.parsson.JsonPatchImpl` and failed the **entire**
timeline response whenever `raw=true` was requested. Added a small `JsonSerializer`
that emits the patch as its RFC-6902 JSON array. Only affects JSON serialization; all
in-process consumers use the getter/builder and are unchanged.

## Testing

- Frontend: added one focused case to `changeEventToString.test.ts` (custom-type URN
  resolves to its display name via the name map) — `47 passed`.
- Backend: added `ChangeTransactionSerializationTest` (rawDiff serializes as a JSON
  array instead of throwing) — passing.
- `spotlessApply` + eslint/prettier clean on changed files.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests added
- [ ] Docs — n/a
- [ ] Breaking changes — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)