### PR TITLE
test(e2e): Attempt to fix domain + edit docs flakes

### DIFF
--- a/e2e-test/ui/playwright/pages/domains/domain-entity.page.ts
+++ b/e2e-test/ui/playwright/pages/domains/domain-entity.page.ts
@@ -94,7 +94,10 @@ export class DomainEntityPage extends BasePage {
   }
 
   private getOwnerOption(displayName: string): Locator {
-    return this.page.getByTestId(/^option-/).filter({ hasText: displayName });
+    // Exact, case-insensitive match — substring matching can hit multiple options
+    // (e.g. searching "datahub" also matches a group named "DataHub SE Team").
+    const escaped = displayName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return this.page.getByTestId(/^option-/).filter({ hasText: new RegExp(`^${escaped}$`, 'i') });
   }
 
   private getEditableContainer(): Locator {

--- a/e2e-test/ui/playwright/tests/mutations/edit-documentation.spec.ts
+++ b/e2e-test/ui/playwright/tests/mutations/edit-documentation.spec.ts
@@ -10,6 +10,7 @@
 
 import { test, expect } from '../../fixtures/base-test';
 import { EntityDocumentationPage } from '../../pages/entity-documentation.page';
+import { TIMEOUTS } from '../../utils/constants';
 
 test.use({ featureName: 'mutations' });
 
@@ -28,12 +29,17 @@ test.describe('edit documentation and link to dataset', () => {
 
     await docPage.navigateToDatasetSchemaTab(DATASET_URN);
     await docPage.editFieldDescription('field_foo', documentationEdited);
-    await expect(page.getByText(documentationEdited).first()).toBeVisible();
-    await expect(page.getByText('(edited)')).toBeVisible();
+    // editFieldDescription only waits for the "Updated!" toast (mutation accepted); the
+    // schema table still needs to refetch and re-render, which can lag under load —
+    // use a generous timeout rather than the 5s default.
+    await expect(page.getByText(documentationEdited).first()).toBeVisible({ timeout: TIMEOUTS.LONG });
+    await expect(page.getByText('(edited)')).toBeVisible({ timeout: TIMEOUTS.LONG });
 
     // Restore original description
     await docPage.editFieldDescription('field_foo', 'Foo field description has changed');
-    await expect(page.getByText('Foo field description has changed').first()).toBeVisible();
-    await expect(page.getByText('(edited)')).toBeVisible();
+    await expect(page.getByText('Foo field description has changed').first()).toBeVisible({
+      timeout: TIMEOUTS.LONG,
+    });
+    await expect(page.getByText('(edited)')).toBeVisible({ timeout: TIMEOUTS.LONG });
   });
 });


### PR DESCRIPTION
Saw the following flakes:
```
  1 flaky
    [chromium] › tests/domains-v2/v2-domains-advanced.spec.ts:93:7 › Domains V2 Advanced Functionality › Verify Add owner to domain 

  1 flaky
    [chromium] › tests/mutations/edit-documentation.spec.ts:25:7 › edit documentation and link to dataset › edit field documentation 
```
Attempting to fix

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
