### PR TITLE
fix(graphql): allow delete of data products without domains

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/DeleteDataProductResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/DeleteDataProductResolver.java
@@ -4,6 +4,7 @@ import com.datahub.authentication.Authentication;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.domain.Domains;
@@ -37,8 +38,14 @@ public class DeleteDataProductResolver implements DataFetcher<CompletableFuture<
           Domains domains =
               _dataProductService.getDataProductDomains(
                   context.getOperationContext(), dataProductUrn);
+          // Manage Data Products on any associated domain authorizes deletion. The
+          // DELETE privilege on the data product itself is the fallback: without it,
+          // a data product with no domain would be undeletable by anyone (including
+          // admins), because the domain-scoped check fails closed on an empty domain
+          // set and no domain-scoped policy can match a product without domains.
           if (!DataProductAuthorizationUtils.isAuthorizedToManageDataProductsOnAnyDomain(
-              context, domains)) {
+                  context, domains)
+              && !AuthorizationUtils.canDeleteEntity(dataProductUrn, context)) {
             throw new AuthorizationException(
                 "Unauthorized to perform this action. Please contact your DataHub administrator.");
           }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/DeleteDataProductResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/DeleteDataProductResolverTest.java
@@ -1,0 +1,107 @@
+package com.linkedin.datahub.graphql.resolvers.dataproduct;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.testng.Assert.*;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.domain.Domains;
+import com.linkedin.metadata.service.DataProductService;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletionException;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+public class DeleteDataProductResolverTest {
+
+  private static final String TEST_DATA_PRODUCT_URN = "urn:li:dataProduct:test-product";
+  private static final Urn TEST_DOMAIN_URN = UrnUtils.getUrn("urn:li:domain:test-domain");
+
+  private DataFetchingEnvironment setupMockEnv(QueryContext context) {
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("urn"))).thenReturn(TEST_DATA_PRODUCT_URN);
+    Mockito.when(mockEnv.getContext()).thenReturn(context);
+    return mockEnv;
+  }
+
+  private static Domains domainsWith(Urn domainUrn) {
+    return new Domains().setDomains(new UrnArray(ImmutableList.of(domainUrn)));
+  }
+
+  @Test
+  public void testDeleteWithoutDomainAsPrivilegedUser() throws Exception {
+    // Regression test: a data product with no domain must remain deletable by
+    // a user holding the DELETE privilege on the entity (e.g. an admin).
+    // The domain-based authorization check alone fails closed for everyone
+    // when the product has no domains.
+    DataProductService mockService = Mockito.mock(DataProductService.class);
+    Mockito.when(mockService.verifyEntityExists(any(), any())).thenReturn(true);
+    Mockito.when(mockService.getDataProductDomains(any(), any())).thenReturn(null);
+
+    DeleteDataProductResolver resolver = new DeleteDataProductResolver(mockService);
+    DataFetchingEnvironment mockEnv = setupMockEnv(getMockAllowContext());
+
+    assertTrue(resolver.get(mockEnv).get());
+    Mockito.verify(mockService, Mockito.times(1))
+        .deleteDataProduct(any(), Mockito.eq(UrnUtils.getUrn(TEST_DATA_PRODUCT_URN)));
+  }
+
+  @Test
+  public void testDeleteWithoutDomainUnauthorized() throws Exception {
+    // Fail-closed is preserved for users without any delete privilege.
+    DataProductService mockService = Mockito.mock(DataProductService.class);
+    Mockito.when(mockService.verifyEntityExists(any(), any())).thenReturn(true);
+    Mockito.when(mockService.getDataProductDomains(any(), any())).thenReturn(null);
+
+    DeleteDataProductResolver resolver = new DeleteDataProductResolver(mockService);
+    DataFetchingEnvironment mockEnv = setupMockEnv(getMockDenyContext());
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockService, Mockito.times(0)).deleteDataProduct(any(), any());
+  }
+
+  @Test
+  public void testDeleteWithDomainAuthorized() throws Exception {
+    DataProductService mockService = Mockito.mock(DataProductService.class);
+    Mockito.when(mockService.verifyEntityExists(any(), any())).thenReturn(true);
+    Mockito.when(mockService.getDataProductDomains(any(), any()))
+        .thenReturn(domainsWith(TEST_DOMAIN_URN));
+
+    DeleteDataProductResolver resolver = new DeleteDataProductResolver(mockService);
+    DataFetchingEnvironment mockEnv = setupMockEnv(getMockAllowContext());
+
+    assertTrue(resolver.get(mockEnv).get());
+    Mockito.verify(mockService, Mockito.times(1))
+        .deleteDataProduct(any(), Mockito.eq(UrnUtils.getUrn(TEST_DATA_PRODUCT_URN)));
+  }
+
+  @Test
+  public void testDeleteWithDomainUnauthorized() throws Exception {
+    DataProductService mockService = Mockito.mock(DataProductService.class);
+    Mockito.when(mockService.verifyEntityExists(any(), any())).thenReturn(true);
+    Mockito.when(mockService.getDataProductDomains(any(), any()))
+        .thenReturn(domainsWith(TEST_DOMAIN_URN));
+
+    DeleteDataProductResolver resolver = new DeleteDataProductResolver(mockService);
+    DataFetchingEnvironment mockEnv = setupMockEnv(getMockDenyContext());
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockService, Mockito.times(0)).deleteDataProduct(any(), any());
+  }
+
+  @Test
+  public void testDeleteNonExistentDataProduct() throws Exception {
+    DataProductService mockService = Mockito.mock(DataProductService.class);
+    Mockito.when(mockService.verifyEntityExists(any(), any())).thenReturn(false);
+
+    DeleteDataProductResolver resolver = new DeleteDataProductResolver(mockService);
+    DataFetchingEnvironment mockEnv = setupMockEnv(getMockAllowContext());
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockService, Mockito.times(0)).deleteDataProduct(any(), any());
+  }
+}


### PR DESCRIPTION
## Description

Since #17904, `deleteDataProduct` authorizes exclusively via **Manage Data Products** on a domain associated with the product. For a data product with **no domain**, the check short-circuits to deny before the authorizer is consulted (`isAuthorizedToManageDataProductsOnAnyDomain` over an empty domain set is unconditionally false), so no policy - including the bootstrap "Manage Data Products on All Domains" admin policies added in #17904 - can grant deletion. The entity becomes undeletable by anyone through GraphQL, including platform admins and the root user.

The UI cannot create domain-less data products (`createDataProduct` requires a domain), but the OpenAPI v3 aspect-write path, the Python SDK, and the Terraform provider legitimately can; that is how this was found (a `terraform destroy` failing with "Unauthorized to perform this action" under an admin token).

### Fix

Fall back to the `DELETE` privilege on the data product itself (`AuthorizationUtils.canDeleteEntity`), mirroring the `manage || canDeleteEntity` pattern `DeleteDomainResolver` already uses. The #17904 hardening is fully preserved: unprivileged users remain denied in every case, and the pre-#17904 fail-open behavior (any authenticated user could delete a domain-less product) is not reintroduced.

### Tests

Adds `DeleteDataProductResolverTest` (there was no existing test for this resolver):

- domain-less product + privileged user -> allowed (the regression case; fails without this fix)
- domain-less product + unprivileged user -> denied (fail-closed preserved)
- domained product + authorized / unauthorized -> unchanged behavior
- nonexistent product -> error

The full `resolvers.dataproduct` test package passes.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes correct labels/tags (`breaking-change`/`potential-downtime`/`deprecation`/`big-changes`) are applied to the PR
