### PR TITLE
fix(ci): make schemaVersion bump rules match backward compatibility

### DIFF
--- a/.github/scripts/bump_schema_versions.md
+++ b/.github/scripts/bump_schema_versions.md
@@ -137,13 +137,25 @@ Before a changed file is considered for bumping (and before it can cascade a bum
 
 A change is treated as backward-compatible when **all** of the following hold (aligned with the report tool's `fields()` / Additive bucket):
 
-- Every field present on the base branch keeps the same name, type, and optional-ness (annotations and defaults are ignored, matching the report).
+- Every field present on the base branch keeps the same name, type, and optional-ness (field **defaults** are ignored, matching the report).
+- Every field's `@Searchable`, `@Relationship`, `@SearchableRef`, `@TimeseriesField`, and `@TimeseriesFieldCollection` annotations are unchanged (see [Reindex-relevant annotations](#reindex-relevant-annotations) below). All other field annotations (e.g. `@deprecated`, `@compliance`, `@UrnValidation`) are ignored.
 - Every newly added record field is declared `optional`.
 - Every enum symbol present on the base branch is still present (new symbols may be added).
 - `includes` clauses are unchanged.
 - The `@Aspect` annotation is unchanged **except** for `schemaVersion` itself (this is what lets a maintainer intentionally remove a version that was bumped for an additive-only change — e.g. CorpUserInfo / #18278).
 
-Anything else — removing or renaming a field, changing a field's type, flipping optional↔required, adding a non-optional field, removing an enum symbol, or any construct the conservative parser cannot model (e.g. `typeref`) — is treated as a real change and bumps normally. The detector **fails closed**: any parse ambiguity resolves toward bumping, because a missed bump (and its skipped migration) is far more dangerous than an unnecessary one.
+Anything else — removing or renaming a field, changing a field's type, flipping optional↔required, adding a non-optional field, removing an enum symbol, changing/adding/removing a reindex-relevant annotation on an existing field, or any construct the conservative parser cannot model (e.g. `typeref`) — is treated as a real change and bumps normally. The detector **fails closed**: any parse ambiguity resolves toward bumping, because a missed bump (and its skipped migration) is far more dangerous than an unnecessary one.
+
+#### Reindex-relevant annotations
+
+`schemaVersion` also has to catch changes that don't alter a field's serialized shape at all but do
+change how it's indexed. `@Searchable`, `@Relationship`, and `@SearchableRef` drive Elasticsearch
+field/graph-edge mapping; `@TimeseriesField` and `@TimeseriesFieldCollection` drive timeseries field
+indexing. Changing one of these on an existing field — e.g. flipping a `@Searchable` `fieldType`
+from `KEYWORD` to `TEXT` — requires a reindex, so it is bump-worthy even though the field's PDL type
+and optionality never moved. This whitelist (`BUMP_WORTHY_ANNOTATIONS` in the script) is intentionally
+narrow: every other field annotation continues to be parsed-and-discarded exactly as before, so it
+never enters the bump decision.
 
 ### Step 4 — Bump the version
 

--- a/.github/scripts/bump_schema_versions.md
+++ b/.github/scripts/bump_schema_versions.md
@@ -1,6 +1,6 @@
 # bump_schema_versions.py
 
-A pre-commit CLI tool that automatically bumps `schemaVersion` annotations on PDL aspect files whenever their content — or the content of any record/enum/typeref they depend on (via `includes` **or** as a field type) — changes relative to the base branch.
+A pre-commit CLI tool that automatically bumps `schemaVersion` annotations on PDL aspect files whenever their content — or the content of any record/enum/typeref they depend on (via `includes` **or** as a field type) — changes **incompatibly** relative to the base branch. Purely additive, backward-compatible changes (see [Backward-compatible changes](#backward-compatible-changes-are-not-bumped)) are left untouched.
 
 ## Why this exists
 
@@ -129,6 +129,20 @@ DataHubIngestionSourceSchedule.pdl  ← changed (non-aspect)
   └─ used as field type in DataHubIngestionSourceInfo.pdl  (aspect → bumped)
 ```
 
+### Backward-compatible changes are not bumped
+
+`schemaVersion` exists so that migration tooling can detect when data stored at an older version needs transformation before it can be read at the newer version. A change that is purely **additive** leaves every previously-serialized aspect valid and complete, so it requires no migration — and therefore no bump. Before a changed file is considered for bumping (and before it can cascade a bump into dependents), the tool checks whether its only diff vs the base branch is backward-compatible. If so, the file is ignored exactly like a comment-only change.
+
+A change is treated as backward-compatible when **all** of the following hold:
+
+- Every field present on the base branch is unchanged (same name, type, default, and field annotations).
+- Every newly added record field is declared `optional`.
+- Every enum symbol present on the base branch is still present (new symbols may be added).
+- `includes` clauses are unchanged.
+- The `@Aspect` annotation is unchanged **except** for `schemaVersion` itself (this is what lets a maintainer intentionally remove or lower a version that was bumped for an additive-only change).
+
+Anything else — removing or renaming a field, changing a field's type/default/annotations, adding a non-optional field, removing an enum symbol, or any construct the conservative parser cannot model (e.g. `typeref`) — is treated as a real change and bumps normally. The detector **fails closed**: any parse ambiguity resolves toward bumping, because a missed bump (and its skipped migration) is far more dangerous than an unnecessary one.
+
 ### Step 4 — Bump the version
 
 For each affected aspect:
@@ -226,5 +240,5 @@ Add to `.pre-commit-config.yaml`:
 
 - Only PDL files under PDL_ROOTS (or default `metadata-models/src/main/pegasus/`) are scanned for the include graph.
 - Only records with an `@Aspect` annotation get a version bump; plain records and union types are skipped.
-- The tool does not validate that the schema change is backwards-compatible — it only tracks that _a_ change occurred.
+- Backward-compatible changes (additive optional fields, added enum symbols, new type definitions) do not bump — see [Backward-compatible changes](#backward-compatible-changes-are-not-bumped). The backward-compatibility check is intentionally conservative and models only records and enums; it fails closed (bumps) on anything it cannot parse, so it never waves through a change it does not fully understand.
 - Deleted aspects (files removed in the diff) are not processed.

--- a/.github/scripts/bump_schema_versions.md
+++ b/.github/scripts/bump_schema_versions.md
@@ -131,17 +131,19 @@ DataHubIngestionSourceSchedule.pdl  ← changed (non-aspect)
 
 ### Backward-compatible changes are not bumped
 
-`schemaVersion` exists so that migration tooling can detect when data stored at an older version needs transformation before it can be read at the newer version. A change that is purely **additive** leaves every previously-serialized aspect valid and complete, so it requires no migration — and therefore no bump. Before a changed file is considered for bumping (and before it can cascade a bump into dependents), the tool checks whether its only diff vs the base branch is backward-compatible. If so, the file is ignored exactly like a comment-only change.
+`schemaVersion` exists so that migration tooling can detect when data stored at an older version needs transformation before it can be read at the newer version. A change that is purely **additive** leaves every previously-serialized aspect valid and complete, so it requires no migration — and therefore no bump. This matches the Additive vs Breaking taxonomy in [`report_aspect_changes.py`](report_pdl_aspect_changes.md): only breaking changes require a version hop.
 
-A change is treated as backward-compatible when **all** of the following hold:
+Before a changed file is considered for bumping (and before it can cascade a bump into dependents), the tool checks whether its only diff vs the base branch is backward-compatible. If so, the file is ignored exactly like a comment-only change.
 
-- Every field present on the base branch is unchanged (same name, type, default, and field annotations).
+A change is treated as backward-compatible when **all** of the following hold (aligned with the report tool's `fields()` / Additive bucket):
+
+- Every field present on the base branch keeps the same name, type, and optional-ness (annotations and defaults are ignored, matching the report).
 - Every newly added record field is declared `optional`.
 - Every enum symbol present on the base branch is still present (new symbols may be added).
 - `includes` clauses are unchanged.
-- The `@Aspect` annotation is unchanged **except** for `schemaVersion` itself (this is what lets a maintainer intentionally remove or lower a version that was bumped for an additive-only change).
+- The `@Aspect` annotation is unchanged **except** for `schemaVersion` itself (this is what lets a maintainer intentionally remove a version that was bumped for an additive-only change — e.g. CorpUserInfo / #18278).
 
-Anything else — removing or renaming a field, changing a field's type/default/annotations, adding a non-optional field, removing an enum symbol, or any construct the conservative parser cannot model (e.g. `typeref`) — is treated as a real change and bumps normally. The detector **fails closed**: any parse ambiguity resolves toward bumping, because a missed bump (and its skipped migration) is far more dangerous than an unnecessary one.
+Anything else — removing or renaming a field, changing a field's type, flipping optional↔required, adding a non-optional field, removing an enum symbol, or any construct the conservative parser cannot model (e.g. `typeref`) — is treated as a real change and bumps normally. The detector **fails closed**: any parse ambiguity resolves toward bumping, because a missed bump (and its skipped migration) is far more dangerous than an unnecessary one.
 
 ### Step 4 — Bump the version
 

--- a/.github/scripts/bump_schema_versions.py
+++ b/.github/scripts/bump_schema_versions.py
@@ -657,6 +657,376 @@ def update_schema_version(content: str, new_version: int) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Backward-compatibility detection
+#
+# A schemaVersion bump signals that aspect data stored at the old version may
+# need migration before it can be read at the new version. A change that only
+# *adds optional fields* to a record (or *adds symbols* to an enum, or adds an
+# entirely new type definition) leaves every previously-serialized aspect valid
+# and complete — no migration is required — so it must NOT trigger a bump.
+#
+# The detector is deliberately conservative and fails closed: anything it
+# cannot prove to be additive-only is treated as a real, bump-worthy change. A
+# false "compatible" verdict would silently skip a needed version hop (and any
+# migration keyed on it), whereas a false "incompatible" verdict merely bumps a
+# version that did not strictly need bumping. Only the former is dangerous, so
+# every parse ambiguity resolves toward bumping.
+# ---------------------------------------------------------------------------
+
+_IDENT_RE = re.compile(r"[A-Za-z_]\w*")
+_SCALAR_VALUE_RE = re.compile(r"[-+\w.]+")
+
+
+def _skip_ws(content: str, i: int) -> int:
+    n = len(content)
+    while i < n and content[i].isspace():
+        i += 1
+    return i
+
+
+def _skip_string_literal(content: str, i: int) -> int:
+    """Given content[i] == '"', return the index just past the closing quote."""
+    n = len(content)
+    j = i + 1
+    while j < n:
+        if content[j] == "\\":
+            j += 2
+            continue
+        if content[j] == '"':
+            return j + 1
+        j += 1
+    return n
+
+
+def _skip_balanced(content: str, i: int) -> int | None:
+    """Given content[i] is an opening '{' or '[', return the index just past
+    the matching close, honoring nesting and string literals. None on imbalance.
+    """
+    pairs = {"}": "{", "]": "["}
+    stack: list[str] = []
+    n = len(content)
+    while i < n:
+        c = content[i]
+        if c == '"':
+            i = _skip_string_literal(content, i)
+            continue
+        if c in "{[":
+            stack.append(c)
+            i += 1
+            continue
+        if c in "}]":
+            if not stack or stack[-1] != pairs[c]:
+                return None
+            stack.pop()
+            i += 1
+            if not stack:
+                return i
+            continue
+        i += 1
+    return None
+
+
+def _skip_value(content: str, i: int) -> int | None:
+    """Skip a PDL annotation value (JSON object/array/string/scalar)."""
+    i = _skip_ws(content, i)
+    if i >= len(content):
+        return None
+    ch = content[i]
+    if ch == '"':
+        return _skip_string_literal(content, i)
+    if ch in "{[":
+        return _skip_balanced(content, i)
+    m = _SCALAR_VALUE_RE.match(content, i)
+    return m.end() if m else None
+
+
+def _read_field_type(body: str, i: int) -> int | None:
+    """Scan a field's type/default expression from i, returning the index of the
+    next field/annotation boundary (or end of body). Boundaries at brace depth 0
+    are a leading '@' (next field's annotation) or an identifier immediately
+    followed by ':' (next field's name). Nested braces/brackets and string
+    literals are skipped wholesale so their contents never look like boundaries.
+    """
+    n = len(body)
+    while i < n:
+        c = body[i]
+        if c.isspace():
+            i += 1
+            continue
+        if c == '"':
+            i = _skip_string_literal(body, i)
+            continue
+        if c == "@" or c == ",":
+            return i
+        if c in "{[":
+            j = _skip_balanced(body, i)
+            if j is None:
+                return None
+            i = j
+            continue
+        if c in "}]":
+            return None
+        m = _IDENT_RE.match(body, i)
+        if m:
+            k = _skip_ws(body, m.end())
+            if k < n and body[k] == ":":
+                return i
+            i = m.end()
+            continue
+        i += 1
+    return i
+
+
+def _type_is_optional(type_text: str) -> bool:
+    """True if a field's type expression is declared `optional` (PDL places the
+    keyword at the start of the type, e.g. `field: optional string`)."""
+    return bool(re.match(r"\s*optional\b", type_text))
+
+
+def _parse_record_fields(body: str) -> dict[str, tuple[str, bool]] | None:
+    """Parse the top-level fields of a record body (comments already stripped).
+
+    Returns {field name: (normalized signature, is_optional)}, or None if the
+    body cannot be parsed unambiguously. The signature covers the field's
+    annotations, type, and default — everything but its doc comment — so any
+    change to those is detected as a diff.
+    """
+    fields: dict[str, tuple[str, bool]] = {}
+    n = len(body)
+    i = _skip_ws(body, 0)
+    pending: list[str] = []
+    while i < n:
+        if body[i] == ",":
+            i = _skip_ws(body, i + 1)
+            continue
+        if body[i] == "@":
+            start = i
+            i += 1
+            m = _IDENT_RE.match(body, i)
+            if not m:
+                return None
+            i = m.end()
+            while i < n and body[i] == ".":
+                m = _IDENT_RE.match(body, i + 1)
+                if not m:
+                    return None
+                i = m.end()
+            j = _skip_ws(body, i)
+            if j < n and body[j] == "=":
+                nxt = _skip_value(body, j + 1)
+                if nxt is None:
+                    return None
+                i = nxt
+            pending.append(body[start:i])
+            i = _skip_ws(body, i)
+            continue
+        m = _IDENT_RE.match(body, i)
+        if not m:
+            return None
+        name = m.group(0)
+        k = _skip_ws(body, m.end())
+        if k >= n or body[k] != ":":
+            return None
+        type_start = _skip_ws(body, k + 1)
+        end = _read_field_type(body, type_start)
+        if end is None:
+            return None
+        type_text = body[type_start:end]
+        sig = normalize_pdl_for_compare(" ".join(pending) + " " + type_text)
+        if name in fields:
+            return None
+        fields[name] = (sig, _type_is_optional(type_text))
+        pending = []
+        i = _skip_ws(body, end)
+    return fields
+
+
+def _parse_enum_symbols(body: str) -> set[str] | None:
+    """Return the set of symbol names in an enum body (comments stripped),
+    ignoring per-symbol annotations. None if it cannot be parsed."""
+    symbols: set[str] = set()
+    n = len(body)
+    i = 0
+    while i < n:
+        ch = body[i]
+        if ch.isspace() or ch == ",":
+            i += 1
+            continue
+        if ch == '"':
+            i = _skip_string_literal(body, i)
+            continue
+        if ch == "@":
+            i += 1
+            m = _IDENT_RE.match(body, i)
+            if not m:
+                return None
+            i = m.end()
+            j = _skip_ws(body, i)
+            if j < n and body[j] == "=":
+                nxt = _skip_value(body, j + 1)
+                if nxt is None:
+                    return None
+                i = nxt
+            continue
+        if ch in "{[":
+            j = _skip_balanced(body, i)
+            if j is None:
+                return None
+            i = j
+            continue
+        m = _IDENT_RE.match(body, i)
+        if m:
+            symbols.add(m.group(0))
+            i = m.end()
+            continue
+        i += 1
+    return symbols
+
+
+def _parse_includes_from_header(header: str) -> set[str]:
+    m = re.search(r"\bincludes\b(.*)", header, re.DOTALL)
+    if not m:
+        return set()
+    return {x.strip() for x in m.group(1).split(",") if x.strip()}
+
+
+def parse_top_level_defs(content: str) -> dict[str, dict] | None:
+    """Parse the top-level record/enum definitions in a PDL file.
+
+    Returns {name: {"kind": "record", "includes": set, "fields": {...}}} or
+    {name: {"kind": "enum", "symbols": set}}. Returns None when the file uses a
+    construct this conservative parser does not model (typeref/fixed) or cannot
+    parse — callers then treat the change as bump-worthy.
+    """
+    c = strip_pdl_comments(content)
+    n = len(c)
+    defs: dict[str, dict] = {}
+    i = 0
+    while i < n:
+        ch = c[i]
+        if ch == '"':
+            i = _skip_string_literal(c, i)
+            continue
+        if ch in "{[":
+            j = _skip_balanced(c, i)
+            if j is None:
+                return None
+            i = j
+            continue
+        m = _IDENT_RE.match(c, i)
+        if not m:
+            i += 1
+            continue
+        word = m.group(0)
+        if word in ("typeref", "fixed"):
+            return None
+        if word not in ("record", "enum"):
+            i = m.end()
+            continue
+        nm = _IDENT_RE.match(c, _skip_ws(c, m.end()))
+        if not nm:
+            return None
+        name = nm.group(0)
+        p = nm.end()
+        while p < n and c[p] != "{":
+            if c[p] == '"':
+                p = _skip_string_literal(c, p)
+                continue
+            p += 1
+        if p >= n:
+            return None
+        header = c[nm.end() : p]
+        body_end = _skip_balanced(c, p)
+        if body_end is None:
+            return None
+        body = c[p + 1 : body_end - 1]
+        if word == "record":
+            fields = _parse_record_fields(body)
+            if fields is None:
+                return None
+            defs[name] = {
+                "kind": "record",
+                "includes": _parse_includes_from_header(header),
+                "fields": fields,
+            }
+        else:
+            symbols = _parse_enum_symbols(body)
+            if symbols is None:
+                return None
+            defs[name] = {"kind": "enum", "symbols": symbols}
+        i = body_end
+    return defs
+
+
+def _aspect_annotation_without_version(content: str) -> dict | None:
+    """Return the parsed @Aspect annotation with schemaVersion removed, or None
+    when the file has no @Aspect annotation (e.g. a shared non-aspect record)."""
+    bounds = find_aspect_annotation_bounds(content)
+    if bounds is None:
+        return None
+    try:
+        data = parse_annotation(content[bounds[0] : bounds[1]])
+    except ValueError:
+        return {"__unparseable__": content[bounds[0] : bounds[1]]}
+    data.pop("schemaVersion", None)
+    return data
+
+
+def _defs_backward_compatible(
+    base_defs: dict[str, dict], cur_defs: dict[str, dict]
+) -> bool:
+    """True iff cur_defs differs from base_defs only by additive, migration-free
+    changes: added optional fields, added enum symbols, and entirely new type
+    definitions. Any removal, type/annotation change, or added non-optional
+    field is treated as incompatible.
+    """
+    for name, bdef in base_defs.items():
+        cdef = cur_defs.get(name)
+        if cdef is None or cdef["kind"] != bdef["kind"]:
+            return False
+        if bdef["kind"] == "record":
+            if bdef["includes"] != cdef["includes"]:
+                return False
+            base_fields = bdef["fields"]
+            cur_fields = cdef["fields"]
+            for fname, (bsig, _bopt) in base_fields.items():
+                cur_field = cur_fields.get(fname)
+                if cur_field is None or cur_field[0] != bsig:
+                    return False
+            for fname, (_csig, copt) in cur_fields.items():
+                if fname not in base_fields and not copt:
+                    return False
+        elif not bdef["symbols"].issubset(cdef["symbols"]):
+            return False
+    return True
+
+
+def is_backward_compatible_change(filepath: str, base_ref: str) -> bool:
+    """Return True if filepath's only diff vs base_ref is backward-compatible
+    (additive optional fields / enum symbols / new type defs), meaning no
+    schemaVersion bump is warranted. Fails closed (returns False) on new files,
+    unreadable files, @Aspect changes beyond schemaVersion, or any parse
+    ambiguity.
+    """
+    base_content = get_file_at_branch(filepath, base_ref)
+    if base_content is None:
+        return False
+    try:
+        current_content = Path(filepath).read_text(encoding="utf-8")
+    except OSError:
+        return False
+    if _aspect_annotation_without_version(
+        base_content
+    ) != _aspect_annotation_without_version(current_content):
+        return False
+    base_defs = parse_top_level_defs(base_content)
+    cur_defs = parse_top_level_defs(current_content)
+    if base_defs is None or cur_defs is None:
+        return False
+    return _defs_backward_compatible(base_defs, cur_defs)
+
+
+# ---------------------------------------------------------------------------
 # Include graph
 # ---------------------------------------------------------------------------
 
@@ -831,6 +1201,26 @@ def main() -> int:
         if args.verbose:
             print(f"Ignoring {len(comment_only)} comment-only PDL change(s):")
             for f in comment_only:
+                print(f"  {f}")
+            print()
+
+    # Drop files whose only diff vs the merge-base is backward-compatible —
+    # additive optional fields, added enum symbols, or new type definitions.
+    # Such changes need no migration, so they must neither bump the edited file
+    # nor cascade a bump into aspects that reference it.
+    backward_compatible = [
+        f for f in directly_changed if is_backward_compatible_change(f, merge_base)
+    ]
+    if backward_compatible:
+        directly_changed = [
+            f for f in directly_changed if f not in set(backward_compatible)
+        ]
+        if args.verbose:
+            print(
+                f"Ignoring {len(backward_compatible)} backward-compatible PDL "
+                "change(s) (additive optional fields / enum symbols only):"
+            )
+            for f in backward_compatible:
                 print(f"  {f}")
             print()
 

--- a/.github/scripts/bump_schema_versions.py
+++ b/.github/scripts/bump_schema_versions.py
@@ -783,24 +783,34 @@ def _type_is_optional(type_text: str) -> bool:
     return bool(re.match(r"\s*optional\b", type_text))
 
 
+def _strip_field_default(type_text: str) -> str:
+    """Drop a trailing PDL default (`= ...`) so type comparison matches the
+    report tool, which ignores defaults when deciding whether a field changed.
+    """
+    return re.sub(r"\s*=\s*.*$", "", type_text).strip()
+
+
 def _parse_record_fields(body: str) -> dict[str, tuple[str, bool]] | None:
     """Parse the top-level fields of a record body (comments already stripped).
 
-    Returns {field name: (normalized signature, is_optional)}, or None if the
-    body cannot be parsed unambiguously. The signature covers the field's
-    annotations, type, and default — everything but its doc comment — so any
-    change to those is detected as a diff.
+    Returns {field name: (normalized type, is_optional)}, or None if the body
+    cannot be parsed unambiguously.
+
+    Comparison is aligned with report_aspect_changes.fields(): only the field's
+    type and optional-ness matter for bump decisions. Annotations and defaults
+    are parsed (so the scanner stays positioned correctly) but do not enter the
+    signature — changing a @Searchable annotation or a default alone is not
+    bump-worthy.
     """
     fields: dict[str, tuple[str, bool]] = {}
     n = len(body)
     i = _skip_ws(body, 0)
-    pending: list[str] = []
     while i < n:
         if body[i] == ",":
             i = _skip_ws(body, i + 1)
             continue
         if body[i] == "@":
-            start = i
+            # Consume the annotation but do not include it in the signature.
             i += 1
             m = _IDENT_RE.match(body, i)
             if not m:
@@ -817,7 +827,6 @@ def _parse_record_fields(body: str) -> dict[str, tuple[str, bool]] | None:
                 if nxt is None:
                     return None
                 i = nxt
-            pending.append(body[start:i])
             i = _skip_ws(body, i)
             continue
         m = _IDENT_RE.match(body, i)
@@ -832,11 +841,10 @@ def _parse_record_fields(body: str) -> dict[str, tuple[str, bool]] | None:
         if end is None:
             return None
         type_text = body[type_start:end]
-        sig = normalize_pdl_for_compare(" ".join(pending) + " " + type_text)
+        type_norm = normalize_pdl_for_compare(_strip_field_default(type_text))
         if name in fields:
             return None
-        fields[name] = (sig, _type_is_optional(type_text))
-        pending = []
+        fields[name] = (type_norm, _type_is_optional(type_text))
         i = _skip_ws(body, end)
     return fields
 
@@ -976,9 +984,15 @@ def _defs_backward_compatible(
     base_defs: dict[str, dict], cur_defs: dict[str, dict]
 ) -> bool:
     """True iff cur_defs differs from base_defs only by additive, migration-free
-    changes: added optional fields, added enum symbols, and entirely new type
-    definitions. Any removal, type/annotation change, or added non-optional
-    field is treated as incompatible.
+    changes — matching report_aspect_changes' Additive bucket:
+
+      - added optional fields
+      - added enum symbols
+      - entirely new type definitions
+      - annotation-only / default-only edits on existing fields
+
+    Any removal, type change, optional→required flip, added non-optional field,
+    includes change, or removed enum symbol is treated as incompatible (bump).
     """
     for name, bdef in base_defs.items():
         cdef = cur_defs.get(name)
@@ -989,11 +1003,21 @@ def _defs_backward_compatible(
                 return False
             base_fields = bdef["fields"]
             cur_fields = cdef["fields"]
-            for fname, (bsig, _bopt) in base_fields.items():
+            for fname, (btype, bopt) in base_fields.items():
                 cur_field = cur_fields.get(fname)
-                if cur_field is None or cur_field[0] != bsig:
+                if cur_field is None:
                     return False
-            for fname, (_csig, copt) in cur_fields.items():
+                ctype, copt = cur_field
+                # Type change or optional→required is breaking (matches report).
+                if ctype != btype:
+                    return False
+                if bopt and not copt:
+                    return False
+                # required→optional is noisy in the report (still sets
+                # has_structural there); treat as bump-worthy to stay aligned.
+                if (not bopt) and copt:
+                    return False
+            for fname, (_ctype, copt) in cur_fields.items():
                 if fname not in base_fields and not copt:
                     return False
         elif not bdef["symbols"].issubset(cdef["symbols"]):

--- a/.github/scripts/bump_schema_versions.py
+++ b/.github/scripts/bump_schema_versions.py
@@ -790,19 +790,40 @@ def _strip_field_default(type_text: str) -> str:
     return re.sub(r"\s*=\s*.*$", "", type_text).strip()
 
 
-def _parse_record_fields(body: str) -> dict[str, tuple[str, bool]] | None:
+# Field-level annotations whose value drives Elasticsearch/graph index mapping
+# (search index fields, graph edges, timeseries field indexing). Changing or
+# adding one of these on an existing field requires a reindex, so — unlike
+# other field annotations (@deprecated, @compliance, @UrnValidation, ...),
+# which carry no reindex-relevant semantics and stay ignored — these must be
+# treated as a real, bump-worthy schema change.
+BUMP_WORTHY_ANNOTATIONS = frozenset(
+    {
+        "Searchable",
+        "Relationship",
+        "SearchableRef",
+        "TimeseriesField",
+        "TimeseriesFieldCollection",
+    }
+)
+
+
+def parse_record_fields(body: str) -> dict[str, tuple[str, bool, dict[str, str]]] | None:
     """Parse the top-level fields of a record body (comments already stripped).
 
-    Returns {field name: (normalized type, is_optional)}, or None if the body
-    cannot be parsed unambiguously.
+    Returns {field name: (normalized type, is_optional, annotations)}, or None
+    if the body cannot be parsed unambiguously. `annotations` maps annotation
+    name -> normalized value text, but only for names in
+    `BUMP_WORTHY_ANNOTATIONS` — every other annotation (and any default value)
+    is parsed (so the scanner stays positioned correctly) but discarded, since
+    only the whitelisted annotations and the field's type/optional-ness matter
+    for bump decisions.
 
-    Comparison is aligned with report_aspect_changes.fields(): only the field's
-    type and optional-ness matter for bump decisions. Annotations and defaults
-    are parsed (so the scanner stays positioned correctly) but do not enter the
-    signature — changing a @Searchable annotation or a default alone is not
-    bump-worthy.
+    Public because `report_aspect_changes.fields()` delegates to this same
+    parser (rather than duplicating the brace-balanced scanning logic) so both
+    tools classify annotation changes identically.
     """
-    fields: dict[str, tuple[str, bool]] = {}
+    fields: dict[str, tuple[str, bool, dict[str, str]]] = {}
+    pending_annotations: dict[str, str] = {}
     n = len(body)
     i = _skip_ws(body, 0)
     while i < n:
@@ -810,11 +831,11 @@ def _parse_record_fields(body: str) -> dict[str, tuple[str, bool]] | None:
             i = _skip_ws(body, i + 1)
             continue
         if body[i] == "@":
-            # Consume the annotation but do not include it in the signature.
             i += 1
             m = _IDENT_RE.match(body, i)
             if not m:
                 return None
+            ann_name = m.group(0)
             i = m.end()
             while i < n and body[i] == ".":
                 m = _IDENT_RE.match(body, i + 1)
@@ -826,6 +847,10 @@ def _parse_record_fields(body: str) -> dict[str, tuple[str, bool]] | None:
                 nxt = _skip_value(body, j + 1)
                 if nxt is None:
                     return None
+                if ann_name in BUMP_WORTHY_ANNOTATIONS:
+                    pending_annotations[ann_name] = normalize_pdl_for_compare(
+                        body[j + 1 : nxt]
+                    )
                 i = nxt
             i = _skip_ws(body, i)
             continue
@@ -844,7 +869,8 @@ def _parse_record_fields(body: str) -> dict[str, tuple[str, bool]] | None:
         type_norm = normalize_pdl_for_compare(_strip_field_default(type_text))
         if name in fields:
             return None
-        fields[name] = (type_norm, _type_is_optional(type_text))
+        fields[name] = (type_norm, _type_is_optional(type_text), pending_annotations)
+        pending_annotations = {}
         i = _skip_ws(body, end)
     return fields
 
@@ -949,7 +975,7 @@ def parse_top_level_defs(content: str) -> dict[str, dict] | None:
             return None
         body = c[p + 1 : body_end - 1]
         if word == "record":
-            fields = _parse_record_fields(body)
+            fields = parse_record_fields(body)
             if fields is None:
                 return None
             defs[name] = {
@@ -989,10 +1015,15 @@ def _defs_backward_compatible(
       - added optional fields
       - added enum symbols
       - entirely new type definitions
-      - annotation-only / default-only edits on existing fields
+      - default-only edits on existing fields
+      - non-whitelisted annotation edits on existing fields (e.g. @deprecated,
+        @compliance, @UrnValidation)
 
     Any removal, type change, optional→required flip, added non-optional field,
-    includes change, or removed enum symbol is treated as incompatible (bump).
+    includes change, removed enum symbol, or a changed/added/removed
+    `BUMP_WORTHY_ANNOTATIONS` value on an existing field (@Searchable,
+    @Relationship, @SearchableRef, @TimeseriesField, @TimeseriesFieldCollection
+    — these drive reindexing) is treated as incompatible (bump).
     """
     for name, bdef in base_defs.items():
         cdef = cur_defs.get(name)
@@ -1003,11 +1034,11 @@ def _defs_backward_compatible(
                 return False
             base_fields = bdef["fields"]
             cur_fields = cdef["fields"]
-            for fname, (btype, bopt) in base_fields.items():
+            for fname, (btype, bopt, bann) in base_fields.items():
                 cur_field = cur_fields.get(fname)
                 if cur_field is None:
                     return False
-                ctype, copt = cur_field
+                ctype, copt, cann = cur_field
                 # Type change or optional→required is breaking (matches report).
                 if ctype != btype:
                     return False
@@ -1017,7 +1048,11 @@ def _defs_backward_compatible(
                 # has_structural there); treat as bump-worthy to stay aligned.
                 if (not bopt) and copt:
                     return False
-            for fname, (_ctype, copt) in cur_fields.items():
+                # A whitelisted annotation (index/reindex-relevant) changing
+                # value, appearing, or disappearing is a real schema change.
+                if bann != cann:
+                    return False
+            for fname, (_ctype, copt, _ann) in cur_fields.items():
                 if fname not in base_fields and not copt:
                     return False
         elif not bdef["symbols"].issubset(cdef["symbols"]):

--- a/.github/scripts/report_aspect_changes.py
+++ b/.github/scripts/report_aspect_changes.py
@@ -402,12 +402,14 @@ def upstream_attribution_for_transitive(
 
 
 # Bump-status classification per aspect (mirrors bump_schema_versions semantics:
-# schemaVersion defaults to 1 when absent; any structural change OR transitive
-# dependency change requires a bump).
-BUMP_DONE = "bump_done"  # head schemaVersion > base AND a real change exists
-BUMP_NEEDED = "bump_needed"  # changed (direct or transitive) but version not bumped
-BUMP_SPURIOUS = "bump_spurious"  # version bumped but NO schema change (auto-bumper side-effect, e.g. PR #9579)
-BUMP_NOT_NEEDED = "bump_not_needed"  # new file, deleted, non-aspect, no change, or version regressed — no forward bump applies
+# schemaVersion defaults to 1 when absent; a *breaking* structural change OR a
+# transitive dependency change requires a bump). Additive-only changes
+# (optional fields, new enum values) do not — previously-serialized aspects
+# remain valid, so no migration / version hop is warranted.
+BUMP_DONE = "bump_done"  # head schemaVersion > base AND a bump-required change exists
+BUMP_NEEDED = "bump_needed"  # breaking change (direct or transitive) but version not bumped
+BUMP_SPURIOUS = "bump_spurious"  # version bumped but NO bump-required change (auto-bumper side-effect, e.g. PR #9579 / CorpUserInfo #18278)
+BUMP_NOT_NEEDED = "bump_not_needed"  # new file, deleted, non-aspect, additive-only, unchanged, or version regressed — no forward bump applies
 # Backwards-compat aliases. Both now resolve to BUMP_NOT_NEEDED so the
 # 4-bucket classification is exhaustive: every changed PDL lands in
 # bump_done / bump_needed / bump_spurious / bump_not_needed.
@@ -416,10 +418,10 @@ BUMP_NA = BUMP_NOT_NEEDED
 
 # Short human-readable descriptions used in the report legend
 BUMP_STATUS_DESCRIPTIONS = {
-    BUMP_DONE: "head schemaVersion > base AND a real change exists (intentional bump)",
-    BUMP_NEEDED: "change exists (direct or transitive) but schemaVersion was NOT bumped",
-    BUMP_SPURIOUS: "schemaVersion bumped but no actual schema change — likely auto-bumper side-effect",
-    BUMP_NOT_NEEDED: "bump is not required — new file, deleted, non-aspect, unchanged, or version regressed",
+    BUMP_DONE: "head schemaVersion > base AND a bump-required (breaking) change exists",
+    BUMP_NEEDED: "breaking change exists (direct or transitive) but schemaVersion was NOT bumped",
+    BUMP_SPURIOUS: "schemaVersion bumped but no bump-required change — likely auto-bumper side-effect",
+    BUMP_NOT_NEEDED: "bump is not required — new file, deleted, non-aspect, additive-only, unchanged, or version regressed",
 }
 
 # Captures `(#1234)` PR reference appended by GitHub squash-merge commit subjects.
@@ -465,10 +467,10 @@ def _bump_breakdown(findings: list["FileFinding"], status: str) -> str:
 
 
 _BUMP_WHY = {
-    BUMP_DONE: "version bumped AND a real schema change exists in the window",
-    BUMP_NEEDED: "schema changed (direct or transitive) but version was NOT bumped",
-    BUMP_SPURIOUS: "version bumped but NO schema change in the contributing PR(s)",
-    BUMP_NOT_NEEDED: "bump is not required (new file, deleted, non-aspect, unchanged, or version regressed)",
+    BUMP_DONE: "version bumped AND a bump-required (breaking) change exists in the window",
+    BUMP_NEEDED: "breaking schema change (direct or transitive) but version was NOT bumped",
+    BUMP_SPURIOUS: "version bumped but NO bump-required change in the contributing PR(s)",
+    BUMP_NOT_NEEDED: "bump is not required (new file, deleted, non-aspect, additive-only, unchanged, or version regressed)",
 }
 
 
@@ -878,7 +880,7 @@ class FileFinding:
     )
     last_commit_date: Optional[str] = None  # YYYY-MM-DD of most recent commit
     has_structural: bool = (
-        False  # tracked so main() can re-classify with transitive context
+        False  # True when a bump-required (breaking) change exists; additive-only does not set this
     )
     old_v: Optional[int] = None  # schemaVersion at base (None if missing/not-aspect)
     new_v: Optional[int] = None  # schemaVersion at head (None if missing/not-aspect)
@@ -969,7 +971,9 @@ def analyze_file(path: str, base: str, head: str) -> FileFinding:
         aspect_name=new_meta.get("name") or old_meta.get("name"),
         head_commit=latest_commit(head, path, base),
     )
-    # Track whether any actual structural changes have been found
+    # Track whether any *bump-required* (breaking) structural changes exist.
+    # Additive-only edits (optional fields, new enum values) are reported in
+    # the Additive bucket but do not set this flag — they need no migration.
     has_structural = False
 
     if not old:
@@ -1003,7 +1007,10 @@ def analyze_file(path: str, base: str, head: str) -> FileFinding:
         opt = "optional" if new_fields[a]["optional"] else "REQUIRED"
         bucket = f.additive if new_fields[a]["optional"] else f.breaking
         bucket.append(f"added {opt} field: {a}: {new_fields[a]['type']}")
-        has_structural = True
+        # Optional field adds are additive / backward-compatible — no bump.
+        # Required field adds are breaking and require a schemaVersion bump.
+        if not new_fields[a]["optional"]:
+            has_structural = True
     for name in sorted(set(old_fields) & set(new_fields)):
         o, n = old_fields[name], new_fields[name]
         if o["optional"] and not n["optional"]:
@@ -1023,7 +1030,7 @@ def analyze_file(path: str, base: str, head: str) -> FileFinding:
             has_structural = True
         for v in sorted(set(new_enums[ename]) - set(old_enums[ename])):
             f.additive.append(f"enum {ename}: added value {v}")
-            has_structural = True
+            # Additive enum values do not require a schemaVersion bump.
 
     if is_aspect:
         # Use bump_schema_versions semantics: missing schemaVersion is treated as 1.

--- a/.github/scripts/report_aspect_changes.py
+++ b/.github/scripts/report_aspect_changes.py
@@ -221,7 +221,17 @@ _FIELD_LINE_RE = re.compile(
 
 
 def fields(src: str) -> dict[str, dict]:
-    """Return {field_name: {'optional': bool, 'type': str}} for the outermost record."""
+    """Return {field_name: {'optional': bool, 'type': str, 'annotations': dict}}
+    for the outermost record.
+
+    Delegates to bump_schema_versions.parse_record_fields — the brace-balanced
+    parser shared with the auto-bumper — so both tools capture the same
+    whitelisted reindex-relevant annotations (@Searchable, @Relationship,
+    @SearchableRef, @TimeseriesField, @TimeseriesFieldCollection) identically,
+    including values that span multiple lines. Falls back to the previous
+    naive per-line scan (no annotation capture) only when that parser returns
+    None — a construct it can't model unambiguously.
+    """
     cleaned = _strip_comments(src)
     m = _RECORD_RE.search(cleaned)
     if not m:
@@ -229,6 +239,20 @@ def fields(src: str) -> dict[str, dict]:
     body = m.group("body")
     # Drop nested record/enum/typeref bodies so we don't pick up their fields
     body = re.sub(r"(record|enum|typeref)\s+\w+[^{}]*\{[^{}]*\}", "", body)
+
+    parsed = bsv.parse_record_fields(body)
+    if parsed is not None:
+        out: dict[str, dict] = {}
+        for name, (typ, opt, ann) in parsed.items():
+            # bsv keeps a leading "optional" keyword inside its type text (so
+            # a required<->optional flip also shows up as a type difference
+            # there); this module tracks optionality separately from type so
+            # such a flip is reported as "required-ness flip", not a type
+            # change — strip the prefix to preserve that distinction.
+            type_only = re.sub(r"^optional\s+", "", typ, count=1)
+            out[name] = {"optional": opt, "type": type_only, "annotations": ann}
+        return out
+
     out: dict[str, dict] = {}
     for raw_line in body.splitlines():
         line = re.sub(r"@\w+(?:\s*=\s*(?:\{[^}]*\}|\"[^\"]*\"|\d+))?", "", raw_line)
@@ -243,6 +267,7 @@ def fields(src: str) -> dict[str, dict]:
         out[name] = {
             "optional": bool(fm.group("opt")),
             "type": fm.group("type").strip().rstrip(","),
+            "annotations": {},
         }
     return out
 
@@ -504,6 +529,7 @@ _REQ_FLIP_RE = re.compile(r"required-ness flip on (\S+): (.+)")
 _TYPE_CHANGE_RE = re.compile(r"type change on (\S+): (.+)")
 _ENUM_CHANGE_RE = re.compile(r"enum (\S+): (added|removed) value (\S+)")
 _RENAME_RE = re.compile(r"record renamed (\S+)→(\S+)")
+_ANNOTATION_CHANGE_RE = re.compile(r"annotation change on (\S+): .+")
 
 
 def _shorten_change_line(line: str) -> str:
@@ -515,6 +541,7 @@ def _shorten_change_line(line: str) -> str:
     `type change on foo: A→B`         → `type change on foo: A→B`
     `enum X: added value Y`           → `enum X: added value Y`
     `record renamed A→B (...)`        → `record renamed A→B`
+    `annotation change on foo: {..} → {..}` → `annotation changed on foo`
     Unrecognised lines pass through verbatim.
     """
     m = _FIELD_ADD_RE.match(line)
@@ -536,6 +563,9 @@ def _shorten_change_line(line: str) -> str:
     m = _RENAME_RE.match(line)
     if m:
         return f"record renamed {m.group(1)}→{m.group(2)}"
+    m = _ANNOTATION_CHANGE_RE.match(line)
+    if m:
+        return f"annotation changed on {m.group(1)}"
     return line
 
 
@@ -1021,6 +1051,10 @@ def analyze_file(path: str, base: str, head: str) -> FileFinding:
             has_structural = True
         if o["type"] != n["type"]:
             f.breaking.append(f"type change on {name}: {o['type']}→{n['type']}")
+            has_structural = True
+        o_ann, n_ann = o.get("annotations") or {}, n.get("annotations") or {}
+        if o_ann != n_ann:
+            f.breaking.append(f"annotation change on {name}: {o_ann or '{}'} → {n_ann or '{}'}")
             has_structural = True
 
     old_enums, new_enums = enums(old), enums(new)

--- a/.github/scripts/report_aspect_changes.py
+++ b/.github/scripts/report_aspect_changes.py
@@ -1517,6 +1517,40 @@ def _is_comment_only_change(path: str, base: str, head: str) -> bool:
     return bsv.normalize_pdl_for_compare(old) == bsv.normalize_pdl_for_compare(new)
 
 
+def _is_backward_compatible_change(path: str, base: str, head: str) -> bool:
+    """True if path's only diff between base and head is backward-compatible —
+    additive optional fields, added enum symbols, new type definitions, or
+    default-only edits on existing fields.
+
+    Mirrors bump_schema_versions.is_backward_compatible_change so the report and
+    the actual bumper agree on which non-aspect edits cascade a schemaVersion
+    bump. Without this filter the report over-flags: any textual change (e.g. an
+    added enum value, an added optional field) that is NOT comment-only would
+    seed the transitive BFS and wrongly mark downstream aspects bump_done, even
+    though the bumper drops such additive changes before cascading.
+
+    The only difference from the bumper is that this compares two git refs (the
+    report's base and head) rather than the working tree, reusing bsv's pure
+    content parsers (parse_top_level_defs, _defs_backward_compatible). Fails
+    closed (returns False → treated as bump-worthy) on created/deleted files,
+    @Aspect changes beyond schemaVersion, or any parse ambiguity — matching the
+    bumper's conservative stance.
+    """
+    old = file_at(base, path)
+    new = file_at(head, path)
+    if not old or not new:
+        return False
+    if bsv._aspect_annotation_without_version(
+        old
+    ) != bsv._aspect_annotation_without_version(new):
+        return False
+    old_defs = bsv.parse_top_level_defs(old)
+    new_defs = bsv.parse_top_level_defs(new)
+    if old_defs is None or new_defs is None:
+        return False
+    return bsv._defs_backward_compatible(old_defs, new_defs)
+
+
 def _classify_window(base: str, head: str) -> list[FileFinding]:
     """Run the full classification for a single base..head window.
 
@@ -1528,16 +1562,25 @@ def _classify_window(base: str, head: str) -> list[FileFinding]:
     findings = [analyze_file(p_, base, head) for p_ in paths]
 
     direct_set = set(paths)
-    # Drop non-aspect records whose only change is comments/whitespace from the
-    # transitive BFS seed: a doc-comment edit carries no schema semantics, so it
-    # must not cascade a schemaVersion bump into aspects that reference it. This
-    # reuses bump_schema_versions' normalize-and-compare so the report classifies
-    # comment-only edits exactly as the bumper does — a real (non-comment) change
-    # to a field default, includes clause, annotation, etc. still seeds the BFS.
+    # Drop non-aspect records whose change does not warrant a downstream bump
+    # from the transitive BFS seed, mirroring the two filters the actual bumper
+    # (bump_schema_versions.main) applies before it cascades:
+    #   1. comment-only / whitespace edits — no schema semantics, and
+    #   2. backward-compatible edits — added optional fields, added enum symbols,
+    #      new type defs, or default-only changes.
+    # Neither requires a migration, so neither must cascade a schemaVersion bump
+    # into aspects that reference the record. Without filter (2) the report would
+    # over-flag: an additive-only upstream change (e.g. a new enum value) would
+    # seed the BFS and mark downstream aspects bump_done, even though the bumper
+    # never bumps them — the exact disagreement this alignment closes. A genuinely
+    # breaking change (removal, type change, required-ness flip, includes change,
+    # reindex-relevant annotation edit) still seeds the BFS.
     non_aspect_changed = [
         f.path
         for f in findings
-        if not f.is_aspect and not _is_comment_only_change(f.path, base, head)
+        if not f.is_aspect
+        and not _is_comment_only_change(f.path, base, head)
+        and not _is_backward_compatible_change(f.path, base, head)
     ]
     if not non_aspect_changed:
         return findings

--- a/.github/scripts/report_pdl_aspect_changes.md
+++ b/.github/scripts/report_pdl_aspect_changes.md
@@ -100,22 +100,24 @@ filtered to `*.pdl`. Files that exist on only one side (added or deleted) are st
 
 ### Step 3 — Classify each changed file
 
-For every changed file the classifier compares base vs. head content and emits findings against **five breaking-change criteria** plus **two `schemaVersion` anomalies**:
+For every changed file the classifier compares base vs. head content and emits findings against **six breaking-change criteria** plus **two `schemaVersion` anomalies**:
 
-| #   | Criterion                                                                        | Bucket   | Bump required? |
-| --- | -------------------------------------------------------------------------------- | -------- | -------------- |
-| 1   | Removed fields                                                                   | breaking | yes            |
-| 2   | Renamed record without `@renamedFrom` annotation                                 | breaking | yes            |
-| 3   | `optional → required` flip                                                       | breaking | yes            |
-| 4   | Enum value removal                                                               | breaking | yes            |
-| 5   | Field type change                                                                | breaking | yes            |
-|     | Added required field                                                             | breaking | yes            |
-|     | **Breaking change without `schemaVersion` bump**                                 | breaking | (flag)         |
-|     | Added optional field                                                             | additive | **no**         |
-|     | Added enum value                                                                 | additive | **no**         |
-|     | `required → optional` flip                                                       | noisy    | yes            |
-|     | Renamed record **with** `@renamedFrom` annotation                                | noisy    | yes            |
-|     | **`schemaVersion` bump without bump-required change** (e.g. CorpUserInfo #18278) | noisy    | — (spurious)   |
+| #   | Criterion                                                                                                                                                                                                                                                 | Bucket   | Bump required? |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------- |
+| 1   | Removed fields                                                                                                                                                                                                                                            | breaking | yes            |
+| 2   | Renamed record without `@renamedFrom` annotation                                                                                                                                                                                                          | breaking | yes            |
+| 3   | `optional → required` flip                                                                                                                                                                                                                                | breaking | yes            |
+| 4   | Enum value removal                                                                                                                                                                                                                                        | breaking | yes            |
+| 5   | Field type change                                                                                                                                                                                                                                         | breaking | yes            |
+| 6   | Changed/added/removed `@Searchable`, `@Relationship`, `@SearchableRef`, `@TimeseriesField`, or `@TimeseriesFieldCollection` on an existing field (reindex-relevant — see [bump_schema_versions.md](bump_schema_versions.md#reindex-relevant-annotations)) | breaking | yes            |
+|     | Added required field                                                                                                                                                                                                                                      | breaking | yes            |
+|     | **Breaking change without `schemaVersion` bump**                                                                                                                                                                                                          | breaking | (flag)         |
+|     | Added optional field                                                                                                                                                                                                                                      | additive | **no**         |
+|     | Added enum value                                                                                                                                                                                                                                          | additive | **no**         |
+|     | `required → optional` flip                                                                                                                                                                                                                                | noisy    | yes            |
+|     | Renamed record **with** `@renamedFrom` annotation                                                                                                                                                                                                         | noisy    | yes            |
+|     | **`schemaVersion` bump without bump-required change** (e.g. CorpUserInfo #18278)                                                                                                                                                                          | noisy    | — (spurious)   |
+|     | Changed a **non-whitelisted** field annotation (e.g. `@deprecated`, `@compliance`, `@UrnValidation`)                                                                                                                                                      | _(none)_ | no             |
 
 ### Step 4 — Walk the dependency graph (transitive impact)
 

--- a/.github/scripts/report_pdl_aspect_changes.md
+++ b/.github/scripts/report_pdl_aspect_changes.md
@@ -102,20 +102,20 @@ filtered to `*.pdl`. Files that exist on only one side (added or deleted) are st
 
 For every changed file the classifier compares base vs. head content and emits findings against **five breaking-change criteria** plus **two `schemaVersion` anomalies**:
 
-| #   | Criterion                                                                 | Bucket   |
-| --- | ------------------------------------------------------------------------- | -------- |
-| 1   | Removed fields                                                            | breaking |
-| 2   | Renamed record without `@renamedFrom` annotation                          | breaking |
-| 3   | `optional → required` flip                                                | breaking |
-| 4   | Enum value removal                                                        | breaking |
-| 5   | Field type change                                                         | breaking |
-|     | Added required field                                                      | breaking |
-|     | **Structural change without `schemaVersion` bump**                        | breaking |
-|     | Added optional field                                                      | additive |
-|     | Added enum value                                                          | additive |
-|     | `required → optional` flip                                                | noisy    |
-|     | Renamed record **with** `@renamedFrom` annotation                         | noisy    |
-|     | **`schemaVersion` bump without structural change** (the PR #9579 pattern) | noisy    |
+| #   | Criterion                                                                        | Bucket   | Bump required? |
+| --- | -------------------------------------------------------------------------------- | -------- | -------------- |
+| 1   | Removed fields                                                                   | breaking | yes            |
+| 2   | Renamed record without `@renamedFrom` annotation                                 | breaking | yes            |
+| 3   | `optional → required` flip                                                       | breaking | yes            |
+| 4   | Enum value removal                                                               | breaking | yes            |
+| 5   | Field type change                                                                | breaking | yes            |
+|     | Added required field                                                             | breaking | yes            |
+|     | **Breaking change without `schemaVersion` bump**                                 | breaking | (flag)         |
+|     | Added optional field                                                             | additive | **no**         |
+|     | Added enum value                                                                 | additive | **no**         |
+|     | `required → optional` flip                                                       | noisy    | yes            |
+|     | Renamed record **with** `@renamedFrom` annotation                                | noisy    | yes            |
+|     | **`schemaVersion` bump without bump-required change** (e.g. CorpUserInfo #18278) | noisy    | — (spurious)   |
 
 ### Step 4 — Walk the dependency graph (transitive impact)
 
@@ -129,12 +129,14 @@ Aspects that were both directly edited AND reached by the BFS get their `bump_st
 
 Each aspect ends with one of four bump statuses:
 
-| Status          | Trigger                                                                                  |
-| --------------- | ---------------------------------------------------------------------------------------- |
-| `bump_done`     | `head schemaVersion > base AND a real change exists` (direct or transitive). Legitimate. |
-| `bump_needed`   | change exists but version NOT bumped — silent migration hazard.                          |
-| `bump_spurious` | version bumped with NO schema change at all (auto-bumper side-effect).                   |
-| `not_sure`      | version regressed (head < base) — manual review.                                         |
+| Status          | Trigger                                                                                               |
+| --------------- | ----------------------------------------------------------------------------------------------------- |
+| `bump_done`     | `head schemaVersion > base AND a bump-required (breaking) change exists` (direct or transitive).      |
+| `bump_needed`   | breaking change exists but version NOT bumped — silent migration hazard.                              |
+| `bump_spurious` | version bumped with NO bump-required change (auto-bumper side-effect; additive-only bumps land here). |
+| `not_sure`      | version regressed (head < base) — manual review.                                                      |
+
+Additive-only changes (new optional fields, new enum values) do **not** require a bump — previously-serialized aspects remain valid. Bumping for them is classified `bump_spurious` (see CorpUserInfo / #18278). This matches [`bump_schema_versions.py`](bump_schema_versions.md)'s backward-compatible skip.
 
 `schemaVersion` defaults to 1 when absent, matching [`bump_schema_versions.md`](bump_schema_versions.md) semantics.
 

--- a/.github/scripts/test/test_bump_schema_versions.py
+++ b/.github/scripts/test/test_bump_schema_versions.py
@@ -711,6 +711,233 @@ def test_is_comment_only_change_false_for_mixed_edit(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# parse_top_level_defs
+# ---------------------------------------------------------------------------
+
+
+def test_parse_top_level_defs_record_fields_and_includes():
+    content = (
+        "namespace com.linkedin.x\n"
+        "import com.linkedin.common.CustomProperties\n"
+        '@Aspect = { "name": "foo" }\n'
+        "record Foo includes CustomProperties {\n"
+        "  active: boolean\n"
+        '  @Searchable = { "fieldType": "KEYWORD" }\n'
+        "  name: optional string\n"
+        "  flag: optional boolean = false\n"
+        "}"
+    )
+    defs = bsv.parse_top_level_defs(content)
+    assert set(defs) == {"Foo"}
+    foo = defs["Foo"]
+    assert foo["kind"] == "record"
+    assert foo["includes"] == {"CustomProperties"}
+    assert set(foo["fields"]) == {"active", "name", "flag"}
+    assert foo["fields"]["active"][1] is False
+    assert foo["fields"]["name"][1] is True
+    assert foo["fields"]["flag"][1] is True
+
+
+def test_parse_top_level_defs_enum_symbols():
+    content = "namespace com.linkedin.a\nenum Mode {\n  ENABLED\n  DISABLED\n}"
+    defs = bsv.parse_top_level_defs(content)
+    assert defs["Mode"]["kind"] == "enum"
+    assert defs["Mode"]["symbols"] == {"ENABLED", "DISABLED"}
+
+
+def test_parse_top_level_defs_typeref_bails():
+    # typeref is unsupported by the conservative parser → None → treated as bump-worthy
+    assert bsv.parse_top_level_defs("namespace x\ntyperef Urn = string") is None
+
+
+def test_parse_record_fields_nested_annotation_braces_do_not_split():
+    # A field annotation with nested objects/arrays must not be mistaken for a
+    # field boundary.
+    body = (
+        '@Searchable = { "w": { "true": 2.0 }, "aliases": [ "_x" ] }\n'
+        "a: boolean\n"
+        "b: optional string\n"
+    )
+    fields = bsv._parse_record_fields(body)
+    assert set(fields) == {"a", "b"}
+    assert fields["b"][1] is True
+
+
+# ---------------------------------------------------------------------------
+# _defs_backward_compatible
+# ---------------------------------------------------------------------------
+
+
+def _record_defs(*field_lines: str, includes: str = "", name: str = "Foo") -> dict:
+    body = "\n".join(field_lines)
+    inc = f" includes {includes}" if includes else ""
+    return bsv.parse_top_level_defs(
+        f"namespace x\nrecord {name}{inc} {{\n{body}\n}}"
+    )
+
+
+def test_bc_added_optional_field_is_compatible():
+    base = _record_defs("a: boolean")
+    cur = _record_defs("a: boolean", "b: optional string")
+    assert bsv._defs_backward_compatible(base, cur) is True
+
+
+def test_bc_added_required_field_is_incompatible():
+    base = _record_defs("a: boolean")
+    cur = _record_defs("a: boolean", "b: string")
+    assert bsv._defs_backward_compatible(base, cur) is False
+
+
+def test_bc_removed_field_is_incompatible():
+    base = _record_defs("a: boolean", "b: optional string")
+    cur = _record_defs("a: boolean")
+    assert bsv._defs_backward_compatible(base, cur) is False
+
+
+def test_bc_changed_field_type_is_incompatible():
+    base = _record_defs("a: optional long")
+    cur = _record_defs("a: optional int")
+    assert bsv._defs_backward_compatible(base, cur) is False
+
+
+def test_bc_changed_field_annotation_is_incompatible():
+    base = _record_defs('@Searchable = { "fieldType": "KEYWORD" }', "a: optional string")
+    cur = _record_defs('@Searchable = { "fieldType": "TEXT" }', "a: optional string")
+    assert bsv._defs_backward_compatible(base, cur) is False
+
+
+def test_bc_changed_includes_is_incompatible():
+    base = _record_defs("a: boolean", includes="Base")
+    cur = _record_defs("a: boolean", includes="Other")
+    assert bsv._defs_backward_compatible(base, cur) is False
+
+
+def test_bc_added_enum_symbol_is_compatible():
+    base = bsv.parse_top_level_defs("namespace x\nenum E { A, B }")
+    cur = bsv.parse_top_level_defs("namespace x\nenum E { A, B, C }")
+    assert bsv._defs_backward_compatible(base, cur) is True
+
+
+def test_bc_removed_enum_symbol_is_incompatible():
+    base = bsv.parse_top_level_defs("namespace x\nenum E { A, B }")
+    cur = bsv.parse_top_level_defs("namespace x\nenum E { A }")
+    assert bsv._defs_backward_compatible(base, cur) is False
+
+
+# ---------------------------------------------------------------------------
+# is_backward_compatible_change
+# ---------------------------------------------------------------------------
+
+
+def test_is_bc_change_added_optional_field(tmp_path, monkeypatch):
+    base = 'namespace x\n@Aspect = { "name": "foo" }\nrecord Foo { a: boolean }'
+    current = (
+        "namespace x\n"
+        '@Aspect = { "name": "foo" }\n'
+        "record Foo { a: boolean\n  b: optional string }"
+    )
+    p = write_pdl(tmp_path, "com/linkedin/x/Foo.pdl", current)
+    monkeypatch.setattr(bsv, "get_file_at_branch", lambda _f, _b: base)
+    assert bsv.is_backward_compatible_change(str(p), "deadbeef") is True
+
+
+def test_is_bc_change_schema_version_removal_only(tmp_path, monkeypatch):
+    # The corpUserInfo case: schemaVersion removed, schema content unchanged.
+    base = (
+        'namespace x\n@Aspect = { "name": "foo", "schemaVersion": 2 }\n'
+        "record Foo { a: boolean\n  b: optional string }"
+    )
+    current = (
+        'namespace x\n@Aspect = { "name": "foo" }\n'
+        "record Foo { a: boolean\n  b: optional string }"
+    )
+    p = write_pdl(tmp_path, "com/linkedin/x/Foo.pdl", current)
+    monkeypatch.setattr(bsv, "get_file_at_branch", lambda _f, _b: base)
+    assert bsv.is_backward_compatible_change(str(p), "deadbeef") is True
+
+
+def test_is_bc_change_aspect_name_change_is_incompatible(tmp_path, monkeypatch):
+    # A change to @Aspect beyond schemaVersion must not be waved through.
+    base = 'namespace x\n@Aspect = { "name": "foo" }\nrecord Foo { a: boolean }'
+    current = (
+        'namespace x\n@Aspect = { "name": "renamed" }\n'
+        "record Foo { a: boolean\n  b: optional string }"
+    )
+    p = write_pdl(tmp_path, "com/linkedin/x/Foo.pdl", current)
+    monkeypatch.setattr(bsv, "get_file_at_branch", lambda _f, _b: base)
+    assert bsv.is_backward_compatible_change(str(p), "deadbeef") is False
+
+
+def test_is_bc_change_new_file_is_not_compatible(tmp_path, monkeypatch):
+    p = write_pdl(tmp_path, "com/linkedin/x/Foo.pdl",
+                  'namespace x\n@Aspect = { "name": "foo" }\nrecord Foo { a: boolean }')
+    monkeypatch.setattr(bsv, "get_file_at_branch", lambda _f, _b: None)
+    assert bsv.is_backward_compatible_change(str(p), "deadbeef") is False
+
+
+# ---------------------------------------------------------------------------
+# main() — backward-compatible changes are neither bumped nor cascaded
+# ---------------------------------------------------------------------------
+
+
+def _optional_field_added(content: str) -> str:
+    return content.replace("{ field: string }", "{ field: string, added: optional int }")
+
+
+def test_backward_compatible_change_is_not_bumped(tmp_path, monkeypatch):
+    # Adding an optional field to an aspect must NOT bump its schemaVersion.
+    base_content = aspect_pdl("myAspect", schema_version=3)
+    aspect = write_pdl(tmp_path, "com/linkedin/dataset/MyAspect.pdl",
+                       _optional_field_added(base_content))
+
+    rc = _run_main(tmp_path, monkeypatch, [aspect], {str(aspect): base_content})
+
+    assert rc == 0
+    assert bsv.get_schema_version(aspect.read_text()) == 3  # unchanged
+
+
+def test_backward_compatible_change_does_not_cascade(tmp_path, monkeypatch):
+    # A shared non-aspect record gains an optional field; the aspect that
+    # includes it must NOT be bumped.
+    base_include = record_pdl("com.linkedin.common", "Base")
+    include = write_pdl(tmp_path, "com/linkedin/common/Base.pdl",
+                        base_include.replace("{ field: string }",
+                                             "{ field: string, added: optional int }"))
+    aspect_content = ("namespace com.linkedin.dataset\nimport com.linkedin.common.Base\n"
+                      + aspect_pdl("myAspect", includes="Base", schema_version=3))
+    aspect = write_pdl(tmp_path, "com/linkedin/dataset/MyAspect.pdl", aspect_content)
+
+    rc = _run_main(tmp_path, monkeypatch, [include],
+                   {str(include): base_include, str(aspect): aspect_content})
+
+    assert rc == 0
+    assert bsv.get_schema_version(aspect.read_text()) == 3  # no cascade
+
+
+def test_check_mode_passes_for_backward_compatible_change(tmp_path, monkeypatch):
+    # --check must not fail a purely additive optional-field change.
+    base_content = aspect_pdl("myAspect", schema_version=3)
+    aspect = write_pdl(tmp_path, "com/linkedin/dataset/MyAspect.pdl",
+                       _optional_field_added(base_content))
+
+    rc = _run_check(tmp_path, monkeypatch, [aspect], {str(aspect): base_content})
+
+    assert rc == 0
+
+
+def test_incompatible_change_still_bumps(tmp_path, monkeypatch):
+    # Guard the safety property: a non-optional added field still bumps.
+    base_content = aspect_pdl("myAspect", schema_version=3)
+    aspect = write_pdl(tmp_path, "com/linkedin/dataset/MyAspect.pdl",
+                       _with_added_field(base_content))  # adds required `added: int`
+
+    rc = _run_main(tmp_path, monkeypatch, [aspect], {str(aspect): base_content})
+
+    assert rc == 0
+    assert bsv.get_schema_version(aspect.read_text()) == 4  # bumped
+
+
+# ---------------------------------------------------------------------------
 # detect_default_branch / get_merge_base / get_base_pdl_changes
 # ---------------------------------------------------------------------------
 

--- a/.github/scripts/test/test_bump_schema_versions.py
+++ b/.github/scripts/test/test_bump_schema_versions.py
@@ -736,6 +736,8 @@ def test_parse_top_level_defs_record_fields_and_includes():
     assert foo["fields"]["active"][1] is False
     assert foo["fields"]["name"][1] is True
     assert foo["fields"]["flag"][1] is True
+    assert foo["fields"]["active"][2] == {}
+    assert foo["fields"]["name"][2] == {"Searchable": '{ "fieldType": "KEYWORD" }'}
 
 
 def test_parse_top_level_defs_enum_symbols():
@@ -758,9 +760,15 @@ def test_parse_record_fields_nested_annotation_braces_do_not_split():
         "a: boolean\n"
         "b: optional string\n"
     )
-    fields = bsv._parse_record_fields(body)
+    fields = bsv.parse_record_fields(body)
     assert set(fields) == {"a", "b"}
     assert fields["b"][1] is True
+    # The @Searchable annotation attaches to the field that follows it (a),
+    # and is captured (whitelisted) rather than merely skipped over.
+    assert fields["a"][2] == {
+        "Searchable": '{ "w": { "true": 2.0 }, "aliases": [ "_x" ] }'
+    }
+    assert fields["b"][2] == {}
 
 
 # ---------------------------------------------------------------------------
@@ -800,11 +808,28 @@ def test_bc_changed_field_type_is_incompatible():
     assert bsv._defs_backward_compatible(base, cur) is False
 
 
-def test_bc_changed_field_annotation_is_compatible():
-    # Annotation-only edits match the report tool (which ignores annotations)
-    # and do not require a bump.
+def test_bc_changed_searchable_annotation_is_incompatible():
+    # @Searchable drives Elasticsearch index mapping, so changing its value on
+    # an existing field requires a reindex — not a no-op, backward-compatible
+    # change — even though nothing about the field's own type/optionality moved.
     base = _record_defs('@Searchable = { "fieldType": "KEYWORD" }', "a: optional string")
     cur = _record_defs('@Searchable = { "fieldType": "TEXT" }', "a: optional string")
+    assert bsv._defs_backward_compatible(base, cur) is False
+
+
+def test_bc_added_searchable_annotation_is_incompatible():
+    # A field with no annotation in base gaining @Searchable in current is
+    # exactly as bump-worthy as changing an existing one's value.
+    base = _record_defs("a: optional string")
+    cur = _record_defs('@Searchable = { "fieldType": "KEYWORD" }', "a: optional string")
+    assert bsv._defs_backward_compatible(base, cur) is False
+
+
+def test_bc_changed_non_whitelisted_annotation_is_compatible():
+    # @deprecated is not reindex-relevant, so it stays ignored — same as
+    # before this change — even though its value differs.
+    base = _record_defs('@deprecated = "old reason"', "a: optional string")
+    cur = _record_defs('@deprecated = "new reason"', "a: optional string")
     assert bsv._defs_backward_compatible(base, cur) is True
 
 

--- a/.github/scripts/test/test_bump_schema_versions.py
+++ b/.github/scripts/test/test_bump_schema_versions.py
@@ -800,9 +800,31 @@ def test_bc_changed_field_type_is_incompatible():
     assert bsv._defs_backward_compatible(base, cur) is False
 
 
-def test_bc_changed_field_annotation_is_incompatible():
+def test_bc_changed_field_annotation_is_compatible():
+    # Annotation-only edits match the report tool (which ignores annotations)
+    # and do not require a bump.
     base = _record_defs('@Searchable = { "fieldType": "KEYWORD" }', "a: optional string")
     cur = _record_defs('@Searchable = { "fieldType": "TEXT" }', "a: optional string")
+    assert bsv._defs_backward_compatible(base, cur) is True
+
+
+def test_bc_changed_field_default_is_compatible():
+    # Defaults are ignored by the report tool's fields() comparison.
+    base = _record_defs("a: optional boolean = false")
+    cur = _record_defs("a: optional boolean = true")
+    assert bsv._defs_backward_compatible(base, cur) is True
+
+
+def test_bc_required_to_optional_is_incompatible():
+    # Matches the report: required→optional is noisy but still bump-required.
+    base = _record_defs("a: string")
+    cur = _record_defs("a: optional string")
+    assert bsv._defs_backward_compatible(base, cur) is False
+
+
+def test_bc_optional_to_required_is_incompatible():
+    base = _record_defs("a: optional string")
+    cur = _record_defs("a: string")
     assert bsv._defs_backward_compatible(base, cur) is False
 
 

--- a/.github/scripts/test/test_report_aspect_changes.py
+++ b/.github/scripts/test/test_report_aspect_changes.py
@@ -324,6 +324,43 @@ def test_fields_ignores_nested_record_fields():
     assert "b" not in fs  # b belongs to Inner, not Outer
 
 
+def test_fields_captures_whitelisted_annotation():
+    src = (
+        "record Foo {\n"
+        '  @Searchable = { "fieldType": "KEYWORD" }\n'
+        "  name: optional string\n"
+        "}"
+    )
+    fs = rac.fields(src)
+    assert fs["name"]["annotations"] == {"Searchable": '{ "fieldType": "KEYWORD" }'}
+
+
+def test_fields_captures_multiline_annotation_value():
+    # The naive per-line regex this delegates away from cannot strip a
+    # multi-line annotation value; the shared bsv parser handles it correctly.
+    src = (
+        "record Foo {\n"
+        "  @Searchable = {\n"
+        '    "fieldType": "KEYWORD"\n'
+        "  }\n"
+        "  name: optional string\n"
+        "}"
+    )
+    fs = rac.fields(src)
+    assert fs["name"]["annotations"] == {"Searchable": '{ "fieldType": "KEYWORD" }'}
+
+
+def test_fields_ignores_non_whitelisted_annotation():
+    src = (
+        "record Foo {\n"
+        '  @deprecated = "use bar instead"\n'
+        "  name: optional string\n"
+        "}"
+    )
+    fs = rac.fields(src)
+    assert fs["name"]["annotations"] == {}
+
+
 def test_enums_returns_symbols_per_enum():
     es = rac.enums(ENUM_PDL)
     assert es == {"FabricType": ["PROD", "CORP", "DEV"]}
@@ -417,6 +454,49 @@ def test_analyze_type_change_is_breaking(monkeypatch):
 
     f = rac.analyze_file("path.pdl", "BASE", "HEAD")
     assert any("type change on x: string→int" in line for line in f.breaking)
+
+
+def test_analyze_searchable_annotation_change_is_breaking(monkeypatch):
+    # @Searchable drives ES index mapping — changing it on an existing field
+    # requires a reindex, so it must be bump-worthy even with no type/optional
+    # change and no schemaVersion bump (silent migration/reindex hazard).
+    old = (
+        'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\n'
+        'record A { @Searchable = { "fieldType": "KEYWORD" } x: string }'
+    )
+    new = (
+        'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\n'
+        'record A { @Searchable = { "fieldType": "TEXT" } x: string }'
+    )
+
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert any("annotation change on x" in line for line in f.breaking)
+    assert f.has_structural is True
+    assert f.bump_status == rac.BUMP_NEEDED
+
+
+def test_analyze_non_whitelisted_annotation_change_is_ignored(monkeypatch):
+    # @deprecated is not reindex-relevant, so a value-only change on it must
+    # not be reported as a schema change at all.
+    old = (
+        'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\n'
+        'record A { @deprecated = "old reason" x: string }'
+    )
+    new = (
+        'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\n'
+        'record A { @deprecated = "new reason" x: string }'
+    )
+
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert f.breaking == []
+    assert f.has_structural is False
+    assert f.bump_status == rac.BUMP_NOT_NEEDED
 
 
 def test_analyze_enum_removal_is_breaking(monkeypatch):

--- a/.github/scripts/test/test_report_aspect_changes.py
+++ b/.github/scripts/test/test_report_aspect_changes.py
@@ -1367,7 +1367,9 @@ def test_main_routes_two_hop_transitive_aspect_to_transitive_section(
     aspect_old = '@Aspect = {"name": "a"}\nrecord AspectA { x: Intermediate }'
     aspect_new = '@Aspect = {"name": "a", "schemaVersion": 2}\nrecord AspectA { x: Intermediate }'
     nested_old = "record Changed { y: string }"
-    nested_new = "record Changed { y: string\n z: optional string }"
+    # A genuinely breaking change (added REQUIRED field) so it seeds the BFS —
+    # an additive optional add would be dropped as backward-compatible.
+    nested_new = "record Changed { y: string\n z: string }"
 
     def fake_changed(base, head):
         return [aspect_path, changed_nested_path]
@@ -1416,9 +1418,12 @@ def test_main_routes_two_hop_transitive_aspect_to_transitive_section(
 
 # ---------------------------------------------------------------------------
 # Transitive BFS seed filtering — must match bump_schema_versions semantics:
-# a non-aspect edit seeds the transitive bump BFS iff it is NOT comment-only
-# (comments/whitespace stripped via bsv.normalize_pdl_for_compare). Created and
-# deleted files count as real changes.
+# a non-aspect edit seeds the transitive bump BFS iff it is NEITHER comment-only
+# (comments/whitespace stripped via bsv.normalize_pdl_for_compare) NOR
+# backward-compatible (added optional fields / enum symbols / new type defs /
+# default-only edits, dropped via bsv.is_backward_compatible_change semantics).
+# Created and deleted files, includes changes, type changes, required-ness
+# flips, and reindex-relevant annotation edits all count as bump-worthy.
 # ---------------------------------------------------------------------------
 
 
@@ -1482,7 +1487,7 @@ def test_comment_only_nonaspect_does_not_seed_transitive_bump(monkeypatch):
             ),
             real: (
                 "record RealChange {\n  y: string\n}",
-                "record RealChange {\n  y: string\n  z: optional string\n}",
+                "record RealChange {\n  y: int\n}",
             ),
             aspect_c: ('@Aspect = {"name": "c", "schemaVersion": 3}\nrecord A { a: string }',) * 2,
             aspect_r: ('@Aspect = {"name": "r", "schemaVersion": 3}\nrecord B { b: string }',) * 2,
@@ -1495,13 +1500,82 @@ def test_comment_only_nonaspect_does_not_seed_transitive_bump(monkeypatch):
     assert by["AspectViaReal.pdl"].bump_status == rac.BUMP_NEEDED
 
 
-def test_noncomment_nonstructural_change_seeds_transitive_bump(monkeypatch):
-    """Parity guard with the bumper: a NON-comment change that analyze_file does
-    not model as structural (here, a field default-value change) must STILL seed
-    the BFS, because bsv.normalize_pdl_for_compare sees a real diff.
+def test_additive_enum_add_on_nonaspect_does_not_seed_transitive_bump(monkeypatch):
+    """Regression: an ADDITIVE-only change to a non-aspect (a new enum symbol)
+    must NOT cascade a breaking bump into aspects that reference it — matching
+    bump_schema_versions.is_backward_compatible_change, which drops additive
+    optional-field / enum-symbol changes before the transitive BFS.
 
-    This is the case the previous has_structural-based filter got wrong: it
-    dropped default/includes/annotation changes that the actual bumper bumps on.
+    Mirrors the DataHubPageModuleType (added OUTPUT_PORTS) →
+    DataHubPageModuleProperties (schemaVersion 3→4) case: the bumper leaves the
+    properties aspect out of `to_bump`, so the report must classify it
+    bump_spurious (bumped with no structural change), not bump_done.
+    """
+    enum = f"{_D}/ModuleType.pdl"
+    aspect = f"{_D}/ModuleProperties.pdl"
+    by, sources = _seed_window(
+        monkeypatch,
+        changed=[enum, aspect],
+        contents={
+            enum: (
+                "enum ModuleType {\n  LINK\n  RICH_TEXT\n}",
+                "enum ModuleType {\n  LINK\n  RICH_TEXT\n  OUTPUT_PORTS\n}",
+            ),
+            aspect: (
+                '@Aspect = {"name": "moduleProperties", "schemaVersion": 3}\n'
+                "record ModuleProperties {\n  t: ModuleType\n}",
+                '@Aspect = {"name": "moduleProperties", "schemaVersion": 4}\n'
+                "record ModuleProperties {\n  t: ModuleType\n}",
+            ),
+        },
+        reached={enum: {aspect}},
+    )
+    # Additive enum-add is backward-compatible → dropped from the seed → no
+    # cascade, so the aspect is judged only on its own (structure-free) diff.
+    assert sources == []
+    assert by["ModuleProperties.pdl"].bump_status == rac.BUMP_SPURIOUS
+
+
+def test_additive_optional_field_on_nonaspect_does_not_seed_transitive_bump(monkeypatch):
+    """Companion to the enum case: adding an OPTIONAL field to a non-aspect record
+    is backward-compatible, so it must not cascade a bump downstream either.
+
+    A genuinely breaking sibling (added REQUIRED field) is kept, proving the
+    filter drops only additive edits, not every change."""
+    additive = f"{_D}/AdditiveField.pdl"
+    breaking = f"{_D}/BreakingField.pdl"
+    aspect_a = f"{_D}/AspectViaAdditive.pdl"
+    aspect_b = f"{_D}/AspectViaBreaking.pdl"
+    by, sources = _seed_window(
+        monkeypatch,
+        changed=[additive, breaking],
+        contents={
+            additive: (
+                "record AdditiveField {\n  y: string\n}",
+                "record AdditiveField {\n  y: string\n  z: optional string\n}",
+            ),
+            breaking: (
+                "record BreakingField {\n  y: string\n}",
+                "record BreakingField {\n  y: string\n  z: string\n}",
+            ),
+            aspect_a: ('@Aspect = {"name": "a", "schemaVersion": 3}\nrecord A { a: string }',) * 2,
+            aspect_b: ('@Aspect = {"name": "b", "schemaVersion": 3}\nrecord B { b: string }',) * 2,
+        },
+        reached={additive: {aspect_a}, breaking: {aspect_b}},
+    )
+    # Only the breaking sibling seeds the BFS.
+    assert sources == [breaking]
+    assert "AspectViaAdditive.pdl" not in by
+    assert by["AspectViaBreaking.pdl"].bump_status == rac.BUMP_NEEDED
+
+
+def test_default_only_change_on_nonaspect_does_not_seed_transitive_bump(monkeypatch):
+    """A field default-value change is backward-compatible per the bumper —
+    bsv.is_backward_compatible_change strips defaults before comparing, so
+    default-only edits are dropped and never cascade. The report must agree.
+
+    (The change is NOT comment-only — normalize_pdl_for_compare keeps the
+    default text — so only the backward-compatible filter drops it.)
     """
     default = f"{_D}/DefaultChange.pdl"
     aspect = f"{_D}/AspectViaDefault.pdl"
@@ -1517,11 +1591,35 @@ def test_noncomment_nonstructural_change_seeds_transitive_bump(monkeypatch):
         },
         reached={default: {aspect}},
     )
-    # has_structural is False (analyze_file doesn't model defaults), but the
-    # change is NOT comment-only, so it must still seed the BFS like the bumper.
-    assert by["DefaultChange.pdl"].has_structural is False
-    assert sources == [default]
-    assert by["AspectViaDefault.pdl"].bump_status == rac.BUMP_NEEDED
+    assert sources == []
+    assert "AspectViaDefault.pdl" not in by
+
+
+def test_includes_change_on_nonaspect_seeds_transitive_bump(monkeypatch):
+    """Parity guard with the bumper: an `includes` change is bump-worthy per
+    bsv._defs_backward_compatible even though analyze_file does not model
+    includes as structural (has_structural stays False). It must still seed the
+    BFS — the case the abandoned has_structural-based filter got wrong.
+    """
+    inc = f"{_D}/IncludesChange.pdl"
+    aspect = f"{_D}/AspectViaIncludes.pdl"
+    by, sources = _seed_window(
+        monkeypatch,
+        changed=[inc],
+        contents={
+            inc: (
+                "record IncludesChange includes Base { x: string }",
+                "record IncludesChange includes Base, Extra { x: string }",
+            ),
+            aspect: ('@Aspect = {"name": "i", "schemaVersion": 5}\nrecord I { i: string }',) * 2,
+        },
+        reached={inc: {aspect}},
+    )
+    # analyze_file doesn't detect includes, so has_structural is False — but the
+    # bumper treats includes changes as breaking, so the report must still seed.
+    assert by["IncludesChange.pdl"].has_structural is False
+    assert sources == [inc]
+    assert by["AspectViaIncludes.pdl"].bump_status == rac.BUMP_NEEDED
 
 
 def test_deleted_nonaspect_seeds_transitive_bump(monkeypatch):
@@ -2154,7 +2252,9 @@ def test_main_reclassifies_aspect_bump_as_done_when_transitively_affected(
     aspect_old = '@Aspect = {"name": "a", "schemaVersion": 1}\nrecord AspectA includes Nested { }'
     aspect_new = '@Aspect = {"name": "a", "schemaVersion": 2}\nrecord AspectA includes Nested { }'
     nested_old = "record Nested { x: string }"
-    nested_new = "record Nested { x: string\n y: optional string }"
+    # A genuinely breaking change (added REQUIRED field) so it seeds the BFS —
+    # an additive optional add would be dropped as backward-compatible.
+    nested_new = "record Nested { x: string\n y: string }"
 
     def fake_changed(base, head):
         return [aspect_path, nested_path]

--- a/.github/scripts/test/test_report_aspect_changes.py
+++ b/.github/scripts/test/test_report_aspect_changes.py
@@ -339,8 +339,10 @@ def test_enums_returns_empty_when_no_enum_present():
 
 
 def test_analyze_pure_addition_is_additive_only(monkeypatch):
+    # Additive optional field with no version bump — stays additive-only and
+    # does not require a schemaVersion bump (CorpUserInfo / #18278 pattern).
     old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
-    new = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: string\n y: optional string }'
+    new = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string\n y: optional string }'
 
     monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
     monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "abc1234 add y")
@@ -349,6 +351,25 @@ def test_analyze_pure_addition_is_additive_only(monkeypatch):
     assert f.is_aspect
     assert any("added optional field: y" in line for line in f.additive)
     assert f.breaking == []
+    assert f.has_structural is False
+    assert f.bump_status == rac.BUMP_NOT_NEEDED
+
+
+def test_analyze_optional_add_with_bump_is_spurious(monkeypatch):
+    # Bumping for an additive-only change is the CorpUserInfo anti-pattern.
+    old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+    new = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: string\n y: optional string }'
+
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert any("added optional field: y" in line for line in f.additive)
+    assert f.has_structural is False
+    assert f.bump_status == rac.BUMP_SPURIOUS
+    assert any(
+        "bumped with NO structural change" in line for line in f.noisy
+    )
 
 
 def test_analyze_removed_field_is_breaking(monkeypatch):
@@ -1090,8 +1111,9 @@ def test_render_summary_counts_are_correct():
 
 
 def test_bump_status_bump_done_when_version_increases(monkeypatch):
-    old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
-    new = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: string\n y: optional string }'
+    # bump_done requires a bump-required (breaking) change, not additive-only.
+    old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string\n y: string }'
+    new = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 2}\nrecord A { x: string }'
     monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
     monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
     f = rac.analyze_file("path.pdl", "BASE", "HEAD")
@@ -1105,6 +1127,16 @@ def test_bump_status_bump_needed_when_structural_change_without_bump(monkeypatch
     monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
     f = rac.analyze_file("path.pdl", "BASE", "HEAD")
     assert f.bump_status == rac.BUMP_NEEDED
+
+
+def test_bump_status_not_needed_for_optional_add_without_bump(monkeypatch):
+    old = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string }'
+    new = 'namespace x\n@Aspect = {"name": "a", "schemaVersion": 1}\nrecord A { x: string\n y: optional string }'
+    monkeypatch.setattr(rac, "file_at", lambda ref, p: old if ref == "BASE" else new)
+    monkeypatch.setattr(rac, "latest_commit", lambda ref, p, base: "")
+    f = rac.analyze_file("path.pdl", "BASE", "HEAD")
+    assert f.bump_status == rac.BUMP_NOT_NEEDED
+    assert f.has_structural is False
 
 
 def test_bump_status_na_when_no_change_and_no_bump(monkeypatch):

--- a/metadata-models/src/main/pegasus/com/linkedin/identity/CorpUserInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/identity/CorpUserInfo.pdl
@@ -9,8 +9,7 @@ import com.linkedin.common.Urn
  * Linkedin corp user information
  */
 @Aspect = {
-  "name": "corpUserInfo",
-  "schemaVersion": 2
+  "name": "corpUserInfo"
 }
 @Aspect.EntityUrns = [ "com.linkedin.common.CorpuserUrn" ]
 record CorpUserInfo includes CustomProperties {

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -2824,8 +2824,7 @@
     } ],
     "Aspect" : {
       "EntityUrns" : [ "com.linkedin.common.CorpuserUrn" ],
-      "name" : "corpUserInfo",
-      "schemaVersion" : 2
+      "name" : "corpUserInfo"
     }
   }, {
     "type" : "record",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -3021,8 +3021,7 @@
                   } ],
                   "Aspect" : {
                     "EntityUrns" : [ "com.linkedin.common.CorpuserUrn" ],
-                    "name" : "corpUserInfo",
-                    "schemaVersion" : 2
+                    "name" : "corpUserInfo"
                   }
                 }, {
                   "type" : "record",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
@@ -2533,8 +2533,7 @@
     } ],
     "Aspect" : {
       "EntityUrns" : [ "com.linkedin.common.CorpuserUrn" ],
-      "name" : "corpUserInfo",
-      "schemaVersion" : 2
+      "name" : "corpUserInfo"
     }
   }, {
     "type" : "record",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.operations.operations.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.operations.operations.snapshot.json
@@ -2527,8 +2527,7 @@
     } ],
     "Aspect" : {
       "EntityUrns" : [ "com.linkedin.common.CorpuserUrn" ],
-      "name" : "corpUserInfo",
-      "schemaVersion" : 2
+      "name" : "corpUserInfo"
     }
   }, {
     "type" : "record",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
@@ -3015,8 +3015,7 @@
                   } ],
                   "Aspect" : {
                     "EntityUrns" : [ "com.linkedin.common.CorpuserUrn" ],
-                    "name" : "corpUserInfo",
-                    "schemaVersion" : 2
+                    "name" : "corpUserInfo"
                   }
                 }, {
                   "type" : "record",


### PR DESCRIPTION
## Summary

Update `bump_schema_versions.py` (the pre-commit auto-bumper) and `report_aspect_changes.py` (the release-window PDL change report) to agree on one shared, accurate definition of "backward-compatible" for `@Aspect` PDL changes.

- Skip the schemaVersion bump for purely additive changes (new optional fields, new enum values) — these need no data migration, so forcing a version hop on them is pure noise (see the CorpUserInfo / #18278 `bump_spurious` pattern this was creating).
- Align the two tools on the same breaking-vs-additive criteria so a change is classified identically whether it's caught by the pre-commit bumper or audited later by the report.
- Treat changes to `@Searchable`, `@Relationship`, `@SearchableRef`, `@TimeseriesField`, or `@TimeseriesFieldCollection` on an existing field as breaking: these annotations drive Elasticsearch/graph index mapping, so changing one requires a reindex even when the field's own PDL type and optionality never moved. Other field annotations (`@deprecated`, `@compliance`, `@UrnValidation`, etc.) remain ignored, matching prior behavior.
- `report_aspect_changes.py`'s field parser now delegates to `bump_schema_versions.py`'s brace-balanced parser instead of its own fragile per-line regex, so both tools parse (and compare) fields — including multi-line annotation values — identically.
- Drop the now-unnecessary corpUserInfo schemaVersion bump (added in #18278 for an optional field) back out of `CorpUserInfo.pdl` and its restli snapshots.

## Test plan

- [x] `pytest .github/scripts/test` — all unit tests pass
- [x] Manual scratch-repo repro: a `@Searchable` `fieldType` change on an existing field is now flagged as needing a bump; a `@deprecated`-only change is still correctly ignored
- [x] Existing PDL model snapshot/CorpUserInfo regression covered by tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)