### PR TITLE
fix(ui): render custom assertion name on the Data Contract tab

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/contract/DataQualityContractSummary.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/contract/DataQualityContractSummary.tsx
@@ -66,7 +66,9 @@ export const DataQualityContractSummary = ({ contracts, showAction = false }: Pr
                     )}
                     {assertion.info?.sqlAssertion && <SqlAssertionDescription assertionInfo={assertion.info} />}
                     {assertion.info?.type === AssertionType.Custom && (
-                        <Typography.Text>{assertion.info?.description}</Typography.Text>
+                        <Typography.Text>
+                            {assertion.info?.description || assertion.info?.customAssertion?.type}
+                        </Typography.Text>
                     )}
                 </>
             ),


### PR DESCRIPTION
## Summary

On the dataset **Contract tab**, the data-quality table rendered a CUSTOM-type assertion using only `assertion.info.description`. Custom assertions without a description (common for externally-ingested checks) therefore showed as **blank text**.

This falls back to the custom assertion's `type` — which is already fetched by the contract query (`customAssertion { type }` via `assertionDetails`) — so the check always has a visible name.

```tsx
{assertion.info?.description || assertion.info?.customAssertion?.type}
```

## Checklist

- [x] `yarnLintFix` clean on the changed file
- [x] No new GraphQL fields needed (data already fetched)

<!-- odcs-connector-tests-note -->
## Connector tests

Part of the ODCS follow-up stack. A companion integration suite for the ODCS source is added in the private `acryldata/connector-tests` repo — acryldata/connector-tests#852 — a hermetic golden-file test that ingests a Bitol ODCS contract and asserts the full mapping (logical datasets, physical bindings, schema + data-quality assertions, and native data contracts). Its committed golden reflects the post-merge behaviour of this stack, so it should be re-blessed at the release that contains these PRs.
