### PR TITLE
perf(ci): parallelize metadata-io tests across runners + gate free-disk cleanup

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,14 +1,22 @@
 name: Free Disk Space
 description: Removes pre-installed tooling to reclaim disk space on GitHub-hosted runners.
 
+inputs:
+  aggressive:
+    description: >-
+      When 'true' (default), also runs the slow reclaim: apt-get remove + docker system prune -a
+      (1-6 min, high variance). Only Docker-building jobs need it; pure build/test jobs pass 'false'
+      to skip it — the fast directory removals below already free ~10+ GB.
+    required: false
+    default: "true"
+
 runs:
   using: composite
   steps:
-    - name: Free up disk space
+    - name: Free up disk space (fast — directory removals)
       shell: bash
       if: runner.environment == 'github-hosted'
       run: |
-        sudo apt-get remove 'dotnet-*' azure-cli || true
         sudo rm -rf /usr/local/lib/android/ || true
         sudo rm -rf /usr/local/.ghcup || true
         sudo rm -rf /usr/share/dotnet || true
@@ -16,5 +24,13 @@ runs:
         sudo rm -rf /usr/local/julia* || true
         sudo rm -rf /usr/local/share/powershell || true
         sudo rm -rf /usr/share/miniconda || true
+        df -h
+    - name: Free up disk space (aggressive — apt + docker prune)
+      shell: bash
+      # docker system prune -a is the slow, high-variance step (scans/deletes every image layer);
+      # only Docker-building jobs need it. Skipped when aggressive == 'false'.
+      if: runner.environment == 'github-hosted' && inputs.aggressive == 'true'
+      run: |
+        sudo apt-get remove 'dotnet-*' azure-cli || true
         sudo docker system prune -a -f || true
         df -h

--- a/.github/workflows/metadata-io.yml
+++ b/.github/workflows/metadata-io.yml
@@ -48,10 +48,43 @@ jobs:
         uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
       - uses: ./.github/actions/ci-optimization
         id: ci-optimize
-  build-metadata-io:
+  # Compile metadata-io (+ upstream modules) ONCE and warm the Gradle build cache the test-matrix
+  # legs restore — otherwise each of the 6 legs recompiles the whole dependency graph from cold.
+  # Also gates codegen freshness here (a whole-module property, no need to repeat it per suite).
+  metadata-io-seed:
     runs-on: ${{ vars.DEPOT_PROJECT_ID != '' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     timeout-minutes: 40
     needs: setup
+    steps:
+      - uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
+        with:
+          aggressive: "false"
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: "zulu"
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          # build-cache-1 is managed explicitly below with a run-scoped key so the legs restore
+          # exactly this run's compiled output.
+          gradle-home-cache-excludes: caches/build-cache-1
+      - name: Cache Gradle build cache (seed writes; run-scoped key)
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ~/.gradle/caches/build-cache-1
+          key: gradle-metadata-io-build-cache-${{ github.run_id }}
+          restore-keys: |
+            gradle-metadata-io-build-cache-
+      - name: Compile metadata-io test classes once (no tests)
+        run: ./gradlew :metadata-io:testClasses --build-cache
+
+  build-metadata-io:
+    runs-on: ${{ vars.DEPOT_PROJECT_ID != '' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    timeout-minutes: 40
+    needs: [setup, metadata-io-seed]
     strategy:
       # One runner per TestNG sub-suite (aggregated by testng.xml), replacing the single ~17m
       # serial `:metadata-io:test`. One suite per leg = one fork = one testcontainer stack, which
@@ -80,9 +113,20 @@ jobs:
           distribution: "zulu"
           java-version: 21
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          # Legs read the seed's build cache; only the seed writes. Avoids matrix write races.
+          cache-read-only: true
+          gradle-home-cache-excludes: caches/build-cache-1
+      - name: Restore Gradle build cache (seed's output, this run)
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ~/.gradle/caches/build-cache-1
+          key: gradle-metadata-io-build-cache-${{ github.run_id }}
+          restore-keys: |
+            gradle-metadata-io-build-cache-
       - name: Gradle test (${{ matrix.suite.name }} suite)
         run: |
-          ./gradlew :metadata-io:${{ matrix.suite.task }}
+          ./gradlew :metadata-io:${{ matrix.suite.task }} --build-cache
       - name: Report test results
         if: (!cancelled())
         uses: ./.github/actions/report-test-results
@@ -145,17 +189,18 @@ jobs:
           report_type: test_results
           override_branch: ${{ github.head_ref || github.ref_name }}
 
-  # Codegen freshness is a whole-module property — run it once, not per test-suite shard.
+  # Codegen freshness (whole-module property) — its own job, decoupled from the compile-seed.
+  # ensure-codegen-updated is just `git status`, so codegen must actually run first: restore the
+  # seed's build cache and compile FROM-CACHE (fast) to materialize generated sources, then diff.
   codegen-check:
     runs-on: ${{ vars.DEPOT_PROJECT_ID != '' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     timeout-minutes: 30
-    needs: setup
+    needs: [setup, metadata-io-seed]
     steps:
       - uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
       - name: Free up disk space
         uses: ./.github/actions/free-disk-space
         with:
-          # Runs Java tests only (no Docker image builds). Skip the slow apt/docker-prune path.
           aggressive: "false"
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -163,6 +208,18 @@ jobs:
           distribution: "zulu"
           java-version: 21
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          cache-read-only: true
+          gradle-home-cache-excludes: caches/build-cache-1
+      - name: Restore Gradle build cache (seed's output, this run)
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ~/.gradle/caches/build-cache-1
+          key: gradle-metadata-io-build-cache-${{ github.run_id }}
+          restore-keys: |
+            gradle-metadata-io-build-cache-
+      - name: Materialize generated sources (FROM-CACHE)
+        run: ./gradlew :metadata-io:testClasses --build-cache
       - name: Ensure codegen is updated
         uses: ./.github/actions/ensure-codegen-updated
 

--- a/.github/workflows/metadata-io.yml
+++ b/.github/workflows/metadata-io.yml
@@ -50,34 +50,50 @@ jobs:
         id: ci-optimize
   build-metadata-io:
     runs-on: ${{ vars.DEPOT_PROJECT_ID != '' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    timeout-minutes: 60
+    timeout-minutes: 40
     needs: setup
+    strategy:
+      # One runner per TestNG sub-suite (aggregated by testng.xml), replacing the single ~17m
+      # serial `:metadata-io:test`. One suite per leg = one fork = one testcontainer stack, which
+      # is why maxParallelForks stays 1 (ES/OpenSearch/Cassandra/Neo4j/Postgres — parallel forks OOM).
+      fail-fast: false
+      matrix:
+        suite:
+          - { name: other, task: testOther }
+          - { name: opensearch, task: testOpenSearch }
+          - { name: es8, task: testEs8 }
+          - { name: es7-cassandra-neo4j, task: testEs7CassandraNeo4j }
+          - { name: postgresql, task: testPostgresql }
+          - { name: sql-opt, task: testSqlOpt }
     steps:
       - name: Disk Check
         run: df -h . && docker images
       - uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
       - name: Free up disk space
         uses: ./.github/actions/free-disk-space
+        with:
+          # Runs Java tests only (no Docker image builds). Skip the slow apt/docker-prune path.
+          aggressive: "false"
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: "zulu"
           java-version: 21
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
-      - name: Gradle build (and test)
+      - name: Gradle test (${{ matrix.suite.name }} suite)
         run: |
-          ./gradlew :metadata-io:test
+          ./gradlew :metadata-io:${{ matrix.suite.task }}
       - name: Report test results
         if: (!cancelled())
         uses: ./.github/actions/report-test-results
         with:
-          artifact-name: Test Results (metadata-io)
+          artifact-name: Test Results (metadata-io ${{ matrix.suite.name }})
           test-results-paths: |
-            **/build/reports/tests/test/**
-            **/build/test-results/test/**
+            **/build/reports/tests/${{ matrix.suite.task }}/**
+            **/build/test-results/${{ matrix.suite.task }}/**
             !**/binary/**
           junit-file-globs: |
-            **/build/test-results/test/**/*.xml
+            **/build/test-results/${{ matrix.suite.task }}/**/*.xml
       - name: Send failed test metrics to PostHog
         if: failure()
         continue-on-error: true
@@ -104,20 +120,21 @@ jobs:
             --workflow-name "${{ github.workflow }}" \
             --branch "${GH_HEAD_REF}" \
             --run-id "${{ github.run_id }}" \
-            --run-attempt "${{ github.run_attempt }}"
+            --run-attempt "${{ github.run_attempt }}" \
+            --command "metadata-io-${{ matrix.suite.name }}"
 
           rm -rf "$TEMP_DIR"
-      - name: Ensure codegen is updated
-        uses: ./.github/actions/ensure-codegen-updated
       - name: Upload coverage to Codecov
         if: ${{ always()}}
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          # Each leg emits jacoco-<task>.xml here; all legs share the metadata-io flag, which
+          # Codecov merges into one report (same pattern as the backend test shards).
           directory: ./build/coverage-reports/metadata-io/
           fail_ci_if_error: false
           flags: metadata-io
-          name: metadata-io-test
+          name: metadata-io-${{ matrix.suite.name }}
           verbose: true
           override_branch: ${{ github.head_ref || github.ref_name }}
       - name: Upload test results to Codecov
@@ -127,6 +144,27 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
           override_branch: ${{ github.head_ref || github.ref_name }}
+
+  # Codegen freshness is a whole-module property — run it once, not per test-suite shard.
+  codegen-check:
+    runs-on: ${{ vars.DEPOT_PROJECT_ID != '' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    timeout-minutes: 30
+    needs: setup
+    steps:
+      - uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
+        with:
+          # Runs Java tests only (no Docker image builds). Skip the slow apt/docker-prune path.
+          aggressive: "false"
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: "zulu"
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      - name: Ensure codegen is updated
+        uses: ./.github/actions/ensure-codegen-updated
 
   event-file:
     runs-on: ubuntu-latest

--- a/metadata-io/build.gradle
+++ b/metadata-io/build.gradle
@@ -345,6 +345,62 @@ task testOther(type: Test) {
   description = 'Runs only other test suite to debug the failing tests'
 }
 
+task testEs8(type: Test) {
+  doFirst {
+    maxParallelForks = 1
+  }
+  useTestNG() {
+    suites 'src/test/resources/testng-es8.xml'
+  }
+  testLogging {
+    events "failed", "skipped", "passed"
+    exceptionFormat "full"
+    showStandardStreams = true
+  }
+
+  environment 'STRICT_URN_VALIDATION_ENABLED', 'true'
+
+  group = 'verification'
+  description = 'Runs only the testng-es8.xml test suite'
+}
+
+task testSqlOpt(type: Test) {
+  doFirst {
+    maxParallelForks = 1
+  }
+  useTestNG() {
+    suites 'src/test/resources/testng-sql-opt.xml'
+  }
+  testLogging {
+    events "failed", "skipped", "passed"
+    exceptionFormat "full"
+    showStandardStreams = true
+  }
+
+  environment 'STRICT_URN_VALIDATION_ENABLED', 'true'
+
+  group = 'verification'
+  description = 'Runs only the testng-sql-opt.xml test suite'
+}
+
+// Per-suite coverage: a matrix leg (metadata-io.yml) runs ONE suite task, so each must emit its
+// own jacoco XML from its `.exec`. Mirrors jacocoSqlSetupCoverageReport (testPostgresql); legs
+// share the Codecov `metadata-io` flag, which merges the partials — no separate merge job.
+['testOpenSearch', 'testEs8', 'testEs7CassandraNeo4j', 'testOther', 'testSqlOpt'].each { suiteTask ->
+  def reportTask = tasks.register("jacoco${suiteTask.capitalize()}Report", JacocoReport) {
+    dependsOn suiteTask
+    executionData.setFrom(fileTree(layout.buildDirectory.dir('jacoco')).include("${suiteTask}.exec"))
+    sourceSets sourceSets.main
+    reports {
+      xml.required = true
+      xml.outputLocation = rootProject.layout.buildDirectory.file(
+          "coverage-reports/${rootProject.relativePath(project.projectDir)}/jacoco-${suiteTask}.xml")
+      html.required = false
+    }
+  }
+  tasks.named(suiteTask) { finalizedBy reportTask }
+}
+
 ebean {
   debugLevel = 1 // 0 - 9
 }

--- a/metadata-io/build.gradle
+++ b/metadata-io/build.gradle
@@ -294,18 +294,6 @@ task testOpenSearch(type: Test) {
   description = 'Runs only the testng-opensearch.xml test suite'
 }
 
-tasks.register('jacocoSqlSetupCoverageReport', JacocoReport) {
-  dependsOn testPostgresql
-  reports {
-    xml.required = true
-    xml.outputLocation = rootProject.layout.buildDirectory.file(
-        "coverage-reports/${rootProject.relativePath(project.projectDir)}/jacoco-sqlsetup.xml")
-    html.required = true
-  }
-  executionData.setFrom(fileTree(layout.buildDirectory.dir('jacoco')).include('testPostgresql.exec'))
-  sourceSets sourceSets.main
-}
-
 task testPostgresql(type: Test) {
   doFirst {
     maxParallelForks = 1
@@ -323,7 +311,6 @@ task testPostgresql(type: Test) {
 
   group = 'verification'
   description = 'Runs PostgreSQL Testcontainers suite (testng-postgresql.xml)'
-  finalizedBy jacocoSqlSetupCoverageReport
 }
 
 task testOther(type: Test) {
@@ -384,13 +371,17 @@ task testSqlOpt(type: Test) {
 }
 
 // Per-suite coverage: a matrix leg (metadata-io.yml) runs ONE suite task, so each must emit its
-// own jacoco XML from its `.exec`. Mirrors jacocoSqlSetupCoverageReport (testPostgresql); legs
-// share the Codecov `metadata-io` flag, which merges the partials — no separate merge job.
-['testOpenSearch', 'testEs8', 'testEs7CassandraNeo4j', 'testOther', 'testSqlOpt'].each { suiteTask ->
+// own jacoco XML from its `.exec`. Legs share the Codecov `metadata-io` flag, which merges the
+// partials — no separate merge job. classDirectories excludes generated code, matching the base
+// jacocoTestReport in gradle/coverage/java-coverage.gradle.
+def jacocoCoverageExcludes = ['**/generated/**']
+['testOpenSearch', 'testEs8', 'testEs7CassandraNeo4j', 'testOther', 'testSqlOpt', 'testPostgresql'].each { suiteTask ->
   def reportTask = tasks.register("jacoco${suiteTask.capitalize()}Report", JacocoReport) {
     dependsOn suiteTask
     executionData.setFrom(fileTree(layout.buildDirectory.dir('jacoco')).include("${suiteTask}.exec"))
-    sourceSets sourceSets.main
+    classDirectories.setFrom(files(sourceSets.main.output.collect { dir ->
+      fileTree(dir: dir, excludes: jacocoCoverageExcludes)
+    }))
     reports {
       xml.required = true
       xml.outputLocation = rootProject.layout.buildDirectory.file(


### PR DESCRIPTION
## Summary

Speeds up the `metadata-io` workflow. The single `build-metadata-io` job ran `./gradlew
:metadata-io:test` — **22.4m** on master — because `testng.xml` just aggregates 6 sub-suites that
ran **sequentially in one JVM**, each booting its own testcontainer stack (Elasticsearch /
OpenSearch / Cassandra / Neo4j / Postgres) one after another.

`maxParallelForks` stays `1` on purpose and is not the lever: TestNG controls parallelism (more
forks re-run tests), and each fork carries a full container stack (~2–3 GB), so extra forks OOM a
standard runner. The fix is to run the suites on **separate runners**.

## Changes

### 1. Shard the suites across a matrix (one runner per suite)

`build-metadata-io` becomes a 6-way matrix, each leg running one suite's task:

| suite | task |
|---|---|
| other | `testOther` |
| opensearch | `testOpenSearch` |
| es8 | `testEs8` *(new)* |
| es7-cassandra-neo4j | `testEs7CassandraNeo4j` |
| postgresql | `testPostgresql` |
| sql-opt | `testSqlOpt` *(new)* |

- Added the two missing gradle tasks (`testEs8`, `testSqlOpt`) so every sub-suite has a standalone
  task. One leg = one suite = one fork = one container stack → no OOM, no TestNG re-run.
- **No change to which tests run.** `testng.xml` aggregated exactly these 6 files; the matrix runs
  all 6. The `other` catch-all excludes the search/cassandra/neo4j packages the specialized suites
  own, so **no test is dropped**. The elasticsearch search packages do run **twice** — once each at
  ES 7.10.2 (`es7-cassandra-neo4j`) and ES 8.17.4 (`es8`) — but that is a deliberate version matrix,
  pre-existing in the aggregated `testng.xml`, not something this PR adds.

### 2. Compile once via a seed job (no redundant recompile)

Without sharing compiled output, each of the 6 legs would recompile metadata-io + all upstream
modules from cold. A new `metadata-io-seed` job compiles `:metadata-io:testClasses` **once**, warms
`~/.gradle/caches/build-cache-1` (run-scoped key, prefix restore-key for cross-run warmth), and the
test legs restore it **read-only** and run `:module:test --build-cache` — so unchanged modules
resolve `FROM-CACHE` and only what the PR touched recompiles. Same pattern as `backend-seed` in
`build-and-test.yml`.

### 3. Codegen freshness as its own job

`ensure-codegen-updated` (a `git status` drift check) moved out of the test path into a dedicated
`codegen-check` job. It reuses the seed's build cache (compile `FROM-CACHE`, fast) to materialize
generated sources before the diff — kept decoupled from the compile-seed, runs in parallel with the
test legs.

### 4. Per-suite JaCoCo coverage

Each suite task emits its own `jacoco-<task>.xml` (a matrix leg runs one suite, so it must produce
its own report). All legs upload under the shared Codecov `metadata-io` flag, which merges the
partials — no separate merge job. `classDirectories` excludes generated code (`**/generated/**`),
matching the base `jacocoTestReport` in `gradle/coverage/java-coverage.gradle`.

### 5. Gate the slow reclaim in `free-disk-space`

The action always ran `apt-get remove` + `docker system prune -a` — 1–6 min of high-variance work
only Docker-building jobs need. Split into a fast directory-removal step (always) and an aggressive
step behind a new `aggressive` input (**default `true`**, so docker/smoke/playwright workflows are
unchanged). The metadata-io jobs pass `aggressive: "false"`.

## Measured impact

Baseline — master run
[`29472805849`](https://github.com/datahub-project/datahub/actions/runs/29472805849): single
`build-metadata-io` job = **22.4m**.

This PR — run
[`29506078518`](https://github.com/datahub-project/datahub/actions/runs/29506078518):

| job | wall |
|---|---|
| `metadata-io-seed` (compile once, warm cache) | 2.9m |
| slowest leg — `es7-cassandra-neo4j` | 9.0m |
| es8 · opensearch · other · postgresql · sql-opt | 7.6 · 5.6 · 4.3 · 3.6 · 2.8m |
| `codegen-check` (parallel with legs) | 2.2m |
| **critical path** (setup → seed → slowest leg) | **~12.5m** |

**~23m → ~12.5m, ~46% faster** to a pass/fail signal.

Cost tradeoff: ~22 runner-min → ~38 across ~8 jobs (parallel wall-time win, more total
runner-minutes). The seed adds a ~3m serial floor but compiles once instead of 6× cold. Note the
"compile once" win is **cache-dependent, not structural**: the legs skip recompilation only because
the upstream tasks are `@CacheableTask` and resolve `FROM-CACHE`. If a future change disables build
caching on an upstream module, those legs would silently recompile from cold. The two
Elasticsearch suites (`es7-cassandra-neo4j` 9m, `es8` 7.6m) dominate — the natural next split target
if this needs to go lower.

## Testing

- Full workflow green on run
  [`29506078518`](https://github.com/datahub-project/datahub/actions/runs/29506078518) — all 6 legs,
  seed, and `codegen-check` pass.
- Confirmed `:metadata-io:testClasses` pulls the codegen graph (`generateAvroSchema` /
  `generateDataTemplate` across metadata-models, metadata-io, li-utils, … + `graphqlCodegen`), so
  `codegen-check`'s `git status` drift check is real, not a no-op.
- YAML + `actionlint` clean on the workflow and action.
- Coverage parity confirmed (Codecov public API, repo totals): base master `2727b96` = **73.97%**
  (236677/319930 lines) vs PR head `f8f6c0d` = **73.97%** (236657/319930). Identical %, same line
  count; hits differ by 20 lines (0.006% — test nondeterminism in the container suites). Since this
  PR changes only how metadata-io tests are distributed, repo-level equality shows the 6 per-suite
  partials merge under the `metadata-io` flag with no coverage loss vs the old single job. (The
  flag-isolated % is on the Codecov dashboard for an exact reading.)

## Checklist

- [x] PR title follows the Contributing Guideline
- [x] Tests — reshuffles existing suites across runners, same test set (no new tests)
- [ ] Docs — n/a (CI-internal)
- [ ] Breaking changes — none (`free-disk-space` input defaults to current behavior)
