### PR TITLE
feat(ingest): authenticated http(s) reads in shared object-store file reader

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/common/http_connection_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/common/http_connection_config.py
@@ -49,3 +49,20 @@ class HTTPConnectionConfig(ConfigModel):
                 "Both username and password are required for HTTP basic authentication."
             )
         return self
+
+    def to_request_kwargs(self) -> dict:
+        """Build the ``verify``/``headers``/``auth`` kwargs for a ``requests`` call.
+
+        Only bearer and basic auth are exposed (not arbitrary headers) because
+        ``requests`` strips the ``Authorization`` header on cross-host
+        redirects, so a bearer token / basic credentials are not leaked to a
+        redirected origin — a custom-header token would not get that protection.
+        """
+        kwargs: dict = {"verify": self.verify_ssl}
+        if self.token is not None:
+            kwargs["headers"] = {
+                "Authorization": f"Bearer {self.token.get_secret_value()}"
+            }
+        elif self.username is not None and self.password is not None:
+            kwargs["auth"] = (self.username, self.password.get_secret_value())
+        return kwargs

--- a/metadata-ingestion/src/datahub/ingestion/source/common/http_connection_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/common/http_connection_config.py
@@ -1,0 +1,42 @@
+from typing import Optional
+
+from pydantic import Field, model_validator
+
+from datahub.configuration.common import ConfigModel, TransparentSecretStr
+
+
+class HTTPConnectionConfig(ConfigModel):
+    """Authentication and TLS options for reading files over http(s)://."""
+
+    token: Optional[TransparentSecretStr] = Field(
+        default=None,
+        description="Bearer token sent as an `Authorization: Bearer <token>` header. "
+        "Mutually exclusive with username/password.",
+    )
+    username: Optional[str] = Field(
+        default=None,
+        description="Username for HTTP Basic authentication (requires password).",
+    )
+    password: Optional[TransparentSecretStr] = Field(
+        default=None,
+        description="Password for HTTP Basic authentication (requires username).",
+    )
+    verify_ssl: bool = Field(
+        default=True,
+        description="Verify the server's TLS certificate. Disable only for trusted "
+        "hosts with self-signed certificates.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_auth(self) -> "HTTPConnectionConfig":
+        if self.token is not None and (
+            self.username is not None or self.password is not None
+        ):
+            raise ValueError(
+                "Set either token (bearer) or username/password (basic), not both."
+            )
+        if (self.username is None) != (self.password is None):
+            raise ValueError(
+                "Both username and password are required for HTTP basic authentication."
+            )
+        return self

--- a/metadata-ingestion/src/datahub/ingestion/source/common/http_connection_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/common/http_connection_config.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from datahub.configuration.common import ConfigModel, TransparentSecretStr
 
@@ -26,6 +26,15 @@ class HTTPConnectionConfig(ConfigModel):
         description="Verify the server's TLS certificate. Disable only for trusted "
         "hosts with self-signed certificates.",
     )
+
+    @field_validator("token", "username", "password", mode="before")
+    @classmethod
+    def _blank_to_none(cls, value: object) -> object:
+        # Empty/whitespace-only strings are treated as "unset" so a blank field
+        # never produces a "Bearer " header or an empty ("", "") basic-auth tuple.
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
 
     @model_validator(mode="after")
     def _validate_auth(self) -> "HTTPConnectionConfig":

--- a/metadata-ingestion/src/datahub/ingestion/source/common/object_store_files.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/common/object_store_files.py
@@ -11,6 +11,7 @@ import requests
 from datahub.ingestion.source.aws.aws_common import AwsConnectionConfig
 from datahub.ingestion.source.aws.s3_util import is_s3_uri
 from datahub.ingestion.source.common.gcs_connection_config import GCSConnectionConfig
+from datahub.ingestion.source.common.http_connection_config import HTTPConnectionConfig
 from datahub.ingestion.source.gcs.gcs_utils import is_gcs_uri
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -72,18 +73,41 @@ def _read_object_store_body(
     return data
 
 
+def _http_request_kwargs(http_connection: Optional[HTTPConnectionConfig]) -> dict:
+    # requests strips the Authorization header on cross-host redirects, so a
+    # bearer token / basic auth is not leaked to a redirected origin. Custom
+    # header schemes would not get that protection, which is why we only expose
+    # bearer + basic here.
+    if http_connection is None:
+        return {}
+    kwargs: dict = {"verify": http_connection.verify_ssl}
+    if http_connection.token is not None:
+        kwargs["headers"] = {
+            "Authorization": f"Bearer {http_connection.token.get_secret_value()}"
+        }
+    elif http_connection.username is not None and http_connection.password is not None:
+        kwargs["auth"] = (
+            http_connection.username,
+            http_connection.password.get_secret_value(),
+        )
+    return kwargs
+
+
 def read_file_as_bytes(
     uri: str,
     aws_connection: Optional[AwsConnectionConfig] = None,
     gcs_connection: Optional[GCSConnectionConfig] = None,
     http_timeout_seconds: int = DEFAULT_HTTP_TIMEOUT_SECONDS,
     max_bytes: Optional[int] = None,
+    http_connection: Optional[HTTPConnectionConfig] = None,
 ) -> bytes:
     """Read a single file from a local path, http(s):// URL, s3:// URI, or gs:// URI.
 
     Object-store URIs require the matching connection config for credentials.
-    When max_bytes is set the read is bounded — an oversized source is rejected
-    from its declared size, or mid-stream, before it is fully buffered.
+    http(s):// URLs may pass an HTTPConnectionConfig for bearer/basic auth and
+    TLS verification. When max_bytes is set the read is bounded — an oversized
+    source is rejected from its declared size, or mid-stream, before it is
+    fully buffered.
     """
     if is_http_uri(uri):
         # stream=True keeps the body out of memory until we pull it chunk by
@@ -93,7 +117,12 @@ def read_file_as_bytes(
         # input, so redirect-based SSRF is an accepted risk here.
         # `with` guarantees the connection is released back to the pool even
         # when the size cap trips before the body is drained.
-        with requests.get(uri, timeout=http_timeout_seconds, stream=True) as resp:
+        with requests.get(
+            uri,
+            timeout=http_timeout_seconds,
+            stream=True,
+            **_http_request_kwargs(http_connection),
+        ) as resp:
             resp.raise_for_status()
             declared = resp.headers.get("Content-Length")
             if declared is not None and declared.isdigit():

--- a/metadata-ingestion/src/datahub/ingestion/source/common/object_store_files.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/common/object_store_files.py
@@ -73,26 +73,6 @@ def _read_object_store_body(
     return data
 
 
-def _http_request_kwargs(http_connection: Optional[HTTPConnectionConfig]) -> dict:
-    # requests strips the Authorization header on cross-host redirects, so a
-    # bearer token / basic auth is not leaked to a redirected origin. Custom
-    # header schemes would not get that protection, which is why we only expose
-    # bearer + basic here.
-    if http_connection is None:
-        return {}
-    kwargs: dict = {"verify": http_connection.verify_ssl}
-    if http_connection.token is not None:
-        kwargs["headers"] = {
-            "Authorization": f"Bearer {http_connection.token.get_secret_value()}"
-        }
-    elif http_connection.username is not None and http_connection.password is not None:
-        kwargs["auth"] = (
-            http_connection.username,
-            http_connection.password.get_secret_value(),
-        )
-    return kwargs
-
-
 def read_file_as_bytes(
     uri: str,
     aws_connection: Optional[AwsConnectionConfig] = None,
@@ -121,7 +101,7 @@ def read_file_as_bytes(
             uri,
             timeout=http_timeout_seconds,
             stream=True,
-            **_http_request_kwargs(http_connection),
+            **(http_connection.to_request_kwargs() if http_connection else {}),
         ) as resp:
             resp.raise_for_status()
             declared = resp.headers.get("Content-Length")

--- a/metadata-ingestion/tests/unit/test_object_store_files.py
+++ b/metadata-ingestion/tests/unit/test_object_store_files.py
@@ -301,6 +301,23 @@ def test_http_connection_config_requires_both_basic_parts():
         HTTPConnectionConfig(username="u")
 
 
+def test_http_connection_config_blank_strings_are_unset():
+    # Blank credentials must not send a "Bearer " header or an empty basic-auth
+    # tuple — they collapse to None (no auth).
+    cfg = HTTPConnectionConfig(token="", username="  ", password="")
+    assert cfg.token is None
+    assert cfg.username is None
+    assert cfg.password is None
+    with mock.patch(
+        "datahub.ingestion.source.common.object_store_files.requests.get"
+    ) as mock_get:
+        mock_get.return_value = _mock_http_response([b"ok"])
+        read_file_as_bytes("https://example.com/contract.yaml", http_connection=cfg)
+        kwargs = mock_get.call_args.kwargs
+        assert "auth" not in kwargs
+        assert "headers" not in kwargs
+
+
 def test_read_file_as_bytes_s3():
     connection = mock.MagicMock()
     s3_client = mock.MagicMock()

--- a/metadata-ingestion/tests/unit/test_object_store_files.py
+++ b/metadata-ingestion/tests/unit/test_object_store_files.py
@@ -1,7 +1,9 @@
 from unittest import mock
 
 import pytest
+from pydantic import ValidationError
 
+from datahub.ingestion.source.common.http_connection_config import HTTPConnectionConfig
 from datahub.ingestion.source.common.object_store_files import (
     FileSizeExceededError,
     expand_local_glob,
@@ -255,6 +257,48 @@ def test_read_file_as_bytes_http_over_cap_without_content_length():
         mock_get.return_value = _mock_http_response([b"x" * 6, b"x" * 6])
         with pytest.raises(ValueError, match="over the configured max_bytes"):
             read_file_as_bytes("https://example.com/big.json", max_bytes=10)
+
+
+def test_read_file_as_bytes_http_bearer_token():
+    with mock.patch(
+        "datahub.ingestion.source.common.object_store_files.requests.get"
+    ) as mock_get:
+        mock_get.return_value = _mock_http_response([b"ok"])
+        read_file_as_bytes(
+            "https://example.com/contract.yaml",
+            http_connection=HTTPConnectionConfig(token="secret-token"),
+        )
+        kwargs = mock_get.call_args.kwargs
+        assert kwargs["headers"] == {"Authorization": "Bearer secret-token"}
+        assert kwargs["verify"] is True
+        assert "auth" not in kwargs
+
+
+def test_read_file_as_bytes_http_basic_auth_and_verify_off():
+    with mock.patch(
+        "datahub.ingestion.source.common.object_store_files.requests.get"
+    ) as mock_get:
+        mock_get.return_value = _mock_http_response([b"ok"])
+        read_file_as_bytes(
+            "https://example.com/contract.yaml",
+            http_connection=HTTPConnectionConfig(
+                username="user", password="pass", verify_ssl=False
+            ),
+        )
+        kwargs = mock_get.call_args.kwargs
+        assert kwargs["auth"] == ("user", "pass")
+        assert kwargs["verify"] is False
+        assert "headers" not in kwargs
+
+
+def test_http_connection_config_rejects_bearer_and_basic_together():
+    with pytest.raises(ValidationError):
+        HTTPConnectionConfig(token="t", username="u", password="p")
+
+
+def test_http_connection_config_requires_both_basic_parts():
+    with pytest.raises(ValidationError):
+        HTTPConnectionConfig(username="u")
 
 
 def test_read_file_as_bytes_s3():


### PR DESCRIPTION
## Summary

- Adds `HTTPConnectionConfig` (shared, in `ingestion/source/common/`) supporting a **bearer token** or **HTTP basic auth** (mutually exclusive, validated) plus a `verify_ssl` toggle.
- Threads an optional `http_connection` through the shared `read_file_as_bytes` helper so `http(s)://` file sources can authenticate. Existing callers (dbt) are unaffected — the parameter defaults to `None`.
- Only bearer + basic are exposed (not arbitrary headers): `requests` strips the `Authorization` header on cross-host redirects, so bearer/basic are not leaked to a redirected origin, whereas custom-header tokens would be.
- Blank credentials (`""` / whitespace-only token, username, or password) normalize to `None`, so an empty field never emits a `Bearer ` header or an empty `("", "")` basic-auth tuple.

This is the shared-framework half of the ODCS authenticated-HTTP work, split out per the repo's "shared changes in their own PR" convention. The consumer (ODCS source + ingestion UI fields) is in #18474, which is stacked on this branch.

## Review notes

- **`verify_ssl=False` warning lives in the consumer.** `read_file_as_bytes` is a pure util with no report handle, so it can't warn. The `self.report.warning` when `http_connection.verify_ssl` is `False` — and its test — are in the ODCS source in the consumer PR #18474, where a report is available.
- **This capability is added ahead of its caller, by design.** `read_file_as_bytes(..., http_connection=)` is wired up by the ODCS config + UI form in #18474 (stacked on this branch). It is staged, not dead code.
- **Blank-string auth tightened.** A `field_validator` collapses empty/whitespace-only `token`/`username`/`password` to `None`, covered by `test_http_connection_config_blank_strings_are_unset`.

## Test plan

- [x] `pytest tests/unit/test_object_store_files.py` — bearer header, basic auth + `verify=False` passthrough, blank-string normalization, and both validator rejections (bearer+basic together; basic missing a half).
- [x] `./gradlew :metadata-ingestion:lint` (ruff + mypy) clean.