### PR TITLE
chore(ingest): restore pre-#17852 convert_urns_to_lowercase gating

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_lowercase_urns.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_lowercase_urns.py
@@ -25,7 +25,29 @@ class AutoLowercaseUrnsProcessor(WorkunitProcessor[AutoLowercaseUrnsProcessorRep
 
     @classmethod
     def should_enable(cls, ctx: WorkunitProcessorContext) -> bool:
-        return bool(getattr(ctx.source_config, "convert_urns_to_lowercase", False))
+        # Gate on the value explicitly set in the recipe rather than the parsed
+        # config's effective (default-applied) value. Enabling this from a
+        # connector default (e.g. Snowflake defaults convert_urns_to_lowercase
+        # to True) lowercases the platform_instance segment of dataset URNs,
+        # which changes asset identity on upgrade and orphans previously
+        # attached metadata (assertions, incidents, manual edits) for recipes
+        # that never explicitly opted in. Restores the pre-#17852 behavior.
+        pipeline_config = getattr(ctx.pipeline_context, "pipeline_config", None)
+        if not (
+            pipeline_config and pipeline_config.source and pipeline_config.source.config
+        ):
+            return False
+        raw_config = pipeline_config.source.config
+        return bool(
+            (
+                hasattr(raw_config, "convert_urns_to_lowercase")
+                and raw_config.convert_urns_to_lowercase
+            )
+            or (
+                hasattr(raw_config, "get")
+                and raw_config.get("convert_urns_to_lowercase")
+            )
+        )
 
     def process(self, stream: Iterable[MetadataWorkUnit]) -> Iterable[MetadataWorkUnit]:
         """Lowercase all dataset urns"""

--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_lowercase_urns.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_lowercase_urns.py
@@ -25,29 +25,34 @@ class AutoLowercaseUrnsProcessor(WorkunitProcessor[AutoLowercaseUrnsProcessorRep
 
     @classmethod
     def should_enable(cls, ctx: WorkunitProcessorContext) -> bool:
-        # Gate on the value explicitly set in the recipe rather than the parsed
-        # config's effective (default-applied) value. Enabling this from a
-        # connector default (e.g. Snowflake defaults convert_urns_to_lowercase
-        # to True) lowercases the platform_instance segment of dataset URNs,
-        # which changes asset identity on upgrade and orphans previously
-        # attached metadata (assertions, incidents, manual edits) for recipes
-        # that never explicitly opted in. Restores the pre-#17852 behavior.
+        # convert_urns_to_lowercase affects dataset identity, so any change in
+        # how the flag is evaluated changes URNs and breaks previously-emitted
+        # entities. We deliberately restore the previous (buggy) behavior — gate
+        # on the value explicitly present in the recipe rather than the parsed
+        # config's default-applied value — to avoid that. The correct,
+        # default-honoring check (to restore once it can be done identity-safely)
+        # would be:
+        #     return bool(getattr(ctx.source_config, "convert_urns_to_lowercase", False))
         pipeline_config = getattr(ctx.pipeline_context, "pipeline_config", None)
-        if not (
-            pipeline_config and pipeline_config.source and pipeline_config.source.config
-        ):
-            return False
-        raw_config = pipeline_config.source.config
-        return bool(
-            (
-                hasattr(raw_config, "convert_urns_to_lowercase")
-                and raw_config.convert_urns_to_lowercase
-            )
-            or (
-                hasattr(raw_config, "get")
-                and raw_config.get("convert_urns_to_lowercase")
-            )
+        raw_config = getattr(getattr(pipeline_config, "source", None), "config", None)
+        # Only what the recipe explicitly set; None means the key is absent.
+        recipe_value = (
+            raw_config.get("convert_urns_to_lowercase")
+            if isinstance(raw_config, dict)
+            else getattr(raw_config, "convert_urns_to_lowercase", None)
         )
+
+        if recipe_value is None and getattr(
+            ctx.source_config, "convert_urns_to_lowercase", False
+        ):
+            ctx.source_report.warning(
+                title="URN lowercasing not applied",
+                message="convert_urns_to_lowercase defaults to true for this source "
+                "but is not set in the recipe; leaving it disabled to preserve "
+                "existing dataset URNs. Set it explicitly in the recipe to enable.",
+            )
+
+        return bool(recipe_value)
 
     def process(self, stream: Iterable[MetadataWorkUnit]) -> Iterable[MetadataWorkUnit]:
         """Lowercase all dataset urns"""

--- a/metadata-ingestion/tests/unit/api/source_helpers/test_source_helpers.py
+++ b/metadata-ingestion/tests/unit/api/source_helpers/test_source_helpers.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import List, Optional, Union
 from unittest import mock
 
@@ -16,6 +17,7 @@ from datahub.ingestion.api.source_helpers import (
     create_dataset_props_patch_builder,
 )
 from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.api.workunit_processor import WorkunitProcessorContext
 from datahub.ingestion.workunit_processors.auto_lowercase_urns import (
     AutoLowercaseUrnsProcessor,
 )
@@ -328,6 +330,52 @@ def test_auto_lowercase_aspects():
     ]
     processor = AutoLowercaseUrnsProcessor(mock.MagicMock())
     assert list(processor.process(mcws)) == expected
+
+
+def _lowercase_ctx(
+    recipe_config: object, parsed_default: bool
+) -> WorkunitProcessorContext:
+    """Build a context whose recipe dict is `recipe_config` and whose parsed
+    source config defaults convert_urns_to_lowercase to `parsed_default`."""
+    pipeline_config = SimpleNamespace(source=SimpleNamespace(config=recipe_config))
+    pipeline_context = SimpleNamespace(pipeline_config=pipeline_config)
+    return WorkunitProcessorContext(
+        source_report=mock.MagicMock(),
+        pipeline_context=pipeline_context,  # type: ignore[arg-type]
+        source_config=SimpleNamespace(convert_urns_to_lowercase=parsed_default),  # type: ignore[arg-type]
+        platform=None,
+    )
+
+
+def test_auto_lowercase_should_enable_ignores_connector_default():
+    # A recipe that never sets the flag must NOT lowercase, even when the
+    # connector default is True (e.g. Snowflake). Guards against the identity
+    # flip regression where the parsed default was honored.
+    assert (
+        AutoLowercaseUrnsProcessor.should_enable(
+            _lowercase_ctx(recipe_config={}, parsed_default=True)
+        )
+        is False
+    )
+
+
+def test_auto_lowercase_should_enable_honors_explicit_recipe_value():
+    assert (
+        AutoLowercaseUrnsProcessor.should_enable(
+            _lowercase_ctx(
+                recipe_config={"convert_urns_to_lowercase": True}, parsed_default=False
+            )
+        )
+        is True
+    )
+    assert (
+        AutoLowercaseUrnsProcessor.should_enable(
+            _lowercase_ctx(
+                recipe_config={"convert_urns_to_lowercase": False}, parsed_default=True
+            )
+        )
+        is False
+    )
 
 
 @time_machine.travel("2023-01-02 00:00:00+00:00", tick=False)


### PR DESCRIPTION
## Summary

The workunit processor refactor (#17852) changed how `AutoLowercaseUrnsProcessor` is gated. Previously the gate read the **raw recipe dict** (`pipeline_config.source.config`), so lowercasing was enabled only when `convert_urns_to_lowercase` was explicitly present in the recipe. After the refactor it reads the **parsed source config** (`ctx.source_config`), so the connector *default* for `convert_urns_to_lowercase` (which is `True` for several sources, e.g. Snowflake) started being honored where it previously was not.

For a recipe that never sets the flag but carries an uppercase `platform_instance`, this lowercases the `platform_instance` segment of the dataset URN on upgrade. Because the URN is the entity's identity, a **new dataset entity is minted** and metadata attached to the old URN — assertions, incidents, and manual edits — is left stranded on the now-orphaned entity.

This restores the pre-refactor behavior: enable the processor only when `convert_urns_to_lowercase` is **explicitly present** in the recipe config, so an upgrade no longer silently changes asset identity for recipes that relied on the default.

## Changes

- `AutoLowercaseUrnsProcessor.should_enable()` now gates on the explicit recipe value (via `ctx.pipeline_context.pipeline_config.source.config`) rather than the parsed config's default-applied value.
- Added unit tests covering: the connector default is ignored when the recipe omits the flag, and an explicit `true`/`false` in the recipe is honored.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing/#commit-message-format))
- [x] Tests added/updated
- [ ] Docs added/updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)