### PR TITLE
fix(gms): repair non-binary metadata_aspect_v2 collation in SqlSetup

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/CreateTablesStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/CreateTablesStep.java
@@ -96,6 +96,9 @@ public class CreateTablesStep implements UpgradeStep {
     try (Connection connection = server.dataSource().getConnection()) {
       dbOps.ensureAspectIndexes(connection);
     }
+    try (Connection connection = server.dataSource().getConnection()) {
+      dbOps.ensureAspectTableCollation(connection);
+    }
 
     if (args.createSchemaVersionIndex()) {
       try (Connection connection = server.dataSource().getConnection()) {

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/DatabaseOperations.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/DatabaseOperations.java
@@ -135,6 +135,22 @@ public interface DatabaseOperations {
   default void ensureAspectIndexes(Connection connection) throws SQLException {}
 
   /**
+   * Ensures the {@code metadata_aspect_v2} key columns use a case- and byte-exact collation. On
+   * MySQL, {@code CREATE TABLE} sets {@code utf8mb4_bin} but that only applies to freshly created
+   * tables — a table created by an older/other provisioning path with a case-insensitive collation
+   * (e.g. {@code utf8mb4_general_ci}, {@code utf8mb4_0900_ai_ci}) is never corrected, since {@code
+   * CREATE TABLE IF NOT EXISTS} is a no-op when the table already exists. A case-insensitive
+   * collation makes {@code EbeanAspectDao.getNextVersions} read back rows for URNs that differ only
+   * in case from the request keys, which throws and drops the entire MCP batch on the async
+   * consumer path (silent, intermittent ingestion data loss). This aligns such existing tables with
+   * {@code ALTER TABLE ... CONVERT TO} only when the collation is wrong. Defaults to a no-op
+   * (PostgreSQL's default collation is byte-exact, so it is unaffected).
+   *
+   * @param connection open JDBC connection to the target database
+   */
+  default void ensureAspectTableCollation(Connection connection) throws SQLException {}
+
+  /**
    * Called after table creation to create any indexes that must run outside a transaction (e.g.
    * CONCURRENTLY). Defaults to a no-op.
    *

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/MySqlDatabaseOperations.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/MySqlDatabaseOperations.java
@@ -37,6 +37,13 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MySqlDatabaseOperations implements DatabaseOperations {
 
+  /**
+   * Byte-exact collation required for metadata_aspect_v2 key columns. Matches the DDL in {@link
+   * #createTableSqlStatements} and docker/mysql-setup; a case-insensitive collation breaks
+   * getNextVersions URN matching.
+   */
+  private static final String ASPECT_TABLE_COLLATION = "utf8mb4_bin";
+
   @Override
   public String createIamUserSql(String username, String iamRole) {
     // The iamRole parameter is not used for MySQL (unlike PostgreSQL)
@@ -167,6 +174,39 @@ public class MySqlDatabaseOperations implements DatabaseOperations {
                     + " "
                     + indexColumnListWithParens);
           }
+        }
+      }
+    }
+  }
+
+  @Override
+  public void ensureAspectTableCollation(Connection connection) throws SQLException {
+    // Detect whether the urn/aspect key columns use a case-insensitive collation. Those are
+    // the columns read back by getNextVersions, so a mismatch on either drops MCP batches.
+    // CREATE TABLE IF NOT EXISTS cannot fix an already-existing table, so align it here
+    // (mirrors ensureAspectIndexes).
+    String checkSql =
+        "SELECT COUNT(*) FROM information_schema.columns "
+            + "WHERE table_schema = DATABASE() AND table_name = 'metadata_aspect_v2' "
+            + "AND column_name IN ('urn', 'aspect') "
+            + "AND collation_name IS NOT NULL AND collation_name <> ?";
+    try (PreparedStatement stmt = connection.prepareStatement(checkSql)) {
+      stmt.setString(1, ASPECT_TABLE_COLLATION);
+      try (ResultSet rs = stmt.executeQuery()) {
+        if (rs.next() && rs.getInt(1) > 0) {
+          log.warn(
+              "metadata_aspect_v2 key columns are not {}; converting table charset/collation to "
+                  + "prevent URN case-collision drops in getNextVersions. This may rebuild the "
+                  + "table and can be slow on large datasets.",
+              ASPECT_TABLE_COLLATION);
+          try (Statement alterStmt = connection.createStatement()) {
+            alterStmt.execute(
+                "ALTER TABLE metadata_aspect_v2 CONVERT TO CHARACTER SET utf8mb4 COLLATE "
+                    + ASPECT_TABLE_COLLATION);
+          }
+          log.info("Converted metadata_aspect_v2 to utf8mb4 / {}", ASPECT_TABLE_COLLATION);
+        } else {
+          log.info("metadata_aspect_v2 key columns already use {}", ASPECT_TABLE_COLLATION);
         }
       }
     }

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/DatabaseOperationsTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/DatabaseOperationsTest.java
@@ -245,6 +245,35 @@ public class DatabaseOperationsTest {
   }
 
   @Test
+  public void testMysqlEnsureAspectTableCollationConvertsWhenWrong() throws SQLException {
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true);
+    // One or more key columns use a non-utf8mb4_bin collation.
+    when(mockResultSet.getInt(1)).thenReturn(1);
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+
+    mysqlOps.ensureAspectTableCollation(mockConnection);
+
+    verify(mockStatement)
+        .execute(
+            "ALTER TABLE metadata_aspect_v2 CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin");
+  }
+
+  @Test
+  public void testMysqlEnsureAspectTableCollationSkipsWhenCorrect() throws SQLException {
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true);
+    // All key columns already utf8mb4_bin -> the "wrong collation" count is zero.
+    when(mockResultSet.getInt(1)).thenReturn(0);
+
+    mysqlOps.ensureAspectTableCollation(mockConnection);
+
+    verify(mockConnection, never()).createStatement();
+  }
+
+  @Test
   public void testPostgresPostSetupDropsInvalidIndexThenCreates() throws SQLException {
     // Simulate pg_index returning a row (invalid index exists)
     when(mockConnection.prepareStatement(org.mockito.ArgumentMatchers.anyString()))


### PR DESCRIPTION
## Summary

`ASYNC_BATCH` managed ingestion can finish `SUCCESS` (sink reports records written, `failures: []`) while the entities **never materialize** in GMS — intermittent, silent data loss. Re-running the identical payload with `mode: SYNC` materializes everything.

### Root cause

When `metadata_aspect_v2` is created with a **case-insensitive collation** (e.g. `utf8mb4_general_ci`, `utf8mb4_0900_ai_ci`) instead of `utf8mb4_bin`, the batch read-back in `EbeanAspectDao.getNextVersions` (`WHERE urn IN (...)`) returns rows for URNs that differ only in case from the request keys. `mergeNextVersionsFromDb` then can't find those keys in the request-keyed map, throws `IllegalStateException: URN or aspect from database did not match request keys`, and `BatchMetadataChangeProposalsProcessor.processBatch` dead-letters the **entire batch** to the FMCP topic — *after* the async sink already ack'd at Kafka-produce time. `SYNC` works because it skips that batch read-back.

Observed signature (`datahub-mce-consumer`):

```
ERROR com.linkedin.metadata.kafka.batch.BatchMetadataChangeProposalsProcessor - MCP Processor Error
java.lang.IllegalStateException: URN or aspect from database did not match request keys ...
```

### Why #16542 didn't cover it

#16542 aligned the `SqlSetup` DDL to `CHARACTER SET utf8mb4 COLLATE utf8mb4_bin`, but that only applies to **freshly created** tables. `CREATE TABLE IF NOT EXISTS` is a no-op on an existing table, so a database already provisioned with the wrong collation is never corrected, and nothing detects it.

### Fix

Add `DatabaseOperations.ensureAspectTableCollation()`, mirroring the existing `ensureAspectIndexes()` precedent that aligns already-existing tables during `SqlSetup`:

- **MySQL:** detect a non-`utf8mb4_bin` collation on the `urn`/`aspect` key columns via `information_schema`, and only when wrong, self-heal with `ALTER TABLE metadata_aspect_v2 CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin`, logging a `WARN` about the potential table rebuild.
- **PostgreSQL:** default no-op (its default collation is byte-exact).
- Wired into `CreateTablesStep` right after `ensureAspectIndexes`.

### Operational notes

- Existing misprovisioned databases are repaired by running `datahub-upgrade SqlSetup`; GMS boot alone does not trigger it.
- The collation repair does **not** recover already-dropped MCPs — affected runs must be re-ingested (or replayed from the FMCP topic) after the `ALTER`.

### Out of scope

The batch processor dead-lettering the *whole* batch when a single key fails (co-batched good MCPs become collateral damage) is a separate, riskier change and is left for a follow-up.

## Testing

- `./gradlew :datahub-upgrade:test --tests "*DatabaseOperationsTest"` — 30 tests pass, incl. two new (`...ConvertsWhenWrong`, `...SkipsWhenCorrect`).
- `./gradlew :datahub-upgrade:spotlessJavaCheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
