### PR TITLE
fix(search): guard STRING structured-property keyword mappings with ignore_above

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilder.java
@@ -261,7 +261,7 @@ public class V2MappingsBuilder implements MappingsBuilder {
               LogicalValueType logicalType = getLogicalValueType(property.getValueType());
               switch (logicalType) {
                 case STRING:
-                  mappingForField = getMappingsForKeyword();
+                  mappingForField = getMappingsForKeywordWithIgnoreAbove();
                   break;
                 case RICH_TEXT:
                   mappingForField = getMappingsForSearchText(FieldType.TEXT_PARTIAL);
@@ -276,7 +276,7 @@ public class V2MappingsBuilder implements MappingsBuilder {
                   mappingForField.put(TYPE, ESUtils.DOUBLE_FIELD_TYPE);
                   break;
                 default:
-                  mappingForField = getMappingsForKeyword();
+                  mappingForField = getMappingsForKeywordWithIgnoreAbove();
                   break;
               }
               return Map.entry(
@@ -376,6 +376,27 @@ public class V2MappingsBuilder implements MappingsBuilder {
     mappingForField.put(NORMALIZER, KEYWORD_NORMALIZER);
     // Add keyword subfield without lowercase filter
     mappingForField.put(FIELDS, ImmutableMap.of(KEYWORD, KEYWORD_TYPE_MAP));
+    return mappingForField;
+  }
+
+  /**
+   * Same shape as {@link #getMappingsForKeyword()} (keyword parent + .keyword sub-field) but with
+   * an {@code ignore_above} guard: a value longer than the limit is skipped from the keyword index
+   * (it remains in _source) instead of failing the whole document write on Lucene's 32,766-byte
+   * per-term limit.
+   */
+  private static Map<String, Object> getMappingsForKeywordWithIgnoreAbove() {
+    Map<String, Object> mappingForField = new HashMap<>();
+    mappingForField.put(TYPE, ESUtils.KEYWORD_FIELD_TYPE);
+    mappingForField.put(NORMALIZER, KEYWORD_NORMALIZER);
+    mappingForField.put("ignore_above", ESUtils.KEYWORD_MAXLENGTH);
+    // Outer KEYWORD is the sub-field name; the inner KEYWORD is the field type value (both
+    // "keyword").
+    // The sub-field carries the same ignore_above guard, so KEYWORD_TYPE_MAP cannot be reused here.
+    mappingForField.put(
+        FIELDS,
+        ImmutableMap.of(
+            KEYWORD, ImmutableMap.of(TYPE, KEYWORD, "ignore_above", ESUtils.KEYWORD_MAXLENGTH)));
     return mappingForField;
   }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapper.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapper.java
@@ -316,7 +316,7 @@ public class FieldTypeMapper {
     switch (valueType) {
       case STRING:
       case RICH_TEXT:
-        return getMappingsForKeyword();
+        return getMappingsForKeywordWithIgnoreAbove();
       case DATE:
         return Map.of("type", DATE_FIELD_TYPE);
       case URN:
@@ -325,7 +325,7 @@ public class FieldTypeMapper {
         return Map.of("type", DOUBLE_FIELD_TYPE);
       default:
         log.debug("LogicalValueType {} not supported, defaulting to keyword", valueType);
-        return getMappingsForKeyword();
+        return getMappingsForKeywordWithIgnoreAbove();
     }
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilderTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.search.elasticsearch.index.entity.v2;
 
 import static com.linkedin.metadata.Constants.*;
+import static com.linkedin.metadata.search.utils.ESUtils.KEYWORD_MAXLENGTH;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 
@@ -381,6 +382,9 @@ public class V2MappingsBuilderTest {
     assertEquals(keyInMap, "testProp");
 
     Object mappings = structuredPropertyFieldMappings.get(keyInMap);
+    // STRING structured properties carry an ignore_above guard (parent + .keyword sub-field) so an
+    // oversized value is skipped from the keyword index instead of failing the whole document
+    // write.
     assertEquals(
         mappings,
         Map.of(
@@ -388,8 +392,10 @@ public class V2MappingsBuilderTest {
             "keyword",
             "normalizer",
             "keyword_normalizer",
+            "ignore_above",
+            KEYWORD_MAXLENGTH,
             "fields",
-            Map.of("keyword", Map.of("type", "keyword"))));
+            Map.of("keyword", Map.of("type", "keyword", "ignore_above", KEYWORD_MAXLENGTH))));
 
     StructuredPropertyDefinition propWithNumericType =
         new StructuredPropertyDefinition()
@@ -532,6 +538,9 @@ public class V2MappingsBuilderTest {
     assertEquals(keyInMap, "_versioned.testProp.00000000000001.string");
 
     Object mappings = structuredPropertyFieldMappings.get(keyInMap);
+    // STRING structured properties carry an ignore_above guard (parent + .keyword sub-field) so an
+    // oversized value is skipped from the keyword index instead of failing the whole document
+    // write.
     assertEquals(
         mappings,
         Map.of(
@@ -539,8 +548,10 @@ public class V2MappingsBuilderTest {
             "keyword",
             "normalizer",
             "keyword_normalizer",
+            "ignore_above",
+            KEYWORD_MAXLENGTH,
             "fields",
-            Map.of("keyword", Map.of("type", "keyword"))));
+            Map.of("keyword", Map.of("type", "keyword", "ignore_above", KEYWORD_MAXLENGTH))));
 
     StructuredPropertyDefinition propWithNumericType =
         new StructuredPropertyDefinition()

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapperTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapperTest.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.search.elasticsearch.index.entity.v3;
 import static com.linkedin.metadata.search.utils.ESUtils.KEYWORD_MAXLENGTH;
 import static org.testng.Assert.*;
 
+import com.linkedin.metadata.models.LogicalValueType;
 import com.linkedin.metadata.models.annotation.SearchableAnnotation.FieldType;
 import java.util.Map;
 import org.testng.annotations.Test;
@@ -33,6 +34,24 @@ public class FieldTypeMapperTest {
   @Test
   public void testGetMappingsForKeywordWithIgnoreAbove() {
     Map<String, Object> mapping = FieldTypeMapper.getMappingsForKeywordWithIgnoreAbove();
+    assertEquals(mapping.get("type"), "keyword");
+    assertEquals(mapping.get("ignore_above"), KEYWORD_MAXLENGTH);
+  }
+
+  @Test
+  public void testStringLogicalValueTypeUsesIgnoreAbove() {
+    // STRING structured properties must carry ignore_above so an oversized value is skipped rather
+    // than failing the whole document write on Lucene's per-term limit (which aborts the reindex).
+    Map<String, Object> mapping =
+        FieldTypeMapper.getMappingsForLogicalValueType(LogicalValueType.STRING);
+    assertEquals(mapping.get("type"), "keyword");
+    assertEquals(mapping.get("ignore_above"), KEYWORD_MAXLENGTH);
+  }
+
+  @Test
+  public void testRichTextLogicalValueTypeUsesIgnoreAbove() {
+    Map<String, Object> mapping =
+        FieldTypeMapper.getMappingsForLogicalValueType(LogicalValueType.RICH_TEXT);
     assertEquals(mapping.get("type"), "keyword");
     assertEquals(mapping.get("ignore_above"), KEYWORD_MAXLENGTH);
   }


### PR DESCRIPTION
STRING structured properties map to a plain `keyword` field with **no `ignore_above`**:
getLogicalValueType(STRING) → getMappingsForKeyword() // keyword, no ignore_above

A value whose UTF-8 encoding exceeds Lucene's 32,766-byte per-term limit is rejected, which fails the whole document write. During a reindex this aborts the operation, so the `system-update` job can loop without completing. `RICH_TEXT` structured props already avoid this (v2 via `getMappingsForSearchText`, which sets `ignore_above`); the STRING and `default` branches do not.
## Change
- **`v2/V2MappingsBuilder`** — add `getMappingsForKeywordWithIgnoreAbove()` (same shape as `getMappingsForKeyword`: keyword parent + normalizer + `.keyword` sub-field) with `ignore_above` on parent and sub-field. `STRING` and `default` branches use it. `RICH_TEXT` unchanged (already guarded).
- **`v3/FieldTypeMapper`** — `getMappingsForLogicalValueType` routes `STRING` / `RICH_TEXT` / `default` to the existing `getMappingsForKeywordWithIgnoreAbove()` instead of the unguarded `getMappingsForKeyword()`.
`ignore_above` uses the existing `ESUtils.KEYWORD_MAXLENGTH`, matching how `getMappingsForSearchText` and the TEXT field types already guard their keyword surfaces.
## Behavior / trade-off
| value length | before | after |
|---|---|---|
| ≤ limit | filterable | **same** — filter/sort/agg + case-insensitive exact match preserved (normalizer kept) |
| > limit | **whole document write rejected** | keyword term skipped (value stays in `_source`), document indexes |
Only exact-match/facet/sort on an over-limit value is lost — which was not possible before anyway, since the document was rejected outright.
## Tests
- `FieldTypeMapperTest` — new: `getMappingsForLogicalValueType(STRING)` and `(RICH_TEXT)` carry `ignore_above`. Both fail on the pre-fix code.
- `V2MappingsBuilderTest` — updated the two STRING structured-property assertions (`testGetIndexMappingsForStructuredProperty`, `...V1`) to expect the `ignore_above` guard on the parent and `.keyword` sub-field.
## Note
`ignore_above` is measured in characters while Lucene's limit is bytes, so a multi-byte value could still exceed the byte limit below `KEYWORD_MAXLENGTH` characters. This is a pre-existing, project-wide property of every `ignore_above = KEYWORD_MAXLENGTH` usage (TEXT fields, `getMappingsForSearchText`, and now STRING SPs), not specific to this change — a byte-safe threshold would be a separate, broader change.