### PR TITLE
chore(ingest/odcs): drop PR-number references from source comments

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_mapper.py
@@ -171,17 +171,16 @@ def _description_to_str(
 def odcs_platform_info_mcp() -> MetadataChangeProposalWrapper:
     """Emit the `odcs` DataPlatformInfo aspect at ingestion time.
 
-    The platform is also registered at GMS boot via the bootstrap MCP added in
-    PR #17332. This runtime emission is kept deliberately: ingestion is
-    version-decoupled from the server, so a run may target a GMS that predates
-    that entry, and emitting the aspect guarantees the platform's display name
-    and logo exist regardless of server version (canonical pattern:
-    confluence_source.py).
+    The platform is also registered at GMS boot via a bootstrap MCP. This runtime
+    emission is kept deliberately: ingestion is version-decoupled from the server,
+    so a run may target a GMS that predates that entry, and emitting the aspect
+    guarantees the platform's display name and logo exist regardless of server
+    version (canonical pattern: confluence_source.py).
 
     The fields below must stay identical to the boot-time entry. DataPlatformInfo
     is a whole-aspect upsert, not a field-level merge, so a divergent run would
     clobber the registry-provided aspect rather than reinforce it -- e.g.
-    omitting logoUrl here would wipe the logo on servers that already have #17332.
+    omitting logoUrl here would wipe the logo on servers that already have it.
     """
     return MetadataChangeProposalWrapper(
         entityUrn=make_data_platform_urn(ODCS_PLATFORM),

--- a/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/odcs/odcs_source.py
@@ -918,8 +918,8 @@ class ODCSSource(StatefulIngestionSourceBase):
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         # Emit the odcs platform aspect once per run. Also registered at GMS
-        # boot (PR #17332); this is the version-independent fallback, and its
-        # fields must stay in sync with that entry -- see odcs_platform_info_mcp().
+        # boot; this is the version-independent fallback, and its fields must
+        # stay in sync with that entry -- see odcs_platform_info_mcp().
         # is_primary_source=False keeps the platform entity out of the
         # stateful-ingestion checkpoint.
         yield odcs_platform_info_mcp().as_workunit(is_primary_source=False)


### PR DESCRIPTION
## Summary

- Rewords the `odcs` platform-info emission comments in `odcs_mapper.py` and `odcs_source.py` so they explain the boot-time-vs-runtime aspect rationale **without** hardcoding a PR number (`#17332`).
- Hardcoded PR references are noise in shipped source; the "why" is preserved.

Comment-only change, no behavior impact.