### PR TITLE
fix(ingestion/mongodb): map unmapped BSON native types instead of falling back to unknown/NullType

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import (
@@ -13,6 +14,12 @@ from typing import (
     ValuesView,
 )
 
+import bson.binary
+import bson.code
+import bson.datetime_ms
+import bson.max_key
+import bson.min_key
+import bson.regex
 import bson.timestamp
 import pymongo.collection
 from packaging import version
@@ -214,6 +221,19 @@ PYMONGO_TYPE_TO_MONGO_TYPE = {
     bson.dbref.DBRef: "dbref",
     bson.objectid.ObjectId: "oid",
     bson.Decimal128: "numberDecimal",
+    # Native type strings below follow the official BSON `$type` aliases:
+    # https://www.mongodb.com/docs/manual/reference/bson-types/
+    # pymongo decodes binData subtype 0 to plain bytes, other subtypes to Binary.
+    bytes: "binData",
+    bson.binary.Binary: "binData",
+    uuid.UUID: "uuid",
+    bson.regex.Regex: "regex",
+    bson.code.Code: "javascript",
+    bson.min_key.MinKey: "minKey",
+    bson.max_key.MaxKey: "maxKey",
+    # BSON Date outside Python's datetime range, returned by pymongo because
+    # of datetime_conversion=DATETIME_AUTO.
+    bson.datetime_ms.DatetimeMS: "date",
     "mixed": "mixed",
 }
 
@@ -231,6 +251,14 @@ _field_type_mapping: Dict[Union[Type, str], Type] = {
     bson.dbref.DBRef: BytesTypeClass,
     bson.objectid.ObjectId: BytesTypeClass,
     bson.Decimal128: NumberTypeClass,
+    bytes: BytesTypeClass,
+    bson.binary.Binary: BytesTypeClass,
+    uuid.UUID: StringTypeClass,
+    bson.regex.Regex: StringTypeClass,
+    bson.code.Code: StringTypeClass,
+    bson.min_key.MinKey: StringTypeClass,
+    bson.max_key.MaxKey: StringTypeClass,
+    bson.datetime_ms.DatetimeMS: TimeTypeClass,
     dict: RecordTypeClass,
     "mixed": UnionTypeClass,
 }

--- a/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import (
@@ -13,6 +14,12 @@ from typing import (
     ValuesView,
 )
 
+import bson.binary
+import bson.code
+import bson.datetime_ms
+import bson.max_key
+import bson.min_key
+import bson.regex
 import bson.timestamp
 import pymongo.collection
 from packaging import version
@@ -214,7 +221,17 @@ PYMONGO_TYPE_TO_MONGO_TYPE = {
     bson.dbref.DBRef: "dbref",
     bson.objectid.ObjectId: "oid",
     bson.Decimal128: "numberDecimal",
+    # pymongo decodes binData subtype 0 to plain bytes, other subtypes to Binary;
+    # both share the existing "binary" native type string.
     bytes: "binary",
+    bson.binary.Binary: "binary",
+    # Native type strings below follow the official BSON `$type` aliases:
+    # https://www.mongodb.com/docs/manual/reference/bson-types/
+    uuid.UUID: "uuid",
+    bson.regex.Regex: "regex",
+    bson.code.Code: "javascript",
+    bson.min_key.MinKey: "minKey",
+    bson.max_key.MaxKey: "maxKey",
     bson.datetime_ms.DatetimeMS: "date",
     "mixed": "mixed",
 }
@@ -234,6 +251,12 @@ _field_type_mapping: Dict[Union[Type, str], Type] = {
     bson.objectid.ObjectId: BytesTypeClass,
     bson.Decimal128: NumberTypeClass,
     bytes: BytesTypeClass,
+    bson.binary.Binary: BytesTypeClass,
+    uuid.UUID: StringTypeClass,
+    bson.regex.Regex: StringTypeClass,
+    bson.code.Code: StringTypeClass,
+    bson.min_key.MinKey: StringTypeClass,
+    bson.max_key.MaxKey: StringTypeClass,
     bson.datetime_ms.DatetimeMS: TimeTypeClass,
     dict: RecordTypeClass,
     "mixed": UnionTypeClass,

--- a/metadata-ingestion/tests/integration/mongodb/mongodb_mces_golden.json
+++ b/metadata-ingestion/tests/integration/mongodb/mongodb_mces_golden.json
@@ -93,8 +93,8 @@
     "aspectName": "datasetProperties",
     "aspect": {
         "json": {
-            "name": "emptyCollection",
             "customProperties": {},
+            "name": "emptyCollection",
             "tags": []
         }
     },
@@ -504,8 +504,8 @@
     "aspectName": "datasetProperties",
     "aspect": {
         "json": {
-            "name": "firstCollection",
             "customProperties": {},
+            "name": "firstCollection",
             "tags": []
         }
     },
@@ -4203,11 +4203,11 @@
     "aspectName": "datasetProperties",
     "aspect": {
         "json": {
-            "name": "largeCollection",
             "customProperties": {
                 "schema.downsampled": "True",
                 "schema.totalFields": "501"
             },
+            "name": "largeCollection",
             "tags": []
         }
     },
@@ -4286,12 +4286,203 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "nativeTypesCollection",
+            "platform": "urn:li:dataPlatform:mongodb",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.Schemaless": {}
+            },
+            "fields": [
+                {
+                    "fieldPath": "_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "oid",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "binaryData",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "binData",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "farFutureDate",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.TimeType": {}
+                        }
+                    },
+                    "nativeDataType": "date",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "jsField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "javascript",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "maxKeyField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "maxKey",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "minKeyField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "minKey",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "name",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "regexField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "regex",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "uuidField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "binData",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
         "json": {
             "container": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "nativeTypesCollection",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:mongodb",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)"
         }
     },
     "systemMetadata": {
@@ -4442,13 +4633,38 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)"
+                },
+                {
+                    "id": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed",
+                    "urn": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
         "json": {
-            "name": "secondCollection",
             "customProperties": {},
+            "name": "secondCollection",
             "tags": []
         }
     },
@@ -4551,6 +4767,22 @@
 {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/integration/mongodb/mongodb_mces_golden.json
+++ b/metadata-ingestion/tests/integration/mongodb/mongodb_mces_golden.json
@@ -93,8 +93,8 @@
     "aspectName": "datasetProperties",
     "aspect": {
         "json": {
-            "name": "emptyCollection",
             "customProperties": {},
+            "name": "emptyCollection",
             "tags": []
         }
     },
@@ -504,8 +504,8 @@
     "aspectName": "datasetProperties",
     "aspect": {
         "json": {
-            "name": "firstCollection",
             "customProperties": {},
+            "name": "firstCollection",
             "tags": []
         }
     },
@@ -4203,11 +4203,11 @@
     "aspectName": "datasetProperties",
     "aspect": {
         "json": {
-            "name": "largeCollection",
             "customProperties": {
                 "schema.downsampled": "True",
                 "schema.totalFields": "501"
             },
+            "name": "largeCollection",
             "tags": []
         }
     },
@@ -4286,12 +4286,203 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "nativeTypesCollection",
+            "platform": "urn:li:dataPlatform:mongodb",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.Schemaless": {}
+            },
+            "fields": [
+                {
+                    "fieldPath": "_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "oid",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "binaryData",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "binary",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "farFutureDate",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.TimeType": {}
+                        }
+                    },
+                    "nativeDataType": "date",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "jsField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "javascript",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "maxKeyField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "maxKey",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "minKeyField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "minKey",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "name",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "regexField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "regex",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "uuidField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "binary",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
         "json": {
             "container": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "nativeTypesCollection",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:mongodb",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)"
         }
     },
     "systemMetadata": {
@@ -4442,13 +4633,38 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)"
+                },
+                {
+                    "id": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed",
+                    "urn": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
         "json": {
-            "name": "secondCollection",
             "customProperties": {},
+            "name": "secondCollection",
             "tags": []
         }
     },
@@ -4551,6 +4767,22 @@
 {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/integration/mongodb/mongodb_mces_no_random_sampling_golden.json
+++ b/metadata-ingestion/tests/integration/mongodb/mongodb_mces_no_random_sampling_golden.json
@@ -4286,12 +4286,203 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-no-random-sampling",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "nativeTypesCollection",
+            "platform": "urn:li:dataPlatform:mongodb",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.Schemaless": {}
+            },
+            "fields": [
+                {
+                    "fieldPath": "_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "oid",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "binaryData",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "binData",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "farFutureDate",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.TimeType": {}
+                        }
+                    },
+                    "nativeDataType": "date",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "jsField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "javascript",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "maxKeyField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "maxKey",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "minKeyField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "minKey",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "name",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "regexField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "regex",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "uuidField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "binData",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-no-random-sampling",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
         "json": {
             "container": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-no-random-sampling",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "nativeTypesCollection",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-no-random-sampling",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:mongodb",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)"
         }
     },
     "systemMetadata": {
@@ -4442,6 +4633,31 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)"
+                },
+                {
+                    "id": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed",
+                    "urn": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-no-random-sampling",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
@@ -4551,6 +4767,22 @@
 {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-no-random-sampling",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/integration/mongodb/mongodb_mces_no_random_sampling_golden.json
+++ b/metadata-ingestion/tests/integration/mongodb/mongodb_mces_no_random_sampling_golden.json
@@ -4286,12 +4286,203 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-no-random-sampling",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "nativeTypesCollection",
+            "platform": "urn:li:dataPlatform:mongodb",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.Schemaless": {}
+            },
+            "fields": [
+                {
+                    "fieldPath": "_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "oid",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "binaryData",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "binary",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "farFutureDate",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.TimeType": {}
+                        }
+                    },
+                    "nativeDataType": "date",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "jsField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "javascript",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "maxKeyField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "maxKey",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "minKeyField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "minKey",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "name",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "regexField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "regex",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "uuidField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "binary",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-no-random-sampling",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
         "json": {
             "container": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-no-random-sampling",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "nativeTypesCollection",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-no-random-sampling",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:mongodb",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)"
         }
     },
     "systemMetadata": {
@@ -4442,6 +4633,31 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)"
+                },
+                {
+                    "id": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed",
+                    "urn": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-no-random-sampling",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
@@ -4551,6 +4767,22 @@
 {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-no-random-sampling",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/integration/mongodb/mongodb_mces_small_schema_size_golden.json
+++ b/metadata-ingestion/tests/integration/mongodb/mongodb_mces_small_schema_size_golden.json
@@ -93,8 +93,8 @@
     "aspectName": "datasetProperties",
     "aspect": {
         "json": {
-            "name": "emptyCollection",
             "customProperties": {},
+            "name": "emptyCollection",
             "tags": []
         }
     },
@@ -360,11 +360,11 @@
     "aspectName": "datasetProperties",
     "aspect": {
         "json": {
-            "name": "firstCollection",
             "customProperties": {
                 "schema.downsampled": "True",
                 "schema.totalFields": "22"
             },
+            "name": "firstCollection",
             "tags": []
         }
     },
@@ -582,11 +582,11 @@
     "aspectName": "datasetProperties",
     "aspect": {
         "json": {
-            "name": "largeCollection",
             "customProperties": {
                 "schema.downsampled": "True",
                 "schema.totalFields": "502"
             },
+            "name": "largeCollection",
             "tags": []
         }
     },
@@ -665,12 +665,203 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-small-schema-size",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "nativeTypesCollection",
+            "platform": "urn:li:dataPlatform:mongodb",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.Schemaless": {}
+            },
+            "fields": [
+                {
+                    "fieldPath": "_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "oid",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "binaryData",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "binData",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "farFutureDate",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.TimeType": {}
+                        }
+                    },
+                    "nativeDataType": "date",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "jsField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "javascript",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "maxKeyField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "maxKey",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "minKeyField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "minKey",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "name",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "regexField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "regex",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "uuidField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "binData",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-small-schema-size",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
         "json": {
             "container": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-small-schema-size",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "nativeTypesCollection",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-small-schema-size",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:mongodb",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)"
         }
     },
     "systemMetadata": {
@@ -821,13 +1012,38 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)"
+                },
+                {
+                    "id": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed",
+                    "urn": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-small-schema-size",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
         "json": {
-            "name": "secondCollection",
             "customProperties": {},
+            "name": "secondCollection",
             "tags": []
         }
     },
@@ -930,6 +1146,22 @@
 {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-small-schema-size",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/integration/mongodb/mongodb_mces_small_schema_size_golden.json
+++ b/metadata-ingestion/tests/integration/mongodb/mongodb_mces_small_schema_size_golden.json
@@ -93,8 +93,8 @@
     "aspectName": "datasetProperties",
     "aspect": {
         "json": {
-            "name": "emptyCollection",
             "customProperties": {},
+            "name": "emptyCollection",
             "tags": []
         }
     },
@@ -360,11 +360,11 @@
     "aspectName": "datasetProperties",
     "aspect": {
         "json": {
-            "name": "firstCollection",
             "customProperties": {
                 "schema.downsampled": "True",
                 "schema.totalFields": "22"
             },
+            "name": "firstCollection",
             "tags": []
         }
     },
@@ -582,11 +582,11 @@
     "aspectName": "datasetProperties",
     "aspect": {
         "json": {
-            "name": "largeCollection",
             "customProperties": {
                 "schema.downsampled": "True",
                 "schema.totalFields": "502"
             },
+            "name": "largeCollection",
             "tags": []
         }
     },
@@ -665,12 +665,203 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-small-schema-size",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "nativeTypesCollection",
+            "platform": "urn:li:dataPlatform:mongodb",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.Schemaless": {}
+            },
+            "fields": [
+                {
+                    "fieldPath": "_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "oid",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "binaryData",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "binary",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "farFutureDate",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.TimeType": {}
+                        }
+                    },
+                    "nativeDataType": "date",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "jsField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "javascript",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "maxKeyField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "maxKey",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "minKeyField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "minKey",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "name",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "regexField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "regex",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "uuidField",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "binary",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-small-schema-size",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
         "json": {
             "container": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-small-schema-size",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "nativeTypesCollection",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-small-schema-size",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:mongodb",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)"
         }
     },
     "systemMetadata": {
@@ -821,13 +1012,38 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:mongodb,instance)"
+                },
+                {
+                    "id": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed",
+                    "urn": "urn:li:container:f5ff6ace1ed73cb3fd4c73dc718c39ed"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-small-schema-size",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
         "json": {
-            "name": "secondCollection",
             "customProperties": {},
+            "name": "secondCollection",
             "tags": []
         }
     },
@@ -930,6 +1146,22 @@
 {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.secondCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test-small-schema-size",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,instance.mngdb.nativeTypesCollection,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/integration/mongodb/setup/mongo_init.js
+++ b/metadata-ingestion/tests/integration/mongodb/setup/mongo_init.js
@@ -102,6 +102,21 @@ db.secondCollection.insertMany([
   },
 ]);
 
+db.nativeTypesCollection.insertMany([
+  {
+    name: "everyBsonType",
+    binaryData: BinData(0, "SGVsbG8gV29ybGQ="),
+    uuidField: UUID("12345678-1234-5678-1234-567812345678"),
+    regexField: /^mongo.*types$/i,
+    jsField: Code("function () { return 1; }"),
+    minKeyField: MinKey(),
+    maxKeyField: MaxKey(),
+    // BSON Date beyond Python's datetime range (year 10000) — decoded by
+    // pymongo as DatetimeMS under datetime_conversion=DATETIME_AUTO.
+    farFutureDate: new Date(253402300800000),
+  },
+]);
+
 var large_field_value = (new Array(250001)).join('x');
 db.emptyCollection.createIndex({ stringField: 1 }, { unique: true });
 db.largeCollection.insertMany([

--- a/metadata-ingestion/tests/unit/test_mongodb_source.py
+++ b/metadata-ingestion/tests/unit/test_mongodb_source.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Any, Dict, List, Set
 from unittest.mock import MagicMock, patch
 
@@ -15,10 +16,13 @@ from datahub.ingestion.source.mongodb import (
 )
 from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeProposal
 from datahub.metadata.schema_classes import (
+    BytesTypeClass,
     ContainerPropertiesClass,
     DataPlatformInstanceClass,
     DatasetPropertiesClass,
     SchemaMetadataClass,
+    StringTypeClass,
+    TimeTypeClass,
 )
 from datahub.utilities.urns.urn import guess_entity_type
 
@@ -261,6 +265,70 @@ def test_mongodb_schema_inference_with_deeply_nested_structures(
         "_id",
     }
     assert field_paths == expected_paths
+
+
+def test_mongodb_native_bson_types_are_mapped(mock_mongo_client, pipeline_context):
+    """
+    Test that BSON native types map to real DataHub types.
+
+    Binary/binData (incl. UUID), Regex, Code, MinKey/MaxKey and DatetimeMS
+    previously fell back to nativeDataType="unknown" / NullType with
+    "Unrecognized column type" warnings (#18571).
+    """
+    mock_mongo_client.list_database_names.return_value = ["test_db"]
+
+    mock_database = MagicMock()
+    mock_mongo_client.__getitem__.return_value = mock_database
+    mock_database.list_collection_names.return_value = ["typed"]
+
+    mock_collection = MagicMock()
+    mock_database.__getitem__.return_value = mock_collection
+
+    mock_collection.aggregate.return_value = [
+        {
+            "_id": bson.ObjectId("507f1f77bcf86cd799439011"),
+            # pymongo decodes binData subtype 0 to plain bytes, other subtypes
+            # (e.g. UUID's subtype 4) to bson.binary.Binary.
+            "raw": b"\x00\x01",
+            "raw_subtyped": bson.Binary(b"\x00\x01", 4),
+            "uid": uuid.UUID("12345678-1234-5678-1234-567812345678"),
+            "pattern": bson.Regex("^foo", "i"),
+            "js": bson.Code("function() { return 1; }"),
+            "lo": bson.MinKey(),
+            "hi": bson.MaxKey(),
+            # BSON Date beyond Python's datetime range, as returned by pymongo
+            # with datetime_conversion=DATETIME_AUTO (year 10000).
+            "far_future": bson.DatetimeMS(253402300800000),
+        }
+    ]
+
+    config = MongoDBConfig(
+        connect_uri="mongodb://localhost:27017", enableSchemaInference=True
+    )
+    source = MongoDBSource(ctx=pipeline_context, config=config)
+
+    workunits = list(source.get_workunits_internal())
+
+    schema_metadata_aspects = get_schema_metadata_aspects(workunits)
+    assert len(schema_metadata_aspects) == 1
+
+    fields = {f.fieldPath: f for f in schema_metadata_aspects[0].fields}
+    expected = {
+        "raw": ("binData", BytesTypeClass),
+        "raw_subtyped": ("binData", BytesTypeClass),
+        "uid": ("uuid", StringTypeClass),
+        "pattern": ("regex", StringTypeClass),
+        "js": ("javascript", StringTypeClass),
+        "lo": ("minKey", StringTypeClass),
+        "hi": ("maxKey", StringTypeClass),
+        "far_future": ("date", TimeTypeClass),
+    }
+    for field_path, (native_type, type_class) in expected.items():
+        assert fields[field_path].nativeDataType == native_type
+        assert isinstance(fields[field_path].type.type, type_class)
+
+    # No "Unrecognized column type" warnings should be reported.
+    assert not source.report.warnings
 
 
 def test_mongodb_schema_inference_disabled(mock_mongo_client, pipeline_context):

--- a/metadata-ingestion/tests/unit/test_mongodb_source.py
+++ b/metadata-ingestion/tests/unit/test_mongodb_source.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Any, Dict, List, Set
 from unittest.mock import MagicMock, patch
 
@@ -15,10 +16,13 @@ from datahub.ingestion.source.mongodb import (
 )
 from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeProposal
 from datahub.metadata.schema_classes import (
+    BytesTypeClass,
     ContainerPropertiesClass,
     DataPlatformInstanceClass,
     DatasetPropertiesClass,
     SchemaMetadataClass,
+    StringTypeClass,
+    TimeTypeClass,
 )
 from datahub.utilities.urns.urn import guess_entity_type
 
@@ -261,6 +265,70 @@ def test_mongodb_schema_inference_with_deeply_nested_structures(
         "_id",
     }
     assert field_paths == expected_paths
+
+
+def test_mongodb_native_bson_types_are_mapped(mock_mongo_client, pipeline_context):
+    """
+    Test that BSON native types map to real DataHub types.
+
+    Binary/binData (incl. UUID), Regex, Code, MinKey/MaxKey and DatetimeMS
+    previously fell back to nativeDataType="unknown" / NullType with
+    "Unrecognized column type" warnings (#18571).
+    """
+    mock_mongo_client.list_database_names.return_value = ["test_db"]
+
+    mock_database = MagicMock()
+    mock_mongo_client.__getitem__.return_value = mock_database
+    mock_database.list_collection_names.return_value = ["typed"]
+
+    mock_collection = MagicMock()
+    mock_database.__getitem__.return_value = mock_collection
+
+    mock_collection.aggregate.return_value = [
+        {
+            "_id": bson.ObjectId("507f1f77bcf86cd799439011"),
+            # pymongo decodes binData subtype 0 to plain bytes, other subtypes
+            # (e.g. UUID's subtype 4) to bson.binary.Binary.
+            "raw": b"\x00\x01",
+            "raw_subtyped": bson.Binary(b"\x00\x01", 4),
+            "uid": uuid.UUID("12345678-1234-5678-1234-567812345678"),
+            "pattern": bson.Regex("^foo", "i"),
+            "js": bson.Code("function() { return 1; }"),
+            "lo": bson.MinKey(),
+            "hi": bson.MaxKey(),
+            # BSON Date beyond Python's datetime range, as returned by pymongo
+            # with datetime_conversion=DATETIME_AUTO (year 10000).
+            "far_future": bson.DatetimeMS(253402300800000),
+        }
+    ]
+
+    config = MongoDBConfig(
+        connect_uri="mongodb://localhost:27017", enableSchemaInference=True
+    )
+    source = MongoDBSource(ctx=pipeline_context, config=config)
+
+    workunits = list(source.get_workunits_internal())
+
+    schema_metadata_aspects = get_schema_metadata_aspects(workunits)
+    assert len(schema_metadata_aspects) == 1
+
+    fields = {f.fieldPath: f for f in schema_metadata_aspects[0].fields}
+    expected = {
+        "raw": ("binary", BytesTypeClass),
+        "raw_subtyped": ("binary", BytesTypeClass),
+        "uid": ("uuid", StringTypeClass),
+        "pattern": ("regex", StringTypeClass),
+        "js": ("javascript", StringTypeClass),
+        "lo": ("minKey", StringTypeClass),
+        "hi": ("maxKey", StringTypeClass),
+        "far_future": ("date", TimeTypeClass),
+    }
+    for field_path, (native_type, type_class) in expected.items():
+        assert fields[field_path].nativeDataType == native_type
+        assert isinstance(fields[field_path].type.type, type_class)
+
+    # No "Unrecognized column type" warnings should be reported.
+    assert not source.report.warnings
 
 
 def test_mongodb_schema_inference_disabled(mock_mongo_client, pipeline_context):


### PR DESCRIPTION
Closes #18571

The MongoDB source maps sampled Python value types through `PYMONGO_TYPE_TO_MONGO_TYPE` and `_field_type_mapping`. Unmapped types fall back to `nativeDataType="unknown"` and DataHub `NullType`, with unrecognized-type warnings.

This PR adds the missing mappings while preserving the source's existing native type names:

| Sampled PyMongo/Python type | nativeDataType | DataHub type |
| --- | --- | --- |
| `bson.binary.Binary` (including UUID subtypes when not decoded to `uuid.UUID`) | `binary` | BytesType |
| `uuid.UUID` | `uuid` | StringType |
| `bson.regex.Regex` | `regex` | StringType |
| `bson.code.Code` (JavaScript with or without scope) | `javascript` | StringType |
| `bson.min_key.MinKey` | `minKey` | StringType |
| `bson.max_key.MaxKey` | `maxKey` | StringType |

These native type names are the MongoDB source's metadata labels, not a strict implementation of MongoDB's official `$type` aliases. In particular, `Binary` uses the existing `binary` label shared with Python `bytes`, rather than introducing `binData`. `uuid` describes a decoded Python UUID; it is not a separate BSON type.

With PyMongo's default `UuidRepresentation.UNSPECIFIED`, binary subtype 0 decodes to `bytes` and other subtypes to `Binary`. With `STANDARD`, subtype 4 decodes to `uuid.UUID`; the legacy UUID representations decode subtype 3 to `uuid.UUID`. The source maps the resulting Python type in each case. These changes describe schema metadata and do not convert the stored MongoDB values.

Existing mappings are unchanged, including `bytes → binary / BytesType` and `DatetimeMS → date / TimeType`. Out-of-range dates remain supported through the source's `datetime_conversion=DATETIME_AUTO` setting and are included in regression coverage. DocumentDB ingestion shares this code path and benefits as well. This follows the same missing-type-mapping approach as the earlier Decimal128 fix (#9073 / #9118).

References: [BSON types](https://www.mongodb.com/docs/manual/reference/bson-types/) and [PyMongo UUID representations](https://www.mongodb.com/docs/languages/python/pymongo-driver/current/data-formats/uuid/).

Testing:

- `test_mongodb_native_bson_types_are_mapped` checks the added type mappings through schema inference, along with existing binary/date behavior and the absence of unrecognized-type warnings.
- `test_mongodb_binary_subtypes_are_mapped_after_bson_decoding` covers BSON subtypes 0 through 9 and user-defined subtype 128 using real BSON encode/decode before schema inference.
- `test_mongodb_uuid_representations_are_mapped_after_bson_decoding` covers subtypes 3 and 4 across all five UUID representations, checking the resulting schema types and absence of unrecognized-type warnings.
- The integration seed includes a `nativeTypesCollection` exercising `BinData`, `UUID()`, a regex literal, `Code`, `MinKey`, `MaxKey`, and a year-10000 `Date`; the three golden files include this collection.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)



