### PR TITLE
fix(lineage): fix wrong viewport while capturing the screenshot

### DIFF
--- a/datahub-web-react/src/app/lineageV2/controls/DownloadLineageScreenshotButton.tsx
+++ b/datahub-web-react/src/app/lineageV2/controls/DownloadLineageScreenshotButton.tsx
@@ -2,7 +2,7 @@ import { Camera } from '@phosphor-icons/react/dist/csr/Camera';
 import { toPng } from 'html-to-image';
 import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getRectOfNodes, getTransformForBounds, useReactFlow } from 'reactflow';
+import { getRectOfNodes, getTransformForBounds, useReactFlow, useStoreApi } from 'reactflow';
 import { useTheme } from 'styled-components';
 
 import LineageControlIcon from '@app/lineage/controls/LineageControlIcon';
@@ -37,6 +37,7 @@ export default function DownloadLineageScreenshotButton({ showExpandedText, isEx
     const { t } = useTranslation('lineage');
     const themeConfig = useTheme();
     const { getNodes } = useReactFlow();
+    const storeApi = useStoreApi();
     const { rootUrn, nodes } = useContext(LineageNodesContext);
 
     const getPreviewImage = () => {
@@ -51,7 +52,18 @@ export default function DownloadLineageScreenshotButton({ showExpandedText, isEx
         // Clean the entity name to be safe for filename use
         const cleanEntityName = entityName.replace(/[^a-zA-Z0-9_-]/g, '_');
 
-        toPng(document.querySelector('.react-flow__viewport') as HTMLElement, {
+        // Scope the viewport lookup to THIS React Flow instance. The page can contain
+        // multiple `.react-flow__viewport` elements (e.g. the Summary tab keeps a hidden
+        // LineageExplorer preview mounted), so a document-wide querySelector may grab the
+        // wrong graph. The store's `domNode` is this instance's `.react-flow` wrapper.
+        const viewport = storeApi.getState().domNode?.querySelector<HTMLElement>('.react-flow__viewport');
+        if (!viewport) {
+            // eslint-disable-next-line no-console
+            console.error('Failed to capture lineage screenshot: react-flow viewport not found');
+            return;
+        }
+
+        toPng(viewport, {
             backgroundColor: themeConfig.colors.bgSurface,
             width: imageWidth,
             height: imageHeight,

--- a/datahub-web-react/src/app/lineageV3/controls/DownloadLineageScreenshotButton.tsx
+++ b/datahub-web-react/src/app/lineageV3/controls/DownloadLineageScreenshotButton.tsx
@@ -2,7 +2,7 @@ import { Camera } from '@phosphor-icons/react/dist/csr/Camera';
 import { toPng } from 'html-to-image';
 import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getRectOfNodes, getTransformForBounds, useReactFlow } from 'reactflow';
+import { getRectOfNodes, getTransformForBounds, useReactFlow, useStoreApi } from 'reactflow';
 import { useTheme } from 'styled-components';
 
 import LineageControlIcon from '@app/lineage/controls/LineageControlIcon';
@@ -19,6 +19,7 @@ export default function DownloadLineageScreenshotButton({ showExpandedText, isEx
     const { t } = useTranslation('lineage');
     const themeConfig = useTheme();
     const { getNodes } = useReactFlow();
+    const storeApi = useStoreApi();
     const { rootUrn, nodes } = useContext(LineageNodesContext);
 
     const getPreviewImage = () => {
@@ -33,7 +34,18 @@ export default function DownloadLineageScreenshotButton({ showExpandedText, isEx
         // Clean the entity name to be safe for filename use
         const cleanEntityName = entityName.replace(/[^a-zA-Z0-9_-]/g, '_');
 
-        toPng(document.querySelector('.react-flow__viewport') as HTMLElement, {
+        // Scope the viewport lookup to THIS React Flow instance. The page can contain
+        // multiple `.react-flow__viewport` elements (e.g. the Summary tab keeps a hidden
+        // LineageExplorer preview mounted), so a document-wide querySelector may grab the
+        // wrong graph. The store's `domNode` is this instance's `.react-flow` wrapper.
+        const viewport = storeApi.getState().domNode?.querySelector<HTMLElement>('.react-flow__viewport');
+        if (!viewport) {
+            // eslint-disable-next-line no-console
+            console.error('Failed to capture lineage screenshot: react-flow viewport not found');
+            return;
+        }
+
+        toPng(viewport, {
             backgroundColor: themeConfig.colors.bgSurface,
             width: imageWidth,
             height: imageHeight,


### PR DESCRIPTION
The problem is related to having two instances of react-flow in the DOM. When we open Summary tab with lineage module it initialize the first one. Then we navigate to Lineage tab when the second one. The Screenshot button chooses the first one that rendering wrong as it's hidden.

Backport of SaaS fix - https://github.com/acryldata/datahub-fork/pull/10898

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
