### PR TITLE
fix(ingest/dataplex): reconcile sync-back-authored metadata on ingest via platform resources

### DIFF
--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -333,6 +333,7 @@ datahub-rest = [
 ]
 
 dataplex = [
+    "cachetools<6.0.0",
     "google-cloud-datacatalog-lineage>=0.5.0,<1.0.0",
     "google-cloud-dataplex<3.0.0",
     "google-cloud-resource-manager<2.0.0",

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -622,7 +622,7 @@ plugins: Dict[str, Set[str]] = {
     | {"sqlalchemy-cockroachdb<2.0.0"},
     "datahub-lineage-file": set(),
     "datahub-business-glossary": set(),
-    "dataplex": dataplex_common,
+    "dataplex": dataplex_common | cachetools_lib,
     "delta-lake": {*delta_lake},
     "db2": {
         # The underlying ibm_db library and Db2 clidriver don't work on Linux ARM

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex.py
@@ -61,6 +61,10 @@ from datahub.ingestion.source.state.stateful_ingestion_base import (
 
 logger = logging.getLogger(__name__)
 
+# OAuth2 scope required for the lookupEntryLinks REST session; service-account
+# credentials must be scoped explicitly or AuthorizedSession token refresh fails.
+_DATAPLEX_OAUTH_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+
 
 def _resolve_project_numbers(
     project_ids: List[str],
@@ -232,7 +236,9 @@ class DataplexSource(StatefulIngestionSourceBase, TestableSource):
 
         creds = self.config.get_credentials()
         credentials = (
-            service_account.Credentials.from_service_account_info(creds)
+            service_account.Credentials.from_service_account_info(
+                creds, scopes=_DATAPLEX_OAUTH_SCOPES
+            )
             if creds
             else None
         )
@@ -365,7 +371,9 @@ class DataplexSource(StatefulIngestionSourceBase, TestableSource):
             config = DataplexConfig.model_validate(config_dict)
             creds = config.get_credentials()
             credentials = (
-                service_account.Credentials.from_service_account_info(creds)
+                service_account.Credentials.from_service_account_info(
+                    creds, scopes=_DATAPLEX_OAUTH_SCOPES
+                )
                 if creds
                 else None
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex.py
@@ -48,6 +48,9 @@ from datahub.ingestion.source.dataplex.dataplex_glossary import (
     DataplexGlossaryProcessor,
 )
 from datahub.ingestion.source.dataplex.dataplex_lineage import DataplexLineageExtractor
+from datahub.ingestion.source.dataplex.dataplex_platform_resource_repository import (
+    DataplexPlatformResourceRepository,
+)
 from datahub.ingestion.source.dataplex.dataplex_report import DataplexReport
 from datahub.ingestion.source.state.redundant_run_skip_handler import (
     RedundantLineageRunSkipHandler,
@@ -281,6 +284,25 @@ class DataplexSource(StatefulIngestionSourceBase, TestableSource):
             ctx=self.ctx_data,
         )
 
+        # Reconciles synced-back glossary terms against previously ingested
+        # platform resources. Requires a DataHub graph connection to read/write
+        # the side-index, so it is unavailable in dry-run / file-sink pipelines.
+        self.platform_resource_repository: Optional[
+            DataplexPlatformResourceRepository
+        ] = None
+        if self.ctx.graph is not None:
+            self.platform_resource_repository = DataplexPlatformResourceRepository(
+                self.ctx.graph
+            )
+        elif self.config.include_glossary_term_associations:
+            self.report.warning(
+                title="Glossary term reconciliation disabled",
+                message="No DataHub graph connection is available, so synced-back "
+                "glossary terms cannot be reconciled. Ingesting native Dataplex term "
+                "URNs as-is. Provide a datahub-rest sink or stateful ingestion to "
+                "enable reconciliation.",
+            )
+
         # Glossary processor — only instantiated when glossary ingestion is enabled.
         self.glossary_processor: Optional[DataplexGlossaryProcessor] = None
         if self.config.include_glossaries:
@@ -325,6 +347,7 @@ class DataplexSource(StatefulIngestionSourceBase, TestableSource):
                 glossary_client=glossary_client,
                 report=self.report.glossary_report,
                 source_report=self.report,
+                platform_resource_repository=self.platform_resource_repository,
             )
 
     @staticmethod

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex.py
@@ -300,7 +300,13 @@ class DataplexSource(StatefulIngestionSourceBase, TestableSource):
             self.platform_resource_repository = DataplexPlatformResourceRepository(
                 self.ctx.graph
             )
-        elif self.config.include_glossary_term_associations:
+        elif (
+            self.config.include_glossaries
+            or self.config.include_glossary_term_associations
+        ):
+            # Both the Phase-1 glossary-term suppression (under include_glossaries)
+            # and the Phase-2 association reconciliation (under
+            # include_glossary_term_associations) need the graph, so warn for either.
             self.report.warning(
                 title="Glossary term reconciliation disabled",
                 message="No DataHub graph connection is available, so synced-back "

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_config.py
@@ -145,12 +145,12 @@ class DataplexConfig(
     )
 
     aspect_pattern: AllowDenyPattern = Field(
-        default=AllowDenyPattern(deny=["datahub_.*"]),
+        default=AllowDenyPattern(deny=["datahub-.*"]),
         description="Regex allow/deny patterns matched against Dataplex aspect type "
         "names to decide which aspects are flattened into DataHub custom properties. "
-        "Defaults to denying DataHub-authored aspects (those prefixed 'datahub_' that "
-        "the DataHub sync-back writes) so synced-back metadata does not return as "
-        "custom-property noise.",
+        "Defaults to denying DataHub-authored aspects (those prefixed 'datahub-' that "
+        "the DataHub sync-back writes, e.g. 'datahub-tags' / 'datahub-properties') so "
+        "synced-back metadata does not return as custom-property noise.",
     )
 
     include_schema: bool = Field(

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_config.py
@@ -144,6 +144,15 @@ class DataplexConfig(
         description="Filters to control which Dataplex resources are ingested.",
     )
 
+    aspect_pattern: AllowDenyPattern = Field(
+        default=AllowDenyPattern(deny=["datahub_.*"]),
+        description="Regex allow/deny patterns matched against Dataplex aspect type "
+        "names to decide which aspects are flattened into DataHub custom properties. "
+        "Defaults to denying DataHub-authored aspects (those prefixed 'datahub_' that "
+        "the DataHub sync-back writes) so synced-back metadata does not return as "
+        "custom-property noise.",
+    )
+
     include_schema: bool = Field(
         default=True,
         description="Whether to extract and ingest schema metadata (columns, types, descriptions). "

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_config.py
@@ -144,7 +144,7 @@ class DataplexConfig(
         description="Filters to control which Dataplex resources are ingested.",
     )
 
-    aspect_pattern: AllowDenyPattern = Field(
+    aspect_type_pattern: AllowDenyPattern = Field(
         default=AllowDenyPattern(deny=["datahub-.*"]),
         description="Regex allow/deny patterns matched against Dataplex aspect type "
         "names to decide which aspects are flattened into DataHub custom properties. "

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_entries.py
@@ -63,12 +63,23 @@ class DataplexEntriesReport(Report):
 
     entries_processed: int = 0
     entries_processed_samples: LossyList[str] = field(default_factory=LossyList)
+    # Aspect types dropped from custom properties by aspect_type_pattern (default
+    # deny "datahub-.*"). Surfaces both the intended sync-back filtering and any
+    # native aspect that happened to match the pattern.
+    aspects_filtered: int = 0
+    aspects_filtered_samples: LossyList[str] = field(default_factory=LossyList)
     catalog_api: dict[str, tuple[int, float]] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         # Lock protecting all mutable fields when report methods are called from
         # parallel worker threads (Phase 1b of process_entries).
         self._lock: threading.Lock = threading.Lock()
+
+    def report_filtered_aspect(self, aspect_type: str) -> None:
+        """Record one aspect type dropped by ``aspect_type_pattern``."""
+        with self._lock:
+            self.aspects_filtered += 1
+            self.aspects_filtered_samples.append(aspect_type)
 
     def report_catalog_api_call(self, api_name: str, elapsed_seconds: float) -> None:
         """Accumulate per-API call count and total latency in seconds."""
@@ -298,6 +309,7 @@ class DataplexEntriesProcessor:
                 config=self.config,
                 location=location,
                 report=self.source_report,
+                entries_report=self.report,
             ),
         )
         if result is None:

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_external_entities.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_external_entities.py
@@ -1,0 +1,102 @@
+from typing import Optional
+
+from datahub.api.entities.external.external_entities import (
+    ExternalEntity,
+    ExternalEntityId,
+    LinkedResourceSet,
+)
+from datahub.api.entities.platformresource.platform_resource import (
+    PlatformResource,
+    PlatformResourceKey,
+)
+
+DATAPLEX_PLATFORM = "dataplex"
+# Must byte-match the resource type + aspect key the DataHub sync-back persists
+# (datahub-fork datahub_integrations/propagation/dataplex).
+DATAPLEX_ASPECT_RESOURCE_TYPE = "DataplexAspectPlatformResource"
+GLOSSARY_TERMS_ASPECT_KEY = "datahub-glossary-terms"
+
+
+class DataplexAspectId(ExternalEntityId):
+    """Identity of a sync-back-authored Dataplex aspect/link platform resource.
+
+    Mirrors the fork's key scheme: primary key ``{entry_name}/{aspect_key}[/{field_key}]``
+    on platform ``dataplex``, resource type ``DataplexAspectPlatformResource``.
+    """
+
+    aspect_key: str
+    entry_name: str
+    field_key: Optional[str] = None
+    # Set by the repository once a matching resource is found in DataHub.
+    persisted: bool = False
+
+    def to_platform_resource_key(self) -> PlatformResourceKey:
+        primary_key = f"{self.entry_name}/{self.aspect_key}"
+        if self.field_key is not None:
+            primary_key = f"{primary_key}/{self.field_key}"
+        return PlatformResourceKey(
+            platform=DATAPLEX_PLATFORM,
+            resource_type=DATAPLEX_ASPECT_RESOURCE_TYPE,
+            primary_key=primary_key,
+        )
+
+
+class DataplexAspectPlatformResource(ExternalEntity):
+    """Ingestion-side view of a sync-back platform resource.
+
+    Field names deliberately match the fork's persisted ``DataplexAspectInfo`` value
+    so the generic repository can deserialize it via ``as_pydantic_object`` (which
+    does not validate the schema ref by default).
+    """
+
+    datahub_urn: str
+    managed_by_datahub: bool
+    aspect_key: str
+    entry_name: str
+    field_key: Optional[str] = None
+
+    def get_id(self) -> ExternalEntityId:
+        return DataplexAspectId(
+            aspect_key=self.aspect_key,
+            entry_name=self.entry_name,
+            field_key=self.field_key,
+        )
+
+    def is_managed_by_datahub(self) -> bool:
+        return self.managed_by_datahub
+
+    def datahub_linked_resources(self) -> LinkedResourceSet:
+        return LinkedResourceSet(urns=[self.datahub_urn])
+
+    def as_platform_resource(self) -> PlatformResource:
+        return PlatformResource.create(
+            key=self.get_id().to_platform_resource_key(),
+            secondary_keys=[self.datahub_urn],
+            value=self,
+        )
+
+    @classmethod
+    def create_default(
+        cls, entity_id: ExternalEntityId, managed_by_datahub: bool
+    ) -> "DataplexAspectPlatformResource":
+        assert isinstance(entity_id, DataplexAspectId)
+        return cls(
+            datahub_urn="",
+            managed_by_datahub=managed_by_datahub,
+            aspect_key=entity_id.aspect_key,
+            entry_name=entity_id.entry_name,
+            field_key=entity_id.field_key,
+        )
+
+    @classmethod
+    def from_external(
+        cls, entry_name: str, native_term_urn: str
+    ) -> "DataplexAspectPlatformResource":
+        """Build a resource marking an externally-authored term link as unmanaged."""
+        return cls(
+            datahub_urn=native_term_urn,
+            managed_by_datahub=False,
+            aspect_key=GLOSSARY_TERMS_ASPECT_KEY,
+            entry_name=entry_name,
+            field_key=native_term_urn,
+        )

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_external_entities.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_external_entities.py
@@ -66,7 +66,10 @@ class DataplexAspectPlatformResource(ExternalEntity):
         return self.managed_by_datahub
 
     def datahub_linked_resources(self) -> LinkedResourceSet:
-        return LinkedResourceSet(urns=[self.datahub_urn])
+        # A default (not-yet-linked) entity has an empty ``datahub_urn``; return an
+        # empty set rather than [""] so a "" never masquerades as a URN (which would
+        # blow up LinkedResourceSet.add / Urn.from_string). Mirrors Unity Catalog.
+        return LinkedResourceSet(urns=[self.datahub_urn] if self.datahub_urn else [])
 
     def as_platform_resource(self) -> PlatformResource:
         return PlatformResource.create(

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_glossary.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_glossary.py
@@ -328,11 +328,17 @@ class DataplexGlossaryProcessor:
             )
             return None
 
-    def _record_external_link(self, entry_name: str, native_term_urn: str) -> None:
-        """Persist a ``managed_by_datahub=false`` platform resource for an
+    def _record_external_link(
+        self, entry_name: str, native_term_urn: str
+    ) -> Iterable[MetadataWorkUnit]:
+        """Emit a ``managed_by_datahub=false`` platform-resource workunit for an
         externally-authored term link so the sync-back guard won't overwrite it.
 
-        Best-effort: never aborts ingestion on failure.
+        Emitted through the sink (like the Unity Catalog and Glue connectors)
+        rather than written directly to the graph, so it respects dry-run/file
+        sinks and stateful ingestion. Best-effort: a failure is reported and
+        never aborts ingestion. No-op when there is no platform-resource
+        repository (nothing to reconcile against).
         """
         if self._platform_resource_repository is None:
             return
@@ -340,13 +346,20 @@ class DataplexGlossaryProcessor:
             resource = DataplexAspectPlatformResource.from_external(
                 entry_name=entry_name, native_term_urn=native_term_urn
             )
-            self._platform_resource_repository.create(resource.as_platform_resource())
+            platform_resource = resource.as_platform_resource()
+            mcps = list(platform_resource.to_mcps())
         except Exception as exc:
             self._source_report.warning(
                 title="Failed to record external glossary term link",
                 message="Sync-back may overwrite this externally-owned term link.",
                 context=f"{entry_name} -> {native_term_urn}",
                 exc=exc,
+            )
+            return
+        for mcp in mcps:
+            yield MetadataWorkUnit(
+                id=f"platform_resource-{platform_resource.id}",
+                mcp=mcp,
             )
 
     def _process_single_glossary(
@@ -572,7 +585,7 @@ class DataplexGlossaryProcessor:
                         )
                         if links.datahub_term_urn is None:
                             # Externally-authored link: mark it unmanaged for the guard.
-                            self._record_external_link(
+                            yield from self._record_external_link(
                                 asset_link.entry_name, links.native_term_urn
                             )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_glossary.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_glossary.py
@@ -646,7 +646,7 @@ class DataplexGlossaryProcessor:
                 for ref in link.get("entryReferences", []):
                     if ref.get("type") != _SOURCE_ROLE:
                         continue
-                    entry_name = ref.get("name", "")
+                    entry_name = self._normalize_entry_project_id(ref.get("name", ""))
                     asset_urn = entry_name_to_urn.get(entry_name)
                     if asset_urn is None:
                         logger.debug(
@@ -665,6 +665,20 @@ class DataplexGlossaryProcessor:
             datahub_term_urn=datahub_term_urn,
             asset_links=asset_links,
         )
+
+    def _normalize_entry_project_id(self, entry_name: str) -> str:
+        """Map a leading ``projects/{number}`` segment back to ``projects/{id}``.
+
+        ``lookupEntryLinks`` returns the source entry's entry-group project as a
+        project *number*, but entries ingested in the entries stage key
+        ``entry_name_to_urn`` by the project *id*. Without this the asset lookup
+        silently misses and no term association is emitted.
+        """
+        for project_id, project_number in self._ctx.project_numbers.items():
+            prefix = f"projects/{project_number}/"
+            if entry_name.startswith(prefix):
+                return f"projects/{project_id}/" + entry_name[len(prefix) :]
+        return entry_name
 
     def _lookup_entry_links(
         self, project_id: str, location: str, term_entry_path: str

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_glossary.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_glossary.py
@@ -13,7 +13,7 @@ import urllib.parse
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from itertools import islice
-from typing import Dict, Iterable, List, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from google.cloud import dataplex_v1
 
@@ -22,6 +22,9 @@ from datahub.ingestion.api.source import SourceReport
 from datahub.ingestion.api.source_helpers import auto_workunit
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.dataplex.dataplex_context import DataplexContext
+from datahub.ingestion.source.dataplex.dataplex_platform_resource_repository import (
+    DataplexPlatformResourceRepository,
+)
 from datahub.metadata.urns import DatasetUrn, GlossaryNodeUrn, GlossaryTermUrn
 from datahub.sdk.dataset import Dataset
 from datahub.sdk.entity import Entity
@@ -111,6 +114,9 @@ class GlossaryTermRef:
     location: str
     glossary_id: str
     term_id: str
+    # Original DataHub term URN when this native term was authored in DataHub and
+    # reconciled via the platform-resource side-index; None otherwise.
+    datahub_term_urn: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +138,7 @@ class DataplexGlossaryReport(Report):
     glossary_terms_processed: int = 0
     glossary_terms_processed_samples: LossyList[str] = field(default_factory=LossyList)
     term_associations_emitted: int = 0
+    terms_reconciled: int = 0
     glossary_api: Dict[str, Tuple[int, float]] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -162,6 +169,10 @@ class DataplexGlossaryReport(Report):
         with self._lock:
             self.term_associations_emitted += 1
 
+    def report_term_reconciled(self) -> None:
+        with self._lock:
+            self.terms_reconciled += 1
+
 
 # ---------------------------------------------------------------------------
 # Processor
@@ -185,6 +196,9 @@ class DataplexGlossaryProcessor:
         glossary_client: dataplex_v1.BusinessGlossaryServiceClient,
         report: DataplexGlossaryReport,
         source_report: SourceReport,
+        platform_resource_repository: Optional[
+            DataplexPlatformResourceRepository
+        ] = None,
     ) -> None:
         self._ctx = ctx
         self._glossary_client = glossary_client
@@ -192,6 +206,7 @@ class DataplexGlossaryProcessor:
         self._source_report = source_report
         self._emitted_terms: List[GlossaryTermRef] = []
         self._emitted_terms_lock = threading.Lock()
+        self._platform_resource_repository = platform_resource_repository
 
     # ------------------------------------------------------------------
     # Phase 1: Glossary ingestion
@@ -262,6 +277,36 @@ class DataplexGlossaryProcessor:
         )
         logger.debug("list_glossaries payload: %s", response)
         return response
+
+    def _reconcile_term(self, native_term_urn: str) -> Optional[str]:
+        """Return the original DataHub term URN if this native term was authored in
+        DataHub (has a ``managed_by_datahub`` platform resource); otherwise None.
+
+        Best-effort: any lookup failure is reported and treated as "not reconciled".
+        """
+        if self._platform_resource_repository is None:
+            return None
+        try:
+            entity_id = self._platform_resource_repository.search_entity_by_urn(
+                native_term_urn
+            )
+            if entity_id is None:
+                return None
+            entity = self._platform_resource_repository.get_entity_from_datahub(
+                entity_id
+            )
+            if not entity.is_managed_by_datahub():
+                return None
+            linked = entity.datahub_linked_resources().urns
+            return linked[0] if linked else None
+        except Exception as exc:
+            self._source_report.warning(
+                title="Glossary term reconciliation lookup failed",
+                message="Falling back to the native Dataplex term URN.",
+                context=native_term_urn,
+                exc=exc,
+            )
+            return None
 
     def _process_single_glossary(
         self,
@@ -346,7 +391,19 @@ class DataplexGlossaryProcessor:
                     "term_id": term_id,
                 },
             )
-            yield glossary_term
+            native_term_urn = str(
+                GlossaryTermUrn(
+                    _term_urn_id(project_id, location, glossary_id, term_id)
+                )
+            )
+            original_term_urn = self._reconcile_term(native_term_urn)
+
+            if original_term_urn is None:
+                # Externally-authored (or no side-index): emit as before.
+                yield glossary_term
+            else:
+                # DataHub-authored round-trip: suppress the duplicate native term.
+                self._report.report_term_reconciled()
 
             with self._emitted_terms_lock:
                 self._emitted_terms.append(
@@ -355,6 +412,7 @@ class DataplexGlossaryProcessor:
                         location=location,
                         glossary_id=glossary_id,
                         term_id=term_id,
+                        datahub_term_urn=original_term_urn,
                     )
                 )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_glossary.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_glossary.py
@@ -22,6 +22,9 @@ from datahub.ingestion.api.source import SourceReport
 from datahub.ingestion.api.source_helpers import auto_workunit
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.dataplex.dataplex_context import DataplexContext
+from datahub.ingestion.source.dataplex.dataplex_external_entities import (
+    DataplexAspectPlatformResource,
+)
 from datahub.ingestion.source.dataplex.dataplex_platform_resource_repository import (
     DataplexPlatformResourceRepository,
 )
@@ -117,6 +120,23 @@ class GlossaryTermRef:
     # Original DataHub term URN when this native term was authored in DataHub and
     # reconciled via the platform-resource side-index; None otherwise.
     datahub_term_urn: Optional[str] = None
+
+
+@dataclass
+class AssetLink:
+    """A single asset entry linked to a term."""
+
+    asset_urn: str
+    entry_name: str
+
+
+@dataclass
+class TermAssetLinks:
+    """All asset links for one term, with the reconciled DataHub URN if any."""
+
+    native_term_urn: str
+    datahub_term_urn: Optional[str]
+    asset_links: List[AssetLink]
 
 
 # ---------------------------------------------------------------------------
@@ -307,6 +327,27 @@ class DataplexGlossaryProcessor:
                 exc=exc,
             )
             return None
+
+    def _record_external_link(self, entry_name: str, native_term_urn: str) -> None:
+        """Persist a ``managed_by_datahub=false`` platform resource for an
+        externally-authored term link so the sync-back guard won't overwrite it.
+
+        Best-effort: never aborts ingestion on failure.
+        """
+        if self._platform_resource_repository is None:
+            return
+        try:
+            resource = DataplexAspectPlatformResource.from_external(
+                entry_name=entry_name, native_term_urn=native_term_urn
+            )
+            self._platform_resource_repository.create(resource.as_platform_resource())
+        except Exception as exc:
+            self._source_report.warning(
+                title="Failed to record external glossary term link",
+                message="Sync-back may overwrite this externally-owned term link.",
+                context=f"{entry_name} -> {native_term_urn}",
+                exc=exc,
+            )
 
     def _process_single_glossary(
         self,
@@ -504,17 +545,14 @@ class DataplexGlossaryProcessor:
                         ref.term_id,
                         location_pairs,
                         entry_name_to_urn,
+                        ref.datahub_term_urn,
                     ): ref
                     for ref in batch
                 }
                 for future in as_completed(futures):
                     ref = futures[future]
                     try:
-                        term_urn_str, linked_asset_urns = future.result()
-                        for asset_urn in linked_asset_urns:
-                            asset_to_terms.setdefault(asset_urn, []).append(
-                                term_urn_str
-                            )
+                        links = future.result()
                     except Exception as exc:
                         self._source_report.warning(
                             title="Term association lookup failed",
@@ -525,6 +563,18 @@ class DataplexGlossaryProcessor:
                             ),
                             exc=exc,
                         )
+                        continue
+
+                    resolved_urn = links.datahub_term_urn or links.native_term_urn
+                    for asset_link in links.asset_links:
+                        asset_to_terms.setdefault(asset_link.asset_urn, []).append(
+                            resolved_urn
+                        )
+                        if links.datahub_term_urn is None:
+                            # Externally-authored link: mark it unmanaged for the guard.
+                            self._record_external_link(
+                                asset_link.entry_name, links.native_term_urn
+                            )
 
         logger.info(
             "Term-asset scan complete: %d assets linked to at least one term",
@@ -551,8 +601,9 @@ class DataplexGlossaryProcessor:
         term_id: str,
         location_pairs: List[Tuple[str, str]],
         entry_name_to_urn: Dict[str, str],
-    ) -> Tuple[str, List[str]]:
-        """Return (term_urn_str, asset_urns) for this term across all locations.
+        datahub_term_urn: Optional[str],
+    ) -> TermAssetLinks:
+        """Return the asset links for this term across all locations.
 
         De-duplicates asset URNs within the scan so the same asset is not
         returned more than once even if multiple location scans return it.
@@ -568,7 +619,7 @@ class DataplexGlossaryProcessor:
         )
 
         seen_asset_urns: set = set()
-        linked_asset_urns: List[str] = []
+        asset_links: List[AssetLink] = []
         for lookup_project_id, location in location_pairs:
             try:
                 links = self._lookup_entry_links(
@@ -605,9 +656,15 @@ class DataplexGlossaryProcessor:
                         continue
                     if asset_urn not in seen_asset_urns:
                         seen_asset_urns.add(asset_urn)
-                        linked_asset_urns.append(asset_urn)
+                        asset_links.append(
+                            AssetLink(asset_urn=asset_urn, entry_name=entry_name)
+                        )
 
-        return term_urn_str, linked_asset_urns
+        return TermAssetLinks(
+            native_term_urn=term_urn_str,
+            datahub_term_urn=datahub_term_urn,
+            asset_links=asset_links,
+        )
 
     def _lookup_entry_links(
         self, project_id: str, location: str, term_entry_path: str

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_glossary.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_glossary.py
@@ -159,6 +159,11 @@ class DataplexGlossaryReport(Report):
     glossary_terms_processed_samples: LossyList[str] = field(default_factory=LossyList)
     term_associations_emitted: int = 0
     terms_reconciled: int = 0
+    # Externally-authored (managed_by_datahub=false) term links recorded so the
+    # sync-back guard won't overwrite them. Counts the opposite of terms_reconciled;
+    # high volume with no reconciliation is expected in the pre-sync-back-deploy window.
+    external_term_links_recorded: int = 0
+    external_term_links_samples: LossyList[str] = field(default_factory=LossyList)
     glossary_api: Dict[str, Tuple[int, float]] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -192,6 +197,13 @@ class DataplexGlossaryReport(Report):
     def report_term_reconciled(self) -> None:
         with self._lock:
             self.terms_reconciled += 1
+
+    def report_external_term_link(self, entry_name: str, native_term_urn: str) -> None:
+        with self._lock:
+            self.external_term_links_recorded += 1
+            self.external_term_links_samples.append(
+                f"{entry_name} -> {native_term_urn}"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -356,6 +368,7 @@ class DataplexGlossaryProcessor:
                 exc=exc,
             )
             return
+        self._report.report_external_term_link(entry_name, native_term_urn)
         for mcp in mcps:
             yield MetadataWorkUnit(
                 id=f"platform_resource-{platform_resource.id}",

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
@@ -408,7 +408,7 @@ class _CommonFields:
 
 
 def _extract_common_fields(
-    entry: dataplex_v1.Entry, aspect_pattern: AllowDenyPattern
+    entry: dataplex_v1.Entry, aspect_type_pattern: AllowDenyPattern
 ) -> _CommonFields:
     entry_group_id = _extract_entry_group_id(entry.name)
     return _CommonFields(
@@ -417,7 +417,7 @@ def _extract_common_fields(
         created=_extract_datetime(entry, "create_time"),
         last_modified=_extract_datetime(entry, "update_time"),
         custom_properties=extract_entry_custom_properties(
-            entry, entry.name, entry_group_id, aspect_pattern
+            entry, entry.name, entry_group_id, aspect_type_pattern
         ),
     )
 
@@ -593,7 +593,7 @@ def build_dataset(
             fqn_regex, platform, entry.fully_qualified_name
         )
 
-    common = _extract_common_fields(entry, ctx.config.aspect_pattern)
+    common = _extract_common_fields(entry, ctx.config.aspect_type_pattern)
     # Only pass parent_container when resolved: the SDK emits an (empty)
     # browsePathsV2 aspect when the kwarg is provided even as None, so omitting
     # it preserves the exact emitted metadata. Two explicit calls (rather than a
@@ -713,7 +713,7 @@ def build_container(
             fqn_regex, platform, entry.fully_qualified_name
         )
 
-    common = _extract_common_fields(entry, ctx.config.aspect_pattern)
+    common = _extract_common_fields(entry, ctx.config.aspect_type_pattern)
     # container_parent_key is effectively always set here — the project key is
     # the fallback and only fails to build when the FQN is unparseable, in which
     # case the container key above already failed and we returned. Passed

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
@@ -33,6 +33,7 @@ from typing import Optional, Pattern, Union
 from google.cloud import dataplex_v1
 from typing_extensions import TypeAlias, assert_never
 
+from datahub.configuration.common import AllowDenyPattern
 from datahub.emitter.mce_builder import make_dataset_urn_with_platform_instance
 from datahub.ingestion.api.source import SourceReport
 from datahub.ingestion.source.common.subtypes import (
@@ -406,7 +407,9 @@ class _CommonFields:
     custom_properties: dict[str, str]
 
 
-def _extract_common_fields(entry: dataplex_v1.Entry) -> _CommonFields:
+def _extract_common_fields(
+    entry: dataplex_v1.Entry, aspect_pattern: AllowDenyPattern
+) -> _CommonFields:
     entry_group_id = _extract_entry_group_id(entry.name)
     return _CommonFields(
         display_name=_extract_display_name(entry),
@@ -414,7 +417,7 @@ def _extract_common_fields(entry: dataplex_v1.Entry) -> _CommonFields:
         created=_extract_datetime(entry, "create_time"),
         last_modified=_extract_datetime(entry, "update_time"),
         custom_properties=extract_entry_custom_properties(
-            entry, entry.name, entry_group_id
+            entry, entry.name, entry_group_id, aspect_pattern
         ),
     )
 
@@ -590,7 +593,7 @@ def build_dataset(
             fqn_regex, platform, entry.fully_qualified_name
         )
 
-    common = _extract_common_fields(entry)
+    common = _extract_common_fields(entry, ctx.config.aspect_pattern)
     # Only pass parent_container when resolved: the SDK emits an (empty)
     # browsePathsV2 aspect when the kwarg is provided even as None, so omitting
     # it preserves the exact emitted metadata. Two explicit calls (rather than a
@@ -710,7 +713,7 @@ def build_container(
             fqn_regex, platform, entry.fully_qualified_name
         )
 
-    common = _extract_common_fields(entry)
+    common = _extract_common_fields(entry, ctx.config.aspect_pattern)
     # container_parent_key is effectively always set here — the project key is
     # the fallback and only fails to build when the FQN is unparseable, in which
     # case the container key above already failed and we returned. Passed

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_mappers.py
@@ -82,6 +82,7 @@ from datahub.ingestion.source.dataplex.dataplex_ids import (
     parse_with_regex,
 )
 from datahub.ingestion.source.dataplex.dataplex_properties import (
+    AspectFilterReporter,
     extract_entry_custom_properties,
 )
 from datahub.ingestion.source.dataplex.dataplex_schema import (
@@ -112,6 +113,9 @@ class EntryMappingContext:
     config: DataplexConfig
     location: str
     report: SourceReport
+    # Optional counter for aspects dropped by aspect_type_pattern (see
+    # extract_entry_custom_properties). None in unit tests that build a bare context.
+    entries_report: Optional[AspectFilterReporter] = None
 
 
 @dataclass(frozen=True)
@@ -408,7 +412,9 @@ class _CommonFields:
 
 
 def _extract_common_fields(
-    entry: dataplex_v1.Entry, aspect_type_pattern: AllowDenyPattern
+    entry: dataplex_v1.Entry,
+    aspect_type_pattern: AllowDenyPattern,
+    report: Optional[AspectFilterReporter] = None,
 ) -> _CommonFields:
     entry_group_id = _extract_entry_group_id(entry.name)
     return _CommonFields(
@@ -417,7 +423,7 @@ def _extract_common_fields(
         created=_extract_datetime(entry, "create_time"),
         last_modified=_extract_datetime(entry, "update_time"),
         custom_properties=extract_entry_custom_properties(
-            entry, entry.name, entry_group_id, aspect_type_pattern
+            entry, entry.name, entry_group_id, aspect_type_pattern, report
         ),
     )
 
@@ -593,7 +599,9 @@ def build_dataset(
             fqn_regex, platform, entry.fully_qualified_name
         )
 
-    common = _extract_common_fields(entry, ctx.config.aspect_type_pattern)
+    common = _extract_common_fields(
+        entry, ctx.config.aspect_type_pattern, ctx.entries_report
+    )
     # Only pass parent_container when resolved: the SDK emits an (empty)
     # browsePathsV2 aspect when the kwarg is provided even as None, so omitting
     # it preserves the exact emitted metadata. Two explicit calls (rather than a
@@ -713,7 +721,9 @@ def build_container(
             fqn_regex, platform, entry.fully_qualified_name
         )
 
-    common = _extract_common_fields(entry, ctx.config.aspect_type_pattern)
+    common = _extract_common_fields(
+        entry, ctx.config.aspect_type_pattern, ctx.entries_report
+    )
     # container_parent_key is effectively always set here — the project key is
     # the fallback and only fails to build when the FQN is unparseable, in which
     # case the container key above already failed and we returned. Passed

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_platform_resource_repository.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_platform_resource_repository.py
@@ -1,0 +1,20 @@
+import logging
+
+from datahub.api.entities.external.external_entities import PlatformResourceRepository
+from datahub.ingestion.source.dataplex.dataplex_external_entities import (
+    DataplexAspectId,
+    DataplexAspectPlatformResource,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DataplexPlatformResourceRepository(
+    PlatformResourceRepository[DataplexAspectId, DataplexAspectPlatformResource]
+):
+    """Reads/writes the Dataplex sync-back platform-resource side-index.
+
+    ``get_resource_type()`` returns ``entity_class.__name__`` — i.e.
+    ``DataplexAspectPlatformResource`` — which is exactly the resource type the
+    sync-back wrote, so lookups match without extra configuration.
+    """

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_properties.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_properties.py
@@ -22,7 +22,10 @@ def extract_aspects_to_custom_properties(
         aspect_pattern: Allow/deny pattern matched against aspect type names
     """
     for aspect_key, aspect_value in aspects.items():
-        aspect_type = aspect_key.split("/")[-1]
+        # Dataplex aspect keys arrive as "<project>.<location>.<aspect_type>"
+        # (and occasionally as a ".../aspectTypes/<aspect_type>" path); take the
+        # final segment either way so the pattern matches the bare aspect type.
+        aspect_type = aspect_key.replace("/", ".").split(".")[-1]
         if not aspect_pattern.allowed(aspect_type):
             continue
         custom_properties[f"dataplex_aspect_{aspect_type}"] = aspect_type

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_properties.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_properties.py
@@ -4,20 +4,27 @@ from typing import Any, Mapping
 
 from google.cloud import dataplex_v1
 
+from datahub.configuration.common import AllowDenyPattern
 from datahub.ingestion.source.dataplex.dataplex_helpers import serialize_field_value
 
 
 def extract_aspects_to_custom_properties(
-    aspects: Mapping[Any, Any], custom_properties: dict[str, str]
+    aspects: Mapping[Any, Any],
+    custom_properties: dict[str, str],
+    aspect_pattern: AllowDenyPattern,
 ) -> None:
-    """Extract aspects as custom properties.
+    """Extract aspects as custom properties, skipping aspect types denied by
+    ``aspect_pattern`` (defaults to denying DataHub-authored ``datahub_*`` aspects).
 
     Args:
         aspects: Dictionary of aspects from entry
         custom_properties: Dictionary to update with aspect properties
+        aspect_pattern: Allow/deny pattern matched against aspect type names
     """
     for aspect_key, aspect_value in aspects.items():
         aspect_type = aspect_key.split("/")[-1]
+        if not aspect_pattern.allowed(aspect_type):
+            continue
         custom_properties[f"dataplex_aspect_{aspect_type}"] = aspect_type
 
         if hasattr(aspect_value, "data") and aspect_value.data:
@@ -27,7 +34,10 @@ def extract_aspects_to_custom_properties(
 
 
 def extract_entry_custom_properties(
-    entry: dataplex_v1.Entry, entry_id: str, entry_group_id: str
+    entry: dataplex_v1.Entry,
+    entry_id: str,
+    entry_group_id: str,
+    aspect_pattern: AllowDenyPattern,
 ) -> dict[str, str]:
     """Extract custom properties from a Dataplex entry.
 
@@ -35,6 +45,7 @@ def extract_entry_custom_properties(
         entry: Entry object from Catalog API
         entry_id: Entry ID
         entry_group_id: Entry group ID
+        aspect_pattern: Allow/deny pattern matched against aspect type names
 
     Returns:
         Dictionary of custom properties
@@ -61,6 +72,8 @@ def extract_entry_custom_properties(
             custom_properties["dataplex_source_platform"] = entry.entry_source.platform
 
     if entry.aspects:
-        extract_aspects_to_custom_properties(entry.aspects, custom_properties)
+        extract_aspects_to_custom_properties(
+            entry.aspects, custom_properties, aspect_pattern
+        )
 
     return custom_properties

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_properties.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_properties.py
@@ -11,22 +11,22 @@ from datahub.ingestion.source.dataplex.dataplex_helpers import serialize_field_v
 def extract_aspects_to_custom_properties(
     aspects: Mapping[Any, Any],
     custom_properties: dict[str, str],
-    aspect_pattern: AllowDenyPattern,
+    aspect_type_pattern: AllowDenyPattern,
 ) -> None:
     """Extract aspects as custom properties, skipping aspect types denied by
-    ``aspect_pattern`` (defaults to denying DataHub-authored ``datahub_*`` aspects).
+    ``aspect_type_pattern`` (defaults to denying DataHub-authored ``datahub-*`` aspects).
 
     Args:
         aspects: Dictionary of aspects from entry
         custom_properties: Dictionary to update with aspect properties
-        aspect_pattern: Allow/deny pattern matched against aspect type names
+        aspect_type_pattern: Allow/deny pattern matched against aspect type names
     """
     for aspect_key, aspect_value in aspects.items():
         # Dataplex aspect keys arrive as "<project>.<location>.<aspect_type>"
         # (and occasionally as a ".../aspectTypes/<aspect_type>" path); take the
         # final segment either way so the pattern matches the bare aspect type.
         aspect_type = aspect_key.replace("/", ".").split(".")[-1]
-        if not aspect_pattern.allowed(aspect_type):
+        if not aspect_type_pattern.allowed(aspect_type):
             continue
         custom_properties[f"dataplex_aspect_{aspect_type}"] = aspect_type
 
@@ -40,7 +40,7 @@ def extract_entry_custom_properties(
     entry: dataplex_v1.Entry,
     entry_id: str,
     entry_group_id: str,
-    aspect_pattern: AllowDenyPattern,
+    aspect_type_pattern: AllowDenyPattern,
 ) -> dict[str, str]:
     """Extract custom properties from a Dataplex entry.
 
@@ -48,7 +48,7 @@ def extract_entry_custom_properties(
         entry: Entry object from Catalog API
         entry_id: Entry ID
         entry_group_id: Entry group ID
-        aspect_pattern: Allow/deny pattern matched against aspect type names
+        aspect_type_pattern: Allow/deny pattern matched against aspect type names
 
     Returns:
         Dictionary of custom properties
@@ -76,7 +76,7 @@ def extract_entry_custom_properties(
 
     if entry.aspects:
         extract_aspects_to_custom_properties(
-            entry.aspects, custom_properties, aspect_pattern
+            entry.aspects, custom_properties, aspect_type_pattern
         )
 
     return custom_properties

--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_properties.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_properties.py
@@ -1,6 +1,6 @@
 """Custom properties extraction utilities for Dataplex source."""
 
-from typing import Any, Mapping
+from typing import Any, Mapping, Optional, Protocol
 
 from google.cloud import dataplex_v1
 
@@ -8,10 +8,21 @@ from datahub.configuration.common import AllowDenyPattern
 from datahub.ingestion.source.dataplex.dataplex_helpers import serialize_field_value
 
 
+class AspectFilterReporter(Protocol):
+    """Minimal report surface for counting aspects dropped by the deny pattern.
+
+    Typed as a Protocol so this module stays free of a report import (the entries
+    report imports the mappers, which import this module).
+    """
+
+    def report_filtered_aspect(self, aspect_type: str) -> None: ...
+
+
 def extract_aspects_to_custom_properties(
     aspects: Mapping[Any, Any],
     custom_properties: dict[str, str],
     aspect_type_pattern: AllowDenyPattern,
+    report: Optional[AspectFilterReporter] = None,
 ) -> None:
     """Extract aspects as custom properties, skipping aspect types denied by
     ``aspect_type_pattern`` (defaults to denying DataHub-authored ``datahub-*`` aspects).
@@ -20,6 +31,7 @@ def extract_aspects_to_custom_properties(
         aspects: Dictionary of aspects from entry
         custom_properties: Dictionary to update with aspect properties
         aspect_type_pattern: Allow/deny pattern matched against aspect type names
+        report: Optional reporter notified of each dropped aspect type
     """
     for aspect_key, aspect_value in aspects.items():
         # Dataplex aspect keys arrive as "<project>.<location>.<aspect_type>"
@@ -27,6 +39,8 @@ def extract_aspects_to_custom_properties(
         # final segment either way so the pattern matches the bare aspect type.
         aspect_type = aspect_key.replace("/", ".").split(".")[-1]
         if not aspect_type_pattern.allowed(aspect_type):
+            if report is not None:
+                report.report_filtered_aspect(aspect_type)
             continue
         custom_properties[f"dataplex_aspect_{aspect_type}"] = aspect_type
 
@@ -41,6 +55,7 @@ def extract_entry_custom_properties(
     entry_id: str,
     entry_group_id: str,
     aspect_type_pattern: AllowDenyPattern,
+    report: Optional[AspectFilterReporter] = None,
 ) -> dict[str, str]:
     """Extract custom properties from a Dataplex entry.
 
@@ -49,6 +64,7 @@ def extract_entry_custom_properties(
         entry_id: Entry ID
         entry_group_id: Entry group ID
         aspect_type_pattern: Allow/deny pattern matched against aspect type names
+        report: Optional reporter notified of each dropped aspect type
 
     Returns:
         Dictionary of custom properties
@@ -76,7 +92,7 @@ def extract_entry_custom_properties(
 
     if entry.aspects:
         extract_aspects_to_custom_properties(
-            entry.aspects, custom_properties, aspect_type_pattern
+            entry.aspects, custom_properties, aspect_type_pattern, report
         )
 
     return custom_properties

--- a/metadata-ingestion/tests/integration/dataplex/test_dataplex_glossary_reconcile.py
+++ b/metadata-ingestion/tests/integration/dataplex/test_dataplex_glossary_reconcile.py
@@ -189,7 +189,7 @@ def test_managed_term_reconciles_to_datahub_urn_and_suppresses_native_entity() -
     assert NATIVE_TERM_URN not in _entity_urns(glossary_workunits)
 
     # No new platform resource was written for an already-managed term.
-    repo.create.assert_not_called()
+    assert not any(wu.id.startswith("platform_resource-") for wu in assoc_workunits)
 
 
 def test_external_term_keeps_native_urn_and_records_unmanaged_resource() -> None:
@@ -207,4 +207,4 @@ def test_external_term_keeps_native_urn_and_records_unmanaged_resource() -> None
     assert NATIVE_TERM_URN in _entity_urns(glossary_workunits)
 
     # One unmanaged platform resource is recorded per linked asset.
-    repo.create.assert_called_once()
+    assert any(wu.id.startswith("platform_resource-") for wu in assoc_workunits)

--- a/metadata-ingestion/tests/integration/dataplex/test_dataplex_glossary_reconcile.py
+++ b/metadata-ingestion/tests/integration/dataplex/test_dataplex_glossary_reconcile.py
@@ -1,0 +1,210 @@
+"""Integration coverage for Dataplex glossary-term reconciliation.
+
+Drives the real ``DataplexGlossaryProcessor`` (both the glossary-listing phase and
+the term-asset association phase) against a mocked ``BusinessGlossaryServiceClient``
+and a mocked ``DataplexPlatformResourceRepository``, proving that:
+
+* a term reconciled to a DataHub-authored glossary term (managed_by_datahub=True)
+  has its native ``dataplex.{...}`` entity suppressed and is emitted on the linked
+  asset under the original DataHub URN, and
+* an externally-authored term is emitted as a native entity, appears on the linked
+  asset under its native URN, and is recorded as an unmanaged platform resource.
+
+This is intentionally a processor-level test (real reconciliation code, mocked
+GCP client + platform-resource repository) rather than a full-pipeline golden
+test, to keep it focused and non-brittle.
+"""
+
+from typing import List, Set, Tuple
+from unittest.mock import MagicMock, Mock
+
+from google.cloud import dataplex_v1
+
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.source.dataplex.dataplex_config import DataplexConfig
+from datahub.ingestion.source.dataplex.dataplex_context import DataplexContext
+from datahub.ingestion.source.dataplex.dataplex_external_entities import (
+    GLOSSARY_TERMS_ASPECT_KEY,
+    DataplexAspectId,
+    DataplexAspectPlatformResource,
+)
+from datahub.ingestion.source.dataplex.dataplex_glossary import (
+    DataplexGlossaryProcessor,
+    DataplexGlossaryReport,
+    _term_urn_id,
+)
+from datahub.ingestion.source.dataplex.dataplex_helpers import EntryDataTuple
+from datahub.metadata.schema_classes import GlossaryTermsClass
+from datahub.metadata.urns import GlossaryTermUrn
+
+PROJECT_ID = "my-project"
+GLOSSARY_LOCATION = "global"
+GLOSSARY_ID = "g1"
+TERM_ID = "pii"
+ASSET_ENTRY_NAME = (
+    "projects/my-project/locations/us/entryGroups/@bigquery/entries/"
+    "bigquery:my-project.dataset.customers"
+)
+ASSET_DATASET_URN = (
+    "urn:li:dataset:(urn:li:dataPlatform:bigquery,my-project.dataset.customers,PROD)"
+)
+MANAGED_DATAHUB_URN = "urn:li:glossaryTerm:pii"
+NATIVE_TERM_URN = str(
+    GlossaryTermUrn(_term_urn_id(PROJECT_ID, GLOSSARY_LOCATION, GLOSSARY_ID, TERM_ID))
+)
+
+
+def _make_config() -> DataplexConfig:
+    return DataplexConfig(
+        project_ids=[PROJECT_ID],
+        entries_locations=["us"],
+        glossary_locations=[GLOSSARY_LOCATION],
+        include_glossaries=True,
+        include_glossary_term_associations=True,
+    )
+
+
+def _make_ctx() -> DataplexContext:
+    ctx = DataplexContext(config=_make_config(), credentials=None)
+    ctx.project_numbers = {PROJECT_ID: "123456789"}
+    ctx.entry_data = [
+        EntryDataTuple(
+            dataplex_entry_short_name="customers",
+            dataplex_entry_name=ASSET_ENTRY_NAME,
+            dataplex_location="us",
+            dataplex_entry_type_short_name="bigquery-table",
+            dataplex_entry_fqn="bigquery:my-project.dataset.customers",
+            datahub_platform="bigquery",
+            datahub_dataset_name="my-project.dataset.customers",
+            datahub_dataset_urn=ASSET_DATASET_URN,
+        )
+    ]
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "entryLinks": [
+            {
+                "entryLinkType": (
+                    "projects/655216118709/locations/global/entryLinkTypes/definition"
+                ),
+                "entryReferences": [
+                    {"type": "SOURCE", "name": ASSET_ENTRY_NAME},
+                    {"type": "TARGET", "name": "term-entry-path"},
+                ],
+            }
+        ]
+    }
+    ctx.authed_session = Mock()
+    ctx.authed_session.get.return_value = mock_response
+    return ctx
+
+
+def _make_glossary_client() -> Mock:
+    glossary_client = Mock(spec=dataplex_v1.BusinessGlossaryServiceClient)
+
+    glossary = dataplex_v1.Glossary()
+    glossary.name = (
+        f"projects/{PROJECT_ID}/locations/{GLOSSARY_LOCATION}/glossaries/{GLOSSARY_ID}"
+    )
+    glossary.display_name = "G1"
+
+    term = dataplex_v1.GlossaryTerm()
+    term.name = f"{glossary.name}/terms/{TERM_ID}"
+    term.parent = glossary.name
+    term.display_name = "PII"
+
+    glossary_client.list_glossaries.return_value = [glossary]
+    glossary_client.list_glossary_categories.return_value = []
+    glossary_client.list_glossary_terms.return_value = [term]
+    return glossary_client
+
+
+def _entity_urns(workunits: List[MetadataWorkUnit]) -> Set[str]:
+    urns = set()
+    for wu in workunits:
+        assert isinstance(wu.metadata, MetadataChangeProposalWrapper)
+        assert wu.metadata.entityUrn is not None
+        urns.add(wu.metadata.entityUrn)
+    return urns
+
+
+def _run_processor(
+    repo: MagicMock,
+) -> Tuple[List[MetadataWorkUnit], List[MetadataWorkUnit]]:
+    ctx = _make_ctx()
+    processor = DataplexGlossaryProcessor(
+        ctx=ctx,
+        glossary_client=_make_glossary_client(),
+        report=DataplexGlossaryReport(),
+        source_report=Mock(),
+        platform_resource_repository=repo,
+    )
+    glossary_workunits = list(processor.process_glossaries([PROJECT_ID], max_workers=1))
+    assoc_workunits = list(
+        processor.process_term_associations([PROJECT_ID], max_workers=1)
+    )
+    return glossary_workunits, assoc_workunits
+
+
+def _glossary_terms_aspect_urns(assoc_workunits: List[MetadataWorkUnit]) -> List[str]:
+    glossary_terms_wu = next(
+        wu
+        for wu in assoc_workunits
+        if isinstance(wu.metadata, MetadataChangeProposalWrapper)
+        and wu.metadata.aspectName == "glossaryTerms"
+    )
+    assert isinstance(glossary_terms_wu.metadata, MetadataChangeProposalWrapper)
+    aspect = glossary_terms_wu.metadata.aspect
+    assert isinstance(aspect, GlossaryTermsClass)
+    return [t.urn for t in aspect.terms]
+
+
+def test_managed_term_reconciles_to_datahub_urn_and_suppresses_native_entity() -> None:
+    """Scenario A: term is DataHub-authored (managed_by_datahub=True)."""
+    repo = MagicMock()
+    entity_id = DataplexAspectId(
+        aspect_key=GLOSSARY_TERMS_ASPECT_KEY,
+        entry_name=ASSET_ENTRY_NAME,
+        field_key=MANAGED_DATAHUB_URN,
+    )
+    repo.search_entity_by_urn.return_value = entity_id
+    repo.get_entity_from_datahub.return_value = DataplexAspectPlatformResource(
+        managed_by_datahub=True,
+        datahub_urn=MANAGED_DATAHUB_URN,
+        aspect_key=GLOSSARY_TERMS_ASPECT_KEY,
+        entry_name=ASSET_ENTRY_NAME,
+        field_key=MANAGED_DATAHUB_URN,
+    )
+
+    glossary_workunits, assoc_workunits = _run_processor(repo)
+
+    # The asset's glossaryTerms aspect carries the original DataHub URN, not the
+    # native Dataplex one.
+    term_urns = _glossary_terms_aspect_urns(assoc_workunits)
+    assert term_urns == [MANAGED_DATAHUB_URN]
+    assert NATIVE_TERM_URN not in term_urns
+
+    # The native GlossaryTerm entity is suppressed (no MCP for it at all).
+    assert NATIVE_TERM_URN not in _entity_urns(glossary_workunits)
+
+    # No new platform resource was written for an already-managed term.
+    repo.create.assert_not_called()
+
+
+def test_external_term_keeps_native_urn_and_records_unmanaged_resource() -> None:
+    """Scenario B: term is externally-authored (no reconciliation match)."""
+    repo = MagicMock()
+    repo.search_entity_by_urn.return_value = None
+
+    glossary_workunits, assoc_workunits = _run_processor(repo)
+
+    # The asset's glossaryTerms aspect carries the native Dataplex URN.
+    term_urns = _glossary_terms_aspect_urns(assoc_workunits)
+    assert term_urns == [NATIVE_TERM_URN]
+
+    # The native GlossaryTerm entity IS emitted.
+    assert NATIVE_TERM_URN in _entity_urns(glossary_workunits)
+
+    # One unmanaged platform resource is recorded per linked asset.
+    repo.create.assert_called_once()

--- a/metadata-ingestion/tests/integration/dataplex/test_dataplex_glossary_reconcile.py
+++ b/metadata-ingestion/tests/integration/dataplex/test_dataplex_glossary_reconcile.py
@@ -131,12 +131,13 @@ def _entity_urns(workunits: List[MetadataWorkUnit]) -> Set[str]:
 
 def _run_processor(
     repo: MagicMock,
-) -> Tuple[List[MetadataWorkUnit], List[MetadataWorkUnit]]:
+) -> Tuple[List[MetadataWorkUnit], List[MetadataWorkUnit], DataplexGlossaryReport]:
     ctx = _make_ctx()
+    report = DataplexGlossaryReport()
     processor = DataplexGlossaryProcessor(
         ctx=ctx,
         glossary_client=_make_glossary_client(),
-        report=DataplexGlossaryReport(),
+        report=report,
         source_report=Mock(),
         platform_resource_repository=repo,
     )
@@ -144,7 +145,7 @@ def _run_processor(
     assoc_workunits = list(
         processor.process_term_associations([PROJECT_ID], max_workers=1)
     )
-    return glossary_workunits, assoc_workunits
+    return glossary_workunits, assoc_workunits, report
 
 
 def _glossary_terms_aspect_urns(assoc_workunits: List[MetadataWorkUnit]) -> List[str]:
@@ -177,7 +178,7 @@ def test_managed_term_reconciles_to_datahub_urn_and_suppresses_native_entity() -
         field_key=MANAGED_DATAHUB_URN,
     )
 
-    glossary_workunits, assoc_workunits = _run_processor(repo)
+    glossary_workunits, assoc_workunits, report = _run_processor(repo)
 
     # The asset's glossaryTerms aspect carries the original DataHub URN, not the
     # native Dataplex one.
@@ -190,6 +191,7 @@ def test_managed_term_reconciles_to_datahub_urn_and_suppresses_native_entity() -
 
     # No new platform resource was written for an already-managed term.
     assert not any(wu.id.startswith("platform_resource-") for wu in assoc_workunits)
+    assert report.external_term_links_recorded == 0
 
 
 def test_external_term_keeps_native_urn_and_records_unmanaged_resource() -> None:
@@ -197,7 +199,7 @@ def test_external_term_keeps_native_urn_and_records_unmanaged_resource() -> None
     repo = MagicMock()
     repo.search_entity_by_urn.return_value = None
 
-    glossary_workunits, assoc_workunits = _run_processor(repo)
+    glossary_workunits, assoc_workunits, report = _run_processor(repo)
 
     # The asset's glossaryTerms aspect carries the native Dataplex URN.
     term_urns = _glossary_terms_aspect_urns(assoc_workunits)
@@ -206,5 +208,9 @@ def test_external_term_keeps_native_urn_and_records_unmanaged_resource() -> None
     # The native GlossaryTerm entity IS emitted.
     assert NATIVE_TERM_URN in _entity_urns(glossary_workunits)
 
-    # One unmanaged platform resource is recorded per linked asset.
+    # One unmanaged platform resource is recorded per linked asset, and counted.
     assert any(wu.id.startswith("platform_resource-") for wu in assoc_workunits)
+    assert report.external_term_links_recorded == 1
+    assert list(report.external_term_links_samples) == [
+        f"{ASSET_ENTRY_NAME} -> {NATIVE_TERM_URN}"
+    ]

--- a/metadata-ingestion/tests/integration/dataplex/test_dataplex_integration.py
+++ b/metadata-ingestion/tests/integration/dataplex/test_dataplex_integration.py
@@ -155,6 +155,18 @@ def create_mock_entry_with_schema(
     return entry
 
 
+def _make_data_aspect(fields: Dict[str, str]) -> Mock:
+    """Mock a Dataplex aspect whose ``.data`` maps field keys to string values.
+
+    Used to attach non-schema aspects (a DataHub-authored ``datahub-*`` aspect
+    and a native harvested one) onto an entry, mirroring how ``.data.items()`` is
+    consumed by ``extract_aspects_to_custom_properties``.
+    """
+    aspect = Mock()
+    aspect.data = dict(fields)
+    return aspect
+
+
 @time_machine.travel(FROZEN_TIME, tick=False)
 @patch("google.auth.default")
 @patch("google.cloud.dataplex_v1.CatalogServiceClient")
@@ -359,6 +371,97 @@ def test_dataplex_empty_catalog(
 
     # Output file should exist but be empty or contain minimal data
     assert mcp_output_path.exists()
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+@patch("google.auth.default")
+@patch("google.cloud.dataplex_v1.CatalogServiceClient")
+@patch("google.cloud.datacatalog_lineage.LineageClient")
+def test_dataplex_native_description_round_trips_but_datahub_aspect_is_guarded(
+    mock_lineage_client_class,
+    mock_catalog_client_class,
+    mock_google_auth,
+    tmp_path,
+):
+    """Round-trip contrast for the 'ingest BigQuery via Dataplex + both sync-backs' setup.
+
+    The BigQuery description-sync action writes DataHub descriptions onto *native*
+    BigQuery columns, which Dataplex harvests into the schema aspect. Those are not
+    ``datahub-*`` aspects, so the loop guard does not cover them and they re-enter
+    DataHub on the next crawl. A Dataplex sync-back aspect (``datahub-*``) is
+    namespaced and must be suppressed by the default ``aspect_type_pattern`` deny.
+    """
+    mock_credentials = Mock()
+    mock_google_auth.return_value = (mock_credentials, "test-project")
+
+    mock_catalog_client = Mock()
+    mock_catalog_client_class.return_value = mock_catalog_client
+    mock_lineage_client = Mock()
+    mock_lineage_client_class.return_value = mock_lineage_client
+
+    mock_entry_group = create_mock_entry_group("test-project", "us", "@bigquery")
+
+    entry = create_mock_entry(
+        project_id="test-project",
+        location="us",
+        entry_group_id="@bigquery",
+        entry_id="customers",
+        fqn="bigquery:test-project.analytics.customers",
+        description="Customer master data table",
+    )
+    # Native schema aspect: the 'email' column description stands in for text the
+    # BigQuery description-sync action wrote onto the native column, which Dataplex
+    # harvests into the schema aspect (real 'dataplex-types.global.schema' key).
+    schema_aspect = Mock()
+    schema_aspect.data = {
+        "fields": [
+            {"name": "email", "type": "STRING", "description": "Synced from DataHub"}
+        ]
+    }
+    entry.aspects = {
+        "dataplex-types.global.schema": schema_aspect,
+        # A Dataplex sync-back aspect (datahub-*) alongside a native harvested aspect
+        # as a control that the guard is selective, not a blanket drop.
+        "test-project.global.datahub-tags": _make_data_aspect(
+            {"pii": "urn:li:tag:pii"}
+        ),
+        "test-project.global.overview": _make_data_aspect(
+            {"note": "harvested-by-dataplex"}
+        ),
+    }
+
+    mock_catalog_client.list_entry_groups.return_value = [mock_entry_group]
+    mock_catalog_client.list_entries.return_value = [entry]
+    mock_catalog_client.get_entry.side_effect = lambda request: entry
+
+    mcp_output_path = tmp_path / "dataplex_roundtrip_mces.json"
+    pipeline = run_and_get_pipeline(dataplex_entries_recipe(str(mcp_output_path)))
+    assert pipeline.source.get_report().failures == []
+
+    with open(mcp_output_path) as f:
+        mcps = json.load(f)
+
+    # 1. Native description round-trips: it lands on the schemaMetadata field,
+    #    proving the guard does not (and cannot) suppress a native harvested field.
+    email_fields = [
+        field
+        for mcp in mcps
+        if mcp.get("aspectName") == "schemaMetadata"
+        for field in mcp["aspect"]["json"]["fields"]
+        if field["fieldPath"] == "email"
+    ]
+    assert email_fields, "expected the 'email' schema field to be emitted"
+    assert email_fields[0]["description"] == "Synced from DataHub"
+
+    # 2. Dataplex sync-back aspect is guarded: no datahub-* aspect leaks into the
+    #    dataset custom properties, while the native 'overview' aspect passes through.
+    props_aspects = [m for m in mcps if m.get("aspectName") == "datasetProperties"]
+    assert props_aspects, "expected a datasetProperties aspect"
+    custom_props = props_aspects[0]["aspect"]["json"]["customProperties"]
+    assert not any("datahub-" in key for key in custom_props), (
+        f"datahub-* aspect leaked into custom properties: {sorted(custom_props)}"
+    )
+    assert "dataplex_aspect_overview" in custom_props
 
 
 def dataplex_lineage_recipe(

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_external_entities.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_external_entities.py
@@ -1,0 +1,38 @@
+from datahub.ingestion.source.dataplex.dataplex_external_entities import (
+    DATAPLEX_ASPECT_RESOURCE_TYPE,
+    DATAPLEX_PLATFORM,
+    GLOSSARY_TERMS_ASPECT_KEY,
+    DataplexAspectId,
+    DataplexAspectPlatformResource,
+)
+
+
+def test_platform_resource_key_matches_syncback_shape():
+    aspect_id = DataplexAspectId(
+        aspect_key=GLOSSARY_TERMS_ASPECT_KEY,
+        entry_name="projects/p/locations/l/entryGroups/@bigquery/entries/e",
+        field_key="urn:li:glossaryTerm:pii",
+    )
+    key = aspect_id.to_platform_resource_key()
+    assert key.platform == DATAPLEX_PLATFORM
+    assert key.resource_type == DATAPLEX_ASPECT_RESOURCE_TYPE
+    assert key.primary_key == (
+        "projects/p/locations/l/entryGroups/@bigquery/entries/e/"
+        "datahub-glossary-terms/urn:li:glossaryTerm:pii"
+    )
+
+
+def test_entity_exposes_linked_resource_and_managed_flag():
+    entity = DataplexAspectPlatformResource(
+        datahub_urn="urn:li:glossaryTerm:pii",
+        managed_by_datahub=True,
+        aspect_key=GLOSSARY_TERMS_ASPECT_KEY,
+        entry_name="projects/p/locations/l/entryGroups/@bigquery/entries/e",
+        field_key="urn:li:glossaryTerm:pii",
+    )
+    assert entity.is_managed_by_datahub()
+    assert entity.datahub_linked_resources().urns == ["urn:li:glossaryTerm:pii"]
+    assert isinstance(entity.get_id(), DataplexAspectId)
+    # Round-trips through PlatformResource with the term URN as a secondary key.
+    pr = entity.as_platform_resource()
+    assert pr.resource_info.secondary_keys == ["urn:li:glossaryTerm:pii"]

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_external_entities.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_external_entities.py
@@ -37,3 +37,17 @@ def test_entity_exposes_linked_resource_and_managed_flag():
     pr = entity.as_platform_resource()
     assert pr.resource_info is not None
     assert pr.resource_info.secondary_keys == ["urn:li:glossaryTerm:pii"]
+
+
+def test_default_entity_has_no_linked_resources():
+    # A not-yet-linked default entity must expose an empty linked-resource set,
+    # never [""] (which would let "" masquerade as a URN).
+    entity = DataplexAspectPlatformResource.create_default(
+        DataplexAspectId(
+            aspect_key=GLOSSARY_TERMS_ASPECT_KEY,
+            entry_name="e",
+            field_key="urn:li:glossaryTerm:x",
+        ),
+        managed_by_datahub=False,
+    )
+    assert entity.datahub_linked_resources().urns == []

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_external_entities.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_external_entities.py
@@ -35,4 +35,5 @@ def test_entity_exposes_linked_resource_and_managed_flag():
     assert isinstance(entity.get_id(), DataplexAspectId)
     # Round-trips through PlatformResource with the term URN as a secondary key.
     pr = entity.as_platform_resource()
+    assert pr.resource_info is not None
     assert pr.resource_info.secondary_keys == ["urn:li:glossaryTerm:pii"]

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_glossary.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_glossary.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from datahub.metadata.urns import GlossaryNodeUrn
+from datahub.metadata.urns import GlossaryNodeUrn, GlossaryTermUrn
 from google.cloud import dataplex_v1
 
 from datahub.ingestion.source.dataplex.dataplex_config import DataplexConfig
@@ -444,6 +444,86 @@ class TestProcessTermAssociations:
         assert processor._report.term_associations_emitted == 1
         assert len(workunits) > 0
 
+    def test_reconciled_term_substitutes_datahub_urn(
+        self,
+        processor: DataplexGlossaryProcessor,
+        ctx: DataplexContext,
+    ) -> None:
+        """A DataHub-authored term (datahub_term_urn set) must appear on the asset
+        under its original DataHub URN, and must not be recorded as an external link."""
+        self._setup_processor_with_terms(processor, ctx)
+        processor._emitted_terms[0].datahub_term_urn = "urn:li:glossaryTerm:pii"
+        repo = MagicMock()
+        processor._platform_resource_repository = repo
+        asset_entry_name = ctx.entry_data[0].dataplex_entry_name
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "entryLinks": [
+                {
+                    "entryLinkType": "projects/655216118709/locations/global/entryLinkTypes/definition",
+                    "entryReferences": [
+                        {"type": "SOURCE", "name": asset_entry_name},
+                    ],
+                }
+            ]
+        }
+
+        with patch.object(ctx, "authed_session") as mock_session:
+            mock_session.get.return_value = mock_response
+            workunits = list(
+                processor.process_term_associations(["my-project"], max_workers=1)
+            )
+
+        glossary_terms_wu = next(
+            wu for wu in workunits if wu.metadata.aspectName == "glossaryTerms"
+        )
+        term_urns = [t.urn for t in glossary_terms_wu.metadata.aspect.terms]
+        assert term_urns == ["urn:li:glossaryTerm:pii"]
+        repo.create.assert_not_called()
+
+    def test_external_term_uses_native_urn_and_records_link(
+        self,
+        processor: DataplexGlossaryProcessor,
+        ctx: DataplexContext,
+    ) -> None:
+        """An externally-authored term (datahub_term_urn unset) must appear under its
+        native Dataplex URN, and the link must be recorded as unmanaged."""
+        self._setup_processor_with_terms(processor, ctx)
+        repo = MagicMock()
+        processor._platform_resource_repository = repo
+        asset_entry_name = ctx.entry_data[0].dataplex_entry_name
+        native_term_urn = str(
+            GlossaryTermUrn(_term_urn_id("my-project", "global", "g1", "t1"))
+        )
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "entryLinks": [
+                {
+                    "entryLinkType": "projects/655216118709/locations/global/entryLinkTypes/definition",
+                    "entryReferences": [
+                        {"type": "SOURCE", "name": asset_entry_name},
+                    ],
+                }
+            ]
+        }
+
+        with patch.object(ctx, "authed_session") as mock_session:
+            mock_session.get.return_value = mock_response
+            workunits = list(
+                processor.process_term_associations(["my-project"], max_workers=1)
+            )
+
+        glossary_terms_wu = next(
+            wu for wu in workunits if wu.metadata.aspectName == "glossaryTerms"
+        )
+        term_urns = [t.urn for t in glossary_terms_wu.metadata.aspect.terms]
+        assert term_urns == [native_term_urn]
+        assert repo.create.call_count == 1
+
 
 # ---------------------------------------------------------------------------
 # Processor: term reconciliation
@@ -485,3 +565,21 @@ class TestReconcileTerm:
         assert _make_processor(repo)._reconcile_term("urn:li:glossaryTerm:x") is None
         # No repository at all -> no reconciliation.
         assert _make_processor(None)._reconcile_term("urn:li:glossaryTerm:x") is None
+
+
+class TestRecordExternalLink:
+    def test_records_external_link_when_not_managed(self) -> None:
+        repo = MagicMock()
+        proc = _make_processor(repo)
+        proc._record_external_link(
+            entry_name="projects/p/locations/l/entryGroups/@bigquery/entries/e",
+            native_term_urn="urn:li:glossaryTerm:dataplex.p.global.g.pii",
+        )
+        assert repo.create.call_count == 1
+
+    def test_no_external_write_without_repo(self) -> None:
+        proc = _make_processor(None)
+        # Must not raise when there is no repository.
+        proc._record_external_link(
+            entry_name="e", native_term_urn="urn:li:glossaryTerm:x"
+        )

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_glossary.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_glossary.py
@@ -1,12 +1,18 @@
 """Unit tests for Dataplex Business Glossary ingestion."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from datahub.metadata.urns import GlossaryNodeUrn
 from google.cloud import dataplex_v1
 
 from datahub.ingestion.source.dataplex.dataplex_config import DataplexConfig
 from datahub.ingestion.source.dataplex.dataplex_context import DataplexContext
+from datahub.ingestion.source.dataplex.dataplex_external_entities import (
+    GLOSSARY_TERMS_ASPECT_KEY,
+    DataplexAspectId,
+    DataplexAspectPlatformResource,
+)
 from datahub.ingestion.source.dataplex.dataplex_glossary import (
     DataplexGlossaryProcessor,
     DataplexGlossaryReport,
@@ -18,7 +24,6 @@ from datahub.ingestion.source.dataplex.dataplex_glossary import (
     _term_urn_id,
 )
 from datahub.ingestion.source.dataplex.dataplex_helpers import EntryDataTuple
-from datahub.metadata.urns import GlossaryNodeUrn
 
 # ---------------------------------------------------------------------------
 # URN helpers
@@ -438,3 +443,45 @@ class TestProcessTermAssociations:
         # One MCP emitted (one asset), not two (which would overwrite each other).
         assert processor._report.term_associations_emitted == 1
         assert len(workunits) > 0
+
+
+# ---------------------------------------------------------------------------
+# Processor: term reconciliation
+# ---------------------------------------------------------------------------
+
+
+def _make_processor(repo: Mock) -> DataplexGlossaryProcessor:
+    return DataplexGlossaryProcessor(
+        ctx=MagicMock(),
+        glossary_client=MagicMock(),
+        report=DataplexGlossaryReport(),
+        source_report=MagicMock(),
+        platform_resource_repository=repo,
+    )
+
+
+class TestReconcileTerm:
+    def test_reconcile_term_returns_original_when_managed(self) -> None:
+        repo = MagicMock()
+        native = "urn:li:glossaryTerm:dataplex.p.global.g.pii"
+        repo.search_entity_by_urn.return_value = DataplexAspectId(
+            aspect_key=GLOSSARY_TERMS_ASPECT_KEY,
+            entry_name="e",
+            field_key="urn:li:glossaryTerm:pii",
+        )
+        repo.get_entity_from_datahub.return_value = DataplexAspectPlatformResource(
+            datahub_urn="urn:li:glossaryTerm:pii",
+            managed_by_datahub=True,
+            aspect_key=GLOSSARY_TERMS_ASPECT_KEY,
+            entry_name="e",
+            field_key="urn:li:glossaryTerm:pii",
+        )
+        proc = _make_processor(repo)
+        assert proc._reconcile_term(native) == "urn:li:glossaryTerm:pii"
+
+    def test_reconcile_term_returns_none_when_unmanaged_or_missing(self) -> None:
+        repo = MagicMock()
+        repo.search_entity_by_urn.return_value = None
+        assert _make_processor(repo)._reconcile_term("urn:li:glossaryTerm:x") is None
+        # No repository at all -> no reconciliation.
+        assert _make_processor(None)._reconcile_term("urn:li:glossaryTerm:x") is None

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_glossary.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_glossary.py
@@ -3,7 +3,6 @@
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from datahub.metadata.urns import GlossaryNodeUrn, GlossaryTermUrn
 from google.cloud import dataplex_v1
 
 from datahub.ingestion.source.dataplex.dataplex_config import DataplexConfig
@@ -24,6 +23,7 @@ from datahub.ingestion.source.dataplex.dataplex_glossary import (
     _term_urn_id,
 )
 from datahub.ingestion.source.dataplex.dataplex_helpers import EntryDataTuple
+from datahub.metadata.urns import GlossaryNodeUrn, GlossaryTermUrn
 
 # ---------------------------------------------------------------------------
 # URN helpers
@@ -565,6 +565,21 @@ class TestReconcileTerm:
         assert _make_processor(repo)._reconcile_term("urn:li:glossaryTerm:x") is None
         # No repository at all -> no reconciliation.
         assert _make_processor(None)._reconcile_term("urn:li:glossaryTerm:x") is None
+
+    def test_reconcile_term_swallows_lookup_errors_and_warns(self) -> None:
+        repo = MagicMock()
+        repo.search_entity_by_urn.side_effect = Exception("boom")
+        source_report = MagicMock()
+        proc = DataplexGlossaryProcessor(
+            ctx=MagicMock(),
+            glossary_client=MagicMock(),
+            report=DataplexGlossaryReport(),
+            source_report=source_report,
+            platform_resource_repository=repo,
+        )
+        result = proc._reconcile_term("urn:li:glossaryTerm:whatever")
+        assert result is None
+        assert source_report.warning.called
 
 
 class TestRecordExternalLink:

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_glossary.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_glossary.py
@@ -482,7 +482,8 @@ class TestProcessTermAssociations:
 
         term_urns = _glossary_term_urns(workunits)
         assert term_urns == ["urn:li:glossaryTerm:pii"]
-        repo.create.assert_not_called()
+        # DataHub-authored term: no external-ownership marker emitted.
+        assert not _platform_resource_wus(workunits)
 
     def test_external_term_uses_native_urn_and_records_link(
         self,
@@ -520,7 +521,8 @@ class TestProcessTermAssociations:
 
         term_urns = _glossary_term_urns(workunits)
         assert term_urns == [native_term_urn]
-        assert repo.create.call_count == 1
+        # External term: an unmanaged platform-resource marker is emitted (workunit).
+        assert _platform_resource_wus(workunits)
 
 
 # ---------------------------------------------------------------------------
@@ -539,6 +541,13 @@ def _glossary_term_urns(workunits: List[MetadataWorkUnit]) -> List[str]:
             assert isinstance(aspect, GlossaryTermsClass)
             return [t.urn for t in aspect.terms]
     raise AssertionError("no glossaryTerms workunit emitted")
+
+
+def _platform_resource_wus(
+    workunits: List[MetadataWorkUnit],
+) -> List[MetadataWorkUnit]:
+    """The emitted managed_by_datahub=false platform-resource marker workunits."""
+    return [wu for wu in workunits if wu.id.startswith("platform_resource-")]
 
 
 def _make_processor(repo: Optional[Mock]) -> DataplexGlossaryProcessor:
@@ -592,20 +601,61 @@ class TestReconcileTerm:
         assert result is None
         assert source_report.warning.called
 
+    def test_reconcile_term_returns_none_when_found_but_unmanaged(self) -> None:
+        native = "urn:li:glossaryTerm:dataplex.p.global.g.native"
+        repo = MagicMock()
+        repo.search_entity_by_urn.return_value = DataplexAspectId(
+            aspect_key=GLOSSARY_TERMS_ASPECT_KEY, entry_name="e", field_key=native
+        )
+        repo.get_entity_from_datahub.return_value = DataplexAspectPlatformResource(
+            datahub_urn=native,
+            managed_by_datahub=False,
+            aspect_key=GLOSSARY_TERMS_ASPECT_KEY,
+            entry_name="e",
+            field_key=native,
+        )
+        assert _make_processor(repo)._reconcile_term(native) is None
+
 
 class TestRecordExternalLink:
     def test_records_external_link_when_not_managed(self) -> None:
         repo = MagicMock()
         proc = _make_processor(repo)
-        proc._record_external_link(
-            entry_name="projects/p/locations/l/entryGroups/@bigquery/entries/e",
-            native_term_urn="urn:li:glossaryTerm:dataplex.p.global.g.pii",
+        wus = list(
+            proc._record_external_link(
+                entry_name="projects/p/locations/l/entryGroups/@bigquery/entries/e",
+                native_term_urn="urn:li:glossaryTerm:dataplex.p.global.g.pii",
+            )
         )
-        assert repo.create.call_count == 1
+        assert len(wus) >= 1
+        assert all(wu.id.startswith("platform_resource-") for wu in wus)
+        # Emitted as workunits, not written directly to the graph.
+        repo.create.assert_not_called()
 
     def test_no_external_write_without_repo(self) -> None:
         proc = _make_processor(None)
-        # Must not raise when there is no repository.
-        proc._record_external_link(
-            entry_name="e", native_term_urn="urn:li:glossaryTerm:x"
+        # No repository -> no workunits, and must not raise.
+        wus = list(
+            proc._record_external_link(
+                entry_name="e", native_term_urn="urn:li:glossaryTerm:x"
+            )
         )
+        assert wus == []
+
+
+class TestNormalizeEntryProjectId:
+    def test_maps_project_number_prefix_to_id(self) -> None:
+        proc = _make_processor(None)
+        proc._ctx.project_numbers = {"my-project": "123456789"}
+        result = proc._normalize_entry_project_id(
+            "projects/123456789/locations/us/entryGroups/@bigquery/entries/foo"
+        )
+        assert result == (
+            "projects/my-project/locations/us/entryGroups/@bigquery/entries/foo"
+        )
+
+    def test_returns_unchanged_when_no_number_matches(self) -> None:
+        proc = _make_processor(None)
+        proc._ctx.project_numbers = {"my-project": "123456789"}
+        entry = "projects/my-project/locations/us/entryGroups/@bigquery/entries/foo"
+        assert proc._normalize_entry_project_id(entry) == entry

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_glossary.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_glossary.py
@@ -1,10 +1,13 @@
 """Unit tests for Dataplex Business Glossary ingestion."""
 
+from typing import List, Optional
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from google.cloud import dataplex_v1
 
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.dataplex.dataplex_config import DataplexConfig
 from datahub.ingestion.source.dataplex.dataplex_context import DataplexContext
 from datahub.ingestion.source.dataplex.dataplex_external_entities import (
@@ -23,6 +26,7 @@ from datahub.ingestion.source.dataplex.dataplex_glossary import (
     _term_urn_id,
 )
 from datahub.ingestion.source.dataplex.dataplex_helpers import EntryDataTuple
+from datahub.metadata.schema_classes import GlossaryTermsClass
 from datahub.metadata.urns import GlossaryNodeUrn, GlossaryTermUrn
 
 # ---------------------------------------------------------------------------
@@ -476,10 +480,7 @@ class TestProcessTermAssociations:
                 processor.process_term_associations(["my-project"], max_workers=1)
             )
 
-        glossary_terms_wu = next(
-            wu for wu in workunits if wu.metadata.aspectName == "glossaryTerms"
-        )
-        term_urns = [t.urn for t in glossary_terms_wu.metadata.aspect.terms]
+        term_urns = _glossary_term_urns(workunits)
         assert term_urns == ["urn:li:glossaryTerm:pii"]
         repo.create.assert_not_called()
 
@@ -517,10 +518,7 @@ class TestProcessTermAssociations:
                 processor.process_term_associations(["my-project"], max_workers=1)
             )
 
-        glossary_terms_wu = next(
-            wu for wu in workunits if wu.metadata.aspectName == "glossaryTerms"
-        )
-        term_urns = [t.urn for t in glossary_terms_wu.metadata.aspect.terms]
+        term_urns = _glossary_term_urns(workunits)
         assert term_urns == [native_term_urn]
         assert repo.create.call_count == 1
 
@@ -530,7 +528,20 @@ class TestProcessTermAssociations:
 # ---------------------------------------------------------------------------
 
 
-def _make_processor(repo: Mock) -> DataplexGlossaryProcessor:
+def _glossary_term_urns(workunits: List[MetadataWorkUnit]) -> List[str]:
+    """Extract the term URNs from the single glossaryTerms workunit (with narrowing)."""
+    for wu in workunits:
+        mcp = wu.metadata
+        if isinstance(mcp, MetadataChangeProposalWrapper) and mcp.aspectName == (
+            "glossaryTerms"
+        ):
+            aspect = mcp.aspect
+            assert isinstance(aspect, GlossaryTermsClass)
+            return [t.urn for t in aspect.terms]
+    raise AssertionError("no glossaryTerms workunit emitted")
+
+
+def _make_processor(repo: Optional[Mock]) -> DataplexGlossaryProcessor:
     return DataplexGlossaryProcessor(
         ctx=MagicMock(),
         glossary_client=MagicMock(),

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_properties.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_properties.py
@@ -5,10 +5,13 @@ from unittest.mock import Mock
 
 from google.cloud import dataplex_v1
 
+from datahub.configuration.common import AllowDenyPattern
 from datahub.ingestion.source.dataplex.dataplex_properties import (
     extract_aspects_to_custom_properties,
     extract_entry_custom_properties,
 )
+
+ALLOW_ALL_ASPECTS = AllowDenyPattern.allow_all()
 
 
 class TestExtractAspectsToCustomProperties:
@@ -31,7 +34,9 @@ class TestExtractAspectsToCustomProperties:
             "dataplex.googleapis.com/partition": aspect_value,
         }
 
-        extract_aspects_to_custom_properties(aspects, custom_properties)
+        extract_aspects_to_custom_properties(
+            aspects, custom_properties, aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         # Check aspect type properties
         assert "dataplex_aspect_schema" in custom_properties
@@ -56,7 +61,9 @@ class TestExtractAspectsToCustomProperties:
             "dataplex.googleapis.com/schema": aspect_value,
         }
 
-        extract_aspects_to_custom_properties(aspects, custom_properties)
+        extract_aspects_to_custom_properties(
+            aspects, custom_properties, aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         # Should still have aspect type property
         assert "dataplex_aspect_schema" in custom_properties
@@ -77,7 +84,9 @@ class TestExtractAspectsToCustomProperties:
             "dataplex.googleapis.com/schema": aspect_value,
         }
 
-        extract_aspects_to_custom_properties(aspects, custom_properties)
+        extract_aspects_to_custom_properties(
+            aspects, custom_properties, aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         # Should have aspect type property
         assert "dataplex_aspect_schema" in custom_properties
@@ -98,7 +107,9 @@ class TestExtractAspectsToCustomProperties:
             "dataplex.googleapis.com/schema": aspect_value,
         }
 
-        extract_aspects_to_custom_properties(aspects, custom_properties)
+        extract_aspects_to_custom_properties(
+            aspects, custom_properties, aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         # Should have aspect type property
         assert "dataplex_aspect_schema" in custom_properties
@@ -118,7 +129,9 @@ class TestExtractAspectsToCustomProperties:
             "projects/test-project/locations/us/entryGroups/@bigquery/aspects/complex_type": aspect_value,
         }
 
-        extract_aspects_to_custom_properties(aspects, custom_properties)
+        extract_aspects_to_custom_properties(
+            aspects, custom_properties, aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         # Should extract the last part of the path as aspect type
         assert "dataplex_aspect_complex_type" in custom_properties
@@ -138,7 +151,9 @@ class TestExtractAspectsToCustomProperties:
             "dataplex.googleapis.com/schema": aspect_value,
         }
 
-        extract_aspects_to_custom_properties(aspects, custom_properties)
+        extract_aspects_to_custom_properties(
+            aspects, custom_properties, aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         # Should preserve existing keys
         assert "existing_key" in custom_properties
@@ -185,7 +200,9 @@ class TestExtractEntryCustomProperties:
             entry_type="TABLE",
         )
 
-        result = extract_entry_custom_properties(entry, "my_table", "@bigquery")
+        result = extract_entry_custom_properties(
+            entry, "my_table", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         assert result["dataplex_ingested"] == "true"
         assert result["dataplex_entry_id"] == "my_table"
@@ -200,7 +217,9 @@ class TestExtractEntryCustomProperties:
         """Test extracting entry properties without entry_type."""
         entry = self.create_mock_entry(entry_type=None)
 
-        result = extract_entry_custom_properties(entry, "test_entry", "@bigquery")
+        result = extract_entry_custom_properties(
+            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         assert "dataplex_entry_type" not in result
         assert result["dataplex_ingested"] == "true"
@@ -209,7 +228,9 @@ class TestExtractEntryCustomProperties:
         """Test extracting entry with parent_entry."""
         entry = self.create_mock_entry(parent_entry="parent_entry_id")
 
-        result = extract_entry_custom_properties(entry, "test_entry", "@bigquery")
+        result = extract_entry_custom_properties(
+            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         assert result["dataplex_parent_entry"] == "parent_entry_id"
 
@@ -220,7 +241,9 @@ class TestExtractEntryCustomProperties:
         if hasattr(entry, "parent_entry"):
             delattr(entry, "parent_entry")
 
-        result = extract_entry_custom_properties(entry, "test_entry", "@bigquery")
+        result = extract_entry_custom_properties(
+            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         assert "dataplex_parent_entry" not in result
 
@@ -230,7 +253,9 @@ class TestExtractEntryCustomProperties:
         entry_source.resource = "projects/test-project/datasets/my_dataset"
         entry = self.create_mock_entry(entry_source=entry_source)
 
-        result = extract_entry_custom_properties(entry, "test_entry", "@bigquery")
+        result = extract_entry_custom_properties(
+            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         assert (
             result["dataplex_source_resource"]
@@ -243,7 +268,9 @@ class TestExtractEntryCustomProperties:
         entry_source.system = "BIGQUERY"
         entry = self.create_mock_entry(entry_source=entry_source)
 
-        result = extract_entry_custom_properties(entry, "test_entry", "@bigquery")
+        result = extract_entry_custom_properties(
+            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         assert result["dataplex_source_system"] == "BIGQUERY"
 
@@ -253,7 +280,9 @@ class TestExtractEntryCustomProperties:
         entry_source.platform = "GCP"
         entry = self.create_mock_entry(entry_source=entry_source)
 
-        result = extract_entry_custom_properties(entry, "test_entry", "@bigquery")
+        result = extract_entry_custom_properties(
+            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         assert result["dataplex_source_platform"] == "GCP"
 
@@ -265,7 +294,9 @@ class TestExtractEntryCustomProperties:
         entry_source.platform = "GCP"
         entry = self.create_mock_entry(entry_source=entry_source)
 
-        result = extract_entry_custom_properties(entry, "test_entry", "@bigquery")
+        result = extract_entry_custom_properties(
+            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         assert (
             result["dataplex_source_resource"]
@@ -280,7 +311,9 @@ class TestExtractEntryCustomProperties:
         # Explicitly set entry_source to None to test the None case
         entry.entry_source = None  # type: ignore[assignment]
 
-        result = extract_entry_custom_properties(entry, "test_entry", "@bigquery")
+        result = extract_entry_custom_properties(
+            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         # Should still have basic properties
         assert result["dataplex_ingested"] == "true"
@@ -301,7 +334,9 @@ class TestExtractEntryCustomProperties:
             delattr(entry_source, "platform")
         entry = self.create_mock_entry(entry_source=entry_source)
 
-        result = extract_entry_custom_properties(entry, "test_entry", "@bigquery")
+        result = extract_entry_custom_properties(
+            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         assert "dataplex_source_resource" not in result
         assert "dataplex_source_system" not in result
@@ -318,7 +353,9 @@ class TestExtractEntryCustomProperties:
 
         entry = self.create_mock_entry(aspects=aspects)
 
-        result = extract_entry_custom_properties(entry, "test_entry", "@bigquery")
+        result = extract_entry_custom_properties(
+            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         # Should have aspect properties
         assert "dataplex_aspect_schema" in result
@@ -329,7 +366,34 @@ class TestExtractEntryCustomProperties:
         """Test extracting entry without aspects."""
         entry = self.create_mock_entry(aspects=None)
 
-        result = extract_entry_custom_properties(entry, "test_entry", "@bigquery")
+        result = extract_entry_custom_properties(
+            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+        )
 
         # Should not have aspect properties
         assert "dataplex_aspect_schema" not in result
+
+
+class _FakeAspectValue:
+    def __init__(self, data):
+        self.data = data
+
+
+def test_aspect_pattern_denies_datahub_authored_aspects():
+    aspects = {
+        "projects/p/locations/l/aspectTypes/datahub_tags": _FakeAspectValue(
+            {"pii": "urn:li:tag:pii"}
+        ),
+        "projects/p/locations/l/aspectTypes/business_metadata": _FakeAspectValue(
+            {"team": "growth"}
+        ),
+    }
+    props: dict = {}
+    extract_aspects_to_custom_properties(
+        aspects, props, aspect_pattern=AllowDenyPattern(deny=["datahub_.*"])
+    )
+    # DataHub-authored aspect is filtered out entirely...
+    assert not any(k.startswith("dataplex_datahub_tags") for k in props)
+    assert "dataplex_aspect_datahub_tags" not in props
+    # ...but a genuine native aspect is still flattened.
+    assert props["dataplex_business_metadata_team"] == "growth"

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_properties.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_properties.py
@@ -380,20 +380,18 @@ class _FakeAspectValue:
 
 
 def test_aspect_pattern_denies_datahub_authored_aspects():
+    # Real Dataplex aspect keys are "<project>.<location>.<aspect_type>", and the
+    # sync-back uses hyphenated type ids (Dataplex forbids underscores).
     aspects = {
-        "projects/p/locations/l/aspectTypes/datahub_tags": _FakeAspectValue(
-            {"pii": "urn:li:tag:pii"}
-        ),
-        "projects/p/locations/l/aspectTypes/business_metadata": _FakeAspectValue(
-            {"team": "growth"}
-        ),
+        "my-project.global.datahub-tags": _FakeAspectValue({"pii": "urn:li:tag:pii"}),
+        "my-project.global.business-metadata": _FakeAspectValue({"team": "growth"}),
     }
-    props: dict = {}
+    props: dict[str, str] = {}
     extract_aspects_to_custom_properties(
-        aspects, props, aspect_pattern=AllowDenyPattern(deny=["datahub_.*"])
+        aspects, props, aspect_pattern=AllowDenyPattern(deny=["datahub-.*"])
     )
     # DataHub-authored aspect is filtered out entirely...
-    assert not any(k.startswith("dataplex_datahub_tags") for k in props)
-    assert "dataplex_aspect_datahub_tags" not in props
-    # ...but a genuine native aspect is still flattened.
-    assert props["dataplex_business_metadata_team"] == "growth"
+    assert not any(k.startswith("dataplex_datahub-tags") for k in props)
+    assert "dataplex_aspect_datahub-tags" not in props
+    # ...but a genuine native aspect is still flattened (matched by bare type name).
+    assert props["dataplex_business-metadata_team"] == "growth"

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_properties.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_properties.py
@@ -35,7 +35,7 @@ class TestExtractAspectsToCustomProperties:
         }
 
         extract_aspects_to_custom_properties(
-            aspects, custom_properties, aspect_pattern=ALLOW_ALL_ASPECTS
+            aspects, custom_properties, aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         # Check aspect type properties
@@ -62,7 +62,7 @@ class TestExtractAspectsToCustomProperties:
         }
 
         extract_aspects_to_custom_properties(
-            aspects, custom_properties, aspect_pattern=ALLOW_ALL_ASPECTS
+            aspects, custom_properties, aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         # Should still have aspect type property
@@ -85,7 +85,7 @@ class TestExtractAspectsToCustomProperties:
         }
 
         extract_aspects_to_custom_properties(
-            aspects, custom_properties, aspect_pattern=ALLOW_ALL_ASPECTS
+            aspects, custom_properties, aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         # Should have aspect type property
@@ -108,7 +108,7 @@ class TestExtractAspectsToCustomProperties:
         }
 
         extract_aspects_to_custom_properties(
-            aspects, custom_properties, aspect_pattern=ALLOW_ALL_ASPECTS
+            aspects, custom_properties, aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         # Should have aspect type property
@@ -130,7 +130,7 @@ class TestExtractAspectsToCustomProperties:
         }
 
         extract_aspects_to_custom_properties(
-            aspects, custom_properties, aspect_pattern=ALLOW_ALL_ASPECTS
+            aspects, custom_properties, aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         # Should extract the last part of the path as aspect type
@@ -152,7 +152,7 @@ class TestExtractAspectsToCustomProperties:
         }
 
         extract_aspects_to_custom_properties(
-            aspects, custom_properties, aspect_pattern=ALLOW_ALL_ASPECTS
+            aspects, custom_properties, aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         # Should preserve existing keys
@@ -201,7 +201,7 @@ class TestExtractEntryCustomProperties:
         )
 
         result = extract_entry_custom_properties(
-            entry, "my_table", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+            entry, "my_table", "@bigquery", aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         assert result["dataplex_ingested"] == "true"
@@ -218,7 +218,7 @@ class TestExtractEntryCustomProperties:
         entry = self.create_mock_entry(entry_type=None)
 
         result = extract_entry_custom_properties(
-            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+            entry, "test_entry", "@bigquery", aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         assert "dataplex_entry_type" not in result
@@ -229,7 +229,7 @@ class TestExtractEntryCustomProperties:
         entry = self.create_mock_entry(parent_entry="parent_entry_id")
 
         result = extract_entry_custom_properties(
-            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+            entry, "test_entry", "@bigquery", aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         assert result["dataplex_parent_entry"] == "parent_entry_id"
@@ -242,7 +242,7 @@ class TestExtractEntryCustomProperties:
             delattr(entry, "parent_entry")
 
         result = extract_entry_custom_properties(
-            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+            entry, "test_entry", "@bigquery", aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         assert "dataplex_parent_entry" not in result
@@ -254,7 +254,7 @@ class TestExtractEntryCustomProperties:
         entry = self.create_mock_entry(entry_source=entry_source)
 
         result = extract_entry_custom_properties(
-            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+            entry, "test_entry", "@bigquery", aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         assert (
@@ -269,7 +269,7 @@ class TestExtractEntryCustomProperties:
         entry = self.create_mock_entry(entry_source=entry_source)
 
         result = extract_entry_custom_properties(
-            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+            entry, "test_entry", "@bigquery", aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         assert result["dataplex_source_system"] == "BIGQUERY"
@@ -281,7 +281,7 @@ class TestExtractEntryCustomProperties:
         entry = self.create_mock_entry(entry_source=entry_source)
 
         result = extract_entry_custom_properties(
-            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+            entry, "test_entry", "@bigquery", aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         assert result["dataplex_source_platform"] == "GCP"
@@ -295,7 +295,7 @@ class TestExtractEntryCustomProperties:
         entry = self.create_mock_entry(entry_source=entry_source)
 
         result = extract_entry_custom_properties(
-            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+            entry, "test_entry", "@bigquery", aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         assert (
@@ -312,7 +312,7 @@ class TestExtractEntryCustomProperties:
         entry.entry_source = None  # type: ignore[assignment]
 
         result = extract_entry_custom_properties(
-            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+            entry, "test_entry", "@bigquery", aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         # Should still have basic properties
@@ -335,7 +335,7 @@ class TestExtractEntryCustomProperties:
         entry = self.create_mock_entry(entry_source=entry_source)
 
         result = extract_entry_custom_properties(
-            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+            entry, "test_entry", "@bigquery", aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         assert "dataplex_source_resource" not in result
@@ -354,7 +354,7 @@ class TestExtractEntryCustomProperties:
         entry = self.create_mock_entry(aspects=aspects)
 
         result = extract_entry_custom_properties(
-            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+            entry, "test_entry", "@bigquery", aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         # Should have aspect properties
@@ -367,7 +367,7 @@ class TestExtractEntryCustomProperties:
         entry = self.create_mock_entry(aspects=None)
 
         result = extract_entry_custom_properties(
-            entry, "test_entry", "@bigquery", aspect_pattern=ALLOW_ALL_ASPECTS
+            entry, "test_entry", "@bigquery", aspect_type_pattern=ALLOW_ALL_ASPECTS
         )
 
         # Should not have aspect properties
@@ -379,7 +379,7 @@ class _FakeAspectValue:
         self.data = data
 
 
-def test_aspect_pattern_denies_datahub_authored_aspects():
+def test_aspect_type_pattern_denies_datahub_authored_aspects():
     # Real Dataplex aspect keys are "<project>.<location>.<aspect_type>", and the
     # sync-back uses hyphenated type ids (Dataplex forbids underscores).
     aspects = {
@@ -388,7 +388,7 @@ def test_aspect_pattern_denies_datahub_authored_aspects():
     }
     props: dict[str, str] = {}
     extract_aspects_to_custom_properties(
-        aspects, props, aspect_pattern=AllowDenyPattern(deny=["datahub-.*"])
+        aspects, props, aspect_type_pattern=AllowDenyPattern(deny=["datahub-.*"])
     )
     # DataHub-authored aspect is filtered out entirely...
     assert not any(k.startswith("dataplex_datahub-tags") for k in props)

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_properties.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_properties.py
@@ -387,11 +387,22 @@ def test_aspect_type_pattern_denies_datahub_authored_aspects():
         "my-project.global.business-metadata": _FakeAspectValue({"team": "growth"}),
     }
     props: dict[str, str] = {}
+    filtered: list[str] = []
+
+    class _Report:
+        def report_filtered_aspect(self, aspect_type: str) -> None:
+            filtered.append(aspect_type)
+
     extract_aspects_to_custom_properties(
-        aspects, props, aspect_type_pattern=AllowDenyPattern(deny=["datahub-.*"])
+        aspects,
+        props,
+        aspect_type_pattern=AllowDenyPattern(deny=["datahub-.*"]),
+        report=_Report(),
     )
     # DataHub-authored aspect is filtered out entirely...
     assert not any(k.startswith("dataplex_datahub-tags") for k in props)
     assert "dataplex_aspect_datahub-tags" not in props
     # ...but a genuine native aspect is still flattened (matched by bare type name).
     assert props["dataplex_business-metadata_team"] == "growth"
+    # ...and the dropped aspect type is surfaced to the report.
+    assert filtered == ["datahub-tags"]

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_source.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_source.py
@@ -676,16 +676,33 @@ def test_platform_resource_repository_none_without_graph() -> None:
     """When the pipeline has no DataHub graph connection (no datahub-rest sink
     or stateful ingestion), the source must not build a platform resource
     repository, since there is nowhere to reconcile against."""
-    from datahub.ingestion.api.common import PipelineContext
-
     config = DataplexConfig(
         project_ids=["project-1"],
         include_lineage=False,
         include_glossaries=False,
+        enable_stateful_lineage_ingestion=False,
     )
-    ctx = PipelineContext(run_id="t")  # no graph
+    ctx = Mock()
+    ctx.graph = None  # no DataHub graph connection
 
-    source = DataplexSource(ctx=ctx, config=config)
+    with (
+        patch(
+            "datahub.ingestion.source.dataplex.dataplex.StatefulIngestionSourceBase.__init__",
+            autospec=True,
+            side_effect=lambda source, _config, _ctx: setattr(source, "ctx", _ctx),
+        ),
+        patch(
+            "datahub.ingestion.source.dataplex.dataplex.dataplex_v1.CatalogServiceClient"
+        ),
+        patch(
+            "datahub.ingestion.source.dataplex.dataplex.google.auth.default",
+            return_value=(Mock(), "project-1"),
+        ),
+        patch(
+            "datahub.ingestion.source.dataplex.dataplex.google.auth.transport.requests.AuthorizedSession"
+        ),
+    ):
+        source = DataplexSource(ctx, config)
 
     assert source.platform_resource_repository is None
 

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_source.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_source.py
@@ -125,11 +125,13 @@ def test_source_init_without_lineage_sets_lineage_members_to_none() -> None:
         enable_stateful_lineage_ingestion=False,
     )
     ctx = Mock()
+    ctx.graph = None
 
     with (
         patch(
             "datahub.ingestion.source.dataplex.dataplex.StatefulIngestionSourceBase.__init__",
-            return_value=None,
+            autospec=True,
+            side_effect=lambda source, _config, _ctx: setattr(source, "ctx", _ctx),
         ),
         patch(
             "datahub.ingestion.source.dataplex.dataplex.dataplex_v1.CatalogServiceClient"
@@ -668,6 +670,24 @@ def test_get_workunits_internal_with_empty_resolved_projects() -> None:
     source.entries_processor.process_entries.assert_called_once_with(
         project_ids=[], max_workers=source.config.max_workers_entries
     )
+
+
+def test_platform_resource_repository_none_without_graph() -> None:
+    """When the pipeline has no DataHub graph connection (no datahub-rest sink
+    or stateful ingestion), the source must not build a platform resource
+    repository, since there is nowhere to reconcile against."""
+    from datahub.ingestion.api.common import PipelineContext
+
+    config = DataplexConfig(
+        project_ids=["project-1"],
+        include_lineage=False,
+        include_glossaries=False,
+    )
+    ctx = PipelineContext(run_id="t")  # no graph
+
+    source = DataplexSource(ctx=ctx, config=config)
+
+    assert source.platform_resource_repository is None
 
 
 def test_create_uses_model_validate_and_constructs_source() -> None:

--- a/metadata-ingestion/uv.lock
+++ b/metadata-ingestion/uv.lock
@@ -416,6 +416,7 @@ datahub-rest = [
     { name = "requests" },
 ]
 dataplex = [
+    { name = "cachetools" },
     { name = "google-cloud-datacatalog-lineage" },
     { name = "google-cloud-dataplex" },
     { name = "google-cloud-resource-manager" },
@@ -1770,6 +1771,7 @@ requires-dist = [
     { name = "cachetools", marker = "extra == 'cockroachdb'", specifier = "<6.0.0" },
     { name = "cachetools", marker = "extra == 'databricks'", specifier = "<6.0.0" },
     { name = "cachetools", marker = "extra == 'datahub'", specifier = "<6.0.0" },
+    { name = "cachetools", marker = "extra == 'dataplex'", specifier = "<6.0.0" },
     { name = "cachetools", marker = "extra == 'db2'", specifier = "<6.0.0" },
     { name = "cachetools", marker = "extra == 'delta-lake'", specifier = "<6.0.0" },
     { name = "cachetools", marker = "extra == 'dev'", specifier = "<6.0.0" },


### PR DESCRIPTION
## Summary

Makes the Dataplex ingestion source idempotent for metadata that a DataHub metadata **sync-back** automation previously wrote into Dataplex, so re-ingestion doesn't produce duplicate glossary terms or custom-property noise — and records externally-owned metadata so the sync-back doesn't overwrite it (loop prevention).

## Reconciliation logic (what the read leg does)

The read leg consults a **platform-resource side-index** (the `DataplexAspectPlatformResource` records the sync-back writes) to decide, per item, whether a piece of Dataplex metadata originated in DataHub or in Dataplex.

### Glossary term ↔ asset links (A2)
For each term linked to an asset (discovered via `lookupEntryLinks`), the read leg reconstructs the native-term URN `dataplex.{project}.{location}.{glossary}.{term_id}` and looks it up in the side-index (`search_entity_by_urn`):

- **DataHub-authored** — a matching platform resource exists with `managed_by_datahub=true` (written by the sync-back when it pushed a DataHub term):
  - **Substitute**: the asset's `glossaryTerms` gets the **original DataHub term URN** (from the resource's linked URN), not the round-tripped `dataplex.{…}` URN.
  - **Suppress**: the native `dataplex.{…}` `GlossaryTerm` entity is **not emitted** (it's a sync-back artifact; emitting it would duplicate the user's real term).
- **Dataplex-origin (external)** — no managed resource found:
  - The native `dataplex.{…}` term URN is kept on the asset and the native `GlossaryTerm` entity **is** emitted (it's genuinely a Dataplex-authored term).
  - **Emit a PlatformResource aspect**: a `DataplexAspectPlatformResource` marker with `managed_by_datahub=false`, keyed `{asset_entry_name}/datahub-glossary-terms/{native_term_urn}` (see "When we emit PlatformResource aspects" below).

### Entry aspects → custom properties (A4)
When flattening a Dataplex entry's aspects into DataHub custom properties (`extract_aspects_to_custom_properties`), the read leg **skips** any aspect whose type name is denied by the new `aspect_type_pattern` config (`AllowDenyPattern`, **default `deny=["datahub-.*"]`**). This drops the `datahub-tags` / `datahub-properties` aspects the sync-back writes (which DataHub already has natively) while still flattening genuine native aspects. No side-index lookup needed — the `datahub-` prefix is self-identifying.

> **Output-format change to note:** to match the deny pattern against the bare aspect *type*, the aspect key is now parsed as `key.replace("/", ".").split(".")[-1]` (final segment). A side effect is that the emitted custom-property keys for **native** aspects now use the bare type name (`dataplex_aspect_<type>` / `dataplex_<type>_<field>`) instead of the full dotted aspect path — a visible change to the emitted custom-property keys for existing native aspects, and two aspects sharing the same final type segment would now collide on one key. This is intentional (so the pattern matches the bare type), but calling it out since it changes output for native aspects.

## When we EMIT a PlatformResource aspect
Only for a **Dataplex-origin (external) glossary term–asset link** — one `managed_by_datahub=false` `DataplexAspectPlatformResource` per `(asset entry, native term)`. It is emitted as a normal **`platform_resource-{id}` workunit through the sink** (like the Unity Catalog / Glue connectors — respects dry-run/file sinks and stateful ingestion; the read leg never writes platform resources out-of-band). This marker is what the sync-back's `is_externally_owned` guard reads to avoid re-pushing (and thus looping on) metadata that originated in Dataplex.

## When we SKIP ingesting an aspect / term
- **A4 skip (custom properties):** any entry aspect whose type name matches `aspect_type_pattern`'s deny list (default the `datahub-*` aspects the sync-back authored) is skipped when building custom properties.
- **A2 suppression (glossary term entity):** a native `dataplex.{…}` term recognized as DataHub-authored (managed side-index record) is not emitted as a `GlossaryTerm` entity; only the original DataHub term is applied to the asset.

## Graceful degradation
A2 reconciliation (substitution/suppression and the `managed_by_datahub=false` marker) requires a DataHub graph connection (`self.ctx.graph`). Without one it is skipped with a warning and the read leg falls back to today's behavior (native URNs, no markers). A4 is graph-independent and always applies.

## Deploy ordering
Reconciliation activates only once the sync-back records the reconstructable native-term URN as a secondary key on its platform resources. That counterpart change lives in the DataHub Cloud sync-back PR: https://github.com/acryldata/datahub-fork/pull/10706 — deploy it with/before relying on reconciliation. Until then the read leg degrades safely (no errors).

## Bundled pre-existing fixes (found while validating end-to-end)
- Scope service-account credentials (`cloud-platform`) so the `lookupEntryLinks` REST session can obtain a token (was `RefreshError` with SA creds).
- Normalize the project **number** → project **id** in the entry-group prefix when matching term-link entries (`lookupEntryLinks` returns the number; ingested entries use the id), so associations resolve.
- Declare `cachetools` on the `dataplex` extra (the platform-resource framework imports it).
- Return an empty linked-resource set (not `[""]`) for a not-yet-linked default entity.

## Testing
- Unit: reconciliation lookup / suppression / substitution with a mocked repository; `aspect_type_pattern` deny filtering (incl. the `aspects_filtered` report counter); external-link marker emitted as a workunit (incl. the `external_term_links_recorded` counter + sample); `_normalize_entry_project_id` and error-swallowing branches. 312 dataplex unit tests pass.
- Integration: processor-level test driving `process_glossaries` + `process_term_associations` (managed → substitute + suppress; external → native URN + `managed_by_datahub=false` workunit).
- Validated end-to-end against a live DataHub + real Dataplex round-trip (sync-back → ingest); both loop-prevention directions confirmed.

## Checklist
- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [ ] Breaking changes documented in `docs/how/updating-datahub.md` (n/a — additive)

