### PR TITLE
feat(metadata-models): add logical platform identity

### DIFF
--- a/metadata-ingestion/docs/sources/odcs/README.md
+++ b/metadata-ingestion/docs/sources/odcs/README.md
@@ -21,6 +21,8 @@ relationship). Propagation of the contract's expectations onto physical instance
 handled by DataHub through that relationship — the source itself never writes assertions
 against physical datasets.
 
+These ODCS datasets live on a data platform explicitly marked as logical.
+
 :::info Logical Models are in private beta
 
 Logical Models render in the DataHub UI only when the `LOGICAL_MODELS_ENABLED` feature flag

--- a/metadata-models/docs/entities/dataPlatform.md
+++ b/metadata-models/docs/entities/dataPlatform.md
@@ -48,7 +48,7 @@ While DataHub ships with 100+ pre-defined platforms, you can create custom platf
 - Logical groupings of related systems
 - Platform variations with specific configurations
 
-When creating custom platforms, follow the naming conventions above and ensure uniqueness across your DataHub instance.
+When creating custom platforms, follow the naming conventions above and ensure uniqueness across your DataHub instance. If datasets on a custom platform represent logical models or specifications rather than physical assets, set `logical: true` in its `dataPlatformInfo` aspect. When `logical` is absent, the platform is treated as non-logical.
 
 ## Important Capabilities
 
@@ -60,6 +60,7 @@ The `dataPlatformInfo` aspect contains the core metadata about a data platform:
 - **displayName**: A user-friendly display name for the platform (e.g., "Google BigQuery" for platform "bigquery")
 - **type**: The category of platform from the PlatformType enumeration
 - **datasetNameDelimiter**: The character used to separate components in dataset names (e.g., "." for Oracle, "/" for HDFS)
+- **logical**: Optional flag indicating that datasets on the platform represent logical models or specifications rather than physical assets; absence is equivalent to `false`
 - **logoUrl**: Optional URL to a logo image representing the platform
 
 #### Platform Types

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
@@ -13,7 +13,7 @@ bootstrap:
       mcps_location: "bootstrap_mcps/root-user.yaml"
 
     - name: data-platforms
-      version: v14
+      version: v15
       blocking: true
       async: false
       mcps_location: "bootstrap_mcps/data-platforms.yaml"

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/data-platforms.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/data-platforms.yaml
@@ -369,6 +369,7 @@
     displayName: Open Data Contract Standard
     type: OTHERS
     logoUrl: "assets/platforms/odcslogo.png"
+    logical: true
 - entityUrn: urn:li:dataPlatform:OpenApi
   entityType: dataPlatform
   aspectName: dataPlatformInfo


### PR DESCRIPTION
## Summary
- add an optional searchable `logical` identity marker to `DataPlatformInfo` and expose it through GraphQL
- bootstrap the generic logical platform with the marker and document custom logical platforms
- regenerate Rest.li snapshots and cover present/absent GraphQL mapping

## Test plan
- [x] `./gradlew :datahub-graphql-core:test --tests com.linkedin.datahub.graphql.types.dataplatform.mappers.DataPlatformPropertiesMapperTest`
- [x] `./gradlew :datahub-web-react:graphqlPrettierCheck :datahub-graphql-core:spotlessCheck`
- [x] model, GraphQL, and Rest.li generation tasks
- [x] pre-commit formatting and schema-version checks

## Checklist
- [x] PR title follows the contributing guidelines
- [x] Tests added or updated
- [x] Documentation added or updated
- [x] No breaking change or migration required

Made with [Cursor](https://cursor.com)