### PR TITLE
feat(ingest/odcs): mark platform as logical

### DIFF
--- a/metadata-ingestion/docs/sources/odcs/README.md
+++ b/metadata-ingestion/docs/sources/odcs/README.md
@@ -21,6 +21,8 @@ relationship). Propagation of the contract's expectations onto physical instance
 handled by DataHub through that relationship — the source itself never writes assertions
 against physical datasets.
 
+These ODCS datasets live on a data platform explicitly marked as logical.
+
 :::info Logical Models are in private beta
 
 Logical Models render in the DataHub UI only when the `LOGICAL_MODELS_ENABLED` feature flag

--- a/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
@@ -230,6 +230,7 @@ def odcs_platform_info_mcp() -> MetadataChangeProposalWrapper:
             datasetNameDelimiter=".",
             displayName="Open Data Contract Standard",
             logoUrl="assets/platforms/odcslogo.png",
+            logical=True,
         ),
     )
 

--- a/metadata-ingestion/tests/integration/odcs/bitol_examples/data-types__all-data-types_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/bitol_examples/data-types__all-data-types_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/integration/odcs/bitol_examples/fundamentals__table-column-description_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/bitol_examples/fundamentals__table-column-description_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/integration/odcs/bitol_examples/quality__column-accuracy_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/bitol_examples/quality__column-accuracy_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/integration/odcs/bitol_examples/quality__column-completeness_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/bitol_examples/quality__column-completeness_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/integration/odcs/bitol_examples/quality__column-custom_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/bitol_examples/quality__column-custom_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/integration/odcs/bitol_examples/quality__column-validity_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/bitol_examples/quality__column-validity_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/integration/odcs/bitol_examples/schema__all-schema-types_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/bitol_examples/schema__all-schema-types_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/integration/odcs/bitol_examples/schema__kafka-schema_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/bitol_examples/schema__kafka-schema_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/integration/odcs/bitol_examples/schema__kafka-schemaregistry_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/bitol_examples/schema__kafka-schemaregistry_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/integration/odcs/bitol_examples/schema__table-column_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/bitol_examples/schema__table-column_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/integration/odcs/bitol_examples/schema__table-columns-with-partition_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/bitol_examples/schema__table-columns-with-partition_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/integration/odcs/bitol_examples/server__kafka-server_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/bitol_examples/server__kafka-server_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/integration/odcs/odcs_bitol_full_example_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/odcs_bitol_full_example_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/integration/odcs/odcs_full_v31_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/odcs_full_v31_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/integration/odcs/odcs_minimal_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/odcs_minimal_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/integration/odcs/odcs_minimal_no_binding_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/odcs_minimal_no_binding_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/integration/odcs/odcs_synthetic_ecommerce_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/odcs_synthetic_ecommerce_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/integration/odcs/odcs_v302_mces_golden.json
+++ b/metadata-ingestion/tests/integration/odcs/odcs_v302_mces_golden.json
@@ -10,6 +10,7 @@
             "displayName": "Open Data Contract Standard",
             "type": "OTHERS",
             "datasetNameDelimiter": ".",
+            "logical": true,
             "logoUrl": "assets/platforms/odcslogo.png"
         }
     },

--- a/metadata-ingestion/tests/unit/odcs/test_odcs_mapper.py
+++ b/metadata-ingestion/tests/unit/odcs/test_odcs_mapper.py
@@ -674,6 +674,7 @@ def test_platform_info_registers_odcs() -> None:
     assert isinstance(mcp.aspect, DataPlatformInfoClass)
     assert mcp.aspect.name == "odcs"
     assert mcp.aspect.displayName == "Open Data Contract Standard"
+    assert mcp.aspect.logical is True
 
 
 # ---------------------------------------------------------------------------

--- a/metadata-ingestion/tests/unit/odcs/test_odcs_source.py
+++ b/metadata-ingestion/tests/unit/odcs/test_odcs_source.py
@@ -295,6 +295,7 @@ def test_platform_info_emitted_once_and_not_primary(tmp_path: pathlib.Path) -> N
     platform_aspect = _mcp(platform_wus[0]).aspect
     assert isinstance(platform_aspect, DataPlatformInfoClass)
     assert platform_aspect.name == "odcs"
+    assert platform_aspect.logical is True
     assert not platform_wus[0].is_primary_source
 
 

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
@@ -13,7 +13,7 @@ bootstrap:
       mcps_location: "bootstrap_mcps/root-user.yaml"
 
     - name: data-platforms
-      version: v15
+      version: v16
       blocking: true
       async: false
       mcps_location: "bootstrap_mcps/data-platforms.yaml"

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/data-platforms.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/data-platforms.yaml
@@ -369,6 +369,7 @@
     displayName: Open Data Contract Standard
     type: OTHERS
     logoUrl: "assets/platforms/odcslogo.png"
+    logical: true
 - entityUrn: urn:li:dataPlatform:OpenApi
   entityType: dataPlatform
   aspectName: dataPlatformInfo


### PR DESCRIPTION
## Summary
- mark the ODCS platform as logical in bootstrap metadata and runtime ingestion emissions
- preserve the marker across whole-aspect upserts and assert it in mapper and source tests
- refresh ODCS integration goldens and clarify the logical-platform identity in connector docs

Depends on #18451.

## Test plan
- [x] `./gradlew :metadata-ingestion:lintFix`
- [x] focused `testSingle` runs for both ODCS unit files
- [x] focused `testSingle` runs for both ODCS integration drivers without golden updates
- [x] regenerated both integration golden sets through `--update-golden-files`
- [x] focused GraphQL mapper test and pre-commit checks

## Checklist
- [x] PR title follows the contributing guidelines
- [x] Tests added or updated
- [x] Documentation added or updated
- [x] No breaking change or migration required

Made with [Cursor](https://cursor.com)