### PR TITLE
refactor(ingest/odcs): type quality arguments and narrow Any usage

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
@@ -199,8 +199,7 @@ def _description_to_str(
         ("usage", description.usage),
         ("limitations", description.limitations),
     ]
-    # Some producers add non-spec prose keys (e.g. summary, description); render
-    # any string-valued extras so operator-authored text is never dropped.
+    # Render non-spec string extras (e.g. summary) so producer prose isn't dropped.
     for key, value in (description.model_extra or {}).items():
         if isinstance(value, str):
             fields.append((key, value))

--- a/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
@@ -194,13 +194,19 @@ def _description_to_str(
         return None
     if isinstance(description, str):
         return description.strip() or None
+    fields: List[Tuple[str, Optional[str]]] = [
+        ("purpose", description.purpose),
+        ("usage", description.usage),
+        ("limitations", description.limitations),
+    ]
+    # Some producers add non-spec prose keys (e.g. summary, description); render
+    # any string-valued extras so operator-authored text is never dropped.
+    for key, value in (description.model_extra or {}).items():
+        if isinstance(value, str):
+            fields.append((key, value))
     parts = [
         f"**{key}**: {value.strip()}"
-        for key, value in (
-            ("purpose", description.purpose),
-            ("usage", description.usage),
-            ("limitations", description.limitations),
-        )
+        for key, value in fields
         if value and value.strip()
     ]
     return "\n\n".join(parts) or None

--- a/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
@@ -1,6 +1,6 @@
 import json
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List, Optional, Set, Tuple, Type, TypeGuard
+from typing import Dict, Iterable, List, Optional, Set, Tuple, Type, TypeGuard, Union
 
 from datahub.emitter import mce_builder
 from datahub.emitter.mce_builder import (
@@ -22,6 +22,7 @@ from datahub.ingestion.source.odcs.odcs_config import (
 from datahub.ingestion.source.odcs.odcs_models import (
     ODCSContract,
     ODCSProperty,
+    ODCSQualityArguments,
     ODCSQualityRule,
     ODCSSchemaObject,
     ODCSServer,
@@ -852,13 +853,13 @@ class _RuleContext:
         return self.rule.name or self.rule.id or f"<unnamed:{self.scope}:{self.index}>"
 
 
-def _num(v: object) -> AssertionStdParameterClass:
+def _num(v: Union[float, int]) -> AssertionStdParameterClass:
     """Normalize a numeric threshold to a stable string form.
 
     Both `5` (int) and `5.0` (float) render as `"5"`; `5.5` renders as `"5.5"`.
     """
     return AssertionStdParameterClass(
-        value=f"{float(v):g}",  # type: ignore[arg-type]
+        value=f"{float(v):g}",
         type=AssertionStdParameterTypeClass.NUMBER,
     )
 
@@ -1003,6 +1004,23 @@ def _render_thresholds(rule: ODCSQualityRule) -> List[str]:
     return parts
 
 
+def _arguments_json(arguments: Optional[ODCSQualityArguments]) -> Optional[str]:
+    """Stable JSON rendering of quality-rule arguments for provenance.
+
+    Serializes by alias and drops nulls so the recorded provenance matches the
+    source document, while `extra="allow"` keeps any engine-specific keys.
+    """
+    if arguments is None:
+        return None
+    payload = arguments.model_dump(by_alias=True, exclude_none=True)
+    if not payload:
+        return None
+    try:
+        return json.dumps(payload, sort_keys=True)
+    except (TypeError, ValueError):
+        return None
+
+
 def _library_rule_logic(rule: ODCSQualityRule) -> Optional[str]:
     """Stable, human-readable rendition of a library rule for custom `logic`.
 
@@ -1014,11 +1032,9 @@ def _library_rule_logic(rule: ODCSQualityRule) -> Optional[str]:
     if not metric:
         return None
     parts = [metric]
-    if rule.arguments:
-        try:
-            parts.append(f"arguments={json.dumps(rule.arguments, sort_keys=True)}")
-        except (TypeError, ValueError):
-            pass
+    args_json = _arguments_json(rule.arguments)
+    if args_json is not None:
+        parts.append(f"arguments={args_json}")
     if rule.validValues is not None:
         try:
             parts.append(f"validValues={json.dumps(rule.validValues)}")
@@ -1081,11 +1097,9 @@ def _custom_props_for_rule(ctx: _RuleContext) -> Dict[str, str]:
         props["odcs.rule.metric"] = metric
     if rule.unit:
         props["odcs.rule.unit"] = rule.unit
-    if rule.arguments:
-        try:
-            props["odcs.rule.arguments"] = json.dumps(rule.arguments, sort_keys=True)
-        except (TypeError, ValueError):
-            pass
+    args_json = _arguments_json(rule.arguments)
+    if args_json is not None:
+        props["odcs.rule.arguments"] = args_json
     if rule.dimension:
         props["odcs.rule.dimension"] = rule.dimension
     if rule.severity:
@@ -1303,7 +1317,7 @@ def _route_library_rule(
     rule = ctx.rule
     metric = rule.effective_metric
     unit = (rule.unit or _UNIT_ROWS).strip().lower()
-    args = rule.arguments or {}
+    args = rule.arguments
 
     if metric == _METRIC_NULL_VALUES:
         if ctx.column is None:
@@ -1333,7 +1347,7 @@ def _route_library_rule(
         )
 
     if metric in (_METRIC_DUPLICATE_VALUES, _METRIC_DUPLICATE_COUNT):
-        if args.get("properties"):
+        if args is not None and args.properties:
             # Multi-column uniqueness (schema-level duplicateValues) has no
             # native DataHub metric; preserve as custom.
             return _custom_or_skip(ctx, trace)
@@ -1350,8 +1364,10 @@ def _route_library_rule(
         return _custom_or_skip(ctx, trace)
 
     if metric in (_METRIC_INVALID_VALUES, _METRIC_VALID_VALUES):
-        valid_values = args.get("validValues") or rule.validValues
-        pattern = args.get("pattern")
+        valid_values = (
+            args.validValues if args is not None else None
+        ) or rule.validValues
+        pattern = args.pattern if args is not None else None
         if ctx.column is None or (valid_values and pattern):
             return _custom_or_skip(ctx, trace)
         fail_threshold = _fail_threshold_from_rule(rule, unit)

--- a/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
@@ -21,6 +21,7 @@ from datahub.ingestion.source.odcs.odcs_config import (
 )
 from datahub.ingestion.source.odcs.odcs_models import (
     ODCSContract,
+    ODCSDescription,
     ODCSProperty,
     ODCSQualityArguments,
     ODCSQualityRule,
@@ -186,21 +187,23 @@ class SchemaBuildResult:
     unmapped_types: List[str] = field(default_factory=list)
 
 
-def _description_to_str(description: object) -> Optional[str]:
-    """ODCS allows description to be a string or an object (e.g. {purpose, usage, limitations})."""
+def _description_to_str(
+    description: Optional[Union[str, ODCSDescription]],
+) -> Optional[str]:
     if description is None:
         return None
     if isinstance(description, str):
         return description.strip() or None
-    if isinstance(description, dict):
-        parts: List[str] = []
-        for key in ("purpose", "usage", "limitations", "summary", "description"):
-            v = description.get(key)
-            if isinstance(v, str) and v.strip():
-                parts.append(f"**{key}**: {v.strip()}")
-        if parts:
-            return "\n\n".join(parts)
-    return None
+    parts = [
+        f"**{key}**: {value.strip()}"
+        for key, value in (
+            ("purpose", description.purpose),
+            ("usage", description.usage),
+            ("limitations", description.limitations),
+        )
+        if value and value.strip()
+    ]
+    return "\n\n".join(parts) or None
 
 
 # ----------------------------------------------------------------------------
@@ -864,8 +867,10 @@ def _num(v: Union[float, int]) -> AssertionStdParameterClass:
     )
 
 
-def _is_plain_number(value: object) -> TypeGuard[float]:
-    """True for int/float but NOT bool (bool is an int subclass in Python)."""
+def _is_plain_number(
+    value: Optional[Union[float, int, str, bool]],
+) -> TypeGuard[float]:
+    # bool is an int subclass in Python, so exclude it explicitly.
     return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
@@ -1005,13 +1010,10 @@ def _render_thresholds(rule: ODCSQualityRule) -> List[str]:
 
 
 def _arguments_json(arguments: Optional[ODCSQualityArguments]) -> Optional[str]:
-    """Stable JSON rendering of quality-rule arguments for provenance.
-
-    Serializes by alias and drops nulls so the recorded provenance matches the
-    source document, while `extra="allow"` keeps any engine-specific keys.
-    """
     if arguments is None:
         return None
+    # by_alias + exclude_none so provenance matches the source document, and
+    # extra="allow" keeps engine-specific keys.
     payload = arguments.model_dump(by_alias=True, exclude_none=True)
     if not payload:
         return None

--- a/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -18,6 +18,7 @@ from pydantic import BaseModel, ConfigDict, Field
 KNOWN_UNMAPPED_CONTRACT_FIELDS = frozenset(
     (
         "price",
+        "roles",
         "slaDefaultElement",
         "slaProperties",
         "support",
@@ -107,7 +108,7 @@ class ODCSAuthoritativeDefinition(ODCSBaseModel):
 
 class ODCSCustomProperty(ODCSBaseModel):
     property: Optional[str] = None
-    value: Optional[Any] = None
+    value: Optional[object] = None
 
 
 class ODCSProperty(ODCSBaseModel):
@@ -116,7 +117,7 @@ class ODCSProperty(ODCSBaseModel):
     name: str
     logicalType: Optional[str] = None
     physicalType: Optional[str] = None
-    description: Optional[Union[str, Dict[str, Any]]] = None
+    description: Optional[Union[str, Dict[str, object]]] = None
     primaryKey: Optional[bool] = None
     primaryKeyPosition: Optional[int] = None
     required: Optional[bool] = None
@@ -140,12 +141,28 @@ class ODCSSchemaObject(ODCSBaseModel):
     physicalName: Optional[str] = None
     physicalType: Optional[str] = None
     logicalType: Optional[str] = None
-    description: Optional[Union[str, Dict[str, Any]]] = None
+    description: Optional[Union[str, Dict[str, object]]] = None
     businessName: Optional[str] = None
     tags: Optional[List[str]] = None
     properties: Optional[List[ODCSProperty]] = None
     authoritativeDefinitions: Optional[List[ODCSAuthoritativeDefinition]] = None
     quality: Optional[List["ODCSQualityRule"]] = None
+
+
+class ODCSQualityArguments(ODCSBaseModel):
+    """v3.1 library-metric arguments (`quality[].arguments`).
+
+    The closed key set the mapper reads is typed; `extra="allow"` keeps any
+    uncommon/engine-specific keys so they still round-trip into the custom
+    assertion provenance instead of being silently dropped.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    validValues: Optional[List[object]] = None
+    pattern: Optional[str] = None
+    missingValues: Optional[List[object]] = None
+    properties: Optional[List[str]] = None
 
 
 class ODCSQualityRule(ODCSBaseModel):
@@ -172,9 +189,9 @@ class ODCSQualityRule(ODCSBaseModel):
     # v3.0.x library rule name; deprecated alias of `metric` in v3.1.
     rule: Optional[str] = None
     # v3.1 metric arguments: validValues, pattern, missingValues, properties.
-    arguments: Optional[Dict[str, Any]] = None
+    arguments: Optional[ODCSQualityArguments] = None
     # v3.0.x form: static list of valid values directly on the rule.
-    validValues: Optional[List[Any]] = None
+    validValues: Optional[List[object]] = None
     dimension: Optional[str] = None
     severity: Optional[str] = None
     businessImpact: Optional[str] = None
@@ -183,9 +200,9 @@ class ODCSQualityRule(ODCSBaseModel):
     scheduler: Optional[str] = None
     query: Optional[str] = None
     engine: Optional[str] = None
-    implementation: Optional[Union[str, Dict[str, Any]]] = None
-    mustBe: Optional[Any] = None
-    mustNotBe: Optional[Any] = None
+    implementation: Optional[Union[str, Dict[str, object]]] = None
+    mustBe: Optional[Union[float, int, str, bool]] = None
+    mustNotBe: Optional[Union[float, int, str, bool]] = None
     mustBeGreaterThan: Optional[float] = None
     mustBeGreaterOrEqualTo: Optional[float] = None
     mustBeLessThan: Optional[float] = None
@@ -269,12 +286,11 @@ class ODCSContract(ODCSBaseModel):
     domain: Optional[str] = None
     dataProduct: Optional[str] = None
     tenant: Optional[str] = None
-    description: Optional[Union[str, Dict[str, Any]]] = None
+    description: Optional[Union[str, Dict[str, object]]] = None
     tags: Optional[List[str]] = None
     schema_: Optional[List[ODCSSchemaObject]] = Field(default=None, alias="schema")
     servers: Optional[List[ODCSServer]] = None
     team: Optional[Union[ODCSTeam, List[ODCSTeamMember]]] = None
-    roles: Optional[List[Dict[str, Any]]] = None
     customProperties: Optional[List[ODCSCustomProperty]] = None
     authoritativeDefinitions: Optional[List[ODCSAuthoritativeDefinition]] = None
     contractCreatedTs: Optional[str] = None

--- a/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_models.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
 # ---------------------------------------------------------------------------
 # Spec-valid fields the source deliberately does not map.
@@ -108,16 +108,24 @@ class ODCSAuthoritativeDefinition(ODCSBaseModel):
 
 class ODCSCustomProperty(ODCSBaseModel):
     property: Optional[str] = None
-    value: Optional[object] = None
+    value: Optional[JsonValue] = None
+
+
+class ODCSDescription(ODCSBaseModel):
+    # v3.1 lets `description` be either a plain string or this object; the
+    # extra keys some producers add are kept so provenance stays faithful.
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    purpose: Optional[str] = None
+    usage: Optional[str] = None
+    limitations: Optional[str] = None
 
 
 class ODCSProperty(ODCSBaseModel):
-    """A column / property within an ODCS schema object."""
-
     name: str
     logicalType: Optional[str] = None
     physicalType: Optional[str] = None
-    description: Optional[Union[str, Dict[str, object]]] = None
+    description: Optional[Union[str, ODCSDescription]] = None
     primaryKey: Optional[bool] = None
     primaryKeyPosition: Optional[int] = None
     required: Optional[bool] = None
@@ -135,13 +143,11 @@ class ODCSProperty(ODCSBaseModel):
 
 
 class ODCSSchemaObject(ODCSBaseModel):
-    """An entry in `schema[]` — typically corresponds to a table/view."""
-
     name: str
     physicalName: Optional[str] = None
     physicalType: Optional[str] = None
     logicalType: Optional[str] = None
-    description: Optional[Union[str, Dict[str, object]]] = None
+    description: Optional[Union[str, ODCSDescription]] = None
     businessName: Optional[str] = None
     tags: Optional[List[str]] = None
     properties: Optional[List[ODCSProperty]] = None
@@ -150,18 +156,13 @@ class ODCSSchemaObject(ODCSBaseModel):
 
 
 class ODCSQualityArguments(ODCSBaseModel):
-    """v3.1 library-metric arguments (`quality[].arguments`).
-
-    The closed key set the mapper reads is typed; `extra="allow"` keeps any
-    uncommon/engine-specific keys so they still round-trip into the custom
-    assertion provenance instead of being silently dropped.
-    """
-
+    # `extra="allow"` keeps engine-specific keys so they round-trip into the
+    # custom-assertion provenance instead of being silently dropped.
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
-    validValues: Optional[List[object]] = None
+    validValues: Optional[List[JsonValue]] = None
     pattern: Optional[str] = None
-    missingValues: Optional[List[object]] = None
+    missingValues: Optional[List[JsonValue]] = None
     properties: Optional[List[str]] = None
 
 
@@ -191,7 +192,7 @@ class ODCSQualityRule(ODCSBaseModel):
     # v3.1 metric arguments: validValues, pattern, missingValues, properties.
     arguments: Optional[ODCSQualityArguments] = None
     # v3.0.x form: static list of valid values directly on the rule.
-    validValues: Optional[List[object]] = None
+    validValues: Optional[List[JsonValue]] = None
     dimension: Optional[str] = None
     severity: Optional[str] = None
     businessImpact: Optional[str] = None
@@ -200,7 +201,7 @@ class ODCSQualityRule(ODCSBaseModel):
     scheduler: Optional[str] = None
     query: Optional[str] = None
     engine: Optional[str] = None
-    implementation: Optional[Union[str, Dict[str, object]]] = None
+    implementation: Optional[Union[str, Dict[str, JsonValue]]] = None
     mustBe: Optional[Union[float, int, str, bool]] = None
     mustNotBe: Optional[Union[float, int, str, bool]] = None
     mustBeGreaterThan: Optional[float] = None
@@ -216,7 +217,7 @@ class ODCSQualityRule(ODCSBaseModel):
 
     @property
     def effective_metric(self) -> Optional[str]:
-        """The library metric/rule name, preferring the canonical v3.1 key."""
+        # Prefer the canonical v3.1 `metric` over the deprecated `rule` alias.
         value = self.metric or self.rule
         if value is None:
             return None
@@ -224,7 +225,6 @@ class ODCSQualityRule(ODCSBaseModel):
 
     @property
     def used_deprecated_rule_key(self) -> bool:
-        """True when only the legacy `rule` key carries the library name."""
         return self.metric is None and self.rule is not None
 
 
@@ -286,7 +286,7 @@ class ODCSContract(ODCSBaseModel):
     domain: Optional[str] = None
     dataProduct: Optional[str] = None
     tenant: Optional[str] = None
-    description: Optional[Union[str, Dict[str, object]]] = None
+    description: Optional[Union[str, ODCSDescription]] = None
     tags: Optional[List[str]] = None
     schema_: Optional[List[ODCSSchemaObject]] = Field(default=None, alias="schema")
     servers: Optional[List[ODCSServer]] = None
@@ -297,7 +297,6 @@ class ODCSContract(ODCSBaseModel):
 
     @property
     def team_members(self) -> List[ODCSTeamMember]:
-        """Team members regardless of which spec shape `team` used."""
         if self.team is None:
             return []
         if isinstance(self.team, ODCSTeam):

--- a/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_source.py
@@ -5,7 +5,7 @@ import os
 import pathlib
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Any, Dict, Iterable, List, Optional, Set
+from typing import Dict, Iterable, List, Optional, Set
 
 import jsonschema
 import yaml
@@ -506,7 +506,7 @@ class ODCSSource(StatefulIngestionSourceBase):
         """
         spec_ignored: List[str] = []
 
-        def walk(node: Any, model_cls: type[BaseModel], path_hint: str) -> None:
+        def walk(node: object, model_cls: type[BaseModel], path_hint: str) -> None:
             if not isinstance(node, dict):
                 return
             allowed = _model_field_keys(model_cls)

--- a/metadata-ingestion/tests/unit/odcs/test_odcs_mapper.py
+++ b/metadata-ingestion/tests/unit/odcs/test_odcs_mapper.py
@@ -563,7 +563,6 @@ def test_description_object_renders_non_spec_extra_prose_keys() -> None:
     )
     props = next(m.aspect for m in mcps if isinstance(m.aspect, DatasetPropertiesClass))
     assert props.description is not None
-    # Spec fields plus the extra string key; the non-string extra is skipped.
     assert "**purpose**: P" in props.description
     assert "**summary**: S" in props.description
     assert "authoritativeDefinitions" not in props.description

--- a/metadata-ingestion/tests/unit/odcs/test_odcs_mapper.py
+++ b/metadata-ingestion/tests/unit/odcs/test_odcs_mapper.py
@@ -884,6 +884,21 @@ def test_missing_values_routes_to_custom_preserving_arguments() -> None:
     )
 
 
+def test_unknown_argument_keys_survive_into_provenance() -> None:
+    # `arguments` is typed but allows extras so engine-specific keys are not
+    # silently dropped -- they still round-trip into the assertion provenance.
+    _, mcps, _ = _route_single(
+        {
+            "metric": "missingValues",
+            "arguments": {"missingValues": ["N/A"], "engineOption": "strict"},
+        }
+    )
+    info = _single_info(mcps)
+    assert info.customProperties["odcs.rule.arguments"] == json.dumps(
+        {"engineOption": "strict", "missingValues": ["N/A"]}, sort_keys=True
+    )
+
+
 def test_row_count_builds_volume_assertion() -> None:
     _, mcps, _ = _route_single(
         {"metric": "rowCount", "mustBeGreaterOrEqualTo": 100}, on_column=None

--- a/metadata-ingestion/tests/unit/odcs/test_odcs_mapper.py
+++ b/metadata-ingestion/tests/unit/odcs/test_odcs_mapper.py
@@ -551,6 +551,24 @@ def test_contract_description_is_fallback() -> None:
     assert props.description == "Contract-level description."
 
 
+def test_description_object_renders_non_spec_extra_prose_keys() -> None:
+    contract = _make_contract(
+        schema=[{"name": "t"}],
+        description={"purpose": "P", "summary": "S", "authoritativeDefinitions": []},
+    )
+    mcps, _ = odcs_to_logical_dataset_mcps(
+        contract=contract,
+        schema_entry=_first_schema(contract),
+        logical_urn=LOGICAL_URN,
+    )
+    props = next(m.aspect for m in mcps if isinstance(m.aspect, DatasetPropertiesClass))
+    assert props.description is not None
+    # Spec fields plus the extra string key; the non-string extra is skipped.
+    assert "**purpose**: P" in props.description
+    assert "**summary**: S" in props.description
+    assert "authoritativeDefinitions" not in props.description
+
+
 def test_institutional_memory_includes_root_authoritative_definitions() -> None:
     contract = _make_contract(
         schema=[


### PR DESCRIPTION
## Summary

Follow-up to #17331. Tightens typing in the ODCS models/mapper:

- Dynamic JSON fields use `pydantic.JsonValue` instead of `Any`/`object`.
- Description fields accept a typed `ODCSDescription` model (or plain string) rather than an untyped dict.
- Quality-argument and rule fields are typed precisely; `_description_to_str` / `_is_plain_number` narrow their inputs.

No behavioural change — golden files are unaffected.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests pass (unit + golden integration)
- [ ] Docs (n/a)
- [ ] Breaking change (n/a)

<!-- odcs-connector-tests-note -->
## Connector tests

Part of the ODCS follow-up stack. A companion integration suite for the ODCS source is added in the private `acryldata/connector-tests` repo — acryldata/connector-tests#852 — a hermetic golden-file test that ingests a Bitol ODCS contract and asserts the full mapping (logical datasets, physical bindings, schema + data-quality assertions, and native data contracts). Its committed golden reflects the post-merge behaviour of this stack, so it should be re-blessed at the release that contains these PRs.
