### PR TITLE
fix(usage): widen usageQuantity from int to long

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/registry/metrics/UsageMetricIncrementResolver.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/registry/metrics/UsageMetricIncrementResolver.java
@@ -66,7 +66,7 @@ public final class UsageMetricIncrementResolver {
       return isKnownRequestPhasePair(metric) ? 0 : -1;
     }
 
-    int usageQuantity = Math.max(1, requestContext.getUsageQuantity());
+    long usageQuantity = Math.max(1L, requestContext.getUsageQuantity());
     return switch (metric.emitWhen()) {
       case ALWAYS -> resolveAlwaysIncrement(
           metric.valueUnit(), operationEntry, requestContext, usageQuantity);
@@ -147,9 +147,9 @@ public final class UsageMetricIncrementResolver {
       @Nonnull ValueUnit valueUnit,
       @Nonnull UsageOperationsRegistry.UsageOperationEntry operationEntry,
       @Nonnull RequestContext requestContext,
-      int usageQuantity) {
+      long usageQuantity) {
     return switch (valueUnit) {
-      case COUNT -> operationEntry.ingestionEndpoint() ? (long) usageQuantity : 1L;
+      case COUNT -> operationEntry.ingestionEndpoint() ? usageQuantity : 1L;
       case INPUT_BYTES -> requestContext.getInputBytes() != null
           ? requestContext.getInputBytes()
           : 0L;
@@ -171,7 +171,7 @@ public final class UsageMetricIncrementResolver {
   private static long resolveCostProfileIncrement(
       @Nonnull ValueUnit valueUnit,
       @Nonnull UsageOperationsRegistry.UsageOperationEntry operationEntry,
-      int usageQuantity) {
+      long usageQuantity) {
     if (valueUnit != ValueUnit.COST_UNITS) {
       return -1;
     }

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/registry/UsageMetricIncrementResolverTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/registry/UsageMetricIncrementResolverTest.java
@@ -24,7 +24,7 @@ public class UsageMetricIncrementResolverTest {
         new UsageMetricRegistryLoader(yamlMapper), java.util.List.of());
   }
 
-  private static RequestContext requestContextWithQuantity(int usageQuantity) {
+  private static RequestContext requestContextWithQuantity(long usageQuantity) {
     return RequestContext.builder()
         .actorUrn("urn:li:corpuser:test")
         .sourceIP("127.0.0.1")

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/RequestContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/RequestContext.java
@@ -100,7 +100,7 @@ public class RequestContext implements ContextInterface {
   private final boolean responseBodyMaterialized;
 
   /** Multiplier for per-proposal ingest cost profiling (batch size). Defaults to 1. */
-  @Builder.Default private final int usageQuantity = 1;
+  @Builder.Default private final long usageQuantity = 1L;
 
   public RequestContext(
       MetricUtils metricUtils,
@@ -175,7 +175,7 @@ public class RequestContext implements ContextInterface {
       @Nullable Long outputBytes,
       boolean requestBodyMaterialized,
       boolean responseBodyMaterialized,
-      int usageQuantity) {
+      long usageQuantity) {
     this.actorUrn = actorUrn;
     this.sourceIP = sourceIP;
     this.requestAPI = requestAPI;
@@ -224,7 +224,7 @@ public class RequestContext implements ContextInterface {
     this.outputBytes = outputBytes;
     this.requestBodyMaterialized = requestBodyMaterialized;
     this.responseBodyMaterialized = responseBodyMaterialized;
-    this.usageQuantity = Math.max(1, usageQuantity);
+    this.usageQuantity = Math.max(1L, usageQuantity);
 
     putUsageFieldsInMdc();
 
@@ -243,33 +243,33 @@ public class RequestContext implements ContextInterface {
   }
 
   /** Counts JSON array elements for ingest batch usage quantity; returns 1 when not an array. */
-  public static int resolveIngestUsageQuantity(
+  public static long resolveIngestUsageQuantity(
       @Nonnull String jsonBody, @Nonnull ObjectMapper objectMapper) {
     try {
       JsonNode node = objectMapper.readTree(jsonBody);
       if (node.isArray()) {
-        return Math.max(1, node.size());
+        return Math.max(1L, node.size());
       }
     } catch (JsonProcessingException e) {
       log.debug("Could not parse ingest body for usage quantity", e);
     }
-    return 1;
+    return 1L;
   }
 
   /** Sums array sizes under a JSON object keyed by entity type (generic multi-type ingest). */
-  public static int resolveIngestUsageQuantity(@Nonnull JsonNode rootObject) {
+  public static long resolveIngestUsageQuantity(@Nonnull JsonNode rootObject) {
     if (!rootObject.isObject()) {
-      return 1;
+      return 1L;
     }
-    int total = 0;
+    long total = 0L;
     for (JsonNode value : rootObject) {
       if (value.isArray()) {
         total += value.size();
       } else {
-        total += 1;
+        total += 1L;
       }
     }
-    return Math.max(1, total);
+    return Math.max(1L, total);
   }
 
   /** Resolves request wire bytes from servlet {@code Content-Length} when not streaming/chunked. */
@@ -344,10 +344,10 @@ public class RequestContext implements ContextInterface {
 
   public static class RequestContextBuilder {
 
-    private int usageQuantity = 1;
+    private long usageQuantity = 1L;
 
-    public RequestContextBuilder usageQuantity(int usageQuantity) {
-      this.usageQuantity = Math.max(1, usageQuantity);
+    public RequestContextBuilder usageQuantity(long usageQuantity) {
+      this.usageQuantity = Math.max(1L, usageQuantity);
       return this;
     }
 
@@ -541,8 +541,8 @@ public class RequestContext implements ContextInterface {
     }
 
     @Nonnull
-    public RequestContextBuilder withUsageQuantity(int quantity) {
-      return usageQuantity(Math.max(1, quantity));
+    public RequestContextBuilder withUsageQuantity(long quantity) {
+      return usageQuantity(Math.max(1L, quantity));
     }
 
     @Nonnull

--- a/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/RequestContextTest.java
+++ b/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/RequestContextTest.java
@@ -681,9 +681,9 @@ public class RequestContextTest {
   @Test
   public void testResolveIngestUsageQuantityFromJsonArray() throws Exception {
     ObjectMapper mapper = new ObjectMapper();
-    assertEquals(RequestContext.resolveIngestUsageQuantity("[1,2,3]", mapper), 3);
-    assertEquals(RequestContext.resolveIngestUsageQuantity("{\"a\":1}", mapper), 1);
-    assertEquals(RequestContext.resolveIngestUsageQuantity("not-json", mapper), 1);
+    assertEquals(RequestContext.resolveIngestUsageQuantity("[1,2,3]", mapper), 3L);
+    assertEquals(RequestContext.resolveIngestUsageQuantity("{\"a\":1}", mapper), 1L);
+    assertEquals(RequestContext.resolveIngestUsageQuantity("not-json", mapper), 1L);
   }
 
   @Test
@@ -692,8 +692,8 @@ public class RequestContextTest {
     JsonNode root =
         mapper.readTree(
             "{\"dataset\":[{\"urn\":\"a\"},{\"urn\":\"b\"}],\"chart\":{\"urn\":\"c\"}}");
-    assertEquals(RequestContext.resolveIngestUsageQuantity(root), 3);
-    assertEquals(RequestContext.resolveIngestUsageQuantity(mapper.readTree("[1]")), 1);
+    assertEquals(RequestContext.resolveIngestUsageQuantity(root), 3L);
+    assertEquals(RequestContext.resolveIngestUsageQuantity(mapper.readTree("[1]")), 1L);
   }
 
   @Test
@@ -745,6 +745,6 @@ public class RequestContextTest {
     assertEquals(builder.peekUsageOperation(), null);
 
     RequestContext context = builder.metricUtils(mockMetricUtils).build();
-    assertEquals(context.getUsageQuantity(), 1);
+    assertEquals(context.getUsageQuantity(), 1L);
   }
 }

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/GenericEntitiesController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/GenericEntitiesController.java
@@ -551,7 +551,7 @@ public abstract class GenericEntitiesController<
       throws InvalidUrnException, JsonProcessingException {
 
     Authentication authentication = AuthenticationContext.getAuthentication();
-    int usageQuantity = RequestContext.resolveIngestUsageQuantity(jsonEntityList, objectMapper);
+    long usageQuantity = RequestContext.resolveIngestUsageQuantity(jsonEntityList, objectMapper);
     OperationContext opContext =
         OperationContext.asSession(
             systemOperationContext,

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/controller/EntityController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/controller/EntityController.java
@@ -418,7 +418,7 @@ public class EntityController
       throws InvalidUrnException, JsonProcessingException {
 
     Authentication authentication = AuthenticationContext.getAuthentication();
-    int usageQuantity =
+    long usageQuantity =
         RequestContext.resolveIngestUsageQuantity(jsonEntityPatchList, objectMapper);
     OperationContext opContext =
         OperationContext.asSession(


### PR DESCRIPTION
## Summary
- Widen `RequestContext.usageQuantity` and related ingest quantity helpers from `int` to `long`
- Update usage metric increment resolution and OpenAPI controllers to match, avoiding overflow on large ingest batches

## Test plan
- [ ] Existing unit tests updated for `long` quantity (`RequestContextTest`, `UsageMetricIncrementResolverTest`)
- [ ] Spotless / compile for touched modules pass
- [ ] Smoke: ingest a batch and confirm usage quantity / cost profiling still increments correctly


Made with [Cursor](https://cursor.com)