### PR TITLE
fix(ingest/dbt): emit platform-instance aspects for target siblings

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -577,15 +577,9 @@ class DBTCommonConfig(
     emit_target_platform_instance_aspects: bool = Field(
         default=True,
         description="When target_platform_instance is set, emit dataPlatformInstance and "
-        "browsePathsV2 aspects for target-platform sibling entities. Without these, a "
-        "target entity that is never ingested directly by the warehouse connector is "
-        "auto-created by the server with a platform-only dataPlatformInstance and a "
-        "name-derived browse path, which surfaces as a duplicate plain-name navigation "
-        "folder and hides the entity from platform-instance filters. browsePathsV2 is "
-        "only written when a DataHub graph connection is available and the entity's "
-        "existing browse path is missing or is a plain name-derived default; "
-        "container-based browse paths written by the warehouse connector are never "
-        "overwritten.",
+        "browsePathsV2 aspects for target-platform sibling entities so they are correctly "
+        "grouped under their platform instance in browse and filters. Browse paths written "
+        "by the warehouse connector are never overwritten.",
     )
     use_identifiers: bool = Field(
         default=False,
@@ -3000,12 +2994,10 @@ class DBTSourceBase(StatefulIngestionSourceBase):
                         for mcp in target_patch.build()
                     )
 
-                # Emit platform-instance metadata for the target entity. If the
-                # target entity is never ingested directly by the warehouse
-                # connector, the server auto-creates it with a platform-only
-                # dataPlatformInstance and a name-derived browse path, which
-                # surfaces as a duplicate plain-name navigation folder and hides
-                # the entity from platform-instance filters.
+                # Deliberately NOT gated by _should_create_sibling_relationships:
+                # lineage emission below also auto-creates target entities, so
+                # these aspects are needed whenever the target URN is referenced,
+                # not only when this source emits the sibling patch itself.
                 for mcp in self._create_target_platform_instance_mcps(
                     node, node_datahub_urn
                 ):
@@ -3081,6 +3073,12 @@ class DBTSourceBase(StatefulIngestionSourceBase):
             ),
         )
 
+        # With neither database nor schema we would emit a single-entry path,
+        # flattening the entity directly under the instance folder; the
+        # server's name-derived default is at least as good, so skip.
+        if node.database is None and node.schema is None:
+            return
+
         if self._should_write_target_browse_path(node_datahub_urn):
             path = [BrowsePathEntryClass(id=instance_urn, urn=instance_urn)]
             for segment in (node.database, node.schema):
@@ -3099,6 +3097,14 @@ class DBTSourceBase(StatefulIngestionSourceBase):
         entity has no browse path yet or carries a plain name-derived default
         (server-generated for auto-created stub entities). Without a graph
         connection we cannot distinguish the two, so we skip the write.
+
+        The first-entry discriminator works because every non-default writer
+        produces a URN first entry: the warehouse connectors' auto_browse_path_v2
+        emits a platform-instance or container URN, and the server's default
+        generation post datahub-project/datahub#17263 resolves the first segment
+        to a dataPlatformInstance URN when one exists. Only pre-#17263
+        server-generated defaults have a plain-name first entry, and those are
+        exactly the paths this method is meant to replace.
         """
         graph = self.ctx.graph
         if graph is None:
@@ -3106,8 +3112,12 @@ class DBTSourceBase(StatefulIngestionSourceBase):
         try:
             existing = graph.get_aspect(node_datahub_urn, BrowsePathsV2Class)
         except Exception as e:
-            logger.debug(
-                f"Skipping browsePathsV2 for {node_datahub_urn}: failed to read existing aspect: {e}"
+            self.report.warning(
+                title="Failed to read existing browse path",
+                message="Could not determine whether the entity's browse path is "
+                "safe to replace; skipping browsePathsV2 emission for this entity.",
+                context=node_datahub_urn,
+                exc=e,
             )
             return False
         if existing is None or not existing.path:

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -104,6 +104,8 @@ from datahub.metadata.com.linkedin.pegasus2avro.schema import (
 )
 from datahub.metadata.schema_classes import (
     AuditStampClass,
+    BrowsePathEntryClass,
+    BrowsePathsV2Class,
     ChangeAuditStampsClass,
     DashboardInfoClass,
     DataPlatformInstanceClass,
@@ -571,6 +573,19 @@ class DBTCommonConfig(
     target_platform_instance: Optional[str] = Field(
         default=None,
         description="The platform instance for the platform that dbt is operating on. Use this if you have multiple instances of the same platform (e.g. redshift) and need to distinguish between them.",
+    )
+    emit_target_platform_instance_aspects: bool = Field(
+        default=True,
+        description="When target_platform_instance is set, emit dataPlatformInstance and "
+        "browsePathsV2 aspects for target-platform sibling entities. Without these, a "
+        "target entity that is never ingested directly by the warehouse connector is "
+        "auto-created by the server with a platform-only dataPlatformInstance and a "
+        "name-derived browse path, which surfaces as a duplicate plain-name navigation "
+        "folder and hides the entity from platform-instance filters. browsePathsV2 is "
+        "only written when a DataHub graph connection is available and the entity's "
+        "existing browse path is missing or is a plain name-derived default; "
+        "container-based browse paths written by the warehouse connector are never "
+        "overwritten.",
     )
     use_identifiers: bool = Field(
         default=False,
@@ -2985,6 +3000,17 @@ class DBTSourceBase(StatefulIngestionSourceBase):
                         for mcp in target_patch.build()
                     )
 
+                # Emit platform-instance metadata for the target entity. If the
+                # target entity is never ingested directly by the warehouse
+                # connector, the server auto-creates it with a platform-only
+                # dataPlatformInstance and a name-derived browse path, which
+                # surfaces as a duplicate plain-name navigation folder and hides
+                # the entity from platform-instance filters.
+                for mcp in self._create_target_platform_instance_mcps(
+                    node, node_datahub_urn
+                ):
+                    yield mcp.as_workunit(is_primary_source=False)
+
                 # This code block is run when we are generating entities of platform type.
                 # We will not link the platform not to the dbt node for type "source" because
                 # in this case the platform table existed first.
@@ -3025,6 +3051,69 @@ class DBTSourceBase(StatefulIngestionSourceBase):
                     message="Failed to emit target-platform metadata for this node; some or all of its workunits may be missing.",
                     kind="emission",
                 )
+
+    def _create_target_platform_instance_mcps(
+        self,
+        node: DBTNode,
+        node_datahub_urn: str,
+    ) -> Iterable[MetadataChangeProposalWrapper]:
+        """Emit dataPlatformInstance (and, when safe, browsePathsV2) for a target entity.
+
+        Only active when target_platform_instance is configured. The
+        dataPlatformInstance value is identical to what the warehouse connector
+        writes for the same entity, so the upsert is a no-op for entities the
+        warehouse connector owns and a fix for sibling-only "stub" entities.
+        """
+        if not self.config.target_platform_instance:
+            return
+        if not self.config.emit_target_platform_instance_aspects:
+            return
+
+        platform_urn = mce_builder.make_data_platform_urn(self.config.target_platform)
+        instance_urn = mce_builder.make_dataplatform_instance_urn(
+            platform_urn, self.config.target_platform_instance
+        )
+        yield MetadataChangeProposalWrapper(
+            entityUrn=node_datahub_urn,
+            aspect=DataPlatformInstanceClass(
+                platform=platform_urn,
+                instance=instance_urn,
+            ),
+        )
+
+        if self._should_write_target_browse_path(node_datahub_urn):
+            path = [BrowsePathEntryClass(id=instance_urn, urn=instance_urn)]
+            for segment in (node.database, node.schema):
+                if segment:
+                    path.append(BrowsePathEntryClass(id=segment))
+            yield MetadataChangeProposalWrapper(
+                entityUrn=node_datahub_urn,
+                aspect=BrowsePathsV2Class(path=path),
+            )
+
+    def _should_write_target_browse_path(self, node_datahub_urn: str) -> bool:
+        """Whether it is safe to write a browsePathsV2 aspect for a target entity.
+
+        The warehouse connector is authoritative for browse paths of entities it
+        ingests (container-based, entries are URNs). Overwrite only when the
+        entity has no browse path yet or carries a plain name-derived default
+        (server-generated for auto-created stub entities). Without a graph
+        connection we cannot distinguish the two, so we skip the write.
+        """
+        graph = self.ctx.graph
+        if graph is None:
+            return False
+        try:
+            existing = graph.get_aspect(node_datahub_urn, BrowsePathsV2Class)
+        except Exception as e:
+            logger.debug(
+                f"Skipping browsePathsV2 for {node_datahub_urn}: failed to read existing aspect: {e}"
+            )
+            return False
+        if existing is None or not existing.path:
+            return True
+        first_entry_id = existing.path[0].id
+        return not first_entry_id.startswith("urn:")
 
     def extract_query_tag_aspects(
         self,

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_with_target_platform_instance_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_with_target_platform_instance_mces_golden.json
@@ -1,5852 +1,6107 @@
 [
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "Model"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "proposedSnapshot": {
-            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-                "aspects": [
-                    {
-                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                            "customProperties": {
-                                "owner": "@alice2",
-                                "business_owner": "jdoe.last@gmail.com",
-                                "data_governance.team_owner": "Finance",
-                                "has_pii": "True",
-                                "int_property": "1",
-                                "double_property": "2.5",
-                                "node_type": "model",
-                                "materialization": "ephemeral",
-                                "dbt_file_path": "models/transform/customer_details.sql",
-                                "language": "sql",
-                                "dbt_unique_id": "model.sample_dbt.customer_details",
-                                "dbt_package_name": "sample_dbt",
-                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                                "manifest_version": "0.19.1",
-                                "manifest_adapter": "postgres",
-                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                                "catalog_version": "0.19.1"
-                            },
-                            "name": "customer_details",
-                            "description": "",
-                            "tags": [
-                                "dbt:test_tag"
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Status": {
-                            "removed": false
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Ownership": {
-                            "owners": [
-                                {
-                                    "owner": "urn:li:corpuser:@alice2",
-                                    "type": "DATAOWNER"
-                                }
-                            ],
-                            "ownerTypes": {},
-                            "lastModified": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            }
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.GlobalTags": {
-                            "tags": [
-                                {
-                                    "tag": "urn:li:tag:dbt:test_tag"
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                            "schemaName": "model.sample_dbt.customer_details",
-                            "platform": "urn:li:dataPlatform:dbt",
-                            "version": 0,
-                            "created": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "lastModified": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "hash": "",
-                            "platformSchema": {
-                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                    "tableSchema": ""
-                                }
-                            },
-                            "fields": [
-                                {
-                                    "fieldPath": "customer_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "INT",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "full_name",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "VARCHAR",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "email",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "TEXT",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "address",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "TEXT",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "city",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "TEXT",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "postal_code",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "TEXT",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "phone",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "TEXT",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                            "upstreams": [
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-                                    "type": "TRANSFORMED"
-                                },
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-                                    "type": "TRANSFORMED"
-                                },
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-                                    "type": "TRANSFORMED"
-                                }
-                            ],
-                            "fineGrainedLineages": [
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),customer_id)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),full_name)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),email)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),address)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),city)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),postal_code)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),phone)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                            "materialized": false,
-                            "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
-                            "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
-                            "viewLanguage": "SQL"
-                        }
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "Model"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "proposedSnapshot": {
-            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                "aspects": [
-                    {
-                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                            "customProperties": {
-                                "business_owner": "jdoe.last",
-                                "data_governance.team_owner": "Sales",
-                                "has_pii": "False",
-                                "int_property": "2",
-                                "double_property": "3.5",
-                                "node_type": "model",
-                                "materialization": "table",
-                                "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
-                                "catalog_type": "BASE TABLE",
-                                "language": "sql",
-                                "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
-                                "dbt_package_name": "sample_dbt",
-                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                                "manifest_version": "0.19.1",
-                                "manifest_adapter": "postgres",
-                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                                "catalog_version": "0.19.1"
-                            },
-                            "name": "an-aliased-view-for-monthly-billing",
-                            "description": "",
-                            "tags": []
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Status": {
-                            "removed": false
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                            "schemaName": "model.sample_dbt.monthly_billing_with_cust",
-                            "platform": "urn:li:dataPlatform:dbt",
-                            "version": 0,
-                            "created": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "lastModified": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "hash": "",
-                            "platformSchema": {
-                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                    "tableSchema": ""
-                                }
-                            },
-                            "fields": [
-                                {
-                                    "fieldPath": "amount",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "numeric",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "billing_month",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "timestamp with time zone",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "customer_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "email",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "text",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                            "upstreams": [
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-                                    "type": "TRANSFORMED"
-                                },
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                                    "type": "TRANSFORMED"
-                                }
-                            ],
-                            "fineGrainedLineages": [
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                            "materialized": true,
-                            "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
-                            "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
-                            "viewLanguage": "SQL"
-                        }
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "Model"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "proposedSnapshot": {
-            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                "aspects": [
-                    {
-                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                            "customProperties": {
-                                "node_type": "model",
-                                "materialization": "view",
-                                "dbt_file_path": "models/base/payments_base.sql",
-                                "catalog_type": "VIEW",
-                                "language": "sql",
-                                "dbt_unique_id": "model.sample_dbt.payments_base",
-                                "dbt_package_name": "sample_dbt",
-                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                                "manifest_version": "0.19.1",
-                                "manifest_adapter": "postgres",
-                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                                "catalog_version": "0.19.1"
-                            },
-                            "name": "an-aliased-view-for-payments",
-                            "description": "",
-                            "tags": []
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Status": {
-                            "removed": false
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                            "schemaName": "model.sample_dbt.payments_base",
-                            "platform": "urn:li:dataPlatform:dbt",
-                            "version": 0,
-                            "created": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "lastModified": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "hash": "",
-                            "platformSchema": {
-                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                    "tableSchema": ""
-                                }
-                            },
-                            "fields": [
-                                {
-                                    "fieldPath": "amount",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "numeric(5,2)",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "customer_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "payment_date",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "timestamp with time zone",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "payment_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "rental_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "staff_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                            "upstreams": [
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-                                    "type": "TRANSFORMED"
-                                },
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                                    "type": "TRANSFORMED"
-                                },
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                                    "type": "TRANSFORMED"
-                                },
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-                                    "type": "TRANSFORMED"
-                                },
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-                                    "type": "TRANSFORMED"
-                                },
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-                                    "type": "TRANSFORMED"
-                                },
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-                                    "type": "TRANSFORMED"
-                                }
-                            ],
-                            "fineGrainedLineages": [
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                            "materialized": false,
-                            "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
-                            "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
-                            "viewLanguage": "SQL"
-                        }
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "Model"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "proposedSnapshot": {
-            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                "aspects": [
-                    {
-                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                            "customProperties": {
-                                "node_type": "model",
-                                "materialization": "table",
-                                "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
-                                "catalog_type": "BASE TABLE",
-                                "language": "sql",
-                                "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
-                                "dbt_package_name": "sample_dbt",
-                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                                "manifest_version": "0.19.1",
-                                "manifest_adapter": "postgres",
-                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                                "catalog_version": "0.19.1"
-                            },
-                            "name": "payments_by_customer_by_month",
-                            "description": "",
-                            "tags": []
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Status": {
-                            "removed": false
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                            "schemaName": "model.sample_dbt.payments_by_customer_by_month",
-                            "platform": "urn:li:dataPlatform:dbt",
-                            "version": 0,
-                            "created": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "lastModified": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "hash": "",
-                            "platformSchema": {
-                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                    "tableSchema": ""
-                                }
-                            },
-                            "fields": [
-                                {
-                                    "fieldPath": "amount",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "numeric",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "billing_month",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "timestamp with time zone",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "customer_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                            "upstreams": [
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                                    "type": "TRANSFORMED"
-                                }
-                            ],
-                            "fineGrainedLineages": [
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
-                                    ],
-                                    "confidenceScore": 0.9
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.ViewProperties": {
-                            "materialized": true,
-                            "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
-                            "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
-                            "viewLanguage": "SQL"
-                        }
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "Source"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "proposedSnapshot": {
-            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-                "aspects": [
-                    {
-                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                            "customProperties": {
-                                "model_maturity": "in dev",
-                                "some_other_property": "test 1",
-                                "owner": "@alice1",
-                                "node_type": "source",
-                                "dbt_file_path": "models/base.yml",
-                                "catalog_type": "BASE TABLE",
-                                "language": "sql",
-                                "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                                "dbt_package_name": "sample_dbt",
-                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                                "manifest_version": "0.19.1",
-                                "manifest_adapter": "postgres",
-                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                                "catalog_version": "0.19.1"
-                            },
-                            "name": "actor",
-                            "description": "description for actor table from dbt",
-                            "tags": []
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Status": {
-                            "removed": false
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Ownership": {
-                            "owners": [
-                                {
-                                    "owner": "urn:li:corpuser:@alice1",
-                                    "type": "DATAOWNER"
-                                }
-                            ],
-                            "ownerTypes": {},
-                            "lastModified": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            }
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                            "schemaName": "source.sample_dbt.pagila.actor",
-                            "platform": "urn:li:dataPlatform:dbt",
-                            "version": 0,
-                            "created": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "lastModified": {
-                                "time": 1581759273000,
-                                "actor": "urn:li:corpuser:dbt_executor"
-                            },
-                            "hash": "",
-                            "platformSchema": {
-                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                    "tableSchema": ""
-                                }
-                            },
-                            "fields": [
-                                {
-                                    "fieldPath": "actor_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "first_name",
-                                    "nullable": false,
-                                    "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "text",
-                                    "recursive": false,
-                                    "globalTags": {
-                                        "tags": [
-                                            {
-                                                "tag": "urn:li:tag:dbt:column_tag"
-                                            }
-                                        ]
-                                    },
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "last_name",
-                                    "nullable": false,
-                                    "description": "description for last_name from dbt",
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "text",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "last_update",
-                                    "nullable": false,
-                                    "description": "description for last_update from dbt",
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "timestamp with time zone",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                            "upstreams": [
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD)",
-                                    "type": "COPY"
-                                }
-                            ],
-                            "fineGrainedLineages": [
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD),actor_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD),first_name)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD),last_name)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD),last_update)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "Source"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "proposedSnapshot": {
-            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-                "aspects": [
-                    {
-                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                            "customProperties": {
-                                "node_type": "source",
-                                "dbt_file_path": "models/base.yml",
-                                "catalog_type": "BASE TABLE",
-                                "language": "sql",
-                                "dbt_unique_id": "source.sample_dbt.pagila.address",
-                                "dbt_package_name": "sample_dbt",
-                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                                "manifest_version": "0.19.1",
-                                "manifest_adapter": "postgres",
-                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                                "catalog_version": "0.19.1"
-                            },
-                            "name": "address",
-                            "description": "a user's address",
-                            "tags": []
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Status": {
-                            "removed": false
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                            "schemaName": "source.sample_dbt.pagila.address",
-                            "platform": "urn:li:dataPlatform:dbt",
-                            "version": 0,
-                            "created": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "lastModified": {
-                                "time": 1623751200000,
-                                "actor": "urn:li:corpuser:dbt_executor"
-                            },
-                            "hash": "",
-                            "platformSchema": {
-                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                    "tableSchema": ""
-                                }
-                            },
-                            "fields": [
-                                {
-                                    "fieldPath": "address",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "text",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "address2",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "text",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "address_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "city_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "district",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "text",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "last_update",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "timestamp with time zone",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "phone",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "text",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "postal_code",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "text",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                            "upstreams": [
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD)",
-                                    "type": "COPY"
-                                }
-                            ],
-                            "fineGrainedLineages": [
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),address)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),address2)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),address_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),city_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),district)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),last_update)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),phone)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),postal_code)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "Source"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "proposedSnapshot": {
-            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-                "aspects": [
-                    {
-                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                            "customProperties": {
-                                "node_type": "source",
-                                "dbt_file_path": "models/base.yml",
-                                "catalog_type": "BASE TABLE",
-                                "language": "sql",
-                                "dbt_unique_id": "source.sample_dbt.pagila.category",
-                                "dbt_package_name": "sample_dbt",
-                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                                "manifest_version": "0.19.1",
-                                "manifest_adapter": "postgres",
-                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                                "catalog_version": "0.19.1"
-                            },
-                            "name": "category",
-                            "description": "a user's category",
-                            "tags": []
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Status": {
-                            "removed": false
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                            "schemaName": "source.sample_dbt.pagila.category",
-                            "platform": "urn:li:dataPlatform:dbt",
-                            "version": 0,
-                            "created": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "lastModified": {
-                                "time": 1623319200000,
-                                "actor": "urn:li:corpuser:dbt_executor"
-                            },
-                            "hash": "",
-                            "platformSchema": {
-                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                    "tableSchema": ""
-                                }
-                            },
-                            "fields": [
-                                {
-                                    "fieldPath": "category_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "last_update",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "timestamp with time zone",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "name",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "text",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                            "upstreams": [
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.category,PROD)",
-                                    "type": "COPY"
-                                }
-                            ],
-                            "fineGrainedLineages": [
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.category,PROD),category_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.category,PROD),last_update)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.category,PROD),name)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "Source"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "proposedSnapshot": {
-            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-                "aspects": [
-                    {
-                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                            "customProperties": {
-                                "node_type": "source",
-                                "dbt_file_path": "models/base.yml",
-                                "catalog_type": "BASE TABLE",
-                                "language": "sql",
-                                "dbt_unique_id": "source.sample_dbt.pagila.city",
-                                "dbt_package_name": "sample_dbt",
-                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                                "manifest_version": "0.19.1",
-                                "manifest_adapter": "postgres",
-                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                                "catalog_version": "0.19.1"
-                            },
-                            "name": "city",
-                            "description": "",
-                            "tags": []
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Status": {
-                            "removed": false
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                            "schemaName": "source.sample_dbt.pagila.city",
-                            "platform": "urn:li:dataPlatform:dbt",
-                            "version": 0,
-                            "created": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "lastModified": {
-                                "time": 1581759925000,
-                                "actor": "urn:li:corpuser:dbt_executor"
-                            },
-                            "hash": "",
-                            "platformSchema": {
-                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                    "tableSchema": ""
-                                }
-                            },
-                            "fields": [
-                                {
-                                    "fieldPath": "city",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "text",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "city_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "country_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "last_update",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "timestamp with time zone",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                            "upstreams": [
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD)",
-                                    "type": "COPY"
-                                }
-                            ],
-                            "fineGrainedLineages": [
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD),city)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD),city_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD),country_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD),last_update)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "Source"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "proposedSnapshot": {
-            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-                "aspects": [
-                    {
-                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                            "customProperties": {
-                                "model_maturity": "in prod",
-                                "owner": "@bob",
-                                "some_other_property": "test 2",
-                                "node_type": "source",
-                                "dbt_file_path": "models/base.yml",
-                                "catalog_type": "BASE TABLE",
-                                "language": "sql",
-                                "dbt_unique_id": "source.sample_dbt.pagila.country",
-                                "dbt_package_name": "sample_dbt",
-                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                                "manifest_version": "0.19.1",
-                                "manifest_adapter": "postgres",
-                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                                "catalog_version": "0.19.1"
-                            },
-                            "name": "country",
-                            "description": "",
-                            "tags": []
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Status": {
-                            "removed": false
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Ownership": {
-                            "owners": [
-                                {
-                                    "owner": "urn:li:corpuser:@bob",
-                                    "type": "DATAOWNER"
-                                }
-                            ],
-                            "ownerTypes": {},
-                            "lastModified": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            }
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                            "schemaName": "source.sample_dbt.pagila.country",
-                            "platform": "urn:li:dataPlatform:dbt",
-                            "version": 0,
-                            "created": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "lastModified": {
-                                "time": 1624033800000,
-                                "actor": "urn:li:corpuser:dbt_executor"
-                            },
-                            "hash": "",
-                            "platformSchema": {
-                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                    "tableSchema": ""
-                                }
-                            },
-                            "fields": [
-                                {
-                                    "fieldPath": "country",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "text",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "country_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "last_update",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "timestamp with time zone",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                            "upstreams": [
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.country,PROD)",
-                                    "type": "COPY"
-                                }
-                            ],
-                            "fineGrainedLineages": [
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.country,PROD),country)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.country,PROD),country_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.country,PROD),last_update)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "Source"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "proposedSnapshot": {
-            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-                "aspects": [
-                    {
-                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                            "customProperties": {
-                                "node_type": "source",
-                                "dbt_file_path": "models/base.yml",
-                                "catalog_type": "BASE TABLE",
-                                "language": "sql",
-                                "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                                "dbt_package_name": "sample_dbt",
-                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                                "manifest_version": "0.19.1",
-                                "manifest_adapter": "postgres",
-                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                                "catalog_version": "0.19.1"
-                            },
-                            "name": "customer",
-                            "description": "description for customer table from dbt",
-                            "tags": []
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Status": {
-                            "removed": false
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                            "schemaName": "source.sample_dbt.pagila.customer",
-                            "platform": "urn:li:dataPlatform:dbt",
-                            "version": 0,
-                            "created": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "lastModified": {
-                                "time": 1624032000000,
-                                "actor": "urn:li:corpuser:dbt_executor"
-                            },
-                            "hash": "",
-                            "platformSchema": {
-                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                    "tableSchema": ""
-                                }
-                            },
-                            "fields": [
-                                {
-                                    "fieldPath": "active",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "activebool",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.BooleanType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "boolean",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "address_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "create_date",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.DateType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "date",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "customer_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "email",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "text",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "first_name",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "text",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "last_name",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.StringType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "text",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "last_update",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "timestamp with time zone",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "store_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                            "upstreams": [
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD)",
-                                    "type": "COPY"
-                                }
-                            ],
-                            "fineGrainedLineages": [
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),active)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),activebool)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),address_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),create_date)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),customer_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),email)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),first_name)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),last_name)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),last_update)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),store_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "Source"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "proposedSnapshot": {
-            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-                "aspects": [
-                    {
-                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                            "customProperties": {
-                                "node_type": "source",
-                                "dbt_file_path": "models/base.yml",
-                                "catalog_type": "BASE TABLE",
-                                "language": "sql",
-                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                                "dbt_package_name": "sample_dbt",
-                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                                "manifest_version": "0.19.1",
-                                "manifest_adapter": "postgres",
-                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                                "catalog_version": "0.19.1"
-                            },
-                            "name": "payment_p2020_01",
-                            "description": "",
-                            "tags": []
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Status": {
-                            "removed": false
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                            "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
-                            "platform": "urn:li:dataPlatform:dbt",
-                            "version": 0,
-                            "created": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "lastModified": {
-                                "time": 1580505371996,
-                                "actor": "urn:li:corpuser:dbt_executor"
-                            },
-                            "hash": "",
-                            "platformSchema": {
-                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                    "tableSchema": ""
-                                }
-                            },
-                            "fields": [
-                                {
-                                    "fieldPath": "amount",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "numeric(5,2)",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "customer_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "payment_date",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "timestamp with time zone",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "payment_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "rental_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "staff_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                            "upstreams": [
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD)",
-                                    "type": "COPY"
-                                }
-                            ],
-                            "fineGrainedLineages": [
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),amount)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),customer_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),payment_date)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),payment_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),rental_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),staff_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "Source"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "proposedSnapshot": {
-            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                "aspects": [
-                    {
-                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                            "customProperties": {
-                                "an_array_property": "['alpha', 'beta', 'charlie']",
-                                "model_maturity": "in prod",
-                                "owner": "@charles",
-                                "some_other_property": "test 3",
-                                "node_type": "source",
-                                "dbt_file_path": "models/base.yml",
-                                "catalog_type": "BASE TABLE",
-                                "language": "sql",
-                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                                "dbt_package_name": "sample_dbt",
-                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                                "manifest_version": "0.19.1",
-                                "manifest_adapter": "postgres",
-                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                                "catalog_version": "0.19.1"
-                            },
-                            "name": "payment_p2020_02",
-                            "description": "",
-                            "tags": []
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Status": {
-                            "removed": false
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Ownership": {
-                            "owners": [
-                                {
-                                    "owner": "urn:li:corpuser:@charles",
-                                    "type": "DATAOWNER"
-                                }
-                            ],
-                            "ownerTypes": {},
-                            "lastModified": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            }
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                            "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
-                            "platform": "urn:li:dataPlatform:dbt",
-                            "version": 0,
-                            "created": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "lastModified": {
-                                "time": 1582319845996,
-                                "actor": "urn:li:corpuser:dbt_executor"
-                            },
-                            "hash": "",
-                            "platformSchema": {
-                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                    "tableSchema": ""
-                                }
-                            },
-                            "fields": [
-                                {
-                                    "fieldPath": "amount",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "numeric(5,2)",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "customer_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "payment_date",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "timestamp with time zone",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "payment_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "rental_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "staff_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                            "upstreams": [
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD)",
-                                    "type": "COPY"
-                                }
-                            ],
-                            "fineGrainedLineages": [
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),amount)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),customer_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),payment_date)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),payment_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),rental_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),staff_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "Source"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "proposedSnapshot": {
-            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-                "aspects": [
-                    {
-                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                            "customProperties": {
-                                "node_type": "source",
-                                "dbt_file_path": "models/base.yml",
-                                "catalog_type": "BASE TABLE",
-                                "language": "sql",
-                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                                "dbt_package_name": "sample_dbt",
-                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                                "manifest_version": "0.19.1",
-                                "manifest_adapter": "postgres",
-                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                                "catalog_version": "0.19.1"
-                            },
-                            "name": "payment_p2020_03",
-                            "description": "",
-                            "tags": []
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Status": {
-                            "removed": false
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                            "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
-                            "platform": "urn:li:dataPlatform:dbt",
-                            "version": 0,
-                            "created": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "lastModified": {
-                                "time": 1584998318996,
-                                "actor": "urn:li:corpuser:dbt_executor"
-                            },
-                            "hash": "",
-                            "platformSchema": {
-                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                    "tableSchema": ""
-                                }
-                            },
-                            "fields": [
-                                {
-                                    "fieldPath": "amount",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "numeric(5,2)",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "customer_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "payment_date",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "timestamp with time zone",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "payment_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "rental_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "staff_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                            "upstreams": [
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD)",
-                                    "type": "COPY"
-                                }
-                            ],
-                            "fineGrainedLineages": [
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),amount)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),customer_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),payment_date)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),payment_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),rental_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),staff_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "Source"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "proposedSnapshot": {
-            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-                "aspects": [
-                    {
-                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                            "customProperties": {
-                                "node_type": "source",
-                                "dbt_file_path": "models/base.yml",
-                                "catalog_type": "BASE TABLE",
-                                "language": "sql",
-                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                                "dbt_package_name": "sample_dbt",
-                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                                "manifest_version": "0.19.1",
-                                "manifest_adapter": "postgres",
-                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                                "catalog_version": "0.19.1"
-                            },
-                            "name": "payment_p2020_04",
-                            "description": "",
-                            "tags": []
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Status": {
-                            "removed": false
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                            "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
-                            "platform": "urn:li:dataPlatform:dbt",
-                            "version": 0,
-                            "created": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "lastModified": {
-                                "time": 1588287228996,
-                                "actor": "urn:li:corpuser:dbt_executor"
-                            },
-                            "hash": "",
-                            "platformSchema": {
-                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                    "tableSchema": ""
-                                }
-                            },
-                            "fields": [
-                                {
-                                    "fieldPath": "amount",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "numeric(5,2)",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "customer_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "payment_date",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "timestamp with time zone",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "payment_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "rental_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "staff_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                            "upstreams": [
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD)",
-                                    "type": "COPY"
-                                }
-                            ],
-                            "fineGrainedLineages": [
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),amount)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),customer_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),payment_date)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),payment_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),rental_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),staff_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "Source"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "proposedSnapshot": {
-            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-                "aspects": [
-                    {
-                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                            "customProperties": {
-                                "node_type": "source",
-                                "dbt_file_path": "models/base.yml",
-                                "catalog_type": "BASE TABLE",
-                                "language": "sql",
-                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                                "dbt_package_name": "sample_dbt",
-                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                                "manifest_version": "0.19.1",
-                                "manifest_adapter": "postgres",
-                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                                "catalog_version": "0.19.1"
-                            },
-                            "name": "payment_p2020_05",
-                            "description": "a payment",
-                            "tags": []
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Status": {
-                            "removed": false
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                            "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
-                            "platform": "urn:li:dataPlatform:dbt",
-                            "version": 0,
-                            "created": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "lastModified": {
-                                "time": 1589460269996,
-                                "actor": "urn:li:corpuser:dbt_executor"
-                            },
-                            "hash": "",
-                            "platformSchema": {
-                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                    "tableSchema": ""
-                                }
-                            },
-                            "fields": [
-                                {
-                                    "fieldPath": "amount",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "numeric(5,2)",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "customer_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "payment_date",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "timestamp with time zone",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "payment_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "rental_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "staff_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                            "upstreams": [
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD)",
-                                    "type": "COPY"
-                                }
-                            ],
-                            "fineGrainedLineages": [
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),amount)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),customer_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),payment_date)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),payment_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),rental_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),staff_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "Source"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "proposedSnapshot": {
-            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-                "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-                "aspects": [
-                    {
-                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                            "customProperties": {
-                                "node_type": "source",
-                                "dbt_file_path": "models/base.yml",
-                                "catalog_type": "BASE TABLE",
-                                "language": "sql",
-                                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                                "dbt_package_name": "sample_dbt",
-                                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                                "manifest_version": "0.19.1",
-                                "manifest_adapter": "postgres",
-                                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                                "catalog_version": "0.19.1"
-                            },
-                            "name": "payment_p2020_06",
-                            "description": "",
-                            "tags": []
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.common.Status": {
-                            "removed": false
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                            "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
-                            "platform": "urn:li:dataPlatform:dbt",
-                            "version": 0,
-                            "created": {
-                                "time": 0,
-                                "actor": "urn:li:corpuser:unknown"
-                            },
-                            "lastModified": {
-                                "time": -62135596800000,
-                                "actor": "urn:li:corpuser:dbt_executor"
-                            },
-                            "hash": "",
-                            "platformSchema": {
-                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                    "tableSchema": ""
-                                }
-                            },
-                            "fields": [
-                                {
-                                    "fieldPath": "amount",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "numeric(5,2)",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "customer_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "payment_date",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.TimeType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "timestamp with time zone",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "payment_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "rental_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                },
-                                {
-                                    "fieldPath": "staff_id",
-                                    "nullable": false,
-                                    "type": {
-                                        "type": {
-                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                        }
-                                    },
-                                    "nativeDataType": "integer",
-                                    "recursive": false,
-                                    "isPartOfKey": false
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
-                            "upstreams": [
-                                {
-                                    "auditStamp": {
-                                        "time": 1643871600000,
-                                        "actor": "urn:li:corpuser:unknown"
-                                    },
-                                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD)",
-                                    "type": "COPY"
-                                }
-                            ],
-                            "fineGrainedLineages": [
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),amount)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),customer_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),payment_date)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),payment_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),rental_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                },
-                                {
-                                    "upstreamType": "FIELD_SET",
-                                    "upstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),staff_id)"
-                                    ],
-                                    "downstreamType": "FIELD",
-                                    "downstreams": [
-                                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
-                                    ],
-                                    "confidenceScore": 1.0
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-        "changeType": "PATCH",
-        "aspectName": "upstreamLineage",
-        "aspect": {
-            "json": [
-                {
-                    "op": "add",
-                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                    "value": {
-                        "auditStamp": {
-                            "time": 1643871600000,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                        "type": "COPY"
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)",
-                    "value": {
-                        "confidenceScore": 1.0
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)",
-                    "value": {
-                        "confidenceScore": 1.0
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)",
-                    "value": {
-                        "confidenceScore": 1.0
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)",
-                    "value": {
-                        "confidenceScore": 1.0
-                    }
-                }
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Model"
             ]
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
         }
     },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-        "changeType": "PATCH",
-        "aspectName": "upstreamLineage",
-        "aspect": {
-            "json": [
-                {
-                    "op": "add",
-                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                    "value": {
-                        "auditStamp": {
-                            "time": 1643871600000,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                        "type": "COPY"
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)",
-                    "value": {
-                        "confidenceScore": 1.0
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)",
-                    "value": {
-                        "confidenceScore": 1.0
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)",
-                    "value": {
-                        "confidenceScore": 1.0
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)",
-                    "value": {
-                        "confidenceScore": 1.0
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)",
-                    "value": {
-                        "confidenceScore": 1.0
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)",
-                    "value": {
-                        "confidenceScore": 1.0
-                    }
-                }
-            ]
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-        "changeType": "PATCH",
-        "aspectName": "upstreamLineage",
-        "aspect": {
-            "json": [
-                {
-                    "op": "add",
-                    "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                    "value": {
-                        "auditStamp": {
-                            "time": 1643871600000,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                        "type": "COPY"
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)",
-                    "value": {
-                        "confidenceScore": 1.0
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)",
-                    "value": {
-                        "confidenceScore": 1.0
-                    }
-                },
-                {
-                    "op": "add",
-                    "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)",
-                    "value": {
-                        "confidenceScore": 1.0
-                    }
-                }
-            ]
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-        "changeType": "UPSERT",
-        "aspectName": "assertionInfo",
-        "aspect": {
-            "json": {
-                "customProperties": {
-                    "dbt_unique_id": "source.sample_dbt.pagila.actor",
-                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                    "manifest_version": "0.19.1",
-                    "manifest_adapter": "postgres",
-                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                    "catalog_version": "0.19.1",
-                    "dbt_freshness_test": "true",
-                    "warn_after_count": "12",
-                    "warn_after_period": "hour",
-                    "error_after_count": "24",
-                    "error_after_period": "hour"
-                },
-                "type": "CUSTOM",
-                "customAssertion": {
-                    "type": "dbt Freshness",
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
-                },
-                "source": {
-                    "type": "EXTERNAL",
-                    "created": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:__datahub_system"
-                    }
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-        "changeType": "UPSERT",
-        "aspectName": "assertionRunEvent",
-        "aspect": {
-            "json": {
-                "timestampMillis": 1624036135925,
-                "runId": "just-some-random-id",
-                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-                "status": "COMPLETE",
-                "result": {
-                    "type": "SUCCESS",
-                    "nativeResults": {
-                        "status": "pass",
-                        "max_loaded_at": "2020-02-15T09:34:33+00:00",
-                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                        "max_loaded_at_time_ago_in_s": "42276862.910052"
-                    }
-                },
-                "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-                "partitionSpec": {
-                    "partition": "FULL_TABLE_SNAPSHOT",
-                    "type": "FULL_TABLE"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-        "changeType": "UPSERT",
-        "aspectName": "assertionInfo",
-        "aspect": {
-            "json": {
-                "customProperties": {
-                    "dbt_unique_id": "source.sample_dbt.pagila.address",
-                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                    "manifest_version": "0.19.1",
-                    "manifest_adapter": "postgres",
-                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                    "catalog_version": "0.19.1",
-                    "dbt_freshness_test": "true",
-                    "warn_after_count": "12",
-                    "warn_after_period": "hour",
-                    "error_after_count": "24",
-                    "error_after_period": "hour"
-                },
-                "type": "CUSTOM",
-                "customAssertion": {
-                    "type": "dbt Freshness",
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
-                },
-                "source": {
-                    "type": "EXTERNAL",
-                    "created": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:__datahub_system"
-                    }
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-        "changeType": "UPSERT",
-        "aspectName": "assertionRunEvent",
-        "aspect": {
-            "json": {
-                "timestampMillis": 1624036135925,
-                "runId": "just-some-random-id",
-                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-                "status": "COMPLETE",
-                "result": {
-                    "type": "SUCCESS",
-                    "nativeResults": {
-                        "status": "warn",
-                        "max_loaded_at": "2021-06-15T10:00:00+00:00",
-                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                        "max_loaded_at_time_ago_in_s": "259200.0"
-                    }
-                },
-                "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-                "partitionSpec": {
-                    "partition": "FULL_TABLE_SNAPSHOT",
-                    "type": "FULL_TABLE"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-        "changeType": "UPSERT",
-        "aspectName": "assertionInfo",
-        "aspect": {
-            "json": {
-                "customProperties": {
-                    "dbt_unique_id": "source.sample_dbt.pagila.category",
-                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                    "manifest_version": "0.19.1",
-                    "manifest_adapter": "postgres",
-                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                    "catalog_version": "0.19.1",
-                    "dbt_freshness_test": "true",
-                    "warn_after_count": "12",
-                    "warn_after_period": "hour",
-                    "error_after_count": "24",
-                    "error_after_period": "hour"
-                },
-                "type": "CUSTOM",
-                "customAssertion": {
-                    "type": "dbt Freshness",
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
-                },
-                "source": {
-                    "type": "EXTERNAL",
-                    "created": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:__datahub_system"
-                    }
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-        "changeType": "UPSERT",
-        "aspectName": "assertionRunEvent",
-        "aspect": {
-            "json": {
-                "timestampMillis": 1624036135925,
-                "runId": "just-some-random-id",
-                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-                "status": "COMPLETE",
-                "result": {
-                    "type": "FAILURE",
-                    "severity": "HIGH",
-                    "nativeResults": {
-                        "status": "error",
-                        "max_loaded_at": "2021-06-10T10:00:00+00:00",
-                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                        "max_loaded_at_time_ago_in_s": "691200.0"
-                    }
-                },
-                "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-                "partitionSpec": {
-                    "partition": "FULL_TABLE_SNAPSHOT",
-                    "type": "FULL_TABLE"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-        "changeType": "UPSERT",
-        "aspectName": "assertionInfo",
-        "aspect": {
-            "json": {
-                "customProperties": {
-                    "dbt_unique_id": "source.sample_dbt.pagila.city",
-                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                    "manifest_version": "0.19.1",
-                    "manifest_adapter": "postgres",
-                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                    "catalog_version": "0.19.1",
-                    "dbt_freshness_test": "true",
-                    "error_after_count": "1",
-                    "error_after_period": "day"
-                },
-                "type": "CUSTOM",
-                "customAssertion": {
-                    "type": "dbt Freshness",
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
-                },
-                "source": {
-                    "type": "EXTERNAL",
-                    "created": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:__datahub_system"
-                    }
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-        "changeType": "UPSERT",
-        "aspectName": "assertionRunEvent",
-        "aspect": {
-            "json": {
-                "timestampMillis": 1624036135925,
-                "runId": "just-some-random-id",
-                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-                "status": "COMPLETE",
-                "result": {
-                    "type": "SUCCESS",
-                    "nativeResults": {
-                        "status": "pass",
-                        "max_loaded_at": "2020-02-15T09:45:25+00:00",
-                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                        "max_loaded_at_time_ago_in_s": "42276862.910052"
-                    }
-                },
-                "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-                "partitionSpec": {
-                    "partition": "FULL_TABLE_SNAPSHOT",
-                    "type": "FULL_TABLE"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-        "changeType": "UPSERT",
-        "aspectName": "assertionInfo",
-        "aspect": {
-            "json": {
-                "customProperties": {
-                    "dbt_unique_id": "source.sample_dbt.pagila.country",
-                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                    "manifest_version": "0.19.1",
-                    "manifest_adapter": "postgres",
-                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                    "catalog_version": "0.19.1",
-                    "dbt_freshness_test": "true",
-                    "warn_after_count": "30",
-                    "warn_after_period": "minute"
-                },
-                "type": "CUSTOM",
-                "customAssertion": {
-                    "type": "dbt Freshness",
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
-                },
-                "source": {
-                    "type": "EXTERNAL",
-                    "created": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:__datahub_system"
-                    }
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-        "changeType": "UPSERT",
-        "aspectName": "assertionRunEvent",
-        "aspect": {
-            "json": {
-                "timestampMillis": 1624036135925,
-                "runId": "just-some-random-id",
-                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-                "status": "COMPLETE",
-                "result": {
-                    "type": "SUCCESS",
-                    "nativeResults": {
-                        "status": "pass",
-                        "max_loaded_at": "2021-06-18T16:30:00+00:00",
-                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                        "max_loaded_at_time_ago_in_s": "2335.925443"
-                    }
-                },
-                "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-                "partitionSpec": {
-                    "partition": "FULL_TABLE_SNAPSHOT",
-                    "type": "FULL_TABLE"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-        "changeType": "UPSERT",
-        "aspectName": "assertionInfo",
-        "aspect": {
-            "json": {
-                "customProperties": {
-                    "dbt_unique_id": "source.sample_dbt.pagila.customer",
-                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                    "manifest_version": "0.19.1",
-                    "manifest_adapter": "postgres",
-                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                    "catalog_version": "0.19.1",
-                    "dbt_freshness_test": "true",
-                    "warn_after_count": "1",
-                    "warn_after_period": "day",
-                    "error_after_count": "2",
-                    "error_after_period": "day"
-                },
-                "type": "CUSTOM",
-                "customAssertion": {
-                    "type": "dbt Freshness",
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
-                },
-                "source": {
-                    "type": "EXTERNAL",
-                    "created": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:__datahub_system"
-                    }
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-        "changeType": "UPSERT",
-        "aspectName": "assertionRunEvent",
-        "aspect": {
-            "json": {
-                "timestampMillis": 1624036135925,
-                "runId": "just-some-random-id",
-                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-                "status": "COMPLETE",
-                "result": {
-                    "type": "SUCCESS",
-                    "nativeResults": {
-                        "status": "pass",
-                        "max_loaded_at": "2021-06-18T16:00:00+00:00",
-                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                        "max_loaded_at_time_ago_in_s": "4085.925443"
-                    }
-                },
-                "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-                "partitionSpec": {
-                    "partition": "FULL_TABLE_SNAPSHOT",
-                    "type": "FULL_TABLE"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-        "changeType": "UPSERT",
-        "aspectName": "assertionInfo",
-        "aspect": {
-            "json": {
-                "customProperties": {
-                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
-                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                    "manifest_version": "0.19.1",
-                    "manifest_adapter": "postgres",
-                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                    "catalog_version": "0.19.1",
-                    "dbt_freshness_test": "true",
-                    "warn_after_count": "3",
-                    "warn_after_period": "day",
-                    "error_after_count": "7",
-                    "error_after_period": "day"
-                },
-                "type": "CUSTOM",
-                "customAssertion": {
-                    "type": "dbt Freshness",
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
-                },
-                "source": {
-                    "type": "EXTERNAL",
-                    "created": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:__datahub_system"
-                    }
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-        "changeType": "UPSERT",
-        "aspectName": "assertionRunEvent",
-        "aspect": {
-            "json": {
-                "timestampMillis": 1624036135925,
-                "runId": "just-some-random-id",
-                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-                "status": "COMPLETE",
-                "result": {
-                    "type": "SUCCESS",
-                    "nativeResults": {
-                        "status": "pass",
-                        "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
-                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                        "max_loaded_at_time_ago_in_s": "42276862.910052"
-                    }
-                },
-                "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-                "partitionSpec": {
-                    "partition": "FULL_TABLE_SNAPSHOT",
-                    "type": "FULL_TABLE"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-        "changeType": "UPSERT",
-        "aspectName": "assertionInfo",
-        "aspect": {
-            "json": {
-                "customProperties": {
-                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
-                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                    "manifest_version": "0.19.1",
-                    "manifest_adapter": "postgres",
-                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                    "catalog_version": "0.19.1",
-                    "dbt_freshness_test": "true",
-                    "warn_after_count": "12",
-                    "warn_after_period": "hour",
-                    "error_after_count": "24",
-                    "error_after_period": "hour"
-                },
-                "type": "CUSTOM",
-                "customAssertion": {
-                    "type": "dbt Freshness",
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
-                },
-                "source": {
-                    "type": "EXTERNAL",
-                    "created": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:__datahub_system"
-                    }
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-        "changeType": "UPSERT",
-        "aspectName": "assertionRunEvent",
-        "aspect": {
-            "json": {
-                "timestampMillis": 1624036135925,
-                "runId": "just-some-random-id",
-                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-                "status": "COMPLETE",
-                "result": {
-                    "type": "SUCCESS",
-                    "nativeResults": {
-                        "status": "pass",
-                        "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
-                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                        "max_loaded_at_time_ago_in_s": "42276862.910052"
-                    }
-                },
-                "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-                "partitionSpec": {
-                    "partition": "FULL_TABLE_SNAPSHOT",
-                    "type": "FULL_TABLE"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-        "changeType": "UPSERT",
-        "aspectName": "assertionInfo",
-        "aspect": {
-            "json": {
-                "customProperties": {
-                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
-                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                    "manifest_version": "0.19.1",
-                    "manifest_adapter": "postgres",
-                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                    "catalog_version": "0.19.1",
-                    "dbt_freshness_test": "true",
-                    "warn_after_count": "12",
-                    "warn_after_period": "hour",
-                    "error_after_count": "24",
-                    "error_after_period": "hour"
-                },
-                "type": "CUSTOM",
-                "customAssertion": {
-                    "type": "dbt Freshness",
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
-                },
-                "source": {
-                    "type": "EXTERNAL",
-                    "created": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:__datahub_system"
-                    }
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-        "changeType": "UPSERT",
-        "aspectName": "assertionRunEvent",
-        "aspect": {
-            "json": {
-                "timestampMillis": 1624036135925,
-                "runId": "just-some-random-id",
-                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-                "status": "COMPLETE",
-                "result": {
-                    "type": "SUCCESS",
-                    "nativeResults": {
-                        "status": "pass",
-                        "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
-                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                        "max_loaded_at_time_ago_in_s": "42276862.910052"
-                    }
-                },
-                "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-                "partitionSpec": {
-                    "partition": "FULL_TABLE_SNAPSHOT",
-                    "type": "FULL_TABLE"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-        "changeType": "UPSERT",
-        "aspectName": "assertionInfo",
-        "aspect": {
-            "json": {
-                "customProperties": {
-                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
-                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                    "manifest_version": "0.19.1",
-                    "manifest_adapter": "postgres",
-                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                    "catalog_version": "0.19.1",
-                    "dbt_freshness_test": "true",
-                    "warn_after_count": "12",
-                    "warn_after_period": "hour",
-                    "error_after_count": "24",
-                    "error_after_period": "hour"
-                },
-                "type": "CUSTOM",
-                "customAssertion": {
-                    "type": "dbt Freshness",
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
-                },
-                "source": {
-                    "type": "EXTERNAL",
-                    "created": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:__datahub_system"
-                    }
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-        "changeType": "UPSERT",
-        "aspectName": "assertionRunEvent",
-        "aspect": {
-            "json": {
-                "timestampMillis": 1624036135925,
-                "runId": "just-some-random-id",
-                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-                "status": "COMPLETE",
-                "result": {
-                    "type": "SUCCESS",
-                    "nativeResults": {
-                        "status": "pass",
-                        "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
-                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                        "max_loaded_at_time_ago_in_s": "42276862.910052"
-                    }
-                },
-                "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-                "partitionSpec": {
-                    "partition": "FULL_TABLE_SNAPSHOT",
-                    "type": "FULL_TABLE"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-        "changeType": "UPSERT",
-        "aspectName": "assertionInfo",
-        "aspect": {
-            "json": {
-                "customProperties": {
-                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
-                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                    "manifest_version": "0.19.1",
-                    "manifest_adapter": "postgres",
-                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                    "catalog_version": "0.19.1",
-                    "dbt_freshness_test": "true",
-                    "warn_after_count": "12",
-                    "warn_after_period": "hour",
-                    "error_after_count": "24",
-                    "error_after_period": "hour"
-                },
-                "type": "CUSTOM",
-                "customAssertion": {
-                    "type": "dbt Freshness",
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
-                },
-                "source": {
-                    "type": "EXTERNAL",
-                    "created": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:__datahub_system"
-                    }
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-        "changeType": "UPSERT",
-        "aspectName": "assertionRunEvent",
-        "aspect": {
-            "json": {
-                "timestampMillis": 1624036135925,
-                "runId": "just-some-random-id",
-                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-                "status": "COMPLETE",
-                "result": {
-                    "type": "SUCCESS",
-                    "nativeResults": {
-                        "status": "pass",
-                        "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
-                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                        "max_loaded_at_time_ago_in_s": "42276862.910052"
-                    }
-                },
-                "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-                "partitionSpec": {
-                    "partition": "FULL_TABLE_SNAPSHOT",
-                    "type": "FULL_TABLE"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-        "changeType": "UPSERT",
-        "aspectName": "assertionInfo",
-        "aspect": {
-            "json": {
-                "customProperties": {
-                    "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
-                    "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
-                    "manifest_version": "0.19.1",
-                    "manifest_adapter": "postgres",
-                    "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                    "catalog_version": "0.19.1",
-                    "dbt_freshness_test": "true",
-                    "warn_after_count": "12",
-                    "warn_after_period": "hour",
-                    "error_after_count": "24",
-                    "error_after_period": "hour"
-                },
-                "type": "CUSTOM",
-                "customAssertion": {
-                    "type": "dbt Freshness",
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
-                },
-                "source": {
-                    "type": "EXTERNAL",
-                    "created": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:__datahub_system"
-                    }
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-        "changeType": "UPSERT",
-        "aspectName": "assertionRunEvent",
-        "aspect": {
-            "json": {
-                "timestampMillis": 1624036135925,
-                "runId": "just-some-random-id",
-                "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-                "status": "COMPLETE",
-                "result": {
-                    "type": "SUCCESS",
-                    "nativeResults": {
-                        "status": "pass",
-                        "max_loaded_at": "0001-01-01T00:00:00+00:00",
-                        "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-                        "max_loaded_at_time_ago_in_s": "42276862.910052"
-                    }
-                },
-                "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-                "partitionSpec": {
-                    "partition": "FULL_TABLE_SNAPSHOT",
-                    "type": "FULL_TABLE"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dashboard",
-        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dashboard",
-        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-        "changeType": "UPSERT",
-        "aspectName": "dashboardInfo",
-        "aspect": {
-            "json": {
-                "customProperties": {
-                    "dbt_unique_id": "exposure.sample_dbt.customer_dashboard",
-                    "exposure_type": "dashboard",
-                    "maturity": "high",
-                    "dbt_package_name": "sample_dbt",
-                    "dbt_file_path": "models/exposures.yml",
-                    "team": "analytics"
-                },
-                "externalUrl": "https://bi.example.com/dashboards/customer",
-                "title": "customer_dashboard",
-                "description": "Dashboard showing customer details and billing",
-                "charts": [],
-                "datasets": [
-                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
-                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
-                ],
-                "dashboards": [],
-                "lastModified": {
-                    "created": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:dbt_ingestion"
-                    },
-                    "lastModified": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:dbt_ingestion"
-                    }
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dashboard",
-        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-        "changeType": "UPSERT",
-        "aspectName": "status",
-        "aspect": {
-            "json": {
-                "removed": false
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dashboard",
-        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "Dashboard"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dashboard",
-        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-        "changeType": "UPSERT",
-        "aspectName": "ownership",
-        "aspect": {
-            "json": {
-                "owners": [
-                    {
-                        "owner": "urn:li:corpuser:analytics@example.com",
-                        "type": "DATAOWNER"
-                    }
-                ],
-                "ownerTypes": {},
-                "lastModified": {
-                    "time": 0,
-                    "actor": "urn:li:corpuser:unknown"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dashboard",
-        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
-        "changeType": "UPSERT",
-        "aspectName": "globalTags",
-        "aspect": {
-            "json": {
-                "tags": [
-                    {
-                        "tag": "urn:li:tag:dbt:executive"
-                    },
-                    {
-                        "tag": "urn:li:tag:dbt:customer"
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dashboard",
-        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-        "changeType": "UPSERT",
-        "aspectName": "dataPlatformInstance",
-        "aspect": {
-            "json": {
-                "platform": "urn:li:dataPlatform:dbt"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dashboard",
-        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-        "changeType": "UPSERT",
-        "aspectName": "dashboardInfo",
-        "aspect": {
-            "json": {
-                "customProperties": {
-                    "dbt_unique_id": "exposure.sample_dbt.payments_ml_model",
-                    "exposure_type": "ml",
-                    "maturity": "medium",
-                    "dbt_package_name": "sample_dbt",
-                    "dbt_file_path": "models/exposures.yml"
-                },
-                "externalUrl": "https://mlflow.example.com/models/payments",
-                "title": "payments_ml_model",
-                "description": "ML model for payment predictions",
-                "charts": [],
-                "datasets": [
-                    "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
-                ],
-                "dashboards": [],
-                "lastModified": {
-                    "created": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:dbt_ingestion"
-                    },
-                    "lastModified": {
-                        "time": 1643871600000,
-                        "actor": "urn:li:corpuser:dbt_ingestion"
-                    }
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dashboard",
-        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-        "changeType": "UPSERT",
-        "aspectName": "status",
-        "aspect": {
-            "json": {
-                "removed": false
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dashboard",
-        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-        "changeType": "UPSERT",
-        "aspectName": "subTypes",
-        "aspect": {
-            "json": {
-                "typeNames": [
-                    "ML Model"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dashboard",
-        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-        "changeType": "UPSERT",
-        "aspectName": "ownership",
-        "aspect": {
-            "json": {
-                "owners": [
-                    {
-                        "owner": "urn:li:corpuser:ds@example.com",
-                        "type": "DATAOWNER"
-                    }
-                ],
-                "ownerTypes": {},
-                "lastModified": {
-                    "time": 0,
-                    "actor": "urn:li:corpuser:unknown"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dashboard",
-        "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
-        "changeType": "UPSERT",
-        "aspectName": "globalTags",
-        "aspect": {
-            "json": {
-                "tags": [
-                    {
-                        "tag": "urn:li:tag:dbt:ml"
-                    },
-                    {
-                        "tag": "urn:li:tag:dbt:payments"
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
-        "changeType": "UPSERT",
-        "aspectName": "status",
-        "aspect": {
-            "json": {
-                "removed": false
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
-        "changeType": "UPSERT",
-        "aspectName": "status",
-        "aspect": {
-            "json": {
-                "removed": false
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
-        "changeType": "UPSERT",
-        "aspectName": "status",
-        "aspect": {
-            "json": {
-                "removed": false
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
-        "changeType": "UPSERT",
-        "aspectName": "status",
-        "aspect": {
-            "json": {
-                "removed": false
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
-        "changeType": "UPSERT",
-        "aspectName": "status",
-        "aspect": {
-            "json": {
-                "removed": false
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
-        "changeType": "UPSERT",
-        "aspectName": "status",
-        "aspect": {
-            "json": {
-                "removed": false
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
-        "changeType": "UPSERT",
-        "aspectName": "status",
-        "aspect": {
-            "json": {
-                "removed": false
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
-        "changeType": "UPSERT",
-        "aspectName": "status",
-        "aspect": {
-            "json": {
-                "removed": false
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
-        "changeType": "UPSERT",
-        "aspectName": "status",
-        "aspect": {
-            "json": {
-                "removed": false
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
-        "changeType": "UPSERT",
-        "aspectName": "status",
-        "aspect": {
-            "json": {
-                "removed": false
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
-        "changeType": "UPSERT",
-        "aspectName": "status",
-        "aspect": {
-            "json": {
-                "removed": false
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "assertion",
-        "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
-        "changeType": "UPSERT",
-        "aspectName": "status",
-        "aspect": {
-            "json": {
-                "removed": false
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "tag",
-        "entityUrn": "urn:li:tag:dbt:column_tag",
-        "changeType": "UPSERT",
-        "aspectName": "tagKey",
-        "aspect": {
-            "json": {
-                "name": "dbt:column_tag"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "tag",
-        "entityUrn": "urn:li:tag:dbt:customer",
-        "changeType": "UPSERT",
-        "aspectName": "tagKey",
-        "aspect": {
-            "json": {
-                "name": "dbt:customer"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "tag",
-        "entityUrn": "urn:li:tag:dbt:executive",
-        "changeType": "UPSERT",
-        "aspectName": "tagKey",
-        "aspect": {
-            "json": {
-                "name": "dbt:executive"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "tag",
-        "entityUrn": "urn:li:tag:dbt:ml",
-        "changeType": "UPSERT",
-        "aspectName": "tagKey",
-        "aspect": {
-            "json": {
-                "name": "dbt:ml"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "tag",
-        "entityUrn": "urn:li:tag:dbt:payments",
-        "changeType": "UPSERT",
-        "aspectName": "tagKey",
-        "aspect": {
-            "json": {
-                "name": "dbt:payments"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "tag",
-        "entityUrn": "urn:li:tag:dbt:test_tag",
-        "changeType": "UPSERT",
-        "aspectName": "tagKey",
-        "aspect": {
-            "json": {
-                "name": "dbt:test_tag"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "dbt-test-with-target-platform-instance",
-            "lastRunId": "no-run-id-provided"
-        }
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
     }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "owner": "@alice2",
+                            "business_owner": "jdoe.last@gmail.com",
+                            "data_governance.team_owner": "Finance",
+                            "has_pii": "True",
+                            "int_property": "1",
+                            "double_property": "2.5",
+                            "node_type": "model",
+                            "materialization": "ephemeral",
+                            "dbt_file_path": "models/transform/customer_details.sql",
+                            "language": "sql",
+                            "dbt_unique_id": "model.sample_dbt.customer_details",
+                            "dbt_package_name": "sample_dbt",
+                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                            "manifest_version": "0.19.1",
+                            "manifest_adapter": "postgres",
+                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                            "catalog_version": "0.19.1"
+                        },
+                        "name": "customer_details",
+                        "description": "",
+                        "tags": [
+                            "dbt:test_tag"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Ownership": {
+                        "owners": [
+                            {
+                                "owner": "urn:li:corpuser:@alice2",
+                                "type": "DATAOWNER"
+                            }
+                        ],
+                        "ownerTypes": {},
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        }
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.GlobalTags": {
+                        "tags": [
+                            {
+                                "tag": "urn:li:tag:dbt:test_tag"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "model.sample_dbt.customer_details",
+                        "platform": "urn:li:dataPlatform:dbt",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "customer_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "INT",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "full_name",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "VARCHAR",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "email",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "TEXT",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "address",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "TEXT",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "city",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "TEXT",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "postal_code",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "TEXT",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "phone",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "TEXT",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                        "upstreams": [
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                                "type": "TRANSFORMED"
+                            },
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                                "type": "TRANSFORMED"
+                            },
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                                "type": "TRANSFORMED"
+                            }
+                        ],
+                        "fineGrainedLineages": [
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),customer_id)"
+                                ],
+                                "confidenceScore": 0.9
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),full_name)"
+                                ],
+                                "confidenceScore": 0.9
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),email)"
+                                ],
+                                "confidenceScore": 0.9
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),address)"
+                                ],
+                                "confidenceScore": 0.9
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),city)"
+                                ],
+                                "confidenceScore": 0.9
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),postal_code)"
+                                ],
+                                "confidenceScore": 0.9
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD),phone)"
+                                ],
+                                "confidenceScore": 0.9
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                        "materialized": false,
+                        "viewLogic": "{{ config(\n    materialized = \"ephemeral\",\n) }}\n\nSELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name as \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\nFROM\n    {{ source('pagila', 'customer')}} c\n    left outer join {{ source('pagila', 'address')}} a on c.address_id = a.address_id\n    left outer join {{ source('pagila', 'city') }} m on a.city_id = m.city_id",
+                        "formattedViewLogic": "SELECT\n  c.customer_id,\n  c.first_name || ' ' || c.last_name AS \"full_name\",\n  c.email,\n  a.address,\n  m.city,\n  a.postal_code,\n  a.phone\nFROM \"pagila\".\"public\".\"customer\" AS c\nLEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n  ON c.address_id = a.address_id\nLEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n  ON a.city_id = m.city_id",
+                        "viewLanguage": "SQL"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Model"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "business_owner": "jdoe.last",
+                            "data_governance.team_owner": "Sales",
+                            "has_pii": "False",
+                            "int_property": "2",
+                            "double_property": "3.5",
+                            "node_type": "model",
+                            "materialization": "table",
+                            "dbt_file_path": "models/billing/monthly_billing_with_cust.sql",
+                            "catalog_type": "BASE TABLE",
+                            "language": "sql",
+                            "dbt_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                            "dbt_package_name": "sample_dbt",
+                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                            "manifest_version": "0.19.1",
+                            "manifest_adapter": "postgres",
+                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                            "catalog_version": "0.19.1"
+                        },
+                        "name": "an-aliased-view-for-monthly-billing",
+                        "description": "",
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "model.sample_dbt.monthly_billing_with_cust",
+                        "platform": "urn:li:dataPlatform:dbt",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "amount",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "numeric",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "billing_month",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                    }
+                                },
+                                "nativeDataType": "timestamp with time zone",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "customer_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "email",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "text",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                        "upstreams": [
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                                "type": "TRANSFORMED"
+                            },
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                                "type": "TRANSFORMED"
+                            }
+                        ],
+                        "fineGrainedLineages": [
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)"
+                                ],
+                                "confidenceScore": 0.9
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)"
+                                ],
+                                "confidenceScore": 0.9
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)"
+                                ],
+                                "confidenceScore": 0.9
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                        "materialized": true,
+                        "viewLogic": "{{ config(\n    materialized = \"table\",\n    alias='an-aliased-view-for-monthly-billing'\n) }}\n\nSELECT \n    pbc.billing_month,\n    pbc.customer_id,\n    pbc.amount,\n    cust.email\nFROM\n    {{ ref('payments_by_customer_by_month')}} pbc\n    left outer join {{ ref('customer_details')}} cust on pbc.customer_id = cust.customer_id\nORDER BY\n    pbc.billing_month",
+                        "formattedViewLogic": "WITH __dbt__CTE__customer_details AS (\n  SELECT\n    c.customer_id,\n    c.first_name || ' ' || c.last_name AS \"full_name\",\n    c.email,\n    a.address,\n    m.city,\n    a.postal_code,\n    a.phone\n  FROM \"pagila\".\"public\".\"customer\" AS c\n  LEFT OUTER JOIN \"pagila\".\"public\".\"address\" AS a\n    ON c.address_id = a.address_id\n  LEFT OUTER JOIN \"pagila\".\"public\".\"city\" AS m\n    ON a.city_id = m.city_id\n)\nSELECT\n  pbc.billing_month,\n  pbc.customer_id,\n  pbc.amount,\n  cust.email\nFROM \"pagila\".\"dbt_postgres\".\"payments_by_customer_by_month\" AS pbc\nLEFT OUTER JOIN __dbt__CTE__customer_details AS cust\n  ON pbc.customer_id = cust.customer_id\nORDER BY\n  pbc.billing_month",
+                        "viewLanguage": "SQL"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Model"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "node_type": "model",
+                            "materialization": "view",
+                            "dbt_file_path": "models/base/payments_base.sql",
+                            "catalog_type": "VIEW",
+                            "language": "sql",
+                            "dbt_unique_id": "model.sample_dbt.payments_base",
+                            "dbt_package_name": "sample_dbt",
+                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                            "manifest_version": "0.19.1",
+                            "manifest_adapter": "postgres",
+                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                            "catalog_version": "0.19.1"
+                        },
+                        "name": "an-aliased-view-for-payments",
+                        "description": "",
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "model.sample_dbt.payments_base",
+                        "platform": "urn:li:dataPlatform:dbt",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "amount",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "numeric(5,2)",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "customer_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "payment_date",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                    }
+                                },
+                                "nativeDataType": "timestamp with time zone",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "payment_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "rental_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "staff_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                        "upstreams": [
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                                "type": "TRANSFORMED"
+                            },
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                                "type": "TRANSFORMED"
+                            },
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                                "type": "TRANSFORMED"
+                            },
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                                "type": "TRANSFORMED"
+                            },
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                                "type": "TRANSFORMED"
+                            },
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                                "type": "TRANSFORMED"
+                            },
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                                "type": "TRANSFORMED"
+                            }
+                        ],
+                        "fineGrainedLineages": [
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                ],
+                                "confidenceScore": 0.9
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                ],
+                                "confidenceScore": 0.9
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                ],
+                                "confidenceScore": 0.9
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)"
+                                ],
+                                "confidenceScore": 0.9
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)"
+                                ],
+                                "confidenceScore": 0.9
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)",
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)"
+                                ],
+                                "confidenceScore": 0.9
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                        "materialized": false,
+                        "viewLogic": "{{ config(\n    materialized=\"view\",\n    alias='an-aliased-view-for-payments'\n) }}\n\nwith payments as (\n\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_01')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_02')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_03')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_04')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_05')}}\n    UNION ALL\n    select \n        *\n    from \n        {{ source('pagila', 'payment_p2020_06')}}\n)\n\nselect *\nfrom payments",
+                        "formattedViewLogic": "WITH payments AS (\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_01\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_02\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_03\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_04\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_05\"\n  UNION ALL\n  SELECT\n    *\n  FROM \"pagila\".\"public\".\"payment_p2020_06\"\n)\nSELECT\n  *\nFROM payments",
+                        "viewLanguage": "SQL"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Model"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "node_type": "model",
+                            "materialization": "table",
+                            "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
+                            "catalog_type": "BASE TABLE",
+                            "language": "sql",
+                            "dbt_unique_id": "model.sample_dbt.payments_by_customer_by_month",
+                            "dbt_package_name": "sample_dbt",
+                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                            "manifest_version": "0.19.1",
+                            "manifest_adapter": "postgres",
+                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                            "catalog_version": "0.19.1"
+                        },
+                        "name": "payments_by_customer_by_month",
+                        "description": "",
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "model.sample_dbt.payments_by_customer_by_month",
+                        "platform": "urn:li:dataPlatform:dbt",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "amount",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "numeric",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "billing_month",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                    }
+                                },
+                                "nativeDataType": "timestamp with time zone",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "customer_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                        "upstreams": [
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                                "type": "TRANSFORMED"
+                            }
+                        ],
+                        "fineGrainedLineages": [
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)"
+                                ],
+                                "confidenceScore": 0.9
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)"
+                                ],
+                                "confidenceScore": 0.9
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)"
+                                ],
+                                "confidenceScore": 0.9
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.ViewProperties": {
+                        "materialized": true,
+                        "viewLogic": "{{ config(\n    materialized = \"table\",\n) }}\n\nSELECT\n    date_trunc('month', payment_date) as \"billing_month\",\n    customer_id,\n    sum(amount) as \"amount\"\nFROM\n    {{ ref('payments_base')}}\nGROUP BY\n    billing_month,\n    customer_id",
+                        "formattedViewLogic": "SELECT\n  DATE_TRUNC('MONTH', payment_date) AS \"billing_month\",\n  customer_id,\n  SUM(amount) AS \"amount\"\nFROM \"pagila\".\"dbt_postgres\".\"an-aliased-view-for-payments\"\nGROUP BY\n  billing_month,\n  customer_id",
+                        "viewLanguage": "SQL"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Source"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "model_maturity": "in dev",
+                            "some_other_property": "test 1",
+                            "owner": "@alice1",
+                            "node_type": "source",
+                            "dbt_file_path": "models/base.yml",
+                            "catalog_type": "BASE TABLE",
+                            "language": "sql",
+                            "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                            "dbt_package_name": "sample_dbt",
+                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                            "manifest_version": "0.19.1",
+                            "manifest_adapter": "postgres",
+                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                            "catalog_version": "0.19.1"
+                        },
+                        "name": "actor",
+                        "description": "description for actor table from dbt",
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Ownership": {
+                        "owners": [
+                            {
+                                "owner": "urn:li:corpuser:@alice1",
+                                "type": "DATAOWNER"
+                            }
+                        ],
+                        "ownerTypes": {},
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        }
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "source.sample_dbt.pagila.actor",
+                        "platform": "urn:li:dataPlatform:dbt",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 1581759273000,
+                            "actor": "urn:li:corpuser:dbt_executor"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "actor_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "first_name",
+                                "nullable": false,
+                                "description": "dbt comment: Actors column \u2013 from postgres\n\ndbt model description: description for first_name from dbt",
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "text",
+                                "recursive": false,
+                                "globalTags": {
+                                    "tags": [
+                                        {
+                                            "tag": "urn:li:tag:dbt:column_tag"
+                                        }
+                                    ]
+                                },
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "last_name",
+                                "nullable": false,
+                                "description": "description for last_name from dbt",
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "text",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "last_update",
+                                "nullable": false,
+                                "description": "description for last_update from dbt",
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                    }
+                                },
+                                "nativeDataType": "timestamp with time zone",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                        "upstreams": [
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD)",
+                                "type": "COPY"
+                            }
+                        ],
+                        "fineGrainedLineages": [
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD),actor_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),actor_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD),first_name)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),first_name)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD),last_name)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_name)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD),last_update)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD),last_update)"
+                                ],
+                                "confidenceScore": 1.0
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Source"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "node_type": "source",
+                            "dbt_file_path": "models/base.yml",
+                            "catalog_type": "BASE TABLE",
+                            "language": "sql",
+                            "dbt_unique_id": "source.sample_dbt.pagila.address",
+                            "dbt_package_name": "sample_dbt",
+                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                            "manifest_version": "0.19.1",
+                            "manifest_adapter": "postgres",
+                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                            "catalog_version": "0.19.1"
+                        },
+                        "name": "address",
+                        "description": "a user's address",
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "source.sample_dbt.pagila.address",
+                        "platform": "urn:li:dataPlatform:dbt",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 1623751200000,
+                            "actor": "urn:li:corpuser:dbt_executor"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "address",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "text",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "address2",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "text",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "address_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "city_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "district",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "text",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "last_update",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                    }
+                                },
+                                "nativeDataType": "timestamp with time zone",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "phone",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "text",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "postal_code",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "text",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                        "upstreams": [
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD)",
+                                "type": "COPY"
+                            }
+                        ],
+                        "fineGrainedLineages": [
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),address)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),address2)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address2)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),address_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),address_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),city_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),city_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),district)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),district)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),last_update)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),last_update)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),phone)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),phone)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD),postal_code)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD),postal_code)"
+                                ],
+                                "confidenceScore": 1.0
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Source"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "node_type": "source",
+                            "dbt_file_path": "models/base.yml",
+                            "catalog_type": "BASE TABLE",
+                            "language": "sql",
+                            "dbt_unique_id": "source.sample_dbt.pagila.category",
+                            "dbt_package_name": "sample_dbt",
+                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                            "manifest_version": "0.19.1",
+                            "manifest_adapter": "postgres",
+                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                            "catalog_version": "0.19.1"
+                        },
+                        "name": "category",
+                        "description": "a user's category",
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "source.sample_dbt.pagila.category",
+                        "platform": "urn:li:dataPlatform:dbt",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 1623319200000,
+                            "actor": "urn:li:corpuser:dbt_executor"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "category_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "last_update",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                    }
+                                },
+                                "nativeDataType": "timestamp with time zone",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "name",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "text",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                        "upstreams": [
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.category,PROD)",
+                                "type": "COPY"
+                            }
+                        ],
+                        "fineGrainedLineages": [
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.category,PROD),category_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),category_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.category,PROD),last_update)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),last_update)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.category,PROD),name)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD),name)"
+                                ],
+                                "confidenceScore": 1.0
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Source"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "node_type": "source",
+                            "dbt_file_path": "models/base.yml",
+                            "catalog_type": "BASE TABLE",
+                            "language": "sql",
+                            "dbt_unique_id": "source.sample_dbt.pagila.city",
+                            "dbt_package_name": "sample_dbt",
+                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                            "manifest_version": "0.19.1",
+                            "manifest_adapter": "postgres",
+                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                            "catalog_version": "0.19.1"
+                        },
+                        "name": "city",
+                        "description": "",
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "source.sample_dbt.pagila.city",
+                        "platform": "urn:li:dataPlatform:dbt",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 1581759925000,
+                            "actor": "urn:li:corpuser:dbt_executor"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "city",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "text",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "city_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "country_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "last_update",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                    }
+                                },
+                                "nativeDataType": "timestamp with time zone",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                        "upstreams": [
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD)",
+                                "type": "COPY"
+                            }
+                        ],
+                        "fineGrainedLineages": [
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD),city)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD),city_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),city_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD),country_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),country_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD),last_update)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD),last_update)"
+                                ],
+                                "confidenceScore": 1.0
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Source"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "model_maturity": "in prod",
+                            "owner": "@bob",
+                            "some_other_property": "test 2",
+                            "node_type": "source",
+                            "dbt_file_path": "models/base.yml",
+                            "catalog_type": "BASE TABLE",
+                            "language": "sql",
+                            "dbt_unique_id": "source.sample_dbt.pagila.country",
+                            "dbt_package_name": "sample_dbt",
+                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                            "manifest_version": "0.19.1",
+                            "manifest_adapter": "postgres",
+                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                            "catalog_version": "0.19.1"
+                        },
+                        "name": "country",
+                        "description": "",
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Ownership": {
+                        "owners": [
+                            {
+                                "owner": "urn:li:corpuser:@bob",
+                                "type": "DATAOWNER"
+                            }
+                        ],
+                        "ownerTypes": {},
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        }
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "source.sample_dbt.pagila.country",
+                        "platform": "urn:li:dataPlatform:dbt",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 1624033800000,
+                            "actor": "urn:li:corpuser:dbt_executor"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "country",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "text",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "country_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "last_update",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                    }
+                                },
+                                "nativeDataType": "timestamp with time zone",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                        "upstreams": [
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.country,PROD)",
+                                "type": "COPY"
+                            }
+                        ],
+                        "fineGrainedLineages": [
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.country,PROD),country)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.country,PROD),country_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),country_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.country,PROD),last_update)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD),last_update)"
+                                ],
+                                "confidenceScore": 1.0
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Source"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "node_type": "source",
+                            "dbt_file_path": "models/base.yml",
+                            "catalog_type": "BASE TABLE",
+                            "language": "sql",
+                            "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                            "dbt_package_name": "sample_dbt",
+                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                            "manifest_version": "0.19.1",
+                            "manifest_adapter": "postgres",
+                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                            "catalog_version": "0.19.1"
+                        },
+                        "name": "customer",
+                        "description": "description for customer table from dbt",
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "source.sample_dbt.pagila.customer",
+                        "platform": "urn:li:dataPlatform:dbt",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 1624032000000,
+                            "actor": "urn:li:corpuser:dbt_executor"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "active",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "activebool",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.BooleanType": {}
+                                    }
+                                },
+                                "nativeDataType": "boolean",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "address_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "create_date",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.DateType": {}
+                                    }
+                                },
+                                "nativeDataType": "date",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "customer_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "email",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "text",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "first_name",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "text",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "last_name",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "text",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "last_update",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                    }
+                                },
+                                "nativeDataType": "timestamp with time zone",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "store_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                        "upstreams": [
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD)",
+                                "type": "COPY"
+                            }
+                        ],
+                        "fineGrainedLineages": [
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),active)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),active)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),activebool)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),activebool)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),address_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),address_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),create_date)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),create_date)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),customer_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),customer_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),email)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),email)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),first_name)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),first_name)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),last_name)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_name)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),last_update)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),last_update)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD),store_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD),store_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Source"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "node_type": "source",
+                            "dbt_file_path": "models/base.yml",
+                            "catalog_type": "BASE TABLE",
+                            "language": "sql",
+                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                            "dbt_package_name": "sample_dbt",
+                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                            "manifest_version": "0.19.1",
+                            "manifest_adapter": "postgres",
+                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                            "catalog_version": "0.19.1"
+                        },
+                        "name": "payment_p2020_01",
+                        "description": "",
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "source.sample_dbt.pagila.payment_p2020_01",
+                        "platform": "urn:li:dataPlatform:dbt",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 1580505371996,
+                            "actor": "urn:li:corpuser:dbt_executor"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "amount",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "numeric(5,2)",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "customer_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "payment_date",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                    }
+                                },
+                                "nativeDataType": "timestamp with time zone",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "payment_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "rental_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "staff_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                        "upstreams": [
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD)",
+                                "type": "COPY"
+                            }
+                        ],
+                        "fineGrainedLineages": [
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),amount)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),amount)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),customer_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),customer_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),payment_date)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_date)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),payment_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),payment_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),rental_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),rental_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD),staff_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD),staff_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Source"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "an_array_property": "['alpha', 'beta', 'charlie']",
+                            "model_maturity": "in prod",
+                            "owner": "@charles",
+                            "some_other_property": "test 3",
+                            "node_type": "source",
+                            "dbt_file_path": "models/base.yml",
+                            "catalog_type": "BASE TABLE",
+                            "language": "sql",
+                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                            "dbt_package_name": "sample_dbt",
+                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                            "manifest_version": "0.19.1",
+                            "manifest_adapter": "postgres",
+                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                            "catalog_version": "0.19.1"
+                        },
+                        "name": "payment_p2020_02",
+                        "description": "",
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Ownership": {
+                        "owners": [
+                            {
+                                "owner": "urn:li:corpuser:@charles",
+                                "type": "DATAOWNER"
+                            }
+                        ],
+                        "ownerTypes": {},
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        }
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "source.sample_dbt.pagila.payment_p2020_02",
+                        "platform": "urn:li:dataPlatform:dbt",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 1582319845996,
+                            "actor": "urn:li:corpuser:dbt_executor"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "amount",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "numeric(5,2)",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "customer_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "payment_date",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                    }
+                                },
+                                "nativeDataType": "timestamp with time zone",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "payment_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "rental_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "staff_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                        "upstreams": [
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD)",
+                                "type": "COPY"
+                            }
+                        ],
+                        "fineGrainedLineages": [
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),amount)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),amount)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),customer_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),customer_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),payment_date)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_date)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),payment_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),payment_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),rental_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),rental_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD),staff_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD),staff_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Source"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "node_type": "source",
+                            "dbt_file_path": "models/base.yml",
+                            "catalog_type": "BASE TABLE",
+                            "language": "sql",
+                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                            "dbt_package_name": "sample_dbt",
+                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                            "manifest_version": "0.19.1",
+                            "manifest_adapter": "postgres",
+                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                            "catalog_version": "0.19.1"
+                        },
+                        "name": "payment_p2020_03",
+                        "description": "",
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "source.sample_dbt.pagila.payment_p2020_03",
+                        "platform": "urn:li:dataPlatform:dbt",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 1584998318996,
+                            "actor": "urn:li:corpuser:dbt_executor"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "amount",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "numeric(5,2)",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "customer_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "payment_date",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                    }
+                                },
+                                "nativeDataType": "timestamp with time zone",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "payment_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "rental_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "staff_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                        "upstreams": [
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD)",
+                                "type": "COPY"
+                            }
+                        ],
+                        "fineGrainedLineages": [
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),amount)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),amount)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),customer_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),customer_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),payment_date)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_date)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),payment_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),payment_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),rental_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),rental_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD),staff_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD),staff_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Source"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "node_type": "source",
+                            "dbt_file_path": "models/base.yml",
+                            "catalog_type": "BASE TABLE",
+                            "language": "sql",
+                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                            "dbt_package_name": "sample_dbt",
+                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                            "manifest_version": "0.19.1",
+                            "manifest_adapter": "postgres",
+                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                            "catalog_version": "0.19.1"
+                        },
+                        "name": "payment_p2020_04",
+                        "description": "",
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "source.sample_dbt.pagila.payment_p2020_04",
+                        "platform": "urn:li:dataPlatform:dbt",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 1588287228996,
+                            "actor": "urn:li:corpuser:dbt_executor"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "amount",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "numeric(5,2)",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "customer_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "payment_date",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                    }
+                                },
+                                "nativeDataType": "timestamp with time zone",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "payment_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "rental_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "staff_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                        "upstreams": [
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD)",
+                                "type": "COPY"
+                            }
+                        ],
+                        "fineGrainedLineages": [
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),amount)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),amount)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),customer_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),customer_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),payment_date)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_date)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),payment_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),payment_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),rental_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),rental_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD),staff_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD),staff_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Source"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "node_type": "source",
+                            "dbt_file_path": "models/base.yml",
+                            "catalog_type": "BASE TABLE",
+                            "language": "sql",
+                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                            "dbt_package_name": "sample_dbt",
+                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                            "manifest_version": "0.19.1",
+                            "manifest_adapter": "postgres",
+                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                            "catalog_version": "0.19.1"
+                        },
+                        "name": "payment_p2020_05",
+                        "description": "a payment",
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "source.sample_dbt.pagila.payment_p2020_05",
+                        "platform": "urn:li:dataPlatform:dbt",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 1589460269996,
+                            "actor": "urn:li:corpuser:dbt_executor"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "amount",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "numeric(5,2)",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "customer_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "payment_date",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                    }
+                                },
+                                "nativeDataType": "timestamp with time zone",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "payment_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "rental_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "staff_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                        "upstreams": [
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD)",
+                                "type": "COPY"
+                            }
+                        ],
+                        "fineGrainedLineages": [
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),amount)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),amount)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),customer_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),customer_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),payment_date)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_date)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),payment_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),payment_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),rental_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),rental_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD),staff_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD),staff_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Source"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "node_type": "source",
+                            "dbt_file_path": "models/base.yml",
+                            "catalog_type": "BASE TABLE",
+                            "language": "sql",
+                            "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                            "dbt_package_name": "sample_dbt",
+                            "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                            "manifest_version": "0.19.1",
+                            "manifest_adapter": "postgres",
+                            "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                            "catalog_version": "0.19.1"
+                        },
+                        "name": "payment_p2020_06",
+                        "description": "",
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "source.sample_dbt.pagila.payment_p2020_06",
+                        "platform": "urn:li:dataPlatform:dbt",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": -62135596800000,
+                            "actor": "urn:li:corpuser:dbt_executor"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "amount",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "numeric(5,2)",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "customer_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "payment_date",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.TimeType": {}
+                                    }
+                                },
+                                "nativeDataType": "timestamp with time zone",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "payment_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "rental_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
+                                "fieldPath": "staff_id",
+                                "nullable": false,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "integer",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+                        "upstreams": [
+                            {
+                                "auditStamp": {
+                                    "time": 1643832000000,
+                                    "actor": "urn:li:corpuser:unknown"
+                                },
+                                "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD)",
+                                "type": "COPY"
+                            }
+                        ],
+                        "fineGrainedLineages": [
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),amount)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),amount)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),customer_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),customer_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),payment_date)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_date)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),payment_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),payment_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),rental_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),rental_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            },
+                            {
+                                "upstreamType": "FIELD_SET",
+                                "upstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD),staff_id)"
+                                ],
+                                "downstreamType": "FIELD",
+                                "downstreams": [
+                                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD),staff_id)"
+                                ],
+                                "confidenceScore": 1.0
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:postgres",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,ps-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                "value": {
+                    "auditStamp": {
+                        "time": 1643832000000,
+                        "actor": "urn:li:corpuser:unknown"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                    "type": "COPY"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),amount)",
+                "value": {
+                    "confidenceScore": 1.0
+                }
+            },
+            {
+                "op": "add",
+                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),billing_month)",
+                "value": {
+                    "confidenceScore": 1.0
+                }
+            },
+            {
+                "op": "add",
+                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),customer_id)",
+                "value": {
+                    "confidenceScore": 1.0
+                }
+            },
+            {
+                "op": "add",
+                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD),email)",
+                "value": {
+                    "confidenceScore": 1.0
+                }
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:postgres",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,ps-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                "value": {
+                    "auditStamp": {
+                        "time": 1643832000000,
+                        "actor": "urn:li:corpuser:unknown"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                    "type": "COPY"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),amount)",
+                "value": {
+                    "confidenceScore": 1.0
+                }
+            },
+            {
+                "op": "add",
+                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),customer_id)",
+                "value": {
+                    "confidenceScore": 1.0
+                }
+            },
+            {
+                "op": "add",
+                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_date)",
+                "value": {
+                    "confidenceScore": 1.0
+                }
+            },
+            {
+                "op": "add",
+                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),payment_id)",
+                "value": {
+                    "confidenceScore": 1.0
+                }
+            },
+            {
+                "op": "add",
+                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),rental_id)",
+                "value": {
+                    "confidenceScore": 1.0
+                }
+            },
+            {
+                "op": "add",
+                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD),staff_id)",
+                "value": {
+                    "confidenceScore": 1.0
+                }
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:postgres",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,ps-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                "value": {
+                    "auditStamp": {
+                        "time": 1643832000000,
+                        "actor": "urn:li:corpuser:unknown"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                    "type": "COPY"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),amount)",
+                "value": {
+                    "confidenceScore": 1.0
+                }
+            },
+            {
+                "op": "add",
+                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),billing_month)",
+                "value": {
+                    "confidenceScore": 1.0
+                }
+            },
+            {
+                "op": "add",
+                "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD),customer_id)",
+                "value": {
+                    "confidenceScore": 1.0
+                }
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.actor,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:postgres",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,ps-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.address,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:postgres",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,ps-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.category,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:postgres",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,ps-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.city,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:postgres",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,ps-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.country,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:postgres",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,ps-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.customer,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:postgres",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,ps-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_01,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:postgres",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,ps-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_02,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:postgres",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,ps-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_03,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:postgres",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,ps-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_04,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:postgres",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,ps-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_05,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:postgres",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,ps-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,ps-instance-1.pagila.public.payment_p2020_06,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:postgres",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,ps-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "dbt Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+            },
+            "source": {
+                "type": "EXTERNAL",
+                "created": {
+                    "time": 1643832000000,
+                    "actor": "urn:li:corpuser:__datahub_system"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "dbt Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+            },
+            "source": {
+                "type": "EXTERNAL",
+                "created": {
+                    "time": 1643832000000,
+                    "actor": "urn:li:corpuser:__datahub_system"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "warn",
+                    "max_loaded_at": "2021-06-15T10:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "259200.0"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "dbt Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+            },
+            "source": {
+                "type": "EXTERNAL",
+                "created": {
+                    "time": 1643832000000,
+                    "actor": "urn:li:corpuser:__datahub_system"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "FAILURE",
+                "severity": "HIGH",
+                "nativeResults": {
+                    "status": "error",
+                    "max_loaded_at": "2021-06-10T10:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "691200.0"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "error_after_count": "1",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "dbt Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+            },
+            "source": {
+                "type": "EXTERNAL",
+                "created": {
+                    "time": 1643832000000,
+                    "actor": "urn:li:corpuser:__datahub_system"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "30",
+                "warn_after_period": "minute"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "dbt Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+            },
+            "source": {
+                "type": "EXTERNAL",
+                "created": {
+                    "time": 1643832000000,
+                    "actor": "urn:li:corpuser:__datahub_system"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2021-06-18T16:30:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "2335.925443"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "1",
+                "warn_after_period": "day",
+                "error_after_count": "2",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "dbt Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+            },
+            "source": {
+                "type": "EXTERNAL",
+                "created": {
+                    "time": 1643832000000,
+                    "actor": "urn:li:corpuser:__datahub_system"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2021-06-18T16:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "4085.925443"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "3",
+                "warn_after_period": "day",
+                "error_after_count": "7",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "dbt Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+            },
+            "source": {
+                "type": "EXTERNAL",
+                "created": {
+                    "time": 1643832000000,
+                    "actor": "urn:li:corpuser:__datahub_system"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "dbt Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+            },
+            "source": {
+                "type": "EXTERNAL",
+                "created": {
+                    "time": 1643832000000,
+                    "actor": "urn:li:corpuser:__datahub_system"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "dbt Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+            },
+            "source": {
+                "type": "EXTERNAL",
+                "created": {
+                    "time": 1643832000000,
+                    "actor": "urn:li:corpuser:__datahub_system"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "dbt Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+            },
+            "source": {
+                "type": "EXTERNAL",
+                "created": {
+                    "time": 1643832000000,
+                    "actor": "urn:li:corpuser:__datahub_system"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "dbt Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+            },
+            "source": {
+                "type": "EXTERNAL",
+                "created": {
+                    "time": 1643832000000,
+                    "actor": "urn:li:corpuser:__datahub_system"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "dbt Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+            },
+            "source": {
+                "type": "EXTERNAL",
+                "created": {
+                    "time": 1643832000000,
+                    "actor": "urn:li:corpuser:__datahub_system"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+    "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "exposure.sample_dbt.customer_dashboard",
+                "exposure_type": "dashboard",
+                "maturity": "high",
+                "dbt_package_name": "sample_dbt",
+                "dbt_file_path": "models/exposures.yml",
+                "team": "analytics"
+            },
+            "externalUrl": "https://bi.example.com/dashboards/customer",
+            "title": "customer_dashboard",
+            "description": "Dashboard showing customer details and billing",
+            "charts": [],
+            "datasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
+            ],
+            "dashboards": [],
+            "lastModified": {
+                "created": {
+                    "time": 1643832000000,
+                    "actor": "urn:li:corpuser:dbt_ingestion"
+                },
+                "lastModified": {
+                    "time": 1643832000000,
+                    "actor": "urn:li:corpuser:dbt_ingestion"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Dashboard"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:analytics@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.customer_dashboard)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:dbt:executive"
+                },
+                {
+                    "tag": "urn:li:tag:dbt:customer"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+    "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "exposure.sample_dbt.payments_ml_model",
+                "exposure_type": "ml",
+                "maturity": "medium",
+                "dbt_package_name": "sample_dbt",
+                "dbt_file_path": "models/exposures.yml"
+            },
+            "externalUrl": "https://mlflow.example.com/models/payments",
+            "title": "payments_ml_model",
+            "description": "ML model for payment predictions",
+            "charts": [],
+            "datasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
+            ],
+            "dashboards": [],
+            "lastModified": {
+                "created": {
+                    "time": 1643832000000,
+                    "actor": "urn:li:corpuser:dbt_ingestion"
+                },
+                "lastModified": {
+                    "time": 1643832000000,
+                    "actor": "urn:li:corpuser:dbt_ingestion"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "ML Model"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:ds@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(dbt,exposure.sample_dbt.payments_ml_model)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:dbt:ml"
+                },
+                {
+                    "tag": "urn:li:tag:dbt:payments"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:dbt:column_tag",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "dbt:column_tag"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:dbt:customer",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "dbt:customer"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:dbt:executive",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "dbt:executive"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:dbt:ml",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "dbt:ml"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:dbt:payments",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "dbt:payments"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:dbt:test_tag",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "dbt:test_tag"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643832000000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+}
 ]

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_target_platform_aspects.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_target_platform_aspects.py
@@ -175,6 +175,31 @@ def test_skips_browse_path_when_aspect_read_fails() -> None:
     assert get_aspect(aspects, BrowsePathsV2Class) is None
 
 
+def test_no_hierarchy_segments_skips_browse_path() -> None:
+    node = create_dbt_node()
+    node.database = None
+    node.schema = None
+    source = create_dbt_source()
+    aspects = target_platform_workunit_aspects(source, node)
+
+    assert get_aspect(aspects, DataPlatformInstanceClass) is not None
+    assert get_aspect(aspects, BrowsePathsV2Class) is None
+
+
+def test_schema_only_none_keeps_database_segment() -> None:
+    node = create_dbt_node()
+    node.schema = None
+    source = create_dbt_source()
+    aspects = target_platform_workunit_aspects(source, node)
+
+    browse = get_aspect(aspects, BrowsePathsV2Class)
+    assert browse is not None
+    assert [entry.id for entry in browse.path] == [
+        INSTANCE_URN,
+        "warehouse_db",
+    ]
+
+
 def test_two_tier_node_omits_database_segment() -> None:
     node = create_dbt_node()
     node.database = None

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_target_platform_aspects.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_target_platform_aspects.py
@@ -7,7 +7,7 @@ name-derived defaults (plain-name browse folder, instance-less
 dataPlatformInstance).
 """
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Type, TypeVar
 from unittest import mock
 
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
@@ -79,7 +79,10 @@ def target_platform_workunit_aspects(source: DBTCoreSource, node: DBTNode) -> Li
     ]
 
 
-def get_aspect(aspects: List, aspect_type: type):
+T = TypeVar("T")
+
+
+def get_aspect(aspects: List, aspect_type: Type[T]) -> Optional[T]:
     matches = [a for a in aspects if isinstance(a, aspect_type)]
     assert len(matches) <= 1
     return matches[0] if matches else None

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_target_platform_aspects.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_target_platform_aspects.py
@@ -1,0 +1,186 @@
+"""Tests for target-platform dataPlatformInstance / browsePathsV2 emission.
+
+When target_platform_instance is set, the dbt source emits platform-instance
+metadata for target-platform sibling entities so that entities created only
+via sibling/lineage references ("stubs") do not fall back to server-generated
+name-derived defaults (plain-name browse folder, instance-less
+dataPlatformInstance).
+"""
+
+from typing import Dict, List, Optional
+from unittest import mock
+
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.dbt.dbt_common import DBTNode
+from datahub.ingestion.source.dbt.dbt_core import DBTCoreConfig, DBTCoreSource
+from datahub.metadata.schema_classes import (
+    BrowsePathEntryClass,
+    BrowsePathsV2Class,
+    DataPlatformInstanceClass,
+)
+
+TARGET_INSTANCE = "warehouse_instance"
+INSTANCE_URN = (
+    f"urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,{TARGET_INSTANCE})"
+)
+
+
+def create_dbt_source(
+    config_overrides: Optional[Dict] = None,
+    graph: Optional[mock.MagicMock] = mock.DEFAULT,
+) -> DBTCoreSource:
+    config: Dict = {
+        "manifest_path": "temp/",
+        "catalog_path": "temp/",
+        "sources_path": "temp/",
+        "target_platform": "postgres",
+        "target_platform_instance": TARGET_INSTANCE,
+        "enable_meta_mapping": False,
+        **(config_overrides or {}),
+    }
+    ctx = PipelineContext(run_id="test-run-id", pipeline_name="dbt-source")
+    if graph is mock.DEFAULT:
+        graph = mock.MagicMock()
+        graph.get_aspect.return_value = None
+    ctx.graph = graph
+    return DBTCoreSource(DBTCoreConfig(**config), ctx)
+
+
+def create_dbt_node() -> DBTNode:
+    return DBTNode(
+        database="warehouse_db",
+        schema="warehouse_schema",
+        name="my_table",
+        alias=None,
+        comment="",
+        description="",
+        language="sql",
+        raw_code=None,
+        dbt_adapter="postgres",
+        dbt_name="model.jaffle_shop.my_table",
+        dbt_file_path="models/my_table.sql",
+        dbt_package_name="jaffle_shop",
+        node_type="model",
+        max_loaded_at=None,
+        materialization="table",
+        catalog_type="table",
+        missing_from_catalog=False,
+        owner=None,
+    )
+
+
+def target_platform_workunit_aspects(source: DBTCoreSource, node: DBTNode) -> List:
+    return [
+        wu.metadata.aspect
+        for wu in source.create_target_platform_mces([node])
+        if isinstance(wu.metadata, MetadataChangeProposalWrapper)
+        and wu.metadata.aspect is not None
+    ]
+
+
+def get_aspect(aspects: List, aspect_type: type):
+    matches = [a for a in aspects if isinstance(a, aspect_type)]
+    assert len(matches) <= 1
+    return matches[0] if matches else None
+
+
+def test_emits_platform_instance_and_browse_path_for_stub_entity() -> None:
+    source = create_dbt_source()
+    aspects = target_platform_workunit_aspects(source, create_dbt_node())
+
+    dpi = get_aspect(aspects, DataPlatformInstanceClass)
+    assert dpi is not None
+    assert dpi.platform == "urn:li:dataPlatform:postgres"
+    assert dpi.instance == INSTANCE_URN
+
+    browse = get_aspect(aspects, BrowsePathsV2Class)
+    assert browse is not None
+    assert browse.path == [
+        BrowsePathEntryClass(id=INSTANCE_URN, urn=INSTANCE_URN),
+        BrowsePathEntryClass(id="warehouse_db"),
+        BrowsePathEntryClass(id="warehouse_schema"),
+    ]
+
+
+def test_preserves_container_based_browse_path() -> None:
+    graph = mock.MagicMock()
+    graph.get_aspect.return_value = BrowsePathsV2Class(
+        path=[
+            BrowsePathEntryClass(id=INSTANCE_URN, urn=INSTANCE_URN),
+            BrowsePathEntryClass(
+                id="urn:li:container:abc123", urn="urn:li:container:abc123"
+            ),
+        ]
+    )
+    source = create_dbt_source(graph=graph)
+    aspects = target_platform_workunit_aspects(source, create_dbt_node())
+
+    assert get_aspect(aspects, DataPlatformInstanceClass) is not None
+    assert get_aspect(aspects, BrowsePathsV2Class) is None
+
+
+def test_replaces_plain_name_derived_browse_path() -> None:
+    graph = mock.MagicMock()
+    graph.get_aspect.return_value = BrowsePathsV2Class(
+        path=[
+            BrowsePathEntryClass(id=TARGET_INSTANCE),
+            BrowsePathEntryClass(id="warehouse_db"),
+        ]
+    )
+    source = create_dbt_source(graph=graph)
+    aspects = target_platform_workunit_aspects(source, create_dbt_node())
+
+    browse = get_aspect(aspects, BrowsePathsV2Class)
+    assert browse is not None
+    assert browse.path[0].urn == INSTANCE_URN
+
+
+def test_no_emission_without_target_platform_instance() -> None:
+    source = create_dbt_source(config_overrides={"target_platform_instance": None})
+    aspects = target_platform_workunit_aspects(source, create_dbt_node())
+
+    assert get_aspect(aspects, DataPlatformInstanceClass) is None
+    assert get_aspect(aspects, BrowsePathsV2Class) is None
+
+
+def test_no_emission_when_disabled_by_config() -> None:
+    source = create_dbt_source(
+        config_overrides={"emit_target_platform_instance_aspects": False}
+    )
+    aspects = target_platform_workunit_aspects(source, create_dbt_node())
+
+    assert get_aspect(aspects, DataPlatformInstanceClass) is None
+    assert get_aspect(aspects, BrowsePathsV2Class) is None
+
+
+def test_skips_browse_path_without_graph_connection() -> None:
+    source = create_dbt_source(graph=None)
+    aspects = target_platform_workunit_aspects(source, create_dbt_node())
+
+    assert get_aspect(aspects, DataPlatformInstanceClass) is not None
+    assert get_aspect(aspects, BrowsePathsV2Class) is None
+
+
+def test_skips_browse_path_when_aspect_read_fails() -> None:
+    graph = mock.MagicMock()
+    graph.get_aspect.side_effect = RuntimeError("connection reset")
+    source = create_dbt_source(graph=graph)
+    aspects = target_platform_workunit_aspects(source, create_dbt_node())
+
+    assert get_aspect(aspects, DataPlatformInstanceClass) is not None
+    assert get_aspect(aspects, BrowsePathsV2Class) is None
+
+
+def test_two_tier_node_omits_database_segment() -> None:
+    node = create_dbt_node()
+    node.database = None
+    source = create_dbt_source()
+    aspects = target_platform_workunit_aspects(source, node)
+
+    browse = get_aspect(aspects, BrowsePathsV2Class)
+    assert browse is not None
+    assert [entry.id for entry in browse.path] == [
+        INSTANCE_URN,
+        "warehouse_schema",
+    ]


### PR DESCRIPTION
## Problem

When a dbt source has `target_platform_instance` set, it emits sibling and lineage MCPs that reference target-platform (warehouse) dataset URNs. For any table whose URN does not yet exist at the time of the dbt run, those references cause the server to auto-create a "stub" dataset entity with default-generated aspects:

- a `dataPlatformInstance` aspect containing the platform only, with no `instance` field, and
- a `browsePathsV2` derived from URN name segments. Because the platform instance is embedded in the URN name (`myinstance.db.schema.table`), the plain instance name becomes the browse root.

The result is a duplicate navigation folder in the Browse sidebar (a plain-name folder alongside the URN-form folder for the same instance) and entities that are invisible to platform-instance facets and filters. The defaults are generated once at entity creation and the dbt source never emits these aspects. For tables the warehouse connector ingests, its next run overwrites the defaults, so the damage is transient; for tables it never ingests (dropped or one-off tables, schemas/shares outside the warehouse recipe scope, test/temp tables) nothing corrects the stubs and they accumulate. A platform-instance URN migration (adding `platform_instance` to existing recipes) creates these stubs en masse, since every URN in the dbt manifest becomes newly-created at once.

Server-side #17263 fixes the browse root for newly-created entities when the platform instance entity already exists, but does not address the instance-less `dataPlatformInstance` aspect, entities created before that fix, or servers without it.

## Fix

When `target_platform_instance` is configured (and the new `emit_target_platform_instance_aspects` config is left enabled), `create_target_platform_mces` now emits for each target-platform entity:

1. A `dataPlatformInstance` aspect carrying the full instance URN. This is value-identical to what the warehouse connector writes for the same entity, so the upsert is a no-op for entities the warehouse connector owns and a fix for sibling-only stubs - including healing existing stubs on the next dbt run.
2. A `browsePathsV2` rooted at the platform-instance URN with database/schema segments, guarded so it never overwrites a container-based browse path written by the warehouse connector: the write only happens when a DataHub graph connection is available and the entity's existing browse path is missing or is a plain name-derived server default. This also heals previously-created stubs in place on re-ingest.

Both emissions are marked `is_primary_source=False`, consistent with the existing target-platform workunits.

## Testing

- New unit tests in `tests/unit/dbt/test_dbt_target_platform_aspects.py` covering: stub emission values, preservation of container-based browse paths, healing of plain name-derived paths, no-op without `target_platform_instance`, config kill-switch, graph-unavailable and aspect-read-failure fallbacks, and two-tier (no database) path structure. Verified red on the pre-fix code (7/8 fail) and green with the fix.
- Full dbt unit suite passes (223 tests).
- All 20 dbt integration tests pass; the `dbt-test-with-target-platform-instance` golden file is regenerated (new `dataPlatformInstance` aspects; no browse paths, as the test pipeline has no graph connection).
