### PR TITLE
fix(ingest/unity): always classify metric views with the "Metric View" subtype

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -279,13 +279,15 @@ class UnityCatalogSourceConfig(
     include_metric_views: bool = pydantic.Field(
         default=False,
         description=(
-            "Enable enriched ingestion of Unity Catalog Metric Views: subtype"
-            " 'Metric View', YAML body as ViewProperties, upstream and column-level"
-            " lineage from `source` / `joins` / `dimensions.expr` / `measures.expr`,"
-            " `Dimension` / `Measure` tags on matching columns, `materialization`"
-            " → `ViewProperties.materialized`, and `filter` as a custom property."
-            " Default `false` keeps metric views as plain Tables. Requires a"
-            " `databricks-sdk` recent enough to expose `TableType.METRIC_VIEW`."
+            "Enable enriched ingestion of Unity Catalog Metric Views: YAML body as"
+            " ViewProperties, upstream and column-level lineage from `source` / `joins`"
+            " / `dimensions.expr` / `measures.expr`, `Dimension` / `Measure` tags on"
+            " matching columns, `materialization` → `ViewProperties.materialized`, and"
+            " `filter` as a custom property. Metric views are always assigned the"
+            " 'Metric View' subtype regardless of this flag (they are never plain"
+            " Tables); this flag only controls the additional enrichment above."
+            " Requires a `databricks-sdk` recent enough to expose"
+            " `TableType.METRIC_VIEW`."
         ),
     )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
@@ -2003,7 +2003,13 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
         return None
 
     def _create_table_sub_type_aspect(self, table: Table) -> SubTypesClass:
-        if table.is_metric_view and self.config.include_metric_views:
+        # Classification is always accurate regardless of include_metric_views: a
+        # metric view is a view, never a plain Table. The flag only gates the richer
+        # enrichment (YAML body parsing, lineage, Dimension/Measure tags), not the
+        # sub-type label. Mislabeling a metric view as "Table" breaks downstream
+        # consumers that reason about entity type (e.g. skipping ANALYZE TABLE, which
+        # Databricks rejects on views).
+        if table.is_metric_view:
             type_name = DatasetSubTypes.METRIC_VIEW
         elif table.is_view:
             type_name = DatasetSubTypes.VIEW

--- a/metadata-ingestion/tests/integration/unity/metric_view_flag_off_mces_golden.json
+++ b/metadata-ingestion/tests/integration/unity/metric_view_flag_off_mces_golden.json
@@ -459,7 +459,7 @@
     "aspect": {
         "json": {
             "typeNames": [
-                "Table"
+                "Metric View"
             ]
         }
     },

--- a/metadata-ingestion/tests/unit/test_unity_catalog_source.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_source.py
@@ -902,13 +902,15 @@ class TestUnityCatalogMetricViews:
         )
         assert config.include_metric_views is False
 
-    def test_subtype_flag_off_emits_table(self):
+    def test_subtype_flag_off_still_emits_metric_view(self):
         from datahub.metadata.schema_classes import SubTypesClass
 
+        # Classification is accurate regardless of the enrichment flag: a metric
+        # view is never a plain Table, even when include_metric_views is off.
         source = self._build_source(include_metric_views=False)
         table, _ = self._build_metric_view_table()
         aspect: SubTypesClass = source._create_table_sub_type_aspect(table)
-        assert aspect.typeNames == ["Table"]
+        assert aspect.typeNames == ["Metric View"]
 
     def test_subtype_flag_on_emits_metric_view(self):
         from datahub.metadata.schema_classes import SubTypesClass


### PR DESCRIPTION
## Summary

Unity Catalog **metric views** are only assigned the `Metric View` subtype when `include_metric_views` is enabled. With the flag off (the **default**), a metric view falls through to the plain **`Table`** subtype — even though the connector still emits its `ViewProperties` (view definition). That's inaccurate: a metric view is a view, not a table.

Beyond being wrong metadata, it breaks downstream consumers that reason about entity type. Concretely: assertion evaluation issues `ANALYZE TABLE … COMPUTE STATISTICS` for table-statistics sources, and Databricks rejects that on views (`UNSUPPORTED_FEATURE.ANALYZE_VIEW`). Because the entity was mislabeled a `Table`, nothing upstream (assertion source-type validation, UI) could prevent it.

## What changed

`include_metric_views` conflated two concerns: **recognizing** a metric view (classification) and **enriching** it (YAML body parsing, source/joins/measures lineage, `Dimension`/`Measure` tags). Only the enrichment should be opt-in. This moves the sub-type decision off the flag:

- **`unity/source.py`** — `_create_table_sub_type_aspect` classifies metric views as `Metric View` regardless of `include_metric_views`. All other flag-gated behavior is unchanged.
- **`unity/config.py`** — clarified the field docs: the flag controls enrichment only; metric views are never plain Tables.
- **Tests** — updated the unit test and regenerated the flag-off integration golden. The only golden change is the metric view's sub-type flipping `Table` → `Metric View`; the genuine base table in the fixture is unchanged.

## Behavior change

Databricks/Unity users running with the default `include_metric_views=False` will see existing metric views re-classified from `Table` to `Metric View` on their next ingestion. This is a metadata-accuracy correction. Enrichment (lineage/tags/parsed view body) still requires the flag.

## Checklist

- [x] PR title follows the Contributing Guideline (Conventional Commits)
- [x] Tests added/updated (unit + regenerated integration golden)
- [x] Docs updated (config field description)
- [ ] No breaking change to APIs; metadata re-classification only