### PR TITLE
perf(recommendations): batch candidate validation to remove per-platform N+1

### DIFF
--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/EntitySearchAggregationSource.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/EntitySearchAggregationSource.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.PriorityQueue;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -57,22 +58,19 @@ public abstract class EntitySearchAggregationSource implements RecommendationSou
   /** Whether the aggregate value is an urn */
   protected abstract boolean isValueUrn();
 
-  /** Whether the urn candidate is valid */
-  protected boolean isValidCandidateUrn(@Nonnull OperationContext opContext, Urn urn) {
-    return entityService.exists(opContext, urn, false);
+  /**
+   * Filters the aggregated urn candidates down to the valid ones in a single batched lookup.
+   * Subclasses that need aspect-level validation should override this and batch the aspect fetch
+   * rather than checking one urn at a time.
+   */
+  protected Set<Urn> getValidCandidateUrns(
+      @Nonnull OperationContext opContext, @Nonnull Set<Urn> candidateUrns) {
+    return entityService.exists(opContext, candidateUrns, false);
   }
 
   /** Whether the string candidate is valid */
   protected boolean isValidCandidateValue(String candidateValue) {
     return true;
-  }
-
-  /** Whether the candidate is valid Calls different functions if candidate is an Urn */
-  protected <T> boolean isValidCandidate(@Nonnull OperationContext opContext, T candidate) {
-    if (candidate instanceof Urn) {
-      return isValidCandidateUrn(opContext, (Urn) candidate);
-    }
-    return isValidCandidateValue(candidate.toString());
   }
 
   @Override
@@ -95,7 +93,11 @@ public abstract class EntitySearchAggregationSource implements RecommendationSou
 
     // If the aggregated values are not urn, simply get top k values with the most counts
     if (!isValueUrn()) {
-      return getTopKValues(opContext, aggregationResult).stream()
+      Map<String, Long> validValues =
+          aggregationResult.entrySet().stream()
+              .filter(entry -> isValidCandidateValue(entry.getKey()))
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+      return getTopKValues(validValues).stream()
           .map(entry -> buildRecommendationContent(entry.getKey(), entry.getValue()))
           .collect(Collectors.toList());
     }
@@ -121,8 +123,15 @@ public abstract class EntitySearchAggregationSource implements RecommendationSou
       return Collections.emptyList();
     }
 
-    // Get the top X valid platforms (ones with logo) with the most number of documents
-    return getTopKValues(opContext, urnCounts).stream()
+    // Validate all candidate urns in a single batched lookup, then take the top X with the most
+    // documents. The candidate set is already bounded by the aggregation size (getMaxContent()).
+    final Set<Urn> validUrns = getValidCandidateUrns(opContext, urnCounts.keySet());
+    Map<Urn, Long> validUrnCounts =
+        urnCounts.entrySet().stream()
+            .filter(entry -> validUrns.contains(entry.getKey()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    return getTopKValues(validUrnCounts).stream()
         .map(entry -> buildRecommendationContent(entry.getKey(), entry.getValue()))
         .collect(Collectors.toList());
   }
@@ -134,17 +143,14 @@ public abstract class EntitySearchAggregationSource implements RecommendationSou
         .collect(Collectors.toList());
   }
 
-  // Get top K entries with the most count
-  private <T> List<Map.Entry<T, Long>> getTopKValues(
-      @Nonnull OperationContext opContext, Map<T, Long> countMap) {
+  // Get top K entries with the most count from an already-validated candidate map
+  private <T> List<Map.Entry<T, Long>> getTopKValues(Map<T, Long> countMap) {
     final PriorityQueue<Map.Entry<T, Long>> queue =
         new PriorityQueue<>(getMaxContent(), Map.Entry.comparingByValue(Comparator.naturalOrder()));
     for (Map.Entry<T, Long> entry : countMap.entrySet()) {
-      if (queue.size() < getMaxContent() && isValidCandidate(opContext, entry.getKey())) {
+      if (queue.size() < getMaxContent()) {
         queue.add(entry);
-      } else if (queue.size() > 0
-          && queue.peek().getValue() < entry.getValue()
-          && isValidCandidate(opContext, entry.getKey())) {
+      } else if (queue.size() > 0 && queue.peek().getValue() < entry.getValue()) {
         queue.poll();
         queue.add(entry);
       }

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/EntitySearchAggregationSource.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/EntitySearchAggregationSource.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
@@ -68,11 +67,6 @@ public abstract class EntitySearchAggregationSource implements RecommendationSou
     return entityService.exists(opContext, candidateUrns, false);
   }
 
-  /** Whether the string candidate is valid */
-  protected boolean isValidCandidateValue(String candidateValue) {
-    return true;
-  }
-
   @Override
   @WithSpan
   public List<RecommendationContent> getRecommendations(
@@ -93,11 +87,7 @@ public abstract class EntitySearchAggregationSource implements RecommendationSou
 
     // If the aggregated values are not urn, simply get top k values with the most counts
     if (!isValueUrn()) {
-      Map<String, Long> validValues =
-          aggregationResult.entrySet().stream()
-              .filter(entry -> isValidCandidateValue(entry.getKey()))
-              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-      return getTopKValues(validValues).stream()
+      return getTopKValues(aggregationResult).stream()
           .map(entry -> buildRecommendationContent(entry.getKey(), entry.getValue()))
           .collect(Collectors.toList());
     }
@@ -163,11 +153,6 @@ public abstract class EntitySearchAggregationSource implements RecommendationSou
       topK.addFirst(queue.poll());
     }
     return topK;
-  }
-
-  private Map<String, Long> mergeAggregation(Map<String, Long> first, Map<String, Long> second) {
-    return Stream.concat(first.entrySet().stream(), second.entrySet().stream())
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, Long::sum));
   }
 
   private <T> RecommendationContent buildRecommendationContent(T candidate, long count) {

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/TopPlatformsSource.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/TopPlatformsSource.java
@@ -12,7 +12,11 @@ import com.linkedin.metadata.recommendation.RecommendationRequestContext;
 import com.linkedin.metadata.recommendation.ScenarioType;
 import com.linkedin.metadata.search.EntitySearchService;
 import io.datahubproject.metadata.context.OperationContext;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -92,12 +96,20 @@ public class TopPlatformsSource extends EntitySearchAggregationSource {
   }
 
   @Override
-  protected boolean isValidCandidateUrn(@Nonnull OperationContext opContext, Urn urn) {
-    RecordTemplate dataPlatformInfo =
-        entityService.getLatestAspect(opContext, urn, "dataPlatformInfo");
-    if (dataPlatformInfo == null) {
-      return false;
-    }
-    return ((DataPlatformInfo) dataPlatformInfo).hasLogoUrl();
+  protected Set<Urn> getValidCandidateUrns(
+      @Nonnull OperationContext opContext, @Nonnull Set<Urn> candidateUrns) {
+    // A platform is a valid candidate only if it has a logo. Fetch the dataPlatformInfo aspect for
+    // every candidate in a single batched call rather than one lookup per platform.
+    final Map<Urn, List<RecordTemplate>> aspects =
+        entityService.getLatestAspects(
+            opContext, candidateUrns, Set.of(Constants.DATA_PLATFORM_INFO_ASPECT_NAME), false);
+    return candidateUrns.stream()
+        .filter(
+            urn ->
+                aspects.getOrDefault(urn, Collections.emptyList()).stream()
+                    .filter(DataPlatformInfo.class::isInstance)
+                    .map(DataPlatformInfo.class::cast)
+                    .anyMatch(DataPlatformInfo::hasLogoUrl))
+        .collect(Collectors.toSet());
   }
 }

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/recommendation/candidatesource/EntitySearchAggregationCandidateSourceTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/recommendation/candidatesource/EntitySearchAggregationCandidateSourceTest.java
@@ -9,6 +9,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.common.urn.TestEntityUrn;
 import com.linkedin.common.urn.Urn;
@@ -24,12 +25,14 @@ import com.linkedin.metadata.recommendation.ScenarioType;
 import com.linkedin.metadata.search.EntitySearchService;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.mockito.Mockito;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -194,9 +197,15 @@ public class EntitySearchAggregationCandidateSourceTest {
     Urn testUrn1 = new TestEntityUrn("testUrn1", "testUrn1", "testUrn1");
     Urn testUrn2 = new TestEntityUrn("testUrn2", "testUrn2", "testUrn2");
     Urn testUrn3 = new TestEntityUrn("testUrn3", "testUrn3", "testUrn3");
-    Mockito.when(entityService.exists(any(), eq(testUrn1), eq(false))).thenReturn(true);
-    Mockito.when(entityService.exists(any(), eq(testUrn2), eq(false))).thenReturn(true);
-    Mockito.when(entityService.exists(any(), eq(testUrn3), eq(false))).thenReturn(true);
+    // The source now validates all candidate urns in a single batched exists() call and keeps only
+    // the ones that exist.
+    Set<Urn> existingUrns = Set.of(testUrn1, testUrn2, testUrn3);
+    Mockito.when(entityService.exists(any(), anyCollection(), eq(false)))
+        .thenAnswer(
+            invocation -> {
+              Collection<Urn> requested = invocation.getArgument(1);
+              return requested.stream().filter(existingUrns::contains).collect(Collectors.toSet());
+            });
 
     Mockito.when(
             entitySearchService.aggregateByValue(

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/recommendation/candidatesource/TopPlatformsSourceTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/recommendation/candidatesource/TopPlatformsSourceTest.java
@@ -1,0 +1,132 @@
+package com.linkedin.metadata.recommendation.candidatesource;
+
+import static com.linkedin.metadata.Constants.DATA_PLATFORM_INFO_ASPECT_NAME;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.common.url.Url;
+import com.linkedin.common.urn.CorpuserUrn;
+import com.linkedin.common.urn.DataPlatformUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.dataplatform.DataPlatformInfo;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.recommendation.RecommendationContent;
+import com.linkedin.metadata.recommendation.RecommendationRequestContext;
+import com.linkedin.metadata.recommendation.ScenarioType;
+import com.linkedin.metadata.search.EntitySearchService;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Proves the TopPlatforms candidate source validates all platform candidates with a single batched
+ * lookup rather than one lookup per candidate (the N+1 that used to live in {@code
+ * isValidCandidateUrn}).
+ */
+public class TopPlatformsSourceTest {
+
+  private final EntityService<?> entityService = mock(EntityService.class);
+  private final EntitySearchService entitySearchService = mock(EntitySearchService.class);
+  private final EntityRegistry entityRegistry = mock(EntityRegistry.class);
+
+  private static final Urn USER = new CorpuserUrn("test");
+  private static final RecommendationRequestContext HOME =
+      new RecommendationRequestContext().setScenario(ScenarioType.HOME);
+
+  private OperationContext opContext;
+  private TopPlatformsSource source;
+
+  @BeforeMethod
+  public void setup() {
+    Mockito.reset(entityService, entitySearchService);
+    opContext = TestOperationContexts.userContextNoSearchAuthorization(USER);
+    source = new TopPlatformsSource(entitySearchService, entityService, entityRegistry);
+  }
+
+  /** Aggregation returns {@code total} platform urns (platform-0 .. platform-{total-1}). */
+  private void stubAggregation(int total) {
+    Map<String, Long> agg = new LinkedHashMap<>();
+    for (int i = 0; i < total; i++) {
+      agg.put(new DataPlatformUrn("platform-" + i).toString(), (long) (total - i));
+    }
+    Mockito.when(
+            entitySearchService.aggregateByValue(
+                any(OperationContext.class), any(), eq("platform"), any(), anyInt()))
+        .thenReturn(agg);
+  }
+
+  /** Only the first {@code withLogoCount} platforms have a logo (i.e. are valid candidates). */
+  private Set<Urn> stubPlatformAspects(int total, int withLogoCount) {
+    Map<Urn, List<RecordTemplate>> aspects = new HashMap<>();
+    for (int i = 0; i < total; i++) {
+      Urn urn = new DataPlatformUrn("platform-" + i);
+      DataPlatformInfo info = new DataPlatformInfo().setName("platform-" + i);
+      if (i < withLogoCount) {
+        info.setLogoUrl(new Url("http://logo/" + i));
+      }
+      aspects.put(urn, List.of(info));
+    }
+    Mockito.when(
+            entityService.getLatestAspects(
+                any(OperationContext.class),
+                anySet(),
+                eq(Set.of(DATA_PLATFORM_INFO_ASPECT_NAME)),
+                eq(false)))
+        .thenReturn(aspects);
+    return aspects.entrySet().stream()
+        .filter(e -> ((DataPlatformInfo) e.getValue().get(0)).hasLogoUrl())
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toSet());
+  }
+
+  @Test
+  public void testValidationIsBatchedNotPerCandidate() {
+    // 30 candidate platforms, 20 of which have logos.
+    stubAggregation(30);
+    Set<Urn> expectedValid = stubPlatformAspects(30, 20);
+
+    List<RecommendationContent> results = source.getRecommendations(opContext, HOME, null);
+
+    // Functional: only the platforms with logos are recommended.
+    Set<Urn> recommended =
+        results.stream().map(RecommendationContent::getEntity).collect(Collectors.toSet());
+    assertEquals(recommended, expectedValid);
+    assertEquals(results.size(), 20);
+
+    // Performance: validation happened in exactly ONE batched call regardless of 30 candidates,
+    // and the old per-candidate single-aspect fetch is never used.
+    verify(entityService, times(1))
+        .getLatestAspects(any(), anySet(), eq(Set.of(DATA_PLATFORM_INFO_ASPECT_NAME)), eq(false));
+    verify(entityService, never()).getLatestAspect(any(), any(Urn.class), anyString());
+  }
+
+  @Test
+  public void testCallCountIsConstantRegardlessOfCandidateCount() {
+    // Small input.
+    stubAggregation(3);
+    stubPlatformAspects(3, 3);
+    source.getRecommendations(opContext, HOME, null);
+    verify(entityService, times(1))
+        .getLatestAspects(any(), anySet(), eq(Set.of(DATA_PLATFORM_INFO_ASPECT_NAME)), eq(false));
+
+    // Large input: still exactly one batched call — call count does not scale with N.
+    clearInvocations(entityService);
+    stubAggregation(30);
+    stubPlatformAspects(30, 30);
+    source.getRecommendations(opContext, HOME, null);
+    verify(entityService, times(1))
+        .getLatestAspects(any(), anySet(), eq(Set.of(DATA_PLATFORM_INFO_ASPECT_NAME)), eq(false));
+    verify(entityService, never()).getLatestAspect(any(), any(Urn.class), anyString());
+  }
+}


### PR DESCRIPTION
## Summary

On the home page, `ListRecommendationsResolver` → `RecommendationsService` runs
several `EntitySearchAggregationSource` candidate sources (Platforms, Domains,
Tags, Terms). After a single Elasticsearch aggregation, the base class
validated **each aggregated candidate one at a time** inside `getTopKValues` —
one backend call per candidate (a classic N+1).

`TopPlatformsSource` was the worst case: it overrode `isValidCandidateUrn` to
call `entityService.getLatestAspect(urn, "dataPlatformInfo")` **per candidate
platform** (up to `maxContent = 40` serial aspect fetches per home-page
request). The domain/tag/term sources hit the base default, which did a
per-candidate `exists()` check.

## Change

Replace the per-candidate validation hook with a batched
`getValidCandidateUrns(opContext, Set<Urn>)` that validates the whole
candidate set in a single call:

- **Base default** batches `entityService.exists(urns)` (one call for all urns).
- **`TopPlatformsSource`** overrides it to fetch `dataPlatformInfo` for all
  candidates via one `getLatestAspects(...)` call, keeping only logo-bearing
  platforms.
- **`getTopKValues`** now selects the top-K from an already-validated map and
  performs no I/O. The candidate set is already bounded by the aggregation
  size, so validate-all-then-top-K is equivalent to the previous
  top-K-among-valid selection.

Because the fix lives in the shared base class, Domains/Tags/Terms are batched
too (they used the per-candidate `exists` default).

## Behavior

Unchanged — identical recommendations are returned. Only the backend call
count per source drops from **O(candidates) → O(1)**.

## Testing & verification

**Unit (deterministic call counts):**
- New `TopPlatformsSourceTest` — with 30 candidate platforms the source makes
  exactly **one** `getLatestAspects` call and **zero** per-candidate
  `getLatestAspect` calls; the call count stays at 1 for both 3 and 30
  candidates (O(1)); and the same logo-bearing platforms are recommended.
- Updated `EntitySearchAggregationCandidateSourceTest` to the batched
  `exists(Collection<Urn>)` contract.

**End-to-end (local quickstart, sample metadata, 13 platforms, OpenTelemetry → Jaeger):**

| Signal | Before | After |
| --- | --- | --- |
| `metadata_aspect_v2` SELECT spans under the `TopPlatforms` `getRecommendations` span | 27 | 1 (single batched query) |
| Spans in the `listRecommendations` trace | 185 | 97 |
| Server-side `listRecommendations` span, p50 | ~20 ms | ~12 ms |

**Client latency (`curl`, 100 warm requests each, identical instance/data):**

| metric | Before (N+1) | After (batched) | improvement |
| --- | --- | --- | --- |
| p50 | 17.6 ms | 14.0 ms | −21% |
| mean | 18.4 ms | 14.7 ms | −20% |
| p90 | 21.1 ms | 16.2 ms | −24% |

The absolute latency delta is modest here because it is a warm, small dataset
(13 platforms, cached rows); the saving scales with the number of platforms
and with cache coldness (up to `maxContent = 40` serial fetches → 1 on a cold
production index). Recommendations were byte-for-byte identical before and
after in all runs.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing/#commit-message-format))
- [x] Tests added/updated
- [ ] Docs — n/a (internal refactor, no user-facing or API change)
