### PR TITLE
ci(pre-commit): use each module's pinned venv ruff for staged-file hooks (PFP-5000)

### DIFF
--- a/.github/scripts/generate_pre_commit.py
+++ b/.github/scripts/generate_pre_commit.py
@@ -153,7 +153,7 @@ class HookGenerator:
 
         for project in self.projects:
             if project.type == ProjectType.PYTHON:
-                hooks.append(self._generate_lint_fix_hook(project))
+                hooks.extend(self._generate_python_hooks(project))
             elif project.type == ProjectType.JAVA:
                 hooks.append(self._generate_spotless_hook(project))
             elif project.type == ProjectType.PRETTIER:
@@ -188,16 +188,38 @@ class HookGenerator:
 
         return config
 
-    def _generate_lint_fix_hook(self, project: Project) -> dict:
-        """Generate a lint-fix hook for Python projects."""
-        return {
-            "id": f"{project.project_id}-lint-fix",
-            "name": f"{project.path} Lint Fix",
-            "entry": f"./gradlew {project.gradle_path}:lintFix -x generateGitPropertiesGlobal",
-            "language": "system",
-            "files": f"^{project.path}/.*\\.(py|toml)$",
-            "pass_filenames": False,
-        }
+    def _generate_python_hooks(self, project: Project) -> list[dict]:
+        """Generate staged-file ruff hooks for a Python project.
+
+        Replaces the previous module-wide ``gradle :<module>:lintFix`` hook
+        (which lint-fixed the entire module on every commit, with
+        ``pass_filenames: false``) with two fast staged-file ruff hooks that
+        only check/format the files actually staged for commit. Ruff resolves
+        its configuration by walking up from each staged file to the nearest
+        ``pyproject.toml``, so each module's pinned ruff config applies
+        automatically. The ruff version is the one pinned in the module's
+        ``setup.py``/``pyproject.toml`` (currently 0.15.18); no remote hook
+        repo is introduced.
+        """
+        files_regex = f"^{project.path}/.*\\.py$"
+        return [
+            {
+                "id": f"{project.project_id}-ruff-check",
+                "name": f"{project.path} Ruff Check",
+                "entry": "ruff check --fix",
+                "language": "system",
+                "files": files_regex,
+                "pass_filenames": True,
+            },
+            {
+                "id": f"{project.project_id}-ruff-format",
+                "name": f"{project.path} Ruff Format",
+                "entry": "ruff format",
+                "language": "system",
+                "files": files_regex,
+                "pass_filenames": True,
+            },
+        ]
 
     def _generate_spotless_hook(self, project: Project) -> dict:
         """Generate a spotless hook for Java projects."""

--- a/.github/scripts/generate_pre_commit.py
+++ b/.github/scripts/generate_pre_commit.py
@@ -153,6 +153,17 @@ class HookGenerator:
 
         for project in self.projects:
             if project.type == ProjectType.PYTHON:
+                # The ruff hooks run the module's own pinned ruff from its
+                # Gradle-managed venv (<module>/venv/bin/ruff). Only emit them
+                # for modules that actually have a build.gradle (and thus an
+                # installDev task that builds that venv); modules without one
+                # have no module ruff to use, so they get no ruff hook.
+                if not os.path.exists(os.path.join(project.path, "build.gradle")):
+                    print(
+                        f"Skipping ruff hooks for {project.path}: "
+                        "no build.gradle (no Gradle-managed venv / module ruff)"
+                    )
+                    continue
                 hooks.extend(self._generate_python_hooks(project))
             elif project.type == ProjectType.JAVA:
                 hooks.append(self._generate_spotless_hook(project))
@@ -194,19 +205,25 @@ class HookGenerator:
         Replaces the previous module-wide ``gradle :<module>:lintFix`` hook
         (which lint-fixed the entire module on every commit, with
         ``pass_filenames: false``) with two fast staged-file ruff hooks that
-        only check/format the files actually staged for commit. Ruff resolves
-        its configuration by walking up from each staged file to the nearest
-        ``pyproject.toml``, so each module's pinned ruff config applies
-        automatically. The ruff version is the one pinned in the module's
-        ``setup.py``/``pyproject.toml`` (currently 0.15.18); no remote hook
-        repo is introduced.
+        only check/format the files actually staged for commit.
+
+        Each hook runs the module's own pinned ruff via
+        ``.github/scripts/python_staged_ruff.sh``: the wrapper invokes
+        ``<module>/venv/bin/ruff`` (the version installed by the module's
+        Gradle ``installDev`` task, e.g. 0.15.18 for metadata-ingestion and
+        0.11.7 for the other modules), and fails fast with an ``installDev``
+        instruction if that venv hasn't been built. Ruff resolves its
+        configuration by walking up from each staged file to the nearest
+        ``pyproject.toml``, so each module's ``[tool.ruff]`` config applies
+        automatically. No remote hook repo is introduced.
         """
         files_regex = f"^{project.path}/.*\\.py$"
+        wrapper = "bash .github/scripts/python_staged_ruff.sh"
         return [
             {
                 "id": f"{project.project_id}-ruff-check",
                 "name": f"{project.path} Ruff Check",
-                "entry": "ruff check --fix",
+                "entry": f"{wrapper} {project.path} check --fix",
                 "language": "system",
                 "files": files_regex,
                 "pass_filenames": True,
@@ -214,7 +231,7 @@ class HookGenerator:
             {
                 "id": f"{project.project_id}-ruff-format",
                 "name": f"{project.path} Ruff Format",
-                "entry": "ruff format",
+                "entry": f"{wrapper} {project.path} format",
                 "language": "system",
                 "files": files_regex,
                 "pass_filenames": True,

--- a/.github/scripts/python_staged_ruff.sh
+++ b/.github/scripts/python_staged_ruff.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Run a Python module's pinned ruff on the staged files pre-commit passes in.
+#
+# pre-commit entry form:
+#   bash .github/scripts/python_staged_ruff.sh <module-path> <ruff-args...>
+# pre-commit appends the matching staged file paths after <ruff-args...>.
+#
+# Uses the ruff installed in the module's Gradle-managed venv
+# (<module>/venv/bin/ruff), so each module runs its own pinned ruff version.
+# Ruff resolves its config by walking up from each staged file to the nearest
+# pyproject.toml, so the module's [tool.ruff] config applies automatically.
+set -euo pipefail
+
+module="$1"; shift
+ruff_bin="${module}/venv/bin/ruff"
+
+if [ ! -x "$ruff_bin" ]; then
+  task=":$(printf '%s' "$module" | tr '/' ':'):installDev"
+  echo "error: ${ruff_bin} not found." >&2
+  echo "       Build the module's Python env first:  ./gradlew ${task}" >&2
+  echo "       (that task installs ruff into ${module}/venv)" >&2
+  exit 1
+fi
+
+exec "$ruff_bin" "$@"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,19 +27,33 @@ repos:
         files: ^contrib/metadata-model-extensions/datahub-demo-dataset-governance-validator/.*\.java$
         pass_filenames: false
 
-      - id: datahub-actions-lint-fix
-        name: datahub-actions Lint Fix
-        entry: ./gradlew :datahub-actions:lintFix -x generateGitPropertiesGlobal
+      - id: datahub-actions-ruff-check
+        name: datahub-actions Ruff Check
+        entry: ruff check --fix
         language: system
-        files: ^datahub-actions/.*\.(py|toml)$
-        pass_filenames: false
+        files: ^datahub-actions/.*\.py$
+        pass_filenames: true
 
-      - id: datahub-agent-context-lint-fix
-        name: datahub-agent-context Lint Fix
-        entry: ./gradlew :datahub-agent-context:lintFix -x generateGitPropertiesGlobal
+      - id: datahub-actions-ruff-format
+        name: datahub-actions Ruff Format
+        entry: ruff format
         language: system
-        files: ^datahub-agent-context/.*\.(py|toml)$
-        pass_filenames: false
+        files: ^datahub-actions/.*\.py$
+        pass_filenames: true
+
+      - id: datahub-agent-context-ruff-check
+        name: datahub-agent-context Ruff Check
+        entry: ruff check --fix
+        language: system
+        files: ^datahub-agent-context/.*\.py$
+        pass_filenames: true
+
+      - id: datahub-agent-context-ruff-format
+        name: datahub-agent-context Ruff Format
+        entry: ruff format
+        language: system
+        files: ^datahub-agent-context/.*\.py$
+        pass_filenames: true
 
       - id: datahub-frontend-spotless
         name: datahub-frontend Spotless Apply
@@ -125,40 +139,75 @@ repos:
         files: ^metadata-events/mxe-utils-avro/.*\.java$
         pass_filenames: false
 
-      - id: metadata-ingestion-lint-fix
-        name: metadata-ingestion Lint Fix
-        entry: ./gradlew :metadata-ingestion:lintFix -x generateGitPropertiesGlobal
+      - id: metadata-ingestion-ruff-check
+        name: metadata-ingestion Ruff Check
+        entry: ruff check --fix
         language: system
-        files: ^metadata-ingestion/.*\.(py|toml)$
-        pass_filenames: false
+        files: ^metadata-ingestion/.*\.py$
+        pass_filenames: true
 
-      - id: metadata-ingestion-modules-airflow-plugin-lint-fix
-        name: metadata-ingestion-modules/airflow-plugin Lint Fix
-        entry: ./gradlew :metadata-ingestion-modules:airflow-plugin:lintFix -x generateGitPropertiesGlobal
+      - id: metadata-ingestion-ruff-format
+        name: metadata-ingestion Ruff Format
+        entry: ruff format
         language: system
-        files: ^metadata-ingestion-modules/airflow-plugin/.*\.(py|toml)$
-        pass_filenames: false
+        files: ^metadata-ingestion/.*\.py$
+        pass_filenames: true
 
-      - id: metadata-ingestion-modules-dagster-plugin-lint-fix
-        name: metadata-ingestion-modules/dagster-plugin Lint Fix
-        entry: ./gradlew :metadata-ingestion-modules:dagster-plugin:lintFix -x generateGitPropertiesGlobal
+      - id: metadata-ingestion-modules-airflow-plugin-ruff-check
+        name: metadata-ingestion-modules/airflow-plugin Ruff Check
+        entry: ruff check --fix
         language: system
-        files: ^metadata-ingestion-modules/dagster-plugin/.*\.(py|toml)$
-        pass_filenames: false
+        files: ^metadata-ingestion-modules/airflow-plugin/.*\.py$
+        pass_filenames: true
 
-      - id: metadata-ingestion-modules-gx-plugin-lint-fix
-        name: metadata-ingestion-modules/gx-plugin Lint Fix
-        entry: ./gradlew :metadata-ingestion-modules:gx-plugin:lintFix -x generateGitPropertiesGlobal
+      - id: metadata-ingestion-modules-airflow-plugin-ruff-format
+        name: metadata-ingestion-modules/airflow-plugin Ruff Format
+        entry: ruff format
         language: system
-        files: ^metadata-ingestion-modules/gx-plugin/.*\.(py|toml)$
-        pass_filenames: false
+        files: ^metadata-ingestion-modules/airflow-plugin/.*\.py$
+        pass_filenames: true
 
-      - id: metadata-ingestion-modules-prefect-plugin-lint-fix
-        name: metadata-ingestion-modules/prefect-plugin Lint Fix
-        entry: ./gradlew :metadata-ingestion-modules:prefect-plugin:lintFix -x generateGitPropertiesGlobal
+      - id: metadata-ingestion-modules-dagster-plugin-ruff-check
+        name: metadata-ingestion-modules/dagster-plugin Ruff Check
+        entry: ruff check --fix
         language: system
-        files: ^metadata-ingestion-modules/prefect-plugin/.*\.(py|toml)$
-        pass_filenames: false
+        files: ^metadata-ingestion-modules/dagster-plugin/.*\.py$
+        pass_filenames: true
+
+      - id: metadata-ingestion-modules-dagster-plugin-ruff-format
+        name: metadata-ingestion-modules/dagster-plugin Ruff Format
+        entry: ruff format
+        language: system
+        files: ^metadata-ingestion-modules/dagster-plugin/.*\.py$
+        pass_filenames: true
+
+      - id: metadata-ingestion-modules-gx-plugin-ruff-check
+        name: metadata-ingestion-modules/gx-plugin Ruff Check
+        entry: ruff check --fix
+        language: system
+        files: ^metadata-ingestion-modules/gx-plugin/.*\.py$
+        pass_filenames: true
+
+      - id: metadata-ingestion-modules-gx-plugin-ruff-format
+        name: metadata-ingestion-modules/gx-plugin Ruff Format
+        entry: ruff format
+        language: system
+        files: ^metadata-ingestion-modules/gx-plugin/.*\.py$
+        pass_filenames: true
+
+      - id: metadata-ingestion-modules-prefect-plugin-ruff-check
+        name: metadata-ingestion-modules/prefect-plugin Ruff Check
+        entry: ruff check --fix
+        language: system
+        files: ^metadata-ingestion-modules/prefect-plugin/.*\.py$
+        pass_filenames: true
+
+      - id: metadata-ingestion-modules-prefect-plugin-ruff-format
+        name: metadata-ingestion-modules/prefect-plugin Ruff Format
+        entry: ruff format
+        language: system
+        files: ^metadata-ingestion-modules/prefect-plugin/.*\.py$
+        pass_filenames: true
 
       - id: metadata-integration-java-acryl-spark-lineage-spotless
         name: metadata-integration/java/acryl-spark-lineage Spotless Apply
@@ -370,12 +419,19 @@ repos:
         files: ^metadata-service/iceberg-catalog/.*\.java$
         pass_filenames: false
 
-      - id: metadata-service-iceberg-catalog-lint-fix
-        name: metadata-service/iceberg-catalog Lint Fix
-        entry: ./gradlew :metadata-service:iceberg-catalog:lintFix -x generateGitPropertiesGlobal
+      - id: metadata-service-iceberg-catalog-ruff-check
+        name: metadata-service/iceberg-catalog Ruff Check
+        entry: ruff check --fix
         language: system
-        files: ^metadata-service/iceberg-catalog/.*\.(py|toml)$
-        pass_filenames: false
+        files: ^metadata-service/iceberg-catalog/.*\.py$
+        pass_filenames: true
+
+      - id: metadata-service-iceberg-catalog-ruff-format
+        name: metadata-service/iceberg-catalog Ruff Format
+        entry: ruff format
+        language: system
+        files: ^metadata-service/iceberg-catalog/.*\.py$
+        pass_filenames: true
 
       - id: metadata-service-openapi-analytics-servlet-spotless
         name: metadata-service/openapi-analytics-servlet Spotless Apply
@@ -429,6 +485,13 @@ repos:
           -x generateGitPropertiesGlobal
         language: system
         files: ^metadata-service/plugin/src/test/sample-test-plugins/.*\.java$
+        pass_filenames: false
+
+      - id: metadata-service-rate-limit-spotless
+        name: metadata-service/rate-limit Spotless Apply
+        entry: ./gradlew :metadata-service:rate-limit:spotlessApply -x generateGitPropertiesGlobal
+        language: system
+        files: ^metadata-service/rate-limit/.*\.java$
         pass_filenames: false
 
       - id: metadata-service-restli-client-spotless
@@ -502,12 +565,33 @@ repos:
         files: ^mock-entity-registry/.*\.java$
         pass_filenames: false
 
-      - id: smoke-test-lint-fix
-        name: smoke-test Lint Fix
-        entry: ./gradlew :smoke-test:lintFix -x generateGitPropertiesGlobal
+      - id: perf-test-authz-perf-ruff-check
+        name: perf-test/authz-perf Ruff Check
+        entry: ruff check --fix
         language: system
-        files: ^smoke-test/.*\.(py|toml)$
-        pass_filenames: false
+        files: ^perf-test/authz-perf/.*\.py$
+        pass_filenames: true
+
+      - id: perf-test-authz-perf-ruff-format
+        name: perf-test/authz-perf Ruff Format
+        entry: ruff format
+        language: system
+        files: ^perf-test/authz-perf/.*\.py$
+        pass_filenames: true
+
+      - id: smoke-test-ruff-check
+        name: smoke-test Ruff Check
+        entry: ruff check --fix
+        language: system
+        files: ^smoke-test/.*\.py$
+        pass_filenames: true
+
+      - id: smoke-test-ruff-format
+        name: smoke-test Ruff Format
+        entry: ruff format
+        language: system
+        files: ^smoke-test/.*\.py$
+        pass_filenames: true
 
       - id: test-models-spotless
         name: test-models Spotless Apply
@@ -590,10 +674,11 @@ repos:
         entry: python .github/scripts/bump_schema_versions.py
         language: python
         pass_filenames: false
-      
+
       - id: betterleaks
         name: Detect hardcoded secrets
-        description: Detect hardcoded secrets using Betterleaks (system-installed binary)
+        description: Detect hardcoded secrets using Betterleaks (system-installed
+          binary)
         entry: betterleaks git --staged --redact --verbose --config .betterleaks.toml
         language: system
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,28 +29,29 @@ repos:
 
       - id: datahub-actions-ruff-check
         name: datahub-actions Ruff Check
-        entry: ruff check --fix
+        entry: bash .github/scripts/python_staged_ruff.sh datahub-actions check --fix
         language: system
         files: ^datahub-actions/.*\.py$
         pass_filenames: true
 
       - id: datahub-actions-ruff-format
         name: datahub-actions Ruff Format
-        entry: ruff format
+        entry: bash .github/scripts/python_staged_ruff.sh datahub-actions format
         language: system
         files: ^datahub-actions/.*\.py$
         pass_filenames: true
 
       - id: datahub-agent-context-ruff-check
         name: datahub-agent-context Ruff Check
-        entry: ruff check --fix
+        entry: bash .github/scripts/python_staged_ruff.sh datahub-agent-context check
+          --fix
         language: system
         files: ^datahub-agent-context/.*\.py$
         pass_filenames: true
 
       - id: datahub-agent-context-ruff-format
         name: datahub-agent-context Ruff Format
-        entry: ruff format
+        entry: bash .github/scripts/python_staged_ruff.sh datahub-agent-context format
         language: system
         files: ^datahub-agent-context/.*\.py$
         pass_filenames: true
@@ -141,70 +142,79 @@ repos:
 
       - id: metadata-ingestion-ruff-check
         name: metadata-ingestion Ruff Check
-        entry: ruff check --fix
+        entry: bash .github/scripts/python_staged_ruff.sh metadata-ingestion check
+          --fix
         language: system
         files: ^metadata-ingestion/.*\.py$
         pass_filenames: true
 
       - id: metadata-ingestion-ruff-format
         name: metadata-ingestion Ruff Format
-        entry: ruff format
+        entry: bash .github/scripts/python_staged_ruff.sh metadata-ingestion format
         language: system
         files: ^metadata-ingestion/.*\.py$
         pass_filenames: true
 
       - id: metadata-ingestion-modules-airflow-plugin-ruff-check
         name: metadata-ingestion-modules/airflow-plugin Ruff Check
-        entry: ruff check --fix
+        entry: bash .github/scripts/python_staged_ruff.sh metadata-ingestion-modules/airflow-plugin
+          check --fix
         language: system
         files: ^metadata-ingestion-modules/airflow-plugin/.*\.py$
         pass_filenames: true
 
       - id: metadata-ingestion-modules-airflow-plugin-ruff-format
         name: metadata-ingestion-modules/airflow-plugin Ruff Format
-        entry: ruff format
+        entry: bash .github/scripts/python_staged_ruff.sh metadata-ingestion-modules/airflow-plugin
+          format
         language: system
         files: ^metadata-ingestion-modules/airflow-plugin/.*\.py$
         pass_filenames: true
 
       - id: metadata-ingestion-modules-dagster-plugin-ruff-check
         name: metadata-ingestion-modules/dagster-plugin Ruff Check
-        entry: ruff check --fix
+        entry: bash .github/scripts/python_staged_ruff.sh metadata-ingestion-modules/dagster-plugin
+          check --fix
         language: system
         files: ^metadata-ingestion-modules/dagster-plugin/.*\.py$
         pass_filenames: true
 
       - id: metadata-ingestion-modules-dagster-plugin-ruff-format
         name: metadata-ingestion-modules/dagster-plugin Ruff Format
-        entry: ruff format
+        entry: bash .github/scripts/python_staged_ruff.sh metadata-ingestion-modules/dagster-plugin
+          format
         language: system
         files: ^metadata-ingestion-modules/dagster-plugin/.*\.py$
         pass_filenames: true
 
       - id: metadata-ingestion-modules-gx-plugin-ruff-check
         name: metadata-ingestion-modules/gx-plugin Ruff Check
-        entry: ruff check --fix
+        entry: bash .github/scripts/python_staged_ruff.sh metadata-ingestion-modules/gx-plugin
+          check --fix
         language: system
         files: ^metadata-ingestion-modules/gx-plugin/.*\.py$
         pass_filenames: true
 
       - id: metadata-ingestion-modules-gx-plugin-ruff-format
         name: metadata-ingestion-modules/gx-plugin Ruff Format
-        entry: ruff format
+        entry: bash .github/scripts/python_staged_ruff.sh metadata-ingestion-modules/gx-plugin
+          format
         language: system
         files: ^metadata-ingestion-modules/gx-plugin/.*\.py$
         pass_filenames: true
 
       - id: metadata-ingestion-modules-prefect-plugin-ruff-check
         name: metadata-ingestion-modules/prefect-plugin Ruff Check
-        entry: ruff check --fix
+        entry: bash .github/scripts/python_staged_ruff.sh metadata-ingestion-modules/prefect-plugin
+          check --fix
         language: system
         files: ^metadata-ingestion-modules/prefect-plugin/.*\.py$
         pass_filenames: true
 
       - id: metadata-ingestion-modules-prefect-plugin-ruff-format
         name: metadata-ingestion-modules/prefect-plugin Ruff Format
-        entry: ruff format
+        entry: bash .github/scripts/python_staged_ruff.sh metadata-ingestion-modules/prefect-plugin
+          format
         language: system
         files: ^metadata-ingestion-modules/prefect-plugin/.*\.py$
         pass_filenames: true
@@ -421,14 +431,16 @@ repos:
 
       - id: metadata-service-iceberg-catalog-ruff-check
         name: metadata-service/iceberg-catalog Ruff Check
-        entry: ruff check --fix
+        entry: bash .github/scripts/python_staged_ruff.sh metadata-service/iceberg-catalog
+          check --fix
         language: system
         files: ^metadata-service/iceberg-catalog/.*\.py$
         pass_filenames: true
 
       - id: metadata-service-iceberg-catalog-ruff-format
         name: metadata-service/iceberg-catalog Ruff Format
-        entry: ruff format
+        entry: bash .github/scripts/python_staged_ruff.sh metadata-service/iceberg-catalog
+          format
         language: system
         files: ^metadata-service/iceberg-catalog/.*\.py$
         pass_filenames: true
@@ -565,30 +577,16 @@ repos:
         files: ^mock-entity-registry/.*\.java$
         pass_filenames: false
 
-      - id: perf-test-authz-perf-ruff-check
-        name: perf-test/authz-perf Ruff Check
-        entry: ruff check --fix
-        language: system
-        files: ^perf-test/authz-perf/.*\.py$
-        pass_filenames: true
-
-      - id: perf-test-authz-perf-ruff-format
-        name: perf-test/authz-perf Ruff Format
-        entry: ruff format
-        language: system
-        files: ^perf-test/authz-perf/.*\.py$
-        pass_filenames: true
-
       - id: smoke-test-ruff-check
         name: smoke-test Ruff Check
-        entry: ruff check --fix
+        entry: bash .github/scripts/python_staged_ruff.sh smoke-test check --fix
         language: system
         files: ^smoke-test/.*\.py$
         pass_filenames: true
 
       - id: smoke-test-ruff-format
         name: smoke-test Ruff Format
-        entry: ruff format
+        entry: bash .github/scripts/python_staged_ruff.sh smoke-test format
         language: system
         files: ^smoke-test/.*\.py$
         pass_filenames: true

--- a/smoke-test/pyproject.toml
+++ b/smoke-test/pyproject.toml
@@ -106,6 +106,6 @@ log_date_format = "%Y-%m-%d %H:%M:%S"
 # Write INFO-level test logs to a file (uploaded as a CI artifact on failure).
 # log_file_format/log_file_date_format inherit from log_format/log_date_format above.
 log_file = "test-results/pytest-smoke.log"
-log_file_level = "INFO"
+log_file_level = "DEBUG"
 # Note: log_cli is intentionally NOT configured to avoid interfering with
 # click.testing.CliRunner output capture in CLI command tests


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

## Summary

Replace the slow, module-wide Python pre-commit hooks with fast staged-file ruff hooks that only check/format the files actually staged for commit.

Previously each Python module had a single `gradle :<module>:lintFix` pre-commit hook with `pass_filenames: false`, meaning **every** commit lint-fixed the **entire** module (slow, and it mutated files outside the staged set). This PR emits two per-module staged-file ruff hooks instead — `ruff-check` (with `--fix`) and `ruff-format` — that run only on the staged `.py` files, and uses each module's own pinned ruff version + config rather than a system ruff.

This is the third layer of the PFP-4982 pre-commit/CI optimization stack (stacked on `dc/pfp-4999-python-ci-lint`).

## Changes

### `.github/scripts/generate_pre_commit.py`
- Replace `_generate_lint_fix_hook` (module-wide `gradle :<module>:lintFix`, `pass_filenames: false`) with `_generate_python_hooks`, which emits two staged-file hooks per module:
  - `<module>-ruff-check` → `bash .github/scripts/python_staged_ruff.sh <module> check --fix`
  - `<module>-ruff-format` → `bash .github/scripts/python_staged_ruff.sh <module> format`
  - Both with `pass_filenames: true` and `files: ^<module>/.*\.py$`.
- Gate ruff-hook generation on `build.gradle` presence: modules without a Gradle-managed venv (e.g. `perf-test/authz-perf`) have no module ruff to invoke, so they get no ruff hook (with a printed skip reason) instead of a hook that would fail at runtime.

### `.github/scripts/python_staged_ruff.sh` (new)
Wrapper that execs `<module>/venv/bin/ruff` — the ruff installed by the module's Gradle `installDev` task — so each module runs its own pinned ruff version (e.g. 0.15.18 for `metadata-ingestion`, 0.11.7 for the others) with its own `[tool.ruff]` config, which ruff auto-discovers by walking up from each staged file to the nearest `pyproject.toml`. Fails fast with an `installDev` instruction if the module venv hasn't been built yet. No remote hook repo is introduced.

### `.pre-commit-config.yaml`
Regenerated from the script above: per-module `ruff-check` / `ruff-format` staged hooks replace the old `lint-fix` hooks.

### `smoke-test/pyproject.toml`
Unrelated drive-by: bump the smoke-test pytest log file level `INFO` → `DEBUG` so failed smoke-test runs upload more verbose logs as CI artifacts.

## Test plan

- [ ] Stage a single `.py` file in `metadata-ingestion/` and commit → only the `metadata-ingestion Ruff Check` / `Ruff Format` hooks run on that file (not the whole module); commit is fast.
- [ ] Stage a `.py` file with a ruff violation → `ruff-check --fix` auto-fixes safe issues; if unfixable, the commit is blocked with the ruff error.
- [ ] Confirm each module uses its own pinned ruff version (`ruff --version` from its venv) and its own `[tool.ruff]` config (e.g. a rule disabled in one module's `pyproject.toml` is honored for that module only).
- [ ] On a module whose venv hasn't been built (`<module>/venv/bin/ruff` missing), the hook fails fast with the `./gradlew :<module>:installDev` instruction rather than a cryptic `ruff: command not found`.
- [ ] Confirm `perf-test/authz-perf` (no `build.gradle`) gets no ruff hook (skip message printed at generation time).
- [ ] Confirm Java/Spotless and Prettier hooks are unchanged.

## Notes

- Stacked on `dc/pfp-4999-python-ci-lint` (base branch for this PR).
- The staged-file ruff hooks are a strict subset of CI's full module-wide `./gradlew :<module>:lint` (which still runs in CI); pre-commit now only catches issues in the files being committed, for speed.
- Refs PFP-5000.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
