### PR TITLE
fix(structured-properties): apply patch value validation under alternate MCP validation

### DIFF
--- a/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/integration/BaseIntegrationTest.java
+++ b/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/integration/BaseIntegrationTest.java
@@ -66,6 +66,12 @@ public abstract class BaseIntegrationTest {
 
   private static String generatedToken;
   private static String generatedTokenId;
+
+  /** Token for tests that need a raw emitter (e.g. seeding aspects the V2 SDK cannot write). */
+  protected static String getAccessToken() {
+    return generatedToken;
+  }
+
   private static final HttpClient httpClient = HttpClient.newHttpClient();
   private static final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/integration/DatasetIntegrationTest.java
+++ b/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/integration/DatasetIntegrationTest.java
@@ -3,10 +3,18 @@ package datahub.client.v2.integration;
 import static org.junit.Assert.*;
 
 import com.linkedin.common.OwnershipType;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.structured.PropertyCardinality;
+import com.linkedin.structured.StructuredPropertyDefinition;
+import datahub.client.MetadataWriteResponse;
+import datahub.client.rest.RestEmitter;
 import datahub.client.v2.entity.Dataset;
+import datahub.event.MetadataChangeProposalWrapper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -178,7 +186,20 @@ public class DatasetIntegrationTest extends BaseIntegrationTest {
 
   @Test
   public void testDatasetWithStructuredProperties() throws Exception {
-    String uniqueName = "test_dataset_with_structured_properties_" + System.currentTimeMillis();
+    long runId = System.currentTimeMillis();
+    String uniqueName = "test_dataset_with_structured_properties_" + runId;
+    // Structured property values are validated against their definitions at write time, so the
+    // definitions must exist before values can be assigned.
+    String slaProperty = "io.acryl.test.replicationSLA_" + runId;
+    String scoreProperty = "io.acryl.test.qualityScore_" + runId;
+    String certificationsProperty = "io.acryl.test.certifications_" + runId;
+    String retentionProperty = "io.acryl.test.retentionDays_" + runId;
+    createStructuredPropertyDefinition(slaProperty, "string", PropertyCardinality.SINGLE);
+    createStructuredPropertyDefinition(scoreProperty, "number", PropertyCardinality.SINGLE);
+    createStructuredPropertyDefinition(
+        certificationsProperty, "string", PropertyCardinality.MULTIPLE);
+    createStructuredPropertyDefinition(retentionProperty, "number", PropertyCardinality.MULTIPLE);
+
     Dataset dataset =
         Dataset.builder()
             .platform("java_sdk_v2_test")
@@ -188,13 +209,12 @@ public class DatasetIntegrationTest extends BaseIntegrationTest {
             .build();
 
     // Set single value properties (type automatically detected)
-    dataset.setStructuredProperty("io.acryl.dataManagement.replicationSLA", "24h");
-    dataset.setStructuredProperty("io.acryl.dataQuality.qualityScore", 95.5);
+    dataset.setStructuredProperty(slaProperty, "24h");
+    dataset.setStructuredProperty(scoreProperty, 95.5);
 
     // Set multiple value properties
-    dataset.setStructuredProperty(
-        "io.acryl.dataManagement.certifications", Arrays.asList("SOC2", "HIPAA", "GDPR"));
-    dataset.setStructuredProperty("io.acryl.privacy.retentionDays", 90, 180, 365);
+    dataset.setStructuredProperty(certificationsProperty, Arrays.asList("SOC2", "HIPAA", "GDPR"));
+    dataset.setStructuredProperty(retentionProperty, 90, 180, 365);
 
     client.entities().upsert(dataset);
 
@@ -211,6 +231,51 @@ public class DatasetIntegrationTest extends BaseIntegrationTest {
 
     // We should have 4 structured properties
     assertEquals(4, structuredProps.getProperties().size());
+  }
+
+  @Test
+  public void testDatasetStructuredPropertyWithoutDefinitionRejected() throws Exception {
+    long runId = System.currentTimeMillis();
+    Dataset dataset =
+        Dataset.builder()
+            .platform("java_sdk_v2_test")
+            .name("test_dataset_sp_missing_definition_" + runId)
+            .env("DEV")
+            .build();
+    // No definition is ever created for this property. The patch write must be rejected the same
+    // way an equivalent upsert is (regression guard: patches previously bypassed this validation).
+    dataset.setStructuredProperty("io.acryl.test.doesNotExist_" + runId, "some value");
+
+    assertThrows(Exception.class, () -> client.entities().upsert(dataset));
+  }
+
+  private static void createStructuredPropertyDefinition(
+      String qualifiedName, String valueType, PropertyCardinality cardinality) throws Exception {
+    StructuredPropertyDefinition definition =
+        new StructuredPropertyDefinition()
+            .setQualifiedName(qualifiedName)
+            .setValueType(Urn.createFromString("urn:li:dataType:datahub." + valueType))
+            .setCardinality(cardinality)
+            .setEntityTypes(
+                new UrnArray(
+                    Collections.singletonList(
+                        Urn.createFromString("urn:li:entityType:datahub.dataset"))));
+
+    MetadataChangeProposalWrapper mcpw =
+        MetadataChangeProposalWrapper.create(
+            b ->
+                b.entityType("structuredProperty")
+                    .entityUrn("urn:li:structuredProperty:" + qualifiedName)
+                    .upsert()
+                    .aspect(definition)
+                    .aspectName("propertyDefinition"));
+
+    try (RestEmitter emitter =
+        RestEmitter.create(b -> b.server(TEST_SERVER).token(getAccessToken()))) {
+      MetadataWriteResponse response = emitter.emit(mcpw, null).get();
+      assertTrue(
+          "Failed to create structured property definition " + qualifiedName, response.isSuccess());
+    }
   }
 
   @Test

--- a/metadata-io/src/main/java/com/linkedin/metadata/structuredproperties/validation/StructuredPropertiesValidator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/structuredproperties/validation/StructuredPropertiesValidator.java
@@ -10,6 +10,8 @@ import static com.linkedin.metadata.structuredproperties.validation.PropertyDefi
 
 import com.datahub.context.OperationFingerprint;
 import com.datahub.util.RecordUtils;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.AuditStamp;
@@ -25,6 +27,7 @@ import com.linkedin.metadata.aspect.AspectRetriever;
 import com.linkedin.metadata.aspect.RetrieverContext;
 import com.linkedin.metadata.aspect.batch.BatchItem;
 import com.linkedin.metadata.aspect.batch.ChangeMCP;
+import com.linkedin.metadata.aspect.batch.MCPItem;
 import com.linkedin.metadata.aspect.patch.GenericJsonPatch;
 import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
 import com.linkedin.metadata.aspect.plugins.validation.AspectPayloadValidator;
@@ -115,12 +118,15 @@ public class StructuredPropertiesValidator extends AspectPayloadValidator {
             .collect(Collectors.toList());
 
     // PATCH has no record template until applyPatch (inside the DB tx). Validate ADD ops here at
-    // request time by inspecting the patch payload — ignore REMOVE (no values to check).
+    // request time by inspecting the patch payload — ignore REMOVE (no values to check). Route on
+    // the change type, not the item class: with alternate MCP validation (the quickstart/docker
+    // default, ALTERNATE_MCP_VALIDATION=true) a patch arrives as a ProposedItem carrying the raw
+    // proposal rather than a PatchItemImpl.
     List<BatchItem> patchAddItems =
         mcpItems.stream()
             .filter(i -> ChangeType.PATCH.equals(i.getChangeType()))
-            .filter(i -> i instanceof PatchItemImpl)
-            .map(i -> (PatchItemImpl) i)
+            .filter(i -> i instanceof MCPItem)
+            .map(i -> (MCPItem) i)
             .map(patchItem -> materializePatchAddUpsert(patchItem, aspectRetriever, objectMapper))
             .flatMap(Optional::stream)
             .collect(Collectors.toList());
@@ -160,7 +166,7 @@ public class StructuredPropertiesValidator extends AspectPayloadValidator {
    * from PATCH {@code add} ops, for request-time value validation.
    */
   private static Optional<BatchItem> materializePatchAddUpsert(
-      @Nonnull PatchItemImpl patchItem,
+      @Nonnull MCPItem patchItem,
       @Nonnull AspectRetriever aspectRetriever,
       @Nonnull ObjectMapper objectMapper) {
     List<StructuredPropertyValueAssignment> adds =
@@ -187,8 +193,8 @@ public class StructuredPropertiesValidator extends AspectPayloadValidator {
 
   @Nonnull
   public static List<StructuredPropertyValueAssignment> extractPatchAddAssignments(
-      @Nonnull PatchItemImpl patchItem, @Nonnull ObjectMapper objectMapper) {
-    GenericJsonPatch genericJsonPatch = patchItem.getGenericJsonPatch();
+      @Nonnull MCPItem patchItem, @Nonnull ObjectMapper objectMapper) {
+    GenericJsonPatch genericJsonPatch = resolveGenericJsonPatch(patchItem, objectMapper);
     if (genericJsonPatch == null || genericJsonPatch.getPatch() == null) {
       return List.of();
     }
@@ -212,6 +218,47 @@ public class StructuredPropertiesValidator extends AspectPayloadValidator {
       }
     }
     return assignments;
+  }
+
+  /**
+   * The patch, regardless of how the item was constructed: a {@link PatchItemImpl} carries it
+   * parsed, while under alternate MCP validation the item is a raw proposal whose aspect payload is
+   * the serialized {@link GenericJsonPatch} (or a bare json-patch ops array).
+   */
+  @Nullable
+  private static GenericJsonPatch resolveGenericJsonPatch(
+      @Nonnull MCPItem patchItem, @Nonnull ObjectMapper objectMapper) {
+    if (patchItem instanceof PatchItemImpl) {
+      return ((PatchItemImpl) patchItem).getGenericJsonPatch();
+    }
+    if (patchItem.getMetadataChangeProposal() == null
+        || !patchItem.getMetadataChangeProposal().hasAspect()) {
+      return null;
+    }
+    String payload =
+        patchItem
+            .getMetadataChangeProposal()
+            .getAspect()
+            .getValue()
+            .asString(StandardCharsets.UTF_8);
+    try {
+      JsonNode parsed = objectMapper.readTree(payload);
+      if (parsed.isObject()) {
+        return objectMapper.treeToValue(parsed, GenericJsonPatch.class);
+      }
+      if (parsed.isArray()) {
+        List<GenericJsonPatch.PatchOp> ops =
+            objectMapper.convertValue(
+                parsed, new TypeReference<List<GenericJsonPatch.PatchOp>>() {});
+        return GenericJsonPatch.builder().patch(ops).build();
+      }
+    } catch (Exception e) {
+      log.warn(
+          "Skipping unparseable structured property PATCH payload on {}: {}",
+          patchItem.getUrn(),
+          e.toString());
+    }
+    return null;
   }
 
   @Nonnull

--- a/metadata-io/src/test/java/com/linkedin/metadata/structuredproperties/validators/StructuredPropertiesValidatorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/structuredproperties/validators/StructuredPropertiesValidatorTest.java
@@ -18,6 +18,7 @@ import com.linkedin.metadata.aspect.patch.GenericJsonPatch;
 import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
 import com.linkedin.metadata.aspect.plugins.validation.AspectValidationException;
 import com.linkedin.metadata.entity.ebean.batch.PatchItemImpl;
+import com.linkedin.metadata.entity.ebean.batch.ProposedItem;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.search.utils.ESUtils;
 import com.linkedin.metadata.structuredproperties.validation.StructuredPropertiesValidator;
@@ -1057,5 +1058,75 @@ public class StructuredPropertiesValidatorTest {
             .size(),
         0,
         "REMOVE ops should not produce assignments for value validation");
+  }
+
+  /**
+   * With alternate MCP validation (the quickstart/docker default, {@code
+   * ALTERNATE_MCP_VALIDATION=true}) a patch reaches the proposed hook as a {@link ProposedItem}
+   * carrying the raw proposal — not a {@link PatchItemImpl} — so the serialized patch must be read
+   * from the MCP payload itself. Routing on the item class silently skips patch validation on every
+   * such deployment.
+   */
+  @Test
+  public void testValidateProposedRejectsPatchAddViaProposedItem() throws Exception {
+    Urn propertyUrn =
+        Urn.createFromString("urn:li:structuredProperty:io.acryl.privacy.retentionTime");
+    StructuredPropertyDefinition stringPropertyDef =
+        new StructuredPropertyDefinition()
+            .setValueType(Urn.createFromString("urn:li:type:datahub.string"))
+            .setAllowedValues(
+                new PropertyValueArray(
+                    List.of(
+                        new PropertyValue().setValue(PrimitivePropertyValue.create("a")),
+                        new PropertyValue().setValue(PrimitivePropertyValue.create("b")))));
+
+    GenericJsonPatch.PatchOp addOp = new GenericJsonPatch.PatchOp();
+    addOp.setOp("add");
+    addOp.setPath("/properties/" + propertyUrn + "/");
+    addOp.setValue(
+        Map.of("propertyUrn", propertyUrn.toString(), "values", List.of(Map.of("string", "c"))));
+
+    GenericJsonPatch genericJsonPatch =
+        GenericJsonPatch.builder()
+            .arrayPrimaryKeys(Map.of("properties", List.of("propertyUrn", "attribution␟source")))
+            .patch(List.of(addOp))
+            .build();
+
+    MetadataChangeProposal mcp = new MetadataChangeProposal();
+    mcp.setEntityUrn(TEST_DATASET_URN);
+    mcp.setEntityType("dataset");
+    mcp.setAspectName(STRUCTURED_PROPERTIES_ASPECT_NAME);
+    mcp.setChangeType(ChangeType.PATCH);
+    mcp.setAspect(
+        GenericRecordUtils.serializePatch(genericJsonPatch, TEST_OP_CONTEXT.getObjectMapper()));
+
+    ProposedItem proposedItem =
+        ProposedItem.builder()
+            .build(
+                mcp,
+                new AuditStamp().setActor(UrnUtils.getUrn("urn:li:corpuser:datahub")).setTime(0L),
+                TEST_REGISTRY);
+
+    RetrieverContext retrieverContext = mock(RetrieverContext.class);
+    MockAspectRetriever aspectRetriever = new MockAspectRetriever(propertyUrn, stringPropertyDef);
+    aspectRetriever.setEntityRegistry(TEST_REGISTRY);
+    when(retrieverContext.getAspectRetriever()).thenReturn(aspectRetriever);
+
+    StructuredPropertiesValidator validator =
+        new StructuredPropertiesValidator()
+            .setConfig(
+                AspectPluginConfig.builder()
+                    .className(StructuredPropertiesValidator.class.getName())
+                    .enabled(true)
+                    .supportedOperations(List.of("UPSERT", "PATCH"))
+                    .supportedEntityAspectNames(List.of(AspectPluginConfig.EntityAspectName.ALL))
+                    .build());
+
+    assertEquals(
+        validator
+            .validateProposed(TEST_OP_CONTEXT, List.of(proposedItem), retrieverContext, null)
+            .count(),
+        1,
+        "A ProposedItem patch ADD with a disallowed value must be rejected at request time");
   }
 }


### PR DESCRIPTION
> Follow-up to #18533, which added request-stage validation of structured-property PATCH `add` ops. This PR is now a slim delta on top of it (the original pre-commit approach was dropped per review, and #18533 landed the request-stage implementation).

## Summary

#18533's patch path routes items via `instanceof PatchItemImpl`:

```java
.filter(i -> ChangeType.PATCH.equals(i.getChangeType()))
.filter(i -> i instanceof PatchItemImpl)
```

Docker/quickstart deployments — **including the CI test environment** — default `ALTERNATE_MCP_VALIDATION=true` (`docker/profiles/docker-compose.gms.yml`), under which every incoming proposal reaches the proposed hook as a **`ProposedItem`** carrying the raw MCP, not a `PatchItemImpl`. The patch validation path therefore never fires on those deployments, and invalid patch values are still silently stored.

**Reproduced live** against a branch-built quickstart GMS (`ALTERNATE_MCP_VALIDATION=true`, `dropMissingPropertyValuesWithWarning=true`): a PATCH assigning a value for a nonexistent structured property returned **200** and the orphan value was persisted (readable via GraphQL with `exists: false` on the property). Neither the validator nor `StructuredPropertiesAssignmentMutator` logged or intervened.

## Fix

Route on the change type instead of the item class, and resolve the patch from whichever shape the item has:

- `PatchItemImpl` → `getGenericJsonPatch()` (unchanged);
- any other `MCPItem` with `changeType=PATCH` (i.e. `ProposedItem` under alternate validation) → parse the serialized `GenericJsonPatch` (or a bare json-patch ops array) from the MCP's aspect payload.

Everything downstream is #18533's existing machinery (`materializePatchAddUpsert` → full `validateProposedUpserts`), unchanged.

**Verified live after the fix** (same server, same payloads):

- PATCH `add` for a nonexistent definition → **422** (was 200 + stored orphan);
- create definition, then PATCH a valid value → **200**.

## Java SDK V2 integration test

`DatasetIntegrationTest.testDatasetWithStructuredProperties` assigned properties whose definitions were never created — it only ever passed because of this bypass (the V2 SDK's `setStructuredProperty` emits PATCH via `StructuredPropertiesPatchBuilder`). It now creates the definitions first (via a raw emitter, since the V2 SDK has no structured-property entity), and a new `testDatasetStructuredPropertyWithoutDefinitionRejected` guards exactly this blindspot end-to-end — CI's quickstart runs with alternate validation enabled, so this test fails on master today and passes with this fix. Both verified against a live branch-built GMS (35/35 in the class).

## Testing

- New unit test `testValidateProposedRejectsPatchAddViaProposedItem` drives a real `ProposedItem` (built exactly as `AspectsBatchImpl.mcps()` does under alternate validation) through the proposed hook; 22/22 in the class.
- Live before/after verification as above.
- Java SDK V2 integration suite green against the branch-built server.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added
- [ ] Docs (n/a — restores #18533's intended behavior on alternate-validation deployments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
