### PR TITLE
fix(search): correct KEYWORD_IGNORE_ABOVE reference in FieldTypeMapperTest

### DIFF
--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapperTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapperTest.java
@@ -1,7 +1,6 @@
 package com.linkedin.metadata.search.elasticsearch.index.entity.v3;
 
 import static com.linkedin.metadata.search.utils.ESUtils.KEYWORD_IGNORE_ABOVE;
-import static com.linkedin.metadata.search.utils.ESUtils.KEYWORD_MAXLENGTH;
 import static org.testng.Assert.*;
 
 import com.linkedin.metadata.models.LogicalValueType;
@@ -46,7 +45,7 @@ public class FieldTypeMapperTest {
     Map<String, Object> mapping =
         FieldTypeMapper.getMappingsForLogicalValueType(LogicalValueType.STRING);
     assertEquals(mapping.get("type"), "keyword");
-    assertEquals(mapping.get("ignore_above"), KEYWORD_MAXLENGTH);
+    assertEquals(mapping.get("ignore_above"), KEYWORD_IGNORE_ABOVE);
   }
 
   @Test
@@ -54,7 +53,7 @@ public class FieldTypeMapperTest {
     Map<String, Object> mapping =
         FieldTypeMapper.getMappingsForLogicalValueType(LogicalValueType.RICH_TEXT);
     assertEquals(mapping.get("type"), "keyword");
-    assertEquals(mapping.get("ignore_above"), KEYWORD_MAXLENGTH);
+    assertEquals(mapping.get("ignore_above"), KEYWORD_IGNORE_ABOVE);
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapperTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapperTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.search.elasticsearch.index.entity.v3;
 
 import static com.linkedin.metadata.search.utils.ESUtils.KEYWORD_IGNORE_ABOVE;
+import static com.linkedin.metadata.search.utils.ESUtils.KEYWORD_MAXLENGTH;
 import static org.testng.Assert.*;
 
 import com.linkedin.metadata.models.LogicalValueType;


### PR DESCRIPTION
## Summary

Fixes a compile break on `master` in `metadata-io` test classes.

#18552 added two tests to `FieldTypeMapperTest` (`testStringLogicalValueTypeUsesIgnoreAbove`,
`testRichTextLogicalValueTypeUsesIgnoreAbove`) that asserted against `KEYWORD_MAXLENGTH`.
Concurrently, `#18549` introduced `ESUtils.KEYWORD_IGNORE_ABOVE` (= `KEYWORD_MAXLENGTH / 4`,
byte-safe) and migrated `FieldTypeMapper` and the existing `FieldTypeMapperTest` asserts to it,
removing the `KEYWORD_MAXLENGTH` import from that file.

#18552  was merged without rebasing onto #18549 , so the new tests reference `KEYWORD_MAXLENGTH`
which is no longer imported in `FieldTypeMapperTest` → `cannot find symbol`, breaking
`:metadata-io:testClasses`.

The assertion was also semantically wrong: `getMappingsForLogicalValueType(STRING|RICH_TEXT)`
delegates to `getMappingsForKeywordWithIgnoreAbove()`, which emits `KEYWORD_IGNORE_ABOVE`, not
`KEYWORD_MAXLENGTH`. Switching to `KEYWORD_IGNORE_ABOVE` fixes both the compile and the assertion.

`V2MappingsBuilderTest` is unaffected — the V2 builder still emits `KEYWORD_MAXLENGTH` and the
import matches.

## Changes

- `FieldTypeMapperTest.java`: `KEYWORD_MAXLENGTH` → `KEYWORD_IGNORE_ABOVE` in the two new STRING/RICH_TEXT tests.
