### PR TITLE
fix(zdu): handle missing index case

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStep.java
@@ -153,56 +153,66 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
               && existingStatus.get() == IncrementalReindexState.Status.IN_PROGRESS
               && existingNextIndex.isPresent()
               && !existingNextIndex.get().isEmpty()) {
-            log.info("Resuming polling for index {} -> {}", config.name(), existingNextIndex.get());
-            int targetShards = ESIndexBuilder.extractTargetShards(config);
-            long persistedSourceDocCount =
-                IncrementalReindexState.get(
-                        upgradeState, config.name(), IncrementalReindexState.SOURCE_DOC_COUNT)
-                    .map(Long::parseLong)
-                    .orElse(0L);
-            String persistedTaskId =
-                IncrementalReindexState.get(
-                        upgradeState, config.name(), IncrementalReindexState.TASK_ID)
-                    .orElse("");
-            // On resume, reindexInfo from the original submission is not available — use empty map.
-            // Stall-retry will re-submit with fresh optimal settings if needed.
-            ESIndexBuilder.PollReindexResult pollResult =
-                indexBuilder.pollReindexCompletion(
-                    opContext,
-                    config.name(),
-                    existingNextIndex.get(),
-                    () -> persistedSourceDocCount,
-                    targetShards,
-                    new HashMap<>(),
-                    persistedTaskId);
-            upgradeState =
-                handlePollResult(
-                    context,
-                    upgradeState,
-                    config.name(),
-                    existingNextIndex.get(),
-                    indexBuilder,
-                    pollResult.completed());
-            if (!pollResult.completed()) {
-              return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.FAILED);
-            }
-            // Restore settings after successful resume
-            indexBuilder.undoReindexOptimalSettings(
-                opContext, existingNextIndex.get(), config, pollResult.latestReindexInfo());
 
-            // Swap alias to next index so new code reads from the updated schema
-            boolean swapped =
-                indexBuilder.validateAndSwapAlias(
-                    opContext, config.name(), existingNextIndex.get());
-            if (!swapped) {
-              log.error(
-                  "Alias swap failed for {} -> {} after resume: doc count mismatch",
-                  config.name(),
-                  existingNextIndex.get());
-              return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.FAILED);
+            if (!indexBuilder.indexExists(opContext, existingNextIndex.get())) {
+              log.warn(
+                  "Target index {} for resume of {} no longer exists in Elasticsearch."
+                      + " Resetting state and restarting reindex from scratch.",
+                  existingNextIndex.get(),
+                  config.name());
+            } else {
+              log.info(
+                  "Resuming polling for index {} -> {}", config.name(), existingNextIndex.get());
+              int targetShards = ESIndexBuilder.extractTargetShards(config);
+              long persistedSourceDocCount =
+                  IncrementalReindexState.get(
+                          upgradeState, config.name(), IncrementalReindexState.SOURCE_DOC_COUNT)
+                      .map(Long::parseLong)
+                      .orElse(0L);
+              String persistedTaskId =
+                  IncrementalReindexState.get(
+                          upgradeState, config.name(), IncrementalReindexState.TASK_ID)
+                      .orElse("");
+              // On resume, reindexInfo from the original submission is not available — use empty
+              // map. Stall-retry will re-submit with fresh optimal settings if needed.
+              ESIndexBuilder.PollReindexResult pollResult =
+                  indexBuilder.pollReindexCompletion(
+                      opContext,
+                      config.name(),
+                      existingNextIndex.get(),
+                      () -> persistedSourceDocCount,
+                      targetShards,
+                      new HashMap<>(),
+                      persistedTaskId);
+              upgradeState =
+                  handlePollResult(
+                      context,
+                      upgradeState,
+                      config.name(),
+                      existingNextIndex.get(),
+                      indexBuilder,
+                      pollResult.completed());
+              if (!pollResult.completed()) {
+                return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.FAILED);
+              }
+              // Restore settings after successful resume
+              indexBuilder.undoReindexOptimalSettings(
+                  opContext, existingNextIndex.get(), config, pollResult.latestReindexInfo());
+
+              // Swap alias to next index so new code reads from the updated schema
+              boolean swapped =
+                  indexBuilder.validateAndSwapAlias(
+                      opContext, config.name(), existingNextIndex.get());
+              if (!swapped) {
+                log.error(
+                    "Alias swap failed for {} -> {} after resume: doc count mismatch",
+                    config.name(),
+                    existingNextIndex.get());
+                return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.FAILED);
+              }
+              log.info("Alias swapped: {} -> {}", config.name(), existingNextIndex.get());
+              continue;
             }
-            log.info("Alias swapped: {} -> {}", config.name(), existingNextIndex.get());
-            continue;
           }
 
           // Fresh start for this index

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStepTest.java
@@ -78,6 +78,7 @@ public class BuildIndicesIncrementalStepTest {
         .thenReturn(Set.of("datasetindex_v2_old"));
     when(indexBuilder.validateAndSwapAlias(any(OperationContext.class), anyString(), anyString()))
         .thenReturn(true);
+    when(indexBuilder.indexExists(any(OperationContext.class), anyString())).thenReturn(true);
 
     step =
         new BuildIndicesIncrementalStep(
@@ -268,6 +269,75 @@ public class BuildIndicesIncrementalStepTest {
             any(OperationContext.class), eq(NEXT_INDEX_NAME), any(ReindexConfig.class), anyMap());
     verify(indexBuilder)
         .validateAndSwapAlias(any(OperationContext.class), eq(INDEX_NAME), eq(NEXT_INDEX_NAME));
+  }
+
+  @Test
+  public void testResumeRestartsFromScratchWhenTargetIndexMissing() throws Throwable {
+    // Simulate previous state with IN_PROGRESS, but the target index no longer exists in ES.
+    // This happens when an instance is paused for an extended period and ES cleanup removes
+    // the partially-populated target index. The step should fall through to the fresh-start
+    // path instead of throwing index_not_found_exception in pollReindexCompletion.
+    Map<String, String> previousState =
+        IncrementalReindexState.setPhase1State(
+            null,
+            INDEX_NAME,
+            NEXT_INDEX_NAME,
+            "datasetindex_v2_old",
+            1679000000000L,
+            500L,
+            "task-abc",
+            true,
+            IncrementalReindexState.Status.IN_PROGRESS);
+
+    DataHubUpgradeResult upgradeResult = mock(DataHubUpgradeResult.class);
+    when(upgradeResult.getResult()).thenReturn(new StringMap(previousState));
+    when(upgrade.getUpgradeResult(any(), any(), any())).thenReturn(Optional.of(upgradeResult));
+
+    // Target index is missing
+    when(indexBuilder.indexExists(any(OperationContext.class), eq(NEXT_INDEX_NAME)))
+        .thenReturn(false);
+
+    // Wire up the fresh-start path that the code should fall through to
+    String freshNextIndex = "datasetindex_v2_0_14_0-0_1679999999999";
+    IncrementalReindexResult freshResult =
+        new IncrementalReindexResult(
+            freshNextIndex, 1679999999999L, "task-fresh", false, 2, 500L, Map.of());
+    when(indexBuilder.buildIndexIncremental(
+            any(OperationContext.class), any(), eq(UPGRADE_VERSION)))
+        .thenReturn(freshResult);
+
+    PollReindexResult pollResult = new PollReindexResult(true, Map.of(), Pair.of(500L, 500L));
+    when(indexBuilder.pollReindexCompletion(
+            any(OperationContext.class),
+            eq(INDEX_NAME),
+            eq(freshNextIndex),
+            any(),
+            anyInt(),
+            anyMap(),
+            eq("task-fresh")))
+        .thenReturn(pollResult);
+    when(indexBuilder.validateAndSwapAlias(
+            any(OperationContext.class), eq(INDEX_NAME), eq(freshNextIndex)))
+        .thenReturn(true);
+
+    UpgradeStepResult result = step.executable().apply(upgradeContext);
+
+    assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
+    // Should NOT have attempted to resume polling on the missing index
+    verify(indexBuilder, never())
+        .pollReindexCompletion(
+            any(OperationContext.class),
+            any(),
+            eq(NEXT_INDEX_NAME),
+            any(),
+            anyInt(),
+            anyMap(),
+            anyString());
+    // Should have started fresh
+    verify(indexBuilder)
+        .buildIndexIncremental(any(OperationContext.class), any(), eq(UPGRADE_VERSION));
+    verify(indexBuilder)
+        .validateAndSwapAlias(any(OperationContext.class), eq(INDEX_NAME), eq(freshNextIndex));
   }
 
   @Test


### PR DESCRIPTION
Handles scenarios where a partial reindex occurs and the index noted by the reindex state has been removed by some outside process. 
