### PR TITLE
docs(agents): add Cursor Cloud specific setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -795,3 +795,25 @@ Gradle tasks manage all venvs automatically. Never create, activate, or pip-inst
 - A new ingestion connector needs more than Python code: a source logo plus an integrations-page logo, UI form pieces, a `datahub.json` update, entry-point registration (`setup.py`/`pyproject.toml`), a refreshed `uv.lock`, and subtypes added to the shared subtypes module rather than defined locally.
 - Avoid Python's stdlib `xml` parser due to a known vulnerability; use a safe XML library (as the HANA-related code does).
 - Keep each connector in its own PR and split shared/framework changes (e.g. sqlglot helpers) into a separate PR; a connector PR's title and description must reference only that connector, not any other connector worked on in the same session.
+
+## Cursor Cloud specific instructions
+
+DataHub runs its full stack as Docker containers, so a working Docker daemon plus `uv` are the two
+hard prerequisites for `scripts/dev/datahub-dev.sh`. Both are installed in the VM image, but note:
+
+- **Docker daemon is not auto-started on VM boot** (the container has no systemd init). Before running
+  any `datahub-dev.sh` command that touches containers (`start`, `rebuild`, `test`, `status`), make
+  sure `dockerd` is running and the socket is usable. If `docker ps` fails, start it once with:
+  `sudo bash -c 'nohup dockerd > /var/log/dockerd.log 2>&1 &'` then `sudo chmod 666 /var/run/docker.sock`.
+  The daemon is configured for `fuse-overlayfs` with the containerd snapshotter disabled (Docker 29
+  requirement) — do not change `/etc/docker/daemon.json`.
+- **`uv` lives at `~/.local/bin`** (already on PATH via `~/.bashrc`). The `datahub-dev.sh` wrapper runs
+  its CLI via `uv run --python 3.11`, which downloads CPython 3.11 on first use.
+- **First `datahub-dev.sh start` is a cold build** that compiles all modules and builds every Docker
+  image from local jars — budget a long timeout (use `start --timeout 2400`). Subsequent starts reuse
+  the built images. Core services: GMS at `http://localhost:8080` (`/health`), frontend UI at
+  `http://localhost:9002` (login `datahub` / `datahub`). See the "Starting / Operating DataHub" section
+  for the full command set — always drive the environment through `scripts/dev/datahub-dev.sh`.
+- **Smoke tests need real test paths.** Pass an existing path under `smoke-test/tests/` to
+  `datahub-dev.sh test` (e.g. `tests/domains/domains_test.py`). The `tests/test_system_info.py` example
+  used elsewhere in this doc does not exist in every checkout — verify the file first.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the DataHub development environment for Cursor Cloud agents, and records the non-obvious startup caveats discovered during setup in `AGENTS.md`.

The only code change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md`. No application code is modified.

## Environment setup performed

- Installed Docker (Docker 29, `fuse-overlayfs` storage driver with containerd snapshotter disabled) and `uv`.
- Verified Java 21 (the repo default), Node 22, and yarn 1.22 are already present.
- Brought up the full stack via `scripts/dev/datahub-dev.sh start` — GMS, frontend, MySQL, Kafka (KRaft), OpenSearch, and the one-shot system-update job all healthy.

## Verification

- GMS `http://localhost:8080/health` → 200; frontend `http://localhost:9002/admin` → 200.
- Hello-world through the UI: logged in with `datahub`/`datahub` and created a Domain "Hello World Cloud", which persisted and rendered on its detail page.
- Smoke tests: `scripts/dev/datahub-dev.sh test tests/domains/domains_test.py` → 3 passed.

[datahub_login_create_domain.mp4](https://cursor.com/agents/bc-660e0b81-fd42-4511-9ae1-8dab22fcb8a8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdatahub_login_create_domain.mp4)

[Create Domain dialog](https://cursor.com/agents/bc-660e0b81-fd42-4511-9ae1-8dab22fcb8a8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F02_create_domain_dialog.webp)
[Hello World Cloud domain detail page](https://cursor.com/agents/bc-660e0b81-fd42-4511-9ae1-8dab22fcb8a8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F03_domain_detail.webp)

## AGENTS.md additions (durable caveats)

- Docker daemon is not auto-started on VM boot — how to start `dockerd` and fix socket perms.
- `uv` location / PATH and that the wrapper downloads CPython 3.11 on first use.
- First `start` is a long cold build; use a generous timeout.
- Smoke tests require real paths under `smoke-test/tests/` (the `test_system_info.py` example doesn't exist in every checkout).

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Links to related issues (n/a)
- [ ] Tests added/updated (n/a — docs only)
- [x] Docs added/updated
- [ ] Breaking changes documented (n/a)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-660e0b81-fd42-4511-9ae1-8dab22fcb8a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-660e0b81-fd42-4511-9ae1-8dab22fcb8a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

