### PR TITLE
perf(recommendations): trim entityPreview fragment on recommendationList (CAT-1320)

### DIFF
--- a/datahub-web-react/src/graphql/recommendationPreview.graphql
+++ b/datahub-web-react/src/graphql/recommendationPreview.graphql
@@ -139,6 +139,11 @@ fragment recommendationEntityPreview on Entity {
     }
     ... on DataJob {
         jobId
+        dataFlow {
+            platform {
+                ...platformFields
+            }
+        }
         properties {
             name
         }
@@ -228,6 +233,7 @@ fragment recommendationEntityPreview on Entity {
     ... on Domain {
         properties {
             name
+            description
         }
         parentDomains {
             ...parentDomainsFields
@@ -235,6 +241,10 @@ fragment recommendationEntityPreview on Entity {
         displayProperties {
             ...displayPropertiesFields
         }
+        ownership {
+            ...ownershipFields
+        }
+        ...domainEntitiesFields
     }
     ... on Container {
         ...entityContainer

--- a/datahub-web-react/src/graphql/recommendationPreview.graphql
+++ b/datahub-web-react/src/graphql/recommendationPreview.graphql
@@ -1,0 +1,245 @@
+fragment recommendationEntityPreview on Entity {
+    urn
+    type
+    ... on Dataset {
+        name
+        platform {
+            ...platformFields
+        }
+        editableProperties {
+            name
+        }
+        properties {
+            name
+        }
+        globalTags {
+            ...globalTagsFields
+        }
+        glossaryTerms {
+            ...glossaryTerms
+        }
+        subTypes {
+            typeNames
+        }
+        domain {
+            ...entityDomain
+        }
+        deprecation {
+            ...deprecationFields
+        }
+        health {
+            ...entityHealth
+        }
+    }
+    ... on CorpUser {
+        username
+        info {
+            displayName
+            title
+            firstName
+            lastName
+            fullName
+        }
+        editableProperties {
+            displayName
+            title
+            pictureLink
+        }
+    }
+    ... on CorpGroup {
+        name
+        info {
+            displayName
+        }
+    }
+    ... on Dashboard {
+        tool
+        dashboardId
+        properties {
+            name
+        }
+        globalTags {
+            ...globalTagsFields
+        }
+        glossaryTerms {
+            ...glossaryTerms
+        }
+        platform {
+            ...platformFields
+        }
+        domain {
+            ...entityDomain
+        }
+        deprecation {
+            ...deprecationFields
+        }
+        subTypes {
+            typeNames
+        }
+        health {
+            ...entityHealth
+        }
+    }
+    ... on Chart {
+        tool
+        chartId
+        properties {
+            name
+        }
+        globalTags {
+            ...globalTagsFields
+        }
+        glossaryTerms {
+            ...glossaryTerms
+        }
+        platform {
+            ...platformFields
+        }
+        domain {
+            ...entityDomain
+        }
+        deprecation {
+            ...deprecationFields
+        }
+        subTypes {
+            typeNames
+        }
+        health {
+            ...entityHealth
+        }
+    }
+    ... on DataFlow {
+        orchestrator
+        flowId
+        cluster
+        properties {
+            name
+        }
+        globalTags {
+            ...globalTagsFields
+        }
+        glossaryTerms {
+            ...glossaryTerms
+        }
+        platform {
+            ...platformFields
+        }
+        domain {
+            ...entityDomain
+        }
+        deprecation {
+            ...deprecationFields
+        }
+        health {
+            ...entityHealth
+        }
+        subTypes {
+            typeNames
+        }
+    }
+    ... on DataJob {
+        jobId
+        properties {
+            name
+        }
+        globalTags {
+            ...globalTagsFields
+        }
+        glossaryTerms {
+            ...glossaryTerms
+        }
+        domain {
+            ...entityDomain
+        }
+        deprecation {
+            ...deprecationFields
+        }
+        subTypes {
+            typeNames
+        }
+        health {
+            ...entityHealth
+        }
+    }
+    ... on GlossaryTerm {
+        name
+        hierarchicalName
+        properties {
+            name
+        }
+        parentNodes {
+            ...parentNodesFields
+        }
+        deprecation {
+            ...deprecationFields
+        }
+    }
+    ... on GlossaryNode {
+        properties {
+            name
+        }
+        parentNodes {
+            ...parentNodesFields
+        }
+    }
+    ... on MLFeatureTable {
+        name
+        platform {
+            ...platformFields
+        }
+        deprecation {
+            ...deprecationFields
+        }
+    }
+    ... on MLModel {
+        name
+        platform {
+            ...platformFields
+        }
+        deprecation {
+            ...deprecationFields
+        }
+    }
+    ... on MLFeature {
+        name
+        deprecation {
+            ...deprecationFields
+        }
+    }
+    ... on MLModelGroup {
+        name
+        platform {
+            ...platformFields
+        }
+        deprecation {
+            ...deprecationFields
+        }
+    }
+    ... on Tag {
+        name
+        properties {
+            name
+            colorHex
+        }
+    }
+    ... on DataPlatform {
+        ...nonConflictingPlatformFields
+    }
+    ... on Domain {
+        properties {
+            name
+        }
+        parentDomains {
+            ...parentDomainsFields
+        }
+        displayProperties {
+            ...displayPropertiesFields
+        }
+    }
+    ... on Container {
+        ...entityContainer
+    }
+    ... on DataProduct {
+        ...dataProductFields
+    }
+}

--- a/datahub-web-react/src/graphql/recommendations.graphql
+++ b/datahub-web-react/src/graphql/recommendations.graphql
@@ -7,7 +7,7 @@ query listRecommendations($input: ListRecommendationsInput!) {
             content {
                 value
                 entity {
-                    ...entityPreview
+                    ...recommendationEntityPreview
                 }
                 params {
                     searchParams {


### PR DESCRIPTION
### Summary

Replaces entityPreview with a slim recommendationEntityPreview on listRecommendations content.entity (recommendations.graphql + new recommendationPreview.graphql). Compact recommendation UI needs name/platform/subTypes (and badge fields where shown); we drop ownership, data-product relationships, version/custom properties, and most descriptions on asset entities that dominate HOME payload. Domain keeps description/ownership/domainEntitiesFields for Domain cards/hovers; DataJob keeps lean dataFlow.platform for logos.
Local floor: ~53% smaller per-entity body, ~29% smaller HOME response (sparse local metadata), ~20% smaller query document — should scale up with richer ownership/tags. entityPreview and its other callers are unchanged.

Scope: `recommendations.graphql`; `entityPreview` and its other callers  are untouched.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
