### PR TITLE
fix(applications): open application page in same tab, not a new tab

### DIFF
--- a/datahub-web-react/src/app/applications/ApplicationsTableColumns.tsx
+++ b/datahub-web-react/src/app/applications/ApplicationsTableColumns.tsx
@@ -4,6 +4,7 @@ import { Dropdown } from 'antd';
 import React from 'react';
 import Highlight from 'react-highlighter';
 import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router';
 import styled from 'styled-components';
 
 import { CardIcons } from '@app/govern/structuredProperties/styledComponents';
@@ -63,11 +64,12 @@ export const ApplicationNameColumn = React.memo(
         searchQuery?: string;
     }) => {
         const entityRegistry = useEntityRegistry();
+        const history = useHistory();
         const url = entityRegistry.getEntityUrl(EntityType.Application, applicationUrn);
 
         return (
             <ColumnContainer>
-                <ApplicationName onClick={() => window.open(url, '_blank')} data-testid={`${applicationUrn}-name`}>
+                <ApplicationName onClick={() => history.push(url)} data-testid={`${applicationUrn}-name`}>
                     <Highlight search={searchQuery}>{displayName}</Highlight>
                 </ApplicationName>
             </ColumnContainer>
@@ -105,13 +107,14 @@ export const ApplicationActionsColumn = React.memo(
         const { t } = useTranslation('misc');
         const { t: tc } = useTranslation('common.actions');
         const entityRegistry = useEntityRegistry();
+        const history = useHistory();
         const url = entityRegistry.getEntityUrl(EntityType.Application, applicationUrn);
 
         const items = [
             {
                 key: '0',
                 label: (
-                    <MenuItem onClick={() => window.open(url, '_blank')} data-testid="action-edit">
+                    <MenuItem onClick={() => history.push(url)} data-testid="action-edit">
                         {tc('view')}
                     </MenuItem>
                 ),


### PR DESCRIPTION
## Summary
- The Applications management table (`/applications`) was the only entity table that opened the entity page in a **new browser tab** (`window.open(url, '_blank')`), inconsistent with every other entity table, which navigates in-tab via React Router.
- Replaced both `window.open(url, '_blank')` call sites in `ApplicationsTableColumns.tsx` — the row name click and the "View" dropdown action — with `useHistory().push(url)`, matching the canonical `history.push(entityRegistry.getEntityUrl(...))` pattern used across the codebase (e.g. `TagsTableColumns`, `DomainNode`, `NodeItem`, `RelatedTermsModule`).

## Context
Clicking an application (its name or the "View" action) previously opened a new browser tab, inconsistent with all other entity links in the UI, which navigate in the same tab. This aligns Applications with the rest of the UI.

## Test plan
- [ ] Open `/applications` (Manage Applications)
- [ ] Click an application name → application entity page opens in the **same** tab (no new tab)
- [ ] Open the row actions dropdown → "View" → opens in the same tab
- [ ] Confirm other entry points to application pages are unaffected

## Checklist
- [x] PR conforms to the Contributing Guideline (PR title: `fix(applications): ...`)
- [ ] Links to related issues (none — standalone consistency fix)
- [ ] Tests added/updated (none — no unit tests exist for this column component; change is a 2-line behavioral alignment mirroring an existing pattern)
- [ ] Docs added/updated (none — no user-facing API or breaking change)
- [ ] Breaking changes documented in `docs/how/updating-datahub.md` (none — non-breaking)

## Verification
- `yarn lint` (eslint + prettier) on the changed file: clean (prettier reported file unchanged)
- `yarn type-check`: no errors in the changed file

Made with [Cursor](https://cursor.com)