### PR TITLE
fix(pgqueue): defer content-type cache publish until after commit

### DIFF
--- a/metadata-ingestion/src/datahub/pgqueue/repository.py
+++ b/metadata-ingestion/src/datahub/pgqueue/repository.py
@@ -208,11 +208,29 @@ class PgQueueRepository:
             self._topic_row_by_name[topic_name] = parsed
             return parsed
 
-    def _ensure_mime_registered(self, conn: PGConnection, mime: str) -> int:
-        """Resolve MIME to catalog id without burning smallint identity on existing MIME rows."""
+    def _ensure_mime_registered(
+        self,
+        conn: PGConnection,
+        mime: str,
+        tx_content_types: Optional[Dict[str, int]] = None,
+    ) -> int:
+        """Resolve MIME to catalog id.
+
+        Lookup first; ``INSERT … ON CONFLICT DO NOTHING`` keeps the transaction
+        valid under concurrent registration (plain INSERT + catch would abort it).
+        Identity may still advance on concurrent first-time inserts of a new MIME.
+
+        IDs from the DB are stored only in ``tx_content_types`` until the surrounding
+        transaction commits. Publishing to the process-wide cache earlier would let
+        concurrent transactions use an uncommitted FK target.
+        """
         cached = self._content_type_id_by_mime.get(mime)
         if cached is not None:
             return cached
+        if tx_content_types is not None:
+            tx_cached = tx_content_types.get(mime)
+            if tx_cached is not None:
+                return tx_cached
         with conn.cursor() as cur:
             cur.execute(
                 f"SELECT id FROM {self._content_type} WHERE mime = %s",
@@ -221,7 +239,11 @@ class PgQueueRepository:
             row = cur.fetchone()
             if row is not None:
                 cid = int(row[0])
-                self._content_type_id_by_mime[mime] = cid
+                if tx_content_types is not None:
+                    tx_content_types[mime] = cid
+                else:
+                    # Standalone callers (tests / no open multi-statement TX): safe to cache.
+                    self._content_type_id_by_mime[mime] = cid
                 return cid
             cur.execute(
                 f"INSERT INTO {self._content_type} (mime) VALUES (%s) "
@@ -235,8 +257,15 @@ class PgQueueRepository:
             row = cur.fetchone()
             assert row is not None
             cid = int(row[0])
-            self._content_type_id_by_mime[mime] = cid
+            if tx_content_types is not None:
+                tx_content_types[mime] = cid
+            else:
+                self._content_type_id_by_mime[mime] = cid
             return cid
+
+    def _publish_content_type_cache(self, tx_content_types: Dict[str, int]) -> None:
+        if tx_content_types:
+            self._content_type_id_by_mime.update(tx_content_types)
 
     def ensure_topic(
         self,
@@ -248,10 +277,11 @@ class PgQueueRepository:
         max_total_payload_bytes: int,
         default_content_type_mime: Optional[str] = None,
         aggressive_retention: bool = False,
+        tx_content_types: Optional[Dict[str, int]] = None,
     ) -> int:
         """Upsert topic catalog row and return ``topic_id``."""
         mime = default_content_type_mime or "application/avro"
-        default_ct_id = self._ensure_mime_registered(conn, mime)
+        default_ct_id = self._ensure_mime_registered(conn, mime, tx_content_types)
         with conn.cursor() as cur:
             cur.execute(
                 f"""
@@ -297,10 +327,11 @@ class PgQueueRepository:
         conn: PGConnection,
         topic_default_id: Optional[int],
         content_type: Optional[str],
+        tx_content_types: Optional[Dict[str, int]] = None,
     ) -> Optional[int]:
         if not content_type:
             return None
-        cid = self._ensure_mime_registered(conn, content_type)
+        cid = self._ensure_mime_registered(conn, content_type, tx_content_types)
         if topic_default_id is not None and topic_default_id == cid:
             return None
         return cid
@@ -316,6 +347,7 @@ class PgQueueRepository:
         content_type: Optional[str],
         headers: Sequence[Tuple[str, bytes]],
         payload_compression: int = 0,
+        tx_content_types: Optional[Dict[str, int]] = None,
     ) -> PgQueueMessageHandle:
         """Insert one row inside the caller's open transaction (no commit)."""
         topic_id, pc, topic_default_ct_id = topic_row
@@ -323,7 +355,7 @@ class PgQueueRepository:
             raise ValueError(f"priority {priority} out of range [0, 9]")
         partition_id = stable_partition_id(routing_key, pc)
         stored_ct_id = self._compute_stored_content_type_id(
-            conn, topic_default_ct_id, content_type
+            conn, topic_default_ct_id, content_type, tx_content_types
         )
 
         lock_k = advisory_lock_key(topic_id, partition_id)
@@ -391,6 +423,7 @@ class PgQueueRepository:
         flush_pg_connection(conn)
         old_autocommit = conn.autocommit
         conn.autocommit = False
+        tx_content_types: Dict[str, int] = {}
         try:
             self.ensure_topic(
                 conn,
@@ -401,6 +434,7 @@ class PgQueueRepository:
                 max_total_payload_bytes,
                 default_content_type_mime=default_content_type_mime,
                 aggressive_retention=aggressive_retention,
+                tx_content_types=tx_content_types,
             )
             topic_row = self._get_topic_row(conn, topic_name)
             handle = self._enqueue_message_in_transaction(
@@ -412,8 +446,10 @@ class PgQueueRepository:
                 content_type=content_type,
                 headers=headers,
                 payload_compression=payload_compression,
+                tx_content_types=tx_content_types,
             )
             conn.commit()
+            self._publish_content_type_cache(tx_content_types)
             return handle
         except Exception:
             conn.rollback()
@@ -439,6 +475,7 @@ class PgQueueRepository:
         flush_pg_connection(conn)
         old_autocommit = conn.autocommit
         conn.autocommit = False
+        tx_content_types: Dict[str, int] = {}
         try:
             handles: List[PgQueueMessageHandle] = []
             topic_rows_in_batch: Dict[str, TopicRow] = {}
@@ -454,6 +491,7 @@ class PgQueueRepository:
                         max_total_payload_bytes,
                         default_content_type_mime=default_content_type_mime,
                         aggressive_retention=aggressive_retention,
+                        tx_content_types=tx_content_types,
                     )
                     topic_row = self._get_topic_row(conn, it.topic_name)
                     topic_rows_in_batch[it.topic_name] = topic_row
@@ -467,9 +505,11 @@ class PgQueueRepository:
                         content_type=it.content_type,
                         headers=it.headers,
                         payload_compression=it.payload_compression,
+                        tx_content_types=tx_content_types,
                     )
                 )
             conn.commit()
+            self._publish_content_type_cache(tx_content_types)
             return handles
         except Exception:
             conn.rollback()

--- a/metadata-io/src/main/java/com/linkedin/metadata/queue/postgres/EbeanPostgresMetadataQueueStore.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/queue/postgres/EbeanPostgresMetadataQueueStore.java
@@ -140,12 +140,15 @@ public class EbeanPostgresMetadataQueueStore implements MetadataQueueStore {
 
   @Override
   public long ensureTopic(@Nonnull String topicName, @Nonnull QueueTopicDefaults defaults) {
+    Map<String, Short> txContentTypes = new HashMap<>();
     try (Transaction tx = database.beginTransaction(TxScope.requiresNew())) {
       Connection conn = tx.connection();
       try {
-        insertTopicIfMissing(conn, topicName, resolveEffectiveDefaults(topicName, defaults));
+        insertTopicIfMissing(
+            conn, topicName, resolveEffectiveDefaults(topicName, defaults), txContentTypes);
         long id = getTopicMeta(conn, topicName).id();
         tx.commit();
+        publishContentTypeCache(txContentTypes);
         return id;
       } catch (SQLException e) {
         tx.rollback();
@@ -165,11 +168,12 @@ public class EbeanPostgresMetadataQueueStore implements MetadataQueueStore {
       @Nonnull Optional<String> contentType,
       @Nonnull List<QueueMessageHeader> headers,
       @Nonnull PgQueuePayloadCompression payloadCompression) {
+    Map<String, Short> txContentTypes = new HashMap<>();
     try (Transaction tx = database.beginTransaction(TxScope.requiresNew())) {
       Connection conn = tx.connection();
       try {
         QueueTopicDefaults effective = resolveEffectiveDefaults(topicName, defaults);
-        insertTopicIfMissing(conn, topicName, effective);
+        insertTopicIfMissing(conn, topicName, effective, txContentTypes);
         QueueMessageHandle handle =
             enqueueInOpenTransaction(
                 conn,
@@ -179,8 +183,10 @@ public class EbeanPostgresMetadataQueueStore implements MetadataQueueStore {
                 payload,
                 contentType,
                 payloadCompression,
-                headers);
+                headers,
+                txContentTypes);
         tx.commit();
+        publishContentTypeCache(txContentTypes);
         return handle;
       } catch (SQLException e) {
         tx.rollback();
@@ -196,6 +202,7 @@ public class EbeanPostgresMetadataQueueStore implements MetadataQueueStore {
     if (items.isEmpty()) {
       return List.of();
     }
+    Map<String, Short> txContentTypes = new HashMap<>();
     try (Transaction tx = database.beginTransaction(TxScope.requiresNew())) {
       Connection conn = tx.connection();
       try {
@@ -209,7 +216,7 @@ public class EbeanPostgresMetadataQueueStore implements MetadataQueueStore {
                     try {
                       QueueTopicDefaults effectiveForTopic =
                           resolveEffectiveDefaults(topic, defaults);
-                      insertTopicIfMissing(conn, topic, effectiveForTopic);
+                      insertTopicIfMissing(conn, topic, effectiveForTopic, txContentTypes);
                       return getTopicMeta(conn, topic);
                     } catch (SQLException e) {
                       throw new IllegalStateException(
@@ -225,9 +232,11 @@ public class EbeanPostgresMetadataQueueStore implements MetadataQueueStore {
                   it.payload(),
                   it.contentType(),
                   it.payloadCompression(),
-                  it.headers()));
+                  it.headers(),
+                  txContentTypes));
         }
         tx.commit();
+        publishContentTypeCache(txContentTypes);
         return out;
       } catch (SQLException e) {
         tx.rollback();
@@ -479,13 +488,17 @@ public class EbeanPostgresMetadataQueueStore implements MetadataQueueStore {
    * below the prior catalog value or below {@code MAX(partition_id)+1} for existing message rows
    * (avoids consumers polling fewer partitions than enqueued data).
    */
-  private void insertTopicIfMissing(Connection conn, String topicName, QueueTopicDefaults defaults)
+  private void insertTopicIfMissing(
+      Connection conn,
+      String topicName,
+      QueueTopicDefaults defaults,
+      Map<String, Short> txContentTypes)
       throws SQLException {
     String mime = defaults.defaultContentTypeMime();
     if (mime == null || mime.isBlank()) {
       mime = "application/avro";
     }
-    short defaultCtId = ensureContentTypeRegistered(conn, mime);
+    short defaultCtId = ensureContentTypeRegistered(conn, mime, txContentTypes);
     String sql =
         "INSERT INTO "
             + tableNames.qualifiedTopic()
@@ -550,19 +563,29 @@ public class EbeanPostgresMetadataQueueStore implements MetadataQueueStore {
   }
 
   /**
-   * Resolves {@code mime} to a catalog id without burning the {@code smallint} identity when the
-   * MIME already exists. Lookup first; {@code INSERT … ON CONFLICT DO NOTHING} avoids identity burn
-   * and keeps the transaction valid under concurrent registration (plain INSERT + catch would leave
-   * Postgres in an aborted-transaction state).
+   * Resolves {@code mime} to a catalog id. Lookup first so the common existing-MIME path does not
+   * touch the {@code smallint} identity. {@code INSERT … ON CONFLICT DO NOTHING} keeps the
+   * transaction valid under concurrent registration (plain INSERT + catch would leave Postgres in
+   * an aborted-transaction state). Concurrent first-time inserts of a new MIME may still advance
+   * the identity sequence.
+   *
+   * <p>IDs resolved from the DB are stored only in {@code txContentTypes} until the surrounding
+   * transaction commits. Publishing to the process-wide {@link #contentTypeIdByMime} cache earlier
+   * would let concurrent transactions use an uncommitted FK target.
    */
-  private short ensureContentTypeRegistered(Connection conn, String mime) throws SQLException {
+  private short ensureContentTypeRegistered(
+      Connection conn, String mime, Map<String, Short> txContentTypes) throws SQLException {
     Short cached = contentTypeIdByMime.get(mime);
     if (cached != null) {
       return cached;
     }
+    Short txCached = txContentTypes.get(mime);
+    if (txCached != null) {
+      return txCached;
+    }
     Short existing = lookupContentTypeId(conn, mime);
     if (existing != null) {
-      contentTypeIdByMime.put(mime, existing);
+      txContentTypes.put(mime, existing);
       return existing;
     }
     try (PreparedStatement ins =
@@ -577,8 +600,14 @@ public class EbeanPostgresMetadataQueueStore implements MetadataQueueStore {
     if (inserted == null) {
       throw new IllegalStateException("content_type missing after insert: " + mime);
     }
-    contentTypeIdByMime.put(mime, inserted);
+    txContentTypes.put(mime, inserted);
     return inserted;
+  }
+
+  private void publishContentTypeCache(Map<String, Short> txContentTypes) {
+    if (!txContentTypes.isEmpty()) {
+      contentTypeIdByMime.putAll(txContentTypes);
+    }
   }
 
   @Nullable
@@ -602,12 +631,16 @@ public class EbeanPostgresMetadataQueueStore implements MetadataQueueStore {
    */
   @Nullable
   private Integer computeStoredContentTypeId(
-      Connection conn, QueueTopicMetadata meta, Optional<String> contentType) throws SQLException {
+      Connection conn,
+      QueueTopicMetadata meta,
+      Optional<String> contentType,
+      Map<String, Short> txContentTypes)
+      throws SQLException {
     Optional<Integer> topicDefault = meta.defaultContentTypeId();
     if (contentType.isEmpty()) {
       return null;
     }
-    short id = ensureContentTypeRegistered(conn, contentType.get());
+    short id = ensureContentTypeRegistered(conn, contentType.get(), txContentTypes);
     if (topicDefault.isPresent() && topicDefault.get() == (int) id) {
       return null;
     }
@@ -630,10 +663,12 @@ public class EbeanPostgresMetadataQueueStore implements MetadataQueueStore {
       byte[] payload,
       Optional<String> contentType,
       PgQueuePayloadCompression payloadCompression,
-      List<QueueMessageHeader> headers)
+      List<QueueMessageHeader> headers,
+      Map<String, Short> txContentTypes)
       throws SQLException {
     QueueTopicMetadata.validatePriority(priority);
-    Integer storedContentTypeId = computeStoredContentTypeId(conn, meta, contentType);
+    Integer storedContentTypeId =
+        computeStoredContentTypeId(conn, meta, contentType, txContentTypes);
     int partitionId = MetadataQueueRouting.stablePartitionId(routingKey, meta.partitionCount());
     long topicPk = meta.id();
     long lockKey = MetadataQueueRouting.advisoryLockKey(topicPk, partitionId);

--- a/metadata-io/src/test/java/com/linkedin/metadata/queue/postgres/EbeanPostgresMetadataQueueStoreIT.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/queue/postgres/EbeanPostgresMetadataQueueStoreIT.java
@@ -36,10 +36,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -479,25 +481,48 @@ public class EbeanPostgresMetadataQueueStoreIT {
   @Test
   public void ensureContentTypeRegistered_uniqueViolationStillResolves() throws Exception {
     String mime = "application/concurrent-" + UUID.randomUUID();
+    String topicA = "topic_a_" + UUID.randomUUID();
+    String topicB = "topic_b_" + UUID.randomUUID();
+    CountDownLatch ready = new CountDownLatch(2);
+    CountDownLatch start = new CountDownLatch(1);
+    AtomicReference<Throwable> firstError = new AtomicReference<>();
+    AtomicReference<Throwable> secondError = new AtomicReference<>();
     ExecutorService pool = Executors.newFixedThreadPool(2);
     try {
       Future<?> first =
           pool.submit(
-              () ->
-                  store.ensureTopic(
-                      "topic_a_" + UUID.randomUUID(),
-                      new QueueTopicDefaults(4, 0, 0L, 0L, false, mime)));
+              () -> {
+                ready.countDown();
+                try {
+                  Assert.assertTrue(start.await(30, TimeUnit.SECONDS));
+                  store.ensureTopic(topicA, new QueueTopicDefaults(4, 0, 0L, 0L, false, mime));
+                } catch (Throwable t) {
+                  firstError.set(t);
+                }
+              });
       Future<?> second =
           pool.submit(
-              () ->
-                  store.ensureTopic(
-                      "topic_b_" + UUID.randomUUID(),
-                      new QueueTopicDefaults(4, 0, 0L, 0L, false, mime)));
+              () -> {
+                ready.countDown();
+                try {
+                  Assert.assertTrue(start.await(30, TimeUnit.SECONDS));
+                  store.ensureTopic(topicB, new QueueTopicDefaults(4, 0, 0L, 0L, false, mime));
+                } catch (Throwable t) {
+                  secondError.set(t);
+                }
+              });
+      Assert.assertTrue(ready.await(30, TimeUnit.SECONDS));
+      start.countDown();
       first.get(60, TimeUnit.SECONDS);
       second.get(60, TimeUnit.SECONDS);
+      Assert.assertNull(firstError.get(), "first ensureTopic failed: " + firstError.get());
+      Assert.assertNull(secondError.get(), "second ensureTopic failed: " + secondError.get());
       Assert.assertEquals(countContentTypeRowsForMime(mime), 1);
+      Assert.assertEquals(topicDefaultContentTypeMime(topicA), mime);
+      Assert.assertEquals(topicDefaultContentTypeMime(topicB), mime);
     } finally {
-      pool.shutdownNow();
+      pool.shutdown();
+      Assert.assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS));
     }
   }
 
@@ -1324,6 +1349,23 @@ public class EbeanPostgresMetadataQueueStoreIT {
       try (ResultSet rs = ps.executeQuery()) {
         rs.next();
         return rs.getInt(1);
+      }
+    }
+  }
+
+  private String topicDefaultContentTypeMime(String topicName) throws Exception {
+    try (Connection c = database.dataSource().getConnection();
+        PreparedStatement ps =
+            c.prepareStatement(
+                "SELECT ct.mime FROM "
+                    + names.qualifiedTopic()
+                    + " t JOIN "
+                    + names.qualifiedContentType()
+                    + " ct ON ct.id = t.default_content_type_id WHERE t.topic_name = ?")) {
+      ps.setString(1, topicName);
+      try (ResultSet rs = ps.executeQuery()) {
+        Assert.assertTrue(rs.next(), "topic missing: " + topicName);
+        return rs.getString(1);
       }
     }
   }


### PR DESCRIPTION
## Summary
- Fixes a real concurrency race behind flaky `EbeanPostgresMetadataQueueStoreIT.ensureContentTypeRegistered_uniqueViolationStillResolves` ([PFP-4702](https://linear.app/acryl-data/issue/PFP-4702/fix-flaky-metadata-io-postgres-queue-store-test)): MIME IDs were published into the process-wide cache inside an open transaction, so a concurrent `ensureTopic` could FK-reference an uncommitted `content_type` row.
- Keep content-type resolutions transaction-local and publish to the shared cache only after a successful commit in Java (`EbeanPostgresMetadataQueueStore`) and Python (`PgQueueRepository`).
- Harden the concurrent IT with latch coordination and assert both topics resolve to the single registered MIME row.

## Test plan
- [x] `./gradlew :metadata-io:spotlessApply`
- [x] Concurrent IT run repeatedly: `EbeanPostgresMetadataQueueStoreIT.ensureContentTypeRegistered_uniqueViolationStillResolves`
- [x] Full `EbeanPostgresMetadataQueueStoreIT` + `PgQueueContentTypeRegistrationTest`
- [x] `./gradlew :metadata-ingestion:lintFix` and `testSingle -PtestFile=tests/unit/pgqueue/test_pgqueue_repository_sql.py`


Made with [Cursor](https://cursor.com)