### PR TITLE
fix(ingest/powerbi): preserve downstream column casing for all SQL-parsed lineage

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
@@ -461,10 +461,9 @@ class AbstractLineage(ABC):
         return Lineage(
             upstreams=dataplatform_tables,
             # sqlglot returns downstream columns in the SQL's alias casing, which
-            # rarely matches the casing PowerBI stores its fields in. Remap here —
-            # in the shared SQL-parsing path — so every platform's native-query and
-            # ODBC lineage gets the fix, not just the Oracle path that used to wrap
-            # this call.
+            # rarely matches the casing PowerBI stores its fields in. Remap in this
+            # shared SQL-parsing path so the downstream column resolves to the real
+            # PowerBI field regardless of the platform driving the parse.
             column_lineage=_remap_column_lineage_to_pbi_fields(
                 (
                     parsed_result.column_lineage
@@ -903,8 +902,6 @@ class OracleLineage(AbstractLineage):
 
         # `default_database` is None for the default 2-part URN shape; set, it
         # produces 3-part URNs matching `add_database_name_to_urn: true`.
-        # parse_custom_sql already remaps downstream columns to the PowerBI field
-        # casing, so no additional wrapping is needed here.
         return self.parse_custom_sql(
             query=query,
             server=server,

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
@@ -188,10 +188,12 @@ def _remap_column_lineage_to_pbi_fields(
     column_lineage: List[ColumnLineageInfo],
     pbi_columns: Optional[List[Column]],
 ) -> List[ColumnLineageInfo]:
-    """sqlglot returns downstream column names in the upstream's case (Oracle is
-    lowercase), but PowerBI fields keep their original casing in the API
-    response. Without this remap, the downstream schemaField URN does not
-    resolve and the column-level edge points to a non-existent field."""
+    """sqlglot returns downstream column names in the parsed SQL's casing (driven
+    by the query's aliases and the source dialect's identifier folding), but
+    PowerBI fields keep their original casing from the API response. Without this
+    remap the downstream schemaField URN does not resolve and the column-level
+    edge points to a non-existent field. Applied for every SQL-parsing path via
+    parse_custom_sql (native-query, ODBC, and the two/three-step patterns)."""
     if not column_lineage or not pbi_columns:
         return column_lineage
 
@@ -458,10 +460,18 @@ class AbstractLineage(ABC):
 
         return Lineage(
             upstreams=dataplatform_tables,
-            column_lineage=(
-                parsed_result.column_lineage
-                if parsed_result.column_lineage is not None
-                else []
+            # sqlglot returns downstream columns in the SQL's alias casing, which
+            # rarely matches the casing PowerBI stores its fields in. Remap here —
+            # in the shared SQL-parsing path — so every platform's native-query and
+            # ODBC lineage gets the fix, not just the Oracle path that used to wrap
+            # this call.
+            column_lineage=_remap_column_lineage_to_pbi_fields(
+                (
+                    parsed_result.column_lineage
+                    if parsed_result.column_lineage is not None
+                    else []
+                ),
+                self.table.columns,
             ),
         )
 
@@ -893,19 +903,14 @@ class OracleLineage(AbstractLineage):
 
         # `default_database` is None for the default 2-part URN shape; set, it
         # produces 3-part URNs matching `add_database_name_to_urn: true`.
-        lineage = self.parse_custom_sql(
+        # parse_custom_sql already remaps downstream columns to the PowerBI field
+        # casing, so no additional wrapping is needed here.
+        return self.parse_custom_sql(
             query=query,
             server=server,
             database=default_database,
             schema=default_schema,
             platform_detail=platform_detail,
-        )
-        return Lineage(
-            upstreams=lineage.upstreams,
-            column_lineage=_remap_column_lineage_to_pbi_fields(
-                lineage.column_lineage,
-                self.table.columns,
-            ),
         )
 
     def _sql_has_unqualified_tables(self, query: str) -> bool:

--- a/metadata-ingestion/tests/integration/powerbi/test_m_parser.py
+++ b/metadata-ingestion/tests/integration/powerbi/test_m_parser.py
@@ -1901,3 +1901,57 @@ def test_direct_table_cll_preserves_upstream_column_casing():
     )
 
     assert lineage[0].column_lineage[0].upstreams[0].column == "CustomerId"
+
+
+def test_native_query_cll_downstream_column_remapped_to_pbi_field_casing():
+    """NativeQuery CLL must remap the parsed downstream column to the PowerBI
+    field's original casing. sqlglot returns the downstream column in the SQL
+    alias' casing (here lowercase), but PowerBI stores fields in their API
+    casing; without the remap the downstream schemaField URN points at a
+    non-existent field and the column-level edge is dropped in the UI."""
+    # The SELECT aliases the output column in lowercase (`AS customerid`) while
+    # PowerBI's field keeps its mixed-case name (`CustomerId`) — the mismatch that
+    # drops the column edge without the remap.
+    q = (
+        "let\n"
+        '    Source = Value.NativeQuery(Sql.Database("my-server", "my_db"), '
+        '"SELECT t.CustomerId AS customerid FROM my_schema.my_table AS t", null, '
+        "[EnableFolding=true])\n"
+        "in\n"
+        "    Source"
+    )
+    table: powerbi_data_classes.Table = powerbi_data_classes.Table(
+        columns=[
+            powerbi_data_classes.Column(
+                name="CustomerId",
+                dataType="Int64",
+                isHidden=False,
+                datahubDataType=NumberTypeClass(),
+            )
+        ],
+        measures=[],
+        expression=q,
+        name="virtual_table",
+        full_name="MyDataSet.virtual_table",
+    )
+
+    reporter = PowerBiDashboardSourceReport()
+    ctx, config, platform_instance_resolver = get_default_instances(
+        override_config={
+            "native_query_parsing": True,
+            "enable_advance_lineage_sql_construct": True,
+            "extract_column_level_lineage": True,
+            "extract_lineage": True,
+        }
+    )
+
+    lineage: List[Lineage] = parser.get_upstream_tables(
+        table,
+        reporter,
+        ctx=ctx,
+        config=config,
+        platform_instance_resolver=platform_instance_resolver,
+    )
+
+    assert lineage[0].column_lineage
+    assert lineage[0].column_lineage[0].downstream.column == "CustomerId"

--- a/metadata-ingestion/tests/unit/powerbi/test_pattern_handler.py
+++ b/metadata-ingestion/tests/unit/powerbi/test_pattern_handler.py
@@ -267,10 +267,12 @@ def test_create_lineage_from_query_skips_warning_when_sql_is_qualified():
     )
 
 
-def test_create_lineage_from_query_uses_oracle_default_schema_and_remaps_columns():
+def test_create_lineage_from_query_threads_oracle_default_schema():
     """When the resolver returns ``OraclePlatformDetail(default_schema='hr')``,
-    ``parse_custom_sql`` must be called with ``schema='hr'`` and the returned
-    column_lineage must be remapped to PowerBI field casing."""
+    ``parse_custom_sql`` must be called with ``schema='hr'`` (and the resolved
+    detail threaded through), and its result returned unchanged. The downstream
+    column remap now lives inside ``parse_custom_sql`` itself, covered by
+    ``test_parse_custom_sql_remaps_downstream_columns_to_pbi_field_casing``."""
     config = _build_config(enable_advance_lineage_sql_construct=True)
     pbi_columns = [
         Column(
@@ -331,17 +333,59 @@ def test_create_lineage_from_query_uses_oracle_default_schema_and_remaps_columns
     # parse_custom_sql so the resolver isn't re-run inside it.
     assert kwargs["platform_detail"] is oracle_detail
 
-    assert result.upstreams == parsed_lineage.upstreams
-    assert len(result.column_lineage) == 1
-    # _remap_column_lineage_to_pbi_fields restores the PowerBI field casing.
-    assert result.column_lineage[0].downstream.column == "EMPLOYEE_ID"
-    # Upstream casing must be preserved (Oracle stores lowercase).
-    assert result.column_lineage[0].upstreams[0].column == "employee_id"
+    # _create_lineage_from_query delegates to parse_custom_sql and returns its
+    # result verbatim (the remap happens inside parse_custom_sql, mocked here).
+    assert result is parsed_lineage
 
     # Unqualified-table SQL was parsed, but with default_schema set the
     # missing-default_schema warning must NOT fire.
     warning_titles = [entry.title for entry in instance.reporter.warnings]
     assert not any("default_schema" in (t or "") for t in warning_titles)
+
+
+def test_parse_custom_sql_remaps_downstream_columns_to_pbi_field_casing():
+    """parse_custom_sql (the shared SQL-parsing path used by native-query, ODBC,
+    Oracle, and the two/three-step patterns) must remap the parsed downstream
+    column from the SQL alias' casing to the PowerBI field's casing, so the
+    downstream schemaField URN resolves to a real field."""
+    config = _build_config(enable_advance_lineage_sql_construct=True)
+    pbi_columns = [
+        Column(
+            name="EmployeeId",
+            dataType="String",
+            isHidden=False,
+            datahubDataType=StringTypeClass(),
+        )
+    ]
+    instance = _build_oracle_lineage(config=config, columns=pbi_columns)
+
+    upstream_urn = "urn:li:dataset:(urn:li:dataPlatform:oracle,hr.employees,PROD)"
+    parsed_result = MagicMock()
+    parsed_result.in_tables = [upstream_urn]
+    parsed_result.debug_info = None
+    parsed_result.column_lineage = [
+        ColumnLineageInfo(
+            downstream=DownstreamColumnRef(table=None, column="employeeid"),
+            upstreams=[ColumnRef(table=upstream_urn, column="employeeid")],
+        )
+    ]
+
+    with patch(
+        "datahub.ingestion.source.powerbi.m_query.pattern_handler."
+        "native_sql_parser.parse_custom_sql",
+        return_value=parsed_result,
+    ):
+        result = instance.parse_custom_sql(
+            query="SELECT employeeid FROM hr.employees",
+            server="server",
+            database=None,
+            schema="hr",
+            platform_detail=PlatformDetail(),
+        )
+
+    assert len(result.column_lineage) == 1
+    # SQL alias casing ("employeeid") remapped to the PowerBI field ("EmployeeId").
+    assert result.column_lineage[0].downstream.column == "EmployeeId"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Column-level lineage from a PowerBI report to its warehouse can silently drop the **column** edges while **table**-level lineage connects fine. The downstream (PowerBI-side) `schemaField` URN is emitted with the casing of the SQL alias rather than PowerBI's real field name, so it points at a non-existent field and the arrow never renders.

`_remap_column_lineage_to_pbi_fields` already exists to correct this — it maps the parsed downstream column back to PowerBI's actual field name (case-insensitive match, exact-case output). But it was wired into **only** the Oracle lineage path. This PR moves it into the shared `AbstractLineage.parse_custom_sql`, so every SQL-parsing path benefits, and removes the now-redundant Oracle-only wrapper.

## When this bug occurs

All of these together:

1. The PowerBI report resolves lineage through a **SQL-parsing path** — the native-query path (`native_query_parsing: true` + `enable_advance_lineage_sql_construct: true`) or ODBC. (The Oracle path was already covered; the direct-table path was never affected.)
2. The report's SQL **aliases its output columns in a casing that differs from the PowerBI field**, e.g. `SELECT c AS customerid` while PowerBI names the field `CustomerId`. Because the warehouse (SQL Server, etc.) is case-insensitive, the query runs fine regardless, so the alias casing is effectively arbitrary and easy to get "wrong".
3. Column-level lineage is enabled (`extract_column_level_lineage: true`).

When those line up, DataHub — which matches `schemaField` URNs case-sensitively — cannot resolve the downstream field, and the column arrow is dropped even though the dataset (table) URNs match.

## How this was found

- Symptom: table-level lineage rendered, column-level did not — which localizes the break to the field layer (dataset URNs already match).
- The ingestion log showed CLL was generated (no parse errors) but the parsed downstream column came through lowercased (`customerid`) while the PowerBI field was `CustomerId`.
- Tracing the code, the native-query path (`NativeQueryLineage` → `parse_custom_sql`) returned the parsed lineage without the downstream remap that the Oracle path applied.

## Relationship to prior work

This is the downstream counterpart to the upstream column-casing fix (#18181). #18181 stopped lowercasing the **upstream** column; this preserves the **downstream** (PowerBI-side) column so both ends of the edge resolve.

## Testing

- **Integration** (`tests/integration/powerbi/test_m_parser.py`): new test on the native-query path asserting the downstream column is remapped to the PowerBI field's casing (`customerid` alias → `CustomerId` field). Verified it fails before the change and passes after.
- **Unit** (`tests/unit/powerbi/test_pattern_handler.py`): because the remap moved out of `OracleLineage` into the shared `parse_custom_sql`, the Oracle unit test (which mocks `parse_custom_sql`) was rescoped to its remaining responsibility — threading `default_schema`/`database`/`platform_detail` and delegating — and a new focused unit test asserts `parse_custom_sql` itself remaps the downstream column to the PowerBI field casing (keeps `testQuick` + codecov patch coverage on the moved logic).
- Full `tests/unit/powerbi/` and `tests/integration/powerbi/test_m_parser.py` suites pass (305 passed, 1 xfail).
- `./gradlew :metadata-ingestion:lint` (ruff + mypy) clean.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added
- [ ] Docs added/updated (n/a)
- [ ] Breaking changes documented (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)