### PR TITLE
fix(metrics): fix lineage module controls and EntityEdge hydration

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -1619,6 +1619,13 @@ public class GmsGraphQLEngine {
   private void configureGenericEntityResolvers(final RuntimeWiring.Builder builder) {
     builder
         .type(
+            "EntityEdge",
+            typeWiring ->
+                typeWiring.dataFetcher(
+                    "destination",
+                    new EntityTypeResolver(
+                        entityTypes, (env) -> ((EntityEdge) env.getSource()).getDestination())))
+        .type(
             "SearchResult",
             typeWiring ->
                 typeWiring.dataFetcher(

--- a/datahub-web-react/src/app/entityV2/metric/MetricEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/metric/MetricEntity.tsx
@@ -16,6 +16,7 @@ import { SidebarGlossaryTermsSection } from '@app/entityV2/shared/containers/pro
 import { SidebarTagsSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarTagsSection';
 import { getDataForEntityType } from '@app/entityV2/shared/containers/profile/utils';
 import SidebarStructuredProperties from '@app/entityV2/shared/sidebarSection/SidebarStructuredProperties';
+import { LineageTab } from '@app/entityV2/shared/tabs/Lineage/LineageTab';
 import { PropertiesTab } from '@app/entityV2/shared/tabs/Properties/PropertiesTab';
 import { EntityTab } from '@app/entityV2/shared/types';
 import SummaryTab from '@app/entityV2/summary/SummaryTab';
@@ -96,6 +97,10 @@ export class MetricEntity implements Entity<Metric> {
                 properties: {
                     hideEditDescription: true,
                 },
+            },
+            {
+                name: i18next.t('entity.types:tab.lineage'),
+                component: LineageTab,
             },
             {
                 name: i18next.t('entity.types:tab.properties', 'Properties'),

--- a/datahub-web-react/src/app/entityV2/semanticModel/SemanticModelEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/semanticModel/SemanticModelEntity.tsx
@@ -125,6 +125,10 @@ export class SemanticModelEntity implements Entity<SemanticModel> {
                 component: DefinitionTab,
             },
             {
+                name: i18next.t('entity.types:tab.lineage'),
+                component: LineageTab,
+            },
+            {
                 name: i18next.t('entity.types:tab.properties', 'Properties'),
                 component: PropertiesTab,
             },

--- a/datahub-web-react/src/app/entityV2/summary/modules/lineage/LineageModule.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/modules/lineage/LineageModule.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router';
 
 import { useEntityData } from '@app/entity/shared/EntityContext';
+import { getEntityPath } from '@app/entityV2/shared/containers/profile/utils';
 import LargeModule from '@app/homeV3/module/components/LargeModule';
 import { ModuleProps } from '@app/homeV3/module/types';
 import LineageExplorer from '@app/lineageV3/LineageExplorer';
@@ -16,7 +17,7 @@ export default function LineageModule(props: ModuleProps) {
     const entityRegistry = useEntityRegistryV2();
 
     const navigateToLineageTab = () => {
-        history.push(`${entityRegistry.getEntityUrl(entityType, urn)}/Lineage`);
+        history.push(getEntityPath(entityType, urn, entityRegistry, false, false, 'Lineage'));
     };
     return (
         <LargeModule

--- a/datahub-web-react/src/app/lineageV3/initialize/ImpactAnalysisNodeInitializer.tsx
+++ b/datahub-web-react/src/app/lineageV3/initialize/ImpactAnalysisNodeInitializer.tsx
@@ -2,9 +2,11 @@ import React, { useContext } from 'react';
 import { ReactFlowProvider } from 'reactflow';
 
 import LineageDisplay from '@app/lineageV3/LineageDisplay';
+import LineageGraphContext from '@app/lineageV3/LineageGraphContext';
 import { FetchStatus, LINEAGE_FILTER_PAGINATION, LineageEntity, LineageNodesContext } from '@app/lineageV3/common';
 import useResetLineageGraph from '@app/lineageV3/initialize/useResetLineageGraph';
 import useSearchAcrossLineage from '@app/lineageV3/queries/useSearchAcrossLineage';
+import { MODULE_VIEW_MAX_PER_LEVEL } from '@app/lineageV3/useComputeGraph/computeImpactAnalysisGraph';
 
 import { EntityType, LineageDirection } from '@types';
 
@@ -29,7 +31,9 @@ export default function ImpactAnalysisNodeInitializer(props: Props) {
  */
 function useInitializeNodes(urn: string, type: EntityType): boolean {
     const context = useContext(LineageNodesContext);
-    useResetLineageGraph(context, urn, type, () => makeInitialNode(urn, type));
+    const { isModuleView } = useContext(LineageGraphContext);
+    const initialLimit = isModuleView ? MODULE_VIEW_MAX_PER_LEVEL : LINEAGE_FILTER_PAGINATION;
+    useResetLineageGraph(context, urn, type, () => makeInitialNode(urn, type, initialLimit));
 
     const { processed: upstreamProcessed } = useSearchAcrossLineage(urn, type, context, LineageDirection.Upstream);
     const { processed: downstreamProcessed } = useSearchAcrossLineage(urn, type, context, LineageDirection.Downstream);
@@ -37,7 +41,7 @@ function useInitializeNodes(urn: string, type: EntityType): boolean {
     return upstreamProcessed && downstreamProcessed;
 }
 
-function makeInitialNode(urn: string, type: EntityType): LineageEntity {
+function makeInitialNode(urn: string, type: EntityType, limit: number): LineageEntity {
     return {
         id: urn,
         urn,
@@ -51,8 +55,8 @@ function makeInitialNode(urn: string, type: EntityType): LineageEntity {
             [LineageDirection.Downstream]: FetchStatus.LOADING,
         },
         filters: {
-            [LineageDirection.Upstream]: { limit: LINEAGE_FILTER_PAGINATION, facetFilters: new Map() },
-            [LineageDirection.Downstream]: { limit: LINEAGE_FILTER_PAGINATION, facetFilters: new Map() },
+            [LineageDirection.Upstream]: { limit, facetFilters: new Map() },
+            [LineageDirection.Downstream]: { limit, facetFilters: new Map() },
         },
     };
 }

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/computeImpactAnalysisGraph.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/computeImpactAnalysisGraph.ts
@@ -13,6 +13,32 @@ import { LevelsInfo } from '@app/lineageV3/useComputeGraph/limitNodes/limitNodes
 
 import { EntityType, LineageDirection } from '@types';
 
+/** Default cap for module-view preview density when filters have not been expanded. */
+export const MODULE_VIEW_MAX_PER_LEVEL = 2;
+
+/**
+ * Module view applies a per-level node cap after pagination. That cap must be at least as large as
+ * the root node's filter limits, otherwise Show More / Show All update the badge but never reveal
+ * nodes. Only the root is considered so default child filter limits (LINEAGE_FILTER_PAGINATION)
+ * do not inflate the compact module preview.
+ */
+export function getModuleViewMaxPerLevel(nodes: NodeContext['nodes'], rootUrn: string): number {
+    let maxPerLevel = MODULE_VIEW_MAX_PER_LEVEL;
+    const root = nodes.get(rootUrn);
+    if (!root) {
+        return maxPerLevel;
+    }
+    const upstreamLimit = root.filters?.[LineageDirection.Upstream]?.limit;
+    const downstreamLimit = root.filters?.[LineageDirection.Downstream]?.limit;
+    if (typeof upstreamLimit === 'number') {
+        maxPerLevel = Math.max(maxPerLevel, upstreamLimit);
+    }
+    if (typeof downstreamLimit === 'number') {
+        maxPerLevel = Math.max(maxPerLevel, downstreamLimit);
+    }
+    return maxPerLevel;
+}
+
 /**
  * Computes an "impact analysis" graph, which shows the upstream and downstream entities of a given entity.
  *
@@ -46,10 +72,11 @@ export default function computeImpactAnalysisGraph(
     isModuleView?: boolean,
     showFilterNodes = true,
 ) {
-    const { adjacencyList, rootType, hideTransformations } = context;
+    const { adjacencyList, rootType, hideTransformations, nodes } = context;
 
     let levelsInfo: LevelsInfo = {};
     let levelsMap = new Map<string, number>();
+    const moduleMaxPerLevel = isModuleView ? getModuleViewMaxPerLevel(nodes, urn) : MODULE_VIEW_MAX_PER_LEVEL;
     // Limit entity nodes per level in module view
     const transformDisplayedNodes = isModuleView
         ? (displayedNodes: LineageNode[]) => {
@@ -58,7 +85,7 @@ export default function computeImpactAnalysisGraph(
                   rootUrn: urn,
                   rootType,
                   adjacencyList,
-                  maxPerLevel: 2,
+                  maxPerLevel: moduleMaxPerLevel,
               });
               levelsInfo = result.levelsInfo;
               levelsMap = result.levelsMap;


### PR DESCRIPTION
## Summary
- "View in Lineage" on Semantic Model / Metric summary modules routes to the profile Lineage tab via `getEntityPath`.
- Make Show All / Show More / Show Less work in the summary Lineage module by syncing module-view per-level caps with the root filter limit.
- Hydrate `EntityEdge.destination` via `EntityTypeResolver` so `getMetric` no longer fails on `metricUpstreams.datasetUpstreams.destination.name` / `platform` NPEs.
- Add Lineage profile tabs for Metric and Semantic Model entities.

Port of [acryldata/datahub-fork#11042](https://github.com/acryldata/datahub-fork/pull/11042).

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

## Test plan
- [ ] On a Metric / Semantic Model profile, confirm "View in Lineage" from the summary Lineage module opens the Lineage tab
- [ ] In the summary Lineage module, confirm Show More / Show All / Show Less reveal and hide nodes correctly
- [ ] Confirm `getMetric` GraphQL queries that request `metricUpstreams.datasetUpstreams.destination { name platform { name } }` succeed

Made with [Cursor](https://cursor.com)