### PR TITLE
fix(ui/ci): generate source maps on Cloudflare Pages previews for Meticulous

### DIFF
--- a/.github/scripts/check_sourcemap_sizes.py
+++ b/.github/scripts/check_sourcemap_sizes.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Fail the frontend preview build if any source map exceeds Cloudflare Pages' per-file limit.
+
+Cloudflare Pages rejects any single file over 25 MiB (26,214,400 bytes — marketed as "26.2 MB"
+using decimal MB), which silently breaks the preview deploy after merge. That preview is the
+environment Meticulous records against, so a rejected *.js.map means no source coverage. This
+guards on the PR instead: hard-fail if any map reaches the limit, warn earlier so a chunk can be
+split (see manualChunks in datahub-web-react/vite.config.ts) before it ever hard-fails.
+
+Comparisons are in BYTES against Cloudflare's exact ceiling — do NOT use 26.2 * 1024 * 1024, which
+is ~1.26 MB too generous and would pass files Cloudflare then rejects.
+"""
+
+import glob
+import os
+import sys
+from typing import List
+
+HARD_LIMIT = 26_214_400  # Cloudflare Pages per-file hard limit (25 MiB), in bytes
+WARN_LIMIT = int(HARD_LIMIT * 0.9)  # early-warning threshold (~90% of the hard limit)
+MIB = 1024 * 1024
+
+DEFAULT_MAPS_GLOB = "datahub-web-react/dist/assets/*.map"
+
+
+def resolve_maps(args: List[str]) -> List[str]:
+    """Resolve the map files from CLI args.
+
+    Accepts either a single glob pattern (when the caller quotes it) or a list of already
+    shell-expanded file paths (when the caller leaves the glob unquoted). Every arg is run through
+    glob.glob so a literal path resolves to itself and an unmatched pattern resolves to nothing;
+    this makes the guard behave identically regardless of how the workflow quotes the argument.
+    """
+    matched: List[str] = []
+    for arg in args:
+        matched.extend(glob.glob(arg))
+    # De-dupe while sorting largest-first, so the summary lists the biggest map at the top.
+    return sorted(set(matched), key=os.path.getsize, reverse=True)
+
+
+def main(args: List[str]) -> int:
+    maps = resolve_maps(args or [DEFAULT_MAPS_GLOB])
+    if not maps:
+        # The build ran with -Psourcemap, so maps must exist here. None means generation silently
+        # broke (e.g. a stale build cache) — fail loudly rather than skip, since a mapless deploy is
+        # exactly the Meticulous-coverage regression this guards against.
+        print(
+            "::error title=No source maps generated::The -Psourcemap build produced no "
+            f"*.js.map matching {' '.join(args) or DEFAULT_MAPS_GLOB}. "
+            "Source-map generation is broken."
+        )
+        print("FAIL: expected source maps after a -Psourcemap build, found none.")
+        return 1
+
+    over, warn = [], []
+    for m in maps:
+        size = os.path.getsize(m)
+        name = os.path.basename(m)
+        print(f"  {size / MIB:6.2f} MiB  {name}")
+        if size >= HARD_LIMIT:
+            over.append((name, size))
+        elif size >= WARN_LIMIT:
+            warn.append((name, size))
+
+    # GitHub Actions annotations surface in the PR "Files changed" / checks UI.
+    for name, size in warn:
+        print(
+            "::warning title=Sourcemap approaching Cloudflare limit::"
+            f"{name} is {size / MIB:.2f} MiB (warn >= {WARN_LIMIT / MIB:.2f} MiB, hard limit "
+            f"{HARD_LIMIT / MIB:.2f} MiB). Split a chunk in vite.config.ts manualChunks soon."
+        )
+
+    if over:
+        for name, size in over:
+            print(
+                "::error title=Sourcemap over Cloudflare limit::"
+                f"{name} is {size / MIB:.2f} MiB ({size} bytes), exceeding the Cloudflare Pages "
+                f"{HARD_LIMIT / MIB:.2f} MiB ({HARD_LIMIT} bytes) per-file limit. Split this chunk "
+                "in vite.config.ts manualChunks."
+            )
+        print(
+            f"\nFAIL: {len(over)} source map(s) exceed the {HARD_LIMIT / MIB:.2f} MiB "
+            "Cloudflare Pages limit."
+        )
+        return 1
+
+    biggest = os.path.getsize(maps[0])
+    print(
+        f"\nOK: all {len(maps)} source maps under {HARD_LIMIT / MIB:.2f} MiB "
+        f"(largest {biggest / MIB:.2f} MiB, {(HARD_LIMIT - biggest) / MIB:.2f} MiB headroom)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/workflows/react-cloudflare-pages.yml
+++ b/.github/workflows/react-cloudflare-pages.yml
@@ -69,65 +69,11 @@ jobs:
       - name: Check sourcemap sizes against Cloudflare limit
         # Must run immediately after the -Psourcemap build and BEFORE "Report initial JS bundle
         # size", which rebuilds dist/ from the base commit without sourcemaps and would wipe the
-        # maps this step inspects. Cloudflare Pages rejects any single file over 25 MiB
-        # (26,214,400 bytes — it markets this as "26.2 MB" using decimal MB), which silently
-        # breaks the deploy after merge (this is why -Psourcemap was hotfix-removed once). Catch
-        # it on the PR instead: hard-fail if any *.map reaches the limit, warn earlier so a chunk
-        # can be split (see manualChunks in vite.config.ts) before it ever hard-fails. Comparisons
-        # are in BYTES against Cloudflare's exact ceiling — do NOT use 26.2*1024*1024, which is
-        # ~1.26 MB too generous and would pass files Cloudflare then rejects.
+        # maps this step inspects. See .github/scripts/check_sourcemap_sizes.py for why the limit
+        # matters (a rejected map silently breaks the Meticulous preview deploy — the reason
+        # -Psourcemap was hotfix-removed once).
         if: ${{ needs.setup.outputs.frontend_change == 'true' }}
-        run: |
-          python3 - <<'PY'
-          import glob, os, sys
-
-          HARD_LIMIT = 26_214_400             # Cloudflare Pages per-file limit: 25 MiB, byte-exact.
-          WARN_LIMIT = int(HARD_LIMIT * 0.9)  # early-warning threshold (~90% of the hard limit)
-          MIB = 1024 * 1024
-
-          maps = sorted(glob.glob('datahub-web-react/dist/assets/*.map'),
-                        key=os.path.getsize, reverse=True)
-          if not maps:
-              # The build ran with -Psourcemap, so maps must exist here. None means generation
-              # silently broke (e.g. a stale build cache) — fail loudly rather than skip, since a
-              # mapless deploy is exactly the Meticulous-coverage regression this guards against.
-              print('::error title=No source maps generated::The -Psourcemap build produced no '
-                    '*.js.map in datahub-web-react/dist/assets. Source-map generation is broken.')
-              print('FAIL: expected source maps after a -Psourcemap build, found none.')
-              sys.exit(1)
-
-          over, warn = [], []
-          for m in maps:
-              size = os.path.getsize(m)
-              name = os.path.basename(m)
-              print(f'  {size / MIB:6.2f} MiB  {name}')
-              if size >= HARD_LIMIT:
-                  over.append((name, size))
-              elif size >= WARN_LIMIT:
-                  warn.append((name, size))
-
-          # GitHub Actions annotations surface in the PR "Files changed" / checks UI.
-          for name, size in warn:
-              print(f'::warning title=Sourcemap approaching Cloudflare limit::'
-                    f'{name} is {size / MIB:.2f} MiB (warn >= {WARN_LIMIT / MIB:.2f} MiB, hard '
-                    f'limit {HARD_LIMIT / MIB:.2f} MiB). Split a chunk in vite.config.ts '
-                    f'manualChunks soon.')
-
-          if over:
-              for name, size in over:
-                  print(f'::error title=Sourcemap over Cloudflare limit::'
-                        f'{name} is {size / MIB:.2f} MiB ({size} bytes), exceeding the Cloudflare '
-                        f'Pages {HARD_LIMIT / MIB:.2f} MiB ({HARD_LIMIT} bytes) per-file limit. '
-                        f'Split this chunk in vite.config.ts manualChunks.')
-              print(f'\nFAIL: {len(over)} source map(s) exceed the {HARD_LIMIT / MIB:.2f} MiB '
-                    f'Cloudflare Pages limit.')
-              sys.exit(1)
-
-          biggest = os.path.getsize(maps[0])
-          print(f'\nOK: all {len(maps)} source maps under {HARD_LIMIT / MIB:.2f} MiB '
-                f'(largest {biggest / MIB:.2f} MiB, {(HARD_LIMIT - biggest) / MIB:.2f} MiB '
-                f'headroom).')
-          PY
+        run: python3 .github/scripts/check_sourcemap_sizes.py datahub-web-react/dist/assets/*.map
       - name: Publish
         if: ${{ needs.setup.outputs.frontend_change == 'true' && needs.setup.outputs.cloudflare_token_available == 'true' }}
         uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca # v1

--- a/.github/workflows/react-cloudflare-pages.yml
+++ b/.github/workflows/react-cloudflare-pages.yml
@@ -65,7 +65,84 @@ jobs:
       - name: Gradle build for frontend
         if: ${{ needs.setup.outputs.frontend_change == 'true' }}
         run: |
-          ./gradlew :datahub-web-react:build -x test -x check --parallel
+          ./gradlew :datahub-web-react:build -Psourcemap -x test -x check --parallel
+      - name: Check sourcemap sizes against Cloudflare limit
+        # Must run immediately after the -Psourcemap build and BEFORE "Report initial JS bundle
+        # size", which rebuilds dist/ from the base commit without sourcemaps and would wipe the
+        # maps this step inspects. Cloudflare Pages rejects any single file over 25 MiB
+        # (26,214,400 bytes — it markets this as "26.2 MB" using decimal MB), which silently
+        # breaks the deploy after merge (this is why -Psourcemap was hotfix-removed once). Catch
+        # it on the PR instead: hard-fail if any *.map reaches the limit, warn earlier so a chunk
+        # can be split (see manualChunks in vite.config.ts) before it ever hard-fails. Comparisons
+        # are in BYTES against Cloudflare's exact ceiling — do NOT use 26.2*1024*1024, which is
+        # ~1.26 MB too generous and would pass files Cloudflare then rejects.
+        if: ${{ needs.setup.outputs.frontend_change == 'true' }}
+        run: |
+          python3 - <<'PY'
+          import glob, os, sys
+
+          HARD_LIMIT = 26_214_400             # Cloudflare Pages per-file limit: 25 MiB, byte-exact.
+          WARN_LIMIT = int(HARD_LIMIT * 0.9)  # early-warning threshold (~90% of the hard limit)
+          MIB = 1024 * 1024
+
+          maps = sorted(glob.glob('datahub-web-react/dist/assets/*.map'),
+                        key=os.path.getsize, reverse=True)
+          if not maps:
+              # The build ran with -Psourcemap, so maps must exist here. None means generation
+              # silently broke (e.g. a stale build cache) — fail loudly rather than skip, since a
+              # mapless deploy is exactly the Meticulous-coverage regression this guards against.
+              print('::error title=No source maps generated::The -Psourcemap build produced no '
+                    '*.js.map in datahub-web-react/dist/assets. Source-map generation is broken.')
+              print('FAIL: expected source maps after a -Psourcemap build, found none.')
+              sys.exit(1)
+
+          over, warn = [], []
+          for m in maps:
+              size = os.path.getsize(m)
+              name = os.path.basename(m)
+              print(f'  {size / MIB:6.2f} MiB  {name}')
+              if size >= HARD_LIMIT:
+                  over.append((name, size))
+              elif size >= WARN_LIMIT:
+                  warn.append((name, size))
+
+          # GitHub Actions annotations surface in the PR "Files changed" / checks UI.
+          for name, size in warn:
+              print(f'::warning title=Sourcemap approaching Cloudflare limit::'
+                    f'{name} is {size / MIB:.2f} MiB (warn >= {WARN_LIMIT / MIB:.2f} MiB, hard '
+                    f'limit {HARD_LIMIT / MIB:.2f} MiB). Split a chunk in vite.config.ts '
+                    f'manualChunks soon.')
+
+          if over:
+              for name, size in over:
+                  print(f'::error title=Sourcemap over Cloudflare limit::'
+                        f'{name} is {size / MIB:.2f} MiB ({size} bytes), exceeding the Cloudflare '
+                        f'Pages {HARD_LIMIT / MIB:.2f} MiB ({HARD_LIMIT} bytes) per-file limit. '
+                        f'Split this chunk in vite.config.ts manualChunks.')
+              print(f'\nFAIL: {len(over)} source map(s) exceed the {HARD_LIMIT / MIB:.2f} MiB '
+                    f'Cloudflare Pages limit.')
+              sys.exit(1)
+
+          biggest = os.path.getsize(maps[0])
+          print(f'\nOK: all {len(maps)} source maps under {HARD_LIMIT / MIB:.2f} MiB '
+                f'(largest {biggest / MIB:.2f} MiB, {(HARD_LIMIT - biggest) / MIB:.2f} MiB '
+                f'headroom).')
+          PY
+      - name: Publish
+        if: ${{ needs.setup.outputs.frontend_change == 'true' && needs.setup.outputs.cloudflare_token_available == 'true' }}
+        uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca # v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: datahub-project-web-react
+          workingDirectory: datahub-web-react
+          directory: dist
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+      # Runs LAST because it is destructive: it checks out the base commit's src/ and rebuilds
+      # dist/ in place (without -Psourcemap) to measure the base bundle size. It must run after
+      # Publish so Cloudflare deploys the real PR build WITH sourcemaps — otherwise the maps
+      # Meticulous needs are overwritten before deploy. continue-on-error keeps a measurement
+      # failure from blocking the deploy.
       - name: Report initial JS bundle size
         if: ${{ needs.setup.outputs.frontend_change == 'true' && github.event_name == 'pull_request' }}
         continue-on-error: true
@@ -117,13 +194,3 @@ jobs:
 
           gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$BODY" --edit-last \
             || gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$BODY"
-      - name: Publish
-        if: ${{ needs.setup.outputs.frontend_change == 'true' && needs.setup.outputs.cloudflare_token_available == 'true' }}
-        uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca # v1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: datahub-project-web-react
-          workingDirectory: datahub-web-react
-          directory: dist
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/datahub-web-react/build.gradle
+++ b/datahub-web-react/build.gradle
@@ -246,6 +246,10 @@ task yarnBuild(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate, generateLa
   args = ['run', project.hasProperty('sourcemap') ? 'buildWithSourceMap' :'build']
 
   outputs.cacheIf { true }
+  // The -Psourcemap flag switches yarnBuild between build-only and buildWithSourceMap-only, which
+  // produce different outputs (with vs without *.js.map). It must be part of the cache key, or a
+  // -Psourcemap build silently restores a prior no-sourcemap cache entry and emits no maps.
+  inputs.property('sourcemap', project.hasProperty('sourcemap'))
   inputs.files(
     file('index.html'),
     project.fileTree(dir: "src"),

--- a/datahub-web-react/src/utils/__tests__/runtimeBasePath.test.ts
+++ b/datahub-web-react/src/utils/__tests__/runtimeBasePath.test.ts
@@ -100,6 +100,19 @@ describe('runtimeBasePath', () => {
 
             expect(result).toBe('');
         });
+
+        it('should ignore an unsubstituted "@basePath" placeholder and fall through to root', () => {
+            // Static hosts (e.g. Cloudflare Pages previews) don't substitute the server's
+            // `<base href="@basePath" />` placeholder; trusting it would break every relative URL.
+            process.env.NODE_ENV = 'production';
+            const mockBaseElement = { getAttribute: mockGetAttribute };
+            mockQuerySelector.mockReturnValue(mockBaseElement);
+            mockGetAttribute.mockReturnValue('@basePath');
+
+            const result = getBasePath();
+
+            expect(result).toBe('');
+        });
     });
 
     describe('getRuntimeBasePath', () => {

--- a/datahub-web-react/src/utils/runtimeBasePath.ts
+++ b/datahub-web-react/src/utils/runtimeBasePath.ts
@@ -11,7 +11,13 @@ export function getBasePath(): string {
     const baseTag = document.querySelector('base');
     if (baseTag) {
         const href = baseTag.getAttribute('href');
-        if (href) {
+        // index.html ships `<base href="@basePath" />` as a placeholder that the datahub-frontend
+        // server substitutes at serve time. Static hosts (e.g. the Cloudflare Pages preview used
+        // for Meticulous) don't substitute it, leaving the literal "@basePath". Trusting that value
+        // makes every relative URL resolve under /@basePath/... — assets and /mfe/config 404, and an
+        // early "Failed to fetch" can hit the top-level error boundary. Treat any unsubstituted
+        // placeholder (leading '@') as "no base tag" and fall through to the root fallback.
+        if (href && !href.startsWith('@')) {
             // Remove trailing slash for consistency (except for root)
             return href === '/' ? '' : href.replace(/\/$/, '');
         }

--- a/datahub-web-react/vite.config.ts
+++ b/datahub-web-react/vite.config.ts
@@ -228,6 +228,16 @@ export default defineConfig(async ({ mode }) => {
             workers: 3, // default is number of CPU cores
             rollupOptions: {
                 output: {
+                    // Emit source maps without inlined sourcesContent. The original source text is
+                    // ~70% of each map's bytes and pushes the largest 'source' map over Cloudflare
+                    // Pages' 25 MiB (26,214,400 byte) per-file limit, which breaks the preview
+                    // deploy Meticulous records against. The mappings + source paths that remain are
+                    // what Meticulous needs to attribute coverage to source files; it fetches the
+                    // original files from the served build rather than reading inlined text. Keeps
+                    // every map well under the limit without splitting app code (static app-code
+                    // splits cut import cycles and cause "cannot access X before initialization"
+                    // TDZ crashes at load).
+                    sourcemapExcludeSources: true,
                     // Split locale JSON files into per-language chunks
                     manualChunks(id: string) {
                         const match = id.match(/\/locales\/([^/]+)\/[^/]+\.json$/);


### PR DESCRIPTION
## Summary

Meticulous source coverage wasn't working on our Cloudflare Pages previews because source maps were not generated.

This PR:
* Re-enables sourcemaps during build generation which enables Meticulous to reach 100% coverage:
* Enables `sourcemapExcludeSources` (don't include sources just the mapping so that each file is around 7MB)

## Drive-by:
- Add a CI guard that fails the PR if any `*.js.map` reaches Cloudflare's limit (byte-exact 26,214,400; warns earlier). Catches size regressions on the PR instead of silently breaking the deploy.
- Fix an intermittent silent crash where Meticulous would show 0 diffs against the CloudFlare env:
   - If failed to fetch fires synchronously at event 0 (during React's initial render) → propagates to ErrorBoundary → crash.
   - If it fires slightly later, async → the app has already mounted → it's caught/tolerated → app renders 

