### PR TITLE
fix(linechart): fix fractional ticks in linechart (bring SaaS fix)

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/dataviz/__tests__/utils.test.ts
+++ b/datahub-web-react/src/alchemy-components/components/dataviz/__tests__/utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { abbreviateNumber } from '@components/components/dataviz/utils';
+
+describe('abbreviateNumber', () => {
+    it('strips floating-point division artifacts on fractional ticks', () => {
+        // 2713.2 / 1000 = 2.7131999999999996 in IEEE-754; must render as 2.7132K.
+        expect(abbreviateNumber(2713.2)).toBe('2.7132K');
+    });
+
+    it('leaves clean values unchanged (no other visible change)', () => {
+        expect(abbreviateNumber(1_500_000)).toBe('1.5M');
+        expect(abbreviateNumber(1_250_000)).toBe('1.25M');
+        expect(abbreviateNumber(1_000_000)).toBe('1M');
+        expect(abbreviateNumber(2_500_000_000)).toBe('2.5B');
+        expect(abbreviateNumber(3_300_000)).toBe('3.3M');
+    });
+
+    it('preserves the negative sign', () => {
+        expect(abbreviateNumber(-2713.2)).toBe('-2.7132K');
+    });
+
+    it('returns sub-1000 values without a suffix', () => {
+        expect(abbreviateNumber(999)).toBe(999);
+        expect(abbreviateNumber(42)).toBe(42);
+    });
+
+    it('also strips float artifacts below 1000 (symmetric cleanup)', () => {
+        // 0.1 + 0.2 = 0.30000000000000004 in IEEE-754.
+        expect(abbreviateNumber(0.1 + 0.2)).toBe(0.3);
+    });
+});

--- a/datahub-web-react/src/alchemy-components/components/dataviz/utils.ts
+++ b/datahub-web-react/src/alchemy-components/components/dataviz/utils.ts
@@ -1,13 +1,21 @@
+// IEEE-754 doubles carry ~16 significant decimal digits, and arithmetic like
+// `2713.2 / 1000` lands 1 ULP off its intended value (= 2.7131999999999996), so
+// String() prints the full noisy tail. Rounding to this many significant figures
+// strips that noise while preserving far more precision than any abbreviated
+// label needs — it sits safely below the ~16-digit noise floor and well above the
+// handful of figures a real tick label uses.
+const ABBREVIATION_SIGNIFICANT_DIGITS = 12;
+
 // Number Abbreviations
 export const abbreviateNumber = (str) => {
     const number = parseFloat(str);
     if (Number.isNaN(number)) return str;
     const sign = number < 0 ? '-' : '';
     const absoluteNumber = Math.abs(number);
-    if (absoluteNumber < 1000) return number;
+    if (absoluteNumber < 1000) return Number(number.toPrecision(ABBREVIATION_SIGNIFICANT_DIGITS));
     const abbreviations = ['K', 'M', 'B', 'T'];
     const index = Math.floor(Math.log10(absoluteNumber) / 3);
     const suffix = abbreviations[index - 1];
     const shortNumber = absoluteNumber / 10 ** (index * 3);
-    return `${sign}${shortNumber}${suffix}`;
+    return `${sign}${Number(shortNumber.toPrecision(ABBREVIATION_SIGNIFICANT_DIGITS))}${suffix}`;
 };

--- a/datahub-web-react/src/app/dataviz/__tests__/utils.test.ts
+++ b/datahub-web-react/src/app/dataviz/__tests__/utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { abbreviateNumber } from '@app/dataviz/utils';
+
+describe('abbreviateNumber', () => {
+    it('abbreviates into K/M/B/T bands', () => {
+        expect(abbreviateNumber(1000)).toBe('1K');
+        expect(abbreviateNumber(1_500_000)).toBe('1.5M');
+        expect(abbreviateNumber(2_500_000_000)).toBe('2.5B');
+        expect(abbreviateNumber(1_000_000_000_000)).toBe('1T');
+    });
+
+    it('strips floating-point division artifacts on fractional ticks', () => {
+        // 2713.2 / 1000 = 2.7131999999999996 in IEEE-754; must render as 2.7132K.
+        expect(abbreviateNumber(2713.2)).toBe('2.7132K');
+    });
+
+    it('leaves clean values unchanged (no other visible change)', () => {
+        expect(abbreviateNumber(1_250_000)).toBe('1.25M');
+        expect(abbreviateNumber(3_300_000)).toBe('3.3M');
+        expect(abbreviateNumber(1_000_000)).toBe('1M');
+    });
+
+    it('preserves precision up to 12 significant figures', () => {
+        expect(abbreviateNumber(123_456_789_012)).toBe('123.456789012B');
+    });
+
+    it('returns sub-1000 values as a number, without a suffix', () => {
+        expect(abbreviateNumber(999)).toBe(999);
+        expect(abbreviateNumber(42)).toBe(42);
+    });
+
+    it('also strips float artifacts below 1000 (symmetric cleanup)', () => {
+        // 0.1 + 0.2 = 0.30000000000000004 in IEEE-754.
+        expect(abbreviateNumber(0.1 + 0.2)).toBe(0.3);
+    });
+
+    it('returns the original string for non-numeric input', () => {
+        expect(abbreviateNumber('abc')).toBe('abc');
+    });
+});

--- a/datahub-web-react/src/app/dataviz/utils.ts
+++ b/datahub-web-react/src/app/dataviz/utils.ts
@@ -1,11 +1,19 @@
+// IEEE-754 doubles carry ~16 significant decimal digits, and arithmetic like
+// `2713.2 / 1000` lands 1 ULP off its intended value (= 2.7131999999999996), so
+// String() prints the full noisy tail. Rounding to this many significant figures
+// strips that noise while preserving far more precision than any abbreviated
+// label needs — it sits safely below the ~16-digit noise floor and well above the
+// handful of figures a real tick label uses.
+const ABBREVIATION_SIGNIFICANT_DIGITS = 12;
+
 // Number Abbreviations
 export const abbreviateNumber = (str) => {
     const number = parseFloat(str);
     if (Number.isNaN(number)) return str;
-    if (number < 1000) return number;
+    if (number < 1000) return Number(number.toPrecision(ABBREVIATION_SIGNIFICANT_DIGITS));
     const abbreviations = ['K', 'M', 'B', 'T'];
     const index = Math.floor(Math.log10(number) / 3);
     const suffix = abbreviations[index - 1];
     const shortNumber = number / 10 ** (index * 3);
-    return `${shortNumber}${suffix}`;
+    return `${Number(shortNumber.toPrecision(ABBREVIATION_SIGNIFICANT_DIGITS))}${suffix}`;
 };


### PR DESCRIPTION
This PR brings the fix for linechart to OSS - https://github.com/acryldata/datahub-fork/pull/10758

<img width="1201" height="913" alt="image" src="https://github.com/user-attachments/assets/aa72a884-b700-4aca-885e-34ad2df6d8bb" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
