### PR TITLE
fix(ingest): Incomplete lineage information emission for large results in Unity Catalog 

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
@@ -1122,7 +1122,9 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
 
             result_dict: FileBackedDict[Dict[str, dict]] = FileBackedDict()
             for row in rows:
-                schema_lineage = result_dict.for_mutation(row["target_table_schema"], default={})
+                schema_lineage = result_dict.for_mutation(
+                    row["target_table_schema"], default={}
+                )
                 table_lineage = schema_lineage.setdefault(row["target_table_name"], {})
                 column_lineage = table_lineage.setdefault(row["target_column_name"], [])
                 column_lineage.append(

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
@@ -1024,15 +1024,16 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
 
                 # Initialize TableLineageInfo for both source and target tables if they're in our catalog
                 for table_name in [source_full_name, target_full_name]:
-                    if (
-                        table_name
-                        and table_name.startswith(f"{catalog}.")
-                        and table_name not in result_dict
-                    ):
-                        result_dict[table_name] = TableLineageInfo()
+                    if table_name and table_name.startswith(f"{catalog}."):
+                        result_dict.for_mutation(
+                            table_name,
+                            default=TableLineageInfo(),
+                        )
 
                 # Process upstream relationships (target table gets upstreams)
                 if target_full_name and target_full_name.startswith(f"{catalog}."):
+                    target_lineage = result_dict.for_mutation(target_full_name)
+
                     # Handle table upstreams
                     if (
                         source_type in ["TABLE", "VIEW"]
@@ -1043,7 +1044,7 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
                             source_type=source_type,
                             last_updated=last_updated,
                         )
-                        result_dict[target_full_name].upstreams.append(upstream)
+                        target_lineage.upstreams.append(upstream)
 
                     # Handle external upstreams (PATH type)
                     elif source_type == "PATH":
@@ -1052,9 +1053,7 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
                             source_type=source_type,
                             last_updated=last_updated,
                         )
-                        result_dict[target_full_name].external_upstreams.append(
-                            external_upstream
-                        )
+                        target_lineage.external_upstreams.append(external_upstream)
 
                     # Handle upstream notebooks (notebook -> table)
                     elif entity_type == "NOTEBOOK":
@@ -1062,9 +1061,7 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
                             id=entity_id,
                             last_updated=last_updated,
                         )
-                        result_dict[target_full_name].upstream_notebooks.append(
-                            notebook_ref
-                        )
+                        target_lineage.upstream_notebooks.append(notebook_ref)
 
                 # Process downstream relationships (source table gets downstream notebooks)
                 if (
@@ -1072,13 +1069,12 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
                     and source_full_name
                     and source_full_name.startswith(f"{catalog}.")
                 ):
+                    source_lineage = result_dict.for_mutation(source_full_name)
                     notebook_ref = NotebookReference(
                         id=entity_id,
                         last_updated=last_updated,
                     )
-                    result_dict[source_full_name].downstream_notebooks.append(
-                        notebook_ref
-                    )
+                    source_lineage.downstream_notebooks.append(notebook_ref)
 
             return result_dict
         except Exception as e:
@@ -1126,9 +1122,10 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
 
             result_dict: FileBackedDict[Dict[str, dict]] = FileBackedDict()
             for row in rows:
-                result_dict.setdefault(row["target_table_schema"], {}).setdefault(
-                    row["target_table_name"], {}
-                ).setdefault(row["target_column_name"], []).append(
+                schema_lineage = result_dict.for_mutation(row["target_table_schema"], default={})
+                table_lineage = schema_lineage.setdefault(row["target_table_name"], {})
+                column_lineage = table_lineage.setdefault(row["target_column_name"], [])
+                column_lineage.append(
                     # make fields look like the response from the older HTTP API
                     {
                         "catalog_name": row["source_table_catalog"],


### PR DESCRIPTION
Issue - While aggregating Unity lineage from system tables, lineage entries were intermittently missing for large results.

### Root Cause

result_dict, which tracks cache entries as:
- dirty: modified in memory and must be flushed to SQLite on eviction
- clean: assumed unchanged from persisted state, so eviction does not write it

In the previous flow:
- A key could be reloaded from disk as clean.
- Code then performed in-place mutations (append)
- If eviction happened before the entry was marked dirty again, those mutations were dropped.

This is why behavior looked fine for small datasets, but failed under larger result sets with higher cache churn.

### Fix Overview
Updated lineage aggregation to use for_mutation(...) before all in-place updates.for_mutation(...) guarantees the entry is marked dirty before mutation, so eviction persists changes.

### Behavior Notes
- No lineage response shape changes.
- No change to lineage query/filter semantics.
- Fix is focused on persistence correctness during cache eviction for large result sets.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->