### PR TITLE
docs(managed-datahub): release notes for v2.0.5

### DIFF
--- a/docs/managed-datahub/release-notes/v_2_0_0.md
+++ b/docs/managed-datahub/release-notes/v_2_0_0.md
@@ -6,6 +6,25 @@ description: "DataHub Cloud v2.0.0 release notes — major release with Search V
 
 ## Release Changelog
 
+### v2.0.5
+
+This release rolls up hotfixes on top of v2.0.4. There are no breaking changes or deprecations.
+
+#### Release Availability Date
+
+TBD
+
+**Recommended Versions**
+
+- **CLI/SDK**: TBD
+- **Remote Executor**: TBD
+- **Helm**: TBD
+
+#### Bug Fixes
+
+- Fixed Search V2.5 returning duplicate entities within a page while dropping an equal number of other matches across pagination boundaries, so paginated search results are now complete and consistent.
+- Fixed proposal listings (for example on Data Products) failing to load with an "all shards failed" error for users belonging to a large number of groups or roles.
+
 ### v2.0.4
 
 This release rolls up hotfixes on top of v2.0.3.

--- a/docs/managed-datahub/release-notes/v_2_0_0.md
+++ b/docs/managed-datahub/release-notes/v_2_0_0.md
@@ -12,13 +12,15 @@ This release rolls up hotfixes on top of v2.0.4. There are no breaking changes o
 
 #### Release Availability Date
 
-TBD
+21-July-2026
 
 **Recommended Versions**
 
-- **CLI/SDK**: TBD
-- **Remote Executor**: TBD
-- **Helm**: TBD
+- **CLI/SDK**: 1.6.0.4
+- **Remote Executor**: v2.0.5-cloud, v2.0.4-cloud, v2.0.3-cloud, v2.0.2-cloud, v2.0.1-cloud, v1.1.3-cloud, v1.0.3-cloud
+- **On-Prem Versions**:
+  - **Helm**: 1.6.189
+  - **API Gateway**: 0.7.3
 
 #### Bug Fixes
 


### PR DESCRIPTION
DataHub Cloud v2.0.5 release notes.

Prepends a `### v2.0.5` block to `docs/managed-datahub/release-notes/v_2_0_0.md` (patch rollup on top of v2.0.4). Two bug fixes; no breaking changes or deprecations.

> Note: built from `v2.0.5rc1-cloud` (stable `v2.0.5-cloud` tag not yet cut). Availability date and recommended versions left as TBD for the release manager.

## Test plan
- [ ] `markdown_format / markdown_format_check (pull_request)` passes (could not run `mdPrettierWrite` locally — no JDK on the author machine)
- [ ] Release Availability Date and Recommended Versions filled in before marking ready
- [ ] Confirm wording of the Search V2.5 fix reads distinctly from the v2.0.4 rescore fix