### PR TITLE
perf(graphql): batch Domain.entities count-only resolution to eliminate N+1

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -25,6 +25,7 @@ import com.linkedin.datahub.graphql.analytics.service.AnalyticsService;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.featureflags.FeatureFlags;
 import com.linkedin.datahub.graphql.generated.*;
+import com.linkedin.datahub.graphql.loaders.DomainEntityCountsBatchLoader;
 import com.linkedin.datahub.graphql.plugins.SemanticSearchPlugin;
 import com.linkedin.datahub.graphql.resolvers.MeResolver;
 import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
@@ -946,6 +947,9 @@ public class GmsGraphQLEngine {
     builder
         .addDataLoaders(loaderSuppliers(loadableTypes))
         .addDataLoader("Aspect", context -> createDataLoader(aspectType, context))
+        .addDataLoader(
+            DomainEntityCountsBatchLoader.LOADER_NAME,
+            context -> DomainEntityCountsBatchLoader.create(entityClient, context))
         .addDataLoader(
             WeaklyTypedAspectsResolver.LOADER_NAME,
             context ->

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/loaders/DomainEntityCountsBatchLoader.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/loaders/DomainEntityCountsBatchLoader.java
@@ -1,0 +1,322 @@
+package com.linkedin.datahub.graphql.loaders;
+
+import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.SEARCHABLE_ENTITY_TYPES;
+import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
+import static com.linkedin.metadata.utils.SearchUtil.INDEX_VIRTUAL_FIELD;
+
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
+import com.linkedin.datahub.graphql.types.entitytype.EntityTypeMapper;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.CriterionArray;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.search.AggregationMetadata;
+import com.linkedin.metadata.search.SearchResult;
+import io.datahubproject.metadata.context.OperationContext;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.dataloader.BatchLoaderContextProvider;
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderOptions;
+
+/**
+ * Per-request DataLoader resolving {@code Domain.entities.total} for the count-only selections in
+ * the {@code domainEntitiesFields} fragment ({@code entities}/{@code dataProducts}/{@code
+ * applicationsInDomain}), collapsing the previous N&times;3 {@code searchAcrossEntities} calls into
+ * a fixed number of aggregation-only searches.
+ *
+ * <p>Each key is a (domain, entity-type constraint) pair. Keys are grouped by their constraint, and
+ * each group issues one aggregation-only search per chunk of domains, faceted on {@code domains}
+ * and filtered by the group's {@code _entityType} criterion. The {@code domains} facet buckets are
+ * keyed by domain urn, so the per-domain totals read back unambiguously &mdash; the entity-type
+ * constraint is expressed as a search filter (exactly as the pre-batch resolver did), never as an
+ * aggregation dimension, so there is no dependence on the entity-type token format the search layer
+ * emits.
+ *
+ * <p><b>Bucket-cap caveat.</b> Like {@code GlossaryTreeCountsBatchLoader}, this relies on a terms
+ * aggregation whose bucket count is capped at {@code min(maxAggValues, maxTermBucketSize)}. Because
+ * the query is already filtered to the chunk's domains, the {@code domains} bucket only needs to
+ * hold those domains (plus any off-chunk domains contributed by multi-domain assets, which are
+ * ignored). We chunk conservatively ({@link #MAX_DOMAINS_PER_AGG}) and raise {@code maxAggValues}.
+ */
+@Slf4j
+public final class DomainEntityCountsBatchLoader {
+
+  public static final String LOADER_NAME = "DomainEntityCounts";
+
+  private static final String DOMAINS_FIELD = "domains";
+  private static final String DOMAINS_KEYWORD_FIELD = DOMAINS_FIELD + ".keyword";
+  private static final String MATCH_ALL_QUERY = "*";
+
+  // Keep chunks safely under the search-layer terms-bucket cap (default maxTermBucketSize == 60),
+  // leaving headroom for off-chunk domains pulled in by multi-domain assets.
+  private static final int MAX_DOMAINS_PER_AGG = 25;
+  private static final int MAX_AGG_VALUES = 1000;
+
+  private DomainEntityCountsBatchLoader() {}
+
+  public static DataLoader<DomainCountKey, Long> create(
+      final EntityClient entityClient, final QueryContext queryContext) {
+    final BatchLoaderContextProvider provider = () -> queryContext;
+    final DataLoaderOptions options =
+        DataLoaderOptions.newOptions().setBatchLoaderContextProvider(provider);
+
+    // Parent the batchLoad span under the operation, not the executor thread (see
+    // GlossaryTreeCountsBatchLoader / EntityAspectsDataLoader).
+    final Context batchContext = Context.current();
+
+    return DataLoader.newDataLoader(
+        (keys, env) ->
+            GraphQLConcurrencyUtils.supplyAsync(
+                () -> {
+                  try (Scope ignored = batchContext.makeCurrent()) {
+                    return batchLoad(keys, (QueryContext) env.getContext(), entityClient);
+                  }
+                },
+                LOADER_NAME,
+                "batchLoad"),
+        options);
+  }
+
+  @WithSpan
+  public static List<Long> batchLoad(
+      final List<DomainCountKey> keys,
+      final QueryContext queryContext,
+      final EntityClient entityClient) {
+    // key -> total, defaulting to zero (a domain with no visible matching assets stays zero).
+    final Map<DomainCountKey, Long> resultByKey = new HashMap<>(keys.size());
+    for (DomainCountKey key : keys) {
+      resultByKey.put(key, 0L);
+    }
+
+    final List<String> entityNames =
+        SEARCHABLE_ENTITY_TYPES.stream()
+            .map(EntityTypeMapper::getName)
+            .collect(Collectors.toList());
+
+    // Group by the entity-type constraint: all keys sharing a constraint are answered by the same
+    // aggregation(s), one per chunk of their domains.
+    final Map<EntityTypeConstraint, List<DomainCountKey>> byConstraint = new LinkedHashMap<>();
+    for (DomainCountKey key : keys) {
+      byConstraint.computeIfAbsent(key.constraint(), k -> new ArrayList<>()).add(key);
+    }
+
+    for (Map.Entry<EntityTypeConstraint, List<DomainCountKey>> group : byConstraint.entrySet()) {
+      final EntityTypeConstraint constraint = group.getKey();
+      final List<String> domainUrns =
+          group.getValue().stream()
+              .map(DomainCountKey::getDomainUrn)
+              .distinct()
+              .collect(Collectors.toList());
+      for (List<String> chunk : partition(domainUrns, MAX_DOMAINS_PER_AGG)) {
+        try {
+          final Map<String, Long> countsByDomain =
+              loadChunk(queryContext, entityClient, entityNames, constraint, chunk);
+          for (DomainCountKey key : group.getValue()) {
+            final Long count = countsByDomain.get(key.getDomainUrn());
+            if (count != null) {
+              resultByKey.put(key, count);
+            }
+          }
+        } catch (Exception e) {
+          log.error(
+              "Failed to batch-load domain entity counts for {} domains (constraint {})",
+              chunk.size(),
+              constraint,
+              e);
+        }
+      }
+    }
+
+    // DataLoader contract: results[i] must correspond to keys[i].
+    final List<Long> ordered = new ArrayList<>(keys.size());
+    for (DomainCountKey key : keys) {
+      ordered.add(resultByKey.get(key));
+    }
+    return ordered;
+  }
+
+  private static Map<String, Long> loadChunk(
+      final QueryContext queryContext,
+      final EntityClient entityClient,
+      final List<String> entityNames,
+      final EntityTypeConstraint constraint,
+      final List<String> domainUrns)
+      throws Exception {
+
+    final OperationContext opContext =
+        queryContext
+            .getOperationContext()
+            .withSearchFlags(
+                flags -> flags.setMaxAggValues(MAX_AGG_VALUES).setIncludeDefaultFacets(false));
+
+    final SearchResult searchResult =
+        entityClient.searchAcrossEntities(
+            opContext,
+            entityNames,
+            MATCH_ALL_QUERY,
+            buildFilter(domainUrns, constraint),
+            0,
+            0,
+            Collections.emptyList(),
+            Collections.singletonList(DOMAINS_FIELD));
+
+    final Map<String, Long> countsByDomain = new HashMap<>();
+    if (searchResult == null
+        || searchResult.getMetadata() == null
+        || searchResult.getMetadata().getAggregations() == null) {
+      return countsByDomain;
+    }
+    for (AggregationMetadata agg : searchResult.getMetadata().getAggregations()) {
+      if (!DOMAINS_FIELD.equals(agg.getName()) || agg.getAggregations() == null) {
+        continue;
+      }
+      // domains-facet bucket keys are domain urns; ignore off-chunk domains from multi-domain
+      // assets.
+      agg.getAggregations()
+          .forEach(
+              (domainUrn, count) -> {
+                if (domainUrns.contains(domainUrn)) {
+                  countsByDomain.merge(domainUrn, count, Long::sum);
+                }
+              });
+    }
+    return countsByDomain;
+  }
+
+  private static Filter buildFilter(
+      final List<String> domainUrns, final EntityTypeConstraint constraint) {
+    final StringArray urnValues = new StringArray();
+    for (String urn : domainUrns) {
+      try {
+        urnValues.add(UrnUtils.getUrn(urn).toString());
+      } catch (Exception e) {
+        log.warn("Skipping malformed domain urn '{}' in domain entity count batch.", urn, e);
+      }
+    }
+
+    final CriterionArray criteria = new CriterionArray();
+    criteria.add(buildCriterion(DOMAINS_KEYWORD_FIELD, Condition.EQUAL, urnValues));
+    if (!constraint.entityTypeNames.isEmpty()) {
+      criteria.add(
+          buildCriterion(
+              INDEX_VIRTUAL_FIELD,
+              Condition.EQUAL,
+              constraint.negated,
+              constraint.entityTypeNames));
+    }
+    return new Filter()
+        .setOr(new ConjunctiveCriterionArray(new ConjunctiveCriterion().setAnd(criteria)));
+  }
+
+  private static <T> List<List<T>> partition(final List<T> list, final int size) {
+    final List<List<T>> chunks = new ArrayList<>();
+    for (int i = 0; i < list.size(); i += size) {
+      chunks.add(list.subList(i, Math.min(i + size, list.size())));
+    }
+    return chunks;
+  }
+
+  /**
+   * The entity-type portion of a count request. Empty {@code entityTypeNames} means no entity-type
+   * constraint (grand total across all searchable types). The names are GraphQL {@code EntityType}
+   * enum values (e.g. {@code DATA_PRODUCT}) applied to the {@code _entityType} search field &mdash;
+   * the same values the {@code domainEntitiesFields} filters use.
+   */
+  private static final class EntityTypeConstraint {
+    private final List<String> entityTypeNames;
+    private final boolean negated;
+
+    EntityTypeConstraint(final List<String> entityTypeNames, final boolean negated) {
+      this.entityTypeNames = entityTypeNames;
+      this.negated = negated;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof EntityTypeConstraint)) {
+        return false;
+      }
+      final EntityTypeConstraint that = (EntityTypeConstraint) o;
+      return negated == that.negated && entityTypeNames.equals(that.entityTypeNames);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(entityTypeNames, negated);
+    }
+
+    @Override
+    public String toString() {
+      return (negated ? "NOT " : "") + entityTypeNames;
+    }
+  }
+
+  /**
+   * Loader key: a domain plus the entity-type constraint to count within it. Two aliases on the
+   * same domain with different constraints are distinct keys; aliases sharing a constraint across
+   * domains are answered by one aggregation.
+   */
+  public static final class DomainCountKey {
+    private final String domainUrn;
+    private final List<String> entityTypeNames;
+    private final boolean negated;
+
+    /** No entity-type constraint: counts all searchable assets in the domain. */
+    public DomainCountKey(final String domainUrn) {
+      this(domainUrn, Collections.emptyList(), false);
+    }
+
+    public DomainCountKey(
+        final String domainUrn, final List<String> entityTypeNames, final boolean negated) {
+      this.domainUrn = domainUrn;
+      this.entityTypeNames = List.copyOf(entityTypeNames);
+      this.negated = negated;
+    }
+
+    public String getDomainUrn() {
+      return domainUrn;
+    }
+
+    private EntityTypeConstraint constraint() {
+      return new EntityTypeConstraint(entityTypeNames, negated);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof DomainCountKey)) {
+        return false;
+      }
+      final DomainCountKey that = (DomainCountKey) o;
+      return negated == that.negated
+          && domainUrn.equals(that.domainUrn)
+          && entityTypeNames.equals(that.entityTypeNames);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(domainUrn, entityTypeNames, negated);
+    }
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/loaders/DomainEntityCountsBatchLoader.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/loaders/DomainEntityCountsBatchLoader.java
@@ -1,6 +1,6 @@
 package com.linkedin.datahub.graphql.loaders;
 
-import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.SEARCHABLE_ENTITY_TYPES;
+import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.getSearchEntityNames;
 import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
 import static com.linkedin.metadata.utils.SearchUtil.INDEX_VIRTUAL_FIELD;
 
@@ -8,7 +8,6 @@ import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
-import com.linkedin.datahub.graphql.types.entitytype.EntityTypeMapper;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
@@ -104,10 +103,14 @@ public final class DomainEntityCountsBatchLoader {
       resultByKey.put(key, 0L);
     }
 
-    final List<String> entityNames =
-        SEARCHABLE_ENTITY_TYPES.stream()
-            .map(EntityTypeMapper::getName)
-            .collect(Collectors.toList());
+    // Same configured search scope the direct resolver path uses, so batched counts and unbatched
+    // counts can never diverge when elasticsearch.search.defaultEntityTypes is set.
+    final List<String> entityNames = getSearchEntityNames(queryContext.getOperationContext());
+    if (entityNames.isEmpty()) {
+      // Empty means "search no entity types" — it must not reach searchAcrossEntities, which would
+      // read it as "all non-empty indices" (Rest.li omit-entities semantics). Every count is zero.
+      return orderedResults(keys, resultByKey);
+    }
 
     // Group by the entity-type constraint: all keys sharing a constraint are answered by the same
     // aggregation(s), one per chunk of their domains.
@@ -148,7 +151,12 @@ public final class DomainEntityCountsBatchLoader {
       }
     }
 
-    // DataLoader contract: results[i] must correspond to keys[i].
+    return orderedResults(keys, resultByKey);
+  }
+
+  /** DataLoader contract: results[i] must correspond to keys[i]. */
+  private static List<Long> orderedResults(
+      final List<DomainCountKey> keys, final Map<DomainCountKey, Long> resultByKey) {
     final List<Long> ordered = new ArrayList<>(keys.size());
     for (DomainCountKey key : keys) {
       ordered.add(resultByKey.get(key));

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/loaders/DomainEntityCountsBatchLoader.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/loaders/DomainEntityCountsBatchLoader.java
@@ -134,10 +134,15 @@ public final class DomainEntityCountsBatchLoader {
             }
           }
         } catch (Exception e) {
-          log.error(
-              "Failed to batch-load domain entity counts for {} domains (constraint {})",
-              chunk.size(),
-              constraint,
+          // Surface the failure rather than swallowing it: a returned 0 is
+          // indistinguishable from a genuinely empty domain and would mask a search
+          // outage as "no assets" in the UI counts. Matches the throw-on-failure
+          // contract of the direct resolver path (DomainEntitiesResolver#resolveDirect)
+          // and the other GMS batch loaders.
+          throw new RuntimeException(
+              String.format(
+                  "Failed to resolve entity counts associated with Domains %s (constraint %s)",
+                  chunk, constraint),
               e);
         }
       }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/domain/DomainEntitiesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/domain/DomainEntitiesResolver.java
@@ -3,12 +3,16 @@ package com.linkedin.datahub.graphql.resolvers.domain;
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
 import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.*;
 import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
+import static com.linkedin.metadata.utils.SearchUtil.INDEX_VIRTUAL_FIELD;
 
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.generated.Domain;
 import com.linkedin.datahub.graphql.generated.DomainEntitiesInput;
+import com.linkedin.datahub.graphql.generated.FacetFilterInput;
 import com.linkedin.datahub.graphql.generated.SearchResults;
+import com.linkedin.datahub.graphql.loaders.DomainEntityCountsBatchLoader;
+import com.linkedin.datahub.graphql.loaders.DomainEntityCountsBatchLoader.DomainCountKey;
 import com.linkedin.datahub.graphql.types.mappers.UrnSearchResultsMapper;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.query.filter.Condition;
@@ -20,8 +24,11 @@ import com.linkedin.metadata.query.filter.Filter;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
+import org.dataloader.DataLoader;
 
 /** Resolves the entities in a particular Domain. */
 @Slf4j
@@ -62,10 +69,91 @@ public class DomainEntitiesResolver implements DataFetcher<CompletableFuture<Sea
     final int start = input.getStart() != null ? input.getStart() : DEFAULT_START;
     final int count = input.getCount() != null ? input.getCount() : DEFAULT_COUNT;
 
+    // Fast path: the common count-only selections (Domain.entities/dataProducts/
+    // applicationsInDomain in the domainEntitiesFields fragment) request no hits, no query, and at
+    // most a single _entityType filter. Serve these from a batched, request-scoped aggregation so a
+    // page of N domains costs a fixed number of searches instead of 3N. See
+    // DomainEntityCountsBatchLoader.
+    if (canServeFromCounts(query, count, input.getFilters())) {
+      return resolveCountFromLoader(environment, urn, start, input.getFilters());
+    }
+
+    return resolveDirect(context, urn, input, query, start, count);
+  }
+
+  private static boolean canServeFromCounts(
+      final String query, final int count, @Nullable final List<FacetFilterInput> filters) {
+    // The batched loader forces query "*", so anything relying on a real query or hit-returning
+    // pagination must take the direct path to preserve exact behavior.
+    if (count != 0 || !DEFAULT_QUERY.equals(query)) {
+      return false;
+    }
+    if (filters == null || filters.isEmpty()) {
+      return true;
+    }
+    // Only a single _entityType filter with an explicit value list and the default (EQUAL)
+    // condition is derivable from the domains aggregation. Anything else — extra fields, multiple
+    // criteria, a non-default condition, or absent values — falls back to the direct search, which
+    // handles it exactly as before.
+    if (filters.size() != 1) {
+      return false;
+    }
+    final FacetFilterInput filter = filters.get(0);
+    return INDEX_VIRTUAL_FIELD.equals(filter.getField())
+        && filter.getCondition() == null
+        && filter.getValues() != null
+        && !filter.getValues().isEmpty();
+  }
+
+  private CompletableFuture<SearchResults> resolveCountFromLoader(
+      final DataFetchingEnvironment environment,
+      final String domainUrn,
+      final int start,
+      @Nullable final List<FacetFilterInput> filters) {
+    final DataLoader<DomainCountKey, Long> loader =
+        environment.getDataLoader(DomainEntityCountsBatchLoader.LOADER_NAME);
+    return loader
+        .load(toKey(domainUrn, filters))
+        .thenApply(total -> toCountOnlyResults(total, start));
+  }
+
+  private static DomainCountKey toKey(
+      final String domainUrn, @Nullable final List<FacetFilterInput> filters) {
+    if (filters == null || filters.isEmpty()) {
+      return new DomainCountKey(domainUrn);
+    }
+    // canServeFromCounts guarantees a single _entityType filter with non-null values here. Its
+    // values are GraphQL EntityType enum names, applied directly to the _entityType search field
+    // (no token mapping). The null-guard is defensive so this stays crash-safe if the gate changes.
+    final FacetFilterInput entityTypeFilter = filters.get(0);
+    final List<String> values =
+        entityTypeFilter.getValues() != null
+            ? entityTypeFilter.getValues()
+            : Collections.emptyList();
+    return new DomainCountKey(
+        domainUrn, values, Boolean.TRUE.equals(entityTypeFilter.getNegated()));
+  }
+
+  private static SearchResults toCountOnlyResults(final Long total, final int start) {
+    final SearchResults results = new SearchResults();
+    results.setStart(start);
+    results.setCount(0);
+    results.setTotal(total != null ? total.intValue() : 0);
+    results.setSearchResults(Collections.emptyList());
+    return results;
+  }
+
+  /** The original, unbatched behavior: one search per invocation. */
+  private CompletableFuture<SearchResults> resolveDirect(
+      final QueryContext context,
+      final String urn,
+      final DomainEntitiesInput input,
+      final String query,
+      final int start,
+      final int count) {
     return GraphQLConcurrencyUtils.supplyAsync(
         () -> {
           try {
-
             final CriterionArray criteria = new CriterionArray();
             final Criterion filterCriterion =
                 buildCriterion(DOMAINS_FIELD_NAME + ".keyword", Condition.EQUAL, urn);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/loaders/DomainEntityCountsBatchLoaderTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/loaders/DomainEntityCountsBatchLoaderTest.java
@@ -1,0 +1,213 @@
+package com.linkedin.datahub.graphql.loaders;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.testng.Assert.*;
+
+import com.linkedin.data.template.LongMap;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.loaders.DomainEntityCountsBatchLoader.DomainCountKey;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.search.AggregationMetadata;
+import com.linkedin.metadata.search.AggregationMetadataArray;
+import com.linkedin.metadata.search.FilterValueArray;
+import com.linkedin.metadata.search.SearchEntityArray;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.search.SearchResultMetadata;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class DomainEntityCountsBatchLoaderTest {
+  private static final String MARKETING = "urn:li:domain:marketing";
+  private static final String FINANCE = "urn:li:domain:finance";
+  private static final String OFF_CHUNK = "urn:li:domain:notrequested";
+  private static final String DOMAINS_FACET = "domains";
+
+  private EntityClient _entityClient;
+  private QueryContext _context;
+
+  @BeforeMethod
+  public void setup() {
+    _entityClient = Mockito.mock(EntityClient.class);
+    _context = getMockAllowContext();
+  }
+
+  /** A search result carrying a {@code domains} facet keyed by domain urn. */
+  private static SearchResult resultWithDomainCounts(Map<String, Long> countsByDomainUrn) {
+    final AggregationMetadata agg =
+        new AggregationMetadata()
+            .setName(DOMAINS_FACET)
+            .setAggregations(new LongMap(countsByDomainUrn))
+            .setFilterValues(new FilterValueArray());
+    return new SearchResult()
+        .setEntities(new SearchEntityArray())
+        .setNumEntities(0)
+        .setFrom(0)
+        .setPageSize(0)
+        .setMetadata(new SearchResultMetadata().setAggregations(new AggregationMetadataArray(agg)));
+  }
+
+  private void stubSearch(SearchResult result) throws Exception {
+    Mockito.when(
+            _entityClient.searchAcrossEntities(
+                any(),
+                any(),
+                any(),
+                nullable(Filter.class),
+                anyInt(),
+                nullable(Integer.class),
+                any(),
+                any()))
+        .thenReturn(result);
+  }
+
+  @Test
+  public void testCountsDistributedByDomainUrn() throws Exception {
+    stubSearch(resultWithDomainCounts(Map.of(MARKETING, 18L, FINANCE, 5L)));
+
+    final List<Long> results =
+        DomainEntityCountsBatchLoader.batchLoad(
+            List.of(new DomainCountKey(MARKETING), new DomainCountKey(FINANCE)),
+            _context,
+            _entityClient);
+
+    assertEquals(results, List.of(18L, 5L));
+    // One constraint (no entity-type filter), one chunk → one aggregation.
+    Mockito.verify(_entityClient, Mockito.times(1))
+        .searchAcrossEntities(
+            any(),
+            any(),
+            any(),
+            nullable(Filter.class),
+            anyInt(),
+            nullable(Integer.class),
+            any(),
+            any());
+  }
+
+  @Test
+  public void testDistinctConstraintsIssueSeparateSearchesAndAttributeIndependently()
+      throws Exception {
+    // Same domain, two different entity-type constraints (the "entities" and "dataProducts"
+    // aliases) → two aggregations, one per constraint. Keys are grouped in insertion order, so the
+    // first search answers the negated group and the second the positive group; returning distinct
+    // per-invocation results proves each constraint's count is attributed to its own key (not
+    // conflated by a grouping/equals bug).
+    Mockito.when(
+            _entityClient.searchAcrossEntities(
+                any(),
+                any(),
+                any(),
+                nullable(Filter.class),
+                anyInt(),
+                nullable(Integer.class),
+                any(),
+                any()))
+        .thenReturn(
+            resultWithDomainCounts(Map.of(MARKETING, 16L)), // negated group ("entities")
+            resultWithDomainCounts(Map.of(MARKETING, 3L))); // positive group ("dataProducts")
+
+    final List<Long> results =
+        DomainEntityCountsBatchLoader.batchLoad(
+            List.of(
+                new DomainCountKey(MARKETING, List.of("DATA_PRODUCT", "DOMAIN"), true),
+                new DomainCountKey(MARKETING, List.of("DATA_PRODUCT"), false)),
+            _context,
+            _entityClient);
+
+    assertEquals(results, List.of(16L, 3L));
+    Mockito.verify(_entityClient, Mockito.times(2))
+        .searchAcrossEntities(
+            any(),
+            any(),
+            any(),
+            nullable(Filter.class),
+            anyInt(),
+            nullable(Integer.class),
+            any(),
+            any());
+  }
+
+  @Test
+  public void testResultsInKeyOrderWithAbsentDomainZeroed() throws Exception {
+    stubSearch(resultWithDomainCounts(Map.of(MARKETING, 5L)));
+
+    // finance absent from the facet (no visible assets) and requested first.
+    final List<Long> results =
+        DomainEntityCountsBatchLoader.batchLoad(
+            List.of(new DomainCountKey(FINANCE), new DomainCountKey(MARKETING)),
+            _context,
+            _entityClient);
+
+    assertEquals(results, List.of(0L, 5L));
+  }
+
+  @Test
+  public void testOffChunkDomainsIgnored() throws Exception {
+    // A multi-domain asset can surface a domain that was never requested; it must not appear as an
+    // extra result nor perturb a requested domain's count.
+    stubSearch(resultWithDomainCounts(Map.of(OFF_CHUNK, 99L, MARKETING, 5L)));
+
+    final List<Long> results =
+        DomainEntityCountsBatchLoader.batchLoad(
+            List.of(new DomainCountKey(MARKETING)), _context, _entityClient);
+
+    assertEquals(results, List.of(5L));
+  }
+
+  @Test
+  public void testSearchFailureYieldsZeroForAllKeys() throws Exception {
+    Mockito.when(
+            _entityClient.searchAcrossEntities(
+                any(),
+                any(),
+                any(),
+                nullable(Filter.class),
+                anyInt(),
+                nullable(Integer.class),
+                any(),
+                any()))
+        .thenThrow(new RuntimeException("es down"));
+
+    final List<Long> results =
+        DomainEntityCountsBatchLoader.batchLoad(
+            List.of(new DomainCountKey(MARKETING), new DomainCountKey(FINANCE)),
+            _context,
+            _entityClient);
+
+    assertEquals(results, List.of(0L, 0L));
+  }
+
+  @Test
+  public void testLargeFanOutIsChunkedAcrossMultipleSearches() throws Exception {
+    stubSearch(resultWithDomainCounts(Map.of()));
+
+    // 30 domains under one constraint exceeds the 25-per-aggregation chunk size → two searches.
+    final List<DomainCountKey> keys = new ArrayList<>();
+    for (int i = 0; i < 30; i++) {
+      keys.add(new DomainCountKey("urn:li:domain:d" + i));
+    }
+
+    final List<Long> results =
+        DomainEntityCountsBatchLoader.batchLoad(keys, _context, _entityClient);
+
+    assertEquals(results.size(), 30);
+    Mockito.verify(_entityClient, Mockito.times(2))
+        .searchAcrossEntities(
+            any(),
+            any(),
+            any(),
+            nullable(Filter.class),
+            anyInt(),
+            nullable(Integer.class),
+            any(),
+            any());
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/loaders/DomainEntityCountsBatchLoaderTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/loaders/DomainEntityCountsBatchLoaderTest.java
@@ -17,6 +17,8 @@ import com.linkedin.metadata.search.FilterValueArray;
 import com.linkedin.metadata.search.SearchEntityArray;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.search.SearchResultMetadata;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.SearchContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -90,6 +92,28 @@ public class DomainEntityCountsBatchLoaderTest {
             nullable(Integer.class),
             any(),
             any());
+  }
+
+  @Test
+  public void testEmptyConfiguredSearchScopeSkipsSearchAndReturnsZeros() throws Exception {
+    // An empty getSearchEntityNames result means "search no entity types". It must not reach
+    // searchAcrossEntities, which would read the empty list as "all non-empty indices" and count
+    // far more than the configured scope allows.
+    final SearchContext emptyScope =
+        SearchContext.EMPTY.toBuilder().defaultSearchEntityNames(List.of()).build();
+    final OperationContext opContext = Mockito.mock(OperationContext.class);
+    Mockito.when(opContext.getSearchContext()).thenReturn(emptyScope);
+    final QueryContext context = Mockito.mock(QueryContext.class);
+    Mockito.when(context.getOperationContext()).thenReturn(opContext);
+
+    final List<Long> results =
+        DomainEntityCountsBatchLoader.batchLoad(
+            List.of(new DomainCountKey(MARKETING), new DomainCountKey(FINANCE)),
+            context,
+            _entityClient);
+
+    assertEquals(results, List.of(0L, 0L));
+    Mockito.verifyNoInteractions(_entityClient);
   }
 
   @Test

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/loaders/DomainEntityCountsBatchLoaderTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/loaders/DomainEntityCountsBatchLoaderTest.java
@@ -163,7 +163,10 @@ public class DomainEntityCountsBatchLoaderTest {
   }
 
   @Test
-  public void testSearchFailureYieldsZeroForAllKeys() throws Exception {
+  public void testSearchFailurePropagatesInsteadOfYieldingZero() throws Exception {
+    // A backend search failure must surface as an error, not a fabricated 0 that reads as an empty
+    // domain and would silently mask a search outage behind wrong UI counts. The cause is preserved
+    // so the underlying failure remains diagnosable.
     Mockito.when(
             _entityClient.searchAcrossEntities(
                 any(),
@@ -176,13 +179,16 @@ public class DomainEntityCountsBatchLoaderTest {
                 any()))
         .thenThrow(new RuntimeException("es down"));
 
-    final List<Long> results =
-        DomainEntityCountsBatchLoader.batchLoad(
-            List.of(new DomainCountKey(MARKETING), new DomainCountKey(FINANCE)),
-            _context,
-            _entityClient);
+    final RuntimeException thrown =
+        expectThrows(
+            RuntimeException.class,
+            () ->
+                DomainEntityCountsBatchLoader.batchLoad(
+                    List.of(new DomainCountKey(MARKETING), new DomainCountKey(FINANCE)),
+                    _context,
+                    _entityClient));
 
-    assertEquals(results, List.of(0L, 0L));
+    assertNotNull(thrown.getCause());
   }
 
   @Test

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/DomainEntitiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/DomainEntitiesResolverTest.java
@@ -5,6 +5,7 @@ import static com.linkedin.metadata.config.search.EntityTypeListConfig.DEFAULT_S
 import static com.linkedin.metadata.config.search.EntityTypeListConfig.parseCsv;
 import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -30,6 +31,7 @@ import com.linkedin.metadata.search.SearchEntityArray;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.search.SearchResultMetadata;
 import graphql.schema.DataFetchingEnvironment;
+import io.datahubproject.metadata.context.OperationContext;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/DomainEntitiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/DomainEntitiesResolverTest.java
@@ -13,6 +13,10 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.Domain;
 import com.linkedin.datahub.graphql.generated.DomainEntitiesInput;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.FacetFilterInput;
+import com.linkedin.datahub.graphql.loaders.DomainEntityCountsBatchLoader;
+import com.linkedin.datahub.graphql.loaders.DomainEntityCountsBatchLoader.DomainCountKey;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
@@ -27,6 +31,9 @@ import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.search.SearchResultMetadata;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.dataloader.DataLoader;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -91,5 +98,161 @@ public class DomainEntitiesResolverTest {
     assertEquals(resolver.get(mockEnv).get().getSearchResults().size(), 1);
     assertEquals(
         resolver.get(mockEnv).get().getSearchResults().get(0).getEntity().getUrn(), childUrn);
+  }
+
+  @Test
+  public void testCountOnlyServedFromBatchedLoader() throws Exception {
+    final String domainUrn = "urn:li:domain:test-domain";
+    final EntityClient mockClient = Mockito.mock(EntityClient.class);
+    final DomainEntitiesResolver resolver = new DomainEntitiesResolver(mockClient);
+
+    // count == 0, no filters, no query → the count-only fast path with a no-constraint key.
+    final DomainEntitiesInput input = new DomainEntitiesInput(null, 0, 0, Collections.emptyList());
+    final DataFetchingEnvironment mockEnv = countOnlyEnv(input, new DomainCountKey(domainUrn), 10L);
+
+    final var results = resolver.get(mockEnv).get();
+
+    assertEquals((int) results.getTotal(), 10);
+    assertEquals((int) results.getCount(), 0);
+    assertTrue(results.getSearchResults().isEmpty());
+    // The batched loader served it — no per-domain search was issued.
+    Mockito.verifyNoInteractions(mockClient);
+  }
+
+  @Test
+  public void testCountOnlyWithNegatedEntityTypeFilterFromLoader() throws Exception {
+    final String domainUrn = "urn:li:domain:test-domain";
+    final EntityClient mockClient = Mockito.mock(EntityClient.class);
+    final DomainEntitiesResolver resolver = new DomainEntitiesResolver(mockClient);
+
+    // The "entities" alias shape: count 0, single negated _entityType filter.
+    final FacetFilterInput entityTypeFilter = new FacetFilterInput();
+    entityTypeFilter.setField("_entityType");
+    entityTypeFilter.setNegated(true);
+    entityTypeFilter.setValues(
+        List.of(EntityType.DATA_PRODUCT.toString(), EntityType.DOMAIN.toString()));
+    final DomainEntitiesInput input =
+        new DomainEntitiesInput(null, 0, 0, List.of(entityTypeFilter));
+
+    // The resolver must build a negated _entityType key with the raw GraphQL enum values.
+    final DomainCountKey expectedKey =
+        new DomainCountKey(
+            domainUrn,
+            List.of(EntityType.DATA_PRODUCT.toString(), EntityType.DOMAIN.toString()),
+            true);
+    final DataFetchingEnvironment mockEnv = countOnlyEnv(input, expectedKey, 16L);
+
+    assertEquals((int) resolver.get(mockEnv).get().getTotal(), 16);
+    Mockito.verifyNoInteractions(mockClient);
+  }
+
+  @Test
+  public void testCountOnlyWithNonEntityTypeFilterFallsBackToDirectSearch() throws Exception {
+    final String domainUrn = "urn:li:domain:test-domain";
+    final EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.when(
+            mockClient.searchAcrossEntities(
+                any(), any(), any(), any(), Mockito.anyInt(), any(), any()))
+        .thenReturn(
+            new SearchResult()
+                .setFrom(0)
+                .setPageSize(0)
+                .setNumEntities(42)
+                .setEntities(new SearchEntityArray())
+                .setMetadata(
+                    new SearchResultMetadata().setAggregations(new AggregationMetadataArray())));
+    final DomainEntitiesResolver resolver = new DomainEntitiesResolver(mockClient);
+
+    // count 0 but a non-_entityType filter is not derivable from the breakdown → direct search.
+    final FacetFilterInput platformFilter = new FacetFilterInput();
+    platformFilter.setField("platform");
+    platformFilter.setValues(List.of("urn:li:dataPlatform:snowflake"));
+    final DomainEntitiesInput input = new DomainEntitiesInput(null, 0, 0, List.of(platformFilter));
+
+    final QueryContext mockContext = Mockito.mock(QueryContext.class);
+    Mockito.when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
+    final DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    final Domain parentDomain = new Domain();
+    parentDomain.setUrn(domainUrn);
+    Mockito.when(mockEnv.getSource()).thenReturn(parentDomain);
+
+    assertEquals((int) resolver.get(mockEnv).get().getTotal(), 42);
+    // The direct path ran; the batched loader was never consulted.
+    Mockito.verify(mockClient, Mockito.times(1))
+        .searchAcrossEntities(any(), any(), any(), any(), Mockito.anyInt(), any(), any());
+    Mockito.verify(mockEnv, Mockito.never()).getDataLoader(any());
+  }
+
+  @Test
+  public void testCountOnlyWithNullValuesEntityTypeFilterFallsBackToDirectSearch()
+      throws Exception {
+    // Regression: an _entityType filter that omits `values` (schema type [String!], nullable) must
+    // not crash the fast path — it falls back to the direct search, which handles null values.
+    final FacetFilterInput noValues = new FacetFilterInput();
+    noValues.setField("_entityType");
+    // values intentionally left null
+    assertFallsBackToDirectSearch(new DomainEntitiesInput(null, 0, 0, List.of(noValues)));
+  }
+
+  /** Runs the resolver and asserts it took the direct search path, never the batched loader. */
+  private static void assertFallsBackToDirectSearch(final DomainEntitiesInput input)
+      throws Exception {
+    final EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.when(
+            mockClient.searchAcrossEntities(
+                any(), any(), any(), any(), Mockito.anyInt(), any(), any()))
+        .thenReturn(
+            new SearchResult()
+                .setFrom(0)
+                .setPageSize(0)
+                .setNumEntities(7)
+                .setEntities(new SearchEntityArray())
+                .setMetadata(
+                    new SearchResultMetadata().setAggregations(new AggregationMetadataArray())));
+    final DomainEntitiesResolver resolver = new DomainEntitiesResolver(mockClient);
+
+    final QueryContext mockContext = getMockAllowContext();
+    final DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    final Domain parentDomain = new Domain();
+    parentDomain.setUrn("urn:li:domain:test-domain");
+    Mockito.when(mockEnv.getSource()).thenReturn(parentDomain);
+
+    // Must not throw (regression guard for null values) and must use the direct path.
+    assertEquals((int) resolver.get(mockEnv).get().getTotal(), 7);
+    Mockito.verify(mockClient, Mockito.times(1))
+        .searchAcrossEntities(any(), any(), any(), any(), Mockito.anyInt(), any(), any());
+    Mockito.verify(mockEnv, Mockito.never()).getDataLoader(any());
+  }
+
+  /**
+   * Builds a mock environment whose {@link DomainEntityCountsBatchLoader} loader resolves {@code
+   * expectedKey} to {@code total}, for exercising the count-only fast path. If the resolver builds
+   * a key other than {@code expectedKey}, {@code load} returns null and the test fails — so this
+   * also asserts the resolver constructs the right key.
+   */
+  private static DataFetchingEnvironment countOnlyEnv(
+      final DomainEntitiesInput input, final DomainCountKey expectedKey, final long total) {
+    final QueryContext mockContext = Mockito.mock(QueryContext.class);
+    Mockito.when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
+
+    @SuppressWarnings("unchecked")
+    final DataLoader<DomainCountKey, Long> mockLoader = Mockito.mock(DataLoader.class);
+    Mockito.when(mockLoader.load(expectedKey)).thenReturn(CompletableFuture.completedFuture(total));
+
+    final DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Mockito.when(
+            mockEnv.<DomainCountKey, Long>getDataLoader(DomainEntityCountsBatchLoader.LOADER_NAME))
+        .thenReturn(mockLoader);
+
+    final Domain parentDomain = new Domain();
+    parentDomain.setUrn(expectedKey.getDomainUrn());
+    Mockito.when(mockEnv.getSource()).thenReturn(parentDomain);
+    return mockEnv;
   }
 }

--- a/smoke-test/tests/domains/domain_entities_batching_test.py
+++ b/smoke-test/tests/domains/domain_entities_batching_test.py
@@ -1,0 +1,195 @@
+import logging
+import os
+import tempfile
+import uuid
+from typing import Any, Dict, List
+
+import pytest
+
+from conftest import _ingest_cleanup_data_impl
+from datahub.emitter.mce_builder import (
+    make_data_product_urn,
+    make_dataset_urn,
+    make_domain_urn,
+)
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.common import PipelineContext, RecordEnvelope
+from datahub.ingestion.api.sink import NoopWriteCallback
+from datahub.ingestion.sink.file import FileSink, FileSinkConfig
+from datahub.metadata.schema_classes import (
+    DataProductPropertiesClass,
+    DatasetPropertiesClass,
+    DomainPropertiesClass,
+    DomainsClass,
+)
+from tests.utils import execute_graphql, with_test_retry
+
+logger = logging.getLogger(__name__)
+
+# Unique per run so the three domains are freshly seeded and their entity counts
+# are deterministic regardless of what else is in the instance.
+_RUN_ID = uuid.uuid4().hex[:8]
+
+# Ground truth. Domain A carries a data product on top of its datasets so the
+# _entityType-filtered (dataProducts) fast path is exercised alongside the plain
+# entities count; Domain C is intentionally empty to cover the zero-count path.
+_DOMAIN_A = make_domain_urn(f"test-batching-a-{_RUN_ID}")
+_DOMAIN_B = make_domain_urn(f"test-batching-b-{_RUN_ID}")
+_DOMAIN_C = make_domain_urn(f"test-batching-c-{_RUN_ID}")
+
+_A_DATASETS = 2
+_B_DATASETS = 3
+_A_DATA_PRODUCTS = 1
+
+# Expected total entities (datasets + data products) and data-product-only counts.
+_EXPECTED = {
+    _DOMAIN_A: {"entities": _A_DATASETS + _A_DATA_PRODUCTS, "dataProducts": 1},
+    _DOMAIN_B: {"entities": _B_DATASETS, "dataProducts": 0},
+    _DOMAIN_C: {"entities": 0, "dataProducts": 0},
+}
+
+
+class _FileEmitter:
+    def __init__(self, filename: str) -> None:
+        self.sink: FileSink = FileSink(
+            ctx=PipelineContext(run_id="domain_entities_batching"),
+            config=FileSinkConfig(filename=filename),
+        )
+
+    def emit(self, event) -> None:
+        self.sink.write_record_async(
+            record_envelope=RecordEnvelope(record=event, metadata={}),
+            write_callback=NoopWriteCallback(),
+        )
+
+    def close(self) -> None:
+        self.sink.close()
+
+
+def _dataset_in_domain(
+    name: str, domain_urn: str
+) -> List[MetadataChangeProposalWrapper]:
+    dataset_urn = make_dataset_urn("snowflake", name)
+    return [
+        MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=DatasetPropertiesClass(name=name),
+        ),
+        MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=DomainsClass(domains=[domain_urn]),
+        ),
+    ]
+
+
+def _data_product_in_domain(
+    dp_id: str, domain_urn: str
+) -> List[MetadataChangeProposalWrapper]:
+    dp_urn = make_data_product_urn(dp_id)
+    return [
+        MetadataChangeProposalWrapper(
+            entityUrn=dp_urn,
+            aspect=DataProductPropertiesClass(name=dp_id),
+        ),
+        MetadataChangeProposalWrapper(
+            entityUrn=dp_urn,
+            aspect=DomainsClass(domains=[domain_urn]),
+        ),
+    ]
+
+
+def _build_test_data(filename: str) -> None:
+    mcps: List[MetadataChangeProposalWrapper] = []
+    for urn, label in ((_DOMAIN_A, "A"), (_DOMAIN_B, "B"), (_DOMAIN_C, "C")):
+        mcps.append(
+            MetadataChangeProposalWrapper(
+                entityUrn=urn,
+                aspect=DomainPropertiesClass(name=f"Batching Test {label} {_RUN_ID}"),
+            )
+        )
+
+    for i in range(_A_DATASETS):
+        mcps += _dataset_in_domain(f"batching_a_{_RUN_ID}_{i}", _DOMAIN_A)
+    for i in range(_A_DATA_PRODUCTS):
+        mcps += _data_product_in_domain(f"batching_a_dp_{_RUN_ID}_{i}", _DOMAIN_A)
+    for i in range(_B_DATASETS):
+        mcps += _dataset_in_domain(f"batching_b_{_RUN_ID}_{i}", _DOMAIN_B)
+
+    emitter = _FileEmitter(filename)
+    for mcp in mcps:
+        emitter.emit(mcp)
+    emitter.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ingest_cleanup_data(auth_session, graph_client):
+    _, filename = tempfile.mkstemp(suffix=".json")
+    try:
+        _build_test_data(filename)
+        yield from _ingest_cleanup_data_impl(
+            auth_session, graph_client, filename, "domain_entities_batching"
+        )
+    finally:
+        os.remove(filename)
+
+
+# Mirrors the domainEntitiesFields fragment the frontend issues for a page of
+# domains: count-only (count: 0) entities, plus an _entityType-filtered alias.
+# Fetching all three domains as aliased fields in a SINGLE request coalesces the
+# per-domain .load() calls into one DomainEntityCountsBatchLoader.batchLoad, so
+# this exercises the batched fast path (and per-domain attribution) end to end.
+_COUNTS_FRAGMENT = """
+    urn
+    entities(input: { start: 0, count: 0 }) {
+      total
+    }
+    dataProducts: entities(
+      input: { start: 0, count: 0, filters: [{ field: "_entityType", values: ["DATA_PRODUCT"] }] }
+    ) {
+      total
+    }
+"""
+
+_BATCHED_COUNTS_QUERY = f"""
+query domainEntityCounts($a: String!, $b: String!, $c: String!) {{
+  a: domain(urn: $a) {{ {_COUNTS_FRAGMENT} }}
+  b: domain(urn: $b) {{ {_COUNTS_FRAGMENT} }}
+  c: domain(urn: $c) {{ {_COUNTS_FRAGMENT} }}
+}}
+"""
+
+
+def test_domain_entities_counts_are_batched_and_correct(auth_session):
+    variables: Dict[str, Any] = {
+        "a": _DOMAIN_A,
+        "b": _DOMAIN_B,
+        "c": _DOMAIN_C,
+    }
+
+    @with_test_retry()
+    def check() -> None:
+        res = execute_graphql(auth_session, _BATCHED_COUNTS_QUERY, variables)
+        data = res["data"]
+        actual = {
+            alias: {
+                "urn": data[alias]["urn"],
+                "entities": data[alias]["entities"]["total"],
+                "dataProducts": data[alias]["dataProducts"]["total"],
+            }
+            for alias in ("a", "b", "c")
+        }
+        logger.info(f"batched domain entity counts: {actual}")
+
+        for alias, urn in (("a", _DOMAIN_A), ("b", _DOMAIN_B), ("c", _DOMAIN_C)):
+            expected = _EXPECTED[urn]
+            assert data[alias]["urn"] == urn
+            assert data[alias]["entities"]["total"] == expected["entities"], (
+                f"{urn} entities: expected {expected['entities']}, "
+                f"got {data[alias]['entities']['total']}"
+            )
+            assert data[alias]["dataProducts"]["total"] == expected["dataProducts"], (
+                f"{urn} dataProducts: expected {expected['dataProducts']}, "
+                f"got {data[alias]['dataProducts']['total']}"
+            )
+
+    check()


### PR DESCRIPTION
## Summary

`Domain.entities` is a GraphQL field resolver invoked once per `Domain`, and the frontend `domainEntitiesFields` fragment selects it three times per domain (`entities` / `dataProducts` / `applicationsInDomain`). Listing or searching **N** domains therefore fired **3N** `searchAcrossEntities` calls — a classic N+1 that also multiplied the DB reads each search carries.

This PR collapses the count-only hot path into a fixed number of aggregation-only searches, growing in chunk-sized steps rather than per-domain.

## Changes

- **`DomainEntityCountsBatchLoader`** (new) — a request-scoped `DataLoader` keyed by `(domain, entity-type constraint)`. It groups requests by constraint and answers each group with one aggregation-only search per chunk of domains (`MAX_DOMAINS_PER_AGG = 25`), faceted on the `domains` field (URN bucket keys) with the entity-type constraint applied as a **search filter**, reusing the existing resolver filter semantics. graphql-java coalesces every per-domain `.load(...)` in an execution tick into one `batchLoad`.
- **`DomainEntitiesResolver`** — routes only the fully-safe count-only fast path through the loader: `count = 0`, default query, no resolved View, no caller `searchFlags`, and at most one `_entityType` filter with the default (EQUAL) condition and an explicit (non-null) value list. Everything else — hit-returning pagination, custom queries, the `listRecommendations` View context, `searchFlags`, non-default conditions, or a value-less filter — keeps the original per-domain search (`resolveDirect`), which handles those exactly as before. Nothing that reads `searchResults` can regress.
- Wired the loader into `GmsGraphQLEngine`.

The entity-type constraint is expressed as a search filter rather than an aggregation dimension, so the counts do not depend on the entity-type token format the search layer emits for the raw aggregation.

## Testing

**Unit** — `DomainEntityCountsBatchLoaderTest` (grouping-by-constraint with independent per-constraint attribution, per-domain distribution, ordering/zeroing, off-chunk isolation, failure handling, chunking) and `DomainEntitiesResolverTest` (fast-path routing vs. direct-search fallback, key construction, and fallback for the value-less `_entityType` filter and for `searchFlags`). Full `:datahub-graphql-core:test` suite green.

**Live end-to-end** — locally seeded instance of 42 domains (each with 12–18 datasets + 3 data products), querying `listDomains` with the `domainEntitiesFields` count aliases. "Before" is the per-domain path (`resolveDirect`), "after" is the batched loader, measured on the same build/data. ES search count via the OpenSearch `search.query_total` delta; DB via the MySQL `Com_select` delta.

| Metric | Before (per-domain N+1) | After (batched) | Improvement |
| --- | --- | --- | --- |
| ES searches / request | 3655 | 175 | ~21x fewer |
| DB SELECTs / request | 388 | 28 | ~14x fewer |
| Mean latency | 287 ms | 83 ms | ~3.5x faster |
| p95 latency | 331 ms | 121 ms | ~2.7x faster |

Page-size sweep on the batched build shows ES cost is **flat within a chunk and steps at the 25-domain boundary** (≤25 domains → 3 constraints × 1 chunk; 26–50 → 3 constraints × 2 chunks); 30→42 domains adds zero extra searches, versus the old path's linear 3N.

**Functional correctness — validated per call.** Across page sizes 10/25/30/42 × 20 iterations, every returned domain's `(entities, dataProducts, applications)` triple matched seeded ground truth exactly and every call was deterministic (0 failures across 2100 per-call assertions). The before/after diff confirmed per-domain counts are identical to the previous resolver for all 42 domains, and a value-less `_entityType` filter returns cleanly (no crash) via the direct-path fallback.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [ ] Docs — n/a (internal perf change, no API/behavior change)
- [ ] Breaking changes — none
