### PR TITLE
style(ingest/odcs): strip decorative section-banner comments

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
@@ -2,12 +2,13 @@ import json
 from dataclasses import dataclass, field
 from typing import Dict, Iterable, List, Optional, Set, Tuple, Type, TypeGuard
 
-from datahub.emitter import mce_builder
 from datahub.emitter.mce_builder import (
     datahub_guid,
+    make_assertion_source,
     make_assertion_urn,
     make_data_platform_urn,
     make_dataset_urn_with_platform_instance,
+    make_schema_field_urn,
     make_tag_urn,
     make_user_urn,
 )
@@ -1082,7 +1083,7 @@ def _assertion_info_template(
     """Shared header for an AssertionInfoClass; caller sets the sub-aspect."""
     return AssertionInfoClass(
         type=assertion_type,
-        source=mce_builder.make_assertion_source(),
+        source=make_assertion_source(),
         description=_description_to_str(ctx.rule.description),
         customProperties=_custom_props_for_rule(ctx),
         externalUrl=_rule_external_url(ctx.rule),
@@ -1214,9 +1215,7 @@ def _build_custom_assertion(
     assertion_urn = _stable_assertion_urn(ctx, rule_kind="custom")
     resolved_type = custom_type or ctx.rule.effective_metric or ctx.rule.type or "odcs"
     field_urn = (
-        mce_builder.make_schema_field_urn(ctx.entity_urn, ctx.column)
-        if ctx.column
-        else None
+        make_schema_field_urn(ctx.entity_urn, ctx.column) if ctx.column else None
     )
     info = _assertion_info_template(ctx, AssertionTypeClass.CUSTOM)
     info.customAssertion = CustomAssertionInfoClass(
@@ -1484,7 +1483,7 @@ def odcs_to_schema_assertion_mcps(
     )
     info = AssertionInfoClass(
         type=AssertionTypeClass.DATA_SCHEMA,
-        source=mce_builder.make_assertion_source(),
+        source=make_assertion_source(),
         description=(
             f"Schema compliance with ODCS contract '{contract.id}' "
             f"schema '{schema_entry.name}'"

--- a/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
@@ -202,11 +202,6 @@ def _description_to_str(description: object) -> Optional[str]:
     return None
 
 
-# ----------------------------------------------------------------------------
-# Platform registration
-# ----------------------------------------------------------------------------
-
-
 def odcs_platform_info_mcp() -> MetadataChangeProposalWrapper:
     """Emit the `odcs` DataPlatformInfo aspect at ingestion time.
 
@@ -232,11 +227,6 @@ def odcs_platform_info_mcp() -> MetadataChangeProposalWrapper:
             logoUrl="assets/platforms/odcslogo.png",
         ),
     )
-
-
-# ----------------------------------------------------------------------------
-# URN + binding resolution
-# ----------------------------------------------------------------------------
 
 
 def odcs_to_logical_dataset_urn(
@@ -480,11 +470,6 @@ def odcs_to_physical_bindings(
     return bindings
 
 
-# ----------------------------------------------------------------------------
-# Shared owner / tag / property helpers
-# ----------------------------------------------------------------------------
-
-
 def _make_tag_associations(
     tags: Optional[List[str]], tag_prefix: Optional[str]
 ) -> List[TagAssociationClass]:
@@ -576,11 +561,6 @@ def _walk_properties(
             yield from _walk_properties(prop.properties, path)
 
 
-# ----------------------------------------------------------------------------
-# Canonical schema metadata (the new piece)
-# ----------------------------------------------------------------------------
-
-
 def _map_field_type(prop: ODCSProperty) -> Tuple[SchemaFieldDataTypeClass, bool]:
     """Map an ODCS property's logical/physical type to a SchemaFieldDataType.
 
@@ -652,11 +632,6 @@ def build_schema_metadata(
         ),
         unmapped_types=unmapped_types,
     )
-
-
-# ----------------------------------------------------------------------------
-# Logical dataset aspects
-# ----------------------------------------------------------------------------
 
 
 def _count_quality_rules(schema_entry: ODCSSchemaObject) -> int:
@@ -824,16 +799,13 @@ def odcs_to_logical_parent_mcp(
     )
 
 
-# ----------------------------------------------------------------------------
-# Assertions — emitted against the LOGICAL dataset
-#
-# ODCS quality rules are the producer's published expectations for the dataset
-# the contract describes, so the Assertion entities target the logical `odcs`
-# dataset (the assertion's `entity` is the logical URN). Propagation of those
-# expectations onto bound physical datasets is handled by a separate DataHub
-# mechanism via the PhysicalInstanceOf relationship — this source never writes
-# assertions against physical URNs.
-# ----------------------------------------------------------------------------
+# Assertions are emitted against the LOGICAL dataset: ODCS quality rules are the
+# producer's published expectations for the dataset the contract describes, so
+# the Assertion entities target the logical `odcs` dataset (the assertion's
+# `entity` is the logical URN). Propagation of those expectations onto bound
+# physical datasets is handled by a separate DataHub mechanism via the
+# PhysicalInstanceOf relationship — this source never writes assertions against
+# physical URNs.
 
 
 @dataclass

--- a/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_models.py
@@ -2,18 +2,14 @@ from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
-# ---------------------------------------------------------------------------
-# Spec-valid fields the source deliberately does not map.
-#
-# The unknown-field walker in odcs_source.py classifies YAML keys three ways:
-# declared on the model (parsed), listed here (spec-valid but unmapped -- one
-# aggregate info per file, no warning), or neither (genuinely unknown -- a
-# per-field warning). These sets are the union of the property keys declared
-# in the vendored v3.0.2 and v3.1.0 JSON Schemas minus the model fields; the
-# drift-guard unit test in tests/unit/odcs/test_odcs_models.py enforces that
-# invariant so a future spec bump fails loudly instead of producing spurious
-# "check spelling" warnings.
-# ---------------------------------------------------------------------------
+# Spec-valid fields the source deliberately does not map. The unknown-field
+# walker in odcs_source.py classifies YAML keys three ways: declared on the
+# model (parsed), listed here (spec-valid but unmapped -- one aggregate info per
+# file, no warning), or neither (genuinely unknown -- a per-field warning).
+# These sets are the union of the property keys declared in the vendored v3.0.2
+# and v3.1.0 JSON Schemas minus the model fields; the drift-guard unit test in
+# tests/unit/odcs/test_odcs_models.py enforces that invariant so a future spec
+# bump fails loudly instead of producing spurious "check spelling" warnings.
 
 KNOWN_UNMAPPED_CONTRACT_FIELDS = frozenset(
     (

--- a/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_source.py
@@ -236,10 +236,6 @@ class ODCSSource(StatefulIngestionSourceBase):
             partial(auto_stale_entity_removal, self.stale_entity_removal_handler),
         ]
 
-    # ------------------------------------------------------------------
-    # Schema validation + file IO
-    # ------------------------------------------------------------------
-
     def _load_validators(self) -> Dict[str, "jsonschema.Draft202012Validator"]:
         validators: Dict[str, jsonschema.Draft202012Validator] = {}
         for version, filename in _VERSION_TO_SCHEMA.items():
@@ -488,10 +484,6 @@ class ODCSSource(StatefulIngestionSourceBase):
             return None
         return raw_text, raw_dict
 
-    # ------------------------------------------------------------------
-    # Unknown-field detection
-    # ------------------------------------------------------------------
-
     def _warn_unknown_fields(self, raw_dict: dict, file_path: pathlib.Path) -> None:
         """Walk the raw YAML dict and classify keys not declared on the model.
 
@@ -557,10 +549,6 @@ class ODCSSource(StatefulIngestionSourceBase):
                 ),
                 context=f"{file_path}: {', '.join(spec_ignored)}",
             )
-
-    # ------------------------------------------------------------------
-    # Per-file processing
-    # ------------------------------------------------------------------
 
     def _urn_exists_in_graph(self, urn: str) -> Optional[bool]:
         """Best-effort, cached existence check for any URN.


### PR DESCRIPTION
## Summary

Follow-up to #17331. Removes the `# ----` divider/section-header comment blocks from the ODCS mapper, models, and source — they add no information the code doesn't already convey. The two blocks carrying real explanatory text (the spec-unmapped-fields note and the logical-assertion rationale) are kept as plain comments.

No behavioural change.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests pass (unit + golden integration)
- [ ] Docs (n/a)
- [ ] Breaking change (n/a)

<!-- odcs-connector-tests-note -->
## Connector tests

Part of the ODCS follow-up stack. A companion integration suite for the ODCS source is added in the private `acryldata/connector-tests` repo — acryldata/connector-tests#852 — a hermetic golden-file test that ingests a Bitol ODCS contract and asserts the full mapping (logical datasets, physical bindings, schema + data-quality assertions, and native data contracts). Its committed golden reflects the post-merge behaviour of this stack, so it should be re-blessed at the release that contains these PRs.
