### PR TITLE
docs(ingest): clarify allow/deny pattern matching is prefix-anchored

### DIFF
--- a/metadata-ingestion/src/datahub/configuration/common.py
+++ b/metadata-ingestion/src/datahub/configuration/common.py
@@ -400,7 +400,13 @@ class ConfigurationMechanism(ABC):
 
 
 class AllowDenyPattern(ConfigModel):
-    """A class to store allow deny regexes"""
+    """A class to store allow deny regexes.
+
+    Patterns are matched against the start of the string only, not the entire
+    string - a pattern does not need to match to the end to be considered a match.
+    For example, the pattern "prod" matches "prod", "prod_east", and "production".
+    To require an exact match, anchor your pattern explicitly, e.g. "^prod$".
+    """
 
     # This regex is used to check if a given rule is a regex expression or a literal.
     # Note that this is not a perfect check. For example, the '.' character should
@@ -410,11 +416,15 @@ class AllowDenyPattern(ConfigModel):
 
     allow: List[str] = Field(
         default=[".*"],
-        description="List of regex patterns to include in ingestion",
+        description="List of regex patterns to include in ingestion. Patterns match "
+        "from the start of the string only, not the entire string - anchor with "
+        "'^...$' for an exact match, e.g. '^prod$'.",
     )
     deny: List[str] = Field(
         default=[],
-        description="List of regex patterns to exclude from ingestion.",
+        description="List of regex patterns to exclude from ingestion. Patterns match "
+        "from the start of the string only, not the entire string - anchor with "
+        "'^...$' for an exact match, e.g. '^prod$'.",
     )
     ignoreCase: Optional[bool] = Field(
         default=True,
@@ -475,9 +485,18 @@ class KeyValuePattern(ConfigModel):
     """
     The key-value pattern is used to map a regex pattern to a set of values.
     For example, you can use it to map a table name to a list of tags to apply to it.
+
+    Rule keys are matched against the start of the string only, not the entire
+    string - a key does not need to match to the end to be considered a match.
+    To require an exact match, anchor your pattern explicitly, e.g. "^prod$".
     """
 
-    rules: Dict[str, List[str]] = {".*": []}
+    rules: Dict[str, List[str]] = Field(
+        default={".*": []},
+        description="Maps a regex pattern to the list of values to apply when it "
+        "matches. Patterns match from the start of the string only, not the entire "
+        "string - anchor with '^...$' for an exact match, e.g. '^prod$'.",
+    )
     first_match_only: bool = Field(
         default=True,
         description="Whether to stop after the first match. If false, all matching rules will be applied.",

--- a/metadata-ingestion/src/datahub/ingestion/source/sql_queries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql_queries.py
@@ -90,7 +90,8 @@ class SqlQueriesSourceConfig(
     )
     temp_table_patterns: List[str] = Field(
         description="Regex patterns for temporary tables to filter in lineage ingestion. "
-        "Specify regex to match the entire table name. This is useful for platforms like Athena "
+        "Patterns match from the start of the table name only, not the entire name - "
+        "anchor with '^...$' for an exact match. This is useful for platforms like Athena "
         "that don't have native temp tables but use naming patterns for fake temp tables.",
         default=[],
     )


### PR DESCRIPTION
## Summary

`AllowDenyPattern` and `KeyValuePattern` (`configuration/common.py`) both match user-supplied regexes via `re.match()`, which only anchors at the start of the string - a pattern like `prod` silently also matches `prod_east` or `production`. Neither class's docstring nor field descriptions mentioned this, so recipe authors reasonably expect exact-name matching from a bare pattern and get silent over-inclusion instead.

This surfaced concretely during a customer incident: a Databricks recipe's `catalog_pattern: ["prod"]` unexpectedly also matched a second real catalog (`prod_mumbai`), broadening a usage-extraction query well past what was intended, with no error or warning at any point.

Also corrects an actively incorrect claim in `SqlQueriesSourceConfig.temp_table_patterns`, which said patterns match "the entire table name" - the implementation uses the same unanchored `re.match()`.

This is a documentation-only change. Changing `re.match()` to `re.fullmatch()` would be a breaking change for the large number of existing recipes across every connector that may already depend on prefix-matching behavior, intentionally or otherwise - not something to change silently.

Related: OSS-1169.

## Test plan

- [x] `ruff check` passes on both changed files
- [x] `ruff format --check` passes on both changed files
- [x] No behavior change - documentation/description text only