### PR TITLE
fix(smoke): clean up shared test-delete dataset after kafka default sink tests

### DIFF
--- a/smoke-test/tests/test_kafka_default_sink.py
+++ b/smoke-test/tests/test_kafka_default_sink.py
@@ -29,6 +29,15 @@ def _clear_default_graph_cache():
     get_default_graph.cache_clear()
 
 
+@pytest.fixture(autouse=True)
+def _cleanup_shared_dataset(graph_client):
+    # This module reuses delete_test.py's dataset urn; remove it after each test so
+    # residue never breaks delete_test's pre-check when it runs later on the same instance.
+    yield
+    graph_client.hard_delete_entity(DATASET_URN)
+    wait_for_writes_to_sync()
+
+
 def _create_default_sink_pipeline(auth_session, monkeypatch, default_sink):
     """Build a no-sink pipeline (the shape UI ingestion uses) whose default sink
     is chosen by env. `default_sink` is "rest" or "kafka"."""


### PR DESCRIPTION
## Summary

`smoke-test/tests/test_kafka_default_sink.py` ingests `tests/delete/cli_test_data.json`, which writes aspects (including `institutionalMemory`) to `urn:li:dataset:(urn:li:dataPlatform:kafka,test-delete,PROD)` — the same urn used by `smoke-test/tests/delete/delete_test.py`. The kafka-sink tests hard-delete that urn at the start of each test but never clean up at the end.

When one of these tests runs before `delete_test.py` on the same instance, the leftover aspects break `delete_test.py::test_delete_reference`'s setup pre-check (`assert "institutionalMemory" not in ...`). This violates the smoke-test idempotency principle that tests must not depend on other tests doing their cleanup.

## Fix

Add an autouse teardown fixture that hard-deletes the shared dataset after each test in the module (and waits for writes to sync), so no residue is left behind regardless of test ordering. `hard_delete_entity` on a nonexistent urn is a no-op, so tests that skip before ingesting are unaffected.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (PR Title Format)
- [x] Tests updated
- [ ] Docs (not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)