### PR TITLE
feat(ingest/ui): support multi-select in RecipeForm SELECT fields

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/builder/RecipeForm/FormField.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/builder/RecipeForm/FormField.tsx
@@ -72,7 +72,11 @@ function SelectField({ field, removeMargin }: CommonFieldProps) {
             data-testid={`field-${field.name}`}
         >
             {field.options && (
-                <Select placeholder={field.placeholder} allowClear={!field.required}>
+                <Select
+                    placeholder={field.placeholder}
+                    allowClear={!field.required}
+                    mode={field.isMultiSelect ? 'multiple' : undefined}
+                >
                     {field.options.map((option) => (
                         <Select.Option key={option.value} value={option.value} data-testid={`option-${option.value}`}>
                             {option.label}

--- a/datahub-web-react/src/app/ingestV2/source/builder/RecipeForm/common.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/builder/RecipeForm/common.tsx
@@ -39,6 +39,8 @@ export interface RecipeField {
     disabled?: boolean;
     dynamicDisabled?: (values: FieldsValues) => boolean;
     options?: Option[];
+    // For FieldType.SELECT: render a multi-select whose form value is a string[].
+    isMultiSelect?: boolean;
     buttonLabel?: string;
     keyField?: RecipeField;
     fields?: RecipeField[];

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/recipeForm/fields/SelectField.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/recipeForm/fields/SelectField.tsx
@@ -8,21 +8,28 @@ import { CommonFieldProps } from '@app/ingestV2/source/multiStepBuilder/steps/st
 export function SelectField({ field, updateFormValue }: CommonFieldProps) {
     const form = Form.useFormInstance();
     const value = Form.useWatch([field.name], form);
+    const { isMultiSelect } = field;
+
+    const selectedValues = (() => {
+        if (isMultiSelect) return Array.isArray(value) ? value : [];
+        return value ? [value] : [];
+    })();
 
     const handleUpdate = (values?: string[]) => {
-        const selectedValue = values?.[0];
-        form.setFieldsValue({ [field.name]: selectedValue });
-        updateFormValue(field.name, selectedValue);
+        const nextValue = isMultiSelect ? (values ?? []) : values?.[0];
+        form.setFieldsValue({ [field.name]: nextValue });
+        updateFormValue(field.name, nextValue);
     };
 
     return (
         <RecipeFormItem recipeField={field} showHelperText>
             <SimpleSelect
-                values={value ? [value] : []}
+                values={selectedValues}
                 onUpdate={handleUpdate}
                 placeholder={field.placeholder}
                 options={field.options ?? []}
                 showClear={!field.required}
+                isMultiSelect={isMultiSelect}
                 width="full"
             />
         </RecipeFormItem>


### PR DESCRIPTION
## Summary

Adds an optional `isMultiSelect` flag to the ingestion `RecipeForm` `SELECT` field so a single form field can hold an array of values instead of one value.

- `RecipeField` gains `isMultiSelect?: boolean`.
- Both SELECT renderers honor it: the legacy `FormField` (passes `mode="multiple"`) and the multi-step builder's `SelectField` (passes `isMultiSelect` to `SimpleSelect` and preserves array values).
- Default behavior is unchanged when the flag is unset, so existing single-select fields are unaffected.

This is a small, reusable framework change split out ahead of the connector form that consumes it (the ODCS ingestion UI form, #18474), per the "shared/framework changes land in their own PR" convention.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly Commit Message Format)
- [ ] Links to related issues (if applicable)
- [ ] Tests added/updated (covered by the consuming connector's tests in #18474)
- [ ] Docs added/updated (if applicable)