### PR TITLE
feat(metrics): add metrics autocomplete and infinite scroll

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -163,6 +163,7 @@ import com.linkedin.datahub.graphql.resolvers.logical.SetLogicalParentResolver;
 import com.linkedin.datahub.graphql.resolvers.metrics.GetRootMetricsResolver;
 import com.linkedin.datahub.graphql.resolvers.metrics.GetSemanticModelsResolver;
 import com.linkedin.datahub.graphql.resolvers.metrics.MetricChildMetricsResolver;
+import com.linkedin.datahub.graphql.resolvers.metrics.ParentMetricsResolver;
 import com.linkedin.datahub.graphql.resolvers.metrics.SemanticModelMetricsResolver;
 import com.linkedin.datahub.graphql.resolvers.module.DeletePageModuleResolver;
 import com.linkedin.datahub.graphql.resolvers.module.UpsertPageModuleResolver;
@@ -4073,6 +4074,7 @@ public class GmsGraphQLEngine {
                           final Metric m = env.getSource();
                           return m.getParentMetric() != null ? m.getParentMetric().getUrn() : null;
                         }))
+                .dataFetcher("parentMetrics", new ParentMetricsResolver(entityClient))
                 .dataFetcher(
                     "platform",
                     new LoadableTypeResolver<>(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/metrics/ParentMetricsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/metrics/ParentMetricsResolver.java
@@ -1,0 +1,132 @@
+package com.linkedin.datahub.graphql.resolvers.metrics;
+
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.getQueryContext;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.Metric;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Walks the parentMetric chain from the source metric up to the root, returning all ancestors in
+ * nearest-first order. Used by the sidebar auto-expand cascade.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class ParentMetricsResolver implements DataFetcher<CompletableFuture<List<Metric>>> {
+
+  private static final int MAX_DEPTH = 20;
+  private static final Set<String> ASPECTS_TO_FETCH =
+      Collections.singleton(Constants.METRIC_RELATIONSHIPS_ASPECT_NAME);
+
+  private final EntityClient _entityClient;
+
+  @Override
+  public CompletableFuture<List<Metric>> get(final DataFetchingEnvironment environment) {
+    final QueryContext context = getQueryContext(environment);
+    final Urn sourceUrn = UrnUtils.getUrn(((Entity) environment.getSource()).getUrn());
+
+    return GraphQLConcurrencyUtils.supplyAsync(
+        () -> {
+          try {
+            final List<Urn> parentUrns = walkParentChain(context, sourceUrn);
+
+            final List<Metric> result = new ArrayList<>(parentUrns.size());
+            if (!parentUrns.isEmpty()) {
+              final Map<Urn, EntityResponse> responses =
+                  _entityClient.batchGetV2(
+                      context.getOperationContext(),
+                      Constants.METRIC_ENTITY_NAME,
+                      new HashSet<>(parentUrns),
+                      null);
+
+              for (Urn parentUrn : parentUrns) {
+                final EntityResponse response = responses.get(parentUrn);
+                final Metric stub = new Metric();
+                stub.setUrn(parentUrn.toString());
+                stub.setType(EntityType.METRIC);
+                if (response != null) {
+                  final EnvelopedAspect keyAspect =
+                      response.getAspects().get(Constants.METRIC_RELATIONSHIPS_ASPECT_NAME);
+                  if (keyAspect != null) {
+                    final com.linkedin.metric.MetricRelationships rel =
+                        new com.linkedin.metric.MetricRelationships(keyAspect.getValue().data());
+                    if (rel.hasParentMetric() && rel.getParentMetric() != null) {
+                      final Metric grandparentStub = new Metric();
+                      grandparentStub.setUrn(rel.getParentMetric().toString());
+                      grandparentStub.setType(EntityType.METRIC);
+                      stub.setParentMetric(grandparentStub);
+                    }
+                  }
+                }
+                result.add(stub);
+              }
+            }
+            return result;
+          } catch (Exception e) {
+            throw new RuntimeException("Failed to load parent metrics for " + sourceUrn, e);
+          }
+        },
+        this.getClass().getSimpleName(),
+        "get");
+  }
+
+  /**
+   * Iteratively fetches the parentMetric chain starting from the source URN. Returns URNs in
+   * nearest-first order (immediate parent first, root last). Guards against cycles with a visited
+   * set and a depth cap.
+   */
+  private List<Urn> walkParentChain(final QueryContext context, final Urn sourceUrn)
+      throws Exception {
+    final List<Urn> chain = new ArrayList<>();
+    final Set<Urn> visited = new HashSet<>();
+    visited.add(sourceUrn);
+
+    Urn current = resolveParent(context, sourceUrn);
+    while (current != null && !visited.contains(current) && chain.size() < MAX_DEPTH) {
+      chain.add(current);
+      visited.add(current);
+      current = resolveParent(context, current);
+    }
+    return chain;
+  }
+
+  private Urn resolveParent(final QueryContext context, final Urn urn) throws Exception {
+    final Map<Urn, EntityResponse> responses =
+        _entityClient.batchGetV2(
+            context.getOperationContext(),
+            Constants.METRIC_ENTITY_NAME,
+            Collections.singleton(urn),
+            ASPECTS_TO_FETCH);
+    final EntityResponse response = responses.get(urn);
+    if (response == null) {
+      return null;
+    }
+    final EnvelopedAspect enveloped =
+        response.getAspects().get(Constants.METRIC_RELATIONSHIPS_ASPECT_NAME);
+    if (enveloped == null) {
+      return null;
+    }
+    final com.linkedin.metric.MetricRelationships rel =
+        new com.linkedin.metric.MetricRelationships(enveloped.getValue().data());
+    return rel.hasParentMetric() ? rel.getParentMetric() : null;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/metrics/SemanticModelMetricsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/metrics/SemanticModelMetricsResolver.java
@@ -32,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 public class SemanticModelMetricsResolver implements DataFetcher<CompletableFuture<ScrollResults>> {
 
   static final String SEMANTIC_MODEL_FIELD_NAME = "semanticModel";
+  static final String HAS_PARENT_METRIC_FIELD_NAME = "hasParentMetric";
 
   private final EntityClient _entityClient;
   private final ViewService _viewService;
@@ -45,11 +46,14 @@ public class SemanticModelMetricsResolver implements DataFetcher<CompletableFutu
 
     final Criterion semanticModelFilter =
         CriterionUtils.buildCriterion(SEMANTIC_MODEL_FIELD_NAME, Condition.EQUAL, entity.getUrn());
+    final Criterion noParentFilter =
+        CriterionUtils.buildCriterion(HAS_PARENT_METRIC_FIELD_NAME, Condition.EQUAL, "false");
     final Filter baseFilter =
         new Filter()
             .setOr(
                 new ConjunctiveCriterionArray(
-                    new ConjunctiveCriterion().setAnd(new CriterionArray(semanticModelFilter))));
+                    new ConjunctiveCriterion()
+                        .setAnd(new CriterionArray(semanticModelFilter, noParentFilter))));
     final Filter inputFilter = ResolverUtils.buildFilter(null, input.getOrFilters());
 
     return SearchUtils.scrollAcrossEntities(

--- a/datahub-graphql-core/src/main/resources/metrics.graphql
+++ b/datahub-graphql-core/src/main/resources/metrics.graphql
@@ -104,6 +104,12 @@ type Metric implements Entity {
   parentMetric: Metric
 
   """
+  All ancestor metrics from immediate parent up to the root, ordered nearest-first.
+  Used by the sidebar to auto-expand the tree to the currently-viewed metric.
+  """
+  parentMetrics: [Metric!]
+
+  """
   Child metrics in the metric hierarchy.
   """
   childMetrics(input: ScrollAcrossEntitiesInput!): ScrollResults

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/metrics/SemanticModelMetricsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/metrics/SemanticModelMetricsResolverTest.java
@@ -105,23 +105,39 @@ public class SemanticModelMetricsResolverTest {
 
     _resolver.get(_dataFetchingEnvironment).get();
 
-    // Verify the filter contains semanticModel=<urn> criterion
+    // Verify the filter contains both semanticModel=<urn> and hasParentMetric=false in the same
+    // conjunction, so the resolver returns only root metrics of the given semantic model.
     Mockito.verify(_entityClient)
         .scrollAcrossEntities(
             any(),
             any(),
             any(),
             Mockito.argThat(
-                filter ->
-                    filter != null
-                        && filter.getOr().stream()
-                            .flatMap(cc -> cc.getAnd().stream())
-                            .anyMatch(
-                                c ->
-                                    SemanticModelMetricsResolver.SEMANTIC_MODEL_FIELD_NAME.equals(
-                                            c.getField())
-                                        && c.getValues() != null
-                                        && c.getValues().contains(TEST_SEMANTIC_MODEL_URN))),
+                filter -> {
+                  if (filter == null) return false;
+                  return filter.getOr().stream()
+                      .anyMatch(
+                          cc -> {
+                            boolean hasSemanticModel =
+                                cc.getAnd().stream()
+                                    .anyMatch(
+                                        c ->
+                                            SemanticModelMetricsResolver.SEMANTIC_MODEL_FIELD_NAME
+                                                    .equals(c.getField())
+                                                && c.getValues() != null
+                                                && c.getValues().contains(TEST_SEMANTIC_MODEL_URN));
+                            boolean hasNoParent =
+                                cc.getAnd().stream()
+                                    .anyMatch(
+                                        c ->
+                                            SemanticModelMetricsResolver
+                                                    .HAS_PARENT_METRIC_FIELD_NAME
+                                                    .equals(c.getField())
+                                                && c.getValues() != null
+                                                && c.getValues().contains("false"));
+                            return hasSemanticModel && hasNoParent;
+                          });
+                }),
             any(),
             any(),
             any(),

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/EntityProfile.tsx
@@ -39,6 +39,7 @@ import LineageExplorer from '@app/lineage/LineageExplorer';
 import useIsLineageMode from '@app/lineage/utils/useIsLineageMode';
 import LineageGraph from '@app/lineageV2/LineageGraph';
 import { useLineageV2 } from '@app/lineageV2/useLineageV2';
+import { useUpdateMetricsEntityDataOnChange } from '@app/metrics/useUpdateMetricsEntityDataOnChange';
 import { OnboardingTour } from '@app/onboarding/OnboardingTour';
 import {
     LINEAGE_GRAPH_INTRO_ID,
@@ -260,6 +261,7 @@ export const EntityProfile = <T, U>({
 
     useUpdateGlossaryEntityDataOnChange(entityData, entityType);
     useUpdateDomainEntityDataOnChangeV2(entityData, entityType);
+    useUpdateMetricsEntityDataOnChange(entityData, entityType);
 
     const maybeUpdateEntity = useUpdateQuery?.({
         onCompleted: () => refetch(),

--- a/datahub-web-react/src/app/metrics/MetricRow.tsx
+++ b/datahub-web-react/src/app/metrics/MetricRow.tsx
@@ -1,79 +1,54 @@
 import { Sigma } from '@phosphor-icons/react/dist/csr/Sigma';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { MetricsTreeItem } from '@app/metrics/MetricsTreeItem';
+import { useMetricsEntityContext } from '@app/metrics/context/MetricsEntityContext';
 import { MetricEntity } from '@app/metrics/metricsTypes';
+import useMetricChildren from '@app/metrics/useMetricChildren';
 import { PageRoutes } from '@conf/Global';
-
-import { useGetMetricChildrenLazyQuery } from '@graphql/metricsBrowse.generated';
-import { EntityType } from '@types';
 
 export type MetricRowProps = {
     /** Indentation level, passed through to `MetricsTreeItem` — increments per nesting depth (metric-in-metric). */
     level: number;
     metric: MetricEntity;
-    searchInput: string;
     isExpanded: boolean;
     isSelected: boolean;
-    cachedChildren: MetricEntity[] | undefined;
     expandedMetricUrns: Set<string>;
-    childMetricsByParentUrn: Record<string, MetricEntity[]>;
     selectedUrn: string | null;
     onToggle: () => void;
-    onChildMetricsFetched: (parentUrn: string, metrics: MetricEntity[]) => void;
     onToggleMetric: (urn: string) => void;
 };
 
 export function MetricRow({
     level,
     metric,
-    searchInput,
     isExpanded,
     isSelected,
-    cachedChildren,
     expandedMetricUrns,
-    childMetricsByParentUrn,
     selectedUrn,
     onToggle,
-    onChildMetricsFetched,
     onToggleMetric,
 }: MetricRowProps) {
     const history = useHistory();
+    const { entityData } = useMetricsEntityContext();
     const hasChildren = (metric.childMetrics?.total ?? 0) > 0;
 
-    const [fetchChildren, { data: childData }] = useGetMetricChildrenLazyQuery();
-
+    // Auto-expand when navigating to a metric whose ancestor chain passes through this metric.
     useEffect(() => {
-        if (isExpanded && !cachedChildren && hasChildren) {
-            fetchChildren({
-                variables: {
-                    input: {
-                        types: [EntityType.Metric],
-                        query: '*',
-                        count: 100,
-                        orFilters: [{ and: [{ field: 'parentMetric', values: [metric.urn] }] }],
-                    },
-                },
-            });
+        if (!entityData?.parentMetrics) return;
+        if (entityData.parentMetrics.some((m) => m.urn === metric.urn) && !isExpanded) {
+            onToggle();
         }
-    }, [isExpanded, cachedChildren, hasChildren, metric.urn, fetchChildren]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [entityData, metric.urn, isExpanded]);
 
-    useEffect(() => {
-        if (!childData?.searchAcrossEntities) return;
-        const directChildren = childData.searchAcrossEntities.searchResults
-            .map((r) => r.entity)
-            .filter((e): e is MetricEntity => e?.__typename === 'Metric');
-        onChildMetricsFetched(metric.urn, directChildren);
-    }, [childData, metric.urn, onChildMetricsFetched]);
+    const { data, scrollRef } = useMetricChildren({
+        mode: { kind: 'metric', parentMetricUrn: metric.urn },
+        skip: !isExpanded || !hasChildren,
+    });
 
-    const filteredChildren = useMemo(() => {
-        const children = cachedChildren ?? [];
-        if (!searchInput) return children;
-        const q = searchInput.toLowerCase();
-        return children.filter((m) => (m.info?.name ?? '').toLowerCase().includes(q));
-    }, [cachedChildren, searchInput]);
-
+    const children = data as MetricEntity[];
     const metricTitle = metric.info?.name ?? metric.urn;
 
     return (
@@ -90,23 +65,20 @@ export function MetricRow({
                 testId={`metrics-sidebar-metric-${metric.urn}`}
             />
             {isExpanded &&
-                filteredChildren.map((child) => (
+                children.map((child) => (
                     <MetricRow
                         key={child.urn}
                         level={level + 1}
                         metric={child}
-                        searchInput={searchInput}
                         isExpanded={expandedMetricUrns.has(child.urn)}
                         isSelected={selectedUrn === child.urn}
-                        cachedChildren={childMetricsByParentUrn[child.urn]}
                         expandedMetricUrns={expandedMetricUrns}
-                        childMetricsByParentUrn={childMetricsByParentUrn}
                         selectedUrn={selectedUrn}
                         onToggle={() => onToggleMetric(child.urn)}
-                        onChildMetricsFetched={onChildMetricsFetched}
                         onToggleMetric={onToggleMetric}
                     />
                 ))}
+            {isExpanded && <div ref={scrollRef} style={{ height: 1 }} />}
         </>
     );
 }

--- a/datahub-web-react/src/app/metrics/MetricsMainContent.tsx
+++ b/datahub-web-react/src/app/metrics/MetricsMainContent.tsx
@@ -3,7 +3,7 @@ import { Clock } from '@phosphor-icons/react/dist/csr/Clock';
 import { Cube } from '@phosphor-icons/react/dist/csr/Cube';
 import { Database } from '@phosphor-icons/react/dist/csr/Database';
 import { Sigma } from '@phosphor-icons/react/dist/csr/Sigma';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import styled, { useTheme } from 'styled-components';
@@ -11,6 +11,7 @@ import styled, { useTheme } from 'styled-components';
 import { ModuleHeader } from '@app/homeV3/module/components/LargeModule';
 import ModuleContainer from '@app/homeV3/module/components/ModuleContainer';
 import ModuleName from '@app/homeV3/module/components/ModuleName';
+import { useMetricsEntityContext } from '@app/metrics/context/MetricsEntityContext';
 import AutoCompleteEntityItem from '@app/searchV2/autoCompleteV2/AutoCompleteEntityItem';
 import { toRelativeTimeString } from '@app/shared/time/timeUtils';
 import { PageRoutes } from '@conf/Global';
@@ -147,6 +148,12 @@ export default function MetricsMainContent() {
     const history = useHistory();
     const theme = useTheme();
     const cardIconStyles = { color: theme.colors.icon };
+
+    // Reset sidebar entity-data so no tree rows auto-expand on the home page.
+    const { setEntityData } = useMetricsEntityContext();
+    useEffect(() => {
+        setEntityData(null);
+    }, [setEntityData]);
     const cardStyle = { flex: 1 };
 
     const { data: modelsData } = useGetSemanticModelsBrowseQuery({

--- a/datahub-web-react/src/app/metrics/MetricsSearch.tsx
+++ b/datahub-web-react/src/app/metrics/MetricsSearch.tsx
@@ -1,0 +1,120 @@
+import { Loader, SearchBar } from '@components';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { useDebounce } from 'react-use';
+import styled from 'styled-components';
+
+import { IconStyleType } from '@app/entityV2/Entity';
+import ClickOutside from '@app/shared/ClickOutside';
+import { useEntityRegistry } from '@app/useEntityRegistry';
+
+import { useGetAutoCompleteMultipleResultsQuery } from '@graphql/search.generated';
+import { EntityType } from '@types';
+
+const SearchWrapper = styled.div`
+    position: relative;
+`;
+
+const ResultsWrapper = styled.div`
+    background-color: ${(props) => props.theme.colors.bg};
+    border-radius: 5px;
+    box-shadow: ${(props) => props.theme.colors.shadowMd};
+    padding: 8px;
+    position: absolute;
+    max-height: 210px;
+    overflow: auto;
+    width: calc(100% - 24px);
+    left: 12px;
+    top: 45px;
+    z-index: 1;
+`;
+
+const LoadingWrapper = styled.div`
+    display: flex;
+    justify-content: center;
+    padding: 4px 0;
+    font-size: 16px;
+`;
+
+const SearchResult = styled(Link)`
+    color: ${(props) => props.theme.colors.text};
+    display: inline-block;
+    height: 100%;
+    padding: 6px 8px;
+    width: 100%;
+
+    &:hover {
+        background-color: ${(props) => props.theme.colors.bgSurface};
+        color: ${(props) => props.theme.colors.text};
+    }
+`;
+
+const InputWrapper = styled.div`
+    padding: 12px;
+`;
+
+const IconWrapper = styled.span`
+    margin-right: 8px;
+`;
+
+export default function MetricsSearch() {
+    const { t } = useTranslation('misc');
+    const [searchInput, setSearchInput] = useState('');
+    const [query, setQuery] = useState('');
+    const [isSearchBarFocused, setIsSearchBarFocused] = useState(false);
+    const entityRegistry = useEntityRegistry();
+
+    useDebounce(() => setQuery(searchInput), 200, [searchInput]);
+
+    const { data, loading } = useGetAutoCompleteMultipleResultsQuery({
+        variables: {
+            input: {
+                types: [EntityType.Metric, EntityType.SemanticModel],
+                query,
+                limit: 50,
+            },
+        },
+        skip: !query,
+    });
+
+    const searchResults = data?.autoCompleteForMultiple?.suggestions?.flatMap((suggestion) => suggestion.entities);
+
+    return (
+        <SearchWrapper>
+            <ClickOutside onClickOutside={() => setIsSearchBarFocused(false)}>
+                <InputWrapper>
+                    <SearchBar
+                        placeholder={t('metrics.searchPlaceholder')}
+                        value={searchInput}
+                        onChange={setSearchInput}
+                        onFocus={() => setIsSearchBarFocused(true)}
+                        data-testid="metrics-sidebar-search-input"
+                    />
+                </InputWrapper>
+                {isSearchBarFocused && (loading || !!searchResults?.length) && (
+                    <ResultsWrapper>
+                        {loading && (
+                            <LoadingWrapper>
+                                <Loader size="md" />
+                            </LoadingWrapper>
+                        )}
+                        {!loading &&
+                            searchResults?.map((result) => (
+                                <SearchResult
+                                    key={result.urn}
+                                    to={`${entityRegistry.getEntityUrl(result.type, result.urn)}`}
+                                    onClick={() => setIsSearchBarFocused(false)}
+                                >
+                                    <IconWrapper>
+                                        {entityRegistry.getIcon(result.type, 12, IconStyleType.ACCENT)}
+                                    </IconWrapper>
+                                    {entityRegistry.getDisplayName(result.type, result)}
+                                </SearchResult>
+                            ))}
+                    </ResultsWrapper>
+                )}
+            </ClickOutside>
+        </SearchWrapper>
+    );
+}

--- a/datahub-web-react/src/app/metrics/MetricsSidebar.tsx
+++ b/datahub-web-react/src/app/metrics/MetricsSidebar.tsx
@@ -1,4 +1,4 @@
-import { Button, EmptyState, SearchBar } from '@components';
+import { Button, EmptyState } from '@components';
 import { ArrowLineLeft } from '@phosphor-icons/react/dist/csr/ArrowLineLeft';
 import { ArrowLineRight } from '@phosphor-icons/react/dist/csr/ArrowLineRight';
 import { House } from '@phosphor-icons/react/dist/csr/House';
@@ -12,14 +12,17 @@ import styled from 'styled-components';
 import { SimpleSelect } from '@components/components/Select/SimpleSelect';
 
 import { TreeSectionHeader } from '@app/homeV2/layout/sidebar/documents/TreeSectionHeader';
+import MetricsSearch from '@app/metrics/MetricsSearch';
 import { SemanticModelRow } from '@app/metrics/SemanticModelRow';
 import { useMetricsEntityContext } from '@app/metrics/context/MetricsEntityContext';
+import { SemanticModel } from '@app/metrics/metricsTypes';
+import useSemanticModelRoots from '@app/metrics/useSemanticModelRoots';
 import PlatformIcon from '@app/sharedV2/icons/PlatformIcon';
 import { useShowNavBarRedesign } from '@app/useShowNavBarRedesign';
 import { PageRoutes } from '@conf/Global';
 
-import { useGetSemanticModelsBrowseQuery } from '@graphql/metricsBrowse.generated';
-import { DataPlatform } from '@types';
+import { useScrollSemanticModelsQuery } from '@graphql/metricsBrowse.generated';
+import { DataPlatform, EntityType } from '@types';
 
 const SIDEBAR_TRANSITION_MS = 300;
 export const SIDEBAR_COLLAPSED_WIDTH = 63;
@@ -67,11 +70,6 @@ const HeaderButtons = styled.div`
 const Separator = styled.div`
     height: 1px;
     background: ${(props) => props.theme.colors.border};
-`;
-
-const SearchInputWrapper = styled.div`
-    padding: 12px;
-    flex-shrink: 0;
 `;
 
 const FiltersWrapper = styled.div`
@@ -268,7 +266,6 @@ function CollapsedMetricsSidebar({
 function ExpandedMetricsSidebar({ onToggleCollapsed }: { onToggleCollapsed: () => void }) {
     const { t } = useTranslation('misc');
     const location = useLocation();
-    const [searchInput, setSearchInput] = useState('');
     const [platformFilter, setPlatformFilter] = useState(ALL_OPTION);
     const [isModelsExpanded, setIsModelsExpanded] = useState(true);
 
@@ -276,23 +273,49 @@ function ExpandedMetricsSidebar({ onToggleCollapsed }: { onToggleCollapsed: () =
         expandedSemanticModelUrns,
         expandedMetricUrns,
         selectedUrn,
-        childMetricsByModelUrn,
-        childMetricsByParentUrn,
         toggleSemanticModel,
         toggleMetric,
         expandAllSemanticModels,
         collapseAllExpanded,
-        setChildMetricsForModel,
-        setChildMetricsForParent,
         refetchKey,
+        entityData,
     } = useMetricsEntityContext();
 
     const isHomeSelected = !!matchPath(location.pathname, { path: PageRoutes.METRICS, exact: true });
 
-    // Fetch root semantic models.
-    const { data: modelsData, refetch: refetchModels } = useGetSemanticModelsBrowseQuery({
-        variables: { input: { count: 100, start: 0 } },
+    const { data: rootModels, scrollRef: rootScrollRef, refetch: refetchModels } = useSemanticModelRoots();
+
+    // Fallback: if the entity currently in the profile lives in a semantic model that hasn't
+    // been fetched into the root list yet (e.g. it's beyond the first page), issue a targeted
+    // search for just that model and prepend it so the auto-expand cascade can start.
+    const missingModelUrn =
+        entityData?.entityType === EntityType.Metric && entityData.semanticModel?.urn
+            ? entityData.semanticModel.urn
+            : null;
+    const isMissingFromRoots = missingModelUrn != null && !rootModels.some((m) => m.urn === missingModelUrn);
+
+    const { data: fallbackData } = useScrollSemanticModelsQuery({
+        skip: !isMissingFromRoots || missingModelUrn == null,
+        variables: {
+            input: {
+                query: '*',
+                types: [EntityType.SemanticModel],
+                count: 1,
+                orFilters: [{ and: [{ field: 'urn', condition: 'EQUAL' as any, values: [missingModelUrn ?? ''] }] }],
+            },
+        },
     });
+
+    const allModels: SemanticModel[] = useMemo(() => {
+        if (!isMissingFromRoots) return rootModels;
+        const fallbackModels = (fallbackData?.scrollAcrossEntities?.searchResults ?? [])
+            .map((r) => r.entity)
+            .filter((e): e is SemanticModel => e?.__typename === 'SemanticModel');
+        if (fallbackModels.length === 0) return rootModels;
+        const existingUrns = new Set(rootModels.map((m) => m.urn));
+        const newModels = fallbackModels.filter((m) => !existingUrns.has(m.urn));
+        return newModels.length > 0 ? [...newModels, ...rootModels] : rootModels;
+    }, [rootModels, fallbackData, isMissingFromRoots]);
 
     // Re-fetch root when refetchKey changes.
     useEffect(() => {
@@ -301,8 +324,6 @@ function ExpandedMetricsSidebar({ onToggleCollapsed }: { onToggleCollapsed: () =
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [refetchKey]);
-
-    const allModels = useMemo(() => modelsData?.getSemanticModels?.semanticModels ?? [], [modelsData]);
 
     // Derive unique platforms for the Platform filter.
     const platformOptions = useMemo(() => {
@@ -325,53 +346,23 @@ function ExpandedMetricsSidebar({ onToggleCollapsed }: { onToggleCollapsed: () =
         }));
     }, [allModels]);
 
-    // Filter semantic models by platform + search.
+    // Apply platform filter (client-side facet over loaded roots).
     const visibleModels = useMemo(() => {
-        return allModels.filter((m) => {
-            if (platformFilter !== ALL_OPTION && m.platform?.urn !== platformFilter) return false;
-            if (searchInput) {
-                const q = searchInput.toLowerCase();
-                const nameMatch = (m.info?.name ?? '').toLowerCase().includes(q);
-                if (!nameMatch) {
-                    // Keep the model visible if any of its cached child metrics match.
-                    const childMetrics = childMetricsByModelUrn[m.urn] ?? [];
-                    const childMatch = childMetrics.some((metric) =>
-                        (metric.info?.name ?? '').toLowerCase().includes(q),
-                    );
-                    if (!childMatch) return false;
-                }
-            }
-            return true;
-        });
-    }, [allModels, platformFilter, searchInput, childMetricsByModelUrn]);
+        if (platformFilter === ALL_OPTION) return allModels;
+        return allModels.filter((m) => m.platform?.urn === platformFilter);
+    }, [allModels, platformFilter]);
 
-    // Expand-all / collapse-all for the "Semantic Models" section. Any expanded
-    // model means the section is "open" → the toggle reads as Collapse all.
+    // Expand-all / collapse-all for the "Semantic Models" section.
     const isSectionExpanded = expandedSemanticModelUrns.size > 0 || expandedMetricUrns.size > 0;
     const handleToggleExpandAll = useCallback(() => {
         if (isSectionExpanded) {
             collapseAllExpanded();
             return;
         }
-        // Open the section so the freshly-expanded rows are visible.
         setIsModelsExpanded(true);
         const expandable = visibleModels.filter((m) => (m.metrics?.total ?? 0) > 0).map((m) => m.urn);
         expandAllSemanticModels(expandable);
     }, [isSectionExpanded, visibleModels, collapseAllExpanded, expandAllSemanticModels]);
-
-    // Auto-expand the semantic model that directly contains the selected metric.
-    // Deeper metric-in-metric ancestors are handled properly in subsequent PR.
-    useEffect(() => {
-        if (!selectedUrn) return;
-        allModels.forEach((m) => {
-            const topLevelMetrics = childMetricsByModelUrn[m.urn] ?? [];
-            const isDirectChild = topLevelMetrics.some((metric) => metric.urn === selectedUrn);
-            if (isDirectChild && !expandedSemanticModelUrns.has(m.urn)) {
-                toggleSemanticModel(m.urn);
-            }
-        });
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [selectedUrn, allModels, childMetricsByModelUrn]);
 
     return (
         <>
@@ -392,14 +383,7 @@ function ExpandedMetricsSidebar({ onToggleCollapsed }: { onToggleCollapsed: () =
             </HeaderControls>
             <Separator />
 
-            <SearchInputWrapper>
-                <SearchBar
-                    placeholder={t('metrics.searchPlaceholder')}
-                    value={searchInput}
-                    onChange={setSearchInput}
-                    data-testid="metrics-sidebar-search-input"
-                />
-            </SearchInputWrapper>
+            <MetricsSearch />
 
             {platformOptions.length > 1 && (
                 <FiltersWrapper>
@@ -439,7 +423,7 @@ function ExpandedMetricsSidebar({ onToggleCollapsed }: { onToggleCollapsed: () =
                 />
                 {isModelsExpanded && (
                     <>
-                        {modelsData && visibleModels.length === 0 && (
+                        {allModels.length === 0 && (
                             <EmptyStateWrapper>
                                 <EmptyState
                                     icon={Sigma}
@@ -453,19 +437,15 @@ function ExpandedMetricsSidebar({ onToggleCollapsed }: { onToggleCollapsed: () =
                             <SemanticModelRow
                                 key={model.urn}
                                 model={model}
-                                searchInput={searchInput}
                                 isExpanded={expandedSemanticModelUrns.has(model.urn)}
                                 isSelected={selectedUrn === model.urn}
-                                cachedMetrics={childMetricsByModelUrn[model.urn]}
                                 expandedMetricUrns={expandedMetricUrns}
-                                childMetricsByParentUrn={childMetricsByParentUrn}
                                 selectedUrn={selectedUrn}
                                 onToggle={() => toggleSemanticModel(model.urn)}
-                                onMetricsFetched={setChildMetricsForModel}
                                 onToggleMetric={toggleMetric}
-                                onChildMetricsFetched={setChildMetricsForParent}
                             />
                         ))}
+                        <div ref={rootScrollRef} style={{ height: 1 }} />
                     </>
                 )}
             </TreeContainer>

--- a/datahub-web-react/src/app/metrics/SemanticModelRow.tsx
+++ b/datahub-web-react/src/app/metrics/SemanticModelRow.tsx
@@ -1,71 +1,52 @@
 import { Cube } from '@phosphor-icons/react/dist/csr/Cube';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { MetricRow } from '@app/metrics/MetricRow';
 import { MetricsTreeItem } from '@app/metrics/MetricsTreeItem';
+import { useMetricsEntityContext } from '@app/metrics/context/MetricsEntityContext';
 import { MetricEntity, SemanticModel } from '@app/metrics/metricsTypes';
+import useMetricChildren from '@app/metrics/useMetricChildren';
 import { PageRoutes } from '@conf/Global';
-
-import { useGetSemanticModelMetricsLazyQuery } from '@graphql/metricsBrowse.generated';
 
 export type SemanticModelRowProps = {
     model: SemanticModel;
-    searchInput: string;
     isExpanded: boolean;
     isSelected: boolean;
-    cachedMetrics: MetricEntity[] | undefined;
     expandedMetricUrns: Set<string>;
-    childMetricsByParentUrn: Record<string, MetricEntity[]>;
     selectedUrn: string | null;
     onToggle: () => void;
-    onMetricsFetched: (modelUrn: string, metrics: MetricEntity[]) => void;
     onToggleMetric: (urn: string) => void;
-    onChildMetricsFetched: (parentUrn: string, metrics: MetricEntity[]) => void;
 };
 
 export function SemanticModelRow({
     model,
-    searchInput,
     isExpanded,
     isSelected,
-    cachedMetrics,
     expandedMetricUrns,
-    childMetricsByParentUrn,
     selectedUrn,
     onToggle,
-    onMetricsFetched,
     onToggleMetric,
-    onChildMetricsFetched,
 }: SemanticModelRowProps) {
     const history = useHistory();
+    const { entityData } = useMetricsEntityContext();
     const hasChildren = (model.metrics?.total ?? 0) > 0;
 
-    const [fetchMetrics, { data: metricsData }] = useGetSemanticModelMetricsLazyQuery();
-
-    // Fetch metrics for this model when it's first expanded.
+    // Auto-expand when navigating to a metric that belongs to this semantic model.
     useEffect(() => {
-        if (isExpanded && !cachedMetrics && hasChildren) {
-            fetchMetrics({ variables: { urn: model.urn, input: { count: 100, query: '*' } } });
+        if (!entityData) return;
+        if (entityData.semanticModel?.urn === model.urn && !isExpanded) {
+            onToggle();
         }
-    }, [isExpanded, cachedMetrics, hasChildren, fetchMetrics, model.urn]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [entityData, model.urn, isExpanded]);
 
-    // When fresh data arrives, populate the cache.
-    useEffect(() => {
-        if (!metricsData?.semanticModel?.metrics) return;
-        const fetched = metricsData.semanticModel.metrics.searchResults
-            .map((r) => r.entity)
-            .filter((e): e is MetricEntity => e?.__typename === 'Metric');
-        onMetricsFetched(model.urn, fetched);
-    }, [metricsData, model.urn, onMetricsFetched]);
+    const { data, scrollRef } = useMetricChildren({
+        mode: { kind: 'model', modelUrn: model.urn },
+        skip: !isExpanded || !hasChildren,
+    });
 
-    const filteredMetrics = useMemo(() => {
-        const metrics = cachedMetrics ?? [];
-        if (!searchInput) return metrics;
-        const q = searchInput.toLowerCase();
-        return metrics.filter((m) => (m.info?.name ?? '').toLowerCase().includes(q));
-    }, [cachedMetrics, searchInput]);
-
+    const metrics = data as MetricEntity[];
     const modelTitle = model.info?.name ?? model.urn;
 
     return (
@@ -83,23 +64,20 @@ export function SemanticModelRow({
                 testId={`metrics-sidebar-model-${model.urn}`}
             />
             {isExpanded &&
-                filteredMetrics.map((metric) => (
+                metrics.map((metric) => (
                     <MetricRow
                         key={metric.urn}
                         level={1}
                         metric={metric}
-                        searchInput={searchInput}
                         isExpanded={expandedMetricUrns.has(metric.urn)}
                         isSelected={selectedUrn === metric.urn}
-                        cachedChildren={childMetricsByParentUrn[metric.urn]}
                         expandedMetricUrns={expandedMetricUrns}
-                        childMetricsByParentUrn={childMetricsByParentUrn}
                         selectedUrn={selectedUrn}
                         onToggle={() => onToggleMetric(metric.urn)}
-                        onChildMetricsFetched={onChildMetricsFetched}
                         onToggleMetric={onToggleMetric}
                     />
                 ))}
+            {isExpanded && <div ref={scrollRef} style={{ height: 1 }} />}
         </>
     );
 }

--- a/datahub-web-react/src/app/metrics/context/MetricsEntityContext.tsx
+++ b/datahub-web-react/src/app/metrics/context/MetricsEntityContext.tsx
@@ -3,51 +3,49 @@ import { matchPath, useLocation } from 'react-router-dom';
 
 import { PageRoutes } from '@conf/Global';
 
-import { GetSemanticModelMetricsQuery } from '@graphql/metricsBrowse.generated';
+import { EntityType } from '@types';
 
-type SearchResultEntity = NonNullable<
-    NonNullable<
-        NonNullable<GetSemanticModelMetricsQuery['semanticModel']>['metrics']
-    >['searchResults'][number]['entity']
->;
-type MetricSearchResult = Extract<SearchResultEntity, { __typename?: 'Metric' }>;
+/** Minimal entity data needed by the sidebar to auto-expand the tree to the active entity. */
+export type MetricsEntityData = {
+    urn: string;
+    entityType: EntityType;
+    /** The semantic model that owns this metric (present when entityType === Metric). */
+    semanticModel?: { urn: string } | null;
+    /** Ancestor metrics from immediate parent to root, nearest first. */
+    parentMetrics?: Array<{ urn: string }> | null;
+};
 
 type MetricsEntityContextType = {
     expandedSemanticModelUrns: Set<string>;
     expandedMetricUrns: Set<string>;
     selectedUrn: string | null;
-    /** Cached per-semantic-model metric fetch results, keyed by model URN. */
-    childMetricsByModelUrn: Record<string, MetricSearchResult[]>;
-    /** Cached per-metric child metrics fetch results, keyed by parent metric URN. */
-    childMetricsByParentUrn: Record<string, MetricSearchResult[]>;
     toggleSemanticModel: (urn: string) => void;
     toggleMetric: (urn: string) => void;
     /** Expand every semantic model in `urns` (union with current). */
     expandAllSemanticModels: (urns: string[]) => void;
     /** Collapse every expanded semantic model and metric. */
     collapseAllExpanded: () => void;
-    setChildMetricsForModel: (modelUrn: string, metrics: MetricSearchResult[]) => void;
-    setChildMetricsForParent: (parentUrn: string, metrics: MetricSearchResult[]) => void;
     /** Signal the sidebar to refetch root + all expanded children. */
     refetchTree: () => void;
     /** Incremented each time refetchTree() is called; consumers subscribe via useEffect. */
     refetchKey: number;
+    /** Entity currently viewed in the profile pane; null on the /metrics home page. */
+    entityData: MetricsEntityData | null;
+    setEntityData: (data: MetricsEntityData | null) => void;
 };
 
 const MetricsEntityContext = createContext<MetricsEntityContextType>({
     expandedSemanticModelUrns: new Set(),
     expandedMetricUrns: new Set(),
     selectedUrn: null,
-    childMetricsByModelUrn: {},
-    childMetricsByParentUrn: {},
     toggleSemanticModel: () => {},
     toggleMetric: () => {},
     expandAllSemanticModels: () => {},
     collapseAllExpanded: () => {},
-    setChildMetricsForModel: () => {},
-    setChildMetricsForParent: () => {},
     refetchTree: () => {},
     refetchKey: 0,
+    entityData: null,
+    setEntityData: () => {},
 });
 
 type Props = {
@@ -68,9 +66,8 @@ export function MetricsEntityContextProvider({ children }: Props) {
     const location = useLocation();
     const [expandedSemanticModelUrns, setExpandedSemanticModelUrns] = useState<Set<string>>(new Set());
     const [expandedMetricUrns, setExpandedMetricUrns] = useState<Set<string>>(new Set());
-    const [childMetricsByModelUrn, setChildMetricsByModelUrn] = useState<Record<string, MetricSearchResult[]>>({});
-    const [childMetricsByParentUrn, setChildMetricsByParentUrn] = useState<Record<string, MetricSearchResult[]>>({});
     const [refetchKey, setRefetchKey] = useState(0);
+    const [entityData, setEntityData] = useState<MetricsEntityData | null>(null);
 
     // Derive selectedUrn from the current route without extra renders.
     const selectedUrn = useMemo(() => {
@@ -108,21 +105,10 @@ export function MetricsEntityContextProvider({ children }: Props) {
         setExpandedMetricUrns(new Set());
     }, []);
 
-    const setChildMetricsForModel = useCallback((modelUrn: string, metrics: MetricSearchResult[]) => {
-        setChildMetricsByModelUrn((prev) => ({ ...prev, [modelUrn]: metrics }));
-    }, []);
-
-    const setChildMetricsForParent = useCallback((parentUrn: string, metrics: MetricSearchResult[]) => {
-        setChildMetricsByParentUrn((prev) => ({ ...prev, [parentUrn]: metrics }));
-    }, []);
-
-    // Use a ref to avoid stale-closure captures in the callback.
     const refetchKeyRef = useRef(0);
     const refetchTree = useCallback(() => {
         refetchKeyRef.current += 1;
         setRefetchKey(refetchKeyRef.current);
-        setChildMetricsByModelUrn({});
-        setChildMetricsByParentUrn({});
     }, []);
 
     const value = useMemo(
@@ -130,31 +116,26 @@ export function MetricsEntityContextProvider({ children }: Props) {
             expandedSemanticModelUrns,
             expandedMetricUrns,
             selectedUrn,
-            childMetricsByModelUrn,
-            childMetricsByParentUrn,
             toggleSemanticModel,
             toggleMetric,
             expandAllSemanticModels,
             collapseAllExpanded,
-            setChildMetricsForModel,
-            setChildMetricsForParent,
             refetchTree,
             refetchKey,
+            entityData,
+            setEntityData,
         }),
         [
             expandedSemanticModelUrns,
             expandedMetricUrns,
             selectedUrn,
-            childMetricsByModelUrn,
-            childMetricsByParentUrn,
             toggleSemanticModel,
             toggleMetric,
             expandAllSemanticModels,
             collapseAllExpanded,
-            setChildMetricsForModel,
-            setChildMetricsForParent,
             refetchTree,
             refetchKey,
+            entityData,
         ],
     );
 

--- a/datahub-web-react/src/app/metrics/metricsTypes.ts
+++ b/datahub-web-react/src/app/metrics/metricsTypes.ts
@@ -1,12 +1,11 @@
-import { GetSemanticModelMetricsQuery, GetSemanticModelsBrowseQuery } from '@graphql/metricsBrowse.generated';
+import { ScrollMetricsQuery, ScrollSemanticModelsQuery } from '@graphql/metricsBrowse.generated';
 
-export type SemanticModel = NonNullable<
-    NonNullable<GetSemanticModelsBrowseQuery['getSemanticModels']>['semanticModels'][number]
+type ScrollMetricSearchResult = NonNullable<
+    NonNullable<ScrollMetricsQuery['scrollAcrossEntities']>['searchResults'][number]['entity']
 >;
+export type MetricEntity = Extract<ScrollMetricSearchResult, { __typename?: 'Metric' }>;
 
-type SearchResultEntity = NonNullable<
-    NonNullable<
-        NonNullable<GetSemanticModelMetricsQuery['semanticModel']>['metrics']
-    >['searchResults'][number]['entity']
+type ScrollSemanticModelSearchResult = NonNullable<
+    NonNullable<ScrollSemanticModelsQuery['scrollAcrossEntities']>['searchResults'][number]['entity']
 >;
-export type MetricEntity = Extract<SearchResultEntity, { __typename?: 'Metric' }>;
+export type SemanticModel = Extract<ScrollSemanticModelSearchResult, { __typename?: 'SemanticModel' }>;

--- a/datahub-web-react/src/app/metrics/useMetricChildren.ts
+++ b/datahub-web-react/src/app/metrics/useMetricChildren.ts
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
+
+import { MetricEntity } from '@app/metrics/metricsTypes';
+import { ENTITY_NAME_FIELD } from '@app/searchV2/context/constants';
+
+import { useScrollMetricsQuery } from '@graphql/metricsBrowse.generated';
+import { EntityType, SortOrder } from '@types';
+
+export const METRIC_CHILDREN_COUNT = 50;
+
+type ModelMode = {
+    kind: 'model';
+    modelUrn: string;
+};
+
+type MetricMode = {
+    kind: 'metric';
+    parentMetricUrn: string;
+};
+
+type Props = {
+    mode: ModelMode | MetricMode;
+    /** Pass true when the parent row is collapsed — skips the query entirely. */
+    skip?: boolean;
+};
+
+function buildScrollInput(mode: ModelMode | MetricMode, scrollId: string | null) {
+    const baseInput = {
+        scrollId,
+        query: '*',
+        types: [EntityType.Metric],
+        count: METRIC_CHILDREN_COUNT,
+        sortInput: {
+            sortCriteria: [{ field: ENTITY_NAME_FIELD, sortOrder: SortOrder.Ascending }],
+        },
+        searchFlags: { skipCache: true },
+    };
+
+    if (mode.kind === 'model') {
+        return {
+            input: {
+                ...baseInput,
+                orFilters: [
+                    {
+                        and: [
+                            { field: 'semanticModel', values: [mode.modelUrn] },
+                            { field: 'hasParentMetric', values: ['false'] },
+                        ],
+                    },
+                ],
+            },
+        };
+    }
+
+    return {
+        input: {
+            ...baseInput,
+            orFilters: [{ and: [{ field: 'parentMetric', values: [mode.parentMetricUrn] }] }],
+        },
+    };
+}
+
+export default function useMetricChildren({ mode, skip }: Props) {
+    const [scrollId, setScrollId] = useState<string | null>(null);
+    const [data, setData] = useState<MetricEntity[]>([]);
+
+    const modeKey = mode.kind === 'model' ? mode.modelUrn : mode.parentMetricUrn;
+
+    // Reset accumulated data when the parent URN changes.
+    useEffect(() => {
+        setScrollId(null);
+        setData([]);
+    }, [modeKey]);
+
+    const { data: scrollData, loading } = useScrollMetricsQuery({
+        variables: buildScrollInput(mode, scrollId),
+        skip: !!skip,
+        notifyOnNetworkStatusChange: true,
+    });
+
+    // Merge incoming results into local state (same merge-not-replace pattern as useGlossaryChildren).
+    useEffect(() => {
+        if (scrollData?.scrollAcrossEntities?.searchResults) {
+            const fresh = scrollData.scrollAcrossEntities.searchResults
+                .map((r) => r.entity)
+                .filter((e): e is MetricEntity => e?.__typename === 'Metric');
+            const freshByUrn = new Map(fresh.map((e) => [e.urn, e]));
+
+            setData((currData) => {
+                const updated = currData.map((e) => freshByUrn.get(e.urn) || e);
+                const seenUrns = new Set(updated.map((e) => e.urn));
+                const additions = fresh.filter((e) => !seenUrns.has(e.urn));
+                if (additions.length === 0 && updated.every((e, i) => e === currData[i])) {
+                    return currData;
+                }
+                return [...updated, ...additions];
+            });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [scrollData]);
+
+    const nextScrollId = scrollData?.scrollAcrossEntities?.nextScrollId;
+
+    const [scrollRef, inView] = useInView({ triggerOnce: false });
+
+    useEffect(() => {
+        if (!loading && nextScrollId && scrollId !== nextScrollId && inView) {
+            setScrollId(nextScrollId);
+        }
+    }, [inView, nextScrollId, scrollId, loading]);
+
+    return {
+        data,
+        loading,
+        scrollRef,
+    };
+}

--- a/datahub-web-react/src/app/metrics/useSemanticModelRoots.ts
+++ b/datahub-web-react/src/app/metrics/useSemanticModelRoots.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
+
+import { SemanticModel } from '@app/metrics/metricsTypes';
+import { ENTITY_NAME_FIELD } from '@app/searchV2/context/constants';
+
+import { useScrollSemanticModelsQuery } from '@graphql/metricsBrowse.generated';
+import { EntityType, SortOrder } from '@types';
+
+export const SEMANTIC_MODEL_COUNT = 50;
+
+function buildScrollInput(scrollId: string | null) {
+    return {
+        input: {
+            scrollId,
+            query: '*',
+            types: [EntityType.SemanticModel],
+            count: SEMANTIC_MODEL_COUNT,
+            sortInput: {
+                sortCriteria: [{ field: ENTITY_NAME_FIELD, sortOrder: SortOrder.Ascending }],
+            },
+            searchFlags: { skipCache: true },
+        },
+    };
+}
+
+export default function useSemanticModelRoots() {
+    const [scrollId, setScrollId] = useState<string | null>(null);
+    const [data, setData] = useState<SemanticModel[]>([]);
+
+    const {
+        data: scrollData,
+        loading,
+        refetch,
+    } = useScrollSemanticModelsQuery({
+        variables: buildScrollInput(scrollId),
+        notifyOnNetworkStatusChange: true,
+    });
+
+    useEffect(() => {
+        if (scrollData?.scrollAcrossEntities?.searchResults) {
+            const fresh = scrollData.scrollAcrossEntities.searchResults
+                .map((r) => r.entity)
+                .filter((e): e is SemanticModel => e?.__typename === 'SemanticModel');
+            const freshByUrn = new Map(fresh.map((e) => [e.urn, e]));
+
+            setData((currData) => {
+                const updated = currData.map((e) => freshByUrn.get(e.urn) || e);
+                const seenUrns = new Set(updated.map((e) => e.urn));
+                const additions = fresh.filter((e) => !seenUrns.has(e.urn));
+                if (additions.length === 0 && updated.every((e, i) => e === currData[i])) {
+                    return currData;
+                }
+                return [...updated, ...additions];
+            });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [scrollData]);
+
+    const nextScrollId = scrollData?.scrollAcrossEntities?.nextScrollId;
+
+    const [scrollRef, inView] = useInView({ triggerOnce: false });
+
+    useEffect(() => {
+        if (!loading && nextScrollId && scrollId !== nextScrollId && inView) {
+            setScrollId(nextScrollId);
+        }
+    }, [inView, nextScrollId, scrollId, loading]);
+
+    return {
+        data,
+        loading,
+        scrollRef,
+        refetch,
+    };
+}

--- a/datahub-web-react/src/app/metrics/useUpdateMetricsEntityDataOnChange.ts
+++ b/datahub-web-react/src/app/metrics/useUpdateMetricsEntityDataOnChange.ts
@@ -1,0 +1,47 @@
+import isEqual from 'lodash/isEqual';
+import { useEffect } from 'react';
+
+import { GenericEntityProperties } from '@app/entity/shared/types';
+import { MetricsEntityData, useMetricsEntityContext } from '@app/metrics/context/MetricsEntityContext';
+import usePrevious from '@app/shared/usePrevious';
+
+import { EntityType } from '@types';
+
+const METRICS_ENTITY_TYPES = new Set([EntityType.Metric, EntityType.SemanticModel]);
+
+/**
+ * Called from EntityProfile whenever the entity data for a metric or semantic-model
+ * profile page changes. Pushes the minimal ancestor info
+ * (semanticModel URN + parentMetrics chain) into MetricsEntityContext so
+ * the sidebar can self-expand to the currently-viewed entity.
+ */
+export function useUpdateMetricsEntityDataOnChange(
+    entityData: GenericEntityProperties | null,
+    entityType: EntityType,
+): void {
+    const { setEntityData } = useMetricsEntityContext();
+    const previousEntityData = usePrevious(entityData);
+
+    useEffect(() => {
+        if (!METRICS_ENTITY_TYPES.has(entityType) || isEqual(entityData, previousEntityData)) {
+            return;
+        }
+
+        if (!entityData) {
+            setEntityData(null);
+            return;
+        }
+
+        const raw = entityData as any;
+        const next: MetricsEntityData = {
+            urn: raw.urn ?? '',
+            entityType,
+            semanticModel: raw.semanticModel ? { urn: raw.semanticModel.urn } : null,
+            parentMetrics: Array.isArray(raw.parentMetrics)
+                ? raw.parentMetrics.map((m: any) => ({ urn: m.urn }))
+                : null,
+        };
+
+        setEntityData(next);
+    });
+}

--- a/datahub-web-react/src/graphql/metric.graphql
+++ b/datahub-web-react/src/graphql/metric.graphql
@@ -132,6 +132,13 @@ fragment metricFields on Metric {
             }
         }
     }
+    parentMetrics {
+        urn
+        type
+        semanticModel {
+            urn
+        }
+    }
     ownership {
         ...ownershipFields
     }

--- a/datahub-web-react/src/graphql/metricsBrowse.graphql
+++ b/datahub-web-react/src/graphql/metricsBrowse.graphql
@@ -65,46 +65,32 @@ query getSemanticModelsBrowse($input: GetRootEntitiesInput!) {
     }
 }
 
-query getSemanticModelMetrics($urn: String!, $input: ScrollAcrossEntitiesInput!) {
-    semanticModel(urn: $urn) {
-        urn
-        metrics(input: $input) {
-            nextScrollId
-            count
-            total
-            searchResults {
-                entity {
-                    urn
-                    type
-                    ... on Metric {
-                        id
-                        path
-                        platform {
-                            ...platformFields
-                        }
-                        info {
-                            name
-                            description
-                            lastModified {
-                                time
-                            }
-                        }
-                        childMetrics(input: { count: 0, query: "*" }) {
-                            total
-                        }
-                        subTypes {
-                            typeNames
-                        }
-                    }
-                }
-            }
+fragment metricBrowseFields on Metric {
+    id
+    path
+    platform {
+        ...platformFields
+    }
+    info {
+        name
+        description
+        lastModified {
+            time
         }
+    }
+    childMetrics(input: { count: 0, query: "*" }) {
+        total
+    }
+    subTypes {
+        typeNames
     }
 }
 
-# Direct children of a metric (used to lazily expand a metric row in the sidebar tree).
-query getMetricChildren($input: SearchAcrossEntitiesInput!) {
-    searchAcrossEntities(input: $input) {
+# Cursor-based scroll for metrics. Works for both model-children and metric-children — callers
+# supply the appropriate orFilters.
+query scrollMetrics($input: ScrollAcrossEntitiesInput!) {
+    scrollAcrossEntities(input: $input) {
+        nextScrollId
         count
         total
         searchResults {
@@ -112,6 +98,24 @@ query getMetricChildren($input: SearchAcrossEntitiesInput!) {
                 urn
                 type
                 ... on Metric {
+                    ...metricBrowseFields
+                }
+            }
+        }
+    }
+}
+
+# Cursor-based scroll for root semantic models in the sidebar tree.
+query scrollSemanticModels($input: ScrollAcrossEntitiesInput!) {
+    scrollAcrossEntities(input: $input) {
+        nextScrollId
+        count
+        total
+        searchResults {
+            entity {
+                urn
+                type
+                ... on SemanticModel {
                     id
                     path
                     platform {
@@ -124,7 +128,7 @@ query getMetricChildren($input: SearchAcrossEntitiesInput!) {
                             time
                         }
                     }
-                    childMetrics(input: { count: 0, query: "*" }) {
+                    metrics(input: { count: 0, query: "*" }) {
                         total
                     }
                     subTypes {

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -397,6 +397,18 @@ fragment autoCompleteFields on Entity {
             }
         }
     }
+    ... on Metric {
+        id
+        info {
+            name
+        }
+    }
+    ... on SemanticModel {
+        id
+        info {
+            name
+        }
+    }
 }
 
 query getAutoCompleteResults($input: AutoCompleteInput!, $skipSiblingsSearch: Boolean = false) {


### PR DESCRIPTION
## Summary
- Bring the Metrics sidebar to Glossary-style browsing: server-side autocomplete search (`MetricsSearch`) and cursor-based infinite scroll for root semantic models and nested metric children.
- Fix duplicate metric rows under a semantic model by returning only root metrics (`hasParentMetric=false`) from `SemanticModelMetricsResolver`.
- Add `parentMetrics` GraphQL field + deep-link auto-expand cascade so navigating to a metric/semantic model expands ancestors in the sidebar tree.

## Test plan
- [ ] Open `/metrics` and confirm semantic models load with infinite scroll at the root of the tree
- [ ] Expand a semantic model and nested metrics; confirm children load via scroll and the sentinel advances pagination
- [ ] Search in the sidebar: autocomplete returns Metric and SemanticModel **names** (not URNs) and links navigate correctly
- [ ] Open a nested metric entity page and confirm the sidebar auto-expands the ancestor chain with a single highlighted row (no duplicates)
- [ ] Filter by platform still works client-side over loaded roots
- [ ] Run `SemanticModelMetricsResolverTest` and frontend lint for touched files


Made with [Cursor](https://cursor.com)