### PR TITLE
feat(ingestion/collibra): thin API client skeleton for Collibra governance migrator [WIP]

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/collibra/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/collibra/client.py
@@ -2,15 +2,18 @@
 # See RFC "Collibra -> DataHub Governance Migrator" (Page 4 Engineering Design,
 # Page 6 Extraction). WIP: `Cfg` and the dataclass models are temporary stubs to
 # be swapped for CollibraSourceConfig (config.py) and pydantic models (models.py);
-# secrets become SecretStr, injected programmatically. `requests` is imported
-# lazily since the connector controls its own deps.
+# secrets become SecretStr, injected programmatically.
 
 from __future__ import annotations
 
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from typing import Iterator, List, Optional, Tuple
+from typing import Any, Iterator, List, Optional, Tuple
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 PAGE_SIZE = 1000  # DGC "Enable maximum paging limit" cap: 1000 elements / call
 
@@ -31,21 +34,23 @@ class Cfg:
 
 
 # --- Step 1: auth + session + retry ------------------------------------------
-def build_session(cfg: Cfg):
+def build_session(cfg: Cfg) -> requests.Session:
     """OAuth2 bearer + TLS + rate-aware retry/backoff, all on one Session."""
-    import requests
-    from requests.adapters import HTTPAdapter
-    from urllib3.util.retry import Retry
 
     class TokenAuth(requests.auth.AuthBase):
         def __init__(self, cfg: Cfg):
             self.cfg, self._tok = cfg, None
 
         def _fetch(self) -> None:
+            client_id = self.cfg.client_id
+            client_secret = self.cfg.client_secret
+            assert client_id and client_secret, (
+                "OAuth requires client_id and client_secret"
+            )
             r = requests.post(
                 f"{self.cfg.url}/rest/oauth/v2/token",
                 data={"grant_type": "client_credentials"},
-                auth=(self.cfg.client_id, self.cfg.client_secret),
+                auth=(client_id, client_secret),
                 verify=self.cfg.ca_cert_path or self.cfg.verify_ssl,
                 timeout=30,
             )
@@ -87,18 +92,18 @@ class Asset:
 
 # --- client ------------------------------------------------------------------
 class CollibraClient:
-    def __init__(self, cfg: Cfg, session=None):
+    def __init__(self, cfg: Cfg, session: Optional[requests.Session] = None):
         self.cfg = cfg
         self.session = session if session is not None else build_session(cfg)
         self._info: Optional[dict] = None
 
     # low-level
-    def _get(self, path: str, params: Optional[dict] = None):
+    def _get(self, path: str, params: Optional[dict] = None) -> requests.Response:
         r = self.session.get(self.cfg.url + path, params=params or {})
         r.raise_for_status()
         return r
 
-    def _post(self, path: str, **kw):
+    def _post(self, path: str, **kw: Any) -> requests.Response:
         r = self.session.post(self.cfg.url + path, **kw)
         r.raise_for_status()
         return r

--- a/metadata-ingestion/src/datahub/ingestion/source/collibra/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/collibra/client.py
@@ -1,7 +1,6 @@
-# Thin Collibra client for the `collibra` ingestion source.
-# See RFC "Collibra -> DataHub Governance Migrator" (Page 4 Engineering Design,
-# Page 6 Extraction). Transport layer only: auth, paging, GraphQL, Output Module,
-# and parallel fan-out. Mapping/resolution/emission live in mapper/urn_resolver/source.
+# Thin Collibra client for the `collibra` ingestion source. Transport layer only:
+# auth, paging, GraphQL, Output Module, and parallel fan-out. Mapping, resolution,
+# and emission live in mapper/urn_resolver/source.
 
 from __future__ import annotations
 

--- a/metadata-ingestion/src/datahub/ingestion/source/collibra/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/collibra/client.py
@@ -1,0 +1,251 @@
+"""
+Thin Collibra client skeleton for the DataHub `collibra` ingestion source.
+
+Belongs at: metadata-ingestion/src/datahub/ingestion/source/collibra/client.py
+Design: RFC "Collibra -> DataHub Governance Migrator", Page 4 (Engineering Design)
+        + Page 6 (Extraction). Tracked in ING-3045.
+
+Stack (no new deps): requests + urllib3.Retry + concurrent.futures + pydantic.
+
+This skeleton keeps `requests` imports lazy and uses stdlib dataclasses for the
+stub models so the __main__ self-check runs with plain `python3`, no network,
+no third-party deps. In the connector:
+  - swap the `Cfg` dataclass for CollibraSourceConfig (pydantic) in config.py
+  - swap the stub dataclass models for pydantic BaseModel in models.py
+  - secrets are SecretStr, injected programmatically (never os.environ)
+"""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Dict, Iterator, List, Optional, Tuple
+
+PAGE_SIZE = 1000  # DGC "Enable maximum paging limit" cap: 1000 elements / call
+
+
+# --- config (skeleton) -------------------------------------------------------
+# ponytail: real connector uses CollibraSourceConfig(StatefulIngestionConfigBase,
+# PlatformInstanceConfigMixin, EnvConfigMixin) in config.py; secrets are SecretStr.
+# This dataclass exists only so the file is standalone + self-checkable.
+@dataclass
+class Cfg:
+    url: str
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
+    verify_ssl: bool = True
+    ca_cert_path: Optional[str] = None
+    max_workers: int = 4  # ponytail: ~4 matches Collibra's concurrent-job ceiling
+    poll_interval_s: float = 2.0
+
+
+# --- Step 1: auth + session + retry ------------------------------------------
+def build_session(cfg: Cfg):
+    """OAuth2 bearer + TLS + rate-aware retry/backoff, all on one Session."""
+    import requests
+    from requests.adapters import HTTPAdapter
+    from urllib3.util.retry import Retry
+
+    class TokenAuth(requests.auth.AuthBase):
+        def __init__(self, cfg: Cfg):
+            self.cfg, self._tok = cfg, None
+
+        def _fetch(self) -> None:
+            r = requests.post(
+                f"{self.cfg.url}/rest/oauth/v2/token",
+                data={"grant_type": "client_credentials"},
+                auth=(self.cfg.client_id, self.cfg.client_secret),
+                verify=self.cfg.ca_cert_path or self.cfg.verify_ssl,
+                timeout=30,
+            )
+            r.raise_for_status()
+            self._tok = r.json()["access_token"]
+
+        def __call__(self, req):
+            if not self._tok:
+                self._fetch()
+            req.headers["Authorization"] = f"Bearer {self._tok}"
+            return req
+
+    s = requests.Session()
+    # respect_retry_after_header=True => 429 Retry-After honored; no hand-rolled backoff.
+    retry = Retry(
+        total=5,
+        backoff_factor=1.0,
+        status_forcelist=[429, 500, 502, 503, 504],
+        respect_retry_after_header=True,
+        allowed_methods=None,  # retry POSTs too (reads are idempotent for us)
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    s.mount("https://", adapter)
+    s.mount("http://", adapter)
+    s.auth = TokenAuth(cfg) if cfg.client_id else None  # else BasicAuth/session
+    s.verify = cfg.ca_cert_path or cfg.verify_ssl
+    # ponytail: if not cfg.verify_ssl -> report.warning(...) in the connector.
+    return s
+
+
+# --- stub models -------------------------------------------------------------
+# ponytail: model only the fields consumed; swap to pydantic BaseModel in models.py.
+@dataclass
+class Asset:
+    id: str
+    name: str
+    type_id: str
+
+
+# --- client ------------------------------------------------------------------
+class CollibraClient:
+    def __init__(self, cfg: Cfg, session=None):
+        self.cfg = cfg
+        self.session = session if session is not None else build_session(cfg)
+        self._info: Optional[dict] = None
+
+    # low-level
+    def _get(self, path: str, params: Optional[dict] = None):
+        r = self.session.get(self.cfg.url + path, params=params or {})
+        r.raise_for_status()
+        return r
+
+    def _post(self, path: str, **kw):
+        r = self.session.post(self.cfg.url + path, **kw)
+        r.raise_for_status()
+        return r
+
+    # Step 2: capability probe
+    def info(self) -> dict:
+        if self._info is None:
+            self._info = self._get("/rest/2.0/application/info").json()
+        return self._info
+
+    def use_graphql(self) -> bool:
+        # ponytail: version gate; derive the threshold from /application/info in Phase 0.
+        return True
+
+    # Step 3: cursor paginator (the core primitive; sequential per collection)
+    def paginate(self, path: str, params: Optional[dict] = None) -> Iterator[dict]:
+        params = {**(params or {}), "limit": PAGE_SIZE, "countLimit": 0}
+        cursor: Optional[str] = None
+        while True:
+            if cursor:
+                params["cursor"] = cursor
+            data = self._get(path, params).json()
+            yield from data.get("results", [])
+            cursor = data.get("nextCursor")  # VERIFY field name against env schema
+            if not cursor:
+                return
+
+    # Step 4: REST reads (examples; add attributes/relations/domains/groups/roles/responsibilities)
+    def asset_types(self) -> Iterator[dict]:
+        return self.paginate("/rest/2.0/assetTypes")
+
+    def communities(self) -> Iterator[dict]:
+        return self.paginate("/rest/2.0/communities")
+
+    def users(self) -> Iterator[dict]:
+        return self.paginate("/rest/2.0/users")
+
+    # Step 5: GraphQL (primary path for the governance graph) — skeleton
+    def graphql(self, query: str, variables: dict) -> dict:
+        return self._post(
+            "/graphql/knowledgeGraph/v1",
+            json={"query": query, "variables": variables},
+        ).json()
+
+    # Step 6: Output Module fallback (submit -> poll -> download)
+    def output_export(self, view_config: dict) -> bytes:
+        job = self._post(
+            "/rest/2.0/outputModule/export/json-job", json=view_config
+        ).json()
+        while True:
+            j = self._get(f"/rest/2.0/jobs/{job['id']}").json()
+            if j["state"] in ("COMPLETED", "ERROR", "CANCELED"):
+                break
+            time.sleep(
+                self.cfg.poll_interval_s
+            )  # ponytail: fixed poll; jitter if jobs run long
+        if j["state"] != "COMPLETED":
+            raise RuntimeError(f"Output Module job {job['id']} -> {j['state']}")
+        file_id = j["result"]["message"]["id"]
+        return self._get(f"/rest/2.0/outputModule/files/{file_id}").content
+
+    # Step 7: parallel partition runner
+    # Parallelism is ACROSS partitions (cursor paging is sequential within one).
+    # partitions: (path, params) per entity-kind / typeId / relationTypeId / community.
+    def extract_parallel(self, partitions: List[Tuple[str, dict]]) -> Iterator[dict]:
+        with ThreadPoolExecutor(max_workers=self.cfg.max_workers) as ex:
+            futs = {
+                ex.submit(lambda p: list(self.paginate(p[0], p[1])), p): p
+                for p in partitions
+            }
+            for f in as_completed(futs):
+                yield from f.result()
+
+
+# --- self-check (no network, no third-party deps) ----------------------------
+class _Resp:
+    def __init__(self, payload=None, content=b""):
+        self._p, self.content = payload, content
+
+    def json(self):
+        return self._p
+
+    def raise_for_status(self):
+        pass
+
+
+class _FakeSession:
+    """Stateless page routes keyed by (path, cursor) + a tiny job state machine."""
+
+    def __init__(self, base: str):
+        self.base = base
+        self.pages: Dict[str, Dict[Optional[str], dict]] = {
+            "/rest/2.0/assetTypes": {
+                None: {"results": [{"id": "1"}, {"id": "2"}], "nextCursor": "c1"},
+                "c1": {"results": [{"id": "3"}, {"id": "4"}], "nextCursor": "c2"},
+                "c2": {"results": [{"id": "5"}, {"id": "6"}], "nextCursor": None},
+            },
+            "/a": {None: {"results": [{"id": "a1"}], "nextCursor": None}},
+            "/b": {None: {"results": [{"id": "b1"}, {"id": "b2"}], "nextCursor": None}},
+        }
+        self._job_polls = 0
+
+    def get(self, url, params=None):
+        path = url[len(self.base) :]
+        if path.startswith("/rest/2.0/jobs/"):
+            self._job_polls += 1
+            state = "COMPLETED" if self._job_polls >= 2 else "RUNNING"
+            return _Resp({"state": state, "result": {"message": {"id": "file9"}}})
+        if path.startswith("/rest/2.0/outputModule/files/"):
+            return _Resp(content=b"BULK")
+        cursor = (params or {}).get("cursor")
+        return _Resp(self.pages[path][cursor])
+
+    def post(self, url, **kw):
+        path = url[len(self.base) :]
+        if path.endswith("/json-job"):
+            return _Resp({"id": "job1"})
+        raise AssertionError(f"unexpected POST {path}")
+
+
+def _selfcheck() -> None:
+    base = "http://x"
+    c = CollibraClient(Cfg(url=base, poll_interval_s=0), session=_FakeSession(base))
+
+    # cursor pagination walks 3 pages and stops on a null cursor
+    ids = [x["id"] for x in c.paginate("/rest/2.0/assetTypes")]
+    assert ids == ["1", "2", "3", "4", "5", "6"], ids
+
+    # parallel fan-out collects every partition (order-independent)
+    got = sorted(x["id"] for x in c.extract_parallel([("/a", {}), ("/b", {})]))
+    assert got == ["a1", "b1", "b2"], got
+
+    # Output Module poll loop: RUNNING -> COMPLETED -> download bytes
+    assert c.output_export({"any": "viewconfig"}) == b"BULK"
+
+    print("client.py self-check: OK")
+
+
+if __name__ == "__main__":
+    _selfcheck()

--- a/metadata-ingestion/src/datahub/ingestion/source/collibra/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/collibra/client.py
@@ -1,178 +1,395 @@
 # Thin Collibra client for the `collibra` ingestion source.
 # See RFC "Collibra -> DataHub Governance Migrator" (Page 4 Engineering Design,
-# Page 6 Extraction). WIP: `Cfg` and the dataclass models are temporary stubs to
-# be swapped for CollibraSourceConfig (config.py) and pydantic models (models.py);
-# secrets become SecretStr, injected programmatically.
+# Page 6 Extraction). Transport layer only: auth, paging, GraphQL, Output Module,
+# and parallel fan-out. Mapping/resolution/emission live in mapper/urn_resolver/source.
 
 from __future__ import annotations
 
+import json
+import logging
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
-from typing import Any, Iterator, List, Optional, Tuple
+from threading import Lock
+from typing import Any, Callable, Iterator, List, Optional, Set, Tuple
 
 import requests
 from requests.adapters import HTTPAdapter
+from requests.auth import AuthBase, HTTPBasicAuth
 from urllib3.util.retry import Retry
 
-PAGE_SIZE = 1000  # DGC "Enable maximum paging limit" cap: 1000 elements / call
+from datahub.configuration.common import AllowDenyPattern
+from datahub.ingestion.source.collibra import constants as c
+from datahub.ingestion.source.collibra.config import (
+    CollibraAuthMethod,
+    CollibraSourceConfig,
+)
+from datahub.ingestion.source.collibra.models import ApplicationInfo, CollibraEntity
+from datahub.ingestion.source.collibra.report import CollibraSourceReport
+
+logger = logging.getLogger(__name__)
 
 
-# --- config (skeleton) -------------------------------------------------------
-# ponytail: real connector uses CollibraSourceConfig(StatefulIngestionConfigBase,
-# PlatformInstanceConfigMixin, EnvConfigMixin) in config.py; secrets are SecretStr.
-# This dataclass exists only so the file is standalone + self-checkable.
-@dataclass
-class Cfg:
-    url: str
-    client_id: Optional[str] = None
-    client_secret: Optional[str] = None
-    verify_ssl: bool = True
-    ca_cert_path: Optional[str] = None
-    max_workers: int = 4  # ponytail: ~4 matches Collibra's concurrent-job ceiling
-    poll_interval_s: float = 2.0
+class CollibraApiError(Exception):
+    pass
 
 
-# --- Step 1: auth + session + retry ------------------------------------------
-def build_session(cfg: Cfg) -> requests.Session:
-    """OAuth2 bearer + TLS + rate-aware retry/backoff, all on one Session."""
+class _BearerAuth(AuthBase):
+    def __init__(self, token: str) -> None:
+        self._token = token
 
-    class TokenAuth(requests.auth.AuthBase):
-        def __init__(self, cfg: Cfg):
-            self.cfg, self._tok = cfg, None
+    def __call__(self, req: requests.PreparedRequest) -> requests.PreparedRequest:
+        req.headers[c.AUTHORIZATION] = c.BEARER.format(self._token)
+        return req
 
-        def _fetch(self) -> None:
-            client_id = self.cfg.client_id
-            client_secret = self.cfg.client_secret
-            assert client_id and client_secret, (
-                "OAuth requires client_id and client_secret"
+
+class _OAuthTokenAuth(AuthBase):
+    def __init__(self, config: CollibraSourceConfig) -> None:
+        self._config = config
+        self._token: Optional[str] = None
+        self._lock = Lock()  # single-flight refresh under parallel workers
+
+    def invalidate(self) -> None:
+        with self._lock:
+            self._token = None
+
+    def _fetch(self) -> None:
+        with self._lock:
+            if self._token:
+                return
+            client_id = self._config.client_id
+            client_secret = self._config.client_secret
+            assert client_id and client_secret  # enforced by config validator
+            resp = requests.post(
+                self._config.url + c.OAUTH_TOKEN,
+                data=c.GRANT_CLIENT_CREDENTIALS,
+                auth=(client_id, client_secret.get_secret_value()),
+                verify=self._config.ca_cert_path or self._config.verify_ssl,
+                timeout=self._config.request_timeout,
             )
-            r = requests.post(
-                f"{self.cfg.url}/rest/oauth/v2/token",
-                data={"grant_type": "client_credentials"},
-                auth=(client_id, client_secret),
-                verify=self.cfg.ca_cert_path or self.cfg.verify_ssl,
-                timeout=30,
-            )
-            r.raise_for_status()
-            self._tok = r.json()["access_token"]
+            resp.raise_for_status()
+            self._token = resp.json()[c.ACCESS_TOKEN_FIELD]
 
-        def __call__(self, req):
-            if not self._tok:
-                self._fetch()
-            req.headers["Authorization"] = f"Bearer {self._tok}"
-            return req
+    def __call__(self, req: requests.PreparedRequest) -> requests.PreparedRequest:
+        if not self._token:
+            self._fetch()
+        req.headers[c.AUTHORIZATION] = c.BEARER.format(self._token)
+        return req
 
-    s = requests.Session()
+
+def _session_login(session: requests.Session, config: CollibraSourceConfig) -> None:
+    assert config.username and config.password
+    resp = session.post(
+        config.url + c.SESSION_LOGIN,
+        json={
+            c.USERNAME_FIELD: config.username,
+            c.PASSWORD_FIELD: config.password.get_secret_value(),
+        },
+        timeout=config.request_timeout,
+    )
+    resp.raise_for_status()
+
+
+def build_session(
+    config: CollibraSourceConfig, report: CollibraSourceReport
+) -> requests.Session:
+    session = requests.Session()
     # respect_retry_after_header=True => 429 Retry-After honored; no hand-rolled backoff.
     retry = Retry(
         total=5,
         backoff_factor=1.0,
-        status_forcelist=[429, 500, 502, 503, 504],
+        status_forcelist=c.RETRY_STATUS,
         respect_retry_after_header=True,
-        allowed_methods=None,  # retry POSTs too (reads are idempotent for us)
+        allowed_methods=None,  # reads are idempotent; retry POSTs too
     )
-    adapter = HTTPAdapter(max_retries=retry)
-    s.mount("https://", adapter)
-    s.mount("http://", adapter)
-    s.auth = TokenAuth(cfg) if cfg.client_id else None  # else BasicAuth/session
-    s.verify = cfg.ca_cert_path or cfg.verify_ssl
-    # ponytail: if not cfg.verify_ssl -> report.warning(...) in the connector.
-    return s
+    adapter = HTTPAdapter(
+        max_retries=retry,
+        pool_connections=config.max_workers,
+        pool_maxsize=config.max_workers,
+    )
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    session.verify = config.ca_cert_path or config.verify_ssl
+    if not config.verify_ssl:
+        report.warning("verify_ssl is disabled; TLS verification is off for Collibra")
+
+    method = config.auth_method
+    if method == CollibraAuthMethod.OAUTH:
+        session.auth = _OAuthTokenAuth(config)
+    elif method == CollibraAuthMethod.BASIC:
+        assert config.username and config.password
+        session.auth = HTTPBasicAuth(
+            config.username, config.password.get_secret_value()
+        )
+    elif method in (CollibraAuthMethod.TOKEN, CollibraAuthMethod.JWT):
+        assert config.token
+        session.auth = _BearerAuth(config.token.get_secret_value())
+    elif method == CollibraAuthMethod.SESSION:
+        _session_login(session, config)
+    return session
 
 
-# --- stub models -------------------------------------------------------------
-# ponytail: model only the fields consumed; swap to pydantic BaseModel in models.py.
-@dataclass
-class Asset:
-    id: str
-    name: str
-    type_id: str
-
-
-# --- client ------------------------------------------------------------------
 class CollibraClient:
-    def __init__(self, cfg: Cfg, session: Optional[requests.Session] = None):
-        self.cfg = cfg
-        self.session = session if session is not None else build_session(cfg)
-        self._info: Optional[dict] = None
+    def __init__(
+        self,
+        config: CollibraSourceConfig,
+        report: Optional[CollibraSourceReport] = None,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self.config = config
+        self.report = report if report is not None else CollibraSourceReport()
+        self.session = (
+            session if session is not None else build_session(config, self.report)
+        )
+        self._info: Optional[ApplicationInfo] = None
 
-    # low-level
-    def _get(self, path: str, params: Optional[dict] = None) -> requests.Response:
-        r = self.session.get(self.cfg.url + path, params=params or {})
-        r.raise_for_status()
-        return r
+    # --- low level -----------------------------------------------------------
+    def _request(self, method: str, path: str, **kw: Any) -> requests.Response:
+        kw.setdefault("timeout", self.config.request_timeout)
+        url = self.config.url + path
+        resp = self.session.request(method, url, **kw)
+        if resp.status_code == c.HTTP_UNAUTHORIZED and self._refresh_auth():
+            resp = self.session.request(method, url, **kw)
+        resp.raise_for_status()
+        return resp
 
-    def _post(self, path: str, **kw: Any) -> requests.Response:
-        r = self.session.post(self.cfg.url + path, **kw)
-        r.raise_for_status()
-        return r
+    def _refresh_auth(self) -> bool:
+        invalidate = getattr(self.session.auth, "invalidate", None)
+        if callable(invalidate):
+            invalidate()
+            return True
+        return False
 
-    # Step 2: capability probe
-    def info(self) -> dict:
+    def _json(self, resp: requests.Response) -> dict:
+        try:
+            return resp.json()
+        except ValueError:
+            self.report.warning(f"Non-JSON response from {resp.url}")
+            return {}
+
+    def _get_json(self, path: str, params: Optional[dict] = None) -> dict:
+        return self._json(self._request("GET", path, params=params or {}))
+
+    # --- capability probe ----------------------------------------------------
+    def info(self) -> ApplicationInfo:
         if self._info is None:
-            self._info = self._get("/rest/2.0/application/info").json()
+            self._info = ApplicationInfo.model_validate(
+                self._get_json(c.APPLICATION_INFO)
+            )
         return self._info
 
+    def _version(self) -> Tuple[int, int]:
+        match = c.VERSION_RE.search(self.info().version or "")
+        if not match:
+            return (0, 0)
+        return (int(match.group(1)), int(match.group(2)))
+
     def use_graphql(self) -> bool:
-        # ponytail: version gate; derive the threshold from /application/info in Phase 0.
-        return True
+        if self.config.force_paging:
+            return False
+        return self._version() >= c.GRAPHQL_MIN_VERSION
 
-    # Step 3: cursor paginator (the core primitive; sequential per collection)
+    def _use_cursor(self) -> bool:
+        if self.config.force_offset_paging:
+            return False
+        return self._version() >= c.CURSOR_MIN_VERSION
+
+    # --- REST paging ---------------------------------------------------------
     def paginate(self, path: str, params: Optional[dict] = None) -> Iterator[dict]:
-        params = {**(params or {}), "limit": PAGE_SIZE, "countLimit": 0}
+        base = {**(params or {}), c.LIMIT: self.config.page_size, c.COUNT_LIMIT: 0}
         cursor: Optional[str] = None
+        seen: Set[str] = set()
         while True:
+            page = dict(base)
             if cursor:
-                params["cursor"] = cursor
-            data = self._get(path, params).json()
-            yield from data.get("results", [])
-            cursor = data.get("nextCursor")  # VERIFY field name against env schema
-            if not cursor:
+                page[c.CURSOR] = cursor
+            data = self._get_json(path, page)
+            rows = data.get(c.RESULTS_FIELD, [])
+            self.report.pages_fetched += 1
+            yield from rows
+            cursor = data.get(c.CURSOR_FIELD)
+            if not cursor or not rows:
                 return
+            if cursor in seen:
+                self.report.warning(f"Cursor loop detected paging {path}; stopping")
+                return
+            seen.add(cursor)
 
-    # Step 4: REST reads (examples; add attributes/relations/domains/groups/roles/responsibilities)
-    def asset_types(self) -> Iterator[dict]:
-        return self.paginate("/rest/2.0/assetTypes")
-
-    def communities(self) -> Iterator[dict]:
-        return self.paginate("/rest/2.0/communities")
-
-    def users(self) -> Iterator[dict]:
-        return self.paginate("/rest/2.0/users")
-
-    # Step 5: GraphQL (primary path for the governance graph) — skeleton
-    def graphql(self, query: str, variables: dict) -> dict:
-        return self._post(
-            "/graphql/knowledgeGraph/v1",
-            json={"query": query, "variables": variables},
-        ).json()
-
-    # Step 6: Output Module fallback (submit -> poll -> download)
-    def output_export(self, view_config: dict) -> bytes:
-        job = self._post(
-            "/rest/2.0/outputModule/export/json-job", json=view_config
-        ).json()
+    def paginate_offset(
+        self, path: str, params: Optional[dict] = None
+    ) -> Iterator[dict]:
+        offset = 0
         while True:
-            j = self._get(f"/rest/2.0/jobs/{job['id']}").json()
-            if j["state"] in ("COMPLETED", "ERROR", "CANCELED"):
-                break
-            time.sleep(
-                self.cfg.poll_interval_s
-            )  # ponytail: fixed poll; jitter if jobs run long
-        if j["state"] != "COMPLETED":
-            raise RuntimeError(f"Output Module job {job['id']} -> {j['state']}")
-        file_id = j["result"]["message"]["id"]
-        return self._get(f"/rest/2.0/outputModule/files/{file_id}").content
-
-    # Step 7: parallel partition runner
-    # Parallelism is ACROSS partitions (cursor paging is sequential within one).
-    # partitions: (path, params) per entity-kind / typeId / relationTypeId / community.
-    def extract_parallel(self, partitions: List[Tuple[str, dict]]) -> Iterator[dict]:
-        with ThreadPoolExecutor(max_workers=self.cfg.max_workers) as ex:
-            futs = {
-                ex.submit(lambda p: list(self.paginate(p[0], p[1])), p): p
-                for p in partitions
+            page = {
+                **(params or {}),
+                c.LIMIT: self.config.page_size,
+                c.OFFSET: offset,
+                c.COUNT_LIMIT: 0,
             }
-            for f in as_completed(futs):
-                yield from f.result()
+            rows = self._get_json(path, page).get(c.RESULTS_FIELD, [])
+            self.report.pages_fetched += 1
+            yield from rows
+            if len(rows) < self.config.page_size:
+                return
+            offset += len(rows)
+
+    def _extract(self, path: str, params: Optional[dict] = None) -> Iterator[dict]:
+        if self._use_cursor():
+            return self.paginate(path, params)
+        return self.paginate_offset(path, params)
+
+    def count(self, path: str, params: Optional[dict] = None) -> Optional[int]:
+        # Offset paging returns the total when counting is enabled (countLimit omitted).
+        data = self._get_json(path, {**(params or {}), c.LIMIT: 1, c.OFFSET: 0})
+        total = data.get(c.TOTAL_FIELD)
+        return int(total) if isinstance(total, int) else None
+
+    # --- GraphQL -------------------------------------------------------------
+    def graphql(self, query: str, variables: Optional[dict] = None) -> dict:
+        resp = self._request(
+            "POST",
+            c.GRAPHQL,
+            json={c.QUERY_FIELD: query, c.VARIABLES_FIELD: variables or {}},
+        )
+        body = self._json(resp)
+        errors = body.get(c.ERRORS_FIELD)
+        if errors:
+            # GraphQL returns HTTP 200 even on failure — surface it instead of
+            # silently treating the error payload as data.
+            raise CollibraApiError(f"GraphQL errors: {errors}")
+        return body.get(c.DATA_FIELD, {})
+
+    def graphql_paginate(
+        self,
+        query: str,
+        variables: Optional[dict],
+        extract: Callable[[dict], Tuple[List[dict], Optional[str]]],
+    ) -> Iterator[dict]:
+        # extract(data) -> (rows, next_cursor). The caller owns the query and its
+        # connection shape (Knowledge Graph paging is version-specific — VERIFY).
+        variables = dict(variables or {})
+        cursor: Optional[str] = None
+        seen: Set[str] = set()
+        while True:
+            variables[c.CURSOR] = cursor
+            rows, cursor = extract(self.graphql(query, variables))
+            yield from rows
+            if not cursor or not rows:
+                return
+            if cursor in seen:
+                self.report.warning("Cursor loop detected in GraphQL paging; stopping")
+                return
+            seen.add(cursor)
+
+    # --- Output Module -------------------------------------------------------
+    def output_export(self, view_config: dict) -> List[dict]:
+        job = self._json(self._request("POST", c.OUTPUT_MODULE_JOB, json=view_config))
+        job_id = job[c.ID_FIELD]
+        self.report.output_jobs += 1
+        status: dict = {}
+        state: Optional[str] = None
+        for _ in range(self.config.poll_max_attempts):
+            status = self._get_json(f"{c.JOBS}/{job_id}")
+            state = status.get(c.JOB_STATE_FIELD)
+            if state in c.JOB_TERMINAL:
+                break
+            time.sleep(self.config.poll_interval)
+        else:
+            raise CollibraApiError(
+                f"Output Module job {job_id} did not finish within "
+                f"{self.config.poll_max_attempts} polls (last state {state})"
+            )
+        if state != c.JOB_SUCCESS:
+            raise CollibraApiError(f"Output Module job {job_id} ended in state {state}")
+        file_id = status[c.RESULT_FIELD][c.MESSAGE_FIELD][c.ID_FIELD]
+        content = self._request("GET", f"{c.OUTPUT_MODULE_FILES}/{file_id}").content
+        return self._parse_output(content)
+
+    def _parse_output(self, content: bytes) -> List[dict]:
+        try:
+            data = json.loads(content)
+        except ValueError:
+            self.report.warning("Output Module file was not valid JSON")
+            return []
+        if isinstance(data, list):
+            return data
+        return data.get(c.RESULTS_FIELD, [])
+
+    # --- typed reads ---------------------------------------------------------
+    def _read(self, path: str, params: Optional[dict] = None) -> List[CollibraEntity]:
+        entities = [
+            CollibraEntity.model_validate(row) for row in self._extract(path, params)
+        ]
+        self.report.entities_extracted += len(entities)
+        return entities
+
+    def _read_filtered(
+        self, path: str, pattern: AllowDenyPattern
+    ) -> List[CollibraEntity]:
+        out: List[CollibraEntity] = []
+        for entity in self._read(path):
+            if entity.name is not None and not pattern.allowed(entity.name):
+                self.report.filtered += 1
+                continue
+            out.append(entity)
+        return out
+
+    def asset_types(self) -> List[CollibraEntity]:
+        return self._read_filtered(c.ASSET_TYPES, self.config.asset_type_pattern)
+
+    def attribute_types(self) -> List[CollibraEntity]:
+        return self._read(c.ATTRIBUTE_TYPES)
+
+    def relation_types(self) -> List[CollibraEntity]:
+        return self._read(c.RELATION_TYPES)
+
+    def domain_types(self) -> List[CollibraEntity]:
+        return self._read(c.DOMAIN_TYPES)
+
+    def communities(self) -> List[CollibraEntity]:
+        return self._read_filtered(c.COMMUNITIES, self.config.community_pattern)
+
+    def domains(self) -> List[CollibraEntity]:
+        return self._read_filtered(c.DOMAINS, self.config.domain_pattern)
+
+    def users(self) -> List[CollibraEntity]:
+        return self._read(c.USERS)
+
+    def user_groups(self) -> List[CollibraEntity]:
+        return self._read(c.USER_GROUPS)
+
+    def roles(self) -> List[CollibraEntity]:
+        return self._read(c.ROLES)
+
+    def responsibilities(self) -> List[CollibraEntity]:
+        return self._read(c.RESPONSIBILITIES)
+
+    def assets(self, type_id: Optional[str] = None) -> List[CollibraEntity]:
+        params = {c.TYPE_ID: type_id} if type_id else None
+        return self._read(c.ASSETS, params)
+
+    def attributes(self, asset_id: Optional[str] = None) -> List[CollibraEntity]:
+        params = {c.ASSET_ID: asset_id} if asset_id else None
+        return self._read(c.ATTRIBUTES, params)
+
+    def relations(self, relation_type_id: Optional[str] = None) -> List[CollibraEntity]:
+        params = {c.RELATION_TYPE_ID: relation_type_id} if relation_type_id else None
+        return self._read(c.RELATIONS, params)
+
+    def count_assets(self, type_id: str) -> Optional[int]:
+        return self.count(c.ASSETS, {c.TYPE_ID: type_id})
+
+    # --- parallel ------------------------------------------------------------
+    def extract_parallel(self, tasks: List[Callable[[], List[Any]]]) -> List[Any]:
+        # Parallelism is ACROSS partitions/tasks (cursor paging is sequential within
+        # one). Each task is a thunk so REST, GraphQL, and Output Module reads all
+        # compose. A failing task is warned + counted, never fatal.
+        results: List[Any] = []
+        with ThreadPoolExecutor(max_workers=self.config.max_workers) as executor:
+            futures = [executor.submit(task) for task in tasks]
+            for future in as_completed(futures):
+                try:
+                    results.extend(future.result())
+                except Exception as e:
+                    self.report.partitions_failed += 1
+                    self.report.warning(f"Extraction partition failed: {e}")
+        return results

--- a/metadata-ingestion/src/datahub/ingestion/source/collibra/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/collibra/client.py
@@ -1,26 +1,16 @@
-"""
-Thin Collibra client skeleton for the DataHub `collibra` ingestion source.
-
-Belongs at: metadata-ingestion/src/datahub/ingestion/source/collibra/client.py
-Design: RFC "Collibra -> DataHub Governance Migrator", Page 4 (Engineering Design)
-        + Page 6 (Extraction). Tracked in ING-3045.
-
-Stack (no new deps): requests + urllib3.Retry + concurrent.futures + pydantic.
-
-This skeleton keeps `requests` imports lazy and uses stdlib dataclasses for the
-stub models so the __main__ self-check runs with plain `python3`, no network,
-no third-party deps. In the connector:
-  - swap the `Cfg` dataclass for CollibraSourceConfig (pydantic) in config.py
-  - swap the stub dataclass models for pydantic BaseModel in models.py
-  - secrets are SecretStr, injected programmatically (never os.environ)
-"""
+# Thin Collibra client for the `collibra` ingestion source.
+# See RFC "Collibra -> DataHub Governance Migrator" (Page 4 Engineering Design,
+# Page 6 Extraction). WIP: `Cfg` and the dataclass models are temporary stubs to
+# be swapped for CollibraSourceConfig (config.py) and pydantic models (models.py);
+# secrets become SecretStr, injected programmatically. `requests` is imported
+# lazily since the connector controls its own deps.
 
 from __future__ import annotations
 
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from typing import Dict, Iterator, List, Optional, Tuple
+from typing import Iterator, List, Optional, Tuple
 
 PAGE_SIZE = 1000  # DGC "Enable maximum paging limit" cap: 1000 elements / call
 
@@ -181,71 +171,3 @@ class CollibraClient:
             }
             for f in as_completed(futs):
                 yield from f.result()
-
-
-# --- self-check (no network, no third-party deps) ----------------------------
-class _Resp:
-    def __init__(self, payload=None, content=b""):
-        self._p, self.content = payload, content
-
-    def json(self):
-        return self._p
-
-    def raise_for_status(self):
-        pass
-
-
-class _FakeSession:
-    """Stateless page routes keyed by (path, cursor) + a tiny job state machine."""
-
-    def __init__(self, base: str):
-        self.base = base
-        self.pages: Dict[str, Dict[Optional[str], dict]] = {
-            "/rest/2.0/assetTypes": {
-                None: {"results": [{"id": "1"}, {"id": "2"}], "nextCursor": "c1"},
-                "c1": {"results": [{"id": "3"}, {"id": "4"}], "nextCursor": "c2"},
-                "c2": {"results": [{"id": "5"}, {"id": "6"}], "nextCursor": None},
-            },
-            "/a": {None: {"results": [{"id": "a1"}], "nextCursor": None}},
-            "/b": {None: {"results": [{"id": "b1"}, {"id": "b2"}], "nextCursor": None}},
-        }
-        self._job_polls = 0
-
-    def get(self, url, params=None):
-        path = url[len(self.base) :]
-        if path.startswith("/rest/2.0/jobs/"):
-            self._job_polls += 1
-            state = "COMPLETED" if self._job_polls >= 2 else "RUNNING"
-            return _Resp({"state": state, "result": {"message": {"id": "file9"}}})
-        if path.startswith("/rest/2.0/outputModule/files/"):
-            return _Resp(content=b"BULK")
-        cursor = (params or {}).get("cursor")
-        return _Resp(self.pages[path][cursor])
-
-    def post(self, url, **kw):
-        path = url[len(self.base) :]
-        if path.endswith("/json-job"):
-            return _Resp({"id": "job1"})
-        raise AssertionError(f"unexpected POST {path}")
-
-
-def _selfcheck() -> None:
-    base = "http://x"
-    c = CollibraClient(Cfg(url=base, poll_interval_s=0), session=_FakeSession(base))
-
-    # cursor pagination walks 3 pages and stops on a null cursor
-    ids = [x["id"] for x in c.paginate("/rest/2.0/assetTypes")]
-    assert ids == ["1", "2", "3", "4", "5", "6"], ids
-
-    # parallel fan-out collects every partition (order-independent)
-    got = sorted(x["id"] for x in c.extract_parallel([("/a", {}), ("/b", {})]))
-    assert got == ["a1", "b1", "b2"], got
-
-    # Output Module poll loop: RUNNING -> COMPLETED -> download bytes
-    assert c.output_export({"any": "viewconfig"}) == b"BULK"
-
-    print("client.py self-check: OK")
-
-
-if __name__ == "__main__":
-    _selfcheck()

--- a/metadata-ingestion/src/datahub/ingestion/source/collibra/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/collibra/config.py
@@ -1,0 +1,113 @@
+from enum import Enum
+from typing import Dict, Optional
+
+from pydantic import Field, SecretStr, model_validator
+
+from datahub.configuration.common import AllowDenyPattern
+from datahub.configuration.source_common import (
+    EnvConfigMixin,
+    PlatformInstanceConfigMixin,
+)
+from datahub.ingestion.source.collibra.constants import PAGE_SIZE
+
+
+class CollibraAuthMethod(str, Enum):
+    OAUTH = "oauth"
+    BASIC = "basic"
+    TOKEN = "token"
+    JWT = "jwt"
+    SESSION = "session"
+
+
+class CollibraSourceConfig(EnvConfigMixin, PlatformInstanceConfigMixin):
+    url: str = Field(description="Base URL of the Collibra Platform / DGC instance.")
+    auth_method: CollibraAuthMethod = Field(
+        default=CollibraAuthMethod.OAUTH,
+        description="Authentication method: oauth, basic, token, jwt, or session.",
+    )
+    client_id: Optional[str] = Field(
+        default=None, description="OAuth2 client id (auth_method=oauth)."
+    )
+    client_secret: Optional[SecretStr] = Field(
+        default=None, description="OAuth2 client secret (auth_method=oauth)."
+    )
+    username: Optional[str] = Field(
+        default=None, description="Username (auth_method=basic or session)."
+    )
+    password: Optional[SecretStr] = Field(
+        default=None, description="Password (auth_method=basic or session)."
+    )
+    token: Optional[SecretStr] = Field(
+        default=None,
+        description="Static bearer or JWT token (auth_method=token or jwt).",
+    )
+    verify_ssl: bool = Field(
+        default=True, description="Verify TLS certificates on Collibra requests."
+    )
+    ca_cert_path: Optional[str] = Field(
+        default=None,
+        description="Path to a private CA bundle if Collibra uses a private CA.",
+    )
+    request_timeout: float = Field(
+        default=60.0, description="Per-request timeout in seconds."
+    )
+    poll_interval: float = Field(
+        default=2.0, description="Seconds between Output Module job status polls."
+    )
+    poll_max_attempts: int = Field(
+        default=900,
+        description="Max Output Module job status polls before giving up.",
+    )
+    max_workers: int = Field(
+        default=4,
+        description="Parallel extraction workers; also the HTTP connection pool size.",
+    )
+    page_size: int = Field(
+        default=PAGE_SIZE, description="Page size for REST paging (DGC caps at 1000)."
+    )
+    force_paging: bool = Field(
+        default=False,
+        description="Use the REST/Output-Module paths even if GraphQL is available.",
+    )
+    force_offset_paging: bool = Field(
+        default=False,
+        description="Use offset paging instead of cursor paging (older DGC versions).",
+    )
+    community_pattern: AllowDenyPattern = Field(
+        default=AllowDenyPattern.allow_all(),
+        description="Regex allow/deny patterns for community names.",
+    )
+    domain_pattern: AllowDenyPattern = Field(
+        default=AllowDenyPattern.allow_all(),
+        description="Regex allow/deny patterns for domain names.",
+    )
+    asset_type_pattern: AllowDenyPattern = Field(
+        default=AllowDenyPattern.allow_all(),
+        description="Regex allow/deny patterns for asset-type names.",
+    )
+    type_mapping: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Collibra type UUID -> DataHub target (produced by Phase 0).",
+    )
+
+    @model_validator(mode="after")
+    def _validate_auth(self) -> "CollibraSourceConfig":
+        method = self.auth_method
+        missing = []
+        if method == CollibraAuthMethod.OAUTH and not (
+            self.client_id and self.client_secret
+        ):
+            missing = ["client_id", "client_secret"]
+        elif method in (CollibraAuthMethod.BASIC, CollibraAuthMethod.SESSION) and not (
+            self.username and self.password
+        ):
+            missing = ["username", "password"]
+        elif method in (CollibraAuthMethod.TOKEN, CollibraAuthMethod.JWT) and (
+            not self.token
+        ):
+            missing = ["token"]
+        if missing:
+            raise ValueError(
+                f"auth_method={method.value} requires: {', '.join(missing)}"
+            )
+        return self

--- a/metadata-ingestion/src/datahub/ingestion/source/collibra/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/collibra/config.py
@@ -87,7 +87,7 @@ class CollibraSourceConfig(EnvConfigMixin, PlatformInstanceConfigMixin):
     )
     type_mapping: Dict[str, str] = Field(
         default_factory=dict,
-        description="Collibra type UUID -> DataHub target (produced by Phase 0).",
+        description="Collibra type UUID -> DataHub target mapping.",
     )
 
     @model_validator(mode="after")

--- a/metadata-ingestion/src/datahub/ingestion/source/collibra/constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/collibra/constants.py
@@ -1,0 +1,72 @@
+import re
+
+# --- endpoints ---------------------------------------------------------------
+APPLICATION_INFO = "/rest/2.0/application/info"
+OAUTH_TOKEN = "/rest/oauth/v2/token"
+SESSION_LOGIN = "/rest/2.0/auth/sessions"
+GRAPHQL = "/graphql/knowledgeGraph/v1"
+
+ASSETS = "/rest/2.0/assets"
+COMMUNITIES = "/rest/2.0/communities"
+DOMAINS = "/rest/2.0/domains"
+ATTRIBUTES = "/rest/2.0/attributes"
+RELATIONS = "/rest/2.0/relations"
+ASSET_TYPES = "/rest/2.0/assetTypes"
+ATTRIBUTE_TYPES = "/rest/2.0/attributeTypes"
+RELATION_TYPES = "/rest/2.0/relationTypes"
+DOMAIN_TYPES = "/rest/2.0/domainTypes"
+USERS = "/rest/2.0/users"
+USER_GROUPS = "/rest/2.0/userGroups"
+ROLES = "/rest/2.0/roles"
+RESPONSIBILITIES = "/rest/2.0/responsibilities"
+OUTPUT_MODULE_JOB = "/rest/2.0/outputModule/export/json-job"
+JOBS = "/rest/2.0/jobs"
+OUTPUT_MODULE_FILES = "/rest/2.0/outputModule/files"
+
+# --- paging / query params ---------------------------------------------------
+LIMIT = "limit"
+COUNT_LIMIT = "countLimit"
+CURSOR = "cursor"
+OFFSET = "offset"
+TYPE_ID = "typeId"
+ASSET_ID = "assetId"
+RELATION_TYPE_ID = "relationTypeId"
+
+# --- response envelope fields ------------------------------------------------
+# VERIFY these against the target env's schema — the public docs are thin on the
+# exact GraphQL/cursor shapes (see Page 6 of the RFC).
+RESULTS_FIELD = "results"
+CURSOR_FIELD = "nextCursor"
+TOTAL_FIELD = "total"
+QUERY_FIELD = "query"
+VARIABLES_FIELD = "variables"
+ERRORS_FIELD = "errors"
+DATA_FIELD = "data"
+ACCESS_TOKEN_FIELD = "access_token"
+ID_FIELD = "id"
+RESULT_FIELD = "result"
+MESSAGE_FIELD = "message"
+USERNAME_FIELD = "username"
+PASSWORD_FIELD = "password"
+
+# --- auth --------------------------------------------------------------------
+GRANT_CLIENT_CREDENTIALS = {"grant_type": "client_credentials"}
+AUTHORIZATION = "Authorization"
+BEARER = "Bearer {}"
+
+# --- jobs --------------------------------------------------------------------
+JOB_STATE_FIELD = "state"
+JOB_SUCCESS = "COMPLETED"
+JOB_TERMINAL = frozenset({"COMPLETED", "ERROR", "CANCELED"})
+
+# --- http --------------------------------------------------------------------
+PAGE_SIZE = 1000  # DGC "Enable maximum paging limit" cap: 1000 elements / call
+RETRY_STATUS = [429, 500, 502, 503, 504]
+HTTP_UNAUTHORIZED = 401
+
+# Knowledge Graph GraphQL and cursor paging require a recent DGC release.
+# VERIFY the exact thresholds in Phase 0 against the customer's version.
+GRAPHQL_MIN_VERSION = (2023, 5)
+CURSOR_MIN_VERSION = (2022, 8)
+
+VERSION_RE = re.compile(r"(\d+)\.(\d+)")

--- a/metadata-ingestion/src/datahub/ingestion/source/collibra/constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/collibra/constants.py
@@ -34,7 +34,7 @@ RELATION_TYPE_ID = "relationTypeId"
 
 # --- response envelope fields ------------------------------------------------
 # VERIFY these against the target env's schema — the public docs are thin on the
-# exact GraphQL/cursor shapes (see Page 6 of the RFC).
+# exact GraphQL/cursor shapes.
 RESULTS_FIELD = "results"
 CURSOR_FIELD = "nextCursor"
 TOTAL_FIELD = "total"
@@ -65,7 +65,7 @@ RETRY_STATUS = [429, 500, 502, 503, 504]
 HTTP_UNAUTHORIZED = 401
 
 # Knowledge Graph GraphQL and cursor paging require a recent DGC release.
-# VERIFY the exact thresholds in Phase 0 against the customer's version.
+# VERIFY the exact thresholds against the target Collibra version.
 GRAPHQL_MIN_VERSION = (2023, 5)
 CURSOR_MIN_VERSION = (2022, 8)
 

--- a/metadata-ingestion/src/datahub/ingestion/source/collibra/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/collibra/models.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+# Lenient models: only the fields the client depends on are typed; the full Collibra
+# payload is preserved via extra="allow" for the mapper. VERIFY exact nested shapes
+# (type/relation/attribute objects) against a real env before relying on extras.
+class CollibraEntity(BaseModel):
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    id: str
+    name: Optional[str] = None
+
+
+class ApplicationInfo(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    version: Optional[str] = None

--- a/metadata-ingestion/src/datahub/ingestion/source/collibra/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/collibra/report.py
@@ -5,8 +5,8 @@ from typing import List
 logger = logging.getLogger(__name__)
 
 
-# ponytail: placeholder report so the client can surface skips/counters standalone.
-# In source.py this becomes CollibraSourceReport(StaleEntityRemovalSourceReport) and
+# Placeholder report so the client can surface skips/counters standalone. In
+# source.py this becomes CollibraSourceReport(StaleEntityRemovalSourceReport) and
 # `warning` delegates to the framework's structured reporting.
 @dataclass
 class CollibraSourceReport:

--- a/metadata-ingestion/src/datahub/ingestion/source/collibra/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/collibra/report.py
@@ -1,0 +1,22 @@
+import logging
+from dataclasses import dataclass, field
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+
+# ponytail: placeholder report so the client can surface skips/counters standalone.
+# In source.py this becomes CollibraSourceReport(StaleEntityRemovalSourceReport) and
+# `warning` delegates to the framework's structured reporting.
+@dataclass
+class CollibraSourceReport:
+    entities_extracted: int = 0
+    pages_fetched: int = 0
+    output_jobs: int = 0
+    partitions_failed: int = 0
+    filtered: int = 0
+    warnings_list: List[str] = field(default_factory=list)
+
+    def warning(self, message: str) -> None:
+        self.warnings_list.append(message)
+        logger.warning(message)

--- a/metadata-ingestion/tests/integration/collibra/test_collibra_client.py
+++ b/metadata-ingestion/tests/integration/collibra/test_collibra_client.py
@@ -1,0 +1,167 @@
+from typing import Any, Dict, Optional, Tuple
+
+import pytest
+
+from datahub.ingestion.source.collibra.client import Cfg, CollibraClient
+
+BASE_URL = "http://mock-collibra.test"
+
+# Three pages of two items each; the third has a null cursor so paging stops.
+ASSET_TYPE_PAGES: Dict[Optional[str], dict] = {
+    None: {"results": [{"id": "1"}, {"id": "2"}], "nextCursor": "c1"},
+    "c1": {"results": [{"id": "3"}, {"id": "4"}], "nextCursor": "c2"},
+    "c2": {"results": [{"id": "5"}, {"id": "6"}], "nextCursor": None},
+}
+
+
+def _paged(pages: Dict[Optional[str], dict]) -> Any:
+    def callback(request: Any, context: Any) -> dict:
+        # requests_mock lowercases qs values; our cursors are already lowercase.
+        cursor = request.qs.get("cursor", [None])[0]
+        return pages[cursor]
+
+    return callback
+
+
+def register_mock_api(
+    request_mock: Any, job_states: Tuple[str, ...] = ("RUNNING", "COMPLETED")
+) -> None:
+    request_mock.post(
+        f"{BASE_URL}/rest/oauth/v2/token",
+        json={"access_token": "test_token"},
+    )
+    request_mock.get(
+        f"{BASE_URL}/rest/2.0/assetTypes",
+        json=_paged(ASSET_TYPE_PAGES),
+    )
+    request_mock.get(
+        f"{BASE_URL}/rest/2.0/communities",
+        json={
+            "results": [{"id": "community-1"}, {"id": "community-2"}],
+            "nextCursor": None,
+        },
+    )
+    request_mock.get(
+        f"{BASE_URL}/rest/2.0/users",
+        json={
+            "results": [{"id": "user-1"}, {"id": "user-2"}],
+            "nextCursor": None,
+        },
+    )
+    request_mock.post(
+        f"{BASE_URL}/graphql/knowledgeGraph/v1",
+        json={"data": {"assets": [{"id": "term-1"}]}},
+    )
+    request_mock.post(
+        f"{BASE_URL}/rest/2.0/outputModule/export/json-job",
+        json={"id": "job1"},
+    )
+
+    states = list(job_states)
+
+    def job_callback(request: Any, context: Any) -> dict:
+        state = states.pop(0) if len(states) > 1 else states[0]
+        return {"state": state, "result": {"message": {"id": "file9"}}}
+
+    request_mock.get(f"{BASE_URL}/rest/2.0/jobs/job1", json=job_callback)
+    request_mock.get(
+        f"{BASE_URL}/rest/2.0/outputModule/files/file9",
+        content=b"col1,col2\n",
+    )
+
+
+def _client() -> CollibraClient:
+    return CollibraClient(
+        Cfg(
+            url=BASE_URL,
+            client_id="test-client",
+            client_secret="test-secret",
+            poll_interval_s=0,
+            max_workers=2,
+        )
+    )
+
+
+@pytest.mark.integration
+def test_cursor_pagination_walks_all_pages(requests_mock: Any) -> None:
+    register_mock_api(requests_mock)
+    client = _client()
+    ids = [a["id"] for a in client.asset_types()]
+    assert ids == ["1", "2", "3", "4", "5", "6"]
+
+
+@pytest.mark.integration
+def test_paginate_sends_paging_params_and_cursor(requests_mock: Any) -> None:
+    register_mock_api(requests_mock)
+    client = _client()
+    list(client.asset_types())
+
+    reqs = [
+        r
+        for r in requests_mock.request_history
+        if "/rest/2.0/assettypes" in r.url.lower()
+    ]
+    assert len(reqs) == 3
+    # first page: paging params set, no cursor
+    assert reqs[0].qs.get("limit") == ["1000"]
+    assert reqs[0].qs.get("countlimit") == ["0"]
+    assert "cursor" not in reqs[0].qs
+    # subsequent pages carry the cursor returned by the previous page
+    assert reqs[1].qs.get("cursor") == ["c1"]
+    assert reqs[2].qs.get("cursor") == ["c2"]
+
+
+@pytest.mark.integration
+def test_parallel_extraction_collects_all_partitions(requests_mock: Any) -> None:
+    register_mock_api(requests_mock)
+    client = _client()
+    items = client.extract_parallel(
+        [
+            ("/rest/2.0/communities", {}),
+            ("/rest/2.0/users", {}),
+        ]
+    )
+    ids = sorted(a["id"] for a in items)
+    assert ids == ["community-1", "community-2", "user-1", "user-2"]
+
+
+@pytest.mark.integration
+def test_output_module_submit_poll_download(requests_mock: Any) -> None:
+    register_mock_api(requests_mock)
+    client = _client()
+    assert client.output_export({"any": "viewconfig"}) == b"col1,col2\n"
+
+
+@pytest.mark.integration
+def test_output_module_failed_job_raises(requests_mock: Any) -> None:
+    register_mock_api(requests_mock, job_states=("ERROR",))
+    client = _client()
+    with pytest.raises(RuntimeError):
+        client.output_export({"any": "viewconfig"})
+
+
+@pytest.mark.integration
+def test_oauth_bearer_token_attached(requests_mock: Any) -> None:
+    register_mock_api(requests_mock)
+    client = _client()
+    list(client.asset_types())
+
+    data_reqs = [
+        r for r in requests_mock.request_history if "assettypes" in r.url.lower()
+    ]
+    assert data_reqs
+    assert data_reqs[0].headers.get("Authorization") == "Bearer test_token"
+
+
+@pytest.mark.integration
+def test_graphql_post_returns_parsed_json(requests_mock: Any) -> None:
+    register_mock_api(requests_mock)
+    client = _client()
+    resp = client.graphql("query { assets { id } }", {"limit": 10})
+    assert resp["data"]["assets"][0]["id"] == "term-1"
+
+    gql = [
+        r for r in requests_mock.request_history if "knowledgegraph" in r.url.lower()
+    ]
+    assert gql[0].json()["query"].startswith("query")
+    assert gql[0].json()["variables"] == {"limit": 10}

--- a/metadata-ingestion/tests/integration/collibra/test_collibra_client.py
+++ b/metadata-ingestion/tests/integration/collibra/test_collibra_client.py
@@ -1,167 +1,322 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 
-from datahub.ingestion.source.collibra.client import Cfg, CollibraClient
+from datahub.configuration.common import AllowDenyPattern
+from datahub.ingestion.source.collibra.client import CollibraApiError, CollibraClient
+from datahub.ingestion.source.collibra.config import CollibraSourceConfig
+from datahub.ingestion.source.collibra.report import CollibraSourceReport
 
 BASE_URL = "http://mock-collibra.test"
 
-# Three pages of two items each; the third has a null cursor so paging stops.
-ASSET_TYPE_PAGES: Dict[Optional[str], dict] = {
-    None: {"results": [{"id": "1"}, {"id": "2"}], "nextCursor": "c1"},
-    "c1": {"results": [{"id": "3"}, {"id": "4"}], "nextCursor": "c2"},
-    "c2": {"results": [{"id": "5"}, {"id": "6"}], "nextCursor": None},
+# assetTypes served two ways: cursor pages (default) and offset pages (fallback).
+CURSOR_PAGES: Dict[Optional[str], dict] = {
+    None: {
+        "results": [
+            {"id": "1", "name": "Business Term"},
+            {"id": "2", "name": "Data Element"},
+        ],
+        "nextCursor": "c1",
+    },
+    "c1": {"results": [{"id": "3", "name": "Policy"}], "nextCursor": None},
+}
+OFFSET_PAGES: Dict[int, dict] = {
+    0: {
+        "results": [
+            {"id": "1", "name": "Business Term"},
+            {"id": "2", "name": "Data Element"},
+        ]
+    },
+    2: {"results": [{"id": "3", "name": "Policy"}]},
 }
 
 
-def _paged(pages: Dict[Optional[str], dict]) -> Any:
-    def callback(request: Any, context: Any) -> dict:
-        # requests_mock lowercases qs values; our cursors are already lowercase.
-        cursor = request.qs.get("cursor", [None])[0]
-        return pages[cursor]
-
-    return callback
+def _asset_types_cb(request: Any, context: Any) -> dict:
+    qs = request.qs
+    if "offset" in qs:
+        return OFFSET_PAGES.get(int(qs["offset"][0]), {"results": []})
+    return CURSOR_PAGES[qs.get("cursor", [None])[0]]
 
 
 def register_mock_api(
-    request_mock: Any, job_states: Tuple[str, ...] = ("RUNNING", "COMPLETED")
+    request_mock: Any,
+    info_version: str = "2024.05",
+    job_states: Tuple[str, ...] = ("RUNNING", "COMPLETED"),
 ) -> None:
-    request_mock.post(
-        f"{BASE_URL}/rest/oauth/v2/token",
-        json={"access_token": "test_token"},
-    )
     request_mock.get(
-        f"{BASE_URL}/rest/2.0/assetTypes",
-        json=_paged(ASSET_TYPE_PAGES),
+        f"{BASE_URL}/rest/2.0/application/info", json={"version": info_version}
     )
+    request_mock.post(
+        f"{BASE_URL}/rest/oauth/v2/token", json={"access_token": "test_token"}
+    )
+    request_mock.get(f"{BASE_URL}/rest/2.0/assetTypes", json=_asset_types_cb)
     request_mock.get(
         f"{BASE_URL}/rest/2.0/communities",
         json={
-            "results": [{"id": "community-1"}, {"id": "community-2"}],
+            "results": [
+                {"id": "co-1", "name": "Finance"},
+                {"id": "co-2", "name": "HR"},
+            ],
             "nextCursor": None,
         },
     )
     request_mock.get(
         f"{BASE_URL}/rest/2.0/users",
-        json={
-            "results": [{"id": "user-1"}, {"id": "user-2"}],
-            "nextCursor": None,
-        },
+        json={"results": [{"id": "u-1", "name": "alice"}], "nextCursor": None},
+    )
+    request_mock.get(
+        f"{BASE_URL}/rest/2.0/assets", json={"results": [{"id": "a-1"}], "total": 42}
     )
     request_mock.post(
-        f"{BASE_URL}/graphql/knowledgeGraph/v1",
-        json={"data": {"assets": [{"id": "term-1"}]}},
-    )
-    request_mock.post(
-        f"{BASE_URL}/rest/2.0/outputModule/export/json-job",
-        json={"id": "job1"},
+        f"{BASE_URL}/rest/2.0/outputModule/export/json-job", json={"id": "job1"}
     )
 
     states = list(job_states)
 
-    def job_callback(request: Any, context: Any) -> dict:
+    def job_cb(request: Any, context: Any) -> dict:
         state = states.pop(0) if len(states) > 1 else states[0]
         return {"state": state, "result": {"message": {"id": "file9"}}}
 
-    request_mock.get(f"{BASE_URL}/rest/2.0/jobs/job1", json=job_callback)
+    request_mock.get(f"{BASE_URL}/rest/2.0/jobs/job1", json=job_cb)
     request_mock.get(
-        f"{BASE_URL}/rest/2.0/outputModule/files/file9",
-        content=b"col1,col2\n",
+        f"{BASE_URL}/rest/2.0/outputModule/files/file9", content=b'[{"id": "r1"}]'
     )
 
 
-def _client() -> CollibraClient:
-    return CollibraClient(
-        Cfg(
-            url=BASE_URL,
-            client_id="test-client",
-            client_secret="test-secret",
-            poll_interval_s=0,
-            max_workers=2,
-        )
+def _config(**overrides: Any) -> CollibraSourceConfig:
+    base: Dict[str, Any] = dict(
+        url=BASE_URL,
+        client_id="test-client",
+        client_secret="test-secret",
+        poll_interval=0.0,
     )
+    base.update(overrides)
+    return CollibraSourceConfig(**base)
+
+
+def _client(
+    report: Optional[CollibraSourceReport] = None, **cfg: Any
+) -> CollibraClient:
+    return CollibraClient(_config(**cfg), report=report)
+
+
+# --- capability probe / version gating ---------------------------------------
+@pytest.mark.integration
+def test_use_graphql_by_version(requests_mock: Any) -> None:
+    register_mock_api(requests_mock, info_version="2024.05")
+    assert _client().use_graphql() is True
+
+    register_mock_api(requests_mock, info_version="2020.01")
+    assert _client().use_graphql() is False
 
 
 @pytest.mark.integration
+def test_force_paging_disables_graphql(requests_mock: Any) -> None:
+    register_mock_api(requests_mock)
+    assert _client(force_paging=True).use_graphql() is False
+
+
+# --- cursor + offset paging ---------------------------------------------------
+@pytest.mark.integration
 def test_cursor_pagination_walks_all_pages(requests_mock: Any) -> None:
     register_mock_api(requests_mock)
-    client = _client()
-    ids = [a["id"] for a in client.asset_types()]
-    assert ids == ["1", "2", "3", "4", "5", "6"]
+    ids = [e.id for e in _client().asset_types()]
+    assert ids == ["1", "2", "3"]
 
 
 @pytest.mark.integration
 def test_paginate_sends_paging_params_and_cursor(requests_mock: Any) -> None:
     register_mock_api(requests_mock)
-    client = _client()
-    list(client.asset_types())
-
+    _client().asset_types()
     reqs = [
         r
         for r in requests_mock.request_history
         if "/rest/2.0/assettypes" in r.url.lower()
     ]
-    assert len(reqs) == 3
-    # first page: paging params set, no cursor
+    assert len(reqs) == 2
     assert reqs[0].qs.get("limit") == ["1000"]
     assert reqs[0].qs.get("countlimit") == ["0"]
     assert "cursor" not in reqs[0].qs
-    # subsequent pages carry the cursor returned by the previous page
     assert reqs[1].qs.get("cursor") == ["c1"]
-    assert reqs[2].qs.get("cursor") == ["c2"]
 
 
 @pytest.mark.integration
-def test_parallel_extraction_collects_all_partitions(requests_mock: Any) -> None:
+def test_offset_paging_fallback(requests_mock: Any) -> None:
     register_mock_api(requests_mock)
-    client = _client()
-    items = client.extract_parallel(
-        [
-            ("/rest/2.0/communities", {}),
-            ("/rest/2.0/users", {}),
-        ]
+    client = _client(force_offset_paging=True, page_size=2)
+    ids = [e.id for e in client.asset_types()]
+    assert ids == ["1", "2", "3"]
+    offsets = [
+        r.qs.get("offset", [None])[0]
+        for r in requests_mock.request_history
+        if "/rest/2.0/assettypes" in r.url.lower()
+    ]
+    assert offsets == ["0", "2"]
+
+
+@pytest.mark.integration
+def test_count_returns_total(requests_mock: Any) -> None:
+    register_mock_api(requests_mock)
+    assert _client().count_assets("some-type") == 42
+
+
+# --- filtering ----------------------------------------------------------------
+@pytest.mark.integration
+def test_asset_type_pattern_filters_and_counts(requests_mock: Any) -> None:
+    register_mock_api(requests_mock)
+    report = CollibraSourceReport()
+    client = _client(
+        report=report, asset_type_pattern=AllowDenyPattern(deny=["Policy"])
     )
-    ids = sorted(a["id"] for a in items)
-    assert ids == ["community-1", "community-2", "user-1", "user-2"]
+    names = [e.name for e in client.asset_types()]
+    assert names == ["Business Term", "Data Element"]
+    assert report.filtered == 1
 
 
+# --- auth ---------------------------------------------------------------------
+@pytest.mark.integration
+def test_oauth_bearer_attached(requests_mock: Any) -> None:
+    register_mock_api(requests_mock)
+    _client().users()
+    data = [r for r in requests_mock.request_history if "/users" in r.url.lower()]
+    assert data[0].headers.get("Authorization") == "Bearer test_token"
+
+
+@pytest.mark.integration
+def test_basic_auth(requests_mock: Any) -> None:
+    register_mock_api(requests_mock)
+    client = _client(
+        auth_method="basic",
+        username="u",
+        password="p",
+        client_id=None,
+        client_secret=None,
+    )
+    client.users()
+    data = [r for r in requests_mock.request_history if "/users" in r.url.lower()]
+    assert data[0].headers.get("Authorization", "").startswith("Basic ")
+
+
+@pytest.mark.integration
+def test_token_auth(requests_mock: Any) -> None:
+    register_mock_api(requests_mock)
+    client = _client(
+        auth_method="token", token="jwt-abc", client_id=None, client_secret=None
+    )
+    client.users()
+    data = [r for r in requests_mock.request_history if "/users" in r.url.lower()]
+    assert data[0].headers.get("Authorization") == "Bearer jwt-abc"
+
+
+@pytest.mark.integration
+def test_token_refresh_on_401(requests_mock: Any) -> None:
+    register_mock_api(requests_mock)
+    # First data call 401s; after re-auth the retry succeeds.
+    requests_mock.get(
+        f"{BASE_URL}/rest/2.0/users",
+        [
+            {"status_code": 401},
+            {
+                "json": {"results": [{"id": "u-1"}], "nextCursor": None},
+                "status_code": 200,
+            },
+        ],
+    )
+    users = _client().users()
+    assert [u.id for u in users] == ["u-1"]
+    token_reqs = [
+        r for r in requests_mock.request_history if "/oauth/" in r.url.lower()
+    ]
+    assert len(token_reqs) == 2  # initial + refresh
+
+
+@pytest.mark.integration
+def test_verify_ssl_disabled_warns(requests_mock: Any) -> None:
+    register_mock_api(requests_mock)
+    report = CollibraSourceReport()
+    _client(report=report, verify_ssl=False)
+    assert any("verify_ssl" in w for w in report.warnings_list)
+
+
+# --- GraphQL ------------------------------------------------------------------
+@pytest.mark.integration
+def test_graphql_returns_data(requests_mock: Any) -> None:
+    register_mock_api(requests_mock)
+    requests_mock.post(
+        f"{BASE_URL}/graphql/knowledgeGraph/v1",
+        json={"data": {"assets": [{"id": "term-1"}]}},
+    )
+    data = _client().graphql("query { assets { id } }", {"limit": 10})
+    assert data["assets"][0]["id"] == "term-1"
+
+
+@pytest.mark.integration
+def test_graphql_errors_raise(requests_mock: Any) -> None:
+    register_mock_api(requests_mock)
+    # GraphQL returns HTTP 200 with an errors array — must not be treated as data.
+    requests_mock.post(
+        f"{BASE_URL}/graphql/knowledgeGraph/v1",
+        json={"errors": [{"message": "boom"}]},
+    )
+    with pytest.raises(CollibraApiError):
+        _client().graphql("query { bad }")
+
+
+@pytest.mark.integration
+def test_graphql_paginate(requests_mock: Any) -> None:
+    register_mock_api(requests_mock)
+    pages: Dict[Optional[str], dict] = {
+        None: {"data": {"conn": {"nodes": [{"id": "a"}], "cursor": "g1"}}},
+        "g1": {"data": {"conn": {"nodes": [{"id": "b"}], "cursor": None}}},
+    }
+
+    def gql_cb(request: Any, context: Any) -> dict:
+        return pages[request.json()["variables"]["cursor"]]
+
+    requests_mock.post(f"{BASE_URL}/graphql/knowledgeGraph/v1", json=gql_cb)
+
+    def extract(data: dict) -> Tuple[List[dict], Optional[str]]:
+        conn = data["conn"]
+        return conn["nodes"], conn["cursor"]
+
+    rows = list(_client().graphql_paginate("query", {}, extract))
+    assert [r["id"] for r in rows] == ["a", "b"]
+
+
+# --- Output Module ------------------------------------------------------------
 @pytest.mark.integration
 def test_output_module_submit_poll_download(requests_mock: Any) -> None:
     register_mock_api(requests_mock)
-    client = _client()
-    assert client.output_export({"any": "viewconfig"}) == b"col1,col2\n"
+    assert _client().output_export({"any": "viewconfig"}) == [{"id": "r1"}]
 
 
 @pytest.mark.integration
 def test_output_module_failed_job_raises(requests_mock: Any) -> None:
     register_mock_api(requests_mock, job_states=("ERROR",))
-    client = _client()
-    with pytest.raises(RuntimeError):
-        client.output_export({"any": "viewconfig"})
+    with pytest.raises(CollibraApiError):
+        _client().output_export({"any": "viewconfig"})
 
 
 @pytest.mark.integration
-def test_oauth_bearer_token_attached(requests_mock: Any) -> None:
-    register_mock_api(requests_mock)
-    client = _client()
-    list(client.asset_types())
-
-    data_reqs = [
-        r for r in requests_mock.request_history if "assettypes" in r.url.lower()
-    ]
-    assert data_reqs
-    assert data_reqs[0].headers.get("Authorization") == "Bearer test_token"
+def test_output_module_poll_timeout(requests_mock: Any) -> None:
+    register_mock_api(requests_mock, job_states=("RUNNING",))
+    with pytest.raises(CollibraApiError):
+        _client(poll_max_attempts=3).output_export({"any": "viewconfig"})
 
 
+# --- parallel extraction ------------------------------------------------------
 @pytest.mark.integration
-def test_graphql_post_returns_parsed_json(requests_mock: Any) -> None:
+def test_extract_parallel_tolerates_partition_failure(requests_mock: Any) -> None:
     register_mock_api(requests_mock)
-    client = _client()
-    resp = client.graphql("query { assets { id } }", {"limit": 10})
-    assert resp["data"]["assets"][0]["id"] == "term-1"
+    report = CollibraSourceReport()
+    client = _client(report=report)
 
-    gql = [
-        r for r in requests_mock.request_history if "knowledgegraph" in r.url.lower()
-    ]
-    assert gql[0].json()["query"].startswith("query")
-    assert gql[0].json()["variables"] == {"limit": 10}
+    def good() -> List[dict]:
+        return [{"id": "a"}]
+
+    def bad() -> List[dict]:
+        raise RuntimeError("boom")
+
+    results = client.extract_parallel([good, bad, good])
+    assert len(results) == 2
+    assert report.partitions_failed == 1


### PR DESCRIPTION
> **Status: Draft / WIP — do not merge.** Opening early to share direction and run CI.

## Summary

First slice of a native **Collibra** ingestion source (`type: collibra`) — a governance migrator that lifts a Collibra instance's governance layer (glossary terms/nodes, tags, domains, custom attributes, responsibilities/ownership, users/groups, status, links) into DataHub and re-attaches it to existing datasets/columns, **without** importing physical schema, tables, or lineage. It is intended to be re-runnable, stateful, and provenance-stamped so native DataHub metadata is never clobbered.

This PR adds only the **thin API client skeleton** (`client.py`). Mapping, resolver, source, and registration land in follow-ups.

## What's in this PR

`metadata-ingestion/src/datahub/ingestion/source/collibra/client.py`:

- Session factory with OAuth2 bearer auth (Basic/session fallback), TLS / private-CA support, and `urllib3.Retry` for rate-aware 429/5xx backoff.
- Cursor paginator (the core read primitive), `countLimit=0`, 1000/page.
- REST reads for operating-model type defs, communities/domains, and people.
- GraphQL Knowledge Graph entrypoint (primary path for the governance graph).
- Output Module submit → poll → download fallback for bulk pulls on large tenants.
- `ThreadPoolExecutor` partition runner for parallel extraction (parallelism is *across* partitions — cursor paging is sequential within one).

**No new runtime dependencies** — `requests` + `urllib3` + stdlib `concurrent.futures` only.

## Not done yet (follow-ups)

- Split the inline no-network self-check into `tests/` with golden files.
- Swap the dataclass stubs for `pydantic` models (`models.py`) and `Cfg` for `CollibraSourceConfig` (`config.py`).
- `mapper.py`, `urn_resolver.py`, `source.py` (StatefulIngestionSourceBase), provenance/attribution, per-aspect PATCH emission + retraction.
- Registration: setup.py entry point, `updateLockFile`, frontend source cards, logo, platform bootstrap, docs.

## Notes for reviewers

- Cursor field name and the Output Module job-status / file-download response shapes are **placeholders** to confirm against a real Collibra environment.
- Emission strategy is intentionally per-aspect (definitional → UPSERT, co-managed multi-valued → PATCH + attribution) to honor the never-clobber requirement; that logic arrives with the mapper/source, not here.

## Testing

The client carries a no-network self-check (cursor pagination, parallel fan-out, Output Module poll loop) that runs under plain `python3`; it will move into the connector's `tests/` before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
