### PR TITLE
ci(connector-tests): map unity source changes to the databricks connector test

### DIFF
--- a/.github/workflows/connector-tests-trigger.yml
+++ b/.github/workflows/connector-tests-trigger.yml
@@ -221,6 +221,7 @@ jobs:
                 sigma)               echo "sigma" ;;
                 snowflake)           echo "snowflake" ;;
                 tableau)             echo "tableau" ;;
+                unity)               echo "databricks" ;;
               esac
             done | sort -u | paste -sd ',')
 


### PR DESCRIPTION
## Summary

The datahub → `acryldata/connector-tests` dispatch (`.github/workflows/connector-tests-trigger.yml`) decides which connector suites to run from a **static map** of datahub connector name → connector-tests connector name. That map was missing `unity`, so changes to the Unity Catalog / Databricks source never selectively triggered the `databricks` connector tests.

The practical effect: a unity-only PR reports "all connector tests passed" without ever running the live databricks suite (it only runs when an unrelated shared/framework change forces `run_all_integration`). This let the databricks golden files drift undetected — e.g. after the Unity metric-view subtype change, the connector-tests `databricks_metric_view_flag_off` golden went stale and was only caught later by an unrelated PR that happened to trigger a full run.

## Change

Add the one missing entry:

```
unity)               echo "databricks" ;;
```

`databricks` was the only connector present in `acryldata/connector-tests` (`athena, azure_data_factory, bigquery, databricks, fabric_onelake, fivetran, looker, powerbi, redshift, sigma, snowflake, tableau`) that had no mapping here; all others were already covered.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR title format)
- [ ] Tests added/updated (n/a — CI trigger mapping)
- [ ] Docs added/updated (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)