### PR TITLE
fix(ci): restore Grype report path in security-scan Linear sync

### DIFF
--- a/.github/scripts/ci/run_security_scan_linear_sync.sh
+++ b/.github/scripts/ci/run_security_scan_linear_sync.sh
@@ -12,14 +12,15 @@ fi
 
 shopt -s nullglob
 files=()
+trivy_count=0 grype_count=0
 if [[ "${SCAN_WITH_TRIVY:-}" == "true" ]]; then
   for f in scan-reports/trivy/*.json; do
-    [[ -f "${f}" ]] && files+=("${f}")
+    [[ -f "${f}" ]] && files+=("${f}") && trivy_count=$((trivy_count + 1))
   done
 fi
 if [[ "${SCAN_WITH_GRYPE:-}" == "true" ]]; then
   for f in scan-reports/grype/*.json; do
-    [[ -f "${f}" ]] && files+=("${f}")
+    [[ -f "${f}" ]] && files+=("${f}") && grype_count=$((grype_count + 1))
   done
 fi
 raw_files=()
@@ -28,6 +29,23 @@ if [[ "${SCAN_WITH_GRYPE:-}" == "true" ]]; then
     [[ -f "${f}" ]] && raw_files+=("${f}")
   done
 fi
+echo "Collected ${trivy_count} trivy + ${grype_count} grype merged report(s), ${#raw_files[@]} grype raw report(s)."
+
+# A scanner whose matrix job succeeded must have produced report files; zero files here means
+# they were lost between upload and download (e.g. artifact path/layout drift) — fail loudly
+# instead of silently syncing partial results. A failed scanner job only warns: partial sync of
+# the other scanner is still valuable, and the "Fail on scanner errors" step reds the run anyway.
+check_scanner_files() {
+  local scanner="$1" enabled="$2" result="$3" count="$4"
+  [[ "${enabled}" == "true" && "${count}" -eq 0 ]] || return 0
+  if [[ "${result}" == "success" ]]; then
+    echo "::error::${scanner} scan job succeeded but no merged ${scanner} report JSONs were found; findings would be silently dropped (check artifact upload/download paths)."
+    exit 1
+  fi
+  echo "::warning::No merged ${scanner} report JSONs (scan job result: ${result:-unknown}); syncing without ${scanner} findings."
+}
+check_scanner_files trivy "${SCAN_WITH_TRIVY:-}" "${SCAN_TRIVY_RESULT:-}" "${trivy_count}"
+check_scanner_files grype "${SCAN_WITH_GRYPE:-}" "${SCAN_GRYPE_RESULT:-}" "${grype_count}"
 
 if [[ ${#files[@]} -eq 0 ]]; then
   echo "::notice::No merged scan report JSONs (e.g. all matrix scanner jobs failed or produced no files). Skipping Linear sync."

--- a/.github/workflows/security-scan-linear-sync.yml
+++ b/.github/workflows/security-scan-linear-sync.yml
@@ -805,29 +805,16 @@ jobs:
           merge-multiple: true
           path: scan-reports/trivy
 
-      - name: Download Grype report artifacts (per-image matrix)
+      # The Grype job uploads one artifact per matrix leg whose internal layout already contains
+      # scan-reports/grype/ and scan-reports-raw/grype/ — extract at the workspace root so the
+      # sync script's globs (scan-reports/grype/*.json, scan-reports-raw/grype/*.json) match.
+      - name: Download Grype report artifacts (merged + raw, per matrix)
         if: env.RESOLVED_SCAN_WITH_GRYPE == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: security-scan-grype--*
           merge-multiple: true
-          path: scan-reports/grype
-
-      - name: Download Trivy raw report artifacts (per-image matrix)
-        if: env.RESOLVED_SCAN_WITH_TRIVY == 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: security-scan-trivy-raw--*
-          merge-multiple: true
-          path: scan-reports-raw/trivy
-
-      - name: Download Grype raw report artifacts (per-image matrix)
-        if: env.RESOLVED_SCAN_WITH_GRYPE == 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: security-scan-grype-raw--*
-          merge-multiple: true
-          path: scan-reports-raw/grype
+          path: .
 
       - name: Sync to Linear
         env:
@@ -846,6 +833,8 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           SCAN_WITH_TRIVY: ${{ env.RESOLVED_SCAN_WITH_TRIVY }}
           SCAN_WITH_GRYPE: ${{ env.RESOLVED_SCAN_WITH_GRYPE }}
+          SCAN_TRIVY_RESULT: ${{ needs['scan-trivy'].result }}
+          SCAN_GRYPE_RESULT: ${{ needs['scan-grype'].result }}
           DATAHUB_SCAN_SEVERITIES: ${{ env.RESOLVED_SCAN_SEVERITY_LEVELS }}
           DATAHUB_VARIANT_TAG_SUFFIXES: ${{ needs.select-runner.outputs.variant_suffix_labels }}
         run: bash .github/scripts/ci/run_security_scan_linear_sync.sh


### PR DESCRIPTION
## Summary

The Grype scan job packages merged and raw reports into a single artifact per matrix leg whose internal layout already contains `scan-reports/grype/` and `scan-reports-raw/grype/` (#17200), but the sync job downloads it to `path: scan-reports/grype` — #17405 reverted the download side without reverting the upload side. The files end up double-nested where `run_security_scan_linear_sync.sh`'s non-recursive globs never match, so every Grype finding has been silently excluded from the Linear sync (the sync ran Trivy-only and reported success).

- Download the Grype artifact at the workspace root (`path: .`) so the script's globs (`scan-reports/grype/*.json`, `scan-reports-raw/grype/*.json`) match, and drop the two dead download steps for `security-scan-trivy-raw--*` / `security-scan-grype-raw--*` artifacts that nothing uploads.
- Guard in `run_security_scan_linear_sync.sh`: log collected report counts and fail loudly when a scanner's matrix job succeeded but zero of its report files were collected (warn-and-continue when the scanner job itself failed), so this class of silent drop can't recur.

## Test Plan

- `bash -n` on the sync script and YAML validation of the workflow.
- Verified the upload side's artifact layout (`grype-artifact/scan-reports/grype` + `grype-artifact/scan-reports-raw/grype`) matches the new root-extraction download, and that the sync job's `needs` covers the new `SCAN_TRIVY_RESULT` / `SCAN_GRYPE_RESULT` env vars.
- The identical fix was validated end-to-end in a downstream deployment of this workflow: a live `workflow_dispatch` run collected 3 trivy + 3 grype merged + 3 raw reports, passed `--raw-report-paths`, and synced previously-dropped Grype-only findings; the guard exits 1 on a succeeded-but-empty scanner and warns-and-continues on a failed scanner job.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)