### PR TITLE
fix(access): update background color of request access button

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/AccessManagement/AccessButtonHelpers.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/AccessManagement/AccessButtonHelpers.tsx
@@ -16,7 +16,10 @@ const StyledAccessButton = styled(Button)`
     border: none;
     font-weight: bold;
 
-    &:hover {
+    &:hover,
+    &:focus,
+    &:focus-visible,
+    &:active {
         background-color: ${(props) => props.theme.colors.buttonSurfaceBrandHover};
         color: ${(props) => props.theme.colors.textOnFillBrand};
         border: none;
@@ -29,7 +32,10 @@ const StyledAccessButton = styled(Button)`
         cursor: not-allowed;
         border: 1px solid ${(props) => props.theme.colors.borderDisabled};
 
-        &:hover {
+        &:hover,
+        &:focus,
+        &:focus-visible,
+        &:active {
             background-color: ${(props) => props.theme.colors.bgDisabled};
             color: ${(props) => props.theme.colors.textDisabled};
             border: 1px solid ${(props) => props.theme.colors.borderDisabled};

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/AccessManagement/AccessButtonHelpers.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/AccessManagement/AccessButtonHelpers.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
  * Supports both enabled (request) and disabled (granted) states.
  */
 export const AccessButton = styled(Button)`
-    background-color: ${(props) => props.theme.colors.bgSurfaceInfo};
+    background-color: ${(props) => props.theme.colors.buttonFillBrand};
     color: ${(props) => props.theme.colors.textOnFillDefault};
     width: 80px;
     height: 30px;
@@ -16,7 +16,10 @@ export const AccessButton = styled(Button)`
     border: none;
     font-weight: bold;
 
-    &:hover {
+    &:hover,
+    &:focus,
+    &:focus-visible,
+    &:active {
         background-color: ${(props) => props.theme.colors.buttonFillBrand};
         color: ${(props) => props.theme.colors.bg};
         border: none;
@@ -29,7 +32,10 @@ export const AccessButton = styled(Button)`
         cursor: not-allowed;
         border: 1px solid ${(props) => props.theme.colors.border};
 
-        &:hover {
+        &:hover,
+        &:focus,
+        &:focus-visible,
+        &:active {
             background-color: ${(props) => props.theme.colors.bgSurface};
             color: ${(props) => props.theme.colors.textDisabled};
             border: 1px solid ${(props) => props.theme.colors.border};


### PR DESCRIPTION
Before
<img width="1661" height="606" alt="image" src="https://github.com/user-attachments/assets/05a30c0b-5a9f-4c79-a6d5-036522512f70" />

After
<img width="1154" height="414" alt="image" src="https://github.com/user-attachments/assets/6d1f1dea-2d90-4f0d-a99a-4733b5a789c3" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
