### PR TITLE
feat(cli/migrate): converter-driven `migrate transform` (generic URN migration)

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -960,6 +960,7 @@ module.exports = {
         "metadata-ingestion/docs/dev_guides/stateful",
         "metadata-ingestion/docs/dev_guides/classification",
         "metadata-ingestion/docs/dev_guides/add_stateful_ingestion_to_source",
+        "metadata-ingestion/docs/dev_guides/ingestion_migrations",
         "metadata-ingestion/docs/dev_guides/sql_profiles",
         "metadata-ingestion/docs/dev_guides/profiling_ingestions",
         "metadata-ingestion/docs/dev_guides/lineage_urn_casing",

--- a/metadata-ingestion/docs/dev_guides/ingestion_migrations.md
+++ b/metadata-ingestion/docs/dev_guides/ingestion_migrations.md
@@ -1,0 +1,84 @@
+# Ingestion Migrations
+
+Ingestion migrations let a connector ship a **one-time fix that reshapes metadata already in DataHub** when the connector introduces a breaking change — for example a URN-scheme change (see [Lineage URN casing](./lineage_urn_casing.md)), an aspect-shape change, or a renamed custom property. Without this, existing entities keep the old shape until they happen to be re-ingested, and references to them dangle.
+
+A migration is declared **in the connector code**, DataHub records which migrations have already been applied, and any not-yet-applied migration runs **before ingestion** (when enabled).
+
+## When to use a migration
+
+Use one when a connector change means metadata **already in DataHub** must be transformed — not merely that future ingestion emits a new shape. If the next normal ingestion run naturally overwrites the affected aspects, you do not need a migration.
+
+## How it works
+
+- Migrations are declared by overriding `get_migrations()` on a source that extends `StatefulIngestionSourceBase`.
+- The set of applied migration ids is stored in a **ledger** that rides the stateful-ingestion checkpoint, keyed per pipeline. So migrations **require stateful ingestion** to be enabled.
+- Before ingestion, a pre-ingestion hook computes the **pending** migrations (declared but not in the ledger) and, when enabled, runs them in declared order, recording each id as it succeeds.
+
+Because the ledger is per pipeline, a migration can re-trigger when a *different* pipeline ingests the same data, and the ledger read is eventually consistent (so two runs of the *same* pipeline in quick succession could both apply). **Migrations must therefore be idempotent** — re-running one must be a no-op. A migration that selects its targets with a filter that matches nothing after the first apply (e.g. "datasets whose URN is not already lowercase") satisfies this naturally.
+
+## Declaring a migration
+
+A `Migration` is a stable `id`, a `description`, and a callable `run(graph, report, dry_run)` containing the migration code:
+
+```python
+from datahub.ingestion.source.state.ingestion_migration import Migration
+from datahub.ingestion.source.state.stateful_ingestion_base import (
+    StatefulIngestionSourceBase,
+)
+
+
+class MySource(StatefulIngestionSourceBase):
+    def get_migrations(self):
+        return [
+            Migration(
+                id="mysource-0001-lowercase-urns",  # stable & unique; never reuse an id
+                description="Lowercase dataset URNs after the casing fix.",
+                run=self._lowercase_urns,
+            ),
+        ]
+
+    def _lowercase_urns(self, graph, report, dry_run):
+        # Migration code: select the affected URNs and mutate them. Idempotent.
+        ...
+```
+
+`run` is a plain callable (method, lambda, or module-level function). It receives the `DataHubGraph`, the source's `SourceReport` (use it to log counts/warnings), and a `dry_run` flag.
+
+### Rename-type migrations
+
+For breaking changes that rename URNs, reuse the `migrate transform` core rather than hand-rolling the rewrite — it moves all aspects and rewrites table- and column-level lineage plus incoming references:
+
+```python
+from datahub.cli.migrate import run_transform
+from datahub.cli.migration_utils import LowercaseConverter
+
+def _lowercase_urns(self, graph, report, dry_run):
+    run_transform(graph, LowercaseConverter(), platform="mysource", dry_run=dry_run)
+```
+
+For aspect-shape changes, fetch the affected aspects and re-emit them in the new shape from within `run`.
+
+## Enabling migrations
+
+Migrations are **disabled by default** — they never mutate metadata silently. Opt in per recipe:
+
+```yaml
+source:
+  type: mysource
+  config:
+    stateful_ingestion:
+      enabled: true
+      migrations:
+        enabled: true        # apply pending migrations before ingestion
+        dry_run: false       # log what would run without mutating
+        fail_on_pending: false  # if true, abort when a migration is pending but disabled
+```
+
+When migrations are pending but `enabled` is false, the run logs a warning listing the pending ids (and fails if `fail_on_pending` is set), so operators know a migration is waiting.
+
+## Guidelines
+
+- **Ids are permanent.** Once a migration has run anywhere, its id is recorded; never reuse or renumber ids. Prefix with the connector and an increasing number: `mysource-0001-...`.
+- **Idempotent, always.** Assume a migration may run more than once against the same data.
+- **A migration failure aborts ingestion** — ingestion should not land on half-migrated metadata. The ledger records only successes, so a re-run resumes at the first unapplied migration.
+- **Prefer a narrowing filter** so an already-migrated instance is a cheap no-op.

--- a/metadata-ingestion/docs/dev_guides/ingestion_migrations.md
+++ b/metadata-ingestion/docs/dev_guides/ingestion_migrations.md
@@ -53,8 +53,16 @@ from datahub.cli.migrate import run_transform
 from datahub.cli.migration_utils import LowercaseConverter
 
 def _lowercase_urns(self, graph, report, dry_run):
-    run_transform(graph, LowercaseConverter(), platform="mysource", dry_run=dry_run)
+    run_transform(
+        graph,
+        LowercaseConverter(),
+        platform="mysource",
+        platform_instance=self.config.platform_instance,  # optional; scope to this instance
+        dry_run=dry_run,
+    )
 ```
+
+`run_transform` discovers **all** matching datasets from the graph for the given `platform` (optionally narrowed to a `platform_instance`) — not just the URNs in the current pipeline's checkpoint state — so a migration reshapes every affected entity regardless of which pipeline produced it. Omit `platform_instance` to cover all instances of the platform.
 
 For aspect-shape changes, fetch the affected aspects and re-emit them in the new shape from within `run`.
 

--- a/metadata-ingestion/scripts/avro_codegen.py
+++ b/metadata-ingestion/scripts/avro_codegen.py
@@ -342,6 +342,14 @@ KEY_ASPECT_NAMES: Set[str] = {{cls.ASPECT_NAME for cls in KEY_ASPECTS.values()}}
 ENTITY_TYPE_NAMES: List[str] = [
     {f",{newline}    ".join(f"'{aspect['Aspect']['keyForEntity']}'" for aspect in aspects if aspect["Aspect"].get("keyForEntity"))}
 ]
+
+# Entity type -> full list of non-key aspect names, sourced verbatim from
+# entity-registry.yml. This is the authoritative set of aspects an entity type
+# may carry (includes timeseries aspects such as datasetProfile).
+ENTITY_TYPE_TO_ASPECT_NAMES: Dict[str, List[str]] = {{
+    {f",{newline}    ".join(f"'{aspect['Aspect']['keyForEntity']}': {aspect['Aspect']['entityAspects']!r}" for aspect in aspects if aspect["Aspect"].get("keyForEntity"))}
+}}
+
 EntityTypeName = Literal[
     {f",{newline}    ".join(f"'{aspect['Aspect']['keyForEntity']}'" for aspect in aspects if aspect["Aspect"].get("keyForEntity"))}
 ]

--- a/metadata-ingestion/src/datahub/cli/migrate.py
+++ b/metadata-ingestion/src/datahub/cli/migrate.py
@@ -181,11 +181,18 @@ def _migrate_single_entity(
     on_conflict: Optional[ConflictStrategy],
     system_metadata: SystemMetadataClass,
     migration_report: MigrationReport,
+    url_map: Optional[Dict[str, str]] = None,
 ) -> None:
     """Migrate a single entity URN to a new URN."""
     new_urn = make_new_urn(src_entity_urn)
     log.debug(f"Will migrate {src_entity_urn} to {new_urn}")
+    # Self-only rewriter for the incoming-reference pass (external referrers).
     rewrite_urn = migration_utils.make_self_urn_rewriter(src_entity_urn, new_urn)
+    # Batch rewriter for the clone path: also rewrites references to *sibling*
+    # entities migrated in the same run (e.g. a co-migrated upstream), which the
+    # eventually-consistent relationship index would miss for this batch.
+    batch_map = url_map or {src_entity_urn: new_urn}
+    clone_rewrite_urn = migration_utils.make_batch_urn_rewriter(batch_map)
 
     # Check if target already exists (for merge mode)
     target_exists = False
@@ -198,7 +205,7 @@ def _migrate_single_entity(
     if target_exists and on_conflict is not None:
         log.info(f"Target {new_urn} exists — merging aspects")
         merged, skipped = merge_entity(
-            src_entity_urn, new_urn, on_conflict, graph, dry_run
+            src_entity_urn, new_urn, on_conflict, graph, dry_run, url_map=batch_map
         )
         migration_report.aspects_merged += merged
         migration_report.conflicts_skipped += skipped
@@ -214,11 +221,12 @@ def _migrate_single_entity(
             dst_urn=new_urn,
             run_id=run_id,
         ):
-            # Rewrite the entity's own self-references inside the aspect body
-            # (e.g. fineGrainedLineages schemaField URNs), driven by the
-            # aspect's relationship/Urn field markers.
+            # Rewrite references inside the aspect body (e.g. fineGrainedLineages
+            # schemaField URNs and upstreamLineage pointers), driven by the
+            # aspect's relationship/Urn field markers. Uses the batch rewriter so
+            # references to co-migrated siblings are also moved to their new URNs.
             if mcp.aspect is not None:
-                transform_urns(mcp.aspect, rewrite_urn)
+                transform_urns(mcp.aspect, clone_rewrite_urn)
             if not dry_run:
                 graph.emit_mcp(mcp)
             migration_report.on_entity_create(mcp.entityUrn, mcp.aspectName)  # type: ignore
@@ -281,6 +289,10 @@ def _migrate_entities(
     migration_report = MigrationReport(run_id, dry_run, keep)
     system_metadata = SystemMetadataClass(runId=run_id)
 
+    # Full old->new map for the whole batch, so each entity's clone rewrites
+    # references to co-migrated siblings (not just its own self-references).
+    url_map = {urn: make_new_urn(urn) for urn in urns_to_migrate}
+
     if not force and not dry_run:
         sampled_urns = random.sample(urns_to_migrate, k=min(10, len(urns_to_migrate)))
         sampled_new_urns = [make_new_urn(u) for u in sampled_urns]
@@ -305,6 +317,7 @@ def _migrate_entities(
                 on_conflict=on_conflict,
                 system_metadata=system_metadata,
                 migration_report=migration_report,
+                url_map=url_map,
             )
         except Exception as e:
             if skip_on_error:

--- a/metadata-ingestion/src/datahub/cli/migrate.py
+++ b/metadata-ingestion/src/datahub/cli/migrate.py
@@ -341,6 +341,7 @@ def run_transform(
     *,
     platform_instance: Optional[str] = None,
     env: str = DEFAULT_ENV,
+    entity_types: Optional[List[str]] = None,
     dry_run: bool = False,
     force: bool = True,
     hard: bool = False,
@@ -349,22 +350,28 @@ def run_transform(
     skip_on_error: bool = False,
     run_id: Optional[str] = None,
 ) -> MigrationReport:
-    """Migrate a platform's datasets under a URN converter (e.g. LowercaseConverter).
+    """Migrate a platform's entities under a URN converter (e.g. LowercaseConverter).
 
-    Discovers non-soft-deleted datasets for ``platform`` (optionally narrowed to
-    ``platform_instance``) from the graph — all such datasets, not just those in
+    Discovers non-soft-deleted entities for ``platform`` (optionally narrowed to
+    ``platform_instance``) from the graph — all such entities, not just those in
     a pipeline's checkpoint state — filters by ``converter.should_convert``, and
     migrates each under ``converter.convert_urn`` using the same aspect/URN-
     rewriting core as instance2instance (no dataPlatformInstance emit). Reusable
     from the ``migrate transform`` command and from connector migrations (see
     get_migrations). ``force`` defaults to True for non-interactive use.
+
+    Entity types to discover come from ``converter.entity_types`` (so the engine
+    is not hardcoded to datasets); pass ``entity_types`` to override. ``env`` is
+    an origin filter and only applies to entity types that carry an origin
+    (datasets).
     """
     run_id = run_id or f"migrate-transform-{converter.name}-{uuid.uuid4()}"
+    discover_types = entity_types or converter.entity_types
     all_urns = graph.get_urns_by_filter(
         platform=platform,
         platform_instance=platform_instance,
         env=env,
-        entity_types=["dataset"],
+        entity_types=discover_types,
         status=RemovedStatusFilter.NOT_SOFT_DELETED,
     )
     urns = [urn for urn in all_urns if converter.should_convert(urn)]

--- a/metadata-ingestion/src/datahub/cli/migrate.py
+++ b/metadata-ingestion/src/datahub/cli/migrate.py
@@ -8,9 +8,8 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import click
 import progressbar
-from avrogen.dict_wrapper import DictWrapper
 
-from datahub.cli import cli_utils, delete_cli, migration_utils
+from datahub.cli import delete_cli, migration_utils
 from datahub.cli.migration_utils import (
     ALL_ENTITY_TYPES,
     ENV_ENTITY_TYPES,
@@ -37,7 +36,6 @@ from datahub.ingestion.graph.client import (
     get_default_graph,
 )
 from datahub.metadata.schema_classes import (
-    ContainerKeyClass,
     ContainerPropertiesClass,
     DataPlatformInstanceClass,
     SystemMetadataClass,
@@ -45,6 +43,7 @@ from datahub.metadata.schema_classes import (
 from datahub.telemetry import telemetry
 from datahub.upgrade import upgrade
 from datahub.utilities.urns.urn import Urn, guess_entity_type
+from datahub.utilities.urns.urn_iter import transform_urns
 
 log = logging.getLogger(__name__)
 
@@ -185,6 +184,7 @@ def _migrate_single_entity(
     """Migrate a single entity URN to a new URN."""
     new_urn = make_new_urn(src_entity_urn)
     log.debug(f"Will migrate {src_entity_urn} to {new_urn}")
+    rewrite_urn = migration_utils.make_self_urn_rewriter(src_entity_urn, new_urn)
 
     # Check if target already exists (for merge mode)
     target_exists = False
@@ -202,12 +202,22 @@ def _migrate_single_entity(
         migration_report.aspects_merged += merged
         migration_report.conflicts_skipped += skipped
     else:
+        # Aspect list comes from the entity registry, not a hand-maintained
+        # constant, so newly-modeled aspects are migrated automatically.
+        aspect_names = migration_utils.get_migratable_aspect_names(
+            guess_entity_type(src_entity_urn)
+        )
         for mcp in migration_utils.clone_aspect(
             src_entity_urn,
-            aspect_names=migration_utils.all_aspects,
+            aspect_names=aspect_names,
             dst_urn=new_urn,
             run_id=run_id,
         ):
+            # Rewrite the entity's own self-references inside the aspect body
+            # (e.g. fineGrainedLineages schemaField URNs), driven by the
+            # aspect's relationship/Urn field markers.
+            if mcp.aspect is not None:
+                transform_urns(mcp.aspect, rewrite_urn)
             if not dry_run:
                 graph.emit_mcp(mcp)
             migration_report.on_entity_create(mcp.entityUrn, mcp.aspectName)  # type: ignore
@@ -226,33 +236,21 @@ def _migrate_single_entity(
         )
     migration_report.on_entity_create(new_urn, "dataPlatformInstance")
 
-    # Update incoming relationships
+    # Update incoming relationships. The relationship index tells us which
+    # entities reference the migrated URN; we then rewrite that reference
+    # wherever it appears, across all of the referencing entity's aspects.
+    seen_targets = set()
     for relationship in migration_utils.get_incoming_relationships(src_entity_urn):
         target_urn = relationship.urn
-        entity_type = guess_entity_type(target_urn)
-        relationship_type = relationship.relationship_type
-        aspect_name = migration_utils.get_aspect_name_from_relationship(
-            relationship_type, entity_type
-        )
-        aspect_map = cli_utils.get_aspects_for_entity(
-            graph._session,
-            graph.config.server,
-            target_urn,
-            aspects=[aspect_name],
-            typed=True,
-        )
-        if aspect_name in aspect_map:
-            aspect = aspect_map[aspect_name]
-            assert isinstance(aspect, DictWrapper)
-            aspect = migration_utils.modify_urn_list_for_aspect(
-                aspect_name, aspect, relationship_type, src_entity_urn, new_urn
-            )
-            mcp = MetadataChangeProposalWrapper(entityUrn=target_urn, aspect=aspect)
+        if target_urn in seen_targets:
+            continue
+        seen_targets.add(target_urn)
+        for mcp in migration_utils.rewrite_incoming_references(
+            graph, target_urn, rewrite_urn
+        ):
             if not dry_run:
                 graph.emit_mcp(mcp)
             migration_report.on_entity_affected(mcp.entityUrn, mcp.aspectName)  # type: ignore
-        else:
-            log.debug(f"Didn't find aspect {aspect_name} for urn {target_urn}")
 
     if not dry_run and not keep:
         log.info(f"will {'hard' if hard else 'soft'} delete {src_entity_urn}")
@@ -373,20 +371,20 @@ def _migrate_containers(
 
         for mcp in migration_utils.clone_aspect(
             src_urn,
-            aspect_names=migration_utils.all_aspects,
+            aspect_names=migration_utils.get_migratable_aspect_names("container"),
             dst_urn=dst_urn,
             run_id=run_id,
         ):
             migration_report.on_entity_create(mcp.entityUrn, mcp.aspectName)  # type: ignore
             assert mcp.aspect
+            # The key aspect (containerKey) is not cloned — GMS derives it from
+            # the new URN's guid. We only need to reseat customProperties on the
+            # cloned containerProperties.
             if mcp.aspectName == "containerProperties":
                 assert isinstance(mcp.aspect, ContainerPropertiesClass)
                 mcp.aspect.customProperties = newKey.model_dump(
                     by_alias=True, exclude_none=True
                 )
-            elif mcp.aspectName == "containerKey":
-                assert isinstance(mcp.aspect, ContainerKeyClass)
-                mcp.aspect.guid = newKey.guid()
             if not dry_run:
                 rest_emitter.emit_mcp(mcp)
                 migration_report.on_entity_affected(mcp.entityUrn, mcp.aspectName)  # type: ignore
@@ -455,35 +453,21 @@ def _process_container_relationships(
     rest_emitter: DatahubRestEmitter,
 ) -> None:
     client = get_default_graph(ClientMode.CLI)
+    rewrite_urn = migration_utils.make_self_urn_rewriter(src_urn, dst_urn)
+    seen_targets = set()
     for relationship in migration_utils.get_incoming_relationships(urn=src_urn):
         target_urn: str = relationship.urn
         if target_urn in container_id_map:
             target_urn = container_id_map[target_urn]
-
-        entity_type = guess_entity_type(target_urn)
-        relationship_type = relationship.relationship_type
-        aspect_name = migration_utils.get_aspect_name_from_relationship(
-            relationship_type, entity_type
-        )
-        aspect_map = cli_utils.get_aspects_for_entity(
-            client._session,
-            client.config.server,
-            target_urn,
-            aspects=[aspect_name],
-            typed=True,
-        )
-        if aspect_name in aspect_map:
-            aspect = aspect_map[aspect_name]
-            assert isinstance(aspect, DictWrapper)
-            aspect = migration_utils.modify_urn_list_for_aspect(
-                aspect_name, aspect, relationship_type, src_urn, dst_urn
-            )
-            mcp = MetadataChangeProposalWrapper(entityUrn=target_urn, aspect=aspect)
+        if target_urn in seen_targets:
+            continue
+        seen_targets.add(target_urn)
+        for mcp in migration_utils.rewrite_incoming_references(
+            client, target_urn, rewrite_urn
+        ):
             if not dry_run:
                 rest_emitter.emit_mcp(mcp)
             migration_report.on_entity_affected(mcp.entityUrn, mcp.aspectName)  # type: ignore
-        else:
-            log.debug(f"Didn't find aspect {aspect_name} for urn {target_urn}")
 
 
 # --- CLI Commands ---

--- a/metadata-ingestion/src/datahub/cli/migrate.py
+++ b/metadata-ingestion/src/datahub/cli/migrate.py
@@ -326,6 +326,7 @@ def run_transform(
     converter: "migration_utils.UrnConverter",
     platform: str,
     *,
+    platform_instance: Optional[str] = None,
     env: str = DEFAULT_ENV,
     dry_run: bool = False,
     force: bool = True,
@@ -337,16 +338,18 @@ def run_transform(
 ) -> MigrationReport:
     """Migrate a platform's datasets under a URN converter (e.g. LowercaseConverter).
 
-    Discovers non-soft-deleted datasets for ``platform``, filters by
-    ``converter.should_convert``, and migrates each under ``converter.convert_urn``
-    using the same aspect/URN-rewriting core as instance2instance (no
-    dataPlatformInstance emit). Reusable from the ``migrate transform`` command
-    and from connector migrations (see get_migrations). ``force`` defaults to
-    True for non-interactive/programmatic use.
+    Discovers non-soft-deleted datasets for ``platform`` (optionally narrowed to
+    ``platform_instance``) from the graph — all such datasets, not just those in
+    a pipeline's checkpoint state — filters by ``converter.should_convert``, and
+    migrates each under ``converter.convert_urn`` using the same aspect/URN-
+    rewriting core as instance2instance (no dataPlatformInstance emit). Reusable
+    from the ``migrate transform`` command and from connector migrations (see
+    get_migrations). ``force`` defaults to True for non-interactive use.
     """
     run_id = run_id or f"migrate-transform-{converter.name}-{uuid.uuid4()}"
     all_urns = graph.get_urns_by_filter(
         platform=platform,
+        platform_instance=platform_instance,
         env=env,
         entity_types=["dataset"],
         status=RemovedStatusFilter.NOT_SOFT_DELETED,
@@ -785,6 +788,12 @@ def instance2instance(
 @migrate.command()
 @click.option("--platform", type=str, required=True)
 @click.option(
+    "--platform-instance",
+    type=str,
+    default=None,
+    help="Only migrate datasets on this platform instance (default: all instances).",
+)
+@click.option(
     "--converter",
     type=click.Choice(list(migration_utils.CONVERTERS.keys())),
     required=True,
@@ -824,6 +833,7 @@ def instance2instance(
 @upgrade.check_upgrade
 def transform(
     platform: str,
+    platform_instance: Optional[str],
     converter: str,
     env: str,
     dry_run: bool,
@@ -845,6 +855,7 @@ def transform(
         graph,
         conv,
         platform,
+        platform_instance=platform_instance,
         env=env,
         dry_run=dry_run,
         force=force,

--- a/metadata-ingestion/src/datahub/cli/migrate.py
+++ b/metadata-ingestion/src/datahub/cli/migrate.py
@@ -35,6 +35,7 @@ from datahub.ingestion.graph.client import (
     DataHubGraph,
     get_default_graph,
 )
+from datahub.ingestion.graph.filters import RemovedStatusFilter
 from datahub.metadata.schema_classes import (
     ContainerPropertiesClass,
     DataPlatformInstanceClass,
@@ -170,8 +171,8 @@ def _warn_dataflow_datajob_coupling(
 def _migrate_single_entity(
     src_entity_urn: str,
     make_new_urn: Callable[[str], str],
-    platform: str,
-    target_instance: str,
+    platform: Optional[str],
+    target_instance: Optional[str],
     dry_run: bool,
     hard: bool,
     keep: bool,
@@ -222,19 +223,23 @@ def _migrate_single_entity(
                 graph.emit_mcp(mcp)
             migration_report.on_entity_create(mcp.entityUrn, mcp.aspectName)  # type: ignore
 
-    # Always emit dataPlatformInstance
-    if not dry_run:
-        graph.emit_mcp(
-            MetadataChangeProposalWrapper(
-                entityUrn=new_urn,
-                aspect=DataPlatformInstanceClass(
-                    platform=make_data_platform_urn(platform),
-                    instance=make_dataplatform_instance_urn(platform, target_instance),
-                ),
-                systemMetadata=system_metadata,
+    # Emit dataPlatformInstance for instance migrations. A generic transform
+    # (e.g. lowercase) leaves platform/target_instance unset and skips this.
+    if platform is not None and target_instance is not None:
+        if not dry_run:
+            graph.emit_mcp(
+                MetadataChangeProposalWrapper(
+                    entityUrn=new_urn,
+                    aspect=DataPlatformInstanceClass(
+                        platform=make_data_platform_urn(platform),
+                        instance=make_dataplatform_instance_urn(
+                            platform, target_instance
+                        ),
+                    ),
+                    systemMetadata=system_metadata,
+                )
             )
-        )
-    migration_report.on_entity_create(new_urn, "dataPlatformInstance")
+        migration_report.on_entity_create(new_urn, "dataPlatformInstance")
 
     # Update incoming relationships. The relationship index tells us which
     # entities reference the migrated URN; we then rewrite that reference
@@ -261,8 +266,8 @@ def _migrate_single_entity(
 def _migrate_entities(
     urns_to_migrate: List[str],
     make_new_urn: Callable[[str], str],
-    platform: str,
-    target_instance: str,
+    platform: Optional[str],
+    target_instance: Optional[str],
     dry_run: bool,
     force: bool,
     hard: bool,
@@ -726,3 +731,96 @@ def instance2instance(
         keep=keep,
         rest_emitter=graph,
     )
+
+
+@migrate.command()
+@click.option("--platform", type=str, required=True)
+@click.option(
+    "--converter",
+    type=click.Choice(list(migration_utils.CONVERTERS.keys())),
+    required=True,
+    help="URN transform to apply.",
+)
+@click.option("--env", type=str, default=DEFAULT_ENV)
+@click.option("--dry-run", "-n", type=bool, is_flag=True, default=False)
+@click.option("-F", "--force", type=bool, is_flag=True, default=False)
+@click.option(
+    "--hard",
+    type=bool,
+    is_flag=True,
+    default=False,
+    help="Hard-delete previous entities instead of soft-delete.",
+)
+@click.option(
+    "--keep",
+    type=bool,
+    is_flag=True,
+    default=False,
+    help="Do not delete previous entities.",
+)
+@click.option(
+    "--on-conflict",
+    type=click.Choice(["overwrite", "patch", "prompt"]),
+    default="patch",
+    help="How to handle existing target entities.",
+)
+@click.option(
+    "--skip-on-error",
+    type=bool,
+    is_flag=True,
+    default=False,
+    help="Skip entities that cause errors instead of aborting.",
+)
+@telemetry.with_telemetry()
+@upgrade.check_upgrade
+def transform(
+    platform: str,
+    converter: str,
+    env: str,
+    dry_run: bool,
+    force: bool,
+    hard: bool,
+    keep: bool,
+    on_conflict: str,
+    skip_on_error: bool,
+) -> None:
+    """Migrate datasets under a URN transform (e.g. lowercase).
+
+    Applies the same aspect-cloning and URN-rewriting as instance2instance, but
+    the new URN is produced by the chosen converter rather than an instance
+    change. Unlike instance2instance, no dataPlatformInstance aspect is emitted.
+    """
+    conv = migration_utils.CONVERTERS[converter]()
+    conflict = ConflictStrategy(on_conflict)
+    run_id = f"migrate-transform-{conv.name}-{uuid.uuid4()}"
+    graph = get_default_graph(ClientMode.CLI)
+
+    all_urns = graph.get_urns_by_filter(
+        platform=platform,
+        env=env,
+        entity_types=["dataset"],
+        status=RemovedStatusFilter.NOT_SOFT_DELETED,
+    )
+    urns = [urn for urn in all_urns if conv.should_convert(urn)]
+    if not urns:
+        click.echo(
+            f"No datasets need '{conv.name}' conversion for platform {platform}."
+        )
+        return
+
+    click.echo(f"Found {len(urns)} datasets to {conv.name}.")
+    report = _migrate_entities(
+        urns_to_migrate=urns,
+        make_new_urn=conv.convert_urn,
+        platform=None,
+        target_instance=None,
+        dry_run=dry_run,
+        force=force,
+        hard=hard,
+        keep=keep,
+        run_id=run_id,
+        graph=graph,
+        on_conflict=conflict,
+        skip_on_error=skip_on_error,
+    )
+    click.echo(f"{report}")

--- a/metadata-ingestion/src/datahub/cli/migrate.py
+++ b/metadata-ingestion/src/datahub/cli/migrate.py
@@ -321,6 +321,55 @@ def _migrate_entities(
     return migration_report
 
 
+def run_transform(
+    graph: DataHubGraph,
+    converter: "migration_utils.UrnConverter",
+    platform: str,
+    *,
+    env: str = DEFAULT_ENV,
+    dry_run: bool = False,
+    force: bool = True,
+    hard: bool = False,
+    keep: bool = False,
+    on_conflict: Optional[ConflictStrategy] = None,
+    skip_on_error: bool = False,
+    run_id: Optional[str] = None,
+) -> MigrationReport:
+    """Migrate a platform's datasets under a URN converter (e.g. LowercaseConverter).
+
+    Discovers non-soft-deleted datasets for ``platform``, filters by
+    ``converter.should_convert``, and migrates each under ``converter.convert_urn``
+    using the same aspect/URN-rewriting core as instance2instance (no
+    dataPlatformInstance emit). Reusable from the ``migrate transform`` command
+    and from connector migrations (see get_migrations). ``force`` defaults to
+    True for non-interactive/programmatic use.
+    """
+    run_id = run_id or f"migrate-transform-{converter.name}-{uuid.uuid4()}"
+    all_urns = graph.get_urns_by_filter(
+        platform=platform,
+        env=env,
+        entity_types=["dataset"],
+        status=RemovedStatusFilter.NOT_SOFT_DELETED,
+    )
+    urns = [urn for urn in all_urns if converter.should_convert(urn)]
+    if not urns:
+        return MigrationReport(run_id, dry_run, keep)
+    return _migrate_entities(
+        urns_to_migrate=urns,
+        make_new_urn=converter.convert_urn,
+        platform=None,
+        target_instance=None,
+        dry_run=dry_run,
+        force=force,
+        hard=hard,
+        keep=keep,
+        run_id=run_id,
+        graph=graph,
+        on_conflict=on_conflict,
+        skip_on_error=skip_on_error,
+    )
+
+
 def _migrate_containers(
     env: str,
     platform: str,
@@ -791,36 +840,17 @@ def transform(
     change. Unlike instance2instance, no dataPlatformInstance aspect is emitted.
     """
     conv = migration_utils.CONVERTERS[converter]()
-    conflict = ConflictStrategy(on_conflict)
-    run_id = f"migrate-transform-{conv.name}-{uuid.uuid4()}"
     graph = get_default_graph(ClientMode.CLI)
-
-    all_urns = graph.get_urns_by_filter(
-        platform=platform,
+    report = run_transform(
+        graph,
+        conv,
+        platform,
         env=env,
-        entity_types=["dataset"],
-        status=RemovedStatusFilter.NOT_SOFT_DELETED,
-    )
-    urns = [urn for urn in all_urns if conv.should_convert(urn)]
-    if not urns:
-        click.echo(
-            f"No datasets need '{conv.name}' conversion for platform {platform}."
-        )
-        return
-
-    click.echo(f"Found {len(urns)} datasets to {conv.name}.")
-    report = _migrate_entities(
-        urns_to_migrate=urns,
-        make_new_urn=conv.convert_urn,
-        platform=None,
-        target_instance=None,
         dry_run=dry_run,
         force=force,
         hard=hard,
         keep=keep,
-        run_id=run_id,
-        graph=graph,
-        on_conflict=conflict,
+        on_conflict=ConflictStrategy(on_conflict),
         skip_on_error=skip_on_error,
     )
     click.echo(f"{report}")

--- a/metadata-ingestion/src/datahub/cli/migration_utils.py
+++ b/metadata-ingestion/src/datahub/cli/migration_utils.py
@@ -2,14 +2,14 @@
 
 import logging
 import uuid
-from typing import Callable, Dict, Iterable, List, Optional, Tuple
+from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import click
 from avrogen.dict_wrapper import DictWrapper
 
 from datahub.cli import cli_utils
+from datahub.emitter.aspect import TIMESERIES_ASPECT_MAP
 from datahub.emitter.mce_builder import (
-    Aspect,
     chart_urn_to_key,
     dashboard_urn_to_key,
     dataset_urn_to_key,
@@ -24,24 +24,20 @@ from datahub.ingestion.graph.client import DataHubGraph, get_default_graph
 from datahub.ingestion.graph.config import ClientMode
 from datahub.ingestion.graph.openapi import RelatedEntity, RelationshipDirection
 from datahub.metadata.schema_classes import (
-    ChartInfoClass,
-    ContainerClass,
-    DashboardInfoClass,
-    DataJobInputOutputClass,
-    DataProcessInfoClass,
+    ENTITY_TYPE_TO_ASPECT_NAMES,
     GlobalTagsClass,
     GlossaryTermsClass,
-    MLFeaturePropertiesClass,
-    MLPrimaryKeyPropertiesClass,
     OwnershipClass,
     SchemaMetadataClass,
     SystemMetadataClass,
     UpstreamLineageClass,
+    _Aspect,
 )
 from datahub.metadata.urns import DataFlowUrn, DataJobUrn
 from datahub.specific.dataset import DatasetPatchBuilder
 from datahub.utilities.str_enum import StrEnum
 from datahub.utilities.urns.urn import guess_entity_type
+from datahub.utilities.urns.urn_iter import list_urns, transform_urns
 
 log = logging.getLogger(__name__)
 
@@ -54,37 +50,6 @@ ALL_ENTITY_TYPES = ["dataset", "chart", "dashboard", "dataFlow", "dataJob"]
 # Entity types that support env/origin filtering in ElasticSearch.
 # Charts, dashboards, dataflows, and datajobs don't have env/origin fields.
 ENV_ENTITY_TYPES = {"dataset"}
-
-# TODO: Make this dynamic based on the real aspect class map.
-all_aspects = [
-    "schemaMetadata",
-    "datasetProperties",
-    "viewProperties",
-    "subTypes",
-    "editableDatasetProperties",
-    "ownership",
-    "datasetDeprecation",
-    "institutionalMemory",
-    "editableSchemaMetadata",
-    "globalTags",
-    "glossaryTerms",
-    "upstreamLineage",
-    "datasetUpstreamLineage",
-    "status",
-    "containerProperties",
-    "dataPlatformInstance",
-    "containerKey",
-    "container",
-    "domains",
-    "editableContainerProperties",
-    # Non-dataset entity aspects
-    "chartInfo",
-    "dashboardInfo",
-    "dataFlowInfo",
-    "dataJobInfo",
-    "dataJobInputOutput",
-    "dataProcessInfo",
-]
 
 
 class ConflictStrategy(StrEnum):
@@ -131,194 +96,95 @@ ALWAYS_OVERWRITE_ASPECTS = {
     "containerKey",
 }
 
+# Aspects the migration must NOT clone verbatim from source to the new URN:
+#  - dataPlatformInstance: re-emitted explicitly with the *new* instance
+#  - incidentsSummary: a platform-computed rollup; a verbatim copy would carry a
+#    stale summary and is re-derived by the platform anyway
+#  - browsePaths/browsePathsV2: encode the *old* instance path; recomputed on read
+# Key aspects (datasetKey, containerKey, ...) are intentionally absent from
+# ENTITY_TYPE_TO_ASPECT_NAMES: their content is bound to the URN and GMS derives
+# them on any write, so they are neither cloned nor listed here.
+SYSTEM_MANAGED_ASPECTS = {
+    "dataPlatformInstance",
+    "incidentsSummary",
+    "browsePaths",
+    "browsePathsV2",
+}
 
-# --- Relationship-to-aspect mapping ---
+_SCHEMA_FIELD_PREFIX = "urn:li:schemaField:"
 
 
-def get_aspect_name_from_relationship(relationship_type: str, entity_type: str) -> str:
-    aspect_map = {
-        "Produces": {"datajob": "dataJobInputOutput"},
-        "Consumes": {
-            "chart": "chartInfo",
-            "dashboard": "dashboardInfo",
-            "datajob": "dataJobInputOutput",
-            "dataProcess": "dataProcessInfo",
-        },
-        "DownstreamOf": {"dataset": "upstreamLineage"},
-        "ForeignKeyToDataset": {"dataset": "schemaMetadata"},
-        "DerivedFrom": {
-            "mlfeature": "mlFeatureProperties",
-            "mlprimarykey": "mlPrimaryKeyProperties",
-        },
-        "IsPartOf": {
-            "container": "container",
-            "dataset": "container",
-            "dashboard": "container",
-            "chart": "container",
-        },
-    }
+def get_migratable_aspect_names(entity_type: str) -> List[str]:
+    """Non-timeseries, user-migratable aspects for an entity type.
 
-    if (
-        relationship_type in aspect_map
-        and entity_type.lower() in aspect_map[relationship_type]
-    ):
-        return aspect_map[relationship_type][entity_type.lower()]
+    Sourced from the generated entity registry (``ENTITY_TYPE_TO_ASPECT_NAMES``)
+    instead of a hand-maintained list, so newly-modeled aspects
+    (``structuredProperties``, ``forms``, ``documentation``, ...) are picked up
+    automatically. Timeseries aspects are excluded (append-only; migrated, if at
+    all, via a separate path), as are system-managed aspects the migration
+    re-derives.
+    """
+    return [
+        a
+        for a in ENTITY_TYPE_TO_ASPECT_NAMES.get(entity_type, [])
+        if a not in TIMESERIES_ASPECT_MAP and a not in SYSTEM_MANAGED_ASPECTS
+    ]
 
-    raise Exception(
-        f"Unable to map aspect name from relationship_type {relationship_type} "
-        f"and entity_type {entity_type}"
+
+def make_self_urn_rewriter(old_urn: str, new_urn: str) -> Callable[[str], str]:
+    """Rewrite references to a single migrated entity URN.
+
+    Intended for use with ``urn_iter.transform_urns``, which walks an aspect
+    using its ``@Relationship``/Urn field markers and applies this function to
+    every URN it finds. Rewrites both the entity URN itself and ``schemaField``
+    URNs that embed it (column-level lineage), so FineGrainedLineage is covered
+    without any per-aspect special-casing. References to *other* entities are
+    left untouched.
+    """
+
+    def rewrite(urn: str) -> str:
+        if urn == old_urn:
+            return new_urn
+        # schemaField URNs are 'urn:li:schemaField:(<datasetUrn>,<field>)'.
+        # Rewrite only when the embedded dataset is the one being migrated.
+        if urn.startswith(f"{_SCHEMA_FIELD_PREFIX}({old_urn},"):
+            return urn.replace(old_urn, new_urn, 1)
+        return urn
+
+    return rewrite
+
+
+def rewrite_incoming_references(
+    graph: DataHubGraph,
+    target_urn: str,
+    rewrite_urn: Callable[[str], str],
+) -> List[MetadataChangeProposalWrapper]:
+    """Rewrite references to a migrated URN across all aspects of one entity.
+
+    Given an entity that references the migrated URN, fetch every (non-timeseries)
+    aspect it has and rewrite each via ``transform_urns`` — driven by the aspect's
+    relationship/Urn field markers. Unlike a hand-maintained relationship-to-aspect
+    map, this rewrites the reference wherever it appears, in any aspect. Returns an
+    MCP for each aspect that actually changed (the caller decides how to emit).
+    """
+    aspect_map = cli_utils.get_aspects_for_entity(
+        graph._session,
+        graph.config.server,
+        target_urn,
+        aspects=[],
+        typed=True,
     )
-
-
-# --- URN list modifiers (rewrite URN references inside aspects) ---
-
-
-class UrnListModifier:
-    @staticmethod
-    def dataJobInputOutput_modifier(
-        aspect: DictWrapper,
-        relationship_type: str,
-        old_urn: str,
-        new_urn: str,
-    ) -> DictWrapper:
-        assert isinstance(aspect, DataJobInputOutputClass)
-        if relationship_type == "Produces":
-            aspect.outputDatasets = [
-                new_urn if d == old_urn else d for d in aspect.outputDatasets
-            ]
-            return aspect
-        if relationship_type == "Consumes":
-            aspect.inputDatasets = [
-                new_urn if d == old_urn else d for d in aspect.inputDatasets
-            ]
-            return aspect
-        raise Exception(
-            f"Unable to map aspect_name: dataJobInputOutput, "
-            f"relationship_type {relationship_type}"
+    changed: List[MetadataChangeProposalWrapper] = []
+    for aspect in aspect_map.values():
+        if not isinstance(aspect, DictWrapper):
+            continue
+        if not any(rewrite_urn(u) != u for u in list_urns(aspect)):
+            continue
+        transform_urns(aspect, rewrite_urn)
+        changed.append(
+            MetadataChangeProposalWrapper(entityUrn=target_urn, aspect=aspect)
         )
-
-    @staticmethod
-    def chartInfo_modifier(
-        aspect: DictWrapper,
-        relationship_type: str,
-        old_urn: str,
-        new_urn: str,
-    ) -> DictWrapper:
-        assert isinstance(aspect, ChartInfoClass)
-        aspect.inputs = [new_urn if x == old_urn else x for x in aspect.inputs or []]
-        return aspect
-
-    @staticmethod
-    def dashboardInfo_modifier(
-        aspect: DictWrapper,
-        relationship_type: str,
-        old_urn: str,
-        new_urn: str,
-    ) -> DictWrapper:
-        assert isinstance(aspect, DashboardInfoClass)
-        aspect.datasets = [
-            new_urn if x == old_urn else x for x in aspect.datasets or []
-        ]
-        if aspect.datasetEdges is not None:
-            for edge in aspect.datasetEdges:
-                if edge.destinationUrn == old_urn:
-                    edge.destinationUrn = new_urn
-        return aspect
-
-    @staticmethod
-    def dataProcessInfo_modifier(
-        aspect: DictWrapper,
-        relationship_type: str,
-        old_urn: str,
-        new_urn: str,
-    ) -> DictWrapper:
-        assert isinstance(aspect, DataProcessInfoClass)
-        if aspect.inputs is not None:
-            aspect.inputs = [new_urn if x == old_urn else x for x in aspect.inputs]
-        return aspect
-
-    @staticmethod
-    def upstreamLineage_modifier(
-        aspect: DictWrapper,
-        relationship_type: str,
-        old_urn: str,
-        new_urn: str,
-    ) -> DictWrapper:
-        assert isinstance(aspect, UpstreamLineageClass)
-        for upstream in aspect.upstreams:
-            if upstream.dataset == old_urn:
-                upstream.dataset = new_urn
-        return aspect
-
-    @staticmethod
-    def schemaMetadata_modifier(
-        aspect: DictWrapper,
-        relationship_type: str,
-        old_urn: str,
-        new_urn: str,
-    ) -> DictWrapper:
-        assert isinstance(aspect, SchemaMetadataClass)
-        for foreignKey in aspect.foreignKeys or []:
-            foreignKey.foreignFields = [
-                f.replace(old_urn, new_urn) for f in foreignKey.foreignFields
-            ]
-            if foreignKey.foreignDataset == old_urn:
-                foreignKey.foreignDataset = new_urn
-        return aspect
-
-    @staticmethod
-    def mlFeatureProperties_modifier(
-        aspect: DictWrapper,
-        relationship_type: str,
-        old_urn: str,
-        new_urn: str,
-    ) -> DictWrapper:
-        assert isinstance(aspect, MLFeaturePropertiesClass)
-        aspect.sources = [new_urn if s == old_urn else s for s in aspect.sources or []]
-        return aspect
-
-    @staticmethod
-    def mlPrimaryKeyProperties_modifier(
-        aspect: DictWrapper,
-        relationship_type: str,
-        old_urn: str,
-        new_urn: str,
-    ) -> DictWrapper:
-        assert isinstance(aspect, MLPrimaryKeyPropertiesClass)
-        aspect.sources = [new_urn if s == old_urn else s for s in aspect.sources]
-        return aspect
-
-    @staticmethod
-    def container_modifier(
-        aspect: DictWrapper,
-        relationship_type: str,
-        old_urn: str,
-        new_urn: str,
-    ) -> DictWrapper:
-        assert isinstance(aspect, ContainerClass)
-        aspect.container = new_urn if aspect.container == old_urn else aspect.container
-        return aspect
-
-
-def modify_urn_list_for_aspect(
-    aspect_name: str,
-    aspect: Aspect,
-    relationship_type: str,
-    old_urn: str,
-    new_urn: str,
-) -> Aspect:
-    if hasattr(UrnListModifier, f"{aspect_name}_modifier"):
-        modifier = getattr(UrnListModifier, f"{aspect_name}_modifier")
-        return modifier(
-            aspect=aspect,
-            relationship_type=relationship_type,
-            old_urn=old_urn,
-            new_urn=new_urn,
-        )
-    raise Exception(
-        f"Unable to map aspect_name: {aspect_name}, "
-        f"relationship_type {relationship_type}"
-    )
+    return changed
 
 
 # --- Aspect cloning and relationship fetching ---
@@ -410,6 +276,8 @@ def merge_additive_aspects(
         assert isinstance(aspect, UpstreamLineageClass)
         for upstream in aspect.upstreams or []:
             patch_builder.add_upstream_lineage(upstream)
+        for fine_grained in aspect.fineGrainedLineages or []:
+            patch_builder.add_fine_grained_lineage(fine_grained)
 
     mcps = patch_builder.build()
     for mcp in mcps:
@@ -608,7 +476,7 @@ def _overwrite_entity(
     aspects_written = 0
     for mcp in clone_aspect(
         src_urn,
-        aspect_names=all_aspects,
+        aspect_names=get_migratable_aspect_names(guess_entity_type(dst_urn)),
         dst_urn=dst_urn,
         graph=graph,
     ):
@@ -646,9 +514,17 @@ def merge_entity(
         graph._session,
         graph.config.server,
         src_urn,
-        aspects=all_aspects,
+        aspects=get_migratable_aspect_names(entity_type),
         typed=True,
     )
+
+    # Rewrite the source's self-references (e.g. fineGrainedLineages schemaField
+    # URNs) to the target URN before merging, so merged aspects don't carry the
+    # old URN — mirroring the clone path.
+    rewrite_urn = make_self_urn_rewriter(src_urn, dst_urn)
+    for aspect in src_aspect_map.values():
+        if isinstance(aspect, DictWrapper):
+            transform_urns(aspect, rewrite_urn)
 
     total_merged = 0
     total_skipped = 0
@@ -720,7 +596,60 @@ def merge_entity(
                 graph.emit_mcp(mcp)
             total_merged += 1
 
+    # Default bucket: any registry aspect not explicitly classified above.
+    merged, skipped = _merge_default_aspects(
+        src_aspect_map, dst_urn, src_urn, graph, on_conflict, dry_run
+    )
+    total_merged += merged
+    total_skipped += skipped
+
     return total_merged, total_skipped
+
+
+def _merge_default_aspects(
+    src_aspect_map: Dict[str, Union[dict, _Aspect]],
+    dst_urn: str,
+    src_urn: str,
+    graph: DataHubGraph,
+    on_conflict: ConflictStrategy,
+    dry_run: bool,
+) -> Tuple[int, int]:
+    """Merge source aspects not handled by any explicit classification bucket.
+
+    Because the aspect list is now sourced dynamically from the entity registry,
+    newly-modeled aspects would otherwise be silently dropped in merge mode.
+    They are treated conflict-aware, like the non-additive bucket, so nothing is
+    lost. Returns (aspects_merged, conflicts_skipped).
+    """
+    classified = (
+        ADDITIVE_ASPECTS
+        | MIXED_ASPECTS
+        | NON_ADDITIVE_ASPECTS
+        | ALWAYS_OVERWRITE_ASPECTS
+    )
+    merged = 0
+    skipped = 0
+    for aspect_name, src_aspect in src_aspect_map.items():
+        if aspect_name in classified or not isinstance(src_aspect, DictWrapper):
+            continue
+        dst_aspect_map = cli_utils.get_aspects_for_entity(
+            graph._session,
+            graph.config.server,
+            dst_urn,
+            aspects=[aspect_name],
+            typed=True,
+        )
+        dst_aspect = dst_aspect_map.get(aspect_name)
+        if isinstance(dst_aspect, DictWrapper) and not should_overwrite_non_additive(
+            aspect_name, src_aspect, dst_aspect, src_urn, dst_urn, on_conflict
+        ):
+            skipped += 1
+            continue
+        mcp = MetadataChangeProposalWrapper(entityUrn=dst_urn, aspect=src_aspect)
+        if not dry_run:
+            graph.emit_mcp(mcp)
+        merged += 1
+    return merged, skipped
 
 
 # --- URN rewriting ---
@@ -752,10 +681,13 @@ _ENTITY_URN_SPECS: Dict[str, _UrnSpec] = {
     "dataset": (
         dataset_urn_to_key,
         lambda key: key.name,
-        lambda key, name, inst: make_dataset_urn_with_platform_instance(
+        # `name` already carries the new instance prefix (added by
+        # _rewrite_name), so platform_instance must be None here — otherwise the
+        # instance segment is prepended twice (e.g. new_inst.new_inst.db.table).
+        lambda key, name, _inst: make_dataset_urn_with_platform_instance(
             platform=key.platform[len("urn:li:dataPlatform:") :],
             name=name,
-            platform_instance=inst,
+            platform_instance=None,
             env=str(key.origin),
         ),
     ),

--- a/metadata-ingestion/src/datahub/cli/migration_utils.py
+++ b/metadata-ingestion/src/datahub/cli/migration_utils.py
@@ -2,7 +2,7 @@
 
 import logging
 import uuid
-from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Callable, Dict, Iterable, List, Optional, Protocol, Tuple, Union
 
 import click
 from avrogen.dict_wrapper import DictWrapper
@@ -37,7 +37,11 @@ from datahub.metadata.urns import DataFlowUrn, DataJobUrn
 from datahub.specific.dataset import DatasetPatchBuilder
 from datahub.utilities.str_enum import StrEnum
 from datahub.utilities.urns.urn import guess_entity_type
-from datahub.utilities.urns.urn_iter import list_urns, transform_urns
+from datahub.utilities.urns.urn_iter import (
+    list_urns,
+    lowercase_dataset_urn,
+    transform_urns,
+)
 
 log = logging.getLogger(__name__)
 
@@ -152,6 +156,40 @@ def make_self_urn_rewriter(old_urn: str, new_urn: str) -> Callable[[str], str]:
         return urn
 
     return rewrite
+
+
+# --- URN converters (pluggable transforms for `migrate transform`) ---
+
+
+class UrnConverter(Protocol):
+    """A pluggable URN transform driving a generic (non-instance) migration."""
+
+    name: str
+
+    def should_convert(self, urn: str) -> bool:
+        """Whether this URN needs converting (skip no-ops)."""
+        ...
+
+    def convert_urn(self, urn: str) -> str:
+        """Return the new URN for a source URN."""
+        ...
+
+
+class LowercaseConverter:
+    """Lowercase the name segment of dataset URNs (e.g. mixed-case -> lowercase)."""
+
+    name = "lowercase"
+
+    def should_convert(self, urn: str) -> bool:
+        return urn != lowercase_dataset_urn(urn)
+
+    def convert_urn(self, urn: str) -> str:
+        return lowercase_dataset_urn(urn)
+
+
+CONVERTERS: Dict[str, Callable[[], UrnConverter]] = {
+    LowercaseConverter.name: LowercaseConverter,
+}
 
 
 def rewrite_incoming_references(

--- a/metadata-ingestion/src/datahub/cli/migration_utils.py
+++ b/metadata-ingestion/src/datahub/cli/migration_utils.py
@@ -184,6 +184,11 @@ class UrnConverter(Protocol):
     """A pluggable URN transform driving a generic (non-instance) migration."""
 
     name: str
+    # Entity types this converter can rewrite; drives run_transform discovery so
+    # the engine isn't hardcoded to datasets. A converter that only knows how to
+    # rewrite dataset URNs declares ["dataset"]; one that handles charts too adds
+    # "chart", etc.
+    entity_types: List[str]
 
     def should_convert(self, urn: str) -> bool:
         """Whether this URN needs converting (skip no-ops)."""
@@ -198,6 +203,8 @@ class LowercaseConverter:
     """Lowercase the name segment of dataset URNs (e.g. mixed-case -> lowercase)."""
 
     name = "lowercase"
+    # lowercase_dataset_urn only understands dataset URNs.
+    entity_types = ["dataset"]
 
     def should_convert(self, urn: str) -> bool:
         return urn != lowercase_dataset_urn(urn)

--- a/metadata-ingestion/src/datahub/cli/migration_utils.py
+++ b/metadata-ingestion/src/datahub/cli/migration_utils.py
@@ -135,27 +135,46 @@ def get_migratable_aspect_names(entity_type: str) -> List[str]:
     ]
 
 
-def make_self_urn_rewriter(old_urn: str, new_urn: str) -> Callable[[str], str]:
-    """Rewrite references to a single migrated entity URN.
+def make_batch_urn_rewriter(url_map: Dict[str, str]) -> Callable[[str], str]:
+    """Rewrite references to any entity migrated in the same batch.
 
     Intended for use with ``urn_iter.transform_urns``, which walks an aspect
     using its ``@Relationship``/Urn field markers and applies this function to
-    every URN it finds. Rewrites both the entity URN itself and ``schemaField``
-    URNs that embed it (column-level lineage), so FineGrainedLineage is covered
-    without any per-aspect special-casing. References to *other* entities are
-    left untouched.
+    every URN it finds. Rewrites both entity URNs present in ``url_map`` and
+    ``schemaField`` URNs that embed them (column-level lineage), so
+    FineGrainedLineage is covered without any per-aspect special-casing.
+
+    Unlike a self-only rewriter, this rewrites cross-references *between*
+    co-migrated entities (e.g. a downstream's ``upstreamLineage`` pointer to a
+    sibling being migrated in the same run) deterministically at clone time —
+    independent of the eventually-consistent relationship index, which is stale
+    for siblings created earlier in the same batch. References to entities
+    outside the batch are left untouched.
     """
 
     def rewrite(urn: str) -> str:
-        if urn == old_urn:
-            return new_urn
+        mapped = url_map.get(urn)
+        if mapped is not None:
+            return mapped
         # schemaField URNs are 'urn:li:schemaField:(<datasetUrn>,<field>)'.
-        # Rewrite only when the embedded dataset is the one being migrated.
-        if urn.startswith(f"{_SCHEMA_FIELD_PREFIX}({old_urn},"):
-            return urn.replace(old_urn, new_urn, 1)
+        # Rewrite when the embedded dataset is any entity being migrated.
+        if urn.startswith(f"{_SCHEMA_FIELD_PREFIX}("):
+            for old_urn, new_urn in url_map.items():
+                if urn.startswith(f"{_SCHEMA_FIELD_PREFIX}({old_urn},"):
+                    return urn.replace(old_urn, new_urn, 1)
         return urn
 
     return rewrite
+
+
+def make_self_urn_rewriter(old_urn: str, new_urn: str) -> Callable[[str], str]:
+    """Rewrite references to a single migrated entity URN.
+
+    A one-entry :func:`make_batch_urn_rewriter`; kept for the incoming-reference
+    path, where an external referrer is rewritten against just the one URN being
+    migrated.
+    """
+    return make_batch_urn_rewriter({old_urn: new_urn})
 
 
 # --- URN converters (pluggable transforms for `migrate transform`) ---
@@ -530,11 +549,15 @@ def merge_entity(
     on_conflict: ConflictStrategy,
     graph: DataHubGraph,
     dry_run: bool,
+    url_map: Optional[Dict[str, str]] = None,
 ) -> tuple[int, int]:
     """Merge all aspects from source entity into existing target.
 
     Only dataset entities support full merge via the Patch API. For other entity
     types (chart, dashboard, dataFlow, dataJob), this falls back to overwrite.
+
+    ``url_map`` is the full old->new map for the batch; when given, merged aspects
+    also rewrite references to co-migrated siblings (not just self-references).
 
     Returns (aspects_merged, conflicts_skipped).
     """
@@ -556,10 +579,11 @@ def merge_entity(
         typed=True,
     )
 
-    # Rewrite the source's self-references (e.g. fineGrainedLineages schemaField
-    # URNs) to the target URN before merging, so merged aspects don't carry the
-    # old URN — mirroring the clone path.
-    rewrite_urn = make_self_urn_rewriter(src_urn, dst_urn)
+    # Rewrite the source's references (e.g. fineGrainedLineages schemaField URNs
+    # and upstreamLineage pointers) before merging, so merged aspects don't carry
+    # old URNs — mirroring the clone path. The batch map also moves references to
+    # co-migrated siblings.
+    rewrite_urn = make_batch_urn_rewriter(url_map or {src_urn: dst_urn})
     for aspect in src_aspect_map.values():
         if isinstance(aspect, DictWrapper):
             transform_urns(aspect, rewrite_urn)

--- a/metadata-ingestion/tests/unit/cli/test_migrate.py
+++ b/metadata-ingestion/tests/unit/cli/test_migrate.py
@@ -139,6 +139,79 @@ class TestMigrateSingleEntity:
         "datahub.cli.migrate.migration_utils.get_incoming_relationships",
         return_value=[],
     )
+    @patch("datahub.cli.migrate.migration_utils.clone_aspect")
+    def test_clone_rewrites_reference_to_co_migrated_sibling(
+        self,
+        mock_clone: MagicMock,
+        mock_rels: MagicMock,
+        mock_delete: MagicMock,
+    ) -> None:
+        """Regression: migrating a downstream must repoint its upstreamLineage +
+        CLL to a sibling migrated in the same batch, without relying on the
+        (eventually-consistent) relationship index."""
+        from datahub.emitter.mce_builder import make_schema_field_urn
+        from datahub.emitter.mcp import MetadataChangeProposalWrapper
+        from datahub.metadata.schema_classes import (
+            FineGrainedLineageClass,
+            FineGrainedLineageDownstreamTypeClass,
+            FineGrainedLineageUpstreamTypeClass,
+            UpstreamClass,
+            UpstreamLineageClass,
+        )
+
+        down_old = "urn:li:dataset:(urn:li:dataPlatform:mysql,db.orders,PROD)"
+        down_new = "urn:li:dataset:(urn:li:dataPlatform:mysql,DB.ORDERS,PROD)"
+        up_old = "urn:li:dataset:(urn:li:dataPlatform:mysql,db.orders_raw,PROD)"
+        up_new = "urn:li:dataset:(urn:li:dataPlatform:mysql,DB.ORDERS_RAW,PROD)"
+
+        aspect = UpstreamLineageClass(
+            upstreams=[UpstreamClass(dataset=up_old, type="TRANSFORMED")],
+            fineGrainedLineages=[
+                FineGrainedLineageClass(
+                    upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                    downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                    upstreams=[make_schema_field_urn(up_old, "order_id")],
+                    downstreams=[make_schema_field_urn(down_old, "order_id")],
+                )
+            ],
+        )
+        mock_clone.return_value = [
+            MetadataChangeProposalWrapper(entityUrn=down_new, aspect=aspect)
+        ]
+
+        deps = self._make_deps(dry_run=False, keep=True)
+        deps["graph"].exists.return_value = False
+        _migrate_single_entity(
+            src_entity_urn=down_old,
+            make_new_urn=lambda _: down_new,
+            platform=None,
+            target_instance=None,
+            dry_run=False,
+            hard=False,
+            keep=True,
+            run_id="test-run",
+            on_conflict=None,
+            url_map={down_old: down_new, up_old: up_new},
+            **deps,
+        )
+
+        emitted = [c.args[0] for c in deps["graph"].emit_mcp.call_args_list]
+        ul = next(
+            a.aspect for a in emitted if isinstance(a.aspect, UpstreamLineageClass)
+        )
+        assert ul.upstreams[0].dataset == up_new
+        assert ul.fineGrainedLineages[0].upstreams == [
+            make_schema_field_urn(up_new, "order_id")
+        ]
+        assert ul.fineGrainedLineages[0].downstreams == [
+            make_schema_field_urn(down_new, "order_id")
+        ]
+
+    @patch("datahub.cli.migrate.delete_cli._delete_one_urn")
+    @patch(
+        "datahub.cli.migrate.migration_utils.get_incoming_relationships",
+        return_value=[],
+    )
     @patch("datahub.cli.migrate.migration_utils.clone_aspect", return_value=[])
     def test_deletes_source_when_not_keep(
         self,

--- a/metadata-ingestion/tests/unit/cli/test_migrate_transform.py
+++ b/metadata-ingestion/tests/unit/cli/test_migrate_transform.py
@@ -62,3 +62,31 @@ class TestMigrateWithoutInstance:
 
         assert emitted, "expected the cloned aspect to be emitted"
         assert not any(isinstance(m.aspect, DataPlatformInstanceClass) for m in emitted)
+
+
+class TestRunTransform:
+    @patch("datahub.cli.migrate._migrate_entities")
+    def test_filters_by_should_convert_and_drops_instance(
+        self, mock_migrate: MagicMock
+    ) -> None:
+        from datahub.cli.migrate import run_transform
+        from datahub.cli.migration_utils import LowercaseConverter
+
+        graph = MagicMock()
+        graph.get_urns_by_filter.return_value = [MIXED, LOWER]  # LOWER already lower
+        run_transform(graph, LowercaseConverter(), "snowflake")
+
+        _, kwargs = mock_migrate.call_args
+        assert kwargs["urns_to_migrate"] == [MIXED]
+        assert kwargs["platform"] is None
+        assert kwargs["target_instance"] is None
+
+    @patch("datahub.cli.migrate._migrate_entities")
+    def test_noop_when_nothing_to_convert(self, mock_migrate: MagicMock) -> None:
+        from datahub.cli.migrate import run_transform
+        from datahub.cli.migration_utils import LowercaseConverter
+
+        graph = MagicMock()
+        graph.get_urns_by_filter.return_value = [LOWER]
+        run_transform(graph, LowercaseConverter(), "snowflake")
+        mock_migrate.assert_not_called()

--- a/metadata-ingestion/tests/unit/cli/test_migrate_transform.py
+++ b/metadata-ingestion/tests/unit/cli/test_migrate_transform.py
@@ -90,3 +90,20 @@ class TestRunTransform:
         graph.get_urns_by_filter.return_value = [LOWER]
         run_transform(graph, LowercaseConverter(), "snowflake")
         mock_migrate.assert_not_called()
+
+    @patch("datahub.cli.migrate._migrate_entities")
+    def test_scopes_discovery_by_platform_instance(
+        self, mock_migrate: MagicMock
+    ) -> None:
+        from datahub.cli.migrate import run_transform
+        from datahub.cli.migration_utils import LowercaseConverter
+
+        graph = MagicMock()
+        graph.get_urns_by_filter.return_value = [MIXED]
+        run_transform(
+            graph, LowercaseConverter(), "snowflake", platform_instance="prod"
+        )
+
+        _, kwargs = graph.get_urns_by_filter.call_args
+        assert kwargs["platform"] == "snowflake"
+        assert kwargs["platform_instance"] == "prod"

--- a/metadata-ingestion/tests/unit/cli/test_migrate_transform.py
+++ b/metadata-ingestion/tests/unit/cli/test_migrate_transform.py
@@ -1,0 +1,64 @@
+"""Tests for the converter-driven generic migration (migrate transform)."""
+
+from unittest.mock import MagicMock, patch
+
+import datahub.cli.migration_utils as migration_utils
+from datahub.cli.migrate import _migrate_single_entity
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.metadata.schema_classes import (
+    DataPlatformInstanceClass,
+    StatusClass,
+    SystemMetadataClass,
+)
+
+MIXED = "urn:li:dataset:(urn:li:dataPlatform:snowflake,MyDb.MySchema.MyTable,PROD)"
+LOWER = "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.mytable,PROD)"
+
+
+class TestLowercaseConverter:
+    def test_convert_and_should_convert(self):
+        c = migration_utils.LowercaseConverter()
+        assert c.name == "lowercase"
+        assert c.convert_urn(MIXED) == LOWER
+        assert c.should_convert(MIXED) is True
+        assert c.should_convert(LOWER) is False
+
+
+class TestMigrateWithoutInstance:
+    """A non-instance migration (e.g. lowercase) must not emit dataPlatformInstance."""
+
+    @patch(
+        "datahub.cli.migrate.migration_utils.get_incoming_relationships",
+        return_value=[],
+    )
+    def test_no_platform_instance_emitted_when_platform_is_none(
+        self, _mock_rels: MagicMock
+    ) -> None:
+        graph = MagicMock()
+        graph.exists.return_value = False
+        emitted = []
+        graph.emit_mcp.side_effect = lambda mcp: emitted.append(mcp)
+
+        cloned = MetadataChangeProposalWrapper(
+            entityUrn=LOWER, aspect=StatusClass(removed=False)
+        )
+        with patch(
+            "datahub.cli.migrate.migration_utils.clone_aspect", return_value=[cloned]
+        ):
+            _migrate_single_entity(
+                src_entity_urn=MIXED,
+                make_new_urn=lambda _: LOWER,
+                platform=None,
+                target_instance=None,
+                dry_run=False,
+                hard=False,
+                keep=True,
+                run_id="t",
+                graph=graph,
+                on_conflict=None,
+                system_metadata=SystemMetadataClass(runId="t"),
+                migration_report=MagicMock(),
+            )
+
+        assert emitted, "expected the cloned aspect to be emitted"
+        assert not any(isinstance(m.aspect, DataPlatformInstanceClass) for m in emitted)

--- a/metadata-ingestion/tests/unit/cli/test_migration_dynamic_aspects.py
+++ b/metadata-ingestion/tests/unit/cli/test_migration_dynamic_aspects.py
@@ -1,0 +1,322 @@
+"""Tests for registry-driven aspect discovery and generic URN rewriting in migration."""
+
+from typing import Dict
+from unittest.mock import MagicMock, patch
+
+from avrogen.dict_wrapper import DictWrapper
+
+import datahub.cli.migration_utils as migration_utils
+from datahub.cli.migrate import _migrate_single_entity
+from datahub.cli.migration_utils import ConflictStrategy, merge_entity
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.metadata.schema_classes import (
+    DatasetLineageTypeClass,
+    FineGrainedLineageClass,
+    FineGrainedLineageDownstreamTypeClass,
+    FineGrainedLineageUpstreamTypeClass,
+    SubTypesClass,
+    SystemMetadataClass,
+    UpstreamClass,
+    UpstreamLineageClass,
+)
+from datahub.utilities.urns.urn_iter import transform_urns
+
+OLD_DS = (
+    "urn:li:dataset:(urn:li:dataPlatform:mysql,old_inst.my_db.my_schema.events,PROD)"
+)
+NEW_DS = (
+    "urn:li:dataset:(urn:li:dataPlatform:mysql,new_inst.my_db.my_schema.events,PROD)"
+)
+OTHER_DS = (
+    "urn:li:dataset:(urn:li:dataPlatform:mysql,old_inst.my_db.my_schema.other,PROD)"
+)
+
+
+def _sf(dataset_urn: str, col: str) -> str:
+    return f"urn:li:schemaField:({dataset_urn},{col})"
+
+
+class TestGetMigratableAspectNames:
+    def test_includes_user_authored_aspects_from_registry(self):
+        result = migration_utils.get_migratable_aspect_names("dataset")
+        assert "upstreamLineage" in result
+        assert "structuredProperties" in result
+        assert "forms" in result
+        # siblings is a relationship aspect (array[Urn], @Relationship), not a
+        # computed rollup — it must be migrated, not skipped.
+        assert "siblings" in result
+
+    def test_excludes_timeseries_aspects(self):
+        result = migration_utils.get_migratable_aspect_names("dataset")
+        assert "datasetProfile" not in result
+        assert "datasetUsageStatistics" not in result
+
+    def test_excludes_system_managed_aspects(self):
+        result = migration_utils.get_migratable_aspect_names("dataset")
+        assert "dataPlatformInstance" not in result
+        assert "browsePaths" not in result
+        assert "browsePathsV2" not in result
+
+    def test_excludes_derived_summary_aspects(self):
+        # incidentsSummary is a platform-computed rollup, not user intent;
+        # cloning it verbatim would carry a stale summary to the new URN.
+        result = migration_utils.get_migratable_aspect_names("dataset")
+        assert "incidentsSummary" not in result
+
+    def test_unknown_entity_type_returns_empty(self):
+        assert migration_utils.get_migratable_aspect_names("nonsense") == []
+
+
+class TestMakeSelfUrnRewriter:
+    def test_rewrites_exact_entity_urn(self):
+        rewrite = migration_utils.make_self_urn_rewriter(OLD_DS, NEW_DS)
+        assert rewrite(OLD_DS) == NEW_DS
+
+    def test_rewrites_embedded_schema_field_urn(self):
+        rewrite = migration_utils.make_self_urn_rewriter(OLD_DS, NEW_DS)
+        assert rewrite(_sf(OLD_DS, "col_a")) == _sf(NEW_DS, "col_a")
+
+    def test_leaves_other_dataset_urn_untouched(self):
+        rewrite = migration_utils.make_self_urn_rewriter(OLD_DS, NEW_DS)
+        assert rewrite(OTHER_DS) == OTHER_DS
+
+    def test_leaves_unrelated_schema_field_untouched(self):
+        rewrite = migration_utils.make_self_urn_rewriter(OLD_DS, NEW_DS)
+        assert rewrite(_sf(OTHER_DS, "col_a")) == _sf(OTHER_DS, "col_a")
+
+
+class TestFineGrainedLineageRewrite:
+    """The headline correctness fix: column-level lineage URNs must be rewritten."""
+
+    def test_transform_urns_rewrites_fine_grained_lineage(self):
+        # A downstream's upstreamLineage pointing at OLD_DS both table- and
+        # column-level (the column-level edge is what the old hand-written
+        # modifier missed).
+        aspect = UpstreamLineageClass(
+            upstreams=[
+                UpstreamClass(dataset=OLD_DS, type=DatasetLineageTypeClass.TRANSFORMED)
+            ],
+            fineGrainedLineages=[
+                FineGrainedLineageClass(
+                    upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                    downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                    upstreams=[_sf(OLD_DS, "col_a")],
+                    downstreams=[_sf(OTHER_DS, "col_a")],
+                )
+            ],
+        )
+
+        transform_urns(aspect, migration_utils.make_self_urn_rewriter(OLD_DS, NEW_DS))
+
+        assert aspect.upstreams[0].dataset == NEW_DS
+        fgl = aspect.fineGrainedLineages
+        assert fgl is not None
+        assert fgl[0].upstreams == [_sf(NEW_DS, "col_a")]
+        # Downstream references a different dataset — must be left untouched.
+        assert fgl[0].downstreams == [_sf(OTHER_DS, "col_a")]
+
+
+class TestClonePathRewritesSelfReferences:
+    """The clone path must rewrite the migrated entity's own aspect URNs."""
+
+    @patch(
+        "datahub.cli.migrate.migration_utils.get_incoming_relationships",
+        return_value=[],
+    )
+    def test_clone_path_rewrites_own_fine_grained_lineage(
+        self, _mock_rels: MagicMock
+    ) -> None:
+        # clone_aspect yields the entity's own upstreamLineage, whose CLL
+        # downstreams reference the entity being migrated (OLD_DS).
+        cloned = MetadataChangeProposalWrapper(
+            entityUrn=NEW_DS,
+            aspect=UpstreamLineageClass(
+                upstreams=[
+                    UpstreamClass(
+                        dataset=OTHER_DS, type=DatasetLineageTypeClass.TRANSFORMED
+                    )
+                ],
+                fineGrainedLineages=[
+                    FineGrainedLineageClass(
+                        upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                        downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                        upstreams=[_sf(OTHER_DS, "col_a")],
+                        downstreams=[_sf(OLD_DS, "col_a")],
+                    )
+                ],
+            ),
+        )
+        graph = MagicMock()
+        graph.exists.return_value = False
+        emitted = []
+        graph.emit_mcp.side_effect = lambda mcp: emitted.append(mcp)
+
+        with patch(
+            "datahub.cli.migrate.migration_utils.clone_aspect",
+            return_value=[cloned],
+        ):
+            _migrate_single_entity(
+                src_entity_urn=OLD_DS,
+                make_new_urn=lambda _: NEW_DS,
+                platform="mysql",
+                target_instance="new_inst",
+                dry_run=False,
+                hard=False,
+                keep=True,
+                run_id="test-run",
+                graph=graph,
+                on_conflict=None,
+                system_metadata=SystemMetadataClass(runId="test-run"),
+                migration_report=MagicMock(),
+            )
+
+        lineage = [
+            m.aspect for m in emitted if isinstance(m.aspect, UpstreamLineageClass)
+        ]
+        assert lineage, "expected an upstreamLineage MCP to be emitted"
+        fgl = lineage[0].fineGrainedLineages
+        assert fgl is not None
+        # The entity's own column-level downstream must point at the new URN.
+        assert fgl[0].downstreams == [_sf(NEW_DS, "col_a")]
+
+
+class TestMergeEntityDefaultBucket:
+    """Registry aspects not in a known classification set must still migrate."""
+
+    @patch("datahub.cli.migration_utils.cli_utils.get_aspects_for_entity")
+    def test_unclassified_aspect_is_migrated_not_dropped(
+        self, mock_get: MagicMock
+    ) -> None:
+        # subTypes is a real dataset aspect that is in none of the additive /
+        # mixed / non-additive / always-overwrite buckets.
+        def side_effect(session, server, urn, aspects=None, typed=False):
+            if urn == OLD_DS:
+                return {"subTypes": SubTypesClass(typeNames=["View"])}
+            return {}  # target has nothing
+
+        mock_get.side_effect = side_effect
+        graph = MagicMock()
+
+        merge_entity(OLD_DS, NEW_DS, ConflictStrategy.PATCH, graph, dry_run=False)
+
+        emitted = [c.args[0].aspect for c in graph.emit_mcp.call_args_list]
+        assert any(isinstance(a, SubTypesClass) for a in emitted), (
+            "subTypes was silently dropped during merge"
+        )
+
+
+class TestProcessContainerRelationships:
+    """Referencing entities must have their container URN rewritten (via transform_urns)."""
+
+    OLD_CONTAINER = "urn:li:container:old-guid"
+    NEW_CONTAINER = "urn:li:container:new-guid"
+    CHILD_DS = (
+        "urn:li:dataset:(urn:li:dataPlatform:mysql,inst.my_db.my_schema.child,PROD)"
+    )
+
+    @patch("datahub.cli.migrate.get_default_graph")
+    @patch("datahub.cli.migration_utils.cli_utils.get_aspects_for_entity")
+    @patch("datahub.cli.migrate.migration_utils.get_incoming_relationships")
+    def test_child_container_reference_is_rewritten(
+        self,
+        mock_rels: MagicMock,
+        mock_get_aspects: MagicMock,
+        mock_graph: MagicMock,
+    ) -> None:
+        from datahub.cli.migrate import _process_container_relationships
+        from datahub.ingestion.graph.openapi import RelatedEntity
+        from datahub.metadata.schema_classes import ContainerClass
+
+        mock_rels.return_value = [
+            RelatedEntity(urn=self.CHILD_DS, relationship_type="IsPartOf")
+        ]
+        mock_get_aspects.return_value = {
+            "container": ContainerClass(container=self.OLD_CONTAINER)
+        }
+        emitter = MagicMock()
+        emitted = []
+        emitter.emit_mcp.side_effect = lambda mcp: emitted.append(mcp)
+
+        _process_container_relationships(
+            container_id_map={self.OLD_CONTAINER: self.NEW_CONTAINER},
+            dry_run=False,
+            src_urn=self.OLD_CONTAINER,
+            dst_urn=self.NEW_CONTAINER,
+            migration_report=MagicMock(),
+            rest_emitter=emitter,
+        )
+
+        containers = [m.aspect for m in emitted if isinstance(m.aspect, ContainerClass)]
+        assert containers, "expected a container MCP to be emitted"
+        assert containers[0].container == self.NEW_CONTAINER
+
+
+class TestRewriteIncomingReferences:
+    """Rewrite the migrated URN across ALL aspects of a referencing entity."""
+
+    DOWNSTREAM = (
+        "urn:li:dataset:(urn:li:dataPlatform:mysql,inst.my_db.my_schema.down,PROD)"
+    )
+
+    @patch("datahub.cli.migration_utils.cli_utils.get_aspects_for_entity")
+    def test_rewrites_only_aspects_that_reference_migrated_urn(
+        self, mock_get: MagicMock
+    ) -> None:
+        from datahub.metadata.schema_classes import StatusClass
+
+        mock_get.return_value = {
+            "upstreamLineage": UpstreamLineageClass(
+                upstreams=[
+                    UpstreamClass(
+                        dataset=OLD_DS, type=DatasetLineageTypeClass.TRANSFORMED
+                    )
+                ]
+            ),
+            "status": StatusClass(removed=False),  # no reference — must be skipped
+        }
+        graph = MagicMock()
+
+        changed = migration_utils.rewrite_incoming_references(
+            graph,
+            self.DOWNSTREAM,
+            migration_utils.make_self_urn_rewriter(OLD_DS, NEW_DS),
+        )
+
+        # Only the aspect that referenced the migrated URN comes back.
+        aspects = [m.aspect for m in changed]
+        assert len(aspects) == 1
+        assert isinstance(aspects[0], UpstreamLineageClass)
+        assert aspects[0].upstreams[0].dataset == NEW_DS
+        assert changed[0].entityUrn == self.DOWNSTREAM
+
+
+class TestMergeCarriesFineGrainedLineage:
+    """Merge mode must carry column-level lineage, not just table-level."""
+
+    @patch("datahub.cli.migration_utils.DatasetPatchBuilder")
+    def test_merge_additive_patches_fine_grained_lineage(
+        self, mock_pb_cls: MagicMock
+    ) -> None:
+        pb = mock_pb_cls.return_value
+        pb.build.return_value = []
+        src: Dict[str, DictWrapper] = {
+            "upstreamLineage": UpstreamLineageClass(
+                upstreams=[
+                    UpstreamClass(
+                        dataset=OTHER_DS, type=DatasetLineageTypeClass.TRANSFORMED
+                    )
+                ],
+                fineGrainedLineages=[
+                    FineGrainedLineageClass(
+                        upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                        downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                        upstreams=[_sf(OTHER_DS, "a")],
+                        downstreams=[_sf(NEW_DS, "b")],
+                    )
+                ],
+            )
+        }
+        migration_utils.merge_additive_aspects(src, NEW_DS, MagicMock(), dry_run=True)
+
+        assert pb.add_upstream_lineage.call_count == 1
+        assert pb.add_fine_grained_lineage.call_count == 1

--- a/metadata-ingestion/tests/unit/cli/test_migration_utils.py
+++ b/metadata-ingestion/tests/unit/cli/test_migration_utils.py
@@ -11,6 +11,7 @@ from datahub.cli.migrate import (
 )
 from datahub.cli.migration_utils import (
     ConflictStrategy,
+    make_batch_urn_rewriter,
     make_i2i_chart_urn,
     make_i2i_dashboard_urn,
     make_i2i_dataflow_urn,
@@ -489,3 +490,71 @@ class TestMergeEntityNonDataset:
 
         mock_clone.assert_called_once()
         assert skipped == 0
+
+
+class TestBatchUrnRewriter:
+    """Batch URN rewriter — rewrites references to any entity migrated together.
+
+    Reproduces the co-migration gap: when two linked datasets are migrated in one
+    pass, the migrated downstream's cross-reference to a co-migrated upstream must
+    be rewritten at clone time (not left to the eventually-consistent relationship
+    index, which is stale for siblings created earlier in the same batch).
+    """
+
+    A = "urn:li:dataset:(urn:li:dataPlatform:mysql,db.orders,PROD)"
+    A_NEW = "urn:li:dataset:(urn:li:dataPlatform:mysql,DB.ORDERS,PROD)"
+    B = "urn:li:dataset:(urn:li:dataPlatform:mysql,db.orders_raw,PROD)"
+    B_NEW = "urn:li:dataset:(urn:li:dataPlatform:mysql,DB.ORDERS_RAW,PROD)"
+
+    def _map(self) -> Dict[str, str]:
+        return {self.A: self.A_NEW, self.B: self.B_NEW}
+
+    def test_rewrites_each_entity_urn_in_the_batch(self):
+        rewrite = make_batch_urn_rewriter(self._map())
+        assert rewrite(self.A) == self.A_NEW
+        assert rewrite(self.B) == self.B_NEW
+
+    def test_leaves_urns_outside_the_batch_untouched(self):
+        rewrite = make_batch_urn_rewriter(self._map())
+        other = "urn:li:dataset:(urn:li:dataPlatform:mysql,db.customers,PROD)"
+        assert rewrite(other) == other
+
+    def test_rewrites_schema_field_of_a_sibling(self):
+        rewrite = make_batch_urn_rewriter(self._map())
+        assert (
+            rewrite(f"urn:li:schemaField:({self.B},order_id)")
+            == f"urn:li:schemaField:({self.B_NEW},order_id)"
+        )
+
+    def test_transform_urns_rewrites_cross_reference_to_sibling(self):
+        """The bug: migrating A must rewrite its upstream pointer + CLL to the
+        co-migrated sibling B, not just A's own self-references."""
+        from datahub.emitter.mce_builder import make_schema_field_urn
+        from datahub.metadata.schema_classes import (
+            FineGrainedLineageClass,
+            FineGrainedLineageDownstreamTypeClass,
+            FineGrainedLineageUpstreamTypeClass,
+        )
+        from datahub.utilities.urns.urn_iter import transform_urns
+
+        aspect = UpstreamLineageClass(
+            upstreams=[UpstreamClass(dataset=self.B, type="TRANSFORMED")],
+            fineGrainedLineages=[
+                FineGrainedLineageClass(
+                    upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                    downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                    upstreams=[make_schema_field_urn(self.B, "order_id")],
+                    downstreams=[make_schema_field_urn(self.A, "order_id")],
+                )
+            ],
+        )
+
+        transform_urns(aspect, make_batch_urn_rewriter(self._map()))
+
+        assert aspect.upstreams[0].dataset == self.B_NEW
+        assert aspect.fineGrainedLineages[0].upstreams == [
+            make_schema_field_urn(self.B_NEW, "order_id")
+        ]
+        assert aspect.fineGrainedLineages[0].downstreams == [
+            make_schema_field_urn(self.A_NEW, "order_id")
+        ]

--- a/metadata-ingestion/tests/unit/cli/test_migration_utils.py
+++ b/metadata-ingestion/tests/unit/cli/test_migration_utils.py
@@ -11,7 +11,6 @@ from datahub.cli.migrate import (
 )
 from datahub.cli.migration_utils import (
     ConflictStrategy,
-    get_aspect_name_from_relationship,
     make_i2i_chart_urn,
     make_i2i_dashboard_urn,
     make_i2i_dataflow_urn,
@@ -24,16 +23,12 @@ from datahub.cli.migration_utils import (
     make_p2i_dataset_urn,
     merge_additive_aspects,
     merge_mixed_aspects,
-    modify_urn_list_for_aspect,
     replace_instance_prefix,
     should_overwrite_non_additive,
 )
 from datahub.metadata.schema_classes import (
     AuditStampClass,
-    ChangeAuditStampsClass,
-    DashboardInfoClass,
     DatasetPropertiesClass,
-    EdgeClass,
     GlobalTagsClass,
     GlossaryTermAssociationClass,
     GlossaryTermsClass,
@@ -44,119 +39,6 @@ from datahub.metadata.schema_classes import (
     UpstreamClass,
     UpstreamLineageClass,
 )
-
-# --- get_aspect_name_from_relationship tests ---
-
-
-class TestGetAspectNameFromRelationship:
-    """Tests for the relationship-type-to-aspect-name mapping."""
-
-    def test_consumes_dashboard_returns_dashboard_info(self):
-        """Dashboard entities with Consumes relationship should map to dashboardInfo."""
-        result = get_aspect_name_from_relationship("Consumes", "dashboard")
-        assert result == "dashboardInfo"
-
-    def test_consumes_chart_returns_chart_info(self):
-        result = get_aspect_name_from_relationship("Consumes", "chart")
-        assert result == "chartInfo"
-
-    def test_consumes_datajob_returns_data_job_input_output(self):
-        result = get_aspect_name_from_relationship("Consumes", "datajob")
-        assert result == "dataJobInputOutput"
-
-    def test_downstream_of_dataset_returns_upstream_lineage(self):
-        result = get_aspect_name_from_relationship("DownstreamOf", "dataset")
-        assert result == "upstreamLineage"
-
-    def test_is_part_of_dataset_returns_container(self):
-        result = get_aspect_name_from_relationship("IsPartOf", "dataset")
-        assert result == "container"
-
-    def test_unknown_relationship_raises(self):
-        with pytest.raises(Exception, match="Unable to map aspect name"):
-            get_aspect_name_from_relationship("UnknownRelType", "dataset")
-
-    def test_unknown_entity_type_raises(self):
-        with pytest.raises(Exception, match="Unable to map aspect name"):
-            get_aspect_name_from_relationship("Consumes", "unknownEntity")
-
-
-# --- DashboardInfo modifier tests ---
-
-
-def _make_audit_stamps() -> ChangeAuditStampsClass:
-    stamp = AuditStampClass(time=0, actor="urn:li:corpuser:test")
-    return ChangeAuditStampsClass(created=stamp, lastModified=stamp)
-
-
-class TestDashboardInfoModifier:
-    """UrnListModifier must handle dashboardInfo for Consumes relationships."""
-
-    OLD_URN = "urn:li:dataset:(urn:li:dataPlatform:powerbi,myDataset,PROD)"
-    NEW_URN = "urn:li:dataset:(urn:li:dataPlatform:powerbi,instance.myDataset,PROD)"
-
-    def test_rewrites_deprecated_datasets_field(self):
-        """The deprecated 'datasets' array should have old URNs replaced."""
-        dashboard_info = DashboardInfoClass(
-            title="Test Dashboard",
-            description="",
-            lastModified=_make_audit_stamps(),
-            datasets=[
-                self.OLD_URN,
-                "urn:li:dataset:(urn:li:dataPlatform:powerbi,other,PROD)",
-            ],
-        )
-
-        result = modify_urn_list_for_aspect(
-            "dashboardInfo", dashboard_info, "Consumes", self.OLD_URN, self.NEW_URN
-        )
-
-        assert isinstance(result, DashboardInfoClass)
-        assert self.NEW_URN in result.datasets
-        assert self.OLD_URN not in result.datasets
-        # Other URNs should be untouched
-        assert (
-            "urn:li:dataset:(urn:li:dataPlatform:powerbi,other,PROD)" in result.datasets
-        )
-
-    def test_rewrites_dataset_edges_field(self):
-        """The newer 'datasetEdges' array should have old URNs replaced."""
-        dashboard_info = DashboardInfoClass(
-            title="Test Dashboard",
-            description="",
-            lastModified=_make_audit_stamps(),
-            datasetEdges=[
-                EdgeClass(destinationUrn=self.OLD_URN),
-                EdgeClass(
-                    destinationUrn="urn:li:dataset:(urn:li:dataPlatform:powerbi,other,PROD)"
-                ),
-            ],
-        )
-
-        result = modify_urn_list_for_aspect(
-            "dashboardInfo", dashboard_info, "Consumes", self.OLD_URN, self.NEW_URN
-        )
-
-        assert isinstance(result, DashboardInfoClass)
-        assert result.datasetEdges is not None
-        dest_urns = [e.destinationUrn for e in result.datasetEdges]
-        assert self.NEW_URN in dest_urns
-        assert self.OLD_URN not in dest_urns
-
-    def test_handles_empty_datasets(self):
-        """Should not crash when datasets and datasetEdges are empty/None."""
-        dashboard_info = DashboardInfoClass(
-            title="Test Dashboard",
-            description="",
-            lastModified=_make_audit_stamps(),
-        )
-
-        result = modify_urn_list_for_aspect(
-            "dashboardInfo", dashboard_info, "Consumes", self.OLD_URN, self.NEW_URN
-        )
-
-        assert isinstance(result, DashboardInfoClass)
-
 
 # --- instance2instance helper tests ---
 
@@ -448,8 +330,10 @@ class TestUrnBuilders:
         result = make_urn(
             "urn:li:dataset:(urn:li:dataPlatform:snowflake,old_inst.db.table,PROD)"
         )
-        assert "new_inst.db.table" in result
-        assert "old_inst" not in result
+        assert (
+            result
+            == "urn:li:dataset:(urn:li:dataPlatform:snowflake,new_inst.db.table,PROD)"
+        )
 
     def test_chart_urn_builder(self):
         make_urn = make_i2i_chart_urn("old_inst", "new_inst")
@@ -501,7 +385,10 @@ class TestP2iUrnBuilders:
         result = make_urn(
             "urn:li:dataset:(urn:li:dataPlatform:powerbi,some.table,PROD)"
         )
-        assert "myinst.some.table" in result
+        assert (
+            result
+            == "urn:li:dataset:(urn:li:dataPlatform:powerbi,myinst.some.table,PROD)"
+        )
 
     def test_p2i_chart_urn(self):
         make_urn = make_p2i_chart_urn("myinst")

--- a/smoke-test/tests/cli/migrate_cmd/test_migrate_instance2instance_smoke.py
+++ b/smoke-test/tests/cli/migrate_cmd/test_migrate_instance2instance_smoke.py
@@ -1,0 +1,402 @@
+import logging
+from random import randint
+
+import pytest
+
+from datahub.emitter.mce_builder import (
+    make_data_platform_urn,
+    make_dataplatform_instance_urn,
+    make_dataset_urn_with_platform_instance,
+    make_schema_field_urn,
+)
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.graph.client import DataHubGraph
+from datahub.metadata.schema_classes import (
+    DataPlatformInstanceClass,
+    DatasetLineageTypeClass,
+    DatasetPropertiesClass,
+    EmbedClass,
+    FineGrainedLineageClass,
+    FineGrainedLineageDownstreamTypeClass,
+    FineGrainedLineageUpstreamTypeClass,
+    GlobalTagsClass,
+    OtherSchemaClass,
+    SchemaFieldClass,
+    SchemaFieldDataTypeClass,
+    SchemaMetadataClass,
+    SiblingsClass,
+    StringTypeClass,
+    SubTypesClass,
+    TagAssociationClass,
+    UpstreamClass,
+    UpstreamLineageClass,
+)
+from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utils import delete_urns, run_datahub_cmd
+
+logger = logging.getLogger(__name__)
+
+PLATFORM = "snowflake"
+ENV = "PROD"
+# Randomize instances so repeated runs don't collide.
+_suffix = randint(10, 100000)
+OLD_INSTANCE = f"mig_old_{_suffix}"
+NEW_INSTANCE = f"mig_new_{_suffix}"
+KEEP_INSTANCE = f"mig_keep_{_suffix}"
+TABLE = "my_db.my_schema.events_agg"
+UPSTREAM_TABLE = "my_db.my_schema.events_raw"
+
+old_down = make_dataset_urn_with_platform_instance(PLATFORM, TABLE, OLD_INSTANCE, ENV)
+new_down = make_dataset_urn_with_platform_instance(PLATFORM, TABLE, NEW_INSTANCE, ENV)
+upstream = make_dataset_urn_with_platform_instance(
+    PLATFORM, UPSTREAM_TABLE, KEEP_INSTANCE, ENV
+)
+# The URN that the old (buggy) builder produced by doubling the instance prefix.
+double_prefixed = make_dataset_urn_with_platform_instance(
+    PLATFORM, f"{NEW_INSTANCE}.{TABLE}", NEW_INSTANCE, ENV
+)
+
+# Separate instances for the incoming-reference test so the two migrations don't
+# interfere.
+OLD_INSTANCE_INC = f"mig_iold_{_suffix}"
+NEW_INSTANCE_INC = f"mig_inew_{_suffix}"
+up_src_old = make_dataset_urn_with_platform_instance(
+    PLATFORM, "my_db.my_schema.up_src", OLD_INSTANCE_INC, ENV
+)
+up_src_new = make_dataset_urn_with_platform_instance(
+    PLATFORM, "my_db.my_schema.up_src", NEW_INSTANCE_INC, ENV
+)
+# A referencing entity on a non-migrated instance.
+ref_down = make_dataset_urn_with_platform_instance(
+    PLATFORM, "my_db.my_schema.ref_down", KEEP_INSTANCE, ENV
+)
+
+# Merge-mode scenario: the target already exists, so migrate merges into it.
+OLD_INSTANCE_MRG = f"mig_mold_{_suffix}"
+NEW_INSTANCE_MRG = f"mig_mnew_{_suffix}"
+mrg_src = make_dataset_urn_with_platform_instance(
+    PLATFORM, "my_db.my_schema.mrg_tbl", OLD_INSTANCE_MRG, ENV
+)
+mrg_tgt = make_dataset_urn_with_platform_instance(
+    PLATFORM, "my_db.my_schema.mrg_tbl", NEW_INSTANCE_MRG, ENV
+)
+mrg_up = make_dataset_urn_with_platform_instance(
+    PLATFORM, "my_db.my_schema.mrg_up", KEEP_INSTANCE, ENV
+)
+
+
+def _schema(field_name: str) -> SchemaMetadataClass:
+    return SchemaMetadataClass(
+        schemaName="s",
+        platform=make_data_platform_urn(PLATFORM),
+        version=0,
+        hash="",
+        platformSchema=OtherSchemaClass(rawSchema=""),
+        fields=[
+            SchemaFieldClass(
+                fieldPath=field_name,
+                type=SchemaFieldDataTypeClass(type=StringTypeClass()),
+                nativeDataType="STRING",
+            )
+        ],
+    )
+
+
+def _instance(name: str) -> DataPlatformInstanceClass:
+    return DataPlatformInstanceClass(
+        platform=make_data_platform_urn(PLATFORM),
+        instance=make_dataplatform_instance_urn(PLATFORM, name),
+    )
+
+
+def _seed(graph_client: DataHubGraph) -> None:
+    mcps = [
+        MetadataChangeProposalWrapper(entityUrn=upstream, aspect=_schema("id")),
+        MetadataChangeProposalWrapper(
+            entityUrn=upstream, aspect=_instance(KEEP_INSTANCE)
+        ),
+        MetadataChangeProposalWrapper(
+            entityUrn=old_down, aspect=_schema("event_count")
+        ),
+        MetadataChangeProposalWrapper(
+            entityUrn=old_down, aspect=_instance(OLD_INSTANCE)
+        ),
+        MetadataChangeProposalWrapper(
+            entityUrn=old_down,
+            aspect=DatasetPropertiesClass(description="downstream aggregate"),
+        ),
+        MetadataChangeProposalWrapper(
+            entityUrn=old_down, aspect=SubTypesClass(typeNames=["View"])
+        ),
+        # embed was absent from the old hardcoded aspect list; it must now be
+        # migrated (guards the registry-driven aspect selection).
+        MetadataChangeProposalWrapper(
+            entityUrn=old_down, aspect=EmbedClass(renderUrl="https://example.com/e")
+        ),
+        # siblings is a relationship aspect and must be carried over.
+        MetadataChangeProposalWrapper(
+            entityUrn=old_down,
+            aspect=SiblingsClass(siblings=[upstream], primary=True),
+        ),
+        MetadataChangeProposalWrapper(
+            entityUrn=old_down,
+            aspect=GlobalTagsClass(
+                tags=[TagAssociationClass(tag="urn:li:tag:mig_smoke")]
+            ),
+        ),
+        MetadataChangeProposalWrapper(
+            entityUrn=old_down,
+            aspect=UpstreamLineageClass(
+                upstreams=[
+                    UpstreamClass(
+                        dataset=upstream, type=DatasetLineageTypeClass.TRANSFORMED
+                    )
+                ],
+                fineGrainedLineages=[
+                    FineGrainedLineageClass(
+                        upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                        downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                        upstreams=[make_schema_field_urn(upstream, "id")],
+                        downstreams=[make_schema_field_urn(old_down, "event_count")],
+                    )
+                ],
+            ),
+        ),
+    ]
+    for mcp in mcps:
+        graph_client.emit_mcp(mcp)
+    wait_for_writes_to_sync()
+
+
+@pytest.fixture(scope="module")
+def seeded(graph_client: DataHubGraph):
+    all_urns = [old_down, new_down, upstream, double_prefixed]
+    delete_urns(graph_client, all_urns)
+    wait_for_writes_to_sync()
+    _seed(graph_client)
+    try:
+        yield
+    finally:
+        delete_urns(graph_client, all_urns)
+        wait_for_writes_to_sync()
+
+
+def test_instance2instance_rewrites_lineage_and_migrates_aspects(
+    graph_client: DataHubGraph, seeded
+) -> None:
+    result = run_datahub_cmd(
+        [
+            "migrate",
+            "instance2instance",
+            "--platform",
+            PLATFORM,
+            "--old-instance",
+            OLD_INSTANCE,
+            "--new-instance",
+            NEW_INSTANCE,
+            "--env",
+            ENV,
+            "--entity-types",
+            "dataset",
+            "--force",
+            "--keep",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    wait_for_writes_to_sync()
+
+    # The migrated URN exists with a single instance prefix, and the doubled
+    # variant produced by the old builder bug does not.
+    assert graph_client.exists(new_down)
+    assert not graph_client.exists(double_prefixed)
+
+    lineage = graph_client.get_aspect(new_down, UpstreamLineageClass)
+    assert lineage is not None
+    fgl = lineage.fineGrainedLineages
+    assert fgl is not None
+
+    # Column-level downstream is rewritten to the new URN; the cross-instance
+    # upstream (table- and column-level) is left untouched.
+    assert fgl[0].downstreams == [make_schema_field_urn(new_down, "event_count")]
+    assert fgl[0].upstreams == [make_schema_field_urn(upstream, "id")]
+    assert [u.dataset for u in lineage.upstreams] == [upstream]
+
+    # Aspects beyond lineage are carried over.
+    assert graph_client.get_aspect(new_down, SubTypesClass) is not None
+    assert graph_client.get_aspect(new_down, DatasetPropertiesClass) is not None
+    assert graph_client.get_aspect(new_down, GlobalTagsClass) is not None
+
+    # An aspect absent from the old hardcoded list is now migrated.
+    assert graph_client.get_aspect(new_down, EmbedClass) is not None
+
+    # siblings is a relationship aspect and is carried over (pointing at the
+    # un-migrated counterpart), not dropped.
+    siblings = graph_client.get_aspect(new_down, SiblingsClass)
+    assert siblings is not None
+    assert siblings.siblings == [upstream]
+
+
+@pytest.fixture(scope="module")
+def seeded_incoming(graph_client: DataHubGraph):
+    all_urns = [up_src_old, up_src_new, ref_down]
+    delete_urns(graph_client, all_urns)
+    wait_for_writes_to_sync()
+    for mcp in [
+        MetadataChangeProposalWrapper(entityUrn=up_src_old, aspect=_schema("id")),
+        MetadataChangeProposalWrapper(
+            entityUrn=up_src_old, aspect=_instance(OLD_INSTANCE_INC)
+        ),
+        MetadataChangeProposalWrapper(entityUrn=ref_down, aspect=_schema("cnt")),
+        MetadataChangeProposalWrapper(
+            entityUrn=ref_down, aspect=_instance(KEEP_INSTANCE)
+        ),
+        MetadataChangeProposalWrapper(
+            entityUrn=ref_down,
+            aspect=UpstreamLineageClass(
+                upstreams=[
+                    UpstreamClass(
+                        dataset=up_src_old, type=DatasetLineageTypeClass.TRANSFORMED
+                    )
+                ],
+                fineGrainedLineages=[
+                    FineGrainedLineageClass(
+                        upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                        downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                        upstreams=[make_schema_field_urn(up_src_old, "id")],
+                        downstreams=[make_schema_field_urn(ref_down, "cnt")],
+                    )
+                ],
+            ),
+        ),
+    ]:
+        graph_client.emit_mcp(mcp)
+    wait_for_writes_to_sync()
+    try:
+        yield
+    finally:
+        delete_urns(graph_client, all_urns)
+        wait_for_writes_to_sync()
+
+
+def test_incoming_references_are_rewritten(
+    graph_client: DataHubGraph, seeded_incoming
+) -> None:
+    # Migrate the UPSTREAM; a non-migrated downstream references it.
+    result = run_datahub_cmd(
+        [
+            "migrate",
+            "instance2instance",
+            "--platform",
+            PLATFORM,
+            "--old-instance",
+            OLD_INSTANCE_INC,
+            "--new-instance",
+            NEW_INSTANCE_INC,
+            "--env",
+            ENV,
+            "--entity-types",
+            "dataset",
+            "--force",
+            "--keep",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    wait_for_writes_to_sync()
+
+    lineage = graph_client.get_aspect(ref_down, UpstreamLineageClass)
+    assert lineage is not None
+    fgl = lineage.fineGrainedLineages
+    assert fgl is not None
+
+    # The reference to the migrated upstream is rewritten both table-level and
+    # column-level. The column-level rewrite is the case the old per-aspect
+    # modifier never handled.
+    assert [u.dataset for u in lineage.upstreams] == [up_src_new]
+    assert fgl[0].upstreams == [make_schema_field_urn(up_src_new, "id")]
+    # ref_down itself was not migrated, so its own downstream field is unchanged.
+    assert fgl[0].downstreams == [make_schema_field_urn(ref_down, "cnt")]
+
+
+@pytest.fixture(scope="module")
+def seeded_merge(graph_client: DataHubGraph):
+    all_urns = [mrg_src, mrg_tgt, mrg_up]
+    delete_urns(graph_client, all_urns)
+    wait_for_writes_to_sync()
+    for mcp in [
+        MetadataChangeProposalWrapper(entityUrn=mrg_up, aspect=_schema("id")),
+        MetadataChangeProposalWrapper(
+            entityUrn=mrg_up, aspect=_instance(KEEP_INSTANCE)
+        ),
+        MetadataChangeProposalWrapper(entityUrn=mrg_src, aspect=_schema("cnt")),
+        MetadataChangeProposalWrapper(
+            entityUrn=mrg_src, aspect=_instance(OLD_INSTANCE_MRG)
+        ),
+        MetadataChangeProposalWrapper(
+            entityUrn=mrg_src,
+            aspect=UpstreamLineageClass(
+                upstreams=[
+                    UpstreamClass(
+                        dataset=mrg_up, type=DatasetLineageTypeClass.TRANSFORMED
+                    )
+                ],
+                fineGrainedLineages=[
+                    FineGrainedLineageClass(
+                        upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                        downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                        upstreams=[make_schema_field_urn(mrg_up, "id")],
+                        downstreams=[make_schema_field_urn(mrg_src, "cnt")],
+                    )
+                ],
+            ),
+        ),
+        # Pre-create the target so the migration merges into it.
+        MetadataChangeProposalWrapper(entityUrn=mrg_tgt, aspect=_schema("cnt")),
+        MetadataChangeProposalWrapper(
+            entityUrn=mrg_tgt, aspect=_instance(NEW_INSTANCE_MRG)
+        ),
+    ]:
+        graph_client.emit_mcp(mcp)
+    wait_for_writes_to_sync()
+    try:
+        yield
+    finally:
+        delete_urns(graph_client, all_urns)
+        wait_for_writes_to_sync()
+
+
+def test_merge_mode_carries_and_rewrites_fine_grained_lineage(
+    graph_client: DataHubGraph, seeded_merge
+) -> None:
+    result = run_datahub_cmd(
+        [
+            "migrate",
+            "instance2instance",
+            "--platform",
+            PLATFORM,
+            "--old-instance",
+            OLD_INSTANCE_MRG,
+            "--new-instance",
+            NEW_INSTANCE_MRG,
+            "--env",
+            ENV,
+            "--entity-types",
+            "dataset",
+            "--on-conflict",
+            "overwrite",
+            "--force",
+            "--keep",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    wait_for_writes_to_sync()
+
+    lineage = graph_client.get_aspect(mrg_tgt, UpstreamLineageClass)
+    assert lineage is not None
+    fgl = lineage.fineGrainedLineages
+    # Column-level lineage is carried into the pre-existing target (not dropped),
+    # with the self-downstream rewritten to the target URN.
+    assert fgl is not None and len(fgl) >= 1
+    downstreams = fgl[0].downstreams or []
+    upstreams = fgl[0].upstreams or []
+    assert make_schema_field_urn(mrg_tgt, "cnt") in downstreams
+    assert make_schema_field_urn(mrg_up, "id") in upstreams

--- a/smoke-test/tests/cli/migrate_cmd/test_migrate_transform_smoke.py
+++ b/smoke-test/tests/cli/migrate_cmd/test_migrate_transform_smoke.py
@@ -1,0 +1,124 @@
+import logging
+from random import randint
+
+import pytest
+
+from datahub.emitter.mce_builder import (
+    make_data_platform_urn,
+    make_dataset_urn_with_platform_instance,
+    make_schema_field_urn,
+)
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.graph.client import DataHubGraph
+from datahub.metadata.schema_classes import (
+    DatasetLineageTypeClass,
+    FineGrainedLineageClass,
+    FineGrainedLineageDownstreamTypeClass,
+    FineGrainedLineageUpstreamTypeClass,
+    OtherSchemaClass,
+    SchemaFieldClass,
+    SchemaFieldDataTypeClass,
+    SchemaMetadataClass,
+    StringTypeClass,
+    SubTypesClass,
+    UpstreamClass,
+    UpstreamLineageClass,
+)
+from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utils import delete_urns, run_datahub_cmd
+
+logger = logging.getLogger(__name__)
+
+# Unique platform so `migrate transform` discovery only touches this dataset.
+PLATFORM = f"lctest{randint(10, 100000)}"
+ENV = "PROD"
+mixed = make_dataset_urn_with_platform_instance(
+    PLATFORM, "MyDb.MySchema.LcTbl", None, ENV
+)
+lower = make_dataset_urn_with_platform_instance(
+    PLATFORM, "mydb.myschema.lctbl", None, ENV
+)
+
+
+@pytest.fixture(scope="module")
+def seeded(graph_client: DataHubGraph):
+    all_urns = [mixed, lower]
+    delete_urns(graph_client, all_urns)
+    wait_for_writes_to_sync()
+    for mcp in [
+        MetadataChangeProposalWrapper(
+            entityUrn=mixed,
+            aspect=SchemaMetadataClass(
+                schemaName="s",
+                platform=make_data_platform_urn(PLATFORM),
+                version=0,
+                hash="",
+                platformSchema=OtherSchemaClass(rawSchema=""),
+                fields=[
+                    SchemaFieldClass(
+                        fieldPath="col_a",
+                        type=SchemaFieldDataTypeClass(type=StringTypeClass()),
+                        nativeDataType="STRING",
+                    )
+                ],
+            ),
+        ),
+        MetadataChangeProposalWrapper(
+            entityUrn=mixed, aspect=SubTypesClass(typeNames=["View"])
+        ),
+        # Self-referential column-level lineage: must be lowercased with the URN.
+        MetadataChangeProposalWrapper(
+            entityUrn=mixed,
+            aspect=UpstreamLineageClass(
+                upstreams=[
+                    UpstreamClass(
+                        dataset=mixed, type=DatasetLineageTypeClass.TRANSFORMED
+                    )
+                ],
+                fineGrainedLineages=[
+                    FineGrainedLineageClass(
+                        upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                        downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                        upstreams=[make_schema_field_urn(mixed, "col_a")],
+                        downstreams=[make_schema_field_urn(mixed, "col_a")],
+                    )
+                ],
+            ),
+        ),
+    ]:
+        graph_client.emit_mcp(mcp)
+    wait_for_writes_to_sync()
+    try:
+        yield
+    finally:
+        delete_urns(graph_client, all_urns)
+        wait_for_writes_to_sync()
+
+
+def test_transform_lowercase(graph_client: DataHubGraph, seeded) -> None:
+    result = run_datahub_cmd(
+        [
+            "migrate",
+            "transform",
+            "--platform",
+            PLATFORM,
+            "--converter",
+            "lowercase",
+            "--env",
+            ENV,
+            "--force",
+            "--keep",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    wait_for_writes_to_sync()
+
+    assert graph_client.exists(lower)
+    assert graph_client.get_aspect(lower, SubTypesClass) is not None
+
+    lineage = graph_client.get_aspect(lower, UpstreamLineageClass)
+    assert lineage is not None and lineage.fineGrainedLineages
+    # The self-referential column-level lineage is lowercased with the URN.
+    assert lineage.fineGrainedLineages[0].downstreams == [
+        make_schema_field_urn(lower, "col_a")
+    ]


### PR DESCRIPTION
Stacked on #18544 (`fix-migrate-dynamic-aspects`) — **review/merge that first**; this PR's base is that branch, so the diff here is only the generalization on top.

## Summary
Generalizes the migration core so an arbitrary URN transform can reuse the aspect-cloning + URN-rewriting + incoming-reference machinery from #18544, and adds a `datahub migrate transform --converter lowercase` command. This subsumes the standalone `datahub-apps` `dataset_migrator` while gaining full aspect coverage, column-level lineage rewriting, and incoming-reference rewriting it never had.

- `platform`/`target_instance` are now optional in the core; the `dataPlatformInstance` emit is skipped for non-instance transforms.
- `UrnConverter` protocol + `LowercaseConverter` (wraps `urn_iter.lowercase_dataset_urn`) + a `CONVERTERS` registry.
- `migrate transform` command: discover a platform's datasets, filter by `should_convert`, migrate under `converter.convert_urn`.

## Testing
Unit tests (converter + no-instance-emit); a smoke test (unique platform → isolated discovery). Verified end-to-end against a live GMS (lowercased URN keeps its aspects and column-level lineage is rewritten).

Linear: ING-3085.
