### PR TITLE
ci(lint): combine Python CI lint jobs into a single python-lint job

### DIFF
--- a/.github/path-filters/lint-jobs-filters.yml
+++ b/.github/path-filters/lint-jobs-filters.yml
@@ -34,5 +34,17 @@ datahub-web-react:
 metadata-ingestion:
   - added|modified: "metadata-ingestion/**"
   - "metadata-models/**"
+datahub-actions:
+  - added|modified: "datahub-actions/**"
+datahub-agent-context:
+  - added|modified: "datahub-agent-context/**"
+airflow-plugin:
+  - added|modified: "metadata-ingestion-modules/airflow-plugin/**"
+gx-plugin:
+  - added|modified: "metadata-ingestion-modules/gx-plugin/**"
+dagster-plugin:
+  - added|modified: "metadata-ingestion-modules/dagster-plugin/**"
+prefect-plugin:
+  - added|modified: "metadata-ingestion-modules/prefect-plugin/**"
 playwright-e2e:
   - added|modified: "e2e-test/ui/playwright/**"

--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -26,6 +26,12 @@ jobs:
       pdl: ${{ steps.filter.outputs.pdl == 'true' || steps.filter.outputs.lint-job == 'true' }}
       datahub-web-react: ${{ steps.filter.outputs.datahub-web-react == 'true' || steps.filter.outputs.lint-job == 'true' }}
       metadata-ingestion: ${{ steps.filter.outputs.metadata-ingestion == 'true' || steps.filter.outputs.lint-job == 'true' }}
+      datahub-actions: ${{ steps.filter.outputs.datahub-actions == 'true' || steps.filter.outputs.lint-job == 'true' }}
+      datahub-agent-context: ${{ steps.filter.outputs.datahub-agent-context == 'true' || steps.filter.outputs.lint-job == 'true' }}
+      airflow-plugin: ${{ steps.filter.outputs.airflow-plugin == 'true' || steps.filter.outputs.lint-job == 'true' }}
+      gx-plugin: ${{ steps.filter.outputs.gx-plugin == 'true' || steps.filter.outputs.lint-job == 'true' }}
+      dagster-plugin: ${{ steps.filter.outputs.dagster-plugin == 'true' || steps.filter.outputs.lint-job == 'true' }}
+      prefect-plugin: ${{ steps.filter.outputs.prefect-plugin == 'true' || steps.filter.outputs.lint-job == 'true' }}
       smoke-test-python: ${{ steps.filter.outputs.smoke-test-python == 'true' || steps.filter.outputs.lint-job == 'true' }}
       smoke-test-cypress: ${{ steps.filter.outputs.smoke-test-cypress == 'true' || steps.filter.outputs.lint-job == 'true' }}
       playwright-e2e: ${{ steps.filter.outputs.playwright-e2e == 'true' || steps.filter.outputs.lint-job == 'true' }}
@@ -244,6 +250,228 @@ jobs:
           path: |
             ${{ env.UV_CACHE_DIR }}
           key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion/setup.py', './metadata-ingestion/uv.lock') }}"
+
+  datahub-actions-lint:
+    name: datahub-actions-lint
+    runs-on: ${{ needs.setup.outputs.default-runner }}
+    needs: setup
+    if: needs.setup.outputs.datahub-actions == 'true'
+    env:
+      UV_CACHE_DIR: /tmp/.uv-cache/
+      DATAHUB_TELEMETRY_ENABLED: false
+    steps:
+      - name: Check out the repo
+        uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: "zulu"
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        name: Restore uv cache
+        with:
+          path: |
+            ${{ env.UV_CACHE_DIR }}
+          key: "uv-${{github.base_ref}}-${{ hashFiles('./datahub-actions/setup.py', './datahub-actions/pyproject.toml') }}"
+      - name: Install system dependencies
+        run: ./metadata-ingestion/scripts/install_deps.sh
+      - name: Run datahub-actions lint
+        run: ./gradlew :datahub-actions:lint
+      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        name: Save uv cache
+        with:
+          path: |
+            ${{ env.UV_CACHE_DIR }}
+          key: "uv-${{github.base_ref}}-${{ hashFiles('./datahub-actions/setup.py', './datahub-actions/pyproject.toml') }}"
+
+  datahub-agent-context-lint:
+    name: datahub-agent-context-lint
+    runs-on: ${{ needs.setup.outputs.default-runner }}
+    needs: setup
+    if: needs.setup.outputs.datahub-agent-context == 'true'
+    env:
+      UV_CACHE_DIR: /tmp/.uv-cache/
+      DATAHUB_TELEMETRY_ENABLED: false
+    steps:
+      - name: Check out the repo
+        uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: "zulu"
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        name: Restore uv cache
+        with:
+          path: |
+            ${{ env.UV_CACHE_DIR }}
+          key: "uv-${{github.base_ref}}-${{ hashFiles('./datahub-agent-context/setup.py', './datahub-agent-context/pyproject.toml') }}"
+      - name: Install system dependencies
+        run: ./metadata-ingestion/scripts/install_deps.sh
+      - name: Run datahub-agent-context lint
+        run: ./gradlew :datahub-agent-context:lint
+      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        name: Save uv cache
+        with:
+          path: |
+            ${{ env.UV_CACHE_DIR }}
+          key: "uv-${{github.base_ref}}-${{ hashFiles('./datahub-agent-context/setup.py', './datahub-agent-context/pyproject.toml') }}"
+
+  airflow-plugin-lint:
+    name: airflow-plugin-lint
+    runs-on: ${{ needs.setup.outputs.default-runner }}
+    needs: setup
+    if: needs.setup.outputs.airflow-plugin == 'true'
+    env:
+      UV_CACHE_DIR: /tmp/.uv-cache/
+      DATAHUB_TELEMETRY_ENABLED: false
+    steps:
+      - name: Check out the repo
+        uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: "zulu"
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        name: Restore uv cache
+        with:
+          path: |
+            ${{ env.UV_CACHE_DIR }}
+          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion-modules/airflow-plugin/setup.py', './metadata-ingestion-modules/airflow-plugin/pyproject.toml') }}"
+      - name: Install system dependencies
+        run: ./metadata-ingestion/scripts/install_deps.sh
+      - name: Run airflow-plugin lint
+        run: ./gradlew :metadata-ingestion-modules:airflow-plugin:lint
+      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        name: Save uv cache
+        with:
+          path: |
+            ${{ env.UV_CACHE_DIR }}
+          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion-modules/airflow-plugin/setup.py', './metadata-ingestion-modules/airflow-plugin/pyproject.toml') }}"
+
+  gx-plugin-lint:
+    name: gx-plugin-lint
+    runs-on: ${{ needs.setup.outputs.default-runner }}
+    needs: setup
+    if: needs.setup.outputs.gx-plugin == 'true'
+    env:
+      UV_CACHE_DIR: /tmp/.uv-cache/
+      DATAHUB_TELEMETRY_ENABLED: false
+    steps:
+      - name: Check out the repo
+        uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: "zulu"
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        name: Restore uv cache
+        with:
+          path: |
+            ${{ env.UV_CACHE_DIR }}
+          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion-modules/gx-plugin/setup.py', './metadata-ingestion-modules/gx-plugin/pyproject.toml') }}"
+      - name: Install system dependencies
+        run: ./metadata-ingestion/scripts/install_deps.sh
+      - name: Run gx-plugin lint
+        run: ./gradlew :metadata-ingestion-modules:gx-plugin:lint
+      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        name: Save uv cache
+        with:
+          path: |
+            ${{ env.UV_CACHE_DIR }}
+          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion-modules/gx-plugin/setup.py', './metadata-ingestion-modules/gx-plugin/pyproject.toml') }}"
+
+  dagster-plugin-lint:
+    name: dagster-plugin-lint
+    runs-on: ${{ needs.setup.outputs.default-runner }}
+    needs: setup
+    if: needs.setup.outputs.dagster-plugin == 'true'
+    env:
+      UV_CACHE_DIR: /tmp/.uv-cache/
+      DATAHUB_TELEMETRY_ENABLED: false
+    steps:
+      - name: Check out the repo
+        uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: "zulu"
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        name: Restore uv cache
+        with:
+          path: |
+            ${{ env.UV_CACHE_DIR }}
+          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion-modules/dagster-plugin/setup.py', './metadata-ingestion-modules/dagster-plugin/pyproject.toml') }}"
+      - name: Install system dependencies
+        run: ./metadata-ingestion/scripts/install_deps.sh
+      - name: Run dagster-plugin lint
+        run: ./gradlew :metadata-ingestion-modules:dagster-plugin:lint
+      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        name: Save uv cache
+        with:
+          path: |
+            ${{ env.UV_CACHE_DIR }}
+          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion-modules/dagster-plugin/setup.py', './metadata-ingestion-modules/dagster-plugin/pyproject.toml') }}"
+
+  prefect-plugin-lint:
+    name: prefect-plugin-lint
+    runs-on: ${{ needs.setup.outputs.default-runner }}
+    needs: setup
+    if: needs.setup.outputs.prefect-plugin == 'true'
+    env:
+      UV_CACHE_DIR: /tmp/.uv-cache/
+      DATAHUB_TELEMETRY_ENABLED: false
+    steps:
+      - name: Check out the repo
+        uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: "zulu"
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        name: Restore uv cache
+        with:
+          path: |
+            ${{ env.UV_CACHE_DIR }}
+          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion-modules/prefect-plugin/setup.py', './metadata-ingestion-modules/prefect-plugin/pyproject.toml') }}"
+      - name: Install system dependencies
+        run: ./metadata-ingestion/scripts/install_deps.sh
+      - name: Run prefect-plugin lint
+        run: ./gradlew :metadata-ingestion-modules:prefect-plugin:lint
+      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        name: Save uv cache
+        with:
+          path: |
+            ${{ env.UV_CACHE_DIR }}
+          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion-modules/prefect-plugin/setup.py', './metadata-ingestion-modules/prefect-plugin/pyproject.toml') }}"
 
   datahub-web-react-lint:
     name: datahub-web-react-lint

--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -32,6 +32,8 @@ jobs:
       gx-plugin: ${{ steps.filter.outputs.gx-plugin == 'true' || steps.filter.outputs.lint-job == 'true' }}
       dagster-plugin: ${{ steps.filter.outputs.dagster-plugin == 'true' || steps.filter.outputs.lint-job == 'true' }}
       prefect-plugin: ${{ steps.filter.outputs.prefect-plugin == 'true' || steps.filter.outputs.lint-job == 'true' }}
+      # Runs the single python-lint job if ANY Python module's files changed.
+      python-lint: ${{ steps.filter.outputs.metadata-ingestion == 'true' || steps.filter.outputs.datahub-actions == 'true' || steps.filter.outputs.datahub-agent-context == 'true' || steps.filter.outputs.airflow-plugin == 'true' || steps.filter.outputs.gx-plugin == 'true' || steps.filter.outputs.dagster-plugin == 'true' || steps.filter.outputs.prefect-plugin == 'true' || steps.filter.outputs.lint-job == 'true' }}
       smoke-test-python: ${{ steps.filter.outputs.smoke-test-python == 'true' || steps.filter.outputs.lint-job == 'true' }}
       smoke-test-cypress: ${{ steps.filter.outputs.smoke-test-cypress == 'true' || steps.filter.outputs.lint-job == 'true' }}
       playwright-e2e: ${{ steps.filter.outputs.playwright-e2e == 'true' || steps.filter.outputs.lint-job == 'true' }}
@@ -214,11 +216,11 @@ jobs:
             ${{ env.UV_CACHE_DIR }}
           key: "uv-${{github.base_ref}}-${{ hashFiles('./smoke-test/requirements.txt', './smoke-test/pyproject.toml') }}"
 
-  metadata-ingestion-lint:
-    name: metadata-ingestion-lint
+  python-lint:
+    name: python-lint
     runs-on: ${{ needs.setup.outputs.default-runner }}
     needs: setup
-    if: needs.setup.outputs.metadata-ingestion == 'true'
+    if: needs.setup.outputs.python-lint == 'true'
     env:
       UV_CACHE_DIR: /tmp/.uv-cache/
       DATAHUB_TELEMETRY_ENABLED: false
@@ -234,244 +236,76 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
-      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        name: Restore uv cache
+      - name: Restore uv cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
-          path: |
-            ${{ env.UV_CACHE_DIR }}
-          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion/setup.py', './metadata-ingestion/uv.lock') }}"
+          path: ${{ env.UV_CACHE_DIR }}
+          # Shared across PRs (no base_ref in the key) so every PR reuses the same uv cache.
+          key: uv-python-lint-${{ hashFiles('./metadata-ingestion/setup.py', './metadata-ingestion/uv.lock', './datahub-actions/setup.py', './datahub-actions/pyproject.toml', './datahub-agent-context/setup.py', './datahub-agent-context/pyproject.toml', './metadata-ingestion-modules/airflow-plugin/setup.py', './metadata-ingestion-modules/airflow-plugin/pyproject.toml', './metadata-ingestion-modules/gx-plugin/setup.py', './metadata-ingestion-modules/gx-plugin/pyproject.toml', './metadata-ingestion-modules/dagster-plugin/setup.py', './metadata-ingestion-modules/dagster-plugin/pyproject.toml', './metadata-ingestion-modules/prefect-plugin/setup.py', './metadata-ingestion-modules/prefect-plugin/pyproject.toml') }}
       - name: Install system dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
-      - name: Run metadata-ingestion lint
+      # Per-module lint steps. Each runs independently (if: always()) so a failure in one
+      # does not skip the others. Each uses its module's own Gradle-managed venv (separate
+      # venvs) while sharing the single uv download cache above. Each is gated by its own
+      # path-filter output.
+      - name: metadata-ingestion lint
+        id: metadata-ingestion-lint
+        if: always() && needs.setup.outputs.metadata-ingestion == 'true'
         run: ./gradlew :metadata-ingestion:lint
-      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        name: Save uv cache
-        with:
-          path: |
-            ${{ env.UV_CACHE_DIR }}
-          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion/setup.py', './metadata-ingestion/uv.lock') }}"
-
-  datahub-actions-lint:
-    name: datahub-actions-lint
-    runs-on: ${{ needs.setup.outputs.default-runner }}
-    needs: setup
-    if: needs.setup.outputs.datahub-actions == 'true'
-    env:
-      UV_CACHE_DIR: /tmp/.uv-cache/
-      DATAHUB_TELEMETRY_ENABLED: false
-    steps:
-      - name: Check out the repo
-        uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
-      - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with:
-          distribution: "zulu"
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.11"
-      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        name: Restore uv cache
-        with:
-          path: |
-            ${{ env.UV_CACHE_DIR }}
-          key: "uv-${{github.base_ref}}-${{ hashFiles('./datahub-actions/setup.py', './datahub-actions/pyproject.toml') }}"
-      - name: Install system dependencies
-        run: ./metadata-ingestion/scripts/install_deps.sh
-      - name: Run datahub-actions lint
+      - name: datahub-actions lint
+        id: datahub-actions-lint
+        if: always() && needs.setup.outputs.datahub-actions == 'true'
         run: ./gradlew :datahub-actions:lint
-      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        name: Save uv cache
-        with:
-          path: |
-            ${{ env.UV_CACHE_DIR }}
-          key: "uv-${{github.base_ref}}-${{ hashFiles('./datahub-actions/setup.py', './datahub-actions/pyproject.toml') }}"
-
-  datahub-agent-context-lint:
-    name: datahub-agent-context-lint
-    runs-on: ${{ needs.setup.outputs.default-runner }}
-    needs: setup
-    if: needs.setup.outputs.datahub-agent-context == 'true'
-    env:
-      UV_CACHE_DIR: /tmp/.uv-cache/
-      DATAHUB_TELEMETRY_ENABLED: false
-    steps:
-      - name: Check out the repo
-        uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
-      - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with:
-          distribution: "zulu"
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.11"
-      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        name: Restore uv cache
-        with:
-          path: |
-            ${{ env.UV_CACHE_DIR }}
-          key: "uv-${{github.base_ref}}-${{ hashFiles('./datahub-agent-context/setup.py', './datahub-agent-context/pyproject.toml') }}"
-      - name: Install system dependencies
-        run: ./metadata-ingestion/scripts/install_deps.sh
-      - name: Run datahub-agent-context lint
+      - name: datahub-agent-context lint
+        id: datahub-agent-context-lint
+        if: always() && needs.setup.outputs.datahub-agent-context == 'true'
         run: ./gradlew :datahub-agent-context:lint
-      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        name: Save uv cache
-        with:
-          path: |
-            ${{ env.UV_CACHE_DIR }}
-          key: "uv-${{github.base_ref}}-${{ hashFiles('./datahub-agent-context/setup.py', './datahub-agent-context/pyproject.toml') }}"
-
-  airflow-plugin-lint:
-    name: airflow-plugin-lint
-    runs-on: ${{ needs.setup.outputs.default-runner }}
-    needs: setup
-    if: needs.setup.outputs.airflow-plugin == 'true'
-    env:
-      UV_CACHE_DIR: /tmp/.uv-cache/
-      DATAHUB_TELEMETRY_ENABLED: false
-    steps:
-      - name: Check out the repo
-        uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
-      - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with:
-          distribution: "zulu"
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.11"
-      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        name: Restore uv cache
-        with:
-          path: |
-            ${{ env.UV_CACHE_DIR }}
-          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion-modules/airflow-plugin/setup.py', './metadata-ingestion-modules/airflow-plugin/pyproject.toml') }}"
-      - name: Install system dependencies
-        run: ./metadata-ingestion/scripts/install_deps.sh
-      - name: Run airflow-plugin lint
+      - name: airflow-plugin lint
+        id: airflow-plugin-lint
+        if: always() && needs.setup.outputs.airflow-plugin == 'true'
         run: ./gradlew :metadata-ingestion-modules:airflow-plugin:lint
-      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        name: Save uv cache
-        with:
-          path: |
-            ${{ env.UV_CACHE_DIR }}
-          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion-modules/airflow-plugin/setup.py', './metadata-ingestion-modules/airflow-plugin/pyproject.toml') }}"
-
-  gx-plugin-lint:
-    name: gx-plugin-lint
-    runs-on: ${{ needs.setup.outputs.default-runner }}
-    needs: setup
-    if: needs.setup.outputs.gx-plugin == 'true'
-    env:
-      UV_CACHE_DIR: /tmp/.uv-cache/
-      DATAHUB_TELEMETRY_ENABLED: false
-    steps:
-      - name: Check out the repo
-        uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
-      - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with:
-          distribution: "zulu"
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.11"
-      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        name: Restore uv cache
-        with:
-          path: |
-            ${{ env.UV_CACHE_DIR }}
-          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion-modules/gx-plugin/setup.py', './metadata-ingestion-modules/gx-plugin/pyproject.toml') }}"
-      - name: Install system dependencies
-        run: ./metadata-ingestion/scripts/install_deps.sh
-      - name: Run gx-plugin lint
+      - name: gx-plugin lint
+        id: gx-plugin-lint
+        if: always() && needs.setup.outputs.gx-plugin == 'true'
         run: ./gradlew :metadata-ingestion-modules:gx-plugin:lint
-      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        name: Save uv cache
-        with:
-          path: |
-            ${{ env.UV_CACHE_DIR }}
-          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion-modules/gx-plugin/setup.py', './metadata-ingestion-modules/gx-plugin/pyproject.toml') }}"
-
-  dagster-plugin-lint:
-    name: dagster-plugin-lint
-    runs-on: ${{ needs.setup.outputs.default-runner }}
-    needs: setup
-    if: needs.setup.outputs.dagster-plugin == 'true'
-    env:
-      UV_CACHE_DIR: /tmp/.uv-cache/
-      DATAHUB_TELEMETRY_ENABLED: false
-    steps:
-      - name: Check out the repo
-        uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
-      - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with:
-          distribution: "zulu"
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.11"
-      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        name: Restore uv cache
-        with:
-          path: |
-            ${{ env.UV_CACHE_DIR }}
-          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion-modules/dagster-plugin/setup.py', './metadata-ingestion-modules/dagster-plugin/pyproject.toml') }}"
-      - name: Install system dependencies
-        run: ./metadata-ingestion/scripts/install_deps.sh
-      - name: Run dagster-plugin lint
+      - name: dagster-plugin lint
+        id: dagster-plugin-lint
+        if: always() && needs.setup.outputs.dagster-plugin == 'true'
         run: ./gradlew :metadata-ingestion-modules:dagster-plugin:lint
-      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        name: Save uv cache
-        with:
-          path: |
-            ${{ env.UV_CACHE_DIR }}
-          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion-modules/dagster-plugin/setup.py', './metadata-ingestion-modules/dagster-plugin/pyproject.toml') }}"
-
-  prefect-plugin-lint:
-    name: prefect-plugin-lint
-    runs-on: ${{ needs.setup.outputs.default-runner }}
-    needs: setup
-    if: needs.setup.outputs.prefect-plugin == 'true'
-    env:
-      UV_CACHE_DIR: /tmp/.uv-cache/
-      DATAHUB_TELEMETRY_ENABLED: false
-    steps:
-      - name: Check out the repo
-        uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
-      - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with:
-          distribution: "zulu"
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.11"
-      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        name: Restore uv cache
-        with:
-          path: |
-            ${{ env.UV_CACHE_DIR }}
-          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion-modules/prefect-plugin/setup.py', './metadata-ingestion-modules/prefect-plugin/pyproject.toml') }}"
-      - name: Install system dependencies
-        run: ./metadata-ingestion/scripts/install_deps.sh
-      - name: Run prefect-plugin lint
+      - name: prefect-plugin lint
+        id: prefect-plugin-lint
+        if: always() && needs.setup.outputs.prefect-plugin == 'true'
         run: ./gradlew :metadata-ingestion-modules:prefect-plugin:lint
-      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        name: Save uv cache
+      - name: Save uv cache
+        if: always()
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
-          path: |
-            ${{ env.UV_CACHE_DIR }}
-          key: "uv-${{github.base_ref}}-${{ hashFiles('./metadata-ingestion-modules/prefect-plugin/setup.py', './metadata-ingestion-modules/prefect-plugin/pyproject.toml') }}"
+          path: ${{ env.UV_CACHE_DIR }}
+          key: uv-python-lint-${{ hashFiles('./metadata-ingestion/setup.py', './metadata-ingestion/uv.lock', './datahub-actions/setup.py', './datahub-actions/pyproject.toml', './datahub-agent-context/setup.py', './datahub-agent-context/pyproject.toml', './metadata-ingestion-modules/airflow-plugin/setup.py', './metadata-ingestion-modules/airflow-plugin/pyproject.toml', './metadata-ingestion-modules/gx-plugin/setup.py', './metadata-ingestion-modules/gx-plugin/pyproject.toml', './metadata-ingestion-modules/dagster-plugin/setup.py', './metadata-ingestion-modules/dagster-plugin/pyproject.toml', './metadata-ingestion-modules/prefect-plugin/setup.py', './metadata-ingestion-modules/prefect-plugin/pyproject.toml') }}
+      - name: Report lint results
+        if: always()
+        env:
+          MI: ${{ steps.metadata-ingestion-lint.outcome }}
+          DA: ${{ steps.datahub-actions-lint.outcome }}
+          DAC: ${{ steps.datahub-agent-context-lint.outcome }}
+          AF: ${{ steps.airflow-plugin-lint.outcome }}
+          GX: ${{ steps.gx-plugin-lint.outcome }}
+          DAG: ${{ steps.dagster-plugin-lint.outcome }}
+          PF: ${{ steps.prefect-plugin-lint.outcome }}
+        run: |
+          failed=()
+          [ "$MI" = "failure" ] && failed+=("metadata-ingestion")
+          [ "$DA" = "failure" ] && failed+=("datahub-actions")
+          [ "$DAC" = "failure" ] && failed+=("datahub-agent-context")
+          [ "$AF" = "failure" ] && failed+=("airflow-plugin")
+          [ "$GX" = "failure" ] && failed+=("gx-plugin")
+          [ "$DAG" = "failure" ] && failed+=("dagster-plugin")
+          [ "$PF" = "failure" ] && failed+=("prefect-plugin")
+          if [ ${#failed[@]} -gt 0 ]; then
+            echo "::error::Python lint failed for: ${failed[*]}"
+            exit 1
+          fi
+          echo "All Python lint steps passed (or were skipped)."
 
   datahub-web-react-lint:
     name: datahub-web-react-lint


### PR DESCRIPTION
<!--
Thank you for contributing to DataHub!
Before you submit your PR, please go through the checklist below:
- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
- [ ] For any breaking change an entry has been made in Updating DataHub
Allowed Types in PR Title: feat, fix, refactor, docs, test, perf, style, build, ci, chore
-->

## Summary

Consolidate the per-module Python CI lint jobs in `.github/workflows/lint-jobs.yml` into one `python-lint` job, and add the path filters + setup outputs needed to drive it. Cuts CI runner usage (one runner instead of N) while keeping per-module isolation, per-module gating, and a shared dependency cache. The `smoke-test-python` lint job is intentionally left as its own job.

Second layer of the PFP-4982 pre-commit/CI optimization stack (stacked on `dc/pfp-4998-ci-filters`).

## Changes
### `.github/path-filters/lint-jobs-filters.yml`
Add path filters for the six Python modules that were previously missing their own filter outputs: `datahub-actions`, `datahub-agent-context`, `airflow-plugin`, `gx-plugin`, `dagster-plugin`, `prefect-plugin`.

### `.github/workflows/lint-jobs.yml`
- **Setup job:** add the six new module filter outputs (each OR'"'"'d with `lint-job`), plus a single `python-lint` output = OR of all six (and `lint-job`). The `python-lint` job runs if **any** Python module'"'"'s files changed.
- **Rename** `metadata-ingestion-lint` → `python-lint`, gated by `needs.setup.outputs.python-lint == '"'"'true'"'"'`.
- **Shared uv cache:** one `UV_CACHE_DIR` cache (restore before install, save at end) keyed on `uv-python-lint-<hash of all modules'"'"' setup.py/pyproject.toml/uv.lock>`. Key omits `github.base_ref` so the cache is shared across PRs on different base branches.
- **Per-module lint steps:** one step per module, each runs `./gradlew :<module>:lint` in its own Gradle-managed venv (separate venvs, shared download cache), gated by `if: always() && needs.setup.outputs.<module> == '"'"'true'"'"'` so a failure in one module does **not** skip the others and each only runs when that module'"'"'s files changed.
- **Report step:** a final `if: always()` step collects each step'"'"'s `outcome`, prints an `::error::` listing failed modules, and exits non-zero if any module failed.

## Test plan
- [ ] PR touching only `metadata-ingestion/` → only the `metadata-ingestion lint` step runs; others skip.
- [ ] PR touching two modules → both steps run; if one fails, the other still runs and the job reports both, failing on the failed one.
- [ ] PR touching no Python module → `python-lint` job is skipped entirely.
- [ ] PR touching `.github/workflows/lint-jobs.yml` → `python-lint` runs all steps via the `lint-job` OR.
- [ ] uv cache restored on a repeat run with unchanged lockfile, across different base branches.
- [ ] `smoke-test-python` lint still runs as its own job, unchanged.

## Notes
- Stacked on `dc/pfp-4998-ci-filters` (base branch for this PR).
- Refs PFP-4999.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
