### PR TITLE
docs: clarify add_structured_properties and save_document signatures

### DIFF
--- a/docs/features/feature-guides/mcp.md
+++ b/docs/features/feature-guides/mcp.md
@@ -114,9 +114,15 @@ Mutation tools are available in [mcp-server-datahub](https://github.com/acryldat
 
 `add_structured_properties` / `remove_structured_properties` — Manage structured properties (typed metadata fields) on entities. Supports string, number, URN, date, and rich text value types.
 
+**Signature:** `add_structured_properties(property_values: Dict[str, List[Union[str, float, int]]], entity_urns: List[str])`
+Note: property keys must be full structured property URNs (e.g. `urn:li:structuredProperty:...`), and each value must be list-wrapped even for single values.
+
 `set_lifecycle_stage` — Set the lifecycle stage (e.g. proposed, approved, deprecated) of an entity or glossary term directly.
 
 `save_document` — Save standalone documents (insights, decisions, FAQs, notes) to DataHub's knowledge base. Documents are organized under a configurable parent folder.
+
+**Signature:** `save_document(document_type, title, content, urn=None, topics=None, related_documents=None, related_assets=None)`
+Note: there is no `parent_folder` parameter — pass the entity URN via `related_assets` to link the document to that entity's own page.
 
 </details>
 


### PR DESCRIPTION
## What
Documentation clarification for two MCP tools where the documented/assumed
signature didn't match the tool's actual accepted arguments, discovered
while building an agent against a live instance.

## Details

**`add_structured_properties`**
The tool expects:
    add_structured_properties(
        property_values: Dict[str, List[Union[str, float, int]]],
        entity_urns: List[str],
    )
A flat `{"urn": ..., "structured_properties": {...}}` shape looks
reasonable but is silently rejected server-side (an "Invalid arguments"
warning in the MCP server log, no client-side exception raised) —
easy to miss during development since nothing crashes.

**`save_document`**
There is no `parent_folder` parameter. The real signature is:
    save_document(
        document_type, title, content,
        urn=None, topics=None,
        related_documents=None, related_assets=None,
    )
`related_assets` is what links a saved document back to an entity so
it appears on that entity's own Documentation tab, not just via search.

## Why this matters
Both mismatches fail silently or non-obviously, which makes them easy
to build against confidently and only discover in a live demo. A short
note in the tool docs would save others the same debugging session.
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
