### PR TITLE
feat(ingest/s3): catalog object-store folders without ingesting files (emit_folders_only)

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/abs/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/abs/report.py
@@ -11,9 +11,13 @@ from datahub.utilities.lossy_collections import LossyList
 class DataLakeSourceReport(StaleEntityRemovalSourceReport):
     files_scanned = 0
     filtered: LossyList[str] = dataclass_field(default_factory=LossyList)
+    folders_scanned: int = 0
 
     def report_file_scanned(self) -> None:
         self.files_scanned += 1
+
+    def report_folder_scanned(self) -> None:
+        self.folders_scanned += 1
 
     def report_file_dropped(self, file: str) -> None:
         self.filtered.append(file)

--- a/metadata-ingestion/src/datahub/ingestion/source/abs/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/abs/source.py
@@ -404,6 +404,21 @@ class ABSSource(StatefulIngestionSourceBase):
                 container_name, f"{folder}{folder_split[1]}"
             )
 
+    def _process_folders(self, path_spec: PathSpec) -> Iterable[MetadataWorkUnit]:
+        """Emit folder Containers for a folders-only path spec, to the depth defined by
+        the wildcards in `include`. Lists only folders — never blobs."""
+        if self.source_config.azure_config is None:
+            raise ValueError("azure_config not set. Cannot browse Azure Blob Storage")
+        container_name = self.source_config.azure_config.container_name
+        relative_glob = get_container_relative_path(path_spec.glob_include)
+        logger.info(f"Processing folders-only path spec: {path_spec.include}")
+        for folder in self.resolve_templated_folders(container_name, relative_glob):
+            self.report.report_folder_scanned()
+            abs_uri = self.create_abs_path(folder.rstrip("/"))
+            yield from self.container_WU_creator.create_folder_containers(
+                abs_uri.rstrip("/")
+            )
+
     def get_dir_to_process(
         self,
         container_name: str,
@@ -574,6 +589,10 @@ class ABSSource(StatefulIngestionSourceBase):
         with PerfTimer():
             assert self.source_config.path_specs
             for path_spec in self.source_config.path_specs:
+                if path_spec.emit_folders_only:
+                    yield from self._process_folders(path_spec)
+                    continue
+
                 file_browser = (
                     self.abs_browser(
                         path_spec, self.source_config.number_of_files_to_sample

--- a/metadata-ingestion/src/datahub/ingestion/source/abs/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/abs/source.py
@@ -413,8 +413,11 @@ class ABSSource(StatefulIngestionSourceBase):
         relative_glob = get_container_relative_path(path_spec.glob_include)
         logger.info(f"Processing folders-only path spec: {path_spec.include}")
         for folder in self.resolve_templated_folders(container_name, relative_glob):
-            self.report.report_folder_scanned()
             abs_uri = self.create_abs_path(folder.rstrip("/"))
+            if not path_spec.folder_allowed(abs_uri):
+                logger.debug(f"Skipping folder excluded by path_spec: {abs_uri}")
+                continue
+            self.report.report_folder_scanned()
             yield from self.container_WU_creator.create_folder_containers(
                 abs_uri.rstrip("/")
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/data_lake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/data_lake_utils.py
@@ -230,3 +230,50 @@ class ContainerWUCreator:
 
         assert parent_key is not None
         yield from add_dataset_to_container(parent_key, dataset_urn)
+
+    def create_folder_containers(self, folder_path: str) -> Iterable[MetadataWorkUnit]:
+        """
+        Emit the bucket and every folder component of ``folder_path`` as Containers,
+        WITHOUT creating or linking any dataset.
+
+        Used by folders-only path specs to catalog storage paths (e.g. unstructured
+        media) without reading file content. Unlike create_container_hierarchy, the
+        final path component is itself a folder (not a dataset leaf), and no
+        add_dataset_to_container link is emitted.
+        """
+        parent_key: Optional[ContainerKey] = None
+        base_full_path = folder_path
+
+        if self.platform in (PLATFORM_S3, PLATFORM_GCS, PLATFORM_ABS):
+            bucket_name = self.get_bucket_name(folder_path)
+            bucket_key = self.gen_bucket_key(bucket_name)
+            yield from self.create_emit_containers(
+                container_key=bucket_key,
+                name=bucket_name,
+                sub_types=[self.get_sub_types()],
+                parent_container_key=None,
+            )
+            parent_key = bucket_key
+            base_full_path = self.get_base_full_path(folder_path)
+
+        base_full_path = base_full_path.strip("/")
+        if not base_full_path:
+            return
+
+        for folder in base_full_path.split("/"):
+            abs_path = folder
+            if parent_key:
+                prefix: str = ""
+                if isinstance(parent_key, BucketKey):
+                    prefix = parent_key.bucket_name
+                elif isinstance(parent_key, FolderKey):
+                    prefix = parent_key.folder_abs_path
+                abs_path = prefix + "/" + folder
+            folder_key = self.gen_folder_key(abs_path)
+            yield from self.create_emit_containers(
+                container_key=folder_key,
+                name=folder,
+                sub_types=[DatasetContainerSubTypes.FOLDER],
+                parent_container_key=parent_key,
+            )
+            parent_key = folder_key

--- a/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/data_lake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/data_lake_utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Tuple
 
 from datahub.emitter.mcp_builder import (
     BucketKey,
@@ -177,24 +177,59 @@ class ContainerWUCreator:
             return get_container_relative_path(path)
         raise ValueError(f"Unable to get base full path from path: {path}")
 
+    def _emit_bucket(
+        self, path: str
+    ) -> Tuple[List[MetadataWorkUnit], Optional[ContainerKey], str]:
+        """Emit the bucket/container for ``path`` (object stores only). Returns the
+        emitted workunits, the bucket key (None for non-object-store platforms), and the
+        bucket-relative base path whose components should become folder containers."""
+        if self.platform in (PLATFORM_S3, PLATFORM_GCS, PLATFORM_ABS):
+            bucket_name = self.get_bucket_name(path)
+            bucket_key = self.gen_bucket_key(bucket_name)
+            wus = list(
+                self.create_emit_containers(
+                    container_key=bucket_key,
+                    name=bucket_name,
+                    sub_types=[self.get_sub_types()],
+                    parent_container_key=None,
+                )
+            )
+            return wus, bucket_key, self.get_base_full_path(path)
+        return [], None, path
+
+    def _emit_folder_chain(
+        self, parent_key: Optional[ContainerKey], folder_names: List[str]
+    ) -> Tuple[List[MetadataWorkUnit], Optional[ContainerKey]]:
+        """Emit a Container per name in ``folder_names``, chained under ``parent_key``.
+        Returns the emitted workunits and the leaf folder's key."""
+        wus: List[MetadataWorkUnit] = []
+        for folder in folder_names:
+            abs_path = folder
+            if parent_key:
+                prefix: str = ""
+                if isinstance(parent_key, BucketKey):
+                    prefix = parent_key.bucket_name
+                elif isinstance(parent_key, FolderKey):
+                    prefix = parent_key.folder_abs_path
+                abs_path = prefix + "/" + folder
+            folder_key = self.gen_folder_key(abs_path)
+            wus.extend(
+                self.create_emit_containers(
+                    container_key=folder_key,
+                    name=folder,
+                    sub_types=[DatasetContainerSubTypes.FOLDER],
+                    parent_container_key=parent_key,
+                )
+            )
+            parent_key = folder_key
+        return wus, parent_key
+
     def create_container_hierarchy(
         self, path: str, dataset_urn: str
     ) -> Iterable[MetadataWorkUnit]:
         logger.debug(f"Creating containers for {dataset_urn}")
-        base_full_path = path
-        parent_key = None
-        if self.platform in (PLATFORM_S3, PLATFORM_GCS, PLATFORM_ABS):
-            bucket_name = self.get_bucket_name(path)
-            bucket_key = self.gen_bucket_key(bucket_name)
-
-            yield from self.create_emit_containers(
-                container_key=bucket_key,
-                name=bucket_name,
-                sub_types=[self.get_sub_types()],
-                parent_container_key=None,
-            )
-            parent_key = bucket_key
-            base_full_path = self.get_base_full_path(path)
+        bucket_wus, parent_key, base_full_path = self._emit_bucket(path)
+        yield from bucket_wus
 
         parent_folder_path = (
             base_full_path[: base_full_path.rfind("/")]
@@ -210,23 +245,10 @@ class ContainerWUCreator:
             return
 
         if parent_folder_path:
-            for folder in parent_folder_path.split("/"):
-                abs_path = folder
-                if parent_key:
-                    prefix: str = ""
-                    if isinstance(parent_key, BucketKey):
-                        prefix = parent_key.bucket_name
-                    elif isinstance(parent_key, FolderKey):
-                        prefix = parent_key.folder_abs_path
-                    abs_path = prefix + "/" + folder
-                folder_key = self.gen_folder_key(abs_path)
-                yield from self.create_emit_containers(
-                    container_key=folder_key,
-                    name=folder,
-                    sub_types=[DatasetContainerSubTypes.FOLDER],
-                    parent_container_key=parent_key,
-                )
-                parent_key = folder_key
+            chain_wus, parent_key = self._emit_folder_chain(
+                parent_key, parent_folder_path.split("/")
+            )
+            yield from chain_wus
 
         assert parent_key is not None
         yield from add_dataset_to_container(parent_key, dataset_urn)
@@ -241,39 +263,12 @@ class ContainerWUCreator:
         final path component is itself a folder (not a dataset leaf), and no
         add_dataset_to_container link is emitted.
         """
-        parent_key: Optional[ContainerKey] = None
-        base_full_path = folder_path
-
-        if self.platform in (PLATFORM_S3, PLATFORM_GCS, PLATFORM_ABS):
-            bucket_name = self.get_bucket_name(folder_path)
-            bucket_key = self.gen_bucket_key(bucket_name)
-            yield from self.create_emit_containers(
-                container_key=bucket_key,
-                name=bucket_name,
-                sub_types=[self.get_sub_types()],
-                parent_container_key=None,
-            )
-            parent_key = bucket_key
-            base_full_path = self.get_base_full_path(folder_path)
+        bucket_wus, parent_key, base_full_path = self._emit_bucket(folder_path)
+        yield from bucket_wus
 
         base_full_path = base_full_path.strip("/")
         if not base_full_path:
             return
 
-        for folder in base_full_path.split("/"):
-            abs_path = folder
-            if parent_key:
-                prefix: str = ""
-                if isinstance(parent_key, BucketKey):
-                    prefix = parent_key.bucket_name
-                elif isinstance(parent_key, FolderKey):
-                    prefix = parent_key.folder_abs_path
-                abs_path = prefix + "/" + folder
-            folder_key = self.gen_folder_key(abs_path)
-            yield from self.create_emit_containers(
-                container_key=folder_key,
-                name=folder,
-                sub_types=[DatasetContainerSubTypes.FOLDER],
-                parent_container_key=parent_key,
-            )
-            parent_key = folder_key
+        chain_wus, _ = self._emit_folder_chain(parent_key, base_full_path.split("/"))
+        yield from chain_wus

--- a/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/path_spec.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/path_spec.py
@@ -150,11 +150,11 @@ class PathSpec(ConfigModel):
 
     emit_folders_only: bool = Field(
         False,
-        description="If set, this path_spec emits folder Containers only, down to the "
-        "depth defined by the wildcards in `include`, and never scans or ingests files "
-        "as datasets. Use to catalog storage paths (e.g. unstructured media) without "
-        "reading file content. `include` must end at a folder and must not contain "
-        "`{table}` or `**`.",
+        description="If set, this path_spec emits folder Containers only and does not scan "
+        "or ingest any files as datasets. Folder depth is set by the number of wildcard "
+        "levels in `include` (e.g. `.../*/` catalogs folders one level deep, `.../*/*/` two "
+        "levels deep). Use to catalog storage paths (e.g. unstructured media) without reading "
+        "file content. `include` must end at a folder and must not contain `{table}` or `**`.",
     )
 
     def is_path_hidden(self, path: str) -> bool:

--- a/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/path_spec.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/path_spec.py
@@ -148,6 +148,15 @@ class PathSpec(ConfigModel):
         description="The tables_filter_pattern configuration field uses regular expressions to filter the tables part of the Pathspec for ingestion, allowing fine-grained control over which tables are included or excluded based on specified patterns. The default setting allows all tables.",
     )
 
+    emit_folders_only: bool = Field(
+        False,
+        description="If set, this path_spec emits folder Containers only, down to the "
+        "depth defined by the wildcards in `include`, and never scans or ingests files "
+        "as datasets. Use to catalog storage paths (e.g. unstructured media) without "
+        "reading file content. `include` must end at a folder and must not contain "
+        "`{table}` or `**`.",
+    )
+
     def is_path_hidden(self, path: str) -> bool:
         # Split the path into directories and filename
         dirs, filename = os.path.split(path)
@@ -277,6 +286,21 @@ class PathSpec(ConfigModel):
         By combining related validations, we ensure they execute in the correct sequence
         and have access to all field values after Pydantic has processed defaults.
         """
+        # Folders-only path specs catalog storage paths; they have no dataset/table
+        # concept, and depth must be explicit wildcard levels (not recursive **).
+        if self.emit_folders_only:
+            if "{table}" in self.include:
+                raise ValueError(
+                    "path_spec.include cannot contain '{table}' when "
+                    "emit_folders_only is set"
+                )
+            if "**" in self.include:
+                raise ValueError(
+                    "path_spec.include cannot contain '**' when "
+                    "emit_folders_only is set; use explicit '*' levels to set depth"
+                )
+            return self
+
         # Handle autodetect_partitions logic first
         if self.autodetect_partitions:
             include = self.include

--- a/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/path_spec.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/path_spec.py
@@ -150,11 +150,13 @@ class PathSpec(ConfigModel):
 
     emit_folders_only: bool = Field(
         False,
-        description="If set, this path_spec emits folder Containers only and does not scan "
-        "or ingest any files as datasets. Folder depth is set by the number of wildcard "
-        "levels in `include` (e.g. `.../*/` catalogs folders one level deep, `.../*/*/` two "
-        "levels deep). Use to catalog storage paths (e.g. unstructured media) without reading "
-        "file content. `include` must end at a folder and must not contain `{table}` or `**`.",
+        description="If set, this path_spec emits each matching storage folder as a DataHub "
+        "Container and creates no dataset entities. Folder depth is set by the number of "
+        "wildcard levels in `include` (e.g. `.../*/` one level deep, `.../*/*/` two levels). "
+        "`exclude` and `include_hidden_folders` still apply to the folder walk; file/dataset "
+        "fields (`file_types`, `default_extension`, `table_name`, `tables_filter_pattern`) are "
+        "rejected since no datasets are produced. `include` must end at a folder and must not "
+        "contain `{table}` or `**`.",
     )
 
     def is_path_hidden(self, path: str) -> bool:
@@ -242,6 +244,23 @@ class PathSpec(ConfigModel):
 
         return True
 
+    def folder_allowed(self, path: str) -> bool:
+        """Filter for folders-only traversal. Applies the folder-relevant rules —
+        hidden-folder skipping and `exclude` — but not the file-extension or table-name
+        checks in `allowed`/`dir_allowed`, since folders-only produces no files or datasets.
+        `is_path_hidden` inspects every path component and `exclude` globs match the full
+        path, so filtering a resolved leaf also drops hidden/excluded ancestors."""
+        if self.is_path_hidden(path) and not self.include_hidden_folders:
+            return False
+        if self.exclude:
+            candidate = path.rstrip("/")
+            for exclude_path in self.exclude:
+                if pathlib.PurePath(candidate).globmatch(
+                    exclude_path.rstrip("/"), flags=pathlib.GLOBSTAR
+                ):
+                    return False
+        return True
+
     @classmethod
     def get_parsable_include(cls, include: str) -> str:
         parsable_include = include
@@ -298,6 +317,27 @@ class PathSpec(ConfigModel):
                 raise ValueError(
                     "path_spec.include cannot contain '**' when "
                     "emit_folders_only is set; use explicit '*' levels to set depth"
+                )
+            # File/dataset-selection fields have no effect in folders-only mode. Reject
+            # them explicitly rather than silently ignoring a value the user set.
+            # (exclude and include_hidden_folders DO apply and are handled in the walk.)
+            if self.table_name is not None:
+                raise ValueError(
+                    "path_spec.table_name is not applicable when emit_folders_only is set"
+                )
+            if self.default_extension is not None:
+                raise ValueError(
+                    "path_spec.default_extension is not applicable when "
+                    "emit_folders_only is set"
+                )
+            if self.file_types != SUPPORTED_FILE_TYPES:
+                raise ValueError(
+                    "path_spec.file_types is not applicable when emit_folders_only is set"
+                )
+            if self.tables_filter_pattern != AllowDenyPattern.allow_all():
+                raise ValueError(
+                    "path_spec.tables_filter_pattern is not applicable when "
+                    "emit_folders_only is set; use exclude to skip folders"
                 )
             return self
 

--- a/metadata-ingestion/src/datahub/ingestion/source/gcs/gcs_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gcs/gcs_source.py
@@ -353,6 +353,7 @@ class GCSSource(StatefulIngestionSourceBase):
                     include_hidden_folders=path_spec.include_hidden_folders,
                     tables_filter_pattern=path_spec.tables_filter_pattern,
                     traversal_method=path_spec.traversal_method,
+                    emit_folders_only=path_spec.emit_folders_only,
                 )
             )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/report.py
@@ -14,6 +14,7 @@ class DataLakeSourceReport(StaleEntityRemovalSourceReport):
     number_of_files_filtered: int = 0
 
     objects_listed: int = 0
+    folders_scanned: int = 0
     # Number of tables for which tags were fetched (one get_s3_tags call each,
     # which may issue multiple AWS requests internally), not a literal API count.
     tables_tagged: int = 0
@@ -24,6 +25,9 @@ class DataLakeSourceReport(StaleEntityRemovalSourceReport):
 
     def report_file_scanned(self) -> None:
         self.files_scanned += 1
+
+    def report_folder_scanned(self) -> None:
+        self.folders_scanned += 1
 
     def report_file_dropped(self, file: str) -> None:
         self.filtered.append(file)

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -683,6 +683,11 @@ class S3Source(StatefulIngestionSourceBase):
         the wildcards in `include`. Lists only folders (CommonPrefixes) — never objects."""
         logger.info(f"Processing folders-only path spec: {path_spec.include}")
         for folder_uri in self.resolve_templated_folders(path_spec.glob_include):
+            if not path_spec.folder_allowed(
+                self._normalize_uri_for_pattern_matching(folder_uri)
+            ):
+                logger.debug(f"Skipping folder excluded by path_spec: {folder_uri}")
+                continue
             self.report.report_folder_scanned()
             yield from self.container_WU_creator.create_folder_containers(
                 folder_uri.rstrip("/")

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -678,6 +678,16 @@ class S3Source(StatefulIngestionSourceBase):
                 f"{folder.path}/{remaining_pattern}"
             )
 
+    def _process_folders(self, path_spec: PathSpec) -> Iterable[MetadataWorkUnit]:
+        """Emit folder Containers for a folders-only path spec, to the depth defined by
+        the wildcards in `include`. Lists only folders (CommonPrefixes) — never objects."""
+        logger.info(f"Processing folders-only path spec: {path_spec.include}")
+        for folder_uri in self.resolve_templated_folders(path_spec.glob_include):
+            self.report.report_folder_scanned()
+            yield from self.container_WU_creator.create_folder_containers(
+                folder_uri.rstrip("/")
+            )
+
     def get_dir_to_process(
         self,
         uri: str,
@@ -1156,6 +1166,10 @@ class S3Source(StatefulIngestionSourceBase):
         with PerfTimer() as timer:
             assert self.source_config.path_specs
             for path_spec in self.source_config.path_specs:
+                if path_spec.emit_folders_only:
+                    yield from self._process_folders(path_spec)
+                    continue
+
                 file_browser = (
                     self.s3_browser(
                         path_spec, self.source_config.number_of_files_to_sample

--- a/metadata-ingestion/tests/integration/s3/golden-files/gcs/golden_mces_folders_only.json
+++ b/metadata-ingestion/tests/integration/s3/golden-files/gcs/golden_mces_folders_only.json
@@ -1,0 +1,546 @@
+[
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:2561abe00289962faf7c8746c44491f5",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "gcs",
+                "env": "PROD",
+                "bucket_name": "my-test-bucket"
+            },
+            "name": "my-test-bucket",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:2f2fdad96ce160f89d41a0c54c8c8259",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:2561abe00289962faf7c8746c44491f5",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:gcs"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:2561abe00289962faf7c8746c44491f5",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "GCS bucket"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:2561abe00289962faf7c8746c44491f5",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:2561abe00289962faf7c8746c44491f5",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:2f2fdad96ce160f89d41a0c54c8c8259",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "gcs",
+                "env": "PROD",
+                "folder_abs_path": "my-test-bucket/folders_only_media/videos/2023"
+            },
+            "name": "2023",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:2f2fdad96ce160f89d41a0c54c8c8259",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:7afd684fdb07e5f5da6cb3575bab1da9"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:2f2fdad96ce160f89d41a0c54c8c8259",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:gcs"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:2f2fdad96ce160f89d41a0c54c8c8259",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:2561abe00289962faf7c8746c44491f5",
+                    "urn": "urn:li:container:2561abe00289962faf7c8746c44491f5"
+                },
+                {
+                    "id": "urn:li:container:f80385313133d6f654dc61333c280de0",
+                    "urn": "urn:li:container:f80385313133d6f654dc61333c280de0"
+                },
+                {
+                    "id": "urn:li:container:7afd684fdb07e5f5da6cb3575bab1da9",
+                    "urn": "urn:li:container:7afd684fdb07e5f5da6cb3575bab1da9"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f80385313133d6f654dc61333c280de0",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:2561abe00289962faf7c8746c44491f5"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:2f2fdad96ce160f89d41a0c54c8c8259",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Folder"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f80385313133d6f654dc61333c280de0",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "gcs",
+                "env": "PROD",
+                "folder_abs_path": "my-test-bucket/folders_only_media"
+            },
+            "name": "folders_only_media",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f80385313133d6f654dc61333c280de0",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:gcs"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f80385313133d6f654dc61333c280de0",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Folder"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f80385313133d6f654dc61333c280de0",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7afd684fdb07e5f5da6cb3575bab1da9",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:f80385313133d6f654dc61333c280de0"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f80385313133d6f654dc61333c280de0",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:2561abe00289962faf7c8746c44491f5",
+                    "urn": "urn:li:container:2561abe00289962faf7c8746c44491f5"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7afd684fdb07e5f5da6cb3575bab1da9",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "gcs",
+                "env": "PROD",
+                "folder_abs_path": "my-test-bucket/folders_only_media/videos"
+            },
+            "name": "videos",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7afd684fdb07e5f5da6cb3575bab1da9",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:gcs"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7afd684fdb07e5f5da6cb3575bab1da9",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Folder"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7afd684fdb07e5f5da6cb3575bab1da9",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7afd684fdb07e5f5da6cb3575bab1da9",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:2561abe00289962faf7c8746c44491f5",
+                    "urn": "urn:li:container:2561abe00289962faf7c8746c44491f5"
+                },
+                {
+                    "id": "urn:li:container:f80385313133d6f654dc61333c280de0",
+                    "urn": "urn:li:container:f80385313133d6f654dc61333c280de0"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:bf0a6d608f8ab9fac60628f974ed74ec",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:7afd684fdb07e5f5da6cb3575bab1da9"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:bf0a6d608f8ab9fac60628f974ed74ec",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:bf0a6d608f8ab9fac60628f974ed74ec",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "gcs",
+                "env": "PROD",
+                "folder_abs_path": "my-test-bucket/folders_only_media/videos/2024"
+            },
+            "name": "2024",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:bf0a6d608f8ab9fac60628f974ed74ec",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:gcs"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:bf0a6d608f8ab9fac60628f974ed74ec",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Folder"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:bf0a6d608f8ab9fac60628f974ed74ec",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:2561abe00289962faf7c8746c44491f5",
+                    "urn": "urn:li:container:2561abe00289962faf7c8746c44491f5"
+                },
+                {
+                    "id": "urn:li:container:f80385313133d6f654dc61333c280de0",
+                    "urn": "urn:li:container:f80385313133d6f654dc61333c280de0"
+                },
+                {
+                    "id": "urn:li:container:7afd684fdb07e5f5da6cb3575bab1da9",
+                    "urn": "urn:li:container:7afd684fdb07e5f5da6cb3575bab1da9"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/s3/golden-files/s3/golden_mces_folders_only.json
+++ b/metadata-ingestion/tests/integration/s3/golden-files/s3/golden_mces_folders_only.json
@@ -1,0 +1,546 @@
+[
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:2151647ff17bde0f948909d19fa91b9b",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "s3",
+                "env": "PROD",
+                "bucket_name": "my-test-bucket"
+            },
+            "name": "my-test-bucket",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:2151647ff17bde0f948909d19fa91b9b",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:2151647ff17bde0f948909d19fa91b9b",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:s3"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:2151647ff17bde0f948909d19fa91b9b",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "S3 bucket"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:2151647ff17bde0f948909d19fa91b9b",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f7f059063bc3087880c2739a170abc2a",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:2151647ff17bde0f948909d19fa91b9b"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f7f059063bc3087880c2739a170abc2a",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "s3",
+                "env": "PROD",
+                "folder_abs_path": "my-test-bucket/folders_only_media"
+            },
+            "name": "folders_only_media",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f7f059063bc3087880c2739a170abc2a",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f7f059063bc3087880c2739a170abc2a",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:s3"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f7f059063bc3087880c2739a170abc2a",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Folder"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f7f059063bc3087880c2739a170abc2a",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:2151647ff17bde0f948909d19fa91b9b",
+                    "urn": "urn:li:container:2151647ff17bde0f948909d19fa91b9b"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f70fc62a65e380916d052286c19dea1c",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:f7f059063bc3087880c2739a170abc2a"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f70fc62a65e380916d052286c19dea1c",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "s3",
+                "env": "PROD",
+                "folder_abs_path": "my-test-bucket/folders_only_media/videos"
+            },
+            "name": "videos",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f70fc62a65e380916d052286c19dea1c",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f70fc62a65e380916d052286c19dea1c",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:s3"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f70fc62a65e380916d052286c19dea1c",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Folder"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:f70fc62a65e380916d052286c19dea1c",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:2151647ff17bde0f948909d19fa91b9b",
+                    "urn": "urn:li:container:2151647ff17bde0f948909d19fa91b9b"
+                },
+                {
+                    "id": "urn:li:container:f7f059063bc3087880c2739a170abc2a",
+                    "urn": "urn:li:container:f7f059063bc3087880c2739a170abc2a"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:c9f17e806271cf91339c08c60221c2f3",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:f70fc62a65e380916d052286c19dea1c"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:c9f17e806271cf91339c08c60221c2f3",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "s3",
+                "env": "PROD",
+                "folder_abs_path": "my-test-bucket/folders_only_media/videos/2023"
+            },
+            "name": "2023",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:c9f17e806271cf91339c08c60221c2f3",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:c9f17e806271cf91339c08c60221c2f3",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:s3"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:c9f17e806271cf91339c08c60221c2f3",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Folder"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:c9f17e806271cf91339c08c60221c2f3",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:2151647ff17bde0f948909d19fa91b9b",
+                    "urn": "urn:li:container:2151647ff17bde0f948909d19fa91b9b"
+                },
+                {
+                    "id": "urn:li:container:f7f059063bc3087880c2739a170abc2a",
+                    "urn": "urn:li:container:f7f059063bc3087880c2739a170abc2a"
+                },
+                {
+                    "id": "urn:li:container:f70fc62a65e380916d052286c19dea1c",
+                    "urn": "urn:li:container:f70fc62a65e380916d052286c19dea1c"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:3fe55af75b1b55e7461b434770e6ac90",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:f70fc62a65e380916d052286c19dea1c"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:3fe55af75b1b55e7461b434770e6ac90",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "s3",
+                "env": "PROD",
+                "folder_abs_path": "my-test-bucket/folders_only_media/videos/2024"
+            },
+            "name": "2024",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:3fe55af75b1b55e7461b434770e6ac90",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:3fe55af75b1b55e7461b434770e6ac90",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:s3"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:3fe55af75b1b55e7461b434770e6ac90",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Folder"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:3fe55af75b1b55e7461b434770e6ac90",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:2151647ff17bde0f948909d19fa91b9b",
+                    "urn": "urn:li:container:2151647ff17bde0f948909d19fa91b9b"
+                },
+                {
+                    "id": "urn:li:container:f7f059063bc3087880c2739a170abc2a",
+                    "urn": "urn:li:container:f7f059063bc3087880c2739a170abc2a"
+                },
+                {
+                    "id": "urn:li:container:f70fc62a65e380916d052286c19dea1c",
+                    "urn": "urn:li:container:f70fc62a65e380916d052286c19dea1c"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "folders_only.json",
+        "lastRunId": "no-run-id-provided"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/s3/sources/s3/folders_only.json
+++ b/metadata-ingestion/tests/integration/s3/sources/s3/folders_only.json
@@ -1,0 +1,19 @@
+{
+  "type": "s3",
+  "config": {
+    "path_specs": [
+      {
+        "include": "s3://my-test-bucket/folders_only_media/*/*/",
+        "emit_folders_only": true
+      }
+    ],
+    "aws_config": {
+      "aws_region": "us-east-1",
+      "aws_access_key_id": "testing",
+      "aws_secret_access_key": "testing"
+    },
+    "profiling": {
+      "enabled": false
+    }
+  }
+}

--- a/metadata-ingestion/tests/integration/s3/test_data/local_system/folders_only_media/audio/podcast.mp3
+++ b/metadata-ingestion/tests/integration/s3/test_data/local_system/folders_only_media/audio/podcast.mp3
@@ -1,0 +1,1 @@
+placeholder

--- a/metadata-ingestion/tests/integration/s3/test_data/local_system/folders_only_media/videos/2023/clip.mp4
+++ b/metadata-ingestion/tests/integration/s3/test_data/local_system/folders_only_media/videos/2023/clip.mp4
@@ -1,0 +1,1 @@
+placeholder

--- a/metadata-ingestion/tests/integration/s3/test_data/local_system/folders_only_media/videos/2024/clip.mp4
+++ b/metadata-ingestion/tests/integration/s3/test_data/local_system/folders_only_media/videos/2024/clip.mp4
@@ -1,0 +1,1 @@
+placeholder

--- a/metadata-ingestion/tests/integration/s3/test_s3.py
+++ b/metadata-ingestion/tests/integration/s3/test_s3.py
@@ -65,6 +65,9 @@ FILE_LIST_FOR_VALIDATION = [
     "folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2021/month=march/part2.json",
     "folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/part3.json",
     "folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/_temporary/dummy.json",
+    "folders_only_media/audio/podcast.mp3",
+    "folders_only_media/videos/2023/clip.mp4",
+    "folders_only_media/videos/2024/clip.mp4",
 ]
 
 

--- a/metadata-ingestion/tests/unit/abs/test_abs_folders_only.py
+++ b/metadata-ingestion/tests/unit/abs/test_abs_folders_only.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.abs.source import ABSSource
+
+
+def _abs_source(include: str) -> ABSSource:
+    return ABSSource.create(
+        {
+            "path_specs": [{"include": include, "emit_folders_only": True}],
+            "azure_config": {
+                "account_name": "acct",
+                "container_name": "media",
+                "sas_token": "dummy",
+            },
+        },
+        PipelineContext(run_id="abs-folders-only-test"),
+    )
+
+
+def test_abs_emit_folders_only_emits_containers():
+    source = _abs_source("https://acct.blob.core.windows.net/media/videos/*/")
+
+    # resolve_templated_folders yields container-relative folder paths.
+    with patch.object(
+        source,
+        "resolve_templated_folders",
+        return_value=iter(["videos/2023/", "videos/2024/"]),
+    ):
+        wus = list(source.get_workunits_internal())
+
+    urns = {wu.get_urn() for wu in wus}
+    assert urns  # non-empty
+    assert all(u.startswith("urn:li:container:") for u in urns)
+    assert not any(u.startswith("urn:li:dataset:") for u in urns)
+    assert source.report.folders_scanned == 2

--- a/metadata-ingestion/tests/unit/abs/test_abs_folders_only.py
+++ b/metadata-ingestion/tests/unit/abs/test_abs_folders_only.py
@@ -1,7 +1,10 @@
+from typing import Iterator, List
 from unittest.mock import patch
 
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.source.abs.source import ABSSource
+from datahub.metadata.schema_classes import ContainerPropertiesClass
 
 
 def _abs_source(include: str) -> ABSSource:
@@ -18,14 +21,32 @@ def _abs_source(include: str) -> ABSSource:
     )
 
 
-def test_abs_emit_folders_only_emits_containers():
-    source = _abs_source("https://acct.blob.core.windows.net/media/videos/*/")
+# Fake Azure folder listing: container-relative prefix -> its immediate subfolders.
+# Includes folders BELOW the glob depth (videos/2023/q1/raw, q2/raw) that a correct
+# depth-limited walk must never list. Only list_folders (the Azure listing primitive)
+# is mocked; the real ABSSource.resolve_templated_folders recursion runs against this.
+_FOLDER_TREE = {
+    "videos/": ["videos/2023"],
+    "videos/2023/": ["videos/2023/q1", "videos/2023/q2"],
+    "videos/2023/q1/": ["videos/2023/q1/raw"],
+    "videos/2023/q2/": ["videos/2023/q2/raw"],
+}
 
-    # resolve_templated_folders yields container-relative folder paths.
-    with patch.object(
-        source,
-        "resolve_templated_folders",
-        return_value=iter(["videos/2023/", "videos/2024/"]),
+
+def _fake_list_folders(
+    container_name: str, prefix: str, azure_config: object = None
+) -> Iterator[str]:
+    return iter(_FOLDER_TREE.get(prefix, []))
+
+
+def test_abs_emit_folders_only_walks_to_glob_depth_containers_only() -> None:
+    # Depth-2 glob (videos/*/*/). q1/q2 sit at the glob depth; 'raw' sits below it
+    # and must be absent, proving the walk stops at the number of '*' levels.
+    source = _abs_source("https://acct.blob.core.windows.net/media/videos/*/*/")
+
+    with patch(
+        "datahub.ingestion.source.abs.source.list_folders",
+        side_effect=_fake_list_folders,
     ):
         wus = list(source.get_workunits_internal())
 
@@ -33,4 +54,17 @@ def test_abs_emit_folders_only_emits_containers():
     assert urns  # non-empty
     assert all(u.startswith("urn:li:container:") for u in urns)
     assert not any(u.startswith("urn:li:dataset:") for u in urns)
+
+    names: List[str] = []
+    for wu in wus:
+        if getattr(wu.metadata, "aspectName", None) != "containerProperties":
+            continue
+        assert isinstance(wu.metadata, MetadataChangeProposalWrapper)
+        aspect = wu.metadata.aspect
+        assert isinstance(aspect, ContainerPropertiesClass)
+        names.append(aspect.name)
+
+    # bucket 'media' + videos + 2023 + q1 + q2, each once. 'raw' (below glob depth)
+    # is absent; the exact-multiset check also fails on any duplicate emission.
+    assert sorted(names) == ["2023", "media", "q1", "q2", "videos"]
     assert source.report.folders_scanned == 2

--- a/metadata-ingestion/tests/unit/data_lake_common/test_container_wu_creator_folders.py
+++ b/metadata-ingestion/tests/unit/data_lake_common/test_container_wu_creator_folders.py
@@ -1,7 +1,9 @@
 from typing import List, Optional
 
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.data_lake_common.data_lake_utils import ContainerWUCreator
+from datahub.metadata.schema_classes import SubTypesClass
 
 
 def _aspect_names(wus: List[MetadataWorkUnit]) -> List[Optional[str]]:
@@ -39,12 +41,14 @@ def test_create_folder_containers_emits_bucket_and_folder_chain() -> None:
     assert len(container_props) == 4
 
     # Subtypes present: exactly one bucket subtype + three FOLDER subtypes
-    subtype_payloads = [
-        wu.metadata.aspect
-        for wu in wus
-        if getattr(wu.metadata, "aspectName", None) == "subTypes"
-    ]
-    flat = [t for a in subtype_payloads for t in a.typeNames]
+    flat: List[str] = []
+    for wu in wus:
+        if getattr(wu.metadata, "aspectName", None) != "subTypes":
+            continue
+        assert isinstance(wu.metadata, MetadataChangeProposalWrapper)
+        aspect = wu.metadata.aspect
+        assert isinstance(aspect, SubTypesClass)
+        flat.extend(aspect.typeNames)
     assert flat.count("Folder") == 3
     assert flat.count("S3 bucket") == 1
 

--- a/metadata-ingestion/tests/unit/data_lake_common/test_container_wu_creator_folders.py
+++ b/metadata-ingestion/tests/unit/data_lake_common/test_container_wu_creator_folders.py
@@ -1,0 +1,65 @@
+from typing import List, Optional
+
+from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.source.data_lake_common.data_lake_utils import ContainerWUCreator
+
+
+def _aspect_names(wus: List[MetadataWorkUnit]) -> List[Optional[str]]:
+    names = []
+    for wu in wus:
+        mcp = wu.metadata
+        # MetadataChangeProposalWrapper exposes aspectName; snapshots do not appear here
+        names.append(getattr(mcp, "aspectName", None))
+    return names
+
+
+def test_create_folder_containers_emits_bucket_and_folder_chain() -> None:
+    creator = ContainerWUCreator(platform="s3", platform_instance=None, env="PROD")
+
+    wus = list(creator.create_folder_containers("s3://my-bucket/media/videos/2024"))
+
+    # No dataset aspects at all — folders only.
+    aspect_names = _aspect_names(wus)
+    assert "datasetProperties" not in aspect_names
+
+    # gen_containers legitimately emits a "container" aspect on each non-root
+    # container to link it to its *parent container* — that's expected. What must
+    # NOT happen is add_dataset_to_container, which would target a dataset urn.
+    # So every "container"-aspect workunit's entity must itself be a container.
+    container_link_wus = [
+        wu for wu in wus if getattr(wu.metadata, "aspectName", None) == "container"
+    ]
+    assert container_link_wus  # sanity: folders do link to their parent container
+    assert all(
+        wu.get_urn().startswith("urn:li:container:") for wu in container_link_wus
+    )
+
+    # One containerProperties per distinct container: bucket + media + videos + 2024 = 4
+    container_props = [n for n in aspect_names if n == "containerProperties"]
+    assert len(container_props) == 4
+
+    # Subtypes present: exactly one bucket subtype + three FOLDER subtypes
+    subtype_payloads = [
+        wu.metadata.aspect
+        for wu in wus
+        if getattr(wu.metadata, "aspectName", None) == "subTypes"
+    ]
+    flat = [t for a in subtype_payloads for t in a.typeNames]
+    assert flat.count("Folder") == 3
+    assert flat.count("S3 bucket") == 1
+
+
+def test_create_folder_containers_dedupes_shared_parents() -> None:
+    creator = ContainerWUCreator(platform="s3", platform_instance=None, env="PROD")
+
+    list(creator.create_folder_containers("s3://my-bucket/media/videos/2023"))
+    second = list(creator.create_folder_containers("s3://my-bucket/media/videos/2024"))
+
+    # 'my-bucket', 'media', 'videos' were already emitted in the first call; only the
+    # new leaf '2024' chain (just the 2024 container) should be emitted the second time.
+    second_props = [
+        wu
+        for wu in second
+        if getattr(wu.metadata, "aspectName", None) == "containerProperties"
+    ]
+    assert len(second_props) == 1

--- a/metadata-ingestion/tests/unit/data_lake_common/test_path_spec_folders_only.py
+++ b/metadata-ingestion/tests/unit/data_lake_common/test_path_spec_folders_only.py
@@ -1,0 +1,29 @@
+import pytest
+
+from datahub.ingestion.source.data_lake_common.path_spec import PathSpec
+
+
+def test_emit_folders_only_defaults_false():
+    spec = PathSpec(include="s3://bucket/media/{table}/*.csv")
+    assert spec.emit_folders_only is False
+
+
+def test_emit_folders_only_accepts_folder_glob():
+    spec = PathSpec(include="s3://bucket/media/*/*/", emit_folders_only=True)
+    assert spec.emit_folders_only is True
+    # depth is defined by the wildcard levels in the glob
+    assert spec.glob_include == "s3://bucket/media/*/*/"
+
+
+def test_emit_folders_only_rejects_table_marker():
+    with pytest.raises(ValueError, match="emit_folders_only"):
+        PathSpec(include="s3://bucket/media/{table}/", emit_folders_only=True)
+
+
+def test_emit_folders_only_rejects_double_star():
+    with pytest.raises(ValueError, match="emit_folders_only"):
+        PathSpec(
+            include="s3://bucket/media/**",
+            emit_folders_only=True,
+            allow_double_stars=True,
+        )

--- a/metadata-ingestion/tests/unit/data_lake_common/test_path_spec_folders_only.py
+++ b/metadata-ingestion/tests/unit/data_lake_common/test_path_spec_folders_only.py
@@ -1,5 +1,6 @@
 import pytest
 
+from datahub.configuration.common import AllowDenyPattern
 from datahub.ingestion.source.data_lake_common.path_spec import PathSpec
 
 
@@ -27,3 +28,42 @@ def test_emit_folders_only_rejects_double_star():
             emit_folders_only=True,
             allow_double_stars=True,
         )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"table_name": "foo"},
+        {"default_extension": "csv"},
+        {"file_types": ["csv"]},
+        {"tables_filter_pattern": AllowDenyPattern(allow=["foo"])},
+    ],
+)
+def test_emit_folders_only_rejects_file_dataset_fields(kwargs):
+    # File/dataset-selection fields have no effect in folders-only mode and are
+    # rejected rather than silently ignored.
+    with pytest.raises(ValueError, match="emit_folders_only"):
+        PathSpec(include="s3://bucket/media/*/", emit_folders_only=True, **kwargs)
+
+
+def test_emit_folders_only_allows_folder_filters():
+    # exclude and include_hidden_folders DO apply to the folder walk -> must be accepted.
+    spec = PathSpec(
+        include="s3://bucket/media/*/",
+        emit_folders_only=True,
+        exclude=["s3://bucket/media/tmp/**"],
+        include_hidden_folders=True,
+    )
+    assert spec.exclude == ["s3://bucket/media/tmp/**"]
+    assert spec.include_hidden_folders is True
+
+
+def test_folder_allowed_applies_hidden_and_exclude():
+    spec = PathSpec(
+        include="s3://bucket/media/*/",
+        emit_folders_only=True,
+        exclude=["s3://bucket/media/tmp/**"],
+    )
+    assert spec.folder_allowed("s3://bucket/media/keep")
+    assert not spec.folder_allowed("s3://bucket/media/tmp/2024")  # excluded subtree
+    assert not spec.folder_allowed("s3://bucket/media/_staging")  # hidden by default

--- a/metadata-ingestion/tests/unit/s3/test_s3_source.py
+++ b/metadata-ingestion/tests/unit/s3/test_s3_source.py
@@ -59,6 +59,7 @@ def _get_s3_source(path_spec_: PathSpec) -> S3Source:
             "path_spec": {
                 "include": path_spec_.include,
                 "table_name": path_spec_.table_name,
+                "emit_folders_only": path_spec_.emit_folders_only,
             },
             "aws_config": {
                 "aws_access_key_id": "test",
@@ -463,6 +464,44 @@ def test_get_folder_info_returns_expected_folder(s3_resource):
         size=150,
         sample_file="s3://my-bucket/my-folder/dir1/0002.csv",
     )
+
+
+def test_s3_emit_folders_only_emits_containers_no_datasets(s3_resource, s3_client):
+    bucket = "media-bucket"
+    s3_client.create_bucket(Bucket=bucket)
+    # Two-level media tree. 'audio' has no second level -> not emitted at depth 2.
+    for key in [
+        "media/videos/2023/clip.mp4",
+        "media/videos/2024/clip.mp4",
+        "media/audio/podcast.mp3",
+    ]:
+        s3_client.put_object(Bucket=bucket, Key=key, Body=b"x")
+
+    source = _get_s3_source(
+        PathSpec(
+            include=f"s3://{bucket}/media/*/*/",
+            emit_folders_only=True,
+        )
+    )
+
+    wus = list(source.get_workunits_internal())
+    urns = {wu.get_urn() for wu in wus}
+
+    # Every workunit is a container; no dataset URNs.
+    assert all(urn.startswith("urn:li:container:") for urn in urns)
+    assert not any(urn.startswith("urn:li:dataset:") for urn in urns)
+
+    # Depth-2 folders present: media/videos/2023 and media/videos/2024 (via their chain),
+    # plus parents bucket, media, videos. 'audio' (depth-1 leaf) is absent by design.
+    aspect_dumps = [
+        wu.metadata.aspect
+        for wu in wus
+        if getattr(wu.metadata, "aspectName", None) == "containerProperties"
+    ]
+    names = {a.name for a in aspect_dumps}
+    assert {"media-bucket", "media", "videos", "2023", "2024"} <= names
+    assert "audio" not in names
+    assert source.report.folders_scanned == 2
 
 
 def test_s3_region_in_external_url():

--- a/metadata-ingestion/tests/unit/s3/test_s3_source.py
+++ b/metadata-ingestion/tests/unit/s3/test_s3_source.py
@@ -61,6 +61,8 @@ def _get_s3_source(path_spec_: PathSpec) -> S3Source:
                 "include": path_spec_.include,
                 "table_name": path_spec_.table_name,
                 "emit_folders_only": path_spec_.emit_folders_only,
+                "exclude": path_spec_.exclude,
+                "include_hidden_folders": path_spec_.include_hidden_folders,
             },
             "aws_config": {
                 "aws_access_key_id": "test",
@@ -510,6 +512,41 @@ def test_s3_emit_folders_only_emits_containers_no_datasets(s3_resource, s3_clien
     # exact-multiset check also fails on any duplicate container emission.
     assert sorted(names) == ["2023", "2024", "media", "media-bucket", "videos"]
     assert source.report.folders_scanned == 2
+
+
+def test_s3_emit_folders_only_applies_exclude_and_hidden(s3_resource, s3_client):
+    bucket = "media-bucket"
+    s3_client.create_bucket(Bucket=bucket)
+    for key in [
+        "media/keep/2024/clip.mp4",
+        "media/skip/2024/clip.mp4",  # excluded via exclude glob
+        "media/_staging/2024/clip.mp4",  # skipped as hidden (default)
+    ]:
+        s3_client.put_object(Bucket=bucket, Key=key, Body=b"x")
+
+    source = _get_s3_source(
+        PathSpec(
+            include=f"s3://{bucket}/media/*/*/",
+            emit_folders_only=True,
+            exclude=[f"s3://{bucket}/media/skip/**"],
+        )
+    )
+
+    wus = list(source.get_workunits_internal())
+    names: List[str] = []
+    for wu in wus:
+        if getattr(wu.metadata, "aspectName", None) != "containerProperties":
+            continue
+        assert isinstance(wu.metadata, MetadataChangeProposalWrapper)
+        aspect = wu.metadata.aspect
+        assert isinstance(aspect, ContainerPropertiesClass)
+        names.append(aspect.name)
+
+    # Only the 'keep' chain survives; 'skip' (exclude) and '_staging' (hidden) are gone.
+    assert set(names) == {"media-bucket", "media", "keep", "2024"}
+    assert "skip" not in names
+    assert "_staging" not in names
+    assert source.report.folders_scanned == 1
 
 
 def test_s3_region_in_external_url():

--- a/metadata-ingestion/tests/unit/s3/test_s3_source.py
+++ b/metadata-ingestion/tests/unit/s3/test_s3_source.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime, timezone
-from typing import List, Tuple
+from typing import List, Set, Tuple
 from unittest.mock import MagicMock, Mock, call, patch
 
 import boto3
@@ -26,6 +26,7 @@ from datahub.ingestion.source.s3.source import (
     TableData,
     partitioned_folder_comparator,
 )
+from datahub.metadata.schema_classes import ContainerPropertiesClass
 
 logging.getLogger("boto3").setLevel(logging.INFO)
 logging.getLogger("botocore").setLevel(logging.INFO)
@@ -493,12 +494,14 @@ def test_s3_emit_folders_only_emits_containers_no_datasets(s3_resource, s3_clien
 
     # Depth-2 folders present: media/videos/2023 and media/videos/2024 (via their chain),
     # plus parents bucket, media, videos. 'audio' (depth-1 leaf) is absent by design.
-    aspect_dumps = [
-        wu.metadata.aspect
-        for wu in wus
-        if getattr(wu.metadata, "aspectName", None) == "containerProperties"
-    ]
-    names = {a.name for a in aspect_dumps}
+    names: Set[str] = set()
+    for wu in wus:
+        if getattr(wu.metadata, "aspectName", None) != "containerProperties":
+            continue
+        assert isinstance(wu.metadata, MetadataChangeProposalWrapper)
+        aspect = wu.metadata.aspect
+        assert isinstance(aspect, ContainerPropertiesClass)
+        names.add(aspect.name)
     assert {"media-bucket", "media", "videos", "2023", "2024"} <= names
     assert "audio" not in names
     assert source.report.folders_scanned == 2

--- a/metadata-ingestion/tests/unit/s3/test_s3_source.py
+++ b/metadata-ingestion/tests/unit/s3/test_s3_source.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime, timezone
-from typing import List, Set, Tuple
+from typing import List, Tuple
 from unittest.mock import MagicMock, Mock, call, patch
 
 import boto3
@@ -470,9 +470,13 @@ def test_get_folder_info_returns_expected_folder(s3_resource):
 def test_s3_emit_folders_only_emits_containers_no_datasets(s3_resource, s3_client):
     bucket = "media-bucket"
     s3_client.create_bucket(Bucket=bucket)
-    # Two-level media tree. 'audio' has no second level -> not emitted at depth 2.
+    # Depth-2 glob (media/*/*/). The tree exercises all three depth edges:
+    #   - videos/2023, videos/2024 sit AT depth 2       -> emitted
+    #   - audio is a depth-1 leaf (no depth-2 child)     -> NOT emitted (too shallow)
+    #   - videos/2023/raw sits BELOW depth 2             -> NOT emitted (depth cap)
     for key in [
         "media/videos/2023/clip.mp4",
+        "media/videos/2023/raw/deep.mp4",
         "media/videos/2024/clip.mp4",
         "media/audio/podcast.mp3",
     ]:
@@ -492,18 +496,19 @@ def test_s3_emit_folders_only_emits_containers_no_datasets(s3_resource, s3_clien
     assert all(urn.startswith("urn:li:container:") for urn in urns)
     assert not any(urn.startswith("urn:li:dataset:") for urn in urns)
 
-    # Depth-2 folders present: media/videos/2023 and media/videos/2024 (via their chain),
-    # plus parents bucket, media, videos. 'audio' (depth-1 leaf) is absent by design.
-    names: Set[str] = set()
+    names: List[str] = []
     for wu in wus:
         if getattr(wu.metadata, "aspectName", None) != "containerProperties":
             continue
         assert isinstance(wu.metadata, MetadataChangeProposalWrapper)
         aspect = wu.metadata.aspect
         assert isinstance(aspect, ContainerPropertiesClass)
-        names.add(aspect.name)
-    assert {"media-bucket", "media", "videos", "2023", "2024"} <= names
-    assert "audio" not in names
+        names.append(aspect.name)
+
+    # Exactly the bucket + the depth<=2 chain, each container emitted once.
+    # Excludes 'audio' (too shallow) and 'raw' (below the glob depth); the
+    # exact-multiset check also fails on any duplicate container emission.
+    assert sorted(names) == ["2023", "2024", "media", "media-bucket", "videos"]
     assert source.report.folders_scanned == 2
 
 


### PR DESCRIPTION
## Summary

Adds an opt-in `emit_folders_only` option to `PathSpec` for the object-store file connectors (**S3**, **GCS**, **ADLS/`abs`**). When set, the connector emits each matching storage **folder** as a governable `Container` (to a glob-defined depth) and creates **no dataset entities**.

**Motivation:** catalog storage paths of unstructured files (audio, video, images, …) as governable assets — owners, tags, glossary terms, domains, documentation — while creating zero dataset entities. Folders are already `Container`s in DataHub, so this needs **no** metadata-model, GraphQL, or frontend changes. (As a side effect it also skips the sample-file reads that normal ingestion does for schema inference, but the value prop is the container-only catalog, not I/O avoidance.)

## How it works

Set `emit_folders_only: true` on a `path_spec`. Folder depth is defined by the number of `*` wildcard levels in `include`:

- `s3://bucket/media/*/` → folders one level deep
- `s3://bucket/media/*/*/` → two levels deep

```yaml
source:
  type: s3
  config:
    path_specs:
      - include: "s3://my-bucket/media/*/*/" # catalog folders two levels deep
        emit_folders_only: true
        exclude: ["s3://my-bucket/media/tmp/**"] # optional; applies to the folder walk
    aws_config:
      aws_region: us-east-1
```

- Short-circuits before any file/object listing — lists folder prefixes only (S3 `CommonPrefixes` / ADLS delimiter listing).
- Emits the bucket plus every folder component as `Container`s (subtype `Folder`); no datasets, no schema inference.
- `exclude` and `include_hidden_folders` **apply** to the folder walk. File/dataset-selection fields (`file_types`, `default_extension`, `table_name`, `tables_filter_pattern`) are **rejected** in validation (rather than silently ignored), since folders-only produces no datasets.
- Validation also rejects `{table}` and `**`; depth must be explicit `*` levels. Want multiple depths/paths? Add more `path_specs`.

## Platforms

- **S3** — core implementation.
- **GCS** — delegates to the internal S3 source; the new field is forwarded in `create_equivalent_s3_path_specs()`.
- **ADLS (`abs`)** — mirrored into the separate `abs` source class; shares the container-emission helper.

## Testing

- **Unit:** config validation (rejects `{table}`/`**` and the file/dataset fields; accepts `exclude`/`include_hidden_folders`); `folder_allowed` (hidden + exclude); `create_folder_containers` (bucket + folder chain, dedup, no dataset aspects); S3 via moto — **depth cap** (a below-glob-depth folder stays absent) and **exclude/hidden** end-to-end; ADLS via a `list_folders` mock so the real walker recursion runs.
- **Integration golden:** end-to-end for **S3 and GCS**, container-only output with the expected hierarchy.

## Follow-ups (non-blocking)

- Whether folders-only belongs on `PathSpec` vs a smaller dedicated config surface is worth a design discussion; kept on `PathSpec` for a minimal, familiar-UX diff, with unsupported fields now rejected rather than ignored.
- `List` → `Set` for `ContainerWUCreator.processed_containers` (pre-existing O(n²) membership check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
