### PR TITLE
fix(metrics): suppress legacy datahub_request_count when aggregation owns it

### DIFF
--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/RequestContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/RequestContext.java
@@ -607,17 +607,19 @@ public class RequestContext implements ContextInterface {
       String requestAPI = requestContext.getRequestAPI().toMetricLabel();
       metricUtils.increment(
           String.format("requestContext_%s_%s_%s", userCategory, agentClass, requestAPI), 1);
-      // Per-request Micrometer counter. When USAGE_AGGREGATION_ENABLED is on, the flush path also
-      // exports datahub_request_count; keep this until aggregation is the default in smoke/dev.
-      metricUtils.incrementMicrometer(
-          MetricUtils.DATAHUB_REQUEST_COUNT,
-          1,
-          "user_category",
-          userCategory,
-          "agent_class",
-          agentClass,
-          "request_api",
-          requestAPI);
+      // Per-request Micrometer counter. Skip when aggregation Micrometer export owns
+      // datahub_request_count (flush uses billing tag keys; Micrometer forbids mixed tag sets).
+      if (!metricUtils.isSuppressLegacyRequestCountMicrometer()) {
+        metricUtils.incrementMicrometer(
+            MetricUtils.DATAHUB_REQUEST_COUNT,
+            1,
+            "user_category",
+            userCategory,
+            "agent_class",
+            agentClass,
+            "request_api",
+            requestAPI);
+      }
     }
   }
 

--- a/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/RequestContextTest.java
+++ b/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/RequestContextTest.java
@@ -331,6 +331,29 @@ public class RequestContextTest {
   }
 
   @Test
+  public void testCaptureAPIMetricsSkipsLegacyRequestCountWhenSuppressed() {
+    when(mockMetricUtils.isSuppressLegacyRequestCountMicrometer()).thenReturn(true);
+
+    RequestContext.builder()
+        .buildRestli(Constants.SYSTEM_ACTOR, null, "test-request")
+        .metricUtils(mockMetricUtils)
+        .build();
+
+    verify(mockMetricUtils, atLeastOnce())
+        .increment(eq("requestContext_system_unknown_restli"), eq(1.0d));
+    verify(mockMetricUtils, never())
+        .incrementMicrometer(
+            eq(MetricUtils.DATAHUB_REQUEST_COUNT),
+            anyDouble(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString(),
+            anyString());
+  }
+
+  @Test
   public void testCaptureAPIMetricsForDatahubUser() {
     RequestContext.builder()
         .buildRestli("urn:li:corpuser:testuser", null, "test-request")

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/system_telemetry/MetricUtilsFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/system_telemetry/MetricUtilsFactory.java
@@ -1,16 +1,54 @@
 package com.linkedin.gms.factory.system_telemetry;
 
 import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.config.UsageAggregationConfiguration;
+import com.linkedin.metadata.config.UsageConfiguration;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@Slf4j
 @Configuration
 public class MetricUtilsFactory {
   @Bean
   public MetricUtils metricUtils(
       MeterRegistry meterRegistry, ConfigurationProvider configurationProvider) {
-    return MetricUtils.builder().registry(meterRegistry).build();
+    boolean suppressLegacyRequestCount =
+        shouldSuppressLegacyRequestCountMicrometer(configurationProvider);
+    if (suppressLegacyRequestCount) {
+      log.info(
+          "Suppressing legacy per-request datahub_request_count Micrometer export; "
+              + "usage aggregation flush owns that meter");
+    }
+    return MetricUtils.builder()
+        .registry(meterRegistry)
+        .suppressLegacyRequestCountMicrometer(suppressLegacyRequestCount)
+        .build();
+  }
+
+  /**
+   * Aggregation Micrometer export registers {@code datahub_request_count} with billing tag keys.
+   * The legacy per-request counter uses a different tag set ({@code user_category}); suppress it so
+   * Micrometer does not reject the flush registration.
+   */
+  static boolean shouldSuppressLegacyRequestCountMicrometer(
+      ConfigurationProvider configurationProvider) {
+    if (configurationProvider == null || configurationProvider.getDatahub() == null) {
+      return false;
+    }
+    UsageConfiguration usage = configurationProvider.getDatahub().getUsage();
+    if (usage == null || usage.getAggregation() == null) {
+      return false;
+    }
+    UsageAggregationConfiguration aggregation = usage.getAggregation();
+    if (!aggregation.isEnabled()) {
+      return false;
+    }
+    UsageAggregationConfiguration.MicrometerExportConfiguration micrometerExport =
+        aggregation.getMicrometerExport();
+    // Match MicrometerUsageFlushSink: enabled when unset (matchIfMissing=true).
+    return micrometerExport == null || micrometerExport.isEnabled();
   }
 }

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/system_telemetry/MetricUtilsFactoryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/system_telemetry/MetricUtilsFactoryTest.java
@@ -1,0 +1,72 @@
+package com.linkedin.gms.factory.system_telemetry;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.config.DataHubConfiguration;
+import com.linkedin.metadata.config.UsageAggregationConfiguration;
+import com.linkedin.metadata.config.UsageConfiguration;
+import org.testng.annotations.Test;
+
+public class MetricUtilsFactoryTest {
+
+  @Test
+  public void testSuppressWhenAggregationAndMicrometerExportEnabled() {
+    assertTrue(MetricUtilsFactory.shouldSuppressLegacyRequestCountMicrometer(provider(true, true)));
+  }
+
+  @Test
+  public void testSuppressWhenMicrometerExportUnset() {
+    ConfigurationProvider provider = mock(ConfigurationProvider.class);
+    DataHubConfiguration datahub = mock(DataHubConfiguration.class);
+    UsageConfiguration usage = mock(UsageConfiguration.class);
+    UsageAggregationConfiguration aggregation = new UsageAggregationConfiguration();
+    aggregation.setEnabled(true);
+    aggregation.setMicrometerExport(null);
+    when(provider.getDatahub()).thenReturn(datahub);
+    when(datahub.getUsage()).thenReturn(usage);
+    when(usage.getAggregation()).thenReturn(aggregation);
+
+    assertTrue(MetricUtilsFactory.shouldSuppressLegacyRequestCountMicrometer(provider));
+  }
+
+  @Test
+  public void testKeepLegacyWhenAggregationDisabled() {
+    assertFalse(
+        MetricUtilsFactory.shouldSuppressLegacyRequestCountMicrometer(provider(false, true)));
+  }
+
+  @Test
+  public void testKeepLegacyWhenMicrometerExportDisabled() {
+    assertFalse(
+        MetricUtilsFactory.shouldSuppressLegacyRequestCountMicrometer(provider(true, false)));
+  }
+
+  @Test
+  public void testKeepLegacyWhenConfigMissing() {
+    assertFalse(MetricUtilsFactory.shouldSuppressLegacyRequestCountMicrometer(null));
+    assertFalse(
+        MetricUtilsFactory.shouldSuppressLegacyRequestCountMicrometer(
+            mock(ConfigurationProvider.class)));
+  }
+
+  private static ConfigurationProvider provider(
+      boolean aggregationEnabled, boolean micrometerExportEnabled) {
+    ConfigurationProvider provider = mock(ConfigurationProvider.class);
+    DataHubConfiguration datahub = mock(DataHubConfiguration.class);
+    UsageConfiguration usage = mock(UsageConfiguration.class);
+    UsageAggregationConfiguration aggregation = new UsageAggregationConfiguration();
+    aggregation.setEnabled(aggregationEnabled);
+    UsageAggregationConfiguration.MicrometerExportConfiguration export =
+        new UsageAggregationConfiguration.MicrometerExportConfiguration();
+    export.setEnabled(micrometerExportEnabled);
+    aggregation.setMicrometerExport(export);
+    when(provider.getDatahub()).thenReturn(datahub);
+    when(datahub.getUsage()).thenReturn(usage);
+    when(usage.getAggregation()).thenReturn(aggregation);
+    return provider;
+  }
+}

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/metrics/MetricUtils.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/metrics/MetricUtils.java
@@ -60,6 +60,16 @@ public class MetricUtils {
   @Deprecated public static final String DELIMITER = "_";
 
   @Builder.Default @NonNull private final MeterRegistry registry = new CompositeMeterRegistry();
+
+  /**
+   * When true, skip the per-request {@link #DATAHUB_REQUEST_COUNT} Micrometer counter. Set when
+   * usage aggregation Micrometer export owns that meter name (flush tags differ from the legacy
+   * {@code user_category} set; Micrometer allows only one tag-key set per name).
+   *
+   * <p>Default false so Mockito mocks keep the legacy path unless explicitly stubbed.
+   */
+  @Builder.Default private final boolean suppressLegacyRequestCountMicrometer = false;
+
   private static final Map<String, Timer> legacyTimeCache = new ConcurrentHashMap<>();
   private static final Map<String, Counter> legacyCounterCache = new ConcurrentHashMap<>();
   private static final Map<String, DistributionSummary> legacyHistogramCache =
@@ -74,6 +84,10 @@ public class MetricUtils {
 
   public MeterRegistry getRegistry() {
     return registry;
+  }
+
+  public boolean isSuppressLegacyRequestCountMicrometer() {
+    return suppressLegacyRequestCountMicrometer;
   }
 
   /**

--- a/smoke-test/tests/metrics/usage_aggregation_metrics.py
+++ b/smoke-test/tests/metrics/usage_aggregation_metrics.py
@@ -14,8 +14,9 @@ from tests.utilities.metadata_operations import get_prometheus_metrics
 
 logger = logging.getLogger(__name__)
 
-# Legacy per-request counter (user_category tags). Aggregation flush also targets this name
-# in Micrometer, but quickstart currently exports aggregation dimensions on byte counters.
+# Legacy per-request counter (user_category tags). When USAGE_AGGREGATION_ENABLED and
+# micrometer export are on, RequestContext skips that legacy Micrometer path so flush
+# can own datahub_request_count with billing tag keys.
 REQUEST_COUNT_METRIC = "datahub_request_count"
 INPUT_BYTES_METRIC = "datahub_usage_input_bytes"
 OUTPUT_BYTES_METRIC = "datahub_usage_output_bytes"


### PR DESCRIPTION
## Summary
- Skip the per-request `datahub_request_count` Micrometer counter when usage aggregation Micrometer export is enabled, so flush can register that meter with new tag keys without Micrometer rejecting mixed tag sets
- Wire the suppress flag from `MetricUtilsFactory` based on aggregation + micrometer-export config (including unset export = enabled, matching `MicrometerUsageFlushSink`)
- Add unit coverage for factory gating and RequestContext skip path

## Test plan
- [ ] `./gradlew :metadata-utils:test :metadata-operation-context:test :metadata-service:factories:test --tests '*MetricUtils*' --tests '*RequestContext*' --tests '*MetricUtilsFactory*'`
- [ ] With `USAGE_AGGREGATION_ENABLED=true`, confirm GMS starts and aggregation flush can register `datahub_request_count` without Micrometer tag-key errors
- [ ] With aggregation disabled, confirm legacy per-request `datahub_request_count` (`user_category` tags) still increments


Made with [Cursor](https://cursor.com)