### PR TITLE
feat(usage): allow metric registry entries to filter by request API

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/registry/metrics/UsageMetricIncrementResolver.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/registry/metrics/UsageMetricIncrementResolver.java
@@ -66,6 +66,10 @@ public final class UsageMetricIncrementResolver {
       return isKnownRequestPhasePair(metric) ? 0 : -1;
     }
 
+    if (!metric.matchesRequestApi(requestContext.getRequestAPI())) {
+      return 0L;
+    }
+
     long usageQuantity = Math.max(1L, requestContext.getUsageQuantity());
     return switch (metric.emitWhen()) {
       case ALWAYS -> resolveAlwaysIncrement(
@@ -98,13 +102,14 @@ public final class UsageMetricIncrementResolver {
       return Optional.of(BILLED_BYTES_METRIC);
     }
     if (isReportDrivenMetric(metric)) {
-      // Do not share DATAHUB_REQUEST_COUNT with api_calls; export under the registry name.
+      // Do not share DATAHUB_REQUEST_COUNT with request-path counters.
       if (metric.valueUnit() == ValueUnit.COUNT) {
         return Optional.of("datahub.usage." + metric.metricName());
       }
       return Optional.empty();
     }
     return switch (metric.valueUnit()) {
+        // Combined request-path counter (api_calls).
       case COUNT -> Optional.of(MetricUtils.DATAHUB_REQUEST_COUNT);
       case INPUT_BYTES -> Optional.of(INPUT_BYTES_METRIC);
       case OUTPUT_BYTES -> Optional.of(OUTPUT_BYTES_METRIC);

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/registry/metrics/UsageMetricRegistry.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/registry/metrics/UsageMetricRegistry.java
@@ -3,12 +3,17 @@ package com.linkedin.metadata.usage.registry.metrics;
 import com.linkedin.metadata.config.usage.loader.UsageMetricRegistryLoader;
 import com.linkedin.metadata.config.usage.manifest.UsageMetricRegistryManifest;
 import com.linkedin.metadata.config.usage.metric.MetricRegistryYamlDefinition;
+import io.datahubproject.metadata.context.RequestContext;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Getter;
 
 @Getter
@@ -113,7 +118,20 @@ public class UsageMetricRegistry {
       MergeKind mergeKind,
       String distinctKey,
       ValueUnit valueUnit,
-      EmitWhen emitWhen) {
+      EmitWhen emitWhen,
+      /** Empty = all request APIs. Otherwise only matching {@link RequestContext.RequestAPI}. */
+      Set<RequestContext.RequestAPI> requestApis) {
+
+    public MetricDefinition {
+      requestApis = requestApis == null ? Set.of() : Set.copyOf(requestApis);
+    }
+
+    public boolean matchesRequestApi(@Nullable RequestContext.RequestAPI requestApi) {
+      if (requestApis.isEmpty()) {
+        return true;
+      }
+      return requestApi != null && requestApis.contains(requestApi);
+    }
 
     public static MetricDefinition fromYamlDefinition(
         @Nonnull String name, @Nonnull MetricRegistryYamlDefinition def) {
@@ -122,7 +140,27 @@ public class UsageMetricRegistry {
           MergeKind.fromYaml(def.getMergeKind()),
           def.getDistinctKey(),
           ValueUnit.fromYaml(def.getValueUnit()),
-          EmitWhen.fromYaml(def.getEmitWhen()));
+          EmitWhen.fromYaml(def.getEmitWhen()),
+          parseRequestApis(def.getRequestApis()));
+    }
+
+    @Nonnull
+    private static Set<RequestContext.RequestAPI> parseRequestApis(@Nullable List<String> rawApis) {
+      if (rawApis == null || rawApis.isEmpty()) {
+        return Set.of();
+      }
+      Set<RequestContext.RequestAPI> parsed = new HashSet<>();
+      for (String raw : rawApis) {
+        if (raw == null || raw.isBlank()) {
+          continue;
+        }
+        try {
+          parsed.add(RequestContext.RequestAPI.valueOf(raw.trim().toUpperCase(Locale.ROOT)));
+        } catch (IllegalArgumentException e) {
+          throw new IllegalArgumentException("Unknown request_api in metric registry: " + raw, e);
+        }
+      }
+      return parsed;
     }
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/store/UsageAggregationStore.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/store/UsageAggregationStore.java
@@ -28,9 +28,9 @@ public interface UsageAggregationStore {
    *
    * <p>Pass the system {@link OperationContext} for actor-class aspect reads and an attributed
    * {@link RequestContext} built by the reporter. Does not invoke {@code SessionContextEnricher} /
-   * request-path {@code api_calls}. Increments additive metrics with {@code emit_when: reported}
-   * and applies the same distinct-metric allowlists as {@link #recordRequest}. Default no-op when a
-   * deployment does not implement the hook.
+   * request-path counters. Increments additive metrics with {@code emit_when: reported} and applies
+   * the same distinct-metric allowlists as {@link #recordRequest}. Default no-op when a deployment
+   * does not implement the hook.
    *
    * @return true when at least one metric bucket was updated
    */

--- a/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/cache/KeyAspectEntityCountCacheTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/cache/KeyAspectEntityCountCacheTest.java
@@ -141,10 +141,21 @@ public class KeyAspectEntityCountCacheTest {
   }
 
   @Test
-  public void staleBuildingClaimCanBeTakenOver() {
+  public void staleBuildingClaimCanBeTakenOver() throws Exception {
     KeyAspectEntityCountCacheKey key = KeyAspectEntityCountCacheKey.of("ctx", List.of("dataset"));
     assertTrue(cache.tryClaimQuery(key, "first", 1L));
-    assertTrue(cache.tryClaimQuery(key, "second", 1L));
+    // Staleness uses wall-clock ">" against staleBuildingMillis; poll until takeover succeeds
+    // so same-ms / sub-ms CI timing cannot flake the assertion.
+    boolean takenOver = false;
+    long deadline = System.currentTimeMillis() + 1_000L;
+    while (System.currentTimeMillis() < deadline) {
+      if (cache.tryClaimQuery(key, "second", 1L)) {
+        takenOver = true;
+        break;
+      }
+      Thread.sleep(2L);
+    }
+    assertTrue(takenOver);
     cache.releaseInFlight(key);
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/registry/UsageMetricIncrementResolverTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/registry/UsageMetricIncrementResolverTest.java
@@ -153,7 +153,8 @@ public class UsageMetricIncrementResolverTest {
             UsageMetricRegistry.MergeKind.ADDITIVE,
             null,
             com.linkedin.metadata.usage.registry.metrics.ValueUnit.COST_UNITS,
-            UsageMetricRegistry.EmitWhen.COST_PROFILE);
+            UsageMetricRegistry.EmitWhen.COST_PROFILE,
+            java.util.Set.of());
     UsageOperationsRegistry ossOps =
         UsageOperationsRegistry.loadOssOnly(new UsageOperationsLoader(yamlMapper()));
     Assert.assertEquals(
@@ -170,7 +171,8 @@ public class UsageMetricIncrementResolverTest {
             UsageMetricRegistry.MergeKind.ADDITIVE,
             null,
             com.linkedin.metadata.usage.registry.metrics.ValueUnit.OUTPUT_BYTES,
-            UsageMetricRegistry.EmitWhen.ALWAYS);
+            UsageMetricRegistry.EmitWhen.ALWAYS,
+            java.util.Set.of());
     Assert.assertEquals(
         UsageMetricIncrementResolver.micrometerCounterName(metric),
         Optional.of(UsageMetricIncrementResolver.BILLED_BYTES_METRIC));
@@ -184,7 +186,8 @@ public class UsageMetricIncrementResolverTest {
             UsageMetricRegistry.MergeKind.DISTINCT,
             "usage_identity",
             com.linkedin.metadata.usage.registry.metrics.ValueUnit.COUNT,
-            UsageMetricRegistry.EmitWhen.ALWAYS);
+            UsageMetricRegistry.EmitWhen.ALWAYS,
+            java.util.Set.of());
     Assert.assertFalse(UsageMetricIncrementResolver.isSupported(metric));
   }
 
@@ -204,7 +207,8 @@ public class UsageMetricIncrementResolverTest {
             UsageMetricRegistry.MergeKind.ADDITIVE,
             null,
             com.linkedin.metadata.usage.registry.metrics.ValueUnit.INPUT_BYTES,
-            UsageMetricRegistry.EmitWhen.INGESTION_REQUEST);
+            UsageMetricRegistry.EmitWhen.INGESTION_REQUEST,
+            java.util.Set.of());
     UsageOperationsRegistry ossOps =
         UsageOperationsRegistry.loadOssOnly(new UsageOperationsLoader(yamlMapper()));
     RequestContext ingestContext =
@@ -263,6 +267,43 @@ public class UsageMetricIncrementResolverTest {
     Assert.assertFalse(
         UsageMetricIncrementResolver.shouldEmitDistinct(
             activeWriters, operationActivity, ossOps.require("other_operations")));
+  }
+
+  @Test
+  public void testApiCallsCountsAllRequestApis() {
+    UsageMetricRegistry registry = ossRegistry();
+    UsageMetricRegistry.MetricDefinition combined = registry.apiUsageMetrics().get("api_calls");
+    Assert.assertNotNull(combined);
+    Assert.assertTrue(combined.requestApis().isEmpty());
+
+    UsageOperationsRegistry.UsageOperationEntry entry =
+        new UsageOperationsRegistry.UsageOperationEntry(
+            io.datahubproject.metadata.context.usage.UsageOperation.METADATA_READ,
+            ActivityClass.READ,
+            false,
+            1,
+            java.util.Set.of());
+    RequestContext graphql =
+        RequestContext.builder()
+            .actorUrn("urn:li:corpuser:test")
+            .sourceIP("127.0.0.1")
+            .requestAPI(RequestContext.RequestAPI.GRAPHQL)
+            .requestID("test")
+            .userAgent("test")
+            .build();
+    RequestContext openapi =
+        RequestContext.builder()
+            .actorUrn("urn:li:corpuser:test")
+            .sourceIP("127.0.0.1")
+            .requestAPI(RequestContext.RequestAPI.OPENAPI)
+            .requestID("test")
+            .userAgent("test")
+            .build();
+
+    Assert.assertEquals(
+        UsageMetricIncrementResolver.resolveRequestPhaseIncrement(combined, entry, graphql), 1L);
+    Assert.assertEquals(
+        UsageMetricIncrementResolver.resolveRequestPhaseIncrement(combined, entry, openapi), 1L);
   }
 
   private static YAMLMapper yamlMapper() {

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/usage/manifest/UsageMetricRegistryManifest.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/usage/manifest/UsageMetricRegistryManifest.java
@@ -16,5 +16,6 @@ public class UsageMetricRegistryManifest {
     private String distinctKey;
     private String valueUnit;
     private String emitWhen;
+    private java.util.List<String> requestApis;
   }
 }

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/usage/metric/MetricRegistryYamlDefinition.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/usage/metric/MetricRegistryYamlDefinition.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.config.usage.metric;
 
+import java.util.List;
 import javax.annotation.Nullable;
 
 /** Shared YAML shape for metric registry entries. */
@@ -16,4 +17,13 @@ public interface MetricRegistryYamlDefinition {
 
   @Nullable
   String getEmitWhen();
+
+  /**
+   * Optional allowlist of {@code request_api} labels (e.g. {@code openapi}, {@code restli}, {@code
+   * graphql}). Empty/null means all request APIs.
+   */
+  @Nullable
+  default List<String> getRequestApis() {
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary
- Add optional `request_apis` on usage metric registry definitions (empty/null = all request APIs), mirroring the existing operations allowlist pattern.
- Skip request-phase increments when the current `RequestContext.RequestAPI` is not in the metric allowlist.
- Cover combined `api_calls` counting across GraphQL and OpenAPI when no allowlist is set.

## Test plan
- [x] `./gradlew :metadata-io:test --tests 'com.linkedin.metadata.usage.registry.UsageMetricIncrementResolverTest'`
- [x] Spotless on touched modules
- [ ] Confirm OSS `usage_metric_registry.yaml` still treats `api_calls` as all-API (no `request_apis`)


Made with [Cursor](https://cursor.com)