### PR TITLE
feat(cli): support OAuth login for support users

### DIFF
--- a/metadata-ingestion/src/datahub/cli/oauth_cli.py
+++ b/metadata-ingestion/src/datahub/cli/oauth_cli.py
@@ -126,14 +126,20 @@ def _discover_oauth_server(gms_url: str) -> Dict[str, Any]:
     return metadata
 
 
-def _register_cli_client(registration_endpoint: str, redirect_uri: str) -> str:
+def _register_cli_client(
+    registration_endpoint: str, redirect_uri: str, support: bool = False
+) -> str:
     """RFC 7591 DCR: register a public PKCE client. Returns client_id."""
     try:
         resp = requests.post(
             registration_endpoint,
             json={
                 "client_name": "DataHub CLI",
-                "grant_types": ["authorization_code", "refresh_token"],
+                "grant_types": (
+                    ["authorization_code"]
+                    if support
+                    else ["authorization_code", "refresh_token"]
+                ),
                 "redirect_uris": [redirect_uri],
                 "token_endpoint_auth_method": "none",
                 "scope": "openid datahub:account",
@@ -204,7 +210,12 @@ def _make_callback_handler(
     return _Handler
 
 
-def pkce_login(gms_url: str, timeout_seconds: int = 120) -> OAuthResult:
+def pkce_login(
+    gms_url: str,
+    timeout_seconds: int = 120,
+    support: bool = False,
+    ticket_id: Optional[str] = None,
+) -> OAuthResult:
     """
     Run a PKCE authorization code flow against the DataHub OAuth2 server.
 
@@ -228,6 +239,9 @@ def pkce_login(gms_url: str, timeout_seconds: int = 120) -> OAuthResult:
     Raises:
         click.ClickException: on any failure with a user-friendly message
     """
+    if support and not ticket_id:
+        raise click.ClickException("Support OAuth login requires --ticket-id.")
+
     click.echo("Checking DataHub instance...")
     _check_cloud_instance(gms_url)
     metadata = _discover_oauth_server(gms_url)
@@ -254,7 +268,9 @@ def pkce_login(gms_url: str, timeout_seconds: int = 120) -> OAuthResult:
     redirect_uri = f"http://127.0.0.1:{port}/callback"
 
     click.echo("Registering OAuth2 client...")
-    client_id = _register_cli_client(registration_endpoint, redirect_uri)
+    client_id = _register_cli_client(
+        registration_endpoint, redirect_uri, support=support
+    )
 
     auth_params = {
         "response_type": "code",
@@ -265,6 +281,8 @@ def pkce_login(gms_url: str, timeout_seconds: int = 120) -> OAuthResult:
         "code_challenge_method": "S256",
         "state": state,
     }
+    if support and ticket_id:
+        auth_params.update({"support": "true", "ticket_id": ticket_id})
     auth_url = f"{authorization_endpoint}?{urllib.parse.urlencode(auth_params)}"
 
     server_thread = threading.Thread(

--- a/metadata-ingestion/src/datahub/cli/sso_cli.py
+++ b/metadata-ingestion/src/datahub/cli/sso_cli.py
@@ -1,7 +1,7 @@
 import logging
 import urllib.parse
 from datetime import datetime
-from typing import Tuple
+from typing import Optional, Tuple
 
 import click
 import requests
@@ -88,6 +88,7 @@ def browser_sso_login(
     token_duration: str,
     timeout_ms: int = 120_000,
     support: bool = False,
+    ticket_id: Optional[str] = None,
 ) -> Tuple[str, str]:
     """Open browser for SSO login, extract session, generate access token.
 
@@ -121,7 +122,10 @@ def browser_sso_login(
             context = browser.new_context()
             page = context.new_page()
 
-            page.goto(f"{frontend_url}{auth_path}")
+            auth_url = f"{frontend_url}{auth_path}"
+            if support and ticket_id:
+                auth_url += "?" + urllib.parse.urlencode({"ticket_id": ticket_id})
+            page.goto(auth_url)
 
             # Wait for the actor cookie, which signals successful SSO login.
             actor_urn = None

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -334,7 +334,13 @@ def _validate_init_inputs(
     "--support",
     is_flag=True,
     default=False,
-    help="Use support login path for DataHub Cloud customer debugging (use with --sso)",
+    help="Use support login for DataHub Cloud customer debugging (use with --oauth or --sso)",
+)
+@click.option(
+    "--ticket-id",
+    type=str,
+    default=None,
+    help="Support ticket ID (required with --oauth --support)",
 )
 @click.option(
     "--agent-context",
@@ -353,6 +359,7 @@ def init(
     sso: bool = False,
     oauth: bool = False,
     support: bool = False,
+    ticket_id: Optional[str] = None,
     agent_context: bool = False,
 ) -> None:
     """Configure which DataHub instance to connect to.
@@ -396,7 +403,7 @@ def init(
 
     \b
     Support Login (DataHub Cloud — customer debugging):
-        datahub init --sso --support \\
+        datahub init --oauth --support --ticket-id SUPPORT-123 \\
             --host https://customer.acryl.io/gms
 
     \b
@@ -426,9 +433,12 @@ def init(
         click.echo(text)
         return
 
-    # Validate: --support requires --sso
-    if support and not sso:
-        raise click.UsageError("--support requires --sso")
+    if support and not (sso or oauth):
+        raise click.UsageError("--support requires --oauth or --sso")
+    if ticket_id and not support:
+        raise click.UsageError("--ticket-id requires --support")
+    if support and oauth and not ticket_id:
+        raise click.UsageError("--oauth --support requires --ticket-id")
 
     # Show deprecation warning if --use-password used
     if use_password:
@@ -490,7 +500,7 @@ def init(
         from datahub.cli.config_utils import write_oauth_config
         from datahub.cli.oauth_cli import pkce_login
 
-        result = pkce_login(host_value)
+        result = pkce_login(host_value, support=support, ticket_id=ticket_id)
         click.echo("✓ Successfully authenticated with DataHub")
         if result.refresh_token:
             click.echo(
@@ -512,7 +522,10 @@ def init(
 
         frontend_url = guess_frontend_url_from_gms_url(host_value)
         _, token_value = browser_sso_login(
-            frontend_url, effective_duration, support=support
+            frontend_url,
+            effective_duration,
+            support=support,
+            ticket_id=ticket_id,
         )
         click.echo(f"✓ Generated token (expires: {effective_duration})")
     elif should_generate_token or use_password:

--- a/metadata-ingestion/tests/unit/cli/test_init_cli.py
+++ b/metadata-ingestion/tests/unit/cli/test_init_cli.py
@@ -636,7 +636,7 @@ class TestSSOLogin:
 
         # Verify frontend URL derivation: 8080 -> 9002
         mock_browser_login.assert_called_once_with(
-            "http://localhost:9002", "ONE_MONTH", support=False
+            "http://localhost:9002", "ONE_MONTH", support=False, ticket_id=None
         )
 
     def test_sso_with_custom_duration(self, temp_config: Path, clean_env: None) -> None:
@@ -657,7 +657,7 @@ class TestSSOLogin:
 
         assert result.exit_code == 0
         mock_browser_login.assert_called_once_with(
-            "http://localhost:9002", "ONE_MONTH", support=False
+            "http://localhost:9002", "ONE_MONTH", support=False, ticket_id=None
         )
 
     def test_sso_with_acryl_cloud_url(self, temp_config: Path, clean_env: None) -> None:
@@ -677,7 +677,10 @@ class TestSSOLogin:
         assert result.exit_code == 0
         # For acryl.io, frontend URL is the base without /gms
         mock_browser_login.assert_called_once_with(
-            "https://my-instance.acryl.io", "ONE_HOUR", support=False
+            "https://my-instance.acryl.io",
+            "ONE_HOUR",
+            support=False,
+            ticket_id=None,
         )
 
     def test_sso_support_flag(self, temp_config: Path, clean_env: None) -> None:
@@ -697,7 +700,7 @@ class TestSSOLogin:
 
         assert result.exit_code == 0
         mock_browser_login.assert_called_once_with(
-            "https://customer.acryl.io", "ONE_HOUR", support=True
+            "https://customer.acryl.io", "ONE_HOUR", support=True, ticket_id=None
         )
 
     def test_support_without_sso_errors(
@@ -716,7 +719,7 @@ class TestSSOLogin:
             ],
         )
         assert result.exit_code != 0
-        assert "--support requires --sso" in result.output
+        assert "--support requires --oauth or --sso" in result.output
 
 
 class TestTokenDuration:

--- a/metadata-ingestion/tests/unit/cli/test_oauth_cli.py
+++ b/metadata-ingestion/tests/unit/cli/test_oauth_cli.py
@@ -267,6 +267,19 @@ class TestRegisterCliClient:
                     "http://127.0.0.1:9999/callback",
                 )
 
+    def test_support_client_cannot_request_refresh_tokens(self) -> None:
+        response = _mock_response(201, {"client_id": "support-client"})
+        with patch("requests.post", return_value=response) as mock_post:
+            _register_cli_client(
+                "https://example.datahub.io/auth/oauth2/register",
+                "http://127.0.0.1:9999/callback",
+                support=True,
+            )
+
+        assert mock_post.call_args.kwargs["json"]["grant_types"] == [
+            "authorization_code"
+        ]
+
 
 # ---------------------------------------------------------------------------
 # _generate_pkce_pair
@@ -382,6 +395,8 @@ class TestPkceLogin:
         dcr_status: int = 201,
         dcr_body: Any = None,
         token_response: Any = None,
+        support: bool = False,
+        ticket_id: str | None = None,
     ) -> OAuthResult:
         """Run pkce_login with the loopback server automatically satisfied."""
         import urllib.request
@@ -395,6 +410,7 @@ class TestPkceLogin:
             from urllib.parse import parse_qs, urlparse
 
             params = parse_qs(urlparse(url).query)
+            self.authorization_params = params
             redirect_uri = params["redirect_uri"][0]
             callback_url = (
                 redirect_uri + "?code=test-code-xyz&state=" + params["state"][0]
@@ -419,7 +435,12 @@ class TestPkceLogin:
             ),
             patch("webbrowser.open", side_effect=_auto_callback),
         ):
-            return pkce_login("https://example.datahub.io/gms", timeout_seconds=10)
+            return pkce_login(
+                "https://example.datahub.io/gms",
+                timeout_seconds=10,
+                support=support,
+                ticket_id=ticket_id,
+            )
 
     def test_happy_path_returns_oauth_result(self) -> None:
         result = self._run_pkce_login()
@@ -434,6 +455,17 @@ class TestPkceLogin:
         result = self._run_pkce_login(token_response=token_resp)
         assert result.access_token == "at-only"
         assert result.refresh_token is None
+
+    def test_support_login_adds_ticket_and_prints_fallback_url(
+        self, capsys: Any
+    ) -> None:
+        self._run_pkce_login(support=True, ticket_id="SUPPORT-123")
+
+        assert self.authorization_params["support"] == ["true"]
+        assert self.authorization_params["ticket_id"] == ["SUPPORT-123"]
+        output = capsys.readouterr().out
+        assert "If the browser does not open automatically" in output
+        assert "ticket_id=SUPPORT-123" in output
 
     def test_oss_instance_raises_clear_message(self) -> None:
         import click

--- a/metadata-ingestion/tests/unit/cli/test_oauth_config.py
+++ b/metadata-ingestion/tests/unit/cli/test_oauth_config.py
@@ -385,7 +385,59 @@ class TestInitOAuthFlag:
             init,
             ["--oauth", "--host", "https://example.datahub.io/gms", "--force"],
         )
-        self.mock_pkce.assert_called_once_with("https://example.datahub.io/gms")
+        self.mock_pkce.assert_called_once_with(
+            "https://example.datahub.io/gms", support=False, ticket_id=None
+        )
+
+    def test_oauth_without_host_prompts_for_cloud_url(
+        self, config_path: Path, clean_env: None
+    ) -> None:
+        result = CliRunner().invoke(
+            init,
+            ["--oauth", "--force"],
+            input="https://example.datahub.io/gms\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Enter your DataHub host" in result.output
+        self.mock_pkce.assert_called_once_with(
+            "https://example.datahub.io/gms", support=False, ticket_id=None
+        )
+
+    def test_oauth_support_passes_ticket_to_pkce_login(
+        self, config_path: Path, clean_env: None
+    ) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            init,
+            [
+                "--oauth",
+                "--support",
+                "--ticket-id",
+                "SUPPORT-123",
+                "--host",
+                "https://example.datahub.io/gms",
+                "--force",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        self.mock_pkce.assert_called_once_with(
+            "https://example.datahub.io/gms",
+            support=True,
+            ticket_id="SUPPORT-123",
+        )
+
+    def test_oauth_support_requires_ticket(
+        self, config_path: Path, clean_env: None
+    ) -> None:
+        result = CliRunner().invoke(
+            init,
+            ["--oauth", "--support", "--host", "https://example.datahub.io/gms"],
+        )
+
+        assert result.exit_code != 0
+        assert "requires --ticket-id" in result.output
 
     def test_oauth_prints_refresh_token_stored_message(
         self, config_path: Path, clean_env: None

--- a/metadata-ingestion/tests/unit/cli/test_sso_cli.py
+++ b/metadata-ingestion/tests/unit/cli/test_sso_cli.py
@@ -43,7 +43,24 @@ def mock_playwright():
 
 
 class TestBrowserSsoLogin:
-    def test_extracts_cookies_and_generates_token(self, mock_playwright: dict) -> None:
+    @pytest.mark.parametrize(
+        ("support", "ticket_id", "expected_auth_url"),
+        [
+            (False, None, "http://localhost:9002/authenticate"),
+            (
+                True,
+                "SUPPORT-123",
+                "http://localhost:9002/support/authenticate?ticket_id=SUPPORT-123",
+            ),
+        ],
+    )
+    def test_extracts_cookies_and_generates_token(
+        self,
+        mock_playwright: dict,
+        support: bool,
+        ticket_id: str | None,
+        expected_auth_url: str,
+    ) -> None:
         """Happy path: SSO login succeeds, cookies extracted, token generated."""
         context = mock_playwright["context"]
         context.cookies.return_value = [
@@ -85,11 +102,15 @@ class TestBrowserSsoLogin:
             mock_session.post.side_effect = [list_response, create_response]
 
             token_name, access_token = browser_sso_login(
-                "http://localhost:9002", "ONE_HOUR"
+                "http://localhost:9002",
+                "ONE_HOUR",
+                support=support,
+                ticket_id=ticket_id,
             )
 
         assert access_token == "generated-sso-token-xyz"
         assert "cli token" in token_name
+        mock_playwright["page"].goto.assert_called_once_with(expected_auth_url)
 
         # Verify cookies were set on the session
         assert mock_session.cookies.set.call_count == 2


### PR DESCRIPTION
## Summary

Adds support OAuth login to `datahub init`:

```bash
datahub init --oauth --support --ticket-id SUPPORT-123 \
  --host https://<tenant-host>/gms
```

Support PKCE clients do not request refresh tokens. The CLI prints the authorization URL as a browser fallback, and bare `datahub init --oauth` continues to prompt for the Cloud host. Existing `--sso --support` behavior remains supported.

## Testing

- `./gradlew :metadata-ingestion:lintFix`
- `./gradlew :metadata-ingestion:lint`
- Focused CLI tests: 119 passed
