### PR TITLE
fix(ingest/grafana): skip General folder (folderId 0) container membership

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
@@ -264,7 +264,7 @@ class GrafanaSource(StatefulIngestionSourceBase):
         )
 
         # If dashboard is in a folder, add it to folder container
-        if dashboard.folder_id:
+        if dashboard.folder_id and dashboard.folder_id != "0":
             folder_key = FolderKey(
                 platform=self.config.platform,
                 instance=self.config.platform_instance,

--- a/metadata-ingestion/tests/integration/grafana/grafana_basic_mcps_golden.json
+++ b/metadata-ingestion/tests/integration/grafana/grafana_basic_mcps_golden.json
@@ -73,31 +73,10 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:839d480ae59afad9450be04d22794390",
     "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1720785600000,
-        "runId": "grafana-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:839d480ae59afad9450be04d22794390",
-    "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08",
-                    "urn": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08"
-                }
-            ]
+            "path": []
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/grafana/grafana_mcps_golden.json
+++ b/metadata-ingestion/tests/integration/grafana/grafana_mcps_golden.json
@@ -76,22 +76,6 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
     "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1720785600000,
-        "runId": "grafana-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
-    "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
@@ -99,10 +83,6 @@
                 {
                     "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)",
                     "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)"
-                },
-                {
-                    "id": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7",
-                    "urn": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7"
                 }
             ]
         }

--- a/metadata-ingestion/tests/unit/grafana/test_grafana_source.py
+++ b/metadata-ingestion/tests/unit/grafana/test_grafana_source.py
@@ -2,11 +2,18 @@ from unittest.mock import patch
 
 import pytest
 
+from datahub.emitter.mce_builder import make_container_urn
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.grafana.grafana_config import GrafanaSourceConfig
 from datahub.ingestion.source.grafana.grafana_source import GrafanaSource
-from datahub.ingestion.source.grafana.models import Dashboard, Folder, Panel
+from datahub.ingestion.source.grafana.models import (
+    Dashboard,
+    DashboardContainerKey,
+    Folder,
+    FolderKey,
+    Panel,
+)
 
 
 @pytest.fixture
@@ -86,6 +93,46 @@ def test_process_dashboard_with_folder(mock_api, mock_source, mock_dashboard):
     # Verify folder container relationship is created
     container_workunits = [wu for wu in workunit_list if "container" in wu.id]
     assert len(container_workunits) > 0
+
+
+@patch("datahub.ingestion.source.grafana.grafana_source.GrafanaAPIClient")
+def test_process_dashboard_general_folder(mock_api, mock_source):
+    dashboard = Dashboard(
+        uid="dash1",
+        title="Test Dashboard",
+        description="Test Description",
+        version="1",
+        panels=[],
+        schemaVersion="1.0",
+        meta={"folderId": "0"},
+    )
+
+    workunit_list = list(mock_source._process_dashboard(dashboard))
+
+    general_folder_urn = make_container_urn(
+        FolderKey(
+            platform=mock_source.config.platform,
+            instance=mock_source.config.platform_instance,
+            folder_id="0",
+        )
+    )
+    dashboard_container_urn = make_container_urn(
+        DashboardContainerKey(
+            platform=mock_source.config.platform,
+            instance=mock_source.config.platform_instance,
+            dashboard_id=dashboard.uid,
+            folder_id=dashboard.folder_id,
+        )
+    )
+
+    assert any(
+        workunit.metadata.entityUrn == dashboard_container_urn
+        for workunit in workunit_list
+    )
+    assert all(
+        getattr(workunit.metadata.aspect, "container", None) != general_folder_urn
+        for workunit in workunit_list
+    )
 
 
 @patch("datahub.ingestion.source.grafana.grafana_source.GrafanaAPIClient")


### PR DESCRIPTION
## Summary

Grafana dashboards in the special "General" folder are attached to a folder container that never exists, leaking a raw container URN into the dashboard's browse path in the UI. This tightens the folder-membership guard so General-folder dashboards keep their own dashboard container but are not attached to the nonexistent folder container.

## Background

General is a virtual root folder represented by `folderId = 0`. Because `Dashboard.folder_id` is `Optional[str]` and `_GrafanaBaseModel` sets `coerce_numbers_to_str=True`, the integer `0` from Grafana is coerced to the truthy string `"0"`, so the `if dashboard.folder_id:` guard in `_process_dashboard` passes for General-folder dashboards and emits an `add_dataset_to_container` workunit pointing at a `FolderKey` URN that is never materialized. The reporter (DoserF, #18260) verified that guarding against `folder_id == "0"` resolves it.

The fix changes the guard to `if dashboard.folder_id and dashboard.folder_id != "0":`. Real folders and folder-less dashboards are unchanged, and the dashboard's own container is unaffected. Added `test_process_dashboard_general_folder` covering the General case; the existing `test_process_dashboard_with_folder` still passes.

- [x] The PR conforms to DataHub's Contributing Guideline (PR Title Format)
- [x] Links to related issues
- [x] Tests for the changes have been added/updated
- [x] Docs related to the changes have been added/updated (N/A - internal bug fix, no user-facing surface)
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in Updating DataHub (N/A - no breaking change)

Fixes #18260

AI was used for assistance.
