### PR TITLE
fix(cli): resolve OAuth2 discovery at origin root, not the /gms path

### DIFF
--- a/metadata-ingestion/src/datahub/cli/oauth_cli.py
+++ b/metadata-ingestion/src/datahub/cli/oauth_cli.py
@@ -66,7 +66,18 @@ def _validate_endpoint_origin(endpoint_url: str, gms_url: str, field: str) -> No
 
 def _discover_oauth_server(gms_url: str) -> Dict[str, Any]:
     """Fetch /.well-known/oauth-authorization-server. Raises ClickException if unavailable."""
-    discovery_url = f"{gms_url.rstrip('/')}/.well-known/oauth-authorization-server"
+    # The OAuth2 authorization server metadata document (RFC 8414) is served at the
+    # origin root, not under the GMS servlet path. For DataHub Cloud, fixup_gms_url
+    # appends "/gms" to the host, but the discovery endpoint lives at the bare host —
+    # e.g. https://acme.acryl.io/.well-known/oauth-authorization-server, not
+    # https://acme.acryl.io/gms/.well-known/... (the latter returns 401).
+    parsed = urllib.parse.urlparse(gms_url)
+    if parsed.scheme and parsed.netloc:
+        origin = f"{parsed.scheme}://{parsed.netloc}"
+    else:
+        # Fall back to the raw URL (minus any path) when no scheme is present.
+        origin = gms_url.rstrip("/")
+    discovery_url = f"{origin}/.well-known/oauth-authorization-server"
     try:
         resp = requests.get(discovery_url, timeout=10)
     except requests.RequestException as e:

--- a/metadata-ingestion/tests/unit/cli/test_oauth_cli.py
+++ b/metadata-ingestion/tests/unit/cli/test_oauth_cli.py
@@ -54,16 +54,24 @@ class TestDiscoverOAuthServer:
         )
         assert meta["token_endpoint"] == _DISCOVERY_DOC["token_endpoint"]
 
-    def test_strips_trailing_slash_from_url(self) -> None:
-        with patch(
-            "requests.get", return_value=_mock_response(200, _DISCOVERY_DOC)
-        ) as mock_get:
-            _discover_oauth_server("https://example.datahub.io/gms/")
-        called_url = mock_get.call_args[0][0]
-        assert (
-            called_url
-            == "https://example.datahub.io/gms/.well-known/oauth-authorization-server"
-        )
+    def test_discovery_uses_origin_root_not_gms_path(self) -> None:
+        # RFC 8414: the discovery document is served at the origin root, so the
+        # "/gms" path (added by fixup_gms_url for Cloud hosts) must be stripped.
+        # Regression test for OAuth login against bare Acryl Cloud hosts.
+        for gms_url in (
+            "https://example.datahub.io/gms",
+            "https://example.datahub.io/gms/",
+            "https://example.datahub.io",
+        ):
+            with patch(
+                "requests.get", return_value=_mock_response(200, _DISCOVERY_DOC)
+            ) as mock_get:
+                _discover_oauth_server(gms_url)
+            called_url = mock_get.call_args[0][0]
+            assert (
+                called_url
+                == "https://example.datahub.io/.well-known/oauth-authorization-server"
+            )
 
     def test_404_raises_with_helpful_message(self) -> None:
         import click
@@ -109,6 +117,30 @@ class TestDiscoverOAuthServer:
             with pytest.raises(click.ClickException) as exc_info:
                 _discover_oauth_server("https://example.datahub.io/gms")
         assert "missing required fields" in str(exc_info.value.format_message())
+
+    def test_bare_acryl_cloud_host_resolves_discovery_to_root(self) -> None:
+        # End-to-end regression: a bare Acryl Cloud host passes through
+        # fixup_gms_url (which appends "/gms") and must still resolve discovery
+        # to the origin root, not "/gms/.well-known/..." (which returned 401).
+        from datahub.cli.cli_utils import fixup_gms_url
+
+        gms_url = fixup_gms_url("https://acme.acryl.io")
+        assert gms_url == "https://acme.acryl.io/gms"
+
+        discovery_doc = {
+            "issuer": "https://acme.acryl.io",
+            "authorization_endpoint": "https://acme.acryl.io/auth/oauth2/authorize",
+            "token_endpoint": "https://acme.acryl.io/auth/oauth2/token",
+            "registration_endpoint": "https://acme.acryl.io/auth/oauth2/register",
+        }
+        with patch(
+            "requests.get", return_value=_mock_response(200, discovery_doc)
+        ) as mock_get:
+            _discover_oauth_server(gms_url)
+        called_url = mock_get.call_args[0][0]
+        assert (
+            called_url == "https://acme.acryl.io/.well-known/oauth-authorization-server"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`datahub init --oauth` against a DataHub Cloud host fails during OAuth2 server discovery with:

```
Error: Unexpected response from https://<host>/gms/.well-known/oauth-authorization-server: HTTP 401.
```

**Root cause.** For any `*.acryl.io` host, `fixup_gms_url` appends `/gms` (`https://acme.acryl.io` → `https://acme.acryl.io/gms`). `_discover_oauth_server` then appended the well-known path to that full URL, producing `https://acme.acryl.io/gms/.well-known/oauth-authorization-server`, which returns **HTTP 401**. Per [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414), the authorization-server metadata document is served at the **origin root** — `https://acme.acryl.io/.well-known/oauth-authorization-server` — which returns the valid discovery document. The `/gms` prefix is correct for GMS API calls (`/config`, token generation) but wrong for OAuth discovery.

**Fix.** Derive the discovery URL from the parsed origin (`scheme://netloc`), stripping any path component. The discovered `authorization_endpoint`/`token_endpoint` come from the discovery document itself, and the same-origin validation compares by netloc — both are unaffected.

## Testing

- `test_discovery_uses_origin_root_not_gms_path` — `/gms`, `/gms/`, and bare-host inputs all resolve discovery to the origin root.
- `test_bare_acryl_cloud_host_resolves_discovery_to_root` — end-to-end regression tying `fixup_gms_url` to `_discover_oauth_server`, reproducing the reported scenario.
- Full suite: `40 passed` in `tests/unit/cli/test_oauth_cli.py`.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [ ] Docs added/updated (n/a — bug fix, no user-facing doc change)
- [ ] Breaking changes documented in `docs/how/updating-datahub.md` (n/a — not a breaking change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
