### PR TITLE
feat(ingestion): per-connector metadata migrations run before ingestion

### DIFF
--- a/metadata-ingestion/docs/dev_guides/ingestion_migrations.md
+++ b/metadata-ingestion/docs/dev_guides/ingestion_migrations.md
@@ -34,6 +34,7 @@ class MySource(StatefulIngestionSourceBase):
                 id="mysource-0001-lowercase-urns",  # stable & unique; never reuse an id
                 description="Lowercase dataset URNs after the casing fix.",
                 run=self._lowercase_urns,
+                apply_before="1.5.0",  # optional; only needed for data from < 1.5.0
             ),
         ]
 
@@ -65,6 +66,17 @@ def _lowercase_urns(self, graph, report, dry_run):
 `run_transform` discovers **all** matching datasets from the graph for the given `platform` (optionally narrowed to a `platform_instance`) — not just the URNs in the current pipeline's checkpoint state — so a migration reshapes every affected entity regardless of which pipeline produced it. Omit `platform_instance` to cover all instances of the platform.
 
 For aspect-shape changes, fetch the affected aspects and re-emit them in the new shape from within `run`.
+
+## Ordering and version gating
+
+**Ordering** is simply the order of the list returned by `get_migrations()`. Pending migrations run top-to-bottom, sequentially, each recorded on success — so if one migration depends on another, put the dependency earlier. The numeric id prefix (`-0001-`, `-0002-`) is a readability convention only; it is not parsed or sorted on. Append new migrations at the end; never reorder or reuse ids.
+
+**Version gating** (`apply_before`) is optional and answers "is this migration still needed?". A migration is only needed for data produced by versions **before** the fix — once the pipeline's last run was already at or after `apply_before`, the newer code emits the correct shape, so the migration is skipped. Set `apply_before` to the release whose output is correct (usually the release that ships the migration):
+
+- last run `< apply_before` (or unknown) → run the migration;
+- last run `>= apply_before` → skip (data already correct).
+
+If you omit `apply_before`, the migration is gated only by the id ledger (runs exactly once, regardless of version). The last-run version is recorded in the ledger when a migration is applied.
 
 ## Enabling migrations
 

--- a/metadata-ingestion/docs/dev_guides/ingestion_migrations.md
+++ b/metadata-ingestion/docs/dev_guides/ingestion_migrations.md
@@ -12,7 +12,7 @@ Use one when a connector change means metadata **already in DataHub** must be tr
 
 - Migrations are declared by overriding `get_migrations()` on a source that extends `StatefulIngestionSourceBase`.
 - The set of applied migration ids is stored in a **ledger** that rides the stateful-ingestion checkpoint, keyed per pipeline. So migrations **require stateful ingestion** to be enabled.
-- Before ingestion, a pre-ingestion hook computes the **pending** migrations (declared but not in the ledger) and, when enabled, runs them in declared order, recording each id as it succeeds.
+- Before ingestion, a pre-ingestion hook computes the **pending** migrations (declared but not in the ledger) and, when enabled, runs them in id order, recording each id as it succeeds.
 
 Because the ledger is per pipeline, a migration can re-trigger when a *different* pipeline ingests the same data, and the ledger read is eventually consistent (so two runs of the *same* pipeline in quick succession could both apply). **Migrations must therefore be idempotent** — re-running one must be a no-op. A migration that selects its targets with a filter that matches nothing after the first apply (e.g. "datasets whose URN is not already lowercase") satisfies this naturally.
 
@@ -31,10 +31,10 @@ class MySource(StatefulIngestionSourceBase):
     def get_migrations(self):
         return [
             Migration(
-                id="mysource-0001-lowercase-urns",  # stable & unique; never reuse an id
+                id="20260722-mysource-lowercase-urns",  # timestamp prefix = run order; never reuse
                 description="Lowercase dataset URNs after the casing fix.",
                 run=self._lowercase_urns,
-                apply_before="1.5.0",  # optional; only needed for data from < 1.5.0
+                fixed_in="1.5.0",  # optional; data from 1.5.0+ is already correct
             ),
         ]
 
@@ -69,14 +69,37 @@ For aspect-shape changes, fetch the affected aspects and re-emit them in the new
 
 ## Ordering and version gating
 
-**Ordering** is simply the order of the list returned by `get_migrations()`. Pending migrations run top-to-bottom, sequentially, each recorded on success — so if one migration depends on another, put the dependency earlier. The numeric id prefix (`-0001-`, `-0002-`) is a readability convention only; it is not parsed or sorted on. Append new migrations at the end; never reorder or reuse ids.
+**Ordering** is by **id**. Pending migrations run sorted by their `id`, each recorded on success — so the id is the ordering key, not the position in the list. Use a **timestamp prefix** (`20260722-...`, optionally `20260722T1530-...`) so migrations run chronologically and a global fix (see below) interleaves correctly with a connector's own. If one migration depends on another, give it a later timestamp. Ids are permanent — never reorder or reuse them.
 
-**Version gating** (`apply_before`) is optional and answers "is this migration still needed?". A migration is only needed for data produced by versions **before** the fix — once the pipeline's last run was already at or after `apply_before`, the newer code emits the correct shape, so the migration is skipped. Set `apply_before` to the release whose output is correct (usually the release that ships the migration):
+**Version gating** is optional and answers "was the data in DataHub produced by an affected version?". Describe the bug's lifecycle with a window `[introduced_in, fixed_in)`:
 
-- last run `< apply_before` (or unknown) → run the migration;
-- last run `>= apply_before` → skip (data already correct).
+- `introduced_in` — the first release that produced the broken shape (inclusive). Data from **before** it was never affected, so the migration is skipped.
+- `fixed_in` — the first release whose output is already correct (exclusive). Data from it onward is already right, so the migration is skipped. (This is the release that usually ships the migration.)
 
-If you omit `apply_before`, the migration is gated only by the id ledger (runs exactly once, regardless of version). The last-run version is recorded in the ledger when a migration is applied.
+So a migration runs only when the last-run version is in `introduced_in <= v < fixed_in`. Either bound may be omitted for a one-sided window; omit both to gate on the id ledger alone. Unknown last-run version → the migration runs (`converter.should_convert` is the fine-grained guard that never rewrites data that doesn't match). The last-run version is refreshed in the ledger on every enabled run.
+
+## Global (cross-connector) migrations
+
+A fix that applies to more than one connector can be registered once instead of copied into each `get_migrations()`. Register a **factory** that receives the running source and returns a `Migration` scoped to it:
+
+```python
+from datahub.ingestion.source.state.ingestion_migration import register_migration, Migration
+
+def _my_global_fix(source):
+    return Migration(
+        id="20260722-lowercase-all-urns",
+        description="Lowercase URNs across connectors after the casing fix.",
+        run=lambda graph, report, dry_run: run_transform(
+            graph, LowercaseConverter(), platform=source.get_platform(),
+            platform_instance=source.config.platform_instance, dry_run=dry_run,
+        ),
+        fixed_in="1.6.0",
+    )
+
+register_migration(_my_global_fix)
+```
+
+The framework merges registered migrations into every source's list (a source-declared id wins on a clash) and gates them with the **same per-pipeline ledger** — so a global migration simply runs once per pipeline, scoped to that pipeline's source. No global ledger or cross-pipeline lock is involved.
 
 ## Enabling migrations
 
@@ -97,7 +120,7 @@ source:
 
 When migrations are pending but `enabled` is false, the run logs a warning listing the pending ids (and fails if `fail_on_pending` is set), so operators know a migration is waiting.
 
-Set `force: true` to re-run every migration regardless of the ledger or `apply_before` gate — useful to re-apply after a fix or to force a one-off re-run. It still requires `enabled: true` to mutate, and (like all migrations) relies on migrations being idempotent.
+Set `force: true` to re-run every migration regardless of the ledger or the version window — useful to re-apply after a fix or to force a one-off re-run. It still requires `enabled: true` to mutate, and (like all migrations) relies on migrations being idempotent.
 
 ## Guidelines
 

--- a/metadata-ingestion/docs/dev_guides/ingestion_migrations.md
+++ b/metadata-ingestion/docs/dev_guides/ingestion_migrations.md
@@ -92,9 +92,12 @@ source:
         enabled: true        # apply pending migrations before ingestion
         dry_run: false       # log what would run without mutating
         fail_on_pending: false  # if true, abort when a migration is pending but disabled
+        force: false         # re-run every migration even if the ledger/version gate would skip it
 ```
 
 When migrations are pending but `enabled` is false, the run logs a warning listing the pending ids (and fails if `fail_on_pending` is set), so operators know a migration is waiting.
+
+Set `force: true` to re-run every migration regardless of the ledger or `apply_before` gate — useful to re-apply after a fix or to force a one-off re-run. It still requires `enabled: true` to mutate, and (like all migrations) relies on migrations being idempotent.
 
 ## Guidelines
 

--- a/metadata-ingestion/src/datahub/ingestion/source/state/ingestion_migration.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/ingestion_migration.py
@@ -147,6 +147,10 @@ class CheckpointMigrationLedger:
         )
         aspect = checkpoint.to_checkpoint_aspect(max_allowed_state_size=2**24)
         if aspect is not None:
+            # Soft-delete the bookkeeping DataJob so it stays out of search/UI
+            # (the timeseries checkpoint aspect remains readable), matching the
+            # built-in checkpointing provider.
+            self.graph.soft_delete_entity(self._urn)
             self.graph.emit_mcp(
                 MetadataChangeProposalWrapper(entityUrn=self._urn, aspect=aspect)
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/state/ingestion_migration.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/ingestion_migration.py
@@ -11,11 +11,12 @@ checkpoint, keyed per pipeline. Migrations must be idempotent (see design spec).
 
 import logging
 from dataclasses import dataclass
-from typing import Callable, List, Optional, Protocol, Set
+from typing import Any, Callable, List, Optional, Protocol, Set
 
 from packaging.version import InvalidVersion, Version
 
 from datahub.configuration.common import ConfigModel
+from datahub.emitter.mce_builder import datahub_guid
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.ingestion_job_checkpointing_provider_base import (
     IngestionCheckpointingProviderBase,
@@ -24,7 +25,10 @@ from datahub.ingestion.api.ingestion_job_checkpointing_provider_base import (
 from datahub.ingestion.api.source import SourceReport
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.ingestion.source.state.checkpoint import Checkpoint, CheckpointStateBase
-from datahub.metadata.schema_classes import DatahubIngestionCheckpointClass
+from datahub.metadata.schema_classes import (
+    DatahubIngestionCheckpointClass,
+    DatahubIngestionRunSummaryClass,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -43,15 +47,24 @@ class Migration:
     means a different pipeline over the same data can re-trigger it.
     """
 
+    # Recommend a timestamp prefix (e.g. "20260722-lowercase-urns"): the id is the
+    # run-ordering key, so global and per-connector migrations interleave by when
+    # the fix was written. Stable and permanent — never reuse or renumber.
     id: str
     description: str
     run: MigrationFn
-    # Optional version gate: the version whose output is already correct (usually
-    # the release that ships this migration). The migration is only needed for
-    # data produced by *earlier* versions, so it is skipped once the pipeline's
-    # last run was already at/after `apply_before` (newer code emits the correct
-    # shape). None => gate on the id ledger only.
-    apply_before: Optional[str] = None
+    # Optional version window [introduced_in, fixed_in) describing the releases
+    # whose output is broken. The migration only needs to run for data produced by
+    # a version inside the window:
+    #   - introduced_in: first version that produced the broken shape (inclusive);
+    #     data from *before* it was never affected, so it is skipped.
+    #   - fixed_in: first version whose output is already correct (exclusive);
+    #     data from it onward is already right, so it is skipped.
+    # Either bound may be omitted for a one-sided gate. Both omitted => gate on the
+    # id ledger only. The gate is a coarse skip; converter.should_convert is the
+    # fine-grained guard that never rewrites data that doesn't match.
+    introduced_in: Optional[str] = None
+    fixed_in: Optional[str] = None
 
 
 class MigrationConfig(ConfigModel):
@@ -65,19 +78,77 @@ class MigrationConfig(ConfigModel):
 
 class MigrationCheckpointState(CheckpointStateBase):
     applied: List[str] = []
-    # The source/CLI version recorded when a migration was last applied. Used by
-    # the optional `apply_before` version gate.
+    # The source/CLI version of the last enabled run, refreshed every run. Used by
+    # the optional [introduced_in, fixed_in) version window to tell whether the
+    # data currently in DataHub was produced by an affected version.
     last_source_version: Optional[str] = None
 
 
-def _is_superseded(apply_before: Optional[str], last_version: Optional[str]) -> bool:
-    """True when the last run was already at/after `apply_before` (data already correct)."""
-    if not apply_before or not last_version:
-        return False
+def _version(v: Optional[str]) -> Optional[Version]:
+    if not v:
+        return None
     try:
-        return Version(last_version) >= Version(apply_before)
+        return Version(v)
     except InvalidVersion:
+        return None
+
+
+def _needs_migration(
+    introduced_in: Optional[str],
+    fixed_in: Optional[str],
+    last_version: Optional[str],
+) -> bool:
+    """Whether data produced by ``last_version`` falls in [introduced_in, fixed_in).
+
+    Unknown/unparseable ``last_version`` => True (apply; ``should_convert`` is the
+    real guard). ``< introduced_in`` => never affected. ``>= fixed_in`` => already
+    correct. Either bound may be absent for a one-sided window.
+    """
+    v = _version(last_version)
+    if v is None:
+        return True
+    low = _version(introduced_in)
+    if low is not None and v < low:
         return False
+    high = _version(fixed_in)
+    if high is not None and v >= high:
+        return False
+    return True
+
+
+# --- Global migrations: fixes that apply across many connectors -----------------
+# Register a factory that receives the running source and returns a Migration
+# scoped to it (so its `run` can target that source's platform/instance). The
+# framework merges these into every source's get_migrations() list; the existing
+# per-pipeline ledger gates each, so no global ledger or cross-pipeline lock is
+# needed — the migration simply runs once per pipeline, like a connector-declared
+# one.
+MigrationFactory = Callable[[Any], Migration]
+
+_GLOBAL_MIGRATIONS: List[MigrationFactory] = []
+
+
+def register_migration(factory: MigrationFactory) -> None:
+    """Register a migration that applies to every stateful source."""
+    _GLOBAL_MIGRATIONS.append(factory)
+
+
+def collect_migrations(
+    source_migrations: List[Migration], source: Any
+) -> List[Migration]:
+    """Merge a source's own migrations with the globally-registered ones.
+
+    Global factories are given the ``source`` so they can scope themselves. A
+    source-declared id wins over a global one on a clash.
+    """
+    merged = list(source_migrations)
+    seen = {m.id for m in merged}
+    for factory in _GLOBAL_MIGRATIONS:
+        migration = factory(source)
+        if migration.id not in seen:
+            merged.append(migration)
+            seen.add(migration.id)
+    return merged
 
 
 class MigrationPendingError(Exception):
@@ -90,6 +161,10 @@ class MigrationLedger(Protocol):
     def read_last_version(self) -> Optional[str]: ...
 
     def record(self, migration_id: str, source_version: Optional[str]) -> None: ...
+
+    def touch_version(self, source_version: Optional[str]) -> None:
+        """Record the current run's version without adding an applied id."""
+        ...
 
 
 class CheckpointMigrationLedger:
@@ -137,6 +212,24 @@ class CheckpointMigrationLedger:
     def record(self, migration_id: str, source_version: Optional[str]) -> None:
         self._applied.add(migration_id)
         self._last_version = source_version
+        self._commit(source_version)
+
+    def touch_version(self, source_version: Optional[str]) -> None:
+        # Refresh the recorded version for the next run's window check, without
+        # adding an applied id. No-op when it hasn't changed (record() just set it).
+        if source_version == self._last_version:
+            return
+        self._last_version = source_version
+        self._commit(source_version)
+
+    def seed_last_version(self, source_version: Optional[str]) -> None:
+        # In-memory only (no emit): supply a version for *this* run's window check
+        # when our own ledger has none yet (e.g. the first run — see
+        # read_last_ingestion_version). Never overrides a version we recorded.
+        if self._last_version is None:
+            self._last_version = source_version
+
+    def _commit(self, source_version: Optional[str]) -> None:
         checkpoint: Checkpoint[MigrationCheckpointState] = Checkpoint(
             job_name=MIGRATIONS_JOB_ID,
             pipeline_name=self.pipeline_name,
@@ -156,6 +249,40 @@ class CheckpointMigrationLedger:
             )
 
 
+def read_last_ingestion_version(
+    graph: DataHubGraph, pipeline_config: Any
+) -> Optional[str]:
+    """Best-effort: the CLI/source version of this pipeline's last ingestion run.
+
+    Reads ``DatahubIngestionRunSummary.softwareVersion`` — a per-pipeline timeseries
+    aspect emitted by the run-summary reporting provider (default-on for the
+    datahub-rest sink / managed ingestion). This lets the ``[introduced_in,
+    fixed_in)`` window fire on the *first* migrations run, before our own ledger
+    has recorded a version. Returns None (→ treat as unknown) on any problem,
+    including when reporting never ran. The URN scheme mirrors
+    ``DatahubIngestionRunSummaryProvider.generate_unique_key``.
+    """
+    if pipeline_config is None:
+        return None
+    try:
+        key = {"type": pipeline_config.source.type}
+        if pipeline_config.pipeline_name:
+            key["pipeline_name"] = pipeline_config.pipeline_name
+        source_config = pipeline_config.source.config or {}
+        if "platform_instance" in source_config:
+            key["platform_instance"] = source_config["platform_instance"]
+        urn = f"urn:li:dataHubIngestionSource:cli-{datahub_guid(key)}"
+        summary = graph.get_latest_timeseries_value(
+            entity_urn=urn,
+            aspect_type=DatahubIngestionRunSummaryClass,
+            filter_criteria_map={},
+        )
+        return summary.softwareVersion if summary is not None else None
+    except Exception as e:
+        logger.debug(f"Could not read last ingestion version for the window gate: {e}")
+        return None
+
+
 def run_migrations(
     migrations: List[Migration],
     ledger: MigrationLedger,
@@ -164,27 +291,33 @@ def run_migrations(
     config: MigrationConfig,
     current_version: str,
 ) -> None:
-    """Apply pending migrations (declared order) before ingestion.
+    """Apply pending migrations (in id order) before ingestion.
 
     Pending = migrations whose id is not in the ledger and whose optional
-    ``apply_before`` version is not already superseded by the last applied version
-    (i.e. still needed for data produced by an earlier version) — unless
-    ``config.force`` is set, which re-runs every migration regardless. If
-    disabled, pending migrations are reported (and optionally fail the run) but
-    not applied. ``current_version`` is recorded on each apply.
+    ``[introduced_in, fixed_in)`` window still covers the version that produced the
+    existing data — unless ``config.force`` is set, which re-runs every migration
+    regardless. Pending migrations run sorted by id, so a global fix and a
+    connector fix interleave by their (recommended timestamp) ids. If disabled,
+    pending migrations are reported (and optionally fail the run) but not applied.
+    On an enabled run the ledger's version is refreshed to ``current_version`` so
+    the next run's window check knows what produced the data.
     """
     applied = ledger.read_applied()
     last_version = ledger.read_last_version()
-    pending = [
-        m
-        for m in migrations
-        if config.force
-        or (m.id not in applied and not _is_superseded(m.apply_before, last_version))
-    ]
-    if not pending:
-        return
+    pending = sorted(
+        (
+            m
+            for m in migrations
+            if config.force
+            or (
+                m.id not in applied
+                and _needs_migration(m.introduced_in, m.fixed_in, last_version)
+            )
+        ),
+        key=lambda m: m.id,
+    )
 
-    if not config.enabled:
+    if pending and not config.enabled:
         message = (
             f"{len(pending)} pending ingestion migration(s): "
             f"{[m.id for m in pending]}. "
@@ -202,3 +335,7 @@ def run_migrations(
         migration.run(graph, report, config.dry_run)
         if not config.dry_run:
             ledger.record(migration.id, current_version)
+
+    # Remember the version that produced the data for the next run's window check.
+    if config.enabled and not config.dry_run:
+        ledger.touch_version(current_version)

--- a/metadata-ingestion/src/datahub/ingestion/source/state/ingestion_migration.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/ingestion_migration.py
@@ -1,0 +1,155 @@
+"""Per-connector ingestion migrations.
+
+A connector author declares one-time metadata migrations (a stable id + the
+migration code) via ``StatefulIngestionSourceBase.get_migrations()``. Before
+ingestion, any migration not yet recorded in the ledger runs (when enabled), so
+metadata already in DataHub is reshaped after a breaking connector change.
+
+The ledger of applied migration ids rides the existing stateful-ingestion
+checkpoint, keyed per pipeline. Migrations must be idempotent (see design spec).
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Callable, List, Protocol, Set
+
+from datahub.configuration.common import ConfigModel
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.ingestion_job_checkpointing_provider_base import (
+    IngestionCheckpointingProviderBase,
+    JobId,
+)
+from datahub.ingestion.api.source import SourceReport
+from datahub.ingestion.graph.client import DataHubGraph
+from datahub.ingestion.source.state.checkpoint import Checkpoint, CheckpointStateBase
+from datahub.metadata.schema_classes import DatahubIngestionCheckpointClass
+
+logger = logging.getLogger(__name__)
+
+# run(graph, report, dry_run) -> None: select the affected URNs and mutate them.
+MigrationFn = Callable[[DataHubGraph, SourceReport, bool], None]
+
+MIGRATIONS_JOB_ID = JobId("ingestion_migrations")
+
+
+@dataclass
+class Migration:
+    """A one-time metadata migration shipped by a connector.
+
+    ``run`` is a plain callable (not a method) so authors can pass a lambda or a
+    module-level function. It must be idempotent — the per-pipeline ledger scope
+    means a different pipeline over the same data can re-trigger it.
+    """
+
+    id: str
+    description: str
+    run: MigrationFn
+
+
+class MigrationConfig(ConfigModel):
+    enabled: bool = False
+    dry_run: bool = False
+    fail_on_pending: bool = False
+
+
+class MigrationCheckpointState(CheckpointStateBase):
+    applied: List[str] = []
+
+
+class MigrationPendingError(Exception):
+    """Raised when migrations are pending but disabled and fail_on_pending is set."""
+
+
+class MigrationLedger(Protocol):
+    def read_applied(self) -> Set[str]: ...
+
+    def record(self, migration_id: str) -> None: ...
+
+
+class CheckpointMigrationLedger:
+    """Applied-migration ledger backed by the stateful-ingestion checkpoint.
+
+    Stored as a ``datahubIngestionCheckpoint`` aspect on the migrations DataJob
+    URN, keyed by pipeline name. Each record is committed immediately (its own
+    emit) so a later ingestion failure cannot lose the record.
+    """
+
+    def __init__(self, graph: DataHubGraph, pipeline_name: str, run_id: str) -> None:
+        self.graph = graph
+        self.pipeline_name = pipeline_name
+        self.run_id = run_id
+        self._urn = IngestionCheckpointingProviderBase.get_data_job_urn(
+            "datahub", pipeline_name, MIGRATIONS_JOB_ID
+        )
+        self._applied: Set[str] = self._read()
+
+    def _read(self) -> Set[str]:
+        aspect = self.graph.get_latest_timeseries_value(
+            entity_urn=self._urn,
+            aspect_type=DatahubIngestionCheckpointClass,
+            filter_criteria_map={"pipelineName": self.pipeline_name},
+        )
+        checkpoint = Checkpoint.create_from_checkpoint_aspect(
+            job_name=MIGRATIONS_JOB_ID,
+            checkpoint_aspect=aspect,
+            state_class=MigrationCheckpointState,
+        )
+        if checkpoint is not None and isinstance(
+            checkpoint.state, MigrationCheckpointState
+        ):
+            return set(checkpoint.state.applied)
+        return set()
+
+    def read_applied(self) -> Set[str]:
+        return set(self._applied)
+
+    def record(self, migration_id: str) -> None:
+        self._applied.add(migration_id)
+        checkpoint: Checkpoint[MigrationCheckpointState] = Checkpoint(
+            job_name=MIGRATIONS_JOB_ID,
+            pipeline_name=self.pipeline_name,
+            run_id=self.run_id,
+            state=MigrationCheckpointState(applied=sorted(self._applied)),
+        )
+        aspect = checkpoint.to_checkpoint_aspect(max_allowed_state_size=2**24)
+        if aspect is not None:
+            self.graph.emit_mcp(
+                MetadataChangeProposalWrapper(entityUrn=self._urn, aspect=aspect)
+            )
+
+
+def run_migrations(
+    migrations: List[Migration],
+    ledger: MigrationLedger,
+    graph: DataHubGraph,
+    report: SourceReport,
+    config: MigrationConfig,
+) -> None:
+    """Apply pending migrations (declared order) before ingestion.
+
+    Pending = migrations whose id is not in the ledger. If disabled, pending
+    migrations are reported (and optionally fail the run) but not applied.
+    """
+    applied = ledger.read_applied()
+    pending = [m for m in migrations if m.id not in applied]
+    if not pending:
+        return
+
+    if not config.enabled:
+        message = (
+            f"{len(pending)} pending ingestion migration(s): "
+            f"{[m.id for m in pending]}. "
+            "Set stateful_ingestion.migrations.enabled=true to apply them."
+        )
+        report.warning(message=message, title="Pending ingestion migrations")
+        if config.fail_on_pending:
+            raise MigrationPendingError(message)
+        return
+
+    for migration in pending:
+        logger.info(
+            f"Running ingestion migration {migration.id}: {migration.description}"
+        )
+        migration.run(graph, report, config.dry_run)
+        if not config.dry_run:
+            ledger.record(migration.id)

--- a/metadata-ingestion/src/datahub/ingestion/source/state/ingestion_migration.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/ingestion_migration.py
@@ -58,6 +58,9 @@ class MigrationConfig(ConfigModel):
     enabled: bool = False
     dry_run: bool = False
     fail_on_pending: bool = False
+    # Re-run every migration even if the ledger/version gate would skip it
+    # (e.g. to re-apply after a fix). Still requires enabled=true to mutate.
+    force: bool = False
 
 
 class MigrationCheckpointState(CheckpointStateBase):
@@ -161,16 +164,18 @@ def run_migrations(
 
     Pending = migrations whose id is not in the ledger and whose optional
     ``apply_before`` version is not already superseded by the last applied version
-    (i.e. still needed for data produced by an earlier version). If disabled,
-    pending migrations are reported (and optionally fail the run) but not
-    applied. ``current_version`` is recorded on each apply.
+    (i.e. still needed for data produced by an earlier version) — unless
+    ``config.force`` is set, which re-runs every migration regardless. If
+    disabled, pending migrations are reported (and optionally fail the run) but
+    not applied. ``current_version`` is recorded on each apply.
     """
     applied = ledger.read_applied()
     last_version = ledger.read_last_version()
     pending = [
         m
         for m in migrations
-        if m.id not in applied and not _is_superseded(m.apply_before, last_version)
+        if config.force
+        or (m.id not in applied and not _is_superseded(m.apply_before, last_version))
     ]
     if not pending:
         return

--- a/metadata-ingestion/src/datahub/ingestion/source/state/ingestion_migration.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/ingestion_migration.py
@@ -11,7 +11,9 @@ checkpoint, keyed per pipeline. Migrations must be idempotent (see design spec).
 
 import logging
 from dataclasses import dataclass
-from typing import Callable, List, Protocol, Set
+from typing import Callable, List, Optional, Protocol, Set
+
+from packaging.version import InvalidVersion, Version
 
 from datahub.configuration.common import ConfigModel
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
@@ -44,6 +46,12 @@ class Migration:
     id: str
     description: str
     run: MigrationFn
+    # Optional version gate: the version whose output is already correct (usually
+    # the release that ships this migration). The migration is only needed for
+    # data produced by *earlier* versions, so it is skipped once the pipeline's
+    # last run was already at/after `apply_before` (newer code emits the correct
+    # shape). None => gate on the id ledger only.
+    apply_before: Optional[str] = None
 
 
 class MigrationConfig(ConfigModel):
@@ -54,6 +62,19 @@ class MigrationConfig(ConfigModel):
 
 class MigrationCheckpointState(CheckpointStateBase):
     applied: List[str] = []
+    # The source/CLI version recorded when a migration was last applied. Used by
+    # the optional `apply_before` version gate.
+    last_source_version: Optional[str] = None
+
+
+def _is_superseded(apply_before: Optional[str], last_version: Optional[str]) -> bool:
+    """True when the last run was already at/after `apply_before` (data already correct)."""
+    if not apply_before or not last_version:
+        return False
+    try:
+        return Version(last_version) >= Version(apply_before)
+    except InvalidVersion:
+        return False
 
 
 class MigrationPendingError(Exception):
@@ -63,7 +84,9 @@ class MigrationPendingError(Exception):
 class MigrationLedger(Protocol):
     def read_applied(self) -> Set[str]: ...
 
-    def record(self, migration_id: str) -> None: ...
+    def read_last_version(self) -> Optional[str]: ...
+
+    def record(self, migration_id: str, source_version: Optional[str]) -> None: ...
 
 
 class CheckpointMigrationLedger:
@@ -81,9 +104,11 @@ class CheckpointMigrationLedger:
         self._urn = IngestionCheckpointingProviderBase.get_data_job_urn(
             "datahub", pipeline_name, MIGRATIONS_JOB_ID
         )
-        self._applied: Set[str] = self._read()
+        state = self._read()
+        self._applied: Set[str] = set(state.applied) if state else set()
+        self._last_version: Optional[str] = state.last_source_version if state else None
 
-    def _read(self) -> Set[str]:
+    def _read(self) -> Optional[MigrationCheckpointState]:
         aspect = self.graph.get_latest_timeseries_value(
             entity_urn=self._urn,
             aspect_type=DatahubIngestionCheckpointClass,
@@ -97,19 +122,25 @@ class CheckpointMigrationLedger:
         if checkpoint is not None and isinstance(
             checkpoint.state, MigrationCheckpointState
         ):
-            return set(checkpoint.state.applied)
-        return set()
+            return checkpoint.state
+        return None
 
     def read_applied(self) -> Set[str]:
         return set(self._applied)
 
-    def record(self, migration_id: str) -> None:
+    def read_last_version(self) -> Optional[str]:
+        return self._last_version
+
+    def record(self, migration_id: str, source_version: Optional[str]) -> None:
         self._applied.add(migration_id)
+        self._last_version = source_version
         checkpoint: Checkpoint[MigrationCheckpointState] = Checkpoint(
             job_name=MIGRATIONS_JOB_ID,
             pipeline_name=self.pipeline_name,
             run_id=self.run_id,
-            state=MigrationCheckpointState(applied=sorted(self._applied)),
+            state=MigrationCheckpointState(
+                applied=sorted(self._applied), last_source_version=source_version
+            ),
         )
         aspect = checkpoint.to_checkpoint_aspect(max_allowed_state_size=2**24)
         if aspect is not None:
@@ -124,14 +155,23 @@ def run_migrations(
     graph: DataHubGraph,
     report: SourceReport,
     config: MigrationConfig,
+    current_version: str,
 ) -> None:
     """Apply pending migrations (declared order) before ingestion.
 
-    Pending = migrations whose id is not in the ledger. If disabled, pending
-    migrations are reported (and optionally fail the run) but not applied.
+    Pending = migrations whose id is not in the ledger and whose optional
+    ``apply_before`` version is not already superseded by the last applied version
+    (i.e. still needed for data produced by an earlier version). If disabled,
+    pending migrations are reported (and optionally fail the run) but not
+    applied. ``current_version`` is recorded on each apply.
     """
     applied = ledger.read_applied()
-    pending = [m for m in migrations if m.id not in applied]
+    last_version = ledger.read_last_version()
+    pending = [
+        m
+        for m in migrations
+        if m.id not in applied and not _is_superseded(m.apply_before, last_version)
+    ]
     if not pending:
         return
 
@@ -152,4 +192,4 @@ def run_migrations(
         )
         migration.run(graph, report, config.dry_run)
         if not config.dry_run:
-            ledger.record(migration.id)
+            ledger.record(migration.id, current_version)

--- a/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
@@ -6,6 +6,7 @@ import pydantic
 from pydantic import BaseModel as GenericModel, model_validator
 from pydantic.fields import Field
 
+from datahub._version import nice_version_name
 from datahub.configuration.common import (
     ConfigModel,
     ConfigurationError,
@@ -270,7 +271,12 @@ class StatefulIngestionSourceBase(Source):
             return
         ledger = CheckpointMigrationLedger(graph, pipeline_name, self.ctx.run_id)
         run_migrations(
-            migrations, ledger, graph, self.report, self._migrations_config
+            migrations,
+            ledger,
+            graph,
+            self.report,
+            self._migrations_config,
+            nice_version_name(),
         )
 
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:

--- a/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, Generic, Optional, Type, TypeVar
+from typing import Any, Dict, Generic, Iterable, List, Optional, Type, TypeVar
 
 import pydantic
 from pydantic import BaseModel as GenericModel, model_validator
@@ -21,7 +21,14 @@ from datahub.ingestion.api.ingestion_job_checkpointing_provider_base import (
     JobId,
 )
 from datahub.ingestion.api.source import Source, SourceCapability, SourceReport
+from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.state.checkpoint import Checkpoint, StateType
+from datahub.ingestion.source.state.ingestion_migration import (
+    CheckpointMigrationLedger,
+    Migration,
+    MigrationConfig,
+    run_migrations,
+)
 from datahub.ingestion.source.state.use_case_handler import (
     StatefulIngestionUsecaseHandlerBase,
 )
@@ -70,6 +77,11 @@ class StatefulIngestionConfig(ConfigModel):
     ignore_new_state: HiddenFromDocs[bool] = Field(
         default=False,
         description="If set to True, ignores the current checkpoint state.",
+    )
+    migrations: MigrationConfig = Field(
+        default_factory=MigrationConfig,
+        description="Per-connector metadata migrations to run before ingestion. "
+        "Disabled by default; migrations only apply when migrations.enabled=true.",
     )
 
     @model_validator(mode="after")
@@ -229,6 +241,43 @@ class StatefulIngestionSourceBase(Source):
         super().__init__(ctx)
         self.report: StatefulIngestionReport = StatefulIngestionReport()
         self.state_provider = StateProviderWrapper(config.stateful_ingestion, ctx)
+        self._migrations_config = (
+            config.stateful_ingestion.migrations
+            if config.stateful_ingestion is not None
+            else MigrationConfig()
+        )
+
+    def get_migrations(self) -> List[Migration]:
+        """One-time metadata migrations to run before ingestion.
+
+        Connectors override this to ship migrations for breaking changes. Each
+        migration must be idempotent (see MigrationConfig / the design spec).
+        """
+        return []
+
+    def _run_pending_migrations(self) -> None:
+        migrations = self.get_migrations()
+        if not migrations:
+            return
+        graph = self.ctx.graph
+        pipeline_name = self.ctx.pipeline_name
+        if graph is None or not pipeline_name:
+            self.report.warning(
+                message="Ingestion migrations are defined but require stateful "
+                "ingestion (a graph and pipeline_name); skipping.",
+                title="Ingestion migrations skipped",
+            )
+            return
+        ledger = CheckpointMigrationLedger(graph, pipeline_name, self.ctx.run_id)
+        run_migrations(
+            migrations, ledger, graph, self.report, self._migrations_config
+        )
+
+    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
+        # Run any pending migrations before producing workunits, so ingestion
+        # lands on already-migrated metadata.
+        self._run_pending_migrations()
+        yield from super().get_workunits()
 
     def warn(self, log: logging.Logger, key: str, reason: str) -> None:
         # TODO: Remove this method.

--- a/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
@@ -28,6 +28,8 @@ from datahub.ingestion.source.state.ingestion_migration import (
     CheckpointMigrationLedger,
     Migration,
     MigrationConfig,
+    collect_migrations,
+    read_last_ingestion_version,
     run_migrations,
 )
 from datahub.ingestion.source.state.use_case_handler import (
@@ -257,7 +259,7 @@ class StatefulIngestionSourceBase(Source):
         return []
 
     def _run_pending_migrations(self) -> None:
-        migrations = self.get_migrations()
+        migrations = collect_migrations(self.get_migrations(), self)
         if not migrations:
             return
         graph = self.ctx.graph
@@ -270,6 +272,15 @@ class StatefulIngestionSourceBase(Source):
             )
             return
         ledger = CheckpointMigrationLedger(graph, pipeline_name, self.ctx.run_id)
+        # First run has no recorded version yet; seed the window gate from the
+        # pipeline's last ingestion run summary (best-effort) so a migration for a
+        # bug the pipeline never hit is skipped rather than scanned.
+        if ledger.read_last_version() is None:
+            ledger.seed_last_version(
+                read_last_ingestion_version(
+                    graph, getattr(self.ctx, "pipeline_config", None)
+                )
+            )
         run_migrations(
             migrations,
             ledger,

--- a/metadata-ingestion/tests/unit/stateful_ingestion/test_ingestion_migration.py
+++ b/metadata-ingestion/tests/unit/stateful_ingestion/test_ingestion_migration.py
@@ -1,6 +1,6 @@
 """Unit tests for the per-connector ingestion migration runner."""
 
-from typing import Iterable, List, Set, Tuple
+from typing import Iterable, List, Optional, Set, Tuple
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,41 +12,55 @@ from datahub.ingestion.source.state.ingestion_migration import (
     run_migrations,
 )
 
+VERSION = "1.5.0"
+
 
 class FakeLedger:
-    def __init__(self, applied: Iterable[str] = ()):
+    def __init__(self, applied: Iterable[str] = (), last_version: Optional[str] = None):
         self._applied: Set[str] = set(applied)
+        self._last_version = last_version
         self.recorded: List[str] = []
+        self.recorded_versions: List[Optional[str]] = []
 
     def read_applied(self) -> Set[str]:
         return set(self._applied)
 
-    def record(self, migration_id: str) -> None:
+    def read_last_version(self) -> Optional[str]:
+        return self._last_version
+
+    def record(self, migration_id: str, source_version: Optional[str]) -> None:
         self._applied.add(migration_id)
         self.recorded.append(migration_id)
+        self.recorded_versions.append(source_version)
 
 
-def _mig(mid: str) -> Tuple[Migration, MagicMock]:
+def _mig(mid: str, apply_before: Optional[str] = None) -> Tuple[Migration, MagicMock]:
     run = MagicMock()
-    return Migration(id=mid, description=mid, run=run), run
+    return (
+        Migration(id=mid, description=mid, run=run, apply_before=apply_before),
+        run,
+    )
 
 
 def test_runs_only_pending_in_order_and_records():
     (a, ra), (b, rb), (c, rc) = _mig("a"), _mig("b"), _mig("c")
     ledger = FakeLedger({"a"})
     graph, report = MagicMock(), MagicMock()
-    run_migrations([a, b, c], ledger, graph, report, MigrationConfig(enabled=True))
+    run_migrations(
+        [a, b, c], ledger, graph, report, MigrationConfig(enabled=True), VERSION
+    )
     ra.assert_not_called()
     rb.assert_called_once_with(graph, report, False)
     rc.assert_called_once_with(graph, report, False)
     assert ledger.recorded == ["b", "c"]
+    assert ledger.recorded_versions == [VERSION, VERSION]
 
 
 def test_declared_order_preserved():
     migs = [_mig("c")[0], _mig("a")[0], _mig("b")[0]]
     ledger = FakeLedger()
     run_migrations(
-        migs, ledger, MagicMock(), MagicMock(), MigrationConfig(enabled=True)
+        migs, ledger, MagicMock(), MagicMock(), MigrationConfig(enabled=True), VERSION
     )
     assert ledger.recorded == ["c", "a", "b"]
 
@@ -55,7 +69,9 @@ def test_disabled_warns_and_skips():
     (a, ra) = _mig("a")
     ledger = FakeLedger()
     report = MagicMock()
-    run_migrations([a], ledger, MagicMock(), report, MigrationConfig(enabled=False))
+    run_migrations(
+        [a], ledger, MagicMock(), report, MigrationConfig(enabled=False), VERSION
+    )
     ra.assert_not_called()
     assert ledger.recorded == []
     report.warning.assert_called_once()
@@ -70,6 +86,7 @@ def test_disabled_fail_on_pending_raises():
             MagicMock(),
             MagicMock(),
             MigrationConfig(enabled=False, fail_on_pending=True),
+            VERSION,
         )
 
 
@@ -78,7 +95,7 @@ def test_dry_run_runs_but_does_not_record():
     ledger = FakeLedger()
     graph, report = MagicMock(), MagicMock()
     run_migrations(
-        [a], ledger, graph, report, MigrationConfig(enabled=True, dry_run=True)
+        [a], ledger, graph, report, MigrationConfig(enabled=True, dry_run=True), VERSION
     )
     ra.assert_called_once_with(graph, report, True)
     assert ledger.recorded == []
@@ -88,7 +105,52 @@ def test_no_pending_is_noop():
     (a, ra) = _mig("a")
     ledger = FakeLedger({"a"})
     report = MagicMock()
-    run_migrations([a], ledger, MagicMock(), report, MigrationConfig(enabled=True))
+    run_migrations(
+        [a], ledger, MagicMock(), report, MigrationConfig(enabled=True), VERSION
+    )
     ra.assert_not_called()
     assert ledger.recorded == []
     report.warning.assert_not_called()
+
+
+# --- version gating (apply_before) ---
+
+
+def test_version_gate_skips_when_last_version_at_or_above_apply_before():
+    (a, ra) = _mig("a", apply_before="1.2.0")
+    ledger = FakeLedger(last_version="1.3.0")  # data already produced by >= 1.2.0
+    report = MagicMock()
+    run_migrations(
+        [a], ledger, MagicMock(), report, MigrationConfig(enabled=True), VERSION
+    )
+    ra.assert_not_called()
+    assert ledger.recorded == []
+    report.warning.assert_not_called()
+
+
+def test_version_gate_runs_when_last_version_below_apply_before():
+    (a, ra) = _mig("a", apply_before="1.2.0")
+    ledger = FakeLedger(last_version="1.1.0")
+    run_migrations(
+        [a], ledger, MagicMock(), MagicMock(), MigrationConfig(enabled=True), VERSION
+    )
+    ra.assert_called_once()
+    assert ledger.recorded == ["a"]
+
+
+def test_version_gate_runs_when_no_last_version():
+    (a, ra) = _mig("a", apply_before="1.2.0")
+    ledger = FakeLedger()  # never migrated before
+    run_migrations(
+        [a], ledger, MagicMock(), MagicMock(), MigrationConfig(enabled=True), VERSION
+    )
+    ra.assert_called_once()
+
+
+def test_no_apply_before_ignores_version():
+    (a, ra) = _mig("a")  # no apply_before
+    ledger = FakeLedger(last_version="9.9.9")
+    run_migrations(
+        [a], ledger, MagicMock(), MagicMock(), MigrationConfig(enabled=True), VERSION
+    )
+    ra.assert_called_once()

--- a/metadata-ingestion/tests/unit/stateful_ingestion/test_ingestion_migration.py
+++ b/metadata-ingestion/tests/unit/stateful_ingestion/test_ingestion_migration.py
@@ -171,3 +171,24 @@ def test_force_reruns_applied_and_version_gated():
     ra.assert_called_once()
     rb.assert_called_once()
     assert set(ledger.recorded) == {"a", "b"}
+
+
+def test_checkpoint_ledger_hides_bookkeeping_datajob():
+    from datahub.ingestion.api.ingestion_job_checkpointing_provider_base import (
+        IngestionCheckpointingProviderBase,
+    )
+    from datahub.ingestion.source.state.ingestion_migration import (
+        MIGRATIONS_JOB_ID,
+        CheckpointMigrationLedger,
+    )
+
+    graph = MagicMock()
+    graph.get_latest_timeseries_value.return_value = None
+    ledger = CheckpointMigrationLedger(graph, "p", "r")
+    ledger.record("m1", "1.0.0")
+
+    urn = IngestionCheckpointingProviderBase.get_data_job_urn(
+        "datahub", "p", MIGRATIONS_JOB_ID
+    )
+    graph.soft_delete_entity.assert_called_with(urn)
+    graph.emit_mcp.assert_called_once()

--- a/metadata-ingestion/tests/unit/stateful_ingestion/test_ingestion_migration.py
+++ b/metadata-ingestion/tests/unit/stateful_ingestion/test_ingestion_migration.py
@@ -154,3 +154,20 @@ def test_no_apply_before_ignores_version():
         [a], ledger, MagicMock(), MagicMock(), MigrationConfig(enabled=True), VERSION
     )
     ra.assert_called_once()
+
+
+def test_force_reruns_applied_and_version_gated():
+    (a, ra) = _mig("a")  # already applied
+    (b, rb) = _mig("b", apply_before="1.2.0")  # version-superseded
+    ledger = FakeLedger({"a"}, last_version="9.9.9")
+    run_migrations(
+        [a, b],
+        ledger,
+        MagicMock(),
+        MagicMock(),
+        MigrationConfig(enabled=True, force=True),
+        VERSION,
+    )
+    ra.assert_called_once()
+    rb.assert_called_once()
+    assert set(ledger.recorded) == {"a", "b"}

--- a/metadata-ingestion/tests/unit/stateful_ingestion/test_ingestion_migration.py
+++ b/metadata-ingestion/tests/unit/stateful_ingestion/test_ingestion_migration.py
@@ -1,14 +1,18 @@
 """Unit tests for the per-connector ingestion migration runner."""
 
-from typing import Iterable, List, Optional, Set, Tuple
+from typing import Iterable, Optional, Set
 from unittest.mock import MagicMock
 
 import pytest
 
 from datahub.ingestion.source.state.ingestion_migration import (
+    _GLOBAL_MIGRATIONS,
     Migration,
     MigrationConfig,
     MigrationPendingError,
+    _needs_migration,
+    collect_migrations,
+    register_migration,
     run_migrations,
 )
 
@@ -19,8 +23,9 @@ class FakeLedger:
     def __init__(self, applied: Iterable[str] = (), last_version: Optional[str] = None):
         self._applied: Set[str] = set(applied)
         self._last_version = last_version
-        self.recorded: List[str] = []
-        self.recorded_versions: List[Optional[str]] = []
+        self.recorded: list = []
+        self.recorded_versions: list = []
+        self.touched: list = []
 
     def read_applied(self) -> Set[str]:
         return set(self._applied)
@@ -30,19 +35,74 @@ class FakeLedger:
 
     def record(self, migration_id: str, source_version: Optional[str]) -> None:
         self._applied.add(migration_id)
+        self._last_version = source_version
         self.recorded.append(migration_id)
         self.recorded_versions.append(source_version)
 
+    def touch_version(self, source_version: Optional[str]) -> None:
+        self._last_version = source_version
+        self.touched.append(source_version)
 
-def _mig(mid: str, apply_before: Optional[str] = None) -> Tuple[Migration, MagicMock]:
+
+def _mig(mid, introduced_in=None, fixed_in=None):
     run = MagicMock()
     return (
-        Migration(id=mid, description=mid, run=run, apply_before=apply_before),
+        Migration(
+            id=mid,
+            description=mid,
+            run=run,
+            introduced_in=introduced_in,
+            fixed_in=fixed_in,
+        ),
         run,
     )
 
 
-def test_runs_only_pending_in_order_and_records():
+@pytest.fixture
+def clean_registry():
+    saved = list(_GLOBAL_MIGRATIONS)
+    _GLOBAL_MIGRATIONS.clear()
+    yield
+    _GLOBAL_MIGRATIONS[:] = saved
+
+
+# --- _needs_migration (version window [introduced_in, fixed_in)) ---
+
+
+def test_needs_migration_unknown_version_applies():
+    assert _needs_migration("1.2.0", "1.4.0", None) is True
+
+
+def test_needs_migration_predates_bug_skips():
+    assert _needs_migration("1.2.0", "1.4.0", "1.1.0") is False
+
+
+def test_needs_migration_in_window_applies():
+    assert _needs_migration("1.2.0", "1.4.0", "1.3.0") is True
+    assert _needs_migration("1.2.0", "1.4.0", "1.2.0") is True  # inclusive lower
+
+
+def test_needs_migration_already_fixed_skips():
+    assert _needs_migration("1.2.0", "1.4.0", "1.4.0") is False  # exclusive upper
+    assert _needs_migration("1.2.0", "1.4.0", "1.5.0") is False
+
+
+def test_needs_migration_open_bounds():
+    assert _needs_migration(None, "1.4.0", "1.0.0") is True  # upper bound only
+    assert _needs_migration(None, "1.4.0", "1.4.0") is False
+    assert _needs_migration("1.2.0", None, "9.9.9") is True  # lower bound only
+    assert _needs_migration("1.2.0", None, "1.1.0") is False
+    assert _needs_migration(None, None, "1.1.0") is True  # no gate
+
+
+def test_needs_migration_invalid_version_applies():
+    assert _needs_migration("1.2.0", "1.4.0", "not-a-version") is True
+
+
+# --- run_migrations ---
+
+
+def test_runs_only_pending_and_records():
     (a, ra), (b, rb), (c, rc) = _mig("a"), _mig("b"), _mig("c")
     ledger = FakeLedger({"a"})
     graph, report = MagicMock(), MagicMock()
@@ -56,16 +116,17 @@ def test_runs_only_pending_in_order_and_records():
     assert ledger.recorded_versions == [VERSION, VERSION]
 
 
-def test_declared_order_preserved():
-    migs = [_mig("c")[0], _mig("a")[0], _mig("b")[0]]
+def test_runs_in_id_order_not_declared_order():
+    # declared out of order; the id drives run order (recommend timestamp-prefixed ids)
+    migs = [_mig("20260901-c")[0], _mig("20260101-a")[0], _mig("20260401-b")[0]]
     ledger = FakeLedger()
     run_migrations(
         migs, ledger, MagicMock(), MagicMock(), MigrationConfig(enabled=True), VERSION
     )
-    assert ledger.recorded == ["c", "a", "b"]
+    assert ledger.recorded == ["20260101-a", "20260401-b", "20260901-c"]
 
 
-def test_disabled_warns_and_skips():
+def test_disabled_warns_skips_and_does_not_touch():
     (a, ra) = _mig("a")
     ledger = FakeLedger()
     report = MagicMock()
@@ -74,6 +135,7 @@ def test_disabled_warns_and_skips():
     )
     ra.assert_not_called()
     assert ledger.recorded == []
+    assert ledger.touched == []
     report.warning.assert_called_once()
 
 
@@ -90,7 +152,7 @@ def test_disabled_fail_on_pending_raises():
         )
 
 
-def test_dry_run_runs_but_does_not_record():
+def test_dry_run_runs_but_does_not_record_or_touch():
     (a, ra) = _mig("a")
     ledger = FakeLedger()
     graph, report = MagicMock(), MagicMock()
@@ -99,38 +161,34 @@ def test_dry_run_runs_but_does_not_record():
     )
     ra.assert_called_once_with(graph, report, True)
     assert ledger.recorded == []
+    assert ledger.touched == []
 
 
-def test_no_pending_is_noop():
+def test_enabled_touches_version_when_nothing_pending():
     (a, ra) = _mig("a")
-    ledger = FakeLedger({"a"})
-    report = MagicMock()
+    ledger = FakeLedger({"a"})  # already applied → nothing pending
     run_migrations(
-        [a], ledger, MagicMock(), report, MigrationConfig(enabled=True), VERSION
+        [a], ledger, MagicMock(), MagicMock(), MigrationConfig(enabled=True), VERSION
     )
     ra.assert_not_called()
-    assert ledger.recorded == []
-    report.warning.assert_not_called()
+    assert ledger.touched == [VERSION]
 
 
-# --- version gating (apply_before) ---
-
-
-def test_version_gate_skips_when_last_version_at_or_above_apply_before():
-    (a, ra) = _mig("a", apply_before="1.2.0")
-    ledger = FakeLedger(last_version="1.3.0")  # data already produced by >= 1.2.0
-    report = MagicMock()
-    run_migrations(
-        [a], ledger, MagicMock(), report, MigrationConfig(enabled=True), VERSION
-    )
-    ra.assert_not_called()
-    assert ledger.recorded == []
-    report.warning.assert_not_called()
-
-
-def test_version_gate_runs_when_last_version_below_apply_before():
-    (a, ra) = _mig("a", apply_before="1.2.0")
+def test_version_window_skips_when_data_predates_bug():
+    (a, ra) = _mig("a", introduced_in="1.2.0", fixed_in="1.4.0")
     ledger = FakeLedger(last_version="1.1.0")
+    report = MagicMock()
+    run_migrations(
+        [a], ledger, MagicMock(), report, MigrationConfig(enabled=True), VERSION
+    )
+    ra.assert_not_called()
+    assert ledger.recorded == []
+    report.warning.assert_not_called()
+
+
+def test_version_window_runs_when_data_in_window():
+    (a, ra) = _mig("a", introduced_in="1.2.0", fixed_in="1.4.0")
+    ledger = FakeLedger(last_version="1.3.0")
     run_migrations(
         [a], ledger, MagicMock(), MagicMock(), MigrationConfig(enabled=True), VERSION
     )
@@ -138,27 +196,18 @@ def test_version_gate_runs_when_last_version_below_apply_before():
     assert ledger.recorded == ["a"]
 
 
-def test_version_gate_runs_when_no_last_version():
-    (a, ra) = _mig("a", apply_before="1.2.0")
-    ledger = FakeLedger()  # never migrated before
+def test_version_window_skips_when_already_fixed():
+    (a, ra) = _mig("a", introduced_in="1.2.0", fixed_in="1.4.0")
+    ledger = FakeLedger(last_version="1.5.0")
     run_migrations(
         [a], ledger, MagicMock(), MagicMock(), MigrationConfig(enabled=True), VERSION
     )
-    ra.assert_called_once()
+    ra.assert_not_called()
 
 
-def test_no_apply_before_ignores_version():
-    (a, ra) = _mig("a")  # no apply_before
-    ledger = FakeLedger(last_version="9.9.9")
-    run_migrations(
-        [a], ledger, MagicMock(), MagicMock(), MigrationConfig(enabled=True), VERSION
-    )
-    ra.assert_called_once()
-
-
-def test_force_reruns_applied_and_version_gated():
+def test_force_reruns_applied_and_out_of_window():
     (a, ra) = _mig("a")  # already applied
-    (b, rb) = _mig("b", apply_before="1.2.0")  # version-superseded
+    (b, rb) = _mig("b", fixed_in="1.2.0")  # data at 9.9.9 → out of window
     ledger = FakeLedger({"a"}, last_version="9.9.9")
     run_migrations(
         [a, b],
@@ -171,6 +220,42 @@ def test_force_reruns_applied_and_version_gated():
     ra.assert_called_once()
     rb.assert_called_once()
     assert set(ledger.recorded) == {"a", "b"}
+
+
+# --- global migration registry ---
+
+
+def test_collect_merges_global_migrations_scoped_to_source(clean_registry):
+    source = MagicMock()
+    seen = []
+
+    def factory(src):
+        seen.append(src)
+        return Migration(id="global-x", description="x", run=MagicMock())
+
+    register_migration(factory)
+    merged = collect_migrations([_mig("a")[0]], source)
+    assert [m.id for m in merged] == ["a", "global-x"]
+    assert seen == [source]  # factory receives the source, for scoping
+
+
+def test_collect_source_declaration_wins_on_id_clash(clean_registry):
+    def factory(src):
+        return Migration(id="dup", description="global", run=MagicMock())
+
+    register_migration(factory)
+    source_mig = Migration(id="dup", description="source", run=MagicMock())
+    merged = collect_migrations([source_mig], MagicMock())
+    assert len(merged) == 1
+    assert merged[0].description == "source"
+
+
+def test_collect_no_global_registered_returns_source_only(clean_registry):
+    source_mig = Migration(id="a", description="a", run=MagicMock())
+    assert collect_migrations([source_mig], MagicMock()) == [source_mig]
+
+
+# --- checkpoint ledger ---
 
 
 def test_checkpoint_ledger_hides_bookkeeping_datajob():
@@ -192,3 +277,89 @@ def test_checkpoint_ledger_hides_bookkeeping_datajob():
     )
     graph.soft_delete_entity.assert_called_with(urn)
     graph.emit_mcp.assert_called_once()
+
+
+def test_checkpoint_ledger_touch_version_persists_without_new_id():
+    from datahub.ingestion.source.state.ingestion_migration import (
+        CheckpointMigrationLedger,
+    )
+
+    graph = MagicMock()
+    graph.get_latest_timeseries_value.return_value = None
+    ledger = CheckpointMigrationLedger(graph, "p", "r")
+    ledger.touch_version("2.0.0")
+    assert ledger.read_last_version() == "2.0.0"
+    assert ledger.read_applied() == set()
+    graph.emit_mcp.assert_called_once()
+
+
+def test_checkpoint_ledger_seed_last_version_in_memory_only():
+    from datahub.ingestion.source.state.ingestion_migration import (
+        CheckpointMigrationLedger,
+    )
+
+    graph = MagicMock()
+    graph.get_latest_timeseries_value.return_value = None
+    ledger = CheckpointMigrationLedger(graph, "p", "r")
+    ledger.seed_last_version("1.1.0")
+    assert ledger.read_last_version() == "1.1.0"
+    graph.emit_mcp.assert_not_called()  # seeding does not persist
+
+    ledger._last_version = "2.0.0"  # once we have a real version, seed is ignored
+    ledger.seed_last_version("1.1.0")
+    assert ledger.read_last_version() == "2.0.0"
+
+
+# --- seeding last_version from DatahubIngestionRunSummary (first-run coverage) ---
+
+
+def _pipeline_config(source_type="mysql", pipeline_name="p", platform_instance=None):
+    pc = MagicMock()
+    pc.source.type = source_type
+    pc.pipeline_name = pipeline_name
+    pc.source.config = (
+        {"platform_instance": platform_instance} if platform_instance else {}
+    )
+    return pc
+
+
+def test_read_last_ingestion_version_from_run_summary():
+    from datahub.ingestion.source.state.ingestion_migration import (
+        read_last_ingestion_version,
+    )
+
+    graph = MagicMock()
+    summary = MagicMock()
+    summary.softwareVersion = "1.3.0"
+    graph.get_latest_timeseries_value.return_value = summary
+    assert read_last_ingestion_version(graph, _pipeline_config()) == "1.3.0"
+    _, kwargs = graph.get_latest_timeseries_value.call_args
+    assert kwargs["entity_urn"].startswith("urn:li:dataHubIngestionSource:cli-")
+
+
+def test_read_last_ingestion_version_none_when_no_config():
+    from datahub.ingestion.source.state.ingestion_migration import (
+        read_last_ingestion_version,
+    )
+
+    assert read_last_ingestion_version(MagicMock(), None) is None
+
+
+def test_read_last_ingestion_version_none_when_no_summary():
+    from datahub.ingestion.source.state.ingestion_migration import (
+        read_last_ingestion_version,
+    )
+
+    graph = MagicMock()
+    graph.get_latest_timeseries_value.return_value = None
+    assert read_last_ingestion_version(graph, _pipeline_config()) is None
+
+
+def test_read_last_ingestion_version_best_effort_on_error():
+    from datahub.ingestion.source.state.ingestion_migration import (
+        read_last_ingestion_version,
+    )
+
+    graph = MagicMock()
+    graph.get_latest_timeseries_value.side_effect = RuntimeError("boom")
+    assert read_last_ingestion_version(graph, _pipeline_config()) is None

--- a/metadata-ingestion/tests/unit/stateful_ingestion/test_ingestion_migration.py
+++ b/metadata-ingestion/tests/unit/stateful_ingestion/test_ingestion_migration.py
@@ -1,0 +1,94 @@
+"""Unit tests for the per-connector ingestion migration runner."""
+
+from typing import Iterable, List, Set, Tuple
+from unittest.mock import MagicMock
+
+import pytest
+
+from datahub.ingestion.source.state.ingestion_migration import (
+    Migration,
+    MigrationConfig,
+    MigrationPendingError,
+    run_migrations,
+)
+
+
+class FakeLedger:
+    def __init__(self, applied: Iterable[str] = ()):
+        self._applied: Set[str] = set(applied)
+        self.recorded: List[str] = []
+
+    def read_applied(self) -> Set[str]:
+        return set(self._applied)
+
+    def record(self, migration_id: str) -> None:
+        self._applied.add(migration_id)
+        self.recorded.append(migration_id)
+
+
+def _mig(mid: str) -> Tuple[Migration, MagicMock]:
+    run = MagicMock()
+    return Migration(id=mid, description=mid, run=run), run
+
+
+def test_runs_only_pending_in_order_and_records():
+    (a, ra), (b, rb), (c, rc) = _mig("a"), _mig("b"), _mig("c")
+    ledger = FakeLedger({"a"})
+    graph, report = MagicMock(), MagicMock()
+    run_migrations([a, b, c], ledger, graph, report, MigrationConfig(enabled=True))
+    ra.assert_not_called()
+    rb.assert_called_once_with(graph, report, False)
+    rc.assert_called_once_with(graph, report, False)
+    assert ledger.recorded == ["b", "c"]
+
+
+def test_declared_order_preserved():
+    migs = [_mig("c")[0], _mig("a")[0], _mig("b")[0]]
+    ledger = FakeLedger()
+    run_migrations(
+        migs, ledger, MagicMock(), MagicMock(), MigrationConfig(enabled=True)
+    )
+    assert ledger.recorded == ["c", "a", "b"]
+
+
+def test_disabled_warns_and_skips():
+    (a, ra) = _mig("a")
+    ledger = FakeLedger()
+    report = MagicMock()
+    run_migrations([a], ledger, MagicMock(), report, MigrationConfig(enabled=False))
+    ra.assert_not_called()
+    assert ledger.recorded == []
+    report.warning.assert_called_once()
+
+
+def test_disabled_fail_on_pending_raises():
+    (a, _ra) = _mig("a")
+    with pytest.raises(MigrationPendingError):
+        run_migrations(
+            [a],
+            FakeLedger(),
+            MagicMock(),
+            MagicMock(),
+            MigrationConfig(enabled=False, fail_on_pending=True),
+        )
+
+
+def test_dry_run_runs_but_does_not_record():
+    (a, ra) = _mig("a")
+    ledger = FakeLedger()
+    graph, report = MagicMock(), MagicMock()
+    run_migrations(
+        [a], ledger, graph, report, MigrationConfig(enabled=True, dry_run=True)
+    )
+    ra.assert_called_once_with(graph, report, True)
+    assert ledger.recorded == []
+
+
+def test_no_pending_is_noop():
+    (a, ra) = _mig("a")
+    ledger = FakeLedger({"a"})
+    report = MagicMock()
+    run_migrations([a], ledger, MagicMock(), report, MigrationConfig(enabled=True))
+    ra.assert_not_called()
+    assert ledger.recorded == []
+    report.warning.assert_not_called()

--- a/smoke-test/tests/migrations/test_ingestion_migrations_smoke.py
+++ b/smoke-test/tests/migrations/test_ingestion_migrations_smoke.py
@@ -1,0 +1,98 @@
+"""Smoke test: per-connector ingestion migrations run before ingestion (live GMS)."""
+
+import logging
+from random import randint
+from typing import List
+
+from datahub.emitter.mce_builder import make_dataset_urn
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.ingestion_job_checkpointing_provider_base import (
+    IngestionCheckpointingProviderBase,
+)
+from datahub.ingestion.api.source import SourceReport
+from datahub.ingestion.graph.client import DataHubGraph
+from datahub.ingestion.source.state.ingestion_migration import (
+    MIGRATIONS_JOB_ID,
+    CheckpointMigrationLedger,
+    Migration,
+    MigrationConfig,
+)
+from datahub.ingestion.source.state.stateful_ingestion_base import (
+    StatefulIngestionConfig,
+    StatefulIngestionConfigBase,
+    StatefulIngestionSourceBase,
+)
+from datahub.metadata.schema_classes import GlobalTagsClass, TagAssociationClass
+from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utils import delete_urns, with_test_retry
+
+logger = logging.getLogger(__name__)
+
+_suffix = randint(10, 100000)
+PIPELINE = f"migrations-smoke-{_suffix}"
+MARKER_DS = make_dataset_urn("snowflake", f"migsmoke_{_suffix}.tbl")
+MIGRATION_ID = "smoke-0001-tag"
+TAG = "urn:li:tag:migrations_smoke"
+
+
+def _tag_marker(graph: DataHubGraph, report: SourceReport, dry_run: bool) -> None:
+    if dry_run:
+        return
+    graph.emit_mcp(
+        MetadataChangeProposalWrapper(
+            entityUrn=MARKER_DS,
+            aspect=GlobalTagsClass(tags=[TagAssociationClass(tag=TAG)]),
+        )
+    )
+
+
+class _MigratingSource(StatefulIngestionSourceBase):
+    def get_migrations(self) -> List[Migration]:
+        return [Migration(id=MIGRATION_ID, description="tag a marker", run=_tag_marker)]
+
+    def get_workunits_internal(self):
+        return []
+
+    def get_report(self) -> SourceReport:
+        return self.report
+
+
+def _make_source(graph: DataHubGraph, enabled: bool) -> _MigratingSource:
+    config = StatefulIngestionConfigBase[StatefulIngestionConfig](
+        stateful_ingestion=StatefulIngestionConfig(
+            enabled=True, migrations=MigrationConfig(enabled=enabled)
+        )
+    )
+    ctx = PipelineContext(
+        run_id="migrations-smoke", graph=graph, pipeline_name=PIPELINE
+    )
+    return _MigratingSource(config, ctx)
+
+
+def test_migration_runs_before_ingestion_and_is_recorded(
+    graph_client: DataHubGraph,
+) -> None:
+    ledger_urn = IngestionCheckpointingProviderBase.get_data_job_urn(
+        "datahub", PIPELINE, MIGRATIONS_JOB_ID
+    )
+    delete_urns(graph_client, [MARKER_DS, ledger_urn])
+    wait_for_writes_to_sync()
+    try:
+        # get_workunits() triggers the pre-ingestion migration hook.
+        list(_make_source(graph_client, enabled=True).get_workunits())
+        wait_for_writes_to_sync()
+
+        @with_test_retry()
+        def check_applied() -> None:
+            tags = graph_client.get_aspect(MARKER_DS, GlobalTagsClass)
+            assert tags is not None and any(t.tag == TAG for t in tags.tags)
+            applied = CheckpointMigrationLedger(
+                graph_client, PIPELINE, "verify"
+            ).read_applied()
+            assert MIGRATION_ID in applied
+
+        check_applied()
+    finally:
+        delete_urns(graph_client, [MARKER_DS, ledger_urn])
+        wait_for_writes_to_sync()


### PR DESCRIPTION
Stacked on #18550 (`ing-3085-generic-migrate-core`), which is stacked on #18544 — **review/merge those first**. This PR's base is #18550, so the diff here is only the migrations mechanism.

## Summary
Adds an Alembic-style, per-connector metadata migration mechanism that runs before ingestion. A connector declares one-time migrations (stable id + migration code) via `StatefulIngestionSourceBase.get_migrations()`; DataHub records which have been applied (a ledger riding the stateful-ingestion checkpoint, keyed per pipeline); and pending migrations run before ingestion when enabled.

- `ingestion_migration.py`: `Migration`, `MigrationConfig` (enabled/dry_run/fail_on_pending — **default off**), `MigrationCheckpointState`, `CheckpointMigrationLedger` (persists applied ids on the migrations DataJob checkpoint, committed per-migration), `run_migrations()`.
- `StatefulIngestionSourceBase`: `get_migrations()` hook, `stateful_ingestion.migrations` config, and a `get_workunits()` override that applies pending migrations before workunit production.
- Rename-type migrations delegate to the `migrate transform` core (#18550); aspect-shape migrations run free-form code.

## Testing
6 unit tests for the runner (pending/order/enabled/disabled/dry-run/no-op); a smoke test (fake source + live GMS). Ledger round-trip and the full hook (config → run → persist → gate) verified end-to-end against a live GMS.

## Follow-ups (out of scope)
A worked-example connector migration, version-based gating. Design spec captures the read-after-write timing caveat (idempotency covers it).
