### PR TITLE
feat(lineage): wire Metric and SemanticModel into lineage V3

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -4089,7 +4089,11 @@ public class GmsGraphQLEngine {
                         }))
                 .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
                 .dataFetcher("exists", new EntityExistsResolver(entityService))
-                .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient)));
+                .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
+                .dataFetcher(
+                    "lineage",
+                    new EntityLineageResultResolver(
+                        siblingGraphService, restrictedService, this.authorizationConfiguration)));
   }
 
   private void configureSemanticModelResolvers(final RuntimeWiring.Builder builder) {
@@ -4115,7 +4119,11 @@ public class GmsGraphQLEngine {
                         }))
                 .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
                 .dataFetcher("exists", new EntityExistsResolver(entityService))
-                .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient)));
+                .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
+                .dataFetcher(
+                    "lineage",
+                    new EntityLineageResultResolver(
+                        siblingGraphService, restrictedService, this.authorizationConfiguration)));
     builder.type(
         "ModelDataset",
         typeWiring ->

--- a/datahub-graphql-core/src/main/resources/metrics.graphql
+++ b/datahub-graphql-core/src/main/resources/metrics.graphql
@@ -46,7 +46,7 @@ type GetSemanticModelsResult {
 """
 A Metric entity from a semantic layer or metric store.
 """
-type Metric implements Entity {
+type Metric implements EntityWithRelationships & Entity {
   """
   The primary key of the Metric.
   """
@@ -187,12 +187,17 @@ type Metric implements Entity {
   Edges extending from this entity.
   """
   relationships(input: RelationshipsInput!): EntityRelationshipsResult
+
+  """
+  Edges extending from this entity grouped by direction in the lineage graph.
+  """
+  lineage(input: LineageInput!): EntityLineageResult
 }
 
 """
 A Semantic Model entity that groups datasets and defines metrics context.
 """
-type SemanticModel implements Entity {
+type SemanticModel implements EntityWithRelationships & Entity {
   """
   The primary key of the SemanticModel.
   """
@@ -318,6 +323,11 @@ type SemanticModel implements Entity {
   Edges extending from this entity.
   """
   relationships(input: RelationshipsInput!): EntityRelationshipsResult
+
+  """
+  Edges extending from this entity grouped by direction in the lineage graph.
+  """
+  lineage(input: LineageInput!): EntityLineageResult
 }
 
 """

--- a/datahub-web-react/src/app/entityV2/metric/MetricEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/metric/MetricEntity.tsx
@@ -149,6 +149,16 @@ export class MetricEntity implements Entity<Metric> {
         return data?.info?.name || data?.id || data?.urn;
     };
 
+    getLineageVizConfig = (entity: Metric) => {
+        return {
+            urn: entity?.urn,
+            name: entity?.info?.name || entity?.id || entity?.urn,
+            type: EntityType.Metric,
+            platform: entity?.platform,
+            deprecation: entity?.deprecation,
+        };
+    };
+
     getOverridePropertiesFromEntity = (data: Metric): GenericEntityProperties => {
         return {
             name: data?.info?.name,
@@ -173,6 +183,7 @@ export class MetricEntity implements Entity<Metric> {
             EntityCapabilityType.GLOSSARY_TERMS,
             EntityCapabilityType.TAGS,
             EntityCapabilityType.DOMAINS,
+            EntityCapabilityType.LINEAGE,
         ]);
     };
 

--- a/datahub-web-react/src/app/entityV2/semanticModel/SemanticModelEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/semanticModel/SemanticModelEntity.tsx
@@ -176,6 +176,17 @@ export class SemanticModelEntity implements Entity<SemanticModel> {
         return data?.info?.name || data?.id || data?.urn;
     };
 
+    getLineageVizConfig = (entity: SemanticModel) => {
+        return {
+            urn: entity?.urn,
+            name: entity?.info?.name || entity?.id || entity?.urn,
+            type: EntityType.SemanticModel,
+            icon: entity?.platform?.properties?.logoUrl || undefined,
+            platform: entity?.platform,
+            deprecation: entity?.deprecation,
+        };
+    };
+
     getOverridePropertiesFromEntity = (data: SemanticModel): GenericEntityProperties => {
         return {
             name: data?.info?.name,
@@ -199,6 +210,7 @@ export class SemanticModelEntity implements Entity<SemanticModel> {
             EntityCapabilityType.GLOSSARY_TERMS,
             EntityCapabilityType.TAGS,
             EntityCapabilityType.DOMAINS,
+            EntityCapabilityType.LINEAGE,
         ]);
     };
 

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/NodeContents.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/NodeContents.tsx
@@ -9,6 +9,7 @@ import styled, { useTheme } from 'styled-components';
 
 import { EventType } from '@app/analytics';
 import analytics from '@app/analytics/analytics';
+import { IconStyleType } from '@app/entityV2/Entity';
 import { LastRunIcon } from '@app/entityV2/dataJob/tabs/RunsTab';
 import StructuredPropertyBadge from '@app/entityV2/shared/containers/profile/header/StructuredPropertyBadge';
 import VersioningBadge from '@app/entityV2/shared/versioning/VersioningBadge';
@@ -361,6 +362,7 @@ function NodeContents(props: Props & LineageEntity & DisplayedColumns) {
                     }
                     extraDetails={extraDetails}
                     properties={properties}
+                    typeIcon={entityRegistry.getIcon(type, 16, IconStyleType.ACCENT)}
                     platformIcons={platformIcons}
                     childrenOpen={showColumns}
                     childrenText={

--- a/datahub-web-react/src/graphql/lineage.graphql
+++ b/datahub-web-react/src/graphql/lineage.graphql
@@ -416,6 +416,108 @@ fragment lineageNodeProperties on EntityWithRelationships {
     ... on MLPrimaryKey {
         ...nonRecursiveMLPrimaryKey
     }
+    ... on Metric {
+        exists
+        path
+        id
+        info {
+            name
+            description
+            externalUrl
+        }
+        platform {
+            ...platformFields
+        }
+        ownership {
+            ...ownershipFields
+        }
+        tags {
+            ...globalTagsFields
+        }
+        glossaryTerms {
+            ...glossaryTerms
+        }
+        domain {
+            ...entityDomain
+        }
+        deprecation {
+            ...deprecationFields
+        }
+        dataPlatformInstance {
+            ...dataPlatformInstanceFields
+        }
+        subTypes {
+            typeNames
+        }
+        status {
+            removed
+        }
+        browsePathV2 {
+            ...browsePathV2Fields
+        }
+        structuredProperties {
+            properties {
+                ...structuredPropertiesFields
+            }
+        }
+    }
+    ... on SemanticModel {
+        exists
+        path
+        id
+        info {
+            name
+            description
+            externalUrl
+        }
+        platform {
+            ...platformFields
+        }
+        ownership {
+            ...ownershipFields
+        }
+        tags {
+            ...globalTagsFields
+        }
+        glossaryTerms {
+            ...glossaryTerms
+        }
+        domain {
+            ...entityDomain
+        }
+        deprecation {
+            ...deprecationFields
+        }
+        dataPlatformInstance {
+            ...dataPlatformInstanceFields
+        }
+        subTypes {
+            typeNames
+        }
+        status {
+            removed
+        }
+        browsePathV2 {
+            ...browsePathV2Fields
+        }
+        structuredProperties {
+            properties {
+                ...structuredPropertiesFields
+            }
+        }
+        fineGrainedLineages {
+            upstreams {
+                urn
+                path
+            }
+            downstreams {
+                urn
+                path
+            }
+            query
+            transformOperation
+        }
+    }
     ... on ERModelRelationship {
         urn
         type

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHookTest.java
@@ -698,6 +698,52 @@ public class UpdateIndicesHookTest {
   }
 
   @Test
+  public void testFineGrainedLineageNotAllowed_When_downstream_is_non_dataset_entity()
+      throws Exception {
+    // Regression test: FineGrainedLineage downstreams aren't always Dataset-backed schemaFields
+    // (e.g. SemanticModel columns via upstreamLineage). Checking the platform exclusion list must
+    // not try to cast the parent's key to DatasetKey when the parent is some other entity type.
+    updateIndicesService.getUpdateGraphIndicesService().setGraphDiffMode(false);
+    updateIndicesService
+        .getUpdateGraphIndicesService()
+        .setFineGrainedLineageNotAllowedForPlatforms(List.of(TEST_HDFS_PLATFORM));
+
+    Urn semanticModelUrn =
+        UrnUtils.getUrn(
+            "urn:li:semanticModel:(urn:li:dataPlatform:snowflake,b2b_sales,b2b_sales_bookings)");
+    Urn upstreamUrn = UrnUtils.getUrn(TEST_SCHEMA_FIELD_HIVE_FIELD_INFO);
+    Urn downstreamUrn =
+        UrnUtils.getUrn(String.format("urn:li:schemaField:(%s,bookings)", semanticModelUrn));
+
+    MetadataChangeLog event =
+        createUpstreamLineageMCLForEntity(
+            SEMANTIC_MODEL_ENTITY_NAME,
+            semanticModelUrn,
+            List.of(upstreamUrn),
+            downstreamUrn,
+            TEST_DATASET_URN);
+
+    // Must not throw (e.g. ClassCastException: SemanticModelKey -> DatasetKey).
+    updateIndicesHook.invoke(opContext, event);
+
+    Edge edge =
+        new Edge(
+            downstreamUrn,
+            upstreamUrn,
+            DOWNSTREAM_OF,
+            null,
+            null,
+            null,
+            null,
+            null,
+            semanticModelUrn,
+            null);
+    // Not excluded: the downstream's parent is a SemanticModel, not the excluded "hdfs" platform.
+    Mockito.verify(mockGraphService, Mockito.times(1))
+        .addEdge(Mockito.eq(opContext), Mockito.eq(edge));
+  }
+
+  @Test
   public void testFineGrainedLineageNotAllowed_When_multiple_upstreams() throws Exception {
     updateIndicesService.getUpdateGraphIndicesService().setGraphDiffMode(false);
     updateIndicesService
@@ -1067,6 +1113,50 @@ public class UpdateIndicesHookTest {
     event.setAspect(GenericRecordUtils.serializeAspect(upstreamLineage));
     event.setEntityUrn(Urn.createFromString(downstreamDataset));
     event.setEntityType(DATASET_ENTITY_NAME);
+    event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
+    return event;
+  }
+
+  /**
+   * Like {@link #createUpstreamLineageMCL}, but for entities other than dataset (e.g.
+   * semanticModel) whose fine-grained lineage downstreams are schemaFields parented by that entity
+   * rather than by a dataset.
+   */
+  private MetadataChangeLog createUpstreamLineageMCLForEntity(
+      String entityType,
+      Urn entityUrn,
+      List<Urn> upstreamSchemaFieldUrns,
+      Urn downstreamSchemaFieldUrn,
+      String upstreamDataset)
+      throws Exception {
+    MetadataChangeLog event = new MetadataChangeLog();
+    event.setAspectName(Constants.UPSTREAM_LINEAGE_ASPECT_NAME);
+    event.setChangeType(ChangeType.UPSERT);
+
+    UpstreamLineage upstreamLineage = new UpstreamLineage();
+    FineGrainedLineageArray fineGrainedLineages = new FineGrainedLineageArray();
+    FineGrainedLineage fineGrainedLineage = new FineGrainedLineage();
+    fineGrainedLineage.setDownstreamType(FineGrainedLineageDownstreamType.FIELD_SET);
+    fineGrainedLineage.setUpstreamType(FineGrainedLineageUpstreamType.FIELD_SET);
+    UrnArray upstreamUrns = new UrnArray();
+    upstreamUrns.addAll(upstreamSchemaFieldUrns);
+    fineGrainedLineage.setUpstreams(upstreamUrns);
+    UrnArray downstreamUrns = new UrnArray();
+    downstreamUrns.add(downstreamSchemaFieldUrn);
+    fineGrainedLineage.setDownstreams(downstreamUrns);
+    fineGrainedLineages.add(fineGrainedLineage);
+    upstreamLineage.setFineGrainedLineages(fineGrainedLineages);
+
+    final UpstreamArray upstreamArray = new UpstreamArray();
+    final Upstream upstream = new Upstream();
+    upstream.setType(DatasetLineageType.TRANSFORMED);
+    upstream.setDataset(DatasetUrn.createFromString(upstreamDataset));
+    upstreamArray.add(upstream);
+    upstreamLineage.setUpstreams(upstreamArray);
+
+    event.setAspect(GenericRecordUtils.serializeAspect(upstreamLineage));
+    event.setEntityUrn(entityUrn);
+    event.setEntityType(entityType);
     event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
     return event;
   }

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/graph/GraphIndexUtils.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/graph/GraphIndexUtils.java
@@ -344,9 +344,11 @@ public class GraphIndexUtils {
   }
 
   // The platform exclusion list (fineGrainedLineageNotAllowedForPlatforms) only makes sense for
-  // Dataset-backed schemaFields (e.g. hdfs, s3). FineGrainedLineage can also point at schemaFields
-  // whose parent is a non-Dataset entity (e.g. SemanticModel), which have no platform concept —
-  // treat those as "not excluded" instead of crashing on the cast to DatasetKey.
+  // Dataset-backed schemaFields (e.g. hdfs, s3), where platform is available from the DatasetKey
+  // in the parent URN. FineGrainedLineage can also point at schemaFields whose parent is a
+  // non-Dataset entity (e.g. SemanticModel): those may have a platform, but it is not embedded
+  // in the URN, so we cannot resolve it here — treat those as "not excluded" instead of crashing
+  // on the cast to DatasetKey.
   @Nullable
   private static String getDatasetPlatformName(EntityRegistry entityRegistry, Urn parentUrn) {
     if (!parentUrn.getEntityType().equals(DATASET_ENTITY_NAME)) {

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/graph/GraphIndexUtils.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/graph/GraphIndexUtils.java
@@ -323,23 +323,40 @@ public class GraphIndexUtils {
       Urn upstream,
       List<String> fineGrainedLineageNotAllowedForPlatforms,
       EntityRegistry entityRegistry) {
-    return !CollectionUtils.isEmpty(fineGrainedLineageNotAllowedForPlatforms)
-        && ((Objects.nonNull(downstream)
-                && downstream.getEntityType().equals(SCHEMA_FIELD_ENTITY_NAME)
-                && fineGrainedLineageNotAllowedForPlatforms.contains(
-                    getDatasetPlatformName(entityRegistry, downstream.getIdAsUrn())))
-            || (Objects.nonNull(upstream)
-                && upstream.getEntityType().equals(SCHEMA_FIELD_ENTITY_NAME)
-                && fineGrainedLineageNotAllowedForPlatforms.contains(
-                    getDatasetPlatformName(entityRegistry, upstream.getIdAsUrn()))));
+    if (CollectionUtils.isEmpty(fineGrainedLineageNotAllowedForPlatforms)) {
+      return false;
+    }
+    // getDatasetPlatformName returns null for non-Dataset parents (e.g. SemanticModel); guard
+    // explicitly rather than relying on List#contains(null), which some List.of(...) instances
+    // reject with an NPE instead of returning false.
+    String downstreamPlatform =
+        Objects.nonNull(downstream) && downstream.getEntityType().equals(SCHEMA_FIELD_ENTITY_NAME)
+            ? getDatasetPlatformName(entityRegistry, downstream.getIdAsUrn())
+            : null;
+    String upstreamPlatform =
+        Objects.nonNull(upstream) && upstream.getEntityType().equals(SCHEMA_FIELD_ENTITY_NAME)
+            ? getDatasetPlatformName(entityRegistry, upstream.getIdAsUrn())
+            : null;
+    return (downstreamPlatform != null
+            && fineGrainedLineageNotAllowedForPlatforms.contains(downstreamPlatform))
+        || (upstreamPlatform != null
+            && fineGrainedLineageNotAllowedForPlatforms.contains(upstreamPlatform));
   }
 
-  private static String getDatasetPlatformName(EntityRegistry entityRegistry, Urn datasetUrn) {
+  // The platform exclusion list (fineGrainedLineageNotAllowedForPlatforms) only makes sense for
+  // Dataset-backed schemaFields (e.g. hdfs, s3). FineGrainedLineage can also point at schemaFields
+  // whose parent is a non-Dataset entity (e.g. SemanticModel), which have no platform concept —
+  // treat those as "not excluded" instead of crashing on the cast to DatasetKey.
+  @Nullable
+  private static String getDatasetPlatformName(EntityRegistry entityRegistry, Urn parentUrn) {
+    if (!parentUrn.getEntityType().equals(DATASET_ENTITY_NAME)) {
+      return null;
+    }
     DatasetKey dsKey =
         (DatasetKey)
             EntityKeyUtils.convertUrnToEntityKey(
-                datasetUrn,
-                entityRegistry.getEntitySpec(datasetUrn.getEntityType()).getKeyAspectSpec());
+                parentUrn,
+                entityRegistry.getEntitySpec(parentUrn.getEntityType()).getKeyAspectSpec());
     DataPlatformKey dpKey =
         (DataPlatformKey)
             EntityKeyUtils.convertUrnToEntityKey(


### PR DESCRIPTION
## Summary
- Make `Metric` and `SemanticModel` implement `EntityWithRelationships`, expose `lineage`, and register `EntityLineageResultResolver` so lineage APIs work for both entity types.
- Add lineage V3 GraphQL fragments plus `getLineageVizConfig` / `LINEAGE` capability so nodes hydrate instead of staying as empty skeletons.
- Prefer the Metric Sigma type icon in lineage cards; fix `ClassCastException` when indexing fine-grained lineage for non-Dataset entities (e.g. SemanticModel).

<img width="1209" height="340" alt="Screenshot 2026-07-17 at 7 08 07 PM" src="https://github.com/user-attachments/assets/9ea4282c-97a3-46cf-b78c-de062386d704" />
