### PR TITLE
ci: fix lint workflow self-filter typo + cache Playwright deps (PFP-4998)

### DIFF
--- a/.github/path-filters/lint-jobs-filters.yml
+++ b/.github/path-filters/lint-jobs-filters.yml
@@ -1,6 +1,6 @@
 lint-job:
   - modified: ".github/workflows/lint-jobs.yml"
-  - ".github/path-filters/lint-job-filter.yml"
+  - ".github/path-filters/lint-jobs-filters.yml"
 markdown:
   - added|modified: "**/*.md"
   - ".github/scripts/check_docusaurus_markdown.py"

--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -302,9 +302,17 @@ jobs:
     runs-on: ${{ needs.setup.outputs.default-gh-runner }}
     needs: setup
     if: needs.setup.outputs.playwright-e2e == 'true'
+    env:
+      YARN_CACHE_FOLDER: /tmp/.yarn-cache/
     steps:
       - name: Check out the repo
         uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
+      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        name: Restore yarn cache
+        with:
+          path: |
+            ${{ env.YARN_CACHE_FOLDER }}
+          key: "yarn-${{ github.base_ref }}-${{ hashFiles('./e2e-test/ui/playwright/yarn.lock') }}"
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -318,3 +326,9 @@ jobs:
       - name: ESLint
         working-directory: e2e-test/ui/playwright
         run: yarn lint
+      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        name: Save yarn cache
+        with:
+          path: |
+            ${{ env.YARN_CACHE_FOLDER }}
+          key: "yarn-${{ github.base_ref }}-${{ hashFiles('./e2e-test/ui/playwright/yarn.lock') }}"


### PR DESCRIPTION
<!--
Thank you for contributing to DataHub!
Before you submit your PR, please go through the checklist below:
- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
- [ ] For any breaking change an entry has been made in Updating DataHub
Allowed Types in PR Title: feat, fix, refactor, docs, test, perf, style, build, ci, chore
-->

## Summary

Two small, independent CI reliability/perf fixes for the lint workflow, both in `.github/workflows/lint-jobs.yml` / its path filters:

1. **Fix the `lint-job` self-filter typo.** `.github/path-filters/lint-jobs-filters.yml` referenced `.github/path-filters/lint-job-filter.yml` (singular) — a path that doesn't exist. The actual filter file is `lint-jobs-filters.yml` (plural). Because of the typo, the `lint-job` filter output never matched, so the workflow couldn't self-trigger on changes to its own config. This corrects the path so the lint job re-runs when the lint config itself changes.
2. **Cache yarn deps for the Playwright e2e lint job.** The `playwright-e2e` job previously re-downloaded yarn dependencies on every run. Add a `YARN_CACHE_FOLDER` + `actions/cache/restore` (before setup) / `actions/cache/save` (after lint) pair, keyed on `yarn-<base_ref>-<hash of e2e-test/ui/playwright/yarn.lock>`. Reuses the yarn cache across runs on the same base branch and cuts job time.

## Changes
- `.github/path-filters/lint-jobs-filters.yml`: `lint-job` self-filter path `lint-job-filter.yml` → `lint-jobs-filters.yml`.
- `.github/workflows/lint-jobs.yml`: add yarn cache restore/save steps + `YARN_CACHE_FOLDER` env to the `playwright-e2e` job.

## Test plan
- [ ] PR touching only `.github/workflows/lint-jobs.yml` → `lint-job` filter evaluates `true` (previously stayed `false`).
- [ ] `playwright-e2e` job restores `yarn-${base_ref}-<lockfile-hash>` on a repeat run and skips the bulk of the yarn download.
- [ ] No regression in lint job triggering for unrelated paths.

## Notes
- Bottom of the PFP-4982 pre-commit/CI optimization stack (base: `master`).
- Refs PFP-4998.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
