### PR TITLE
fix(metrics): fix sidebar expand/collapse all and related-metrics label

### DIFF
--- a/datahub-web-react/src/app/entityV2/summary/modules/relatedMetrics/RelatedMetricsModule.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/modules/relatedMetrics/RelatedMetricsModule.tsx
@@ -13,7 +13,7 @@ import { ModuleProps } from '@app/homeV3/module/types';
 import { DataHubPageModuleType, Entity, EntityEdge, Metric } from '@types';
 
 const RELATIONSHIP_LABEL = {
-    parentMetric: 'Used In',
+    parentMetric: 'Child of',
     derivedFrom: 'Derived From',
     relatedMetrics: 'Related To',
 } as const;

--- a/datahub-web-react/src/app/metrics/MetricRow.tsx
+++ b/datahub-web-react/src/app/metrics/MetricRow.tsx
@@ -41,7 +41,7 @@ export function MetricRow({
             onToggle();
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [entityData, metric.urn, isExpanded]);
+    }, [entityData?.urn, metric.urn]);
 
     const { data, scrollRef } = useMetricChildren({
         mode: { kind: 'metric', parentMetricUrn: metric.urn },

--- a/datahub-web-react/src/app/metrics/SemanticModelRow.tsx
+++ b/datahub-web-react/src/app/metrics/SemanticModelRow.tsx
@@ -39,7 +39,7 @@ export function SemanticModelRow({
             onToggle();
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [entityData, model.urn, isExpanded]);
+    }, [entityData?.urn, entityData?.semanticModel?.urn, model.urn]);
 
     const { data, scrollRef } = useMetricChildren({
         mode: { kind: 'model', modelUrn: model.urn },


### PR DESCRIPTION
## Summary
- Fix Metrics sidebar expand/collapse-all being immediately undone by auto-expand effects while a metric profile is open
- Rename Related Metrics parent relationship pill from "Used In" to "Child of"

Port of [acryldata/datahub-fork#11117](https://github.com/acryldata/datahub-fork/pull/11117).

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

## Test plan
- [ ] Open a metric profile, collapse all in the Metrics sidebar, confirm rows stay collapsed
- [ ] Navigate between metrics and confirm ancestors still auto-expand as expected
- [ ] Confirm Related Metrics parent pill shows "Child of" instead of "Used In"

Made with [Cursor](https://cursor.com)