### PR TITLE
fix(ingest/odcs): close silent-failure gaps in validation and telemetry

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
@@ -1,6 +1,6 @@
 import json
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List, Optional, Tuple, Type, TypeGuard
+from typing import Dict, Iterable, List, Optional, Set, Tuple, Type, TypeGuard
 
 from datahub.emitter import mce_builder
 from datahub.emitter.mce_builder import (
@@ -551,7 +551,7 @@ def unmapped_owner_roles(contract: ODCSContract) -> List[str]:
     source can surface it for telemetry. Mirrors the eligibility rules in
     `_make_owners` (skip departed members and members with no identifier).
     """
-    roles: set = set()
+    roles: Set[str] = set()
     for member in contract.team_members:
         if member.dateOut:
             continue

--- a/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
@@ -543,6 +543,26 @@ def _make_owners(
     return owners
 
 
+def unmapped_owner_roles(contract: ODCSContract) -> List[str]:
+    """Distinct non-empty `team[].role` values that fall back to TECHNICAL_OWNER.
+
+    An empty/absent role legitimately defaults; a *named* role the map does not
+    know (e.g. `producer`, `consumer`, or a typo) is silently coerced, so the
+    source can surface it for telemetry. Mirrors the eligibility rules in
+    `_make_owners` (skip departed members and members with no identifier).
+    """
+    roles: set = set()
+    for member in contract.team_members:
+        if member.dateOut:
+            continue
+        if not (member.username or member.name):
+            continue
+        role_key = (member.role or "").strip()
+        if role_key and role_key not in _OWNER_ROLE_MAP:
+            roles.add(role_key)
+    return sorted(roles)
+
+
 def _walk_properties(
     properties: Optional[List[ODCSProperty]], parent_path: str = ""
 ) -> Iterable[Tuple[str, ODCSProperty]]:

--- a/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_source.py
@@ -33,6 +33,7 @@ from datahub.ingestion.source.odcs.odcs_mapper import (
     odcs_to_logical_parent_mcp,
     odcs_to_physical_bindings,
     odcs_to_schema_assertion_mcps,
+    unmapped_owner_roles,
 )
 from datahub.ingestion.source.odcs.odcs_models import (
     KNOWN_UNMAPPED_AUTHDEF_FIELDS,
@@ -138,12 +139,15 @@ class ODCSSourceReport(StaleEntityRemovalSourceReport):
     physical_urns_verified: int = 0
     physical_urns_unverified: int = 0
     physical_urns_link_conflicts: int = 0
+    physical_urns_verify_failed: int = 0
     physical_names_passthrough: int = 0
     owners_unresolved: int = 0
+    contracts_validation_skipped: int = 0
     files_skipped: List[str] = field(default_factory=list)
     rules_skipped_no_threshold: List[str] = field(default_factory=list)
     rules_routed_to_custom: List[str] = field(default_factory=list)
     schema_type_fallbacks: List[str] = field(default_factory=list)
+    owners_role_defaulted: List[str] = field(default_factory=list)
     spec_fields_ignored: List[str] = field(default_factory=list)
 
 
@@ -210,6 +214,9 @@ class ODCSSource(StatefulIngestionSourceBase):
         # physical URN (one get_aspect per unique URN), for cross-run conflict
         # detection. `None` means "no existing link" (or lookup unavailable).
         self._physical_parent_cache: Dict[str, Optional[str]] = {}
+        # URNs whose graph lookup raised and were assumed-present (fail-open),
+        # so they are never miscounted as genuinely verified.
+        self._urn_verify_failed: Set[str] = set()
         # Owner URNs already warned about (report-only resolution check).
         self._owners_warned: Set[str] = set()
 
@@ -233,15 +240,40 @@ class ODCSSource(StatefulIngestionSourceBase):
     # Schema validation + file IO
     # ------------------------------------------------------------------
 
-    def _load_validators(self) -> dict:
-        validators: dict = {}
+    def _load_validators(self) -> Dict[str, "jsonschema.Draft202012Validator"]:
+        validators: Dict[str, jsonschema.Draft202012Validator] = {}
         for version, filename in _VERSION_TO_SCHEMA.items():
             path = _SCHEMA_DIR / filename
             if not path.exists():
                 continue
-            with open(path) as fp:
-                schema = json.load(fp)
+            # Guard per-file: a corrupt/missing vendored schema must degrade to
+            # "this version is unvalidated" (surfaced below), never abort the
+            # whole source in __init__.
+            try:
+                with open(path) as fp:
+                    schema = json.load(fp)
+            except (OSError, ValueError) as e:
+                self.report.warning(
+                    title="Could not load ODCS JSON Schema",
+                    message="Contracts of this version will not be schema-validated.",
+                    context=f"{path} (version {version})",
+                    exc=e,
+                )
+                continue
             validators[version] = jsonschema.Draft202012Validator(schema)
+        if not validators:
+            # No validators at all: strict_validation becomes a silent no-op and
+            # every contract passes with zero checking. Surface it once.
+            self.report.warning(
+                title="ODCS JSON Schema validators unavailable",
+                message=(
+                    "No vendored ODCS schemas could be loaded, so contracts will "
+                    "not be schema-validated this run (strict_validation has no "
+                    "effect). This usually indicates a packaging or checkout "
+                    "regression in the odcs_schema/ directory."
+                ),
+                context=str(_SCHEMA_DIR),
+            )
         return validators
 
     def _glob_root(self, pattern: str) -> pathlib.Path:
@@ -375,8 +407,20 @@ class ODCSSource(StatefulIngestionSourceBase):
         if validator is None:
             validator = self._validators.get(_DEFAULT_VERSION)
         if validator is None:
+            # No validator resolved: the contract is passed through unchecked.
+            # Counted so a zero-validation run is visible in the report even
+            # when the one-time load warning scrolled past.
+            self.report.contracts_validation_skipped += 1
             return True
-        errors = sorted(validator.iter_errors(raw_dict), key=lambda e: e.path)
+        # `err.path` mixes str property names and int array indices in one
+        # deque; sorting deques compares elements pairwise, so a str-vs-int
+        # comparison raises TypeError on already-invalid contracts. Sort by the
+        # stringified path instead so validation feedback is never lost to an
+        # opaque "unhandled error" skip.
+        errors = sorted(
+            validator.iter_errors(raw_dict),
+            key=lambda e: [str(p) for p in e.absolute_path],
+        )
         if not errors:
             return True
         self.report.validation_errors += len(errors)
@@ -540,6 +584,8 @@ class ODCSSource(StatefulIngestionSourceBase):
                 context=urn,
                 exc=e,
             )
+            # Record the fail-open so callers never tally it as verified.
+            self._urn_verify_failed.add(urn)
             exists = True
         self._urn_exists_cache[urn] = exists
         return exists
@@ -549,7 +595,10 @@ class ODCSSource(StatefulIngestionSourceBase):
         if exists is None:
             # No graph: emit without verification.
             return True
-        if exists:
+        if urn in self._urn_verify_failed:
+            # Assumed-present due to a lookup error, not actually confirmed.
+            self.report.physical_urns_verify_failed += 1
+        elif exists:
             self.report.physical_urns_verified += 1
         return exists
 
@@ -630,6 +679,9 @@ class ODCSSource(StatefulIngestionSourceBase):
             )
             self.report.contracts_skipped += 1
             return
+
+        for role_key in unmapped_owner_roles(contract):
+            self.report.owners_role_defaulted.append(f"{contract.id}: {role_key}")
 
         overrides = self.config.physical_urn_overrides.get(contract.id)
         if overrides:

--- a/metadata-ingestion/tests/unit/odcs/test_odcs_mapper.py
+++ b/metadata-ingestion/tests/unit/odcs/test_odcs_mapper.py
@@ -17,6 +17,7 @@ from datahub.ingestion.source.odcs.odcs_mapper import (
     odcs_to_logical_parent_mcp,
     odcs_to_physical_bindings,
     odcs_to_schema_assertion_mcps,
+    unmapped_owner_roles,
 )
 from datahub.ingestion.source.odcs.odcs_models import (
     ODCSContract,
@@ -611,6 +612,25 @@ def test_owners_roles_dedup_and_dateout() -> None:
     assert by_urn["urn:li:corpuser:erin"] == OwnershipTypeClass.TECHNICAL_OWNER
     assert "urn:li:corpuser:dave" not in by_urn
     assert len(owners) == 3
+
+
+def test_unmapped_owner_roles_surfaces_only_named_unknown_roles() -> None:
+    contract = _make_contract(
+        schema=[{"name": "t"}],
+        team=[
+            {"username": "alice", "role": "owner"},  # mapped -> excluded
+            {"username": "bob"},  # no role -> legitimate default, excluded
+            {"username": "carol", "role": "producer"},  # named unknown -> reported
+            {"username": "dan", "role": "producer"},  # dedup
+            {"username": "eve", "role": "consumer"},  # named unknown -> reported
+            {
+                "username": "frank",
+                "role": "approver",
+                "dateOut": "2024-01-01",  # departed -> excluded
+            },
+        ],
+    )
+    assert unmapped_owner_roles(contract) == ["consumer", "producer"]
 
 
 def test_owner_strip_email_domain() -> None:

--- a/metadata-ingestion/tests/unit/odcs/test_odcs_source.py
+++ b/metadata-ingestion/tests/unit/odcs/test_odcs_source.py
@@ -237,6 +237,69 @@ def test_validate_lenient_default_proceeds_on_invalid_doc(
     assert len(src.report.warnings) >= 1
 
 
+def test_validate_sorts_mixed_type_error_paths_without_crashing(
+    tmp_path: pathlib.Path,
+) -> None:
+    """JSON Schema error paths mix str property names and int array indices.
+    Sorting the raw deques compares str-vs-int and raises TypeError in Py3,
+    which would demote actionable validation feedback to an opaque skip. The
+    source sorts by the stringified path instead."""
+    from collections import deque
+
+    class _FakeErr:
+        def __init__(self, path: list, message: str) -> None:
+            self.absolute_path = deque(path)
+            self.path = deque(path)
+            self.message = message
+
+    class _FakeValidator:
+        def __init__(self, errors: list) -> None:
+            self._errors = errors
+
+        def iter_errors(self, raw_dict: dict) -> Any:
+            return iter(self._errors)
+
+    errors = [_FakeErr(["schema", 0], "a"), _FakeErr(["schema", "x"], "b")]
+    # Document the underlying footgun the fix guards against.
+    with pytest.raises(TypeError):
+        sorted(errors, key=lambda e: e.path)
+
+    src = _make_source(tmp_path)
+    src._validators = {"3.1.0": _FakeValidator(errors)}  # type: ignore[dict-item]
+    ok = src._validate({"apiVersion": "3.1.0", "id": "x"}, tmp_path / "f.yaml")
+    assert ok  # lenient default proceeds after reporting
+    assert src.report.validation_errors == 2
+
+
+def test_validate_counts_skips_when_no_validator_available(
+    tmp_path: pathlib.Path,
+) -> None:
+    """With no validators loaded, strict_validation is a silent no-op; the
+    per-contract skip is counted so a zero-validation run is visible."""
+    src = _make_source(tmp_path)
+    src._validators = {}
+    ok = src._validate({"apiVersion": "3.1.0", "id": "x"}, tmp_path / "f.yaml")
+    assert ok
+    assert src.report.contracts_validation_skipped == 1
+
+
+def test_missing_schema_dir_warns_once(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A vendored-schema packaging/checkout regression must surface a warning,
+    not silently disable validation for the whole run."""
+    import datahub.ingestion.source.odcs.odcs_source as mod
+
+    src = _make_source(tmp_path)
+    monkeypatch.setattr(mod, "_SCHEMA_DIR", tmp_path / "does-not-exist")
+    validators = src._load_validators()
+    assert validators == {}
+    assert any(
+        "validators unavailable" in str(getattr(w, "title", "")).lower()
+        for w in src.report.warnings
+    )
+
+
 # ---------------------------------------------------------------------------
 # Unknown-field classification
 # ---------------------------------------------------------------------------
@@ -468,6 +531,9 @@ def test_verification_fails_open_on_graph_error(tmp_path: pathlib.Path) -> None:
         "Could not verify URN existence" in str(getattr(w, "title", ""))
         for w in src.report.warnings
     )
+    # A fail-open must not be tallied as genuinely verified.
+    assert src.report.physical_urns_verify_failed == 1
+    assert src.report.physical_urns_verified == 0
 
 
 def _link_conflict_warnings(src: ODCSSource) -> List:
@@ -697,6 +763,25 @@ def test_owner_normalization_knobs_reach_emitted_ownership(
     workunits = list(src.get_workunits_internal())
     ownerships = _aspects_of(workunits, OwnershipClass)
     assert ownerships[0].owners[0].owner == "urn:li:corpuser:alice@acme.example"
+
+
+def test_unmapped_owner_role_is_recorded(tmp_path: pathlib.Path) -> None:
+    """A named role the map does not know is silently coerced to
+    TECHNICAL_OWNER; the source records it so the coercion is visible."""
+    body = _VALID_CONTRACT_BODY.replace(
+        "\nschema:\n",
+        """
+team:
+  - username: alice
+    role: producer
+schema:
+""",
+    )
+    contract_file = tmp_path / "c.odcs.yaml"
+    contract_file.write_text(body, encoding="utf-8")
+    src = _make_source(tmp_path, path=str(contract_file))
+    list(src.get_workunits_internal())
+    assert src.report.owners_role_defaulted == ["test-contract-1: producer"]
 
 
 def test_owner_normalization_knobs_are_mutually_exclusive() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #17331. Closes several silent-failure gaps in the ODCS source:

- `strict_validation` no longer silently no-ops when a validator is unavailable for a supported `apiVersion`.
- `_validate` sorts `jsonschema` errors by `absolute_path` stringified, avoiding a `TypeError` on mixed-type deque paths.
- Owner-role resolution and verified-count telemetry surface via report counters/warnings rather than being dropped.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [ ] Docs (n/a)
- [ ] Breaking change (n/a)

<!-- odcs-connector-tests-note -->
## Connector tests

Part of the ODCS follow-up stack. A companion integration suite for the ODCS source is added in the private `acryldata/connector-tests` repo — acryldata/connector-tests#852 — a hermetic golden-file test that ingests a Bitol ODCS contract and asserts the full mapping (logical datasets, physical bindings, schema + data-quality assertions, and native data contracts). Its committed golden reflects the post-merge behaviour of this stack, so it should be re-blessed at the release that contains these PRs.
