### PR TITLE
ci(pre-commit): add staged-only mypy hooks at pre-push for modules that run mypy (PFP-5000)

### DIFF
--- a/.github/scripts/generate_pre_commit.py
+++ b/.github/scripts/generate_pre_commit.py
@@ -219,7 +219,7 @@ class HookGenerator:
         """
         files_regex = f"^{project.path}/.*\\.py$"
         wrapper = "bash .github/scripts/python_staged_ruff.sh"
-        return [
+        hooks = [
             {
                 "id": f"{project.project_id}-ruff-check",
                 "name": f"{project.path} Ruff Check",
@@ -237,6 +237,39 @@ class HookGenerator:
                 "pass_filenames": True,
             },
         ]
+        # mypy is slow, so it runs at pre-push (not pre-commit) and only on the
+        # staged files. Only emit a mypy hook for modules whose Gradle lint
+        # task actually runs mypy (detected via `"mypy` in build.gradle).
+        if self._module_has_mypy(project):
+            hooks.append(
+                {
+                    "id": f"{project.project_id}-mypy",
+                    "name": f"{project.path} Mypy",
+                    "entry": f"bash .github/scripts/python_staged_mypy.sh {project.path}",
+                    "language": "system",
+                    "files": files_regex,
+                    "pass_filenames": True,
+                    # mypy is slow; run it at pre-push on staged files only.
+                    # CI still runs the full module-wide mypy via
+                    # `./gradlew :<module>:lint`. See PFP-5002.
+                    "stages": ["pre-push"],
+                }
+            )
+        return hooks
+
+    def _module_has_mypy(self, project: Project) -> bool:
+        """Return True if the module's build.gradle runs mypy in a lint task.
+
+        Detects the ``"mypy`` token (a double-quoted mypy command string in the
+        Gradle Exec commandLine), which is present in lint/pythonLint tasks that
+        invoke mypy and absent from modules that only run ruff.
+        """
+        gradle_file = os.path.join(project.path, "build.gradle")
+        try:
+            with open(gradle_file) as f:
+                return '"mypy' in f.read()
+        except OSError:
+            return False
 
     def _generate_spotless_hook(self, project: Project) -> dict:
         """Generate a spotless hook for Java projects."""

--- a/.github/scripts/python_staged_mypy.sh
+++ b/.github/scripts/python_staged_mypy.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Run a Python module's pinned mypy (from its Gradle-managed venv) on the staged
+# files pre-commit passes in, at the pre-push stage (mypy is slow, so it is kept
+# out of the pre-commit path; see PFP-5002).
+#
+# pre-commit entry form:
+#   bash .github/scripts/python_staged_mypy.sh <module-path>
+# pre-commit appends the matching staged file paths.
+#
+# Uses <module>/venv/bin/mypy and runs from the module dir so mypy discovers the
+# module's mypy config (setup.cfg [mypy] / pyproject [tool.mypy]). Staged file
+# paths are converted from repo-root-relative to module-relative.
+set -euo pipefail
+
+module="$1"; shift
+root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+mypy_bin="${root}/${module}/venv/bin/mypy"
+
+if [ ! -x "$mypy_bin" ]; then
+  task=":$(printf '%s' "$module" | tr '/' ':'):installDev"
+  echo "error: ${mypy_bin} not found." >&2
+  echo "       Build the module's Python env first:  ./gradlew ${task}" >&2
+  exit 1
+fi
+
+# Convert repo-root-relative staged paths to module-relative.
+rel=()
+for f in "$@"; do
+  case "$f" in
+    "${module}/"*) rel+=("${f#"${module}/"}");;
+    *) rel+=("$f");;
+  esac
+done
+
+# pre-commit only invokes this hook when at least one file matches `files`, but
+# guard against an empty list anyway (mypy with no args errors out).
+if [ "${#rel[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+cd "${root}/${module}"
+# --follow-imports=silent: only report errors in the staged files themselves;
+# mypy still follows imports to resolve types but does not report errors in the
+# silently-followed modules. CI runs the full module-wide mypy via
+# `./gradlew :<module>:lint`.
+exec "$mypy_bin" --show-traceback --show-error-codes --follow-imports=silent "${rel[@]}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,15 @@ repos:
         files: ^datahub-actions/.*\.py$
         pass_filenames: true
 
+      - id: datahub-actions-mypy
+        name: datahub-actions Mypy
+        entry: bash .github/scripts/python_staged_mypy.sh datahub-actions
+        language: system
+        files: ^datahub-actions/.*\.py$
+        pass_filenames: true
+        stages:
+          - pre-push
+
       - id: datahub-agent-context-ruff-check
         name: datahub-agent-context Ruff Check
         entry: bash .github/scripts/python_staged_ruff.sh datahub-agent-context check
@@ -55,6 +64,15 @@ repos:
         language: system
         files: ^datahub-agent-context/.*\.py$
         pass_filenames: true
+
+      - id: datahub-agent-context-mypy
+        name: datahub-agent-context Mypy
+        entry: bash .github/scripts/python_staged_mypy.sh datahub-agent-context
+        language: system
+        files: ^datahub-agent-context/.*\.py$
+        pass_filenames: true
+        stages:
+          - pre-push
 
       - id: datahub-frontend-spotless
         name: datahub-frontend Spotless Apply
@@ -155,6 +173,15 @@ repos:
         files: ^metadata-ingestion/.*\.py$
         pass_filenames: true
 
+      - id: metadata-ingestion-mypy
+        name: metadata-ingestion Mypy
+        entry: bash .github/scripts/python_staged_mypy.sh metadata-ingestion
+        language: system
+        files: ^metadata-ingestion/.*\.py$
+        pass_filenames: true
+        stages:
+          - pre-push
+
       - id: metadata-ingestion-modules-airflow-plugin-ruff-check
         name: metadata-ingestion-modules/airflow-plugin Ruff Check
         entry: bash .github/scripts/python_staged_ruff.sh metadata-ingestion-modules/airflow-plugin
@@ -170,6 +197,15 @@ repos:
         language: system
         files: ^metadata-ingestion-modules/airflow-plugin/.*\.py$
         pass_filenames: true
+
+      - id: metadata-ingestion-modules-airflow-plugin-mypy
+        name: metadata-ingestion-modules/airflow-plugin Mypy
+        entry: bash .github/scripts/python_staged_mypy.sh metadata-ingestion-modules/airflow-plugin
+        language: system
+        files: ^metadata-ingestion-modules/airflow-plugin/.*\.py$
+        pass_filenames: true
+        stages:
+          - pre-push
 
       - id: metadata-ingestion-modules-dagster-plugin-ruff-check
         name: metadata-ingestion-modules/dagster-plugin Ruff Check
@@ -187,6 +223,15 @@ repos:
         files: ^metadata-ingestion-modules/dagster-plugin/.*\.py$
         pass_filenames: true
 
+      - id: metadata-ingestion-modules-dagster-plugin-mypy
+        name: metadata-ingestion-modules/dagster-plugin Mypy
+        entry: bash .github/scripts/python_staged_mypy.sh metadata-ingestion-modules/dagster-plugin
+        language: system
+        files: ^metadata-ingestion-modules/dagster-plugin/.*\.py$
+        pass_filenames: true
+        stages:
+          - pre-push
+
       - id: metadata-ingestion-modules-gx-plugin-ruff-check
         name: metadata-ingestion-modules/gx-plugin Ruff Check
         entry: bash .github/scripts/python_staged_ruff.sh metadata-ingestion-modules/gx-plugin
@@ -203,6 +248,15 @@ repos:
         files: ^metadata-ingestion-modules/gx-plugin/.*\.py$
         pass_filenames: true
 
+      - id: metadata-ingestion-modules-gx-plugin-mypy
+        name: metadata-ingestion-modules/gx-plugin Mypy
+        entry: bash .github/scripts/python_staged_mypy.sh metadata-ingestion-modules/gx-plugin
+        language: system
+        files: ^metadata-ingestion-modules/gx-plugin/.*\.py$
+        pass_filenames: true
+        stages:
+          - pre-push
+
       - id: metadata-ingestion-modules-prefect-plugin-ruff-check
         name: metadata-ingestion-modules/prefect-plugin Ruff Check
         entry: bash .github/scripts/python_staged_ruff.sh metadata-ingestion-modules/prefect-plugin
@@ -218,6 +272,15 @@ repos:
         language: system
         files: ^metadata-ingestion-modules/prefect-plugin/.*\.py$
         pass_filenames: true
+
+      - id: metadata-ingestion-modules-prefect-plugin-mypy
+        name: metadata-ingestion-modules/prefect-plugin Mypy
+        entry: bash .github/scripts/python_staged_mypy.sh metadata-ingestion-modules/prefect-plugin
+        language: system
+        files: ^metadata-ingestion-modules/prefect-plugin/.*\.py$
+        pass_filenames: true
+        stages:
+          - pre-push
 
       - id: metadata-integration-java-acryl-spark-lineage-spotless
         name: metadata-integration/java/acryl-spark-lineage Spotless Apply
@@ -590,6 +653,15 @@ repos:
         language: system
         files: ^smoke-test/.*\.py$
         pass_filenames: true
+
+      - id: smoke-test-mypy
+        name: smoke-test Mypy
+        entry: bash .github/scripts/python_staged_mypy.sh smoke-test
+        language: system
+        files: ^smoke-test/.*\.py$
+        pass_filenames: true
+        stages:
+          - pre-push
 
       - id: test-models-spotless
         name: test-models Spotless Apply


### PR DESCRIPTION
<!--
Thank you for contributing to DataHub!
Before you submit your PR, please go through the checklist below:
- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
- [ ] For any breaking change an entry has been made in Updating DataHub
Allowed Types in PR Title: feat, fix, refactor, docs, test, perf, style, build, ci, chore
-->

## Summary

Add staged-only **mypy** pre-push hooks for the Python modules whose Gradle lint task actually runs mypy. mypy is slow, so it runs at the **pre-push** stage (not pre-commit) and only on the files staged for the push — keeping commits fast while still catching type errors before they reach the remote. CI'"'"'s full module-wide `./gradlew :<module>:lint` (which includes mypy) is unchanged.

Fourth layer of the PFP-4982 pre-commit/CI optimization stack (stacked on `dc/pfp-5000-staged-ruff`).

## Changes
### `.github/scripts/generate_pre_commit.py`
- Extend `_generate_python_hooks` to also emit a `<module>-mypy` hook **only** when the module'"'"'s `build.gradle` lint task runs mypy, detected via the `"mypy` token in the Gradle file (new `_module_has_mypy` helper).
- The mypy hook is assigned `stages: [pre-push]` (mypy is slow); the existing ruff hooks are unchanged.

### `.github/scripts/python_staged_mypy.sh` (new)
Wrapper that runs the module'"'"'s own pinned mypy from its Gradle-managed venv (`<module>/venv/bin/mypy`) from the module directory, so mypy discovers the module'"'"s mypy config (`setup.cfg [mypy]` / `pyproject.toml [tool.mypy]`, including per-module overrides like `[mypy-datahub.*]`). Staged file paths are converted from repo-root-relative to module-relative. Fails fast with an `installDev` instruction if the module venv hasn'"'"'t been built. Uses `--follow-imports=silent` so only errors in the staged files themselves are reported (mypy still resolves imports for typing, but doesn'"'"'t report errors in silently-followed modules) — a fast subset of CI'"'"'s full module-wide mypy.

### `.pre-commit-config.yaml`
Regenerated: per-module `<module>-mypy` pre-push hooks added for the modules that run mypy.

## Test plan
- [ ] Stage a `.py` file in a module that runs mypy (e.g. `metadata-ingestion`) and run `git push` → the `<module> Mypy` hook runs on just that file; push is blocked on type errors in the staged file.
- [ ] Confirm each module uses its own pinned mypy version + its own `[tool.mypy]` / `setup.cfg [mypy]` config (e.g. a per-module `[mypy-datahub.*]` override is honored).
- [ ] On a module whose venv hasn'"'"'t been built, the hook fails fast with the `./gradlew :<module>:installDev` instruction.
- [ ] Module whose `build.gradle` does **not** run mypy (ruff-only) → no mypy hook emitted.
- [ ] `pre-commit` (commit-time) hooks unchanged; mypy only fires at `git push`.

## Notes
- Stacked on `dc/pfp-5000-staged-ruff` (base branch for this PR).
- The staged mypy check is a subset of CI'"'"'s full `./gradlew :<module>:lint` (which still runs in CI); pre-push now only type-checks the files being pushed, for speed.
- Refs PFP-5000, PFP-5002.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
