### PR TITLE
refactor(ingest): deprecate report_warning/report_failure in favor of warning/failure

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -22,6 +22,9 @@ description: "Release notes and breaking change history for upgrading DataHub be
 
 ### Deprecations
 
+- **(Ingestion SDK)** `SourceReport.report_warning()` is deprecated in favor of `warning()`. Existing callers should migrate. The method will be removed in a future release.
+- **(Ingestion SDK)** `SourceReport.report_failure()` is deprecated in favor of `failure()`. Same timeline.
+
 ### Other Notable Changes
 
 - #13726: Removed dgraph from tests

--- a/metadata-ingestion/src/datahub/ingestion/api/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/source.py
@@ -21,7 +21,7 @@ from typing import (
 )
 
 from pydantic import BaseModel
-from typing_extensions import LiteralString, Self
+from typing_extensions import LiteralString, Self, deprecated
 
 from datahub.configuration.common import ConfigModel
 from datahub.configuration.env_vars import (
@@ -284,27 +284,6 @@ class SourceReport(ExamplesReport, IngestionStageReport):
 
         super()._store_workunit_data(wu)
 
-    def report_warning(
-        self,
-        message: LiteralString,
-        context: Optional[str] = None,
-        title: Optional[LiteralString] = None,
-        exc: Optional[BaseException] = None,
-        log_category: Optional[StructuredLogCategory] = None,
-    ) -> None:
-        """
-        See docs of StructuredLogs.report_log for details of args
-        """
-        self._structured_logs.report_log(
-            StructuredLogLevel.WARN,
-            message,
-            title,
-            context,
-            exc,
-            log=False,
-            log_category=log_category,
-        )
-
     def warning(
         self,
         message: LiteralString,
@@ -314,8 +293,25 @@ class SourceReport(ExamplesReport, IngestionStageReport):
         log: bool = True,
         log_category: Optional[StructuredLogCategory] = None,
     ) -> None:
-        """
-        See docs of StructuredLogs.report_log for details of args
+        """Report a user-facing warning for the ingestion run.
+
+        Warnings are surfaced in the ingestion report UI and optionally logged
+        to the console. Use for non-fatal issues that operators should be aware
+        of (e.g. skipped entities, degraded functionality, missing permissions).
+
+        Args:
+            message: Human-readable description of the warning. Must be a
+                literal string (no f-strings) so that identical warnings are
+                grouped together in the report.
+            context: Additional detail such as the affected entity or query.
+                Multiple calls with the same ``message`` but different
+                ``context`` values are grouped under one report entry.
+            title: Optional heading / category shown in the UI.
+            exc: Exception that triggered the warning, if any. The stack trace
+                is logged at DEBUG level when *log* is True.
+            log: Whether to also emit the warning to the Python logger
+                (default ``True``).
+            log_category: Optional structured-log category for filtering.
         """
         self._structured_logs.report_log(
             StructuredLogLevel.WARN,
@@ -327,7 +323,8 @@ class SourceReport(ExamplesReport, IngestionStageReport):
             log_category=log_category,
         )
 
-    def report_failure(
+    @deprecated("Use warning() instead.")
+    def report_warning(
         self,
         message: LiteralString,
         context: Optional[str] = None,
@@ -336,15 +333,12 @@ class SourceReport(ExamplesReport, IngestionStageReport):
         log: bool = True,
         log_category: Optional[StructuredLogCategory] = None,
     ) -> None:
-        """
-        See docs of StructuredLogs.report_log for details of args
-        """
-        self._structured_logs.report_log(
-            StructuredLogLevel.ERROR,
-            message,
-            title,
-            context,
-            exc,
+        """Deprecated: use ``warning()`` instead. Will be removed in a future release."""
+        self.warning(
+            message=message,
+            context=context,
+            title=title,
+            exc=exc,
             log=log,
             log_category=log_category,
         )
@@ -358,8 +352,22 @@ class SourceReport(ExamplesReport, IngestionStageReport):
         log: bool = True,
         log_category: Optional[StructuredLogCategory] = None,
     ) -> None:
-        """
-        See docs of StructuredLogs.report_log for details of args
+        """Report a user-facing failure for the ingestion run.
+
+        Failures indicate errors that prevented metadata from being ingested
+        correctly. They are surfaced prominently in the ingestion report UI
+        and logged to the console by default.
+
+        Args:
+            message: Human-readable description of the failure. Must be a
+                literal string (no f-strings) so that identical failures are
+                grouped together in the report.
+            context: Additional detail such as the affected entity or query.
+            title: Optional heading / category shown in the UI.
+            exc: Exception that triggered the failure, if any.
+            log: Whether to also emit the failure to the Python logger
+                (default ``True``).
+            log_category: Optional structured-log category for filtering.
         """
         self._structured_logs.report_log(
             StructuredLogLevel.ERROR,
@@ -367,6 +375,26 @@ class SourceReport(ExamplesReport, IngestionStageReport):
             title,
             context,
             exc,
+            log=log,
+            log_category=log_category,
+        )
+
+    @deprecated("Use failure() instead.")
+    def report_failure(
+        self,
+        message: LiteralString,
+        context: Optional[str] = None,
+        title: Optional[LiteralString] = None,
+        exc: Optional[BaseException] = None,
+        log: bool = True,
+        log_category: Optional[StructuredLogCategory] = None,
+    ) -> None:
+        """Deprecated: use ``failure()`` instead. Will be removed in a future release."""
+        self.failure(
+            message=message,
+            context=context,
+            title=title,
+            exc=exc,
             log=log,
             log_category=log_category,
         )

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -998,7 +998,7 @@ class Pipeline:
         logger.exception(
             f"Ingestion pipeline threw an uncaught exception: {exc}", stacklevel=2
         )
-        self.source.get_report().report_failure(
+        self.source.get_report().failure(
             title="Pipeline Error",
             message="Ingestion pipeline raised an unexpected exception!",
             exc=exc,

--- a/metadata-ingestion/src/datahub/ingestion/source/abs/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/abs/source.py
@@ -217,15 +217,17 @@ class ABSSource(StatefulIngestionSourceBase):
             elif extension == ".avro":
                 fields = avro.AvroInferrer().infer_schema(file)
             else:
-                self.report.report_warning(
+                self.report.warning(
                     table_data.full_path,
                     f"file {table_data.full_path} has unsupported extension",
+                    log=False,
                 )
             file.close()
         except Exception as e:
-            self.report.report_warning(
+            self.report.warning(
                 table_data.full_path,
                 f"could not infer schema for file {table_data.full_path}: {e}",
+                log=False,
             )
             file.close()
         logger.debug(f"Extracted fields in schema: {fields}")
@@ -525,8 +527,10 @@ class ABSSource(StatefulIngestionSourceBase):
                         logger.debug(
                             f"Got NoSuchBucket exception for {container_name}", e
                         )
-                        self.get_report().report_warning(
-                            "Missing bucket", f"No bucket found {container_name}"
+                        self.get_report().warning(
+                            "Missing bucket",
+                            f"No bucket found {container_name}",
+                            log=False,
                         )
                     else:
                         raise e

--- a/metadata-ingestion/src/datahub/ingestion/source/aerospike.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aerospike.py
@@ -380,9 +380,10 @@ class AerospikeSource(StatefulIngestionSourceBase):
         """
         type_string = PYTHON_TYPE_TO_AEROSPIKE_TYPE.get(field_type)
         if type_string is None:
-            self.report.report_warning(
+            self.report.warning(
                 message="unable to map type to metadata schema",
                 context=f"{set_name}: {field_type}",
+                log=False,
             )
             type_string = "unknown"
 
@@ -404,9 +405,10 @@ class AerospikeSource(StatefulIngestionSourceBase):
         TypeClass: Optional[Type] = _field_type_mapping.get(field_type)
 
         if TypeClass is None:
-            self.report.report_warning(
+            self.report.warning(
                 message="unable to map type to metadata schema",
                 context=f"{set_name}: {field_type}",
+                log=False,
             )
             TypeClass = NullTypeClass
 
@@ -600,10 +602,11 @@ class AerospikeSource(StatefulIngestionSourceBase):
                     f"Truncated schema from {len(schema)} to {len(truncated_schema)}"
                 )
                 schema_depth = max([len(k) for k in schema])
-                self.report.report_warning(
+                self.report.warning(
                     title="Schema depth limit reached",
                     message="Truncating the collection schema because it has too many nested levels.",
                     context=f"Schema Depth: {len(schema)}, Configured threshold: {self.config.infer_schema_depth}",
+                    log=False,
                 )
                 custom_properties["schema.truncated"] = "True"
                 custom_properties["schema.totalDepth"] = f"{schema_depth}"
@@ -612,10 +615,11 @@ class AerospikeSource(StatefulIngestionSourceBase):
         schema_size = len(schema)
         max_schema_size = self.config.max_schema_size
         if max_schema_size is not None and schema_size > max_schema_size:
-            self.report.report_warning(
+            self.report.warning(
                 title="Too many schema fields",
                 message="Downsampling the collection schema because it has too many schema fields.",
                 context=f"Schema Size: {schema_size}, Configured threshold: {max_schema_size}",
+                log=False,
             )
             custom_properties["schema.downsampled"] = "True"
             custom_properties["schema.totalFields"] = f"{schema_size}"

--- a/metadata-ingestion/src/datahub/ingestion/source/airbyte/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/airbyte/source.py
@@ -344,7 +344,7 @@ class AirbyteSource(StatefulIngestionSourceBase):
                         conn_id = getattr(connection, "connection_id", "unknown")
                         conn_name = getattr(connection, "name", "unknown")
                         ws_id = getattr(workspace, "workspace_id", "unknown")
-                        self.report.report_failure(
+                        self.report.failure(
                             message="Failed to process connection",
                             context=f"workspace-{ws_id}/connection-{conn_id}/{conn_name}",
                             exc=e,
@@ -354,7 +354,7 @@ class AirbyteSource(StatefulIngestionSourceBase):
                 raise
             except Exception as e:
                 workspace_id = getattr(workspace, "workspace_id", "unknown")
-                self.report.report_failure(
+                self.report.failure(
                     message="Failed to process workspace",
                     context=f"workspace-{workspace_id}",
                     exc=e,
@@ -370,7 +370,7 @@ class AirbyteSource(StatefulIngestionSourceBase):
                 yield from self._create_lineage_workunits(pipeline_info)
             except Exception as e:
                 conn_id = pipeline_info.connection.connection_id or "unknown"
-                self.report.report_failure(
+                self.report.failure(
                     message="Failed to process pipeline",
                     context=f"pipeline-{conn_id}",
                     exc=e,
@@ -538,7 +538,7 @@ class AirbyteSource(StatefulIngestionSourceBase):
                     continue
 
         except Exception as e:
-            self.report.report_failure(
+            self.report.failure(
                 message="Failed to process job executions",
                 context=f"job-executions-{connection_id}-{stream_name}",
                 exc=e,
@@ -1110,7 +1110,7 @@ class AirbyteSource(StatefulIngestionSourceBase):
             except Exception as e:
                 conn_name = getattr(pipeline_info.connection, "name", "unknown")
                 ws_id = getattr(pipeline_info.workspace, "workspace_id", "unknown")
-                self.report.report_failure(
+                self.report.failure(
                     message="Failed to process stream",
                     context=f"workspace-{ws_id}/connection-{connection_id}/{conn_name}/stream-{stream_info.details.stream_name}",
                     exc=e,

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -1023,9 +1023,10 @@ class GlueSource(StatefulIngestionSourceBase):
 
         # catch any other cases where the script path is invalid
         if not script_path.startswith("s3://"):
-            self.report_warning(
+            self.report.warning(
                 flow_urn,
                 f"Error parsing DAG for Glue job. The script {script_path} is not a valid S3 path.",
+                log=False,
             )
             self.report.num_job_script_location_invalid += 1
 
@@ -1049,16 +1050,18 @@ class GlueSource(StatefulIngestionSourceBase):
         try:
             obj = self.s3_client.get_object(Bucket=bucket, Key=key)
         except botocore.exceptions.ClientError as e:
-            self.report_warning(
+            self.report.warning(
                 flow_urn,
                 f"Unable to download DAG for Glue job from {script_path}, so job subtasks and lineage will be missing: {e}",
+                log=False,
             )
             self.report.num_job_script_failed_download += 1
             return None
         except botocore.exceptions.ParamValidationError as e:
-            self.report_warning(
+            self.report.warning(
                 flow_urn,
                 f"Invalid S3 path for Glue job script {script_path}: {e}",
+                log=False,
             )
             self.report.num_job_script_location_invalid += 1
             return None
@@ -1084,9 +1087,10 @@ class GlueSource(StatefulIngestionSourceBase):
 
         # sometimes the Python script can be user-modified and the script is not valid for graph extraction
         except self.glue_client.exceptions.InvalidInputException as e:
-            self.report_warning(
+            self.report.warning(
                 flow_urn,
                 f"Error parsing DAG for Glue job. The script {script_path} cannot be processed by Glue (this usually occurs when it has been user-modified): {e}",
+                log=False,
             )
             self.report.num_job_script_failed_parsing += 1
 
@@ -1144,15 +1148,17 @@ class GlueSource(StatefulIngestionSourceBase):
             generate_column_lineage=False,
         )
         if result.debug_info.error:
-            self.report_warning(
+            self.report.warning(
                 flow_urn,
                 f"Failed to parse SQL query for node {node_label}: {result.debug_info.error}. Skipping",
+                log=False,
             )
             return None
         if not result.in_tables:
-            self.report_warning(
+            self.report.warning(
                 flow_urn,
                 f"No tables found in SQL query for node {node_label}. Skipping",
+                log=False,
             )
             return None
         return result.in_tables
@@ -1180,38 +1186,43 @@ class GlueSource(StatefulIngestionSourceBase):
                     "JDBC_CONNECTION_URL"
                 )
                 if not jdbc_url:
-                    self.report_warning(
+                    self.report.warning(
                         flow_urn,
                         f"Glue connection {connection_name!r} has no JDBC_CONNECTION_URL. Skipping",
+                        log=False,
                     )
                 else:
                     try:
                         result = self._parse_jdbc_url(jdbc_url)
                     except Exception as e:
-                        self.report_warning(
+                        self.report.warning(
                             flow_urn,
                             f"Failed to parse JDBC URL for connection {connection_name!r}: {e}. Skipping",
+                            log=False,
                         )
                         result = None
             elif conn_type in GLUE_NATIVE_CONNECTION_TYPE_MAP:
                 platform = GLUE_NATIVE_CONNECTION_TYPE_MAP[conn_type]
                 database = props.get("DATABASE")
                 if not database:
-                    self.report_warning(
+                    self.report.warning(
                         flow_urn,
                         f"Glue connection {connection_name!r} has no DATABASE property. Skipping",
+                        log=False,
                     )
                 else:
                     result = (platform, database)
             else:
-                self.report_warning(
+                self.report.warning(
                     flow_urn,
                     f"Unsupported Glue connection type {conn_type!r} for connection {connection_name!r}. Skipping",
+                    log=False,
                 )
         except Exception as e:
-            self.report_warning(
+            self.report.warning(
                 flow_urn,
                 f"Failed to fetch Glue connection {connection_name!r}: {e}. Skipping",
+                log=False,
             )
             return None
 
@@ -1299,8 +1310,10 @@ class GlueSource(StatefulIngestionSourceBase):
                 query, platform, database, flow_urn, node_label
             )
 
-        self.report_warning(
-            flow_urn, f"Missing dbtable or query for node {node_label}. Skipping"
+        self.report.warning(
+            flow_urn,
+            f"Missing dbtable or query for node {node_label}. Skipping",
+            log=False,
         )
         return None
 
@@ -1312,17 +1325,20 @@ class GlueSource(StatefulIngestionSourceBase):
         node_label = f"{node['NodeType']}-{node['Id']}"
 
         if not jdbc_url:
-            self.report_warning(
-                flow_urn, f"Missing JDBC URL for node {node_label}. Skipping"
+            self.report.warning(
+                flow_urn,
+                f"Missing JDBC URL for node {node_label}. Skipping",
+                log=False,
             )
             return None
 
         try:
             platform, database = self._parse_jdbc_url(jdbc_url)
         except ValueError as e:
-            self.report_warning(
+            self.report.warning(
                 flow_urn,
                 f"Failed to parse JDBC URL for node {node_label}: {e}. Skipping",
+                log=False,
             )
             return None
 
@@ -1341,8 +1357,10 @@ class GlueSource(StatefulIngestionSourceBase):
                 query, platform, database, flow_urn, node_label
             )
 
-        self.report_warning(
-            flow_urn, f"Missing dbtable or query for node {node_label}. Skipping"
+        self.report.warning(
+            flow_urn,
+            f"Missing dbtable or query for node {node_label}. Skipping",
+            log=False,
         )
         return None
 
@@ -1381,9 +1399,10 @@ class GlueSource(StatefulIngestionSourceBase):
                 s3_uri = self.get_s3_uri(node_args)
 
                 if s3_uri is None:
-                    self.report_warning(
+                    self.report.warning(
                         flow_urn,
                         f"Could not find S3 path for job {node['NodeType']}-{node['Id']} in flow {flow_urn}. Skipping",
+                        log=False,
                     )
                     return None
 
@@ -1409,9 +1428,10 @@ class GlueSource(StatefulIngestionSourceBase):
 
             else:
                 if self.source_config.ignore_unsupported_connectors:
-                    self.report_warning(
+                    self.report.warning(
                         flow_urn,
                         f"Unrecognized node {node['NodeType']}-{node['Id']} in flow {flow_urn}. Args: {node_args} Skipping",
+                        log=False,
                     )
                     return None
                 else:
@@ -1468,10 +1488,11 @@ class GlueSource(StatefulIngestionSourceBase):
             # Source and Target for some edges is not available
             # in nodes. this may lead to broken edge in lineage.
             if source_node is None or target_node is None:
-                self.report_warning(
+                self.report.warning(
                     flow_urn,
                     f"Unrecognized source or target node in edge: {edge}. Skipping."
                     "This may lead to missing lineage",
+                    log=False,
                 )
                 continue
 
@@ -2036,9 +2057,10 @@ class GlueSource(StatefulIngestionSourceBase):
                         f"Failed to create platform resource for tag {tag}: {e}",
                         exc_info=True,
                     )
-                    self.report.report_warning(
+                    self.report.warning(
                         context="Failed to create platform resource",
                         message=f"Failed to create platform resource for Tag: {tag}",
+                        log=False,
                     )
 
     def gen_database_containers(
@@ -2058,9 +2080,10 @@ class GlueSource(StatefulIngestionSourceBase):
                     except InvalidUrnError:
                         continue
             except Exception:
-                self.report_warning(
-                    reason="Failed to extract Lake Formation tags for database",
-                    key=database["Name"],
+                self.report.warning(
+                    "Failed to extract Lake Formation tags for database",
+                    context=database["Name"],
+                    log=False,
                 )
         domain_urn = self._gen_domain_urn(database["Name"])
         database_container_key = self.gen_database_key(database["Name"])
@@ -2120,7 +2143,7 @@ class GlueSource(StatefulIngestionSourceBase):
             try:
                 yield from self._gen_table_wu(table=table)
             except KeyError as e:
-                self.report.report_failure(
+                self.report.failure(
                     message="Failed to extract workunit for table",
                     context=f"Table: {table_name}",
                     exc=e,
@@ -2137,7 +2160,7 @@ class GlueSource(StatefulIngestionSourceBase):
                 for mcp in self.aggregator.gen_metadata():
                     yield mcp.as_workunit()
             except Exception as e:
-                self.report.report_failure(
+                self.report.failure(
                     message="Failed to generate view lineage from SQL parsing",
                     context="SqlParsingAggregator.gen_metadata",
                     exc=e,
@@ -2223,9 +2246,10 @@ class GlueSource(StatefulIngestionSourceBase):
         """
         view_text = table.get("ViewOriginalText") or table.get("ViewExpandedText")
         if not isinstance(view_text, str) or not view_text:
-            self.report.report_warning(
+            self.report.warning(
                 message="View has no SQL definition",
                 context=f"table={full_table_name}",
+                log=False,
             )
             return None
 
@@ -2235,18 +2259,20 @@ class GlueSource(StatefulIngestionSourceBase):
             try:
                 original_sql = decode_presto_view(view_text).get("originalSql")
             except Exception as e:
-                self.report.report_warning(
+                self.report.warning(
                     message="Failed to decode Presto view definition",
                     context=f"table={full_table_name}: {e}",
+                    log=False,
                 )
                 return None
             if isinstance(original_sql, str) and original_sql:
                 return GlueViewDefinition(
                     sql=original_sql, dialect=self._PRESTO_VIEW_DIALECT
                 )
-            self.report.report_warning(
+            self.report.warning(
                 message="Presto view definition missing 'originalSql'",
                 context=f"table={full_table_name}",
+                log=False,
             )
             return None
 
@@ -2440,7 +2466,7 @@ class GlueSource(StatefulIngestionSourceBase):
                 metadata_record, table["DatabaseName"], table["Name"]
             )
         except KeyError as e:
-            self.report.report_failure(
+            self.report.failure(
                 message="Failed to extract profile for table",
                 context=f"Table: {dataset_urn}",
                 exc=e,
@@ -2683,9 +2709,10 @@ class GlueSource(StatefulIngestionSourceBase):
             )
 
         except Exception as e:
-            self.report_warning(
+            self.report.warning(
                 dataset_urn,
                 f"Could not parse schema for {table_name} because of {type(e).__name__}: {e}",
+                log=False,
             )
             self.report.num_dataset_invalid_delta_schema += 1
             return None
@@ -2785,9 +2812,10 @@ class GlueSource(StatefulIngestionSourceBase):
                         aspect=StructuredPropertiesClass(properties=assignments),
                     ).as_workunit()
             except Exception as e:
-                self.report.report_warning(
+                self.report.warning(
                     message="Failed to emit column parameters for column",
                     context=f"dataset={dataset_urn} column={column.get('Name', '?')!r}: {e}",
+                    log=False,
                 )
 
     def _get_s3_tags(self, table: Dict, dataset_urn: str) -> Optional[GlobalTagsClass]:
@@ -2919,10 +2947,6 @@ class GlueSource(StatefulIngestionSourceBase):
 
     def get_report(self):
         return self.report
-
-    def report_warning(self, key: str, reason: str) -> None:
-        logger.warning(f"{key}: {reason}")
-        self.report.report_warning(key, reason)
 
 
 def _redact_secret_fields_in_dataflow_script(script: str) -> str:

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/sagemaker_processors/feature_groups.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/sagemaker_processors/feature_groups.py
@@ -141,8 +141,10 @@ class FeatureGroupProcessor:
         mapped_type = self.field_type_mappings.get(aws_type)
 
         if mapped_type is None:
-            self.report.report_warning(
-                feature_name, f"unable to map type {aws_type} to metadata schema"
+            self.report.warning(
+                feature_name,
+                f"unable to map type {aws_type} to metadata schema",
+                log=False,
             )
             mapped_type = MLFeatureDataType.UNKNOWN
 

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/sagemaker_processors/jobs.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/sagemaker_processors/jobs.py
@@ -394,9 +394,10 @@ class JobProcessor:
         if mapped_status is None:
             mapped_status = JobStatusClass.UNKNOWN
 
-            self.report.report_warning(
+            self.report.warning(
                 name,
                 f"Unknown status for {name} ({arn}): {sagemaker_status}",
+                log=False,
             )
 
         job_urn = make_sagemaker_job_urn(job_type.value, name, arn, self.env)
@@ -561,9 +562,10 @@ class JobProcessor:
                     )
                 )
             else:
-                self.report.report_warning(
+                self.report.warning(
                     name,
                     f"Unable to find ARN for training job {training_job['DefinitionName']} produced by hyperparameter tuning job {arn}",
+                    log=False,
                 )
 
         job_snapshot, job_name, job_arn = self.create_common_job_snapshot(

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/sagemaker_processors/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/sagemaker_processors/models.py
@@ -164,9 +164,10 @@ class ModelProcessor:
         endpoint_status = ENDPOINT_STATUS_MAP.get(sagemaker_status)
 
         if endpoint_status is None:
-            self.report.report_warning(
+            self.report.warning(
                 endpoint_arn,
                 f"Unknown status for {endpoint_name} ({endpoint_arn}): {sagemaker_status}",
+                log=False,
             )
 
             endpoint_status = DeploymentStatusClass.UNKNOWN

--- a/metadata-ingestion/src/datahub/ingestion/source/azure_data_factory/adf_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/azure_data_factory/adf_report.py
@@ -108,20 +108,22 @@ class AzureDataFactorySourceReport(StaleEntityRemovalSourceReport):
     def report_lineage_failed(self, entity_name: str, error: str) -> None:
         """Record a lineage extraction failure."""
         self.lineage_extraction_failures += 1
-        self.report_warning(
+        self.warning(
             title="Lineage Extraction Failed",
             message="Unable to extract lineage for this entity.",
             context=f"entity={entity_name}, error={error}",
+            log=False,
         )
 
     def report_unmapped_platform(
         self, dataset_name: str, linked_service_type: str
     ) -> None:
         """Record a dataset with unmapped platform via structured warning."""
-        self.report_warning(
+        self.warning(
             title="Unmapped Linked Service Type",
             message="Lineage skipped for dataset using unsupported linked service type.",
             context=f"dataset={dataset_name}, linked_service_type={linked_service_type}",
+            log=False,
         )
 
     def report_column_lineage_extracted(self) -> None:
@@ -164,8 +166,9 @@ class AzureDataFactorySourceReport(StaleEntityRemovalSourceReport):
     def report_api_error(self, endpoint: str, error: str) -> None:
         """Record an API error."""
         self.api_calls_total_error_count += 1
-        self.report_warning(
+        self.warning(
             title="API Error",
             message="Failed to call Azure Data Factory API.",
             context=f"endpoint={endpoint}, error={error}",
+            log=False,
         )

--- a/metadata-ingestion/src/datahub/ingestion/source/azure_data_factory/adf_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/azure_data_factory/adf_source.py
@@ -230,7 +230,7 @@ class AzureDataFactorySource(StatefulIngestionSourceBase):
                 self.client.get_factories(resource_group=self.config.resource_group)
             )
         except Exception as e:
-            self.report.report_failure(
+            self.report.failure(
                 title="Failed to List Data Factories",
                 message="Unable to retrieve Data Factories from Azure. Check permissions and subscription ID.",
                 context=f"subscription={self.config.subscription_id}",
@@ -279,11 +279,12 @@ class AzureDataFactorySource(StatefulIngestionSourceBase):
                     yield from self._process_execution_history(factory, resource_group)
 
             except Exception as e:
-                self.report.report_warning(
+                self.report.warning(
                     title="Failed to Process Data Factory",
                     message="Error processing Data Factory. Skipping to next.",
                     context=f"factory={factory_name}",
                     exc=e,
+                    log=False,
                 )
 
     def _extract_resource_group(self, resource_id: str) -> str:
@@ -419,11 +420,12 @@ class AzureDataFactorySource(StatefulIngestionSourceBase):
                 if pipeline.name:  # Skip pipelines with no name
                     self._pipelines_cache[factory_key][pipeline.name] = pipeline
         except Exception as e:
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to List Pipelines",
                 message="Unable to retrieve pipelines from factory.",
                 context=f"factory={factory_name}",
                 exc=e,
+                log=False,
             )
             return  # Can't process pipelines if we can't list them
 
@@ -1244,11 +1246,12 @@ class AzureDataFactorySource(StatefulIngestionSourceBase):
                 )
             )
         except Exception as e:
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to Fetch Execution History",
                 message="Unable to retrieve pipeline runs.",
                 context=f"factory={factory_name}",
                 exc=e,
+                log=False,
             )
             return
 

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
@@ -237,11 +237,12 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
                         batch_size=self.config.schema_resolution_batch_size,
                     )
                 except Exception as e:
-                    self.report.report_warning(
+                    self.report.warning(
                         message="Failed to bulk-load schemas from DataHub for SQL lineage. "
                         "Lineage resolution will proceed with an empty schema resolver.",
                         context=str(e),
                         exc=e,
+                        log=False,
                     )
             else:
                 logger.warning(
@@ -257,12 +258,13 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
             and self.config.schema_pattern is not None
             and self.config.schema_pattern != AllowDenyPattern.allow_all()
         ):
-            self.report.report_warning(
+            self.report.warning(
                 message="Please update `schema_pattern` to match against fully qualified schema name `<database_name>.<schema_name>` and set config `match_fully_qualified_names : True`."
                 "Current default `match_fully_qualified_names: False` is only to maintain backward compatibility. "
                 "The config option `match_fully_qualified_names` will be removed in future and the default behavior will be like `match_fully_qualified_names: True`.",
                 context="Config option deprecation warning",
                 title="Config option deprecation warning",
+                log=False,
             )
 
         # Unlike the forwarded usage.start_time/end_time/bucket_duration/max_query_duration
@@ -271,18 +273,20 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
         # in the UI), not just the config-validation-time logger.warning.
         if self.config.use_queries_v2:
             if self.config.usage.include_read_operational_stats:
-                self.report.report_warning(
+                self.report.warning(
                     message="`usage.include_read_operational_stats` is only supported with the legacy extraction path "
                     "(`use_queries_v2: False`) and is ignored under queries-v2.",
                     context="Config option deprecation warning",
                     title="Config option deprecation warning",
+                    log=False,
                 )
             if self.config.usage.apply_view_usage_to_tables:
-                self.report.report_warning(
+                self.report.warning(
                     message="`usage.apply_view_usage_to_tables` is only supported with the legacy extraction path "
                     "(`use_queries_v2: False`) and is ignored under queries-v2.",
                     context="Config option deprecation warning",
                     title="Config option deprecation warning",
+                    log=False,
                 )
 
     def _build_queries_extractor_config(self) -> BigQueryQueriesExtractorConfig:

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
@@ -995,7 +995,7 @@ def query_project_list_from_labels(
     )
 
     if not projects:  # Report failure on exception and if empty list is returned
-        report.report_failure(
+        report.failure(
             "metadata-extraction",
             "Get projects didn't return any project with any of the specified label(s). "
             "Maybe resourcemanager.projects.list permission is missing for the service account. "

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/profiler.py
@@ -316,10 +316,11 @@ WHERE
             and bq_table.partition_info.column
             is not None  # Only skip if it's a real partitioned column, not a pseudo-partition
         ):
-            self.report.report_warning(
+            self.report.warning(
                 title="Profile skipped for partitioned table",
                 message="profile skipped as partition id or type was invalid",
                 context=profile_request.pretty_name,
+                log=False,
             )
             return None
 

--- a/metadata-ingestion/src/datahub/ingestion/source/cassandra/cassandra.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/cassandra/cassandra.py
@@ -230,8 +230,10 @@ class CassandraSource(StatefulIngestionSourceBase):
             CassandraToSchemaFieldConverter.get_schema_fields(column_infos)
         )
         if not schema_fields:
-            self.report.report_warning(
-                message="Table has no columns, skipping", context=table_name
+            self.report.warning(
+                message="Table has no columns, skipping",
+                context=table_name,
+                log=False,
             )
             return None
 

--- a/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_report.py
@@ -58,7 +58,7 @@ class ConfluenceSourceReport(StaleEntityRemovalSourceReport):
         """Record space processing failure."""
         self.spaces_failed += 1
         self.failed_spaces.append(space_key)
-        self.report_warning(space_key, f"Failed to process space: {error}")
+        self.warning(space_key, f"Failed to process space: {error}", log=False)
 
     def report_page_scanned(self) -> None:
         """Record that a page was scanned."""
@@ -77,13 +77,13 @@ class ConfluenceSourceReport(StaleEntityRemovalSourceReport):
     def report_page_skipped(self, page_id: str, reason: str) -> None:
         """Record that a page was skipped."""
         self.pages_skipped += 1
-        self.report_warning(page_id, f"Skipped page: {reason}")
+        self.warning(page_id, f"Skipped page: {reason}", log=False)
 
     def report_page_failed(self, page_id: str, space_key: str, error: str) -> None:
         """Record page processing failure."""
         self.pages_failed += 1
         self.failed_pages.append((space_key, page_id))
-        self.report_failure(page_id, f"Failed to process page: {error}")
+        self.failure(page_id, f"Failed to process page: {error}")
 
     def report_folder_failed(self, folder_id: str, error: str) -> None:
         """Record a folder discovery/emission failure.
@@ -93,7 +93,7 @@ class ConfluenceSourceReport(StaleEntityRemovalSourceReport):
         rather than a hard failure — it must never sink the ingestion job.
         """
         self.folders_failed += 1
-        self.report_warning(folder_id, f"Failed to process folder: {error}")
+        self.warning(folder_id, f"Failed to process folder: {error}", log=False)
 
     def report_text_extracted(self, num_bytes: int) -> None:
         """Record text extraction metrics."""

--- a/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_source.py
@@ -491,7 +491,7 @@ class ConfluenceSource(StatefulIngestionSourceBase, TestableSource):
 
             except Exception as e:
                 logger.error(f"Failed to discover spaces: {e}")
-                self.report.report_failure("space_discovery", str(e))
+                self.report.failure("space_discovery", str(e))
                 return []
 
         # Apply spaces.deny filter
@@ -573,7 +573,7 @@ class ConfluenceSource(StatefulIngestionSourceBase, TestableSource):
 
         except Exception as e:
             logger.error(f"Failed to fetch page {page_id}: {e}")
-            self.report.report_failure(f"page_{page_id}", str(e))
+            self.report.failure(f"page_{page_id}", str(e))
 
             if not self.config.advanced.continue_on_failure:
                 raise
@@ -653,7 +653,7 @@ class ConfluenceSource(StatefulIngestionSourceBase, TestableSource):
                 yield from self._get_pages_in_space(space_key)
             except Exception as e:
                 logger.error(f"Failed to process space '{space_key}': {e}")
-                self.report.report_failure(f"space_{space_key}", str(e))
+                self.report.failure(f"space_{space_key}", str(e))
 
                 if not self.config.advanced.continue_on_failure:
                     raise
@@ -697,7 +697,7 @@ class ConfluenceSource(StatefulIngestionSourceBase, TestableSource):
 
             except Exception as e:
                 logger.error(f"Failed to process page '{page_id}': {e}")
-                self.report.report_failure(f"page_{page_id}", str(e))
+                self.report.failure(f"page_{page_id}", str(e))
 
                 if not self.config.advanced.continue_on_failure:
                     raise

--- a/metadata-ingestion/src/datahub/ingestion/source/confluent_schema_registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluent_schema_registry.py
@@ -273,13 +273,14 @@ class ConfluentSchemaRegistry(KafkaSchemaRegistryBase):
                 )
                 schema = registered_schema.schema
             except Exception as e:
-                self.report.report_warning(
+                self.report.warning(
                     title="Failed to get subject schema from schema registry",
                     message=f"Failed to get {kafka_entity} {schema_type_str or ''} schema from schema registry",
                     context=(
                         f"{topic}: {topic_subject}" if not is_subject else topic_subject
                     ),
                     exc=e,
+                    log=False,
                 )
         else:
             logger.debug(
@@ -431,9 +432,10 @@ class ConfluentSchemaRegistry(KafkaSchemaRegistryBase):
                 )
             )
         elif not self.source_config.ignore_warnings_on_schema_type:
-            self.report.report_warning(
+            self.report.warning(
                 topic,
                 f"Parsing kafka schema type {schema.schema_type} is currently not implemented",
+                log=False,
             )
         return fields
 

--- a/metadata-ingestion/src/datahub/ingestion/source/csv_enricher.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/csv_enricher.py
@@ -697,9 +697,10 @@ class CSVEnricherSource(Source):
             and ownership_type != OwnershipTypeClass.CUSTOM
         ):
             resource_urn = row["resource"]
-            self.report.report_warning(
+            self.report.warning(
                 f"{resource_urn}-invalid-ownership-type",
                 "Ownership type URN is set but ownership type is not CUSTOM. Setting ownership_type to CUSTOM.",
+                log=False,
             )
             ownership_type = OwnershipTypeClass.CUSTOM
 

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_source.py
@@ -71,7 +71,7 @@ class DataHubSource(StatefulIngestionSourceBase):
                 f"Ensure your configuration excludes these sensitive entity patterns: {', '.join(DEFAULT_URN_DENY_PATTERNS)}. "
                 "These defaults prevent copying credentials and creating invalid entities."
             )
-            self.report.report_warning("urn_pattern_override", warning_msg)
+            self.report.warning("urn_pattern_override", warning_msg, log=False)
 
         self.stateful_ingestion_handler = StatefulDataHubIngestionHandler(self)
 
@@ -213,7 +213,7 @@ class DataHubSource(StatefulIngestionSourceBase):
 
     def _get_api_workunits(self) -> Iterable[MetadataWorkUnit]:
         if self.ctx.graph is None:
-            self.report.report_failure(
+            self.report.failure(
                 "datahub_api",
                 "Specify datahub_api on your ingestion recipe to ingest from the DataHub API",
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -284,11 +284,12 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
         # cleanly without processing (this is expected, not a failure).
         if self.lock is not None and not self.lock.acquire():
             self.report.lock_skipped_run = True
-            self.report.report_warning(
+            self.report.warning(
                 title="Run skipped (lock held)",
                 message="Another datahub-documents run is in progress; this run exited "
                 "without processing to avoid duplicate work. Adjust the schedule or "
                 "locking.lock_ttl_seconds if this happens persistently.",
+                log=False,
             )
             return
 
@@ -299,7 +300,7 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                 yield from self._process_batch_mode()
         except Exception as e:
             logger.error(f"Failed to run Unstructured pipeline: {e}", exc_info=True)
-            self.report.report_failure(str(e))
+            self.report.failure(str(e))
         finally:
             # Save state after processing
             if self.config.incremental.enabled:

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -1544,11 +1544,12 @@ class DBTSourceBase(StatefulIngestionSourceBase):
             try:
                 self._upstream_exists_cache[urn] = self.ctx.graph.exists(urn)
             except Exception as e:
-                self.report.report_warning(
+                self.report.warning(
                     title="Upstream existence check failed",
                     message="Could not verify upstream existence; keeping the lineage edge to avoid silent lineage loss.",
                     context=urn,
                     exc=e,
+                    log=False,
                 )
                 self._upstream_exists_cache[urn] = True  # fail open
             if not self._upstream_exists_cache[urn]:
@@ -2815,7 +2816,7 @@ class DBTSourceBase(StatefulIngestionSourceBase):
         if not isinstance(queries, list):
             msg = f"Invalid meta.queries in {node.dbt_name}: expected list, got {type(queries).__name__}"
             logger.warning(msg)
-            self.report.report_warning(node.dbt_name, msg)
+            self.report.warning(node.dbt_name, msg, log=False)
             return
 
         # Ephemeral models don't exist in target platform, so queries can't be linked
@@ -2874,7 +2875,7 @@ class DBTSourceBase(StatefulIngestionSourceBase):
             if query_urn_str in seen_urns:
                 msg = f"Query '{query_name}' in {node.dbt_name} skipped: URN collision with '{seen_urns[query_urn_str]}'"
                 logger.warning(msg)
-                self.report.report_warning(node.dbt_name, msg)
+                self.report.warning(node.dbt_name, msg, log=False)
                 self.report.num_queries_failed += 1
                 self.report.queries_failed_list.append(
                     f"{node.dbt_name}.{query_name}: URN collision"
@@ -3434,10 +3435,11 @@ class DBTSourceBase(StatefulIngestionSourceBase):
                 )
 
             if node.cll_debug_info and node.cll_debug_info.error:
-                self.report.report_warning(
+                self.report.warning(
                     "Error parsing SQL to generate column lineage",
                     context=node.dbt_name,
                     exc=node.cll_debug_info.error,
+                    log=False,
                 )
 
             cll = None
@@ -3474,9 +3476,10 @@ class DBTSourceBase(StatefulIngestionSourceBase):
             else:
                 if self.config.prefer_sql_parser_lineage:
                     if node.upstream_cll:
-                        self.report.report_warning(
+                        self.report.warning(
                             "SQL parser lineage is not available for this node, falling back to dbt-based column lineage.",
                             context=node.dbt_name,
+                            log=False,
                         )
                     else:
                         # SQL parsing failed entirely, which is already reported above.

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_core.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_core.py
@@ -1010,7 +1010,7 @@ class DBTCoreSource(DBTSourceBase, TestableSource):
                 and catalog_version.startswith("1.7.")
                 and version.parse(catalog_version) < version.parse("1.7.3")
             ):
-                self.report.report_warning(
+                self.report.warning(
                     title="Dbt Catalog Version",
                     message="Due to a bug in dbt version between 1.7.0 and 1.7.2, you will have incomplete metadata "
                     "source",
@@ -1018,6 +1018,7 @@ class DBTCoreSource(DBTSourceBase, TestableSource):
                     f"sources."
                     "Please upgrade to dbt version 1.7.3 or later. "
                     "See https://github.com/dbt-labs/dbt-core/issues/9119 for details on the bug.",
+                    log=False,
                 )
         except Exception as e:
             self.report.info(

--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_api.py
@@ -1266,11 +1266,12 @@ class DremioAPIOperations:
                     f"Error in chunked query extraction at offset {offset}: {e}"
                 )
                 if "'rows'" in str(e):
-                    self.report.report_warning(
+                    self.report.warning(
                         f"Dremio crash detected during query extraction "
                         f"(KeyError: 'rows' - likely OOM). Current chunk_size: {chunk_size}. "
                         f"Consider reducing chunk size if this persists.",
                         context="query_extraction",
+                        log=False,
                     )
                 break
 

--- a/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dremio/dremio_source.py
@@ -371,7 +371,7 @@ class DremioSource(StatefulIngestionSourceBase):
                     )
                 except Exception as exc:
                     self.report.num_containers_failed += 1
-                    self.report.report_failure(
+                    self.report.failure(
                         message="Failed to process Dremio container",
                         context=f"{'.'.join(container.path)}.{container.container_name}",
                         exc=exc,
@@ -401,7 +401,7 @@ class DremioSource(StatefulIngestionSourceBase):
                     )
                 except Exception as exc:
                     self.report.num_datasets_failed += 1
-                    self.report.report_failure(
+                    self.report.failure(
                         message="Failed to process Dremio dataset",
                         context=f"{'.'.join(dataset_info.path)}.{dataset_info.resource_name}",
                         exc=exc,
@@ -419,7 +419,7 @@ class DremioSource(StatefulIngestionSourceBase):
                 try:
                     yield from self.process_glossary_term(glossary_term)
                 except Exception as exc:
-                    self.report.report_failure(
+                    self.report.failure(
                         message="Failed to process Glossary terms",
                         context=f"{glossary_term.glossary_term}",
                         exc=exc,
@@ -452,7 +452,7 @@ class DremioSource(StatefulIngestionSourceBase):
                             self.report.profiling_skipped_other[
                                 target.resource_name
                             ] += 1
-                            self.report.report_failure(
+                            self.report.failure(
                                 message="Failed to profile dataset",
                                 context=target.full_table_name,
                                 exc=exc,
@@ -682,7 +682,7 @@ class DremioSource(StatefulIngestionSourceBase):
             try:
                 self.process_query(query)
             except Exception as exc:
-                self.report.report_failure(
+                self.report.failure(
                     message="Failed to process dremio query",
                     context=f"{query.job_id}: {exc}",
                     exc=exc,

--- a/metadata-ingestion/src/datahub/ingestion/source/dynamodb/dynamodb.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dynamodb/dynamodb.py
@@ -486,10 +486,11 @@ class DynamoDBSource(StatefulIngestionSourceBase):
         table_fields = list(schema.values())
         if schema_size > self.config.max_schema_size:
             # downsample the schema, using frequency as the sort key
-            self.report.report_warning(
+            self.report.warning(
                 title="Schema Size Too Large",
                 message=f"Downsampling the table schema because `max_schema_size` threshold is {self.config.max_schema_size}",
                 context=f"Collection: {dataset_urn}",
+                log=False,
             )
 
             # Add this information to the custom properties so user can know they are looking at down sampled schema
@@ -559,10 +560,11 @@ class DynamoDBSource(StatefulIngestionSourceBase):
             attribute_type
         )
         if type_string is None:
-            self.report.report_warning(
+            self.report.warning(
                 title="Unable to Map Attribute Type",
                 message=f"Unable to map type {attribute_type} to native data type",
                 context=f"Collection: {table_name}",
+                log=False,
             )
             return _attribute_type_to_native_type_mapping[attribute_type]
         return type_string
@@ -576,10 +578,11 @@ class DynamoDBSource(StatefulIngestionSourceBase):
         )
 
         if type_class is None:
-            self.report.report_warning(
+            self.report.warning(
                 title="Unable to Map Field Type",
                 message=f"Unable to map type {attribute_type} to metadata schema field type",
                 context=f"Collection: {table_name}",
+                log=False,
             )
             type_class = NullTypeClass
         return SchemaFieldDataType(type=type_class())

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/data_factory/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/data_factory/lineage.py
@@ -345,11 +345,12 @@ class InvokePipelineLineageExtractor:
         if operation_type == self.SUPPORTED_OPERATION_TYPE:
             return self._resolve_fabric_pipeline(activity, parent_workspace_id)
 
-        self._report.report_warning(
+        self._report.warning(
             title="InvokePipeline Lineage Not Resolved",
             message="Unsupported operationType. "
             "Only InvokeFabricPipeline is supported.",
             context=f"activity={activity.name}, operationType={operation_type}",
+            log=False,
         )
         return None
 

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/data_factory/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/data_factory/source.py
@@ -275,15 +275,16 @@ class FabricDataFactorySource(StatefulIngestionSourceBase):
                         )
 
                 except Exception as e:
-                    self.report.report_warning(
+                    self.report.warning(
                         title="Failed to Process Workspace",
                         message="Error processing workspace. Skipping to next.",
                         context=f"workspace={workspace.name}",
                         exc=e,
+                        log=False,
                     )
 
         except Exception as e:
-            self.report.report_failure(
+            self.report.failure(
                 title="Failed to List Workspaces",
                 message="Unable to retrieve workspaces from Fabric.",
                 context="",
@@ -314,12 +315,13 @@ class FabricDataFactorySource(StatefulIngestionSourceBase):
                 )
                 self._pipeline_activities_cache[(workspace_id, item.id)] = activities
             except Exception as e:
-                self.report.report_warning(
+                self.report.warning(
                     title="Failed to Fetch Pipeline Activities",
                     message="Could not retrieve activities. "
                     "Skipping activities for this pipeline.",
                     context=f"pipeline={item.name}",
                     exc=e,
+                    log=False,
                 )
                 self._pipeline_activities_cache[(workspace_id, item.id)] = []
 
@@ -334,12 +336,13 @@ class FabricDataFactorySource(StatefulIngestionSourceBase):
                 if conn.id not in self._connections_cache:
                     self._connections_cache[conn.id] = conn
         except Exception as e:
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to Fetch Item Connections",
                 message="Could not retrieve connections for item. "
                 "Lineage may be incomplete for this pipeline.",
                 context=f"pipeline={item.name}",
                 exc=e,
+                log=False,
             )
 
     def _create_workspace_container(
@@ -534,12 +537,13 @@ class FabricDataFactorySource(StatefulIngestionSourceBase):
                 yield datajob
                 self.report.report_activity_scanned()
             except Exception as e:
-                self.report.report_warning(
+                self.report.warning(
                     title="Failed to Emit Activity",
                     message="Error processing activity. Skipping to next.",
                     context=f"pipeline={pipeline_item.name}, "
                     f"activity={activity.name}, type={activity.type}",
                     exc=e,
+                    log=False,
                 )
 
     def _resolve_upstream_edges(
@@ -603,29 +607,32 @@ class FabricDataFactorySource(StatefulIngestionSourceBase):
                 self.report.report_lineage_extracted()
             elif missing_source and missing_sink:
                 self.report.report_lineage_failed(activity_key)
-                self.report.report_warning(
+                self.report.warning(
                     title="Copy Activity Lineage Not Resolved",
                     message="Neither source nor destination could be resolved.",
                     context=activity_key,
+                    log=False,
                 )
             else:
                 self.report.report_lineage_extracted()
                 missing_side = "source (input)" if missing_source else "sink (output)"
-                self.report.report_warning(
+                self.report.warning(
                     title="Copy Activity Lineage Partially Resolved",
                     message=f"Missing {missing_side} dataset. "
                     f"Check the activity's {missing_side} connection type and settings.",
                     context=activity_key,
+                    log=False,
                 )
             return input_urns, output_urns
         except Exception as e:
             self.report.report_lineage_failed(activity_key)
-            self.report.report_warning(
+            self.report.warning(
                 title="Copy Activity Lineage Extraction Error",
                 message="Unexpected error extracting lineage. "
                 "Activity will be emitted without lineage.",
                 context=activity_key,
                 exc=e,
+                log=False,
             )
             return [], []
 
@@ -661,11 +668,12 @@ class FabricDataFactorySource(StatefulIngestionSourceBase):
                 lookback_window_start=lookback_window_start,
             )
         except Exception as e:
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to Fetch Pipeline Runs",
                 message="Could not retrieve run history. Skipping runs for this pipeline.",
                 context=f"pipeline={pipeline_item.name}",
                 exc=e,
+                log=False,
             )
             return
 
@@ -683,11 +691,12 @@ class FabricDataFactorySource(StatefulIngestionSourceBase):
                     flow_urn=flow_urn,
                 )
             except Exception as e:
-                self.report.report_warning(
+                self.report.warning(
                     title="Failed to Process Pipeline Run",
                     message="Error processing pipeline run. Skipping to next run.",
                     context=f"pipeline={pipeline_item.name}, run={run.id}",
                     exc=e,
+                    log=False,
                 )
 
     @staticmethod
@@ -778,11 +787,12 @@ class FabricDataFactorySource(StatefulIngestionSourceBase):
                 lookback_window_end=datetime.now(timezone.utc),
             )
         except Exception as e:
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to Fetch Activity Runs",
                 message="Could not retrieve activity runs. Skipping for this pipeline run.",
                 context=f"pipeline={pipeline_item.name}, run={run.id}",
                 exc=e,
+                log=False,
             )
             return
 
@@ -795,13 +805,14 @@ class FabricDataFactorySource(StatefulIngestionSourceBase):
                 )
                 self.report.report_activity_run_scanned()
             except Exception as e:
-                self.report.report_warning(
+                self.report.warning(
                     title="Failed to Emit Activity Run",
                     message="Error processing activity run. Skipping to next.",
                     context=f"pipeline={pipeline_item.name}, "
                     f"activity={activity_run.activity_name}, "
                     f"run={activity_run.activity_run_id}",
                     exc=e,
+                    log=False,
                 )
 
     def _emit_activity_run(

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/report.py
@@ -140,8 +140,9 @@ class FabricOneLakeSourceReport(StaleEntityRemovalSourceReport):
     def report_api_error(self, endpoint: str, error: str) -> None:
         """Record an API error."""
         self.api_calls_total_error_count += 1
-        self.report_warning(
+        self.warning(
             title="API Error",
             message="Failed to call Fabric REST API.",
             context=f"endpoint={endpoint}, error={error}",
+            log=False,
         )

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/source.py
@@ -292,15 +292,16 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
                     yield from self._process_workspace_items(workspace)
 
                 except Exception as e:
-                    self.report.report_warning(
+                    self.report.warning(
                         title="Failed to Process Workspace",
                         message="Error processing workspace. Skipping to next.",
                         context=f"workspace={workspace.name}",
                         exc=e,
+                        log=False,
                     )
 
         except Exception as e:
-            self.report.report_failure(
+            self.report.failure(
                 title="Failed to List Workspaces",
                 message="Unable to retrieve workspaces from Fabric.",
                 context="",
@@ -323,7 +324,7 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
             aggregator_drain_succeeded = True
             logger.info(f"SQL aggregator drained: emitted {emitted} MCPs")
         except Exception as e:
-            self.report.report_failure(
+            self.report.failure(
                 title="Failed to Generate Lineage / Usage",
                 message="Error draining SQL aggregator for lineage and usage.",
                 context=f"mcps_emitted_before_failure={emitted}",
@@ -379,11 +380,12 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
                     )
                     yield from self._process_lakehouse(workspace, lakehouse)
             except Exception as e:
-                self.report.report_warning(
+                self.report.warning(
                     title="Failed to List Lakehouses",
                     message="Unable to retrieve lakehouses from workspace.",
                     context=f"workspace={workspace.name}",
                     exc=e,
+                    log=False,
                 )
 
         # Process warehouses
@@ -401,11 +403,12 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
                     )
                     yield from self._process_warehouse(workspace, warehouse)
             except Exception as e:
-                self.report.report_warning(
+                self.report.warning(
                     title="Failed to List Warehouses",
                     message="Unable to retrieve warehouses from workspace.",
                     context=f"workspace={workspace.name}",
                     exc=e,
+                    log=False,
                 )
 
     def _process_lakehouse(
@@ -639,11 +642,12 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
                     )
 
         except Exception as e:
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to Process Tables",
                 message="Unable to retrieve tables from item.",
                 context=f"item_id={item_id}, item_type={item_type}",
                 exc=e,
+                log=False,
             )
 
     def _get_columns(
@@ -773,7 +777,7 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
                 "usage statistics will be skipped for this item.",
                 exc_info=True,
             )
-            self.report.report_warning(
+            self.report.warning(
                 title="SQL Analytics Endpoint Initialization Failed",
                 message=(
                     "Failed to initialize the SQL Analytics Endpoint client. "
@@ -782,6 +786,7 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
                 ),
                 context=f"item_id={item_id}, item_type={item_type}, error={error_msg}",
                 exc=e,
+                log=False,
             )
             return None
 
@@ -810,7 +815,7 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
                 "Tables and views will be emitted without column-level schema.",
                 exc_info=True,
             )
-            self.report.report_warning(
+            self.report.warning(
                 title="Column Metadata Extraction Failed",
                 message=(
                     "Failed to query INFORMATION_SCHEMA.COLUMNS. Tables and views "
@@ -818,6 +823,7 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
                 ),
                 context=f"item_id={item_id}, item_type={item_type}, error={error_msg}",
                 exc=e,
+                log=False,
             )
             return {}
 
@@ -877,13 +883,14 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
                 "Views will be missing for this item.",
                 exc_info=True,
             )
-            self.report.report_warning(
+            self.report.warning(
                 title="View Discovery Failed",
                 message=(
                     "Failed to query INFORMATION_SCHEMA.VIEWS. Views will be missing for this item."
                 ),
                 context=f"item_id={item_id}, item_type={item_type}",
                 exc=e,
+                log=False,
             )
             return
 

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/usage.py
@@ -142,7 +142,7 @@ class FabricUsageExtractor:
                 f"Failed usage extraction for item='{item_display_name}' "
                 f"workspace_id={workspace_id} item_id={item_id}: {e}"
             )
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to Extract Usage",
                 message=(
                     "Error reading queryinsights.exec_requests_history. "
@@ -150,6 +150,7 @@ class FabricUsageExtractor:
                 ),
                 context=f"workspace_id={workspace_id}, item_id={item_id}",
                 exc=e,
+                log=False,
             )
             # Mark this item's step as failed so the skip handler refuses to advance
             # the usage checkpoint. Otherwise a window where every item failed would

--- a/metadata-ingestion/src/datahub/ingestion/source/feast.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/feast.py
@@ -164,9 +164,10 @@ class FeastRepositorySource(StatefulIngestionSourceBase):
         ml_feature_data_type = _field_type_mapping.get(field_type)
 
         if ml_feature_data_type is None:
-            self.report.report_warning(
+            self.report.warning(
                 "unable to map type",
                 f"unable to map type {field_type} to metadata schema to parent: {parent_name}",
+                log=False,
             )
 
             ml_feature_data_type = MLFeatureDataType.UNKNOWN

--- a/metadata-ingestion/src/datahub/ingestion/source/file.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/file.py
@@ -358,7 +358,7 @@ class GenericFileSource(StatefulIngestionSourceBase, TestableSource):
                     self.report.add_deserialize_time(deserialize_duration)
                     yield i, item
             except Exception as e:
-                self.report.report_failure(f"{file_status.path}-{i}", str(e))
+                self.report.failure(f"{file_status.path}-{i}", str(e))
 
     @staticmethod
     def test_connection(config_dict: dict) -> TestConnectionReport:

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/dataprocess_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/dataprocess_cleanup.py
@@ -266,9 +266,7 @@ class DataProcessCleanup:
                     deleted_count_last_n += 1
                     futures[future]["deleted"] = True
                 except Exception as e:
-                    self.report.report_failure(
-                        f"Exception while deleting DPI: {e}", exc=e
-                    )
+                    self.report.failure(f"Exception while deleting DPI: {e}", exc=e)
             if (
                 deleted_count_last_n % self.config.batch_size == 0
                 and deleted_count_last_n > 0
@@ -361,7 +359,7 @@ class DataProcessCleanup:
                 deleted_count_retention += 1
                 futures[future]["deleted"] = True
             except Exception as e:
-                self.report.report_failure(f"Exception while deleting DPI: {e}", exc=e)
+                self.report.failure(f"Exception while deleting DPI: {e}", exc=e)
 
             if (
                 deleted_count_retention % self.config.batch_size == 0

--- a/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
@@ -523,11 +523,12 @@ class _SingleDatasetProfiler(BasicDatasetProfilerBase):
                 f"Caught exception while attempting to get column cardinality for column {column}. {e}"
             )
 
-            self.report.report_warning(
+            self.report.warning(
                 title="Profiling: Unable to Calculate Cardinality",
                 message="The cardinality for the column will not be accessible",
                 context=f"{self.dataset_name}.{column}",
                 exc=e,
+                log=False,
             )
             return
 
@@ -611,11 +612,12 @@ class _SingleDatasetProfiler(BasicDatasetProfilerBase):
                 f"Caught exception while attempting to get column min for column {column}. {e}"
             )
 
-            self.report.report_warning(
+            self.report.warning(
                 title="Profiling: Unable to Calculate Min",
                 message="The min for the column will not be accessible",
                 context=f"{self.dataset_name}.{column}",
                 exc=e,
+                log=False,
             )
 
     @_run_with_query_combiner
@@ -631,11 +633,12 @@ class _SingleDatasetProfiler(BasicDatasetProfilerBase):
                 f"Caught exception while attempting to get column max for column {column}. {e}"
             )
 
-            self.report.report_warning(
+            self.report.warning(
                 title="Profiling: Unable to Calculate Max",
                 message="The max for the column will not be accessible",
                 context=f"{self.dataset_name}.{column}",
                 exc=e,
+                log=False,
             )
 
     @_run_with_query_combiner
@@ -651,11 +654,12 @@ class _SingleDatasetProfiler(BasicDatasetProfilerBase):
                 f"Caught exception while attempting to get column mean for column {column}. {e}"
             )
 
-            self.report.report_warning(
+            self.report.warning(
                 title="Profiling: Unable to Calculate Mean",
                 message="The mean for the column will not be accessible",
                 context=f"{self.dataset_name}.{column}",
                 exc=e,
+                log=False,
             )
 
     @_run_with_query_combiner
@@ -698,11 +702,12 @@ class _SingleDatasetProfiler(BasicDatasetProfilerBase):
                 f"Caught exception while attempting to get column median for column {column}. {e}"
             )
 
-            self.report.report_warning(
+            self.report.warning(
                 title="Profiling: Unable to Calculate Medians",
                 message="The medians for the column will not be accessible",
                 context=f"{self.dataset_name}.{column}",
                 exc=e,
+                log=False,
             )
 
     @_run_with_query_combiner
@@ -717,11 +722,12 @@ class _SingleDatasetProfiler(BasicDatasetProfilerBase):
             logger.debug(
                 f"Caught exception while attempting to get column stddev for column {column}. {e}"
             )
-            self.report.report_warning(
+            self.report.warning(
                 title="Profiling: Unable to Calculate Standard Deviation",
                 message="The standard deviation for the column will not be accessible",
                 context=f"{self.dataset_name}.{column}",
                 exc=e,
+                log=False,
             )
 
     @_run_with_query_combiner
@@ -761,11 +767,12 @@ class _SingleDatasetProfiler(BasicDatasetProfilerBase):
                 f"Caught exception while attempting to get column quantiles for column {column}. {e}"
             )
 
-            self.report.report_warning(
+            self.report.warning(
                 title="Profiling: Unable to Calculate Quantiles",
                 message="The quantiles for the column will not be accessible",
                 context=f"{self.dataset_name}.{column}",
                 exc=e,
+                log=False,
             )
 
     @_run_with_query_combiner
@@ -801,11 +808,12 @@ class _SingleDatasetProfiler(BasicDatasetProfilerBase):
                 f"Caught exception while attempting to get distinct value frequencies for column {column}. {e}"
             )
 
-            self.report.report_warning(
+            self.report.warning(
                 title="Profiling: Unable to Calculate Distinct Value Frequencies",
                 message="Distinct value frequencies for the column will not be accessible",
                 context=f"{self.dataset_name}.{column}",
                 exc=e,
+                log=False,
             )
 
     @_run_with_query_combiner
@@ -838,11 +846,12 @@ class _SingleDatasetProfiler(BasicDatasetProfilerBase):
                 f"Caught exception while attempting to get column histogram for column {column}. {e}"
             )
 
-            self.report.report_warning(
+            self.report.warning(
                 title="Profiling: Unable to Calculate Histogram",
                 message="The histogram for the column will not be accessible",
                 context=f"{self.dataset_name}.{column}",
                 exc=e,
+                log=False,
             )
 
     @_run_with_query_combiner
@@ -873,11 +882,12 @@ class _SingleDatasetProfiler(BasicDatasetProfilerBase):
                 f"Caught exception while attempting to get sample values for column {column}. {e}"
             )
 
-            self.report.report_warning(
+            self.report.warning(
                 title="Profiling: Unable to Calculate Sample Values",
                 message="The sample values for the column will not be accessible",
                 context=f"{self.dataset_name}.{column}",
                 exc=e,
+                log=False,
             )
 
     def generate_dataset_profile(  # noqa: C901 (complexity)
@@ -1577,9 +1587,10 @@ def create_athena_temp_table(
         if not instance.config.catch_exceptions:
             raise e
         logger.exception(f"Encountered exception while profiling {table_pretty_name}")
-        instance.report.report_warning(
+        instance.report.warning(
             table_pretty_name,
             f"Profiling exception {e} when running custom sql {sql}",
+            log=False,
         )
         return None
     finally:
@@ -1610,9 +1621,10 @@ def create_bigquery_temp_table(
             logger.exception(
                 f"Encountered exception while profiling {table_pretty_name}"
             )
-            instance.report.report_warning(
+            instance.report.warning(
                 table_pretty_name,
                 f"Profiling exception {e} when running custom sql {bq_sql}",
+                log=False,
             )
             return None
 

--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_api.py
@@ -74,7 +74,7 @@ class GrafanaAPIClient:
                 folders.extend(Folder.model_validate(folder) for folder in batch)
                 page += 1
             except requests.exceptions.RequestException as e:
-                self.report.report_failure(
+                self.report.failure(
                     title="Folder Fetch Error",
                     message="Failed to fetch folders on page",
                     context=str(page),
@@ -134,7 +134,7 @@ class GrafanaAPIClient:
                         dashboards.append(dashboard)
                 page += 1
             except requests.exceptions.RequestException as e:
-                self.report.report_failure(
+                self.report.failure(
                     title="Dashboard Search Error",
                     message="Failed to fetch dashboards on page",
                     context=str(page),

--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
@@ -150,7 +150,7 @@ class GrafanaSource(StatefulIngestionSourceBase):
                 )
                 response.raise_for_status()
             except requests.exceptions.RequestException as e:
-                self.report.report_failure(
+                self.report.failure(
                     title="Dashboard Search Error",
                     message="Failed to fetch dashboards in basic mode",
                     context=str(e),

--- a/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
@@ -236,7 +236,7 @@ class IcebergSource(StatefulIngestionSourceBase):
                     exc=e,
                 )
             except Exception as e:
-                self.report.report_failure(
+                self.report.failure(
                     title="Error when processing a namespace",
                     message="Skipping the namespace due to errors while processing it.",
                     context=str(namespace),
@@ -353,7 +353,7 @@ class IcebergSource(StatefulIngestionSourceBase):
                     dataset_path, dataset_name, namespace_urn
                 )
             except Exception as e:
-                self.report.report_failure(
+                self.report.failure(
                     title="Error when processing a table",
                     message="Skipping the table due to errors when processing it.",
                     context=str(dataset_path),
@@ -363,7 +363,7 @@ class IcebergSource(StatefulIngestionSourceBase):
         try:
             self.catalog = self.config.get_catalog()
         except Exception as e:
-            self.report.report_failure(
+            self.report.failure(
                 title="Failed to initialize catalog object",
                 message="Couldn't start the ingestion due to failure to initialize catalog object.",
                 exc=e,
@@ -373,7 +373,7 @@ class IcebergSource(StatefulIngestionSourceBase):
         try:
             yield from self._process_namespaces()
         except Exception as e:
-            self.report.report_failure(
+            self.report.failure(
                 title="Failed to list namespaces",
                 message="Couldn't start the ingestion due to a failure to process the list of the namespaces",
                 exc=e,
@@ -420,11 +420,12 @@ class IcebergSource(StatefulIngestionSourceBase):
                 )
             self.namespaces.append((namespace, namespace_urn))
         except NoSuchNamespaceError as e:
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to retrieve namespace properties",
                 message="Couldn't find the namespace, was it deleted during the ingestion?",
                 context=namespace_repr,
                 exc=e,
+                log=False,
             )
             return
         except RESTError as e:
@@ -435,7 +436,7 @@ class IcebergSource(StatefulIngestionSourceBase):
                 exc=e,
             )
         except Exception as e:
-            self.report.report_failure(
+            self.report.failure(
                 title="Failed to process namespace",
                 message="Unhandled exception happened during processing of the namespace",
                 context=namespace_repr,

--- a/metadata-ingestion/src/datahub/ingestion/source/identity/azure_ad.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/identity/azure_ad.py
@@ -234,7 +234,7 @@ class AzureADSource(StatefulIngestionSourceBase):
                 f"Token response content: {str(token_response.content)}"
             )
             logger.error(error_str)
-            self.report.report_failure("get_token", error_str)
+            self.report.failure("get_token", error_str)
             click.echo("Error: Token response invalid")
             exit()
 
@@ -293,7 +293,7 @@ class AzureADSource(StatefulIngestionSourceBase):
                 datahub_corp_group_urn = self._map_azure_ad_group_to_urn(azure_ad_group)
                 if not datahub_corp_group_urn:
                     error_str = f"Failed to extract DataHub Group Name from Azure AD Group named {azure_ad_group.get('displayName')}. Skipping..."
-                    self.report.report_failure("azure_ad_group_mapping", error_str)
+                    self.report.failure("azure_ad_group_mapping", error_str)
                     continue
                 self._add_group_members_to_group_membership(
                     datahub_corp_group_urn,
@@ -367,7 +367,7 @@ class AzureADSource(StatefulIngestionSourceBase):
         user_urn = self._map_azure_ad_user_to_urn(azure_ad_user)
         if not user_urn:
             error_str = f"Failed to extract DataHub Username from Azure ADUser {azure_ad_user.get('displayName')}. Skipping..."
-            self.report.report_failure("azure_ad_user_mapping", error_str)
+            self.report.failure("azure_ad_user_mapping", error_str)
         else:
             self.azure_ad_groups_users.append(azure_ad_user)
             # update/create the GroupMembership aspect for this group member.
@@ -446,7 +446,7 @@ class AzureADSource(StatefulIngestionSourceBase):
                 )
                 logger.debug(f"URL = {url}")
                 logger.error(error_str)
-                self.report.report_failure("_get_azure_ad_data_", error_str)
+                self.report.failure("_get_azure_ad_data_", error_str)
                 raise Exception(f"Unable to get {url}, error {response.status_code}")
 
     def _map_identity_to_urn(self, func, id_to_extract, mapping_identifier, id_type):
@@ -463,7 +463,7 @@ class AzureADSource(StatefulIngestionSourceBase):
             )
         if error_str is not None:
             logger.error(error_str)
-            self.report.report_failure(mapping_identifier, error_str)
+            self.report.failure(mapping_identifier, error_str)
         return result, error_str
 
     def _map_azure_ad_groups(self, azure_ad_groups):
@@ -471,7 +471,7 @@ class AzureADSource(StatefulIngestionSourceBase):
             try:
                 yield from self._map_azure_ad_group(azure_ad_group)
             except Exception as e:
-                self.report.report_failure("azure_ad_group", str(e))
+                self.report.failure("azure_ad_group", str(e))
 
     def _map_azure_ad_group(self, azure_ad_group):
         # Resolve group name and apply filters before building the URN.
@@ -483,7 +483,7 @@ class AzureADSource(StatefulIngestionSourceBase):
         # exception contract (which other callers rely on).
         raw_name = azure_ad_group.get(self.config.azure_ad_response_to_groupname_attr)
         if raw_name is None:
-            self.report.report_failure(
+            self.report.failure(
                 "azure_ad_group_mapping",
                 f"Attribute '{self.config.azure_ad_response_to_groupname_attr}' not found in group response. "
                 f"Check azure_ad_response_to_groupname_attr in your config.",

--- a/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
@@ -284,7 +284,7 @@ class OktaSource(StatefulIngestionSourceBase):
                 if datahub_corp_group_urn is None:
                     error_str = f"Failed to extract DataHub Group Name from Okta Group: Invalid regex pattern provided or missing profile attribute for group named {okta_group.profile.name}. Skipping..."
                     logger.error(error_str)
-                    self.report.report_failure("okta_group_mapping", error_str)
+                    self.report.failure("okta_group_mapping", error_str)
                     continue
 
                 # Extract and map users for each group.
@@ -296,7 +296,7 @@ class OktaSource(StatefulIngestionSourceBase):
                     if datahub_corp_user_urn is None:
                         error_str = f"Failed to extract DataHub Username from Okta User: Invalid regex pattern provided or missing profile attribute for User with login {okta_user.profile.login}. Skipping..."
                         logger.error(error_str)
-                        self.report.report_failure("okta_user_mapping", error_str)
+                        self.report.failure("okta_user_mapping", error_str)
                         continue
 
                     if self.config.ingest_groups_users:
@@ -384,12 +384,12 @@ class OktaSource(StatefulIngestionSourceBase):
                 self.okta_client.list_groups(query_parameters)
             )
         except OktaAPIException as api_err:
-            self.report.report_failure(
+            self.report.failure(
                 "okta_groups", f"Failed to fetch Groups from Okta API: {api_err}"
             )
         while True:
             if err:
-                self.report.report_failure(
+                self.report.failure(
                     "okta_groups", f"Failed to fetch Groups from Okta API: {err}"
                 )
             if groups:
@@ -399,7 +399,7 @@ class OktaSource(StatefulIngestionSourceBase):
                 try:
                     groups, err = event_loop.run_until_complete(resp.next())
                 except OktaAPIException as api_err:
-                    self.report.report_failure(
+                    self.report.failure(
                         "okta_groups",
                         f"Failed to fetch Groups from Okta API: {api_err}",
                     )
@@ -420,13 +420,13 @@ class OktaSource(StatefulIngestionSourceBase):
                 self.okta_client.list_group_users(group.id, query_parameters)
             )
         except OktaAPIException as api_err:
-            self.report.report_failure(
+            self.report.failure(
                 "okta_group_users",
                 f"Failed to fetch Users of Group {group.profile.name} from Okta API: {api_err}",
             )
         while True:
             if err:
-                self.report.report_failure(
+                self.report.failure(
                     "okta_group_users",
                     f"Failed to fetch Users of Group {group.profile.name} from Okta API: {err}",
                 )
@@ -437,7 +437,7 @@ class OktaSource(StatefulIngestionSourceBase):
                 try:
                     users, err = event_loop.run_until_complete(resp.next())
                 except OktaAPIException as api_err:
-                    self.report.report_failure(
+                    self.report.failure(
                         "okta_group_users",
                         f"Failed to fetch Users of Group {group.profile.name} from Okta API: {api_err}",
                     )
@@ -459,12 +459,12 @@ class OktaSource(StatefulIngestionSourceBase):
                 self.okta_client.list_users(query_parameters)
             )
         except OktaAPIException as api_err:
-            self.report.report_failure(
+            self.report.failure(
                 "okta_users", f"Failed to fetch Users from Okta API: {api_err}"
             )
         while True:
             if err:
-                self.report.report_failure(
+                self.report.failure(
                     "okta_users", f"Failed to fetch Users from Okta API: {err}"
                 )
             if users:
@@ -474,7 +474,7 @@ class OktaSource(StatefulIngestionSourceBase):
                 try:
                     users, err = event_loop.run_until_complete(resp.next())
                 except OktaAPIException as api_err:
-                    self.report.report_failure(
+                    self.report.failure(
                         "okta_users", f"Failed to fetch Users from Okta API: {api_err}"
                     )
             else:
@@ -501,7 +501,7 @@ class OktaSource(StatefulIngestionSourceBase):
             if corp_group_urn is None:
                 error_str = f"Failed to extract DataHub Group Name from Okta Group: Invalid regex pattern provided or missing profile attribute for group named {okta_group.profile.name}. Skipping..."
                 logger.error(error_str)
-                self.report.report_failure("okta_group_mapping", error_str)
+                self.report.failure("okta_group_mapping", error_str)
                 continue
             corp_group_snapshot = CorpGroupSnapshot(
                 urn=corp_group_urn,
@@ -552,7 +552,7 @@ class OktaSource(StatefulIngestionSourceBase):
             if corp_user_urn is None:
                 error_str = f"Failed to extract DataHub Username from Okta User: Invalid regex pattern provided or missing profile attribute for User with login {okta_user.profile.login}. Skipping..."
                 logger.error(error_str)
-                self.report.report_failure("okta_user_mapping", error_str)
+                self.report.failure("okta_user_mapping", error_str)
                 continue
             corp_user_snapshot = CorpUserSnapshot(
                 urn=corp_user_urn,

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka.py
@@ -389,9 +389,10 @@ class KafkaSource(StatefulIngestionSourceBase, TestableSource):
             self.admin_client = get_kafka_admin_client(self.source_config.connection)
         except Exception as e:
             logger.debug(e, exc_info=e)
-            self.report.report_warning(
+            self.report.warning(
                 "kafka-admin-client",
                 f"Failed to create Kafka Admin Client due to error {e}.",
+                log=False,
             )
 
     @staticmethod
@@ -506,8 +507,10 @@ class KafkaSource(StatefulIngestionSourceBase, TestableSource):
 
             except Exception as e:
                 logger.warning(f"Failed to extract topic {topic}", exc_info=True)
-                self.report.report_warning(
-                    "topic", f"Exception while extracting topic {topic}: {e}"
+                self.report.warning(
+                    "topic",
+                    f"Exception while extracting topic {topic}: {e}",
+                    log=False,
                 )
 
         # Collect samples and compute profiles in parallel — each worker owns its consumer
@@ -525,14 +528,16 @@ class KafkaSource(StatefulIngestionSourceBase, TestableSource):
                     logger.warning(
                         f"Failed to extract subject {subject}", exc_info=True
                     )
-                    self.report.report_warning(
-                        "subject", f"Exception while extracting topic {subject}: {e}"
+                    self.report.warning(
+                        "subject",
+                        f"Exception while extracting topic {subject}: {e}",
+                        log=False,
                     )
 
     def _locked_warning(self, key: str, message: str) -> None:
         # report_warning is not thread-safe; serialize the profiling worker calls.
         with self._report_lock:
-            self.report.report_warning(key, message)
+            self.report.warning(key, message, log=False)
 
     def get_sample_messages(
         self,
@@ -897,10 +902,11 @@ class KafkaSource(StatefulIngestionSourceBase, TestableSource):
                             # which would pollute the profile as a fake topic column.
                             with self._report_lock:
                                 self.report.profiling_avro_decode_failures += 1
-                                self.report.report_warning(
+                                self.report.warning(
                                     "avro-decode",
                                     f"Skipped a message for topic {topic} that failed Avro "
                                     f"decoding ({type(e).__name__}): {e}",
+                                    log=False,
                                 )
                             return None
 
@@ -923,9 +929,10 @@ class KafkaSource(StatefulIngestionSourceBase, TestableSource):
                 # pollute the profile as a synthetic field value.
                 with self._report_lock:
                     self.report.profiling_samples_skipped += 1
-                    self.report.report_warning(
+                    self.report.warning(
                         "profiling",
                         f"Skipped a message for topic {topic} that failed to decode: {e}",
+                        log=False,
                     )
                 return None
 
@@ -954,9 +961,10 @@ class KafkaSource(StatefulIngestionSourceBase, TestableSource):
             with self._report_lock:
                 self.report.profiling_topics_dropped += 1
                 if self.source_config.profiling.report_dropped_profiles:
-                    self.report.report_warning(
+                    self.report.warning(
                         "profiling",
                         f"No samples collected for topic {topic}; profile dropped.",
+                        log=False,
                     )
             return None
 
@@ -1021,9 +1029,10 @@ class KafkaSource(StatefulIngestionSourceBase, TestableSource):
                     # other workers may still be mutating the same counters.
                     with self._report_lock:
                         self.report.profiling_topics_dropped += 1
-                        self.report.report_warning(
+                        self.report.warning(
                             "profiling",
                             f"Failed to profile topic {topic_name}: {str(e)}",
+                            log=False,
                         )
 
     def _resolve_missing_schemas(
@@ -1349,10 +1358,11 @@ class KafkaSource(StatefulIngestionSourceBase, TestableSource):
                 extra_topic_details = self.fetch_topic_configurations(topics)
             except Exception as e:
                 logger.debug(e, exc_info=e)
-                self.report.report_warning(
+                self.report.warning(
                     "topic-config",
                     f"Failed to fetch topic configuration details (partitions, "
                     f"retention, cleanup policy, etc.) due to error {e}.",
+                    log=False,
                 )
         return extra_topic_details
 

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka_profiler.py
@@ -170,11 +170,12 @@ class KafkaProfiler:
                     if report is not None:
                         with report_lock or nullcontext():
                             report.profiling_samples_skipped += profiler.samples_skipped
-                            report.report_warning(
+                            report.warning(
                                 "profiling",
                                 f"Profiling of topic {topic_name} skipped "
                                 f"{profiler.samples_skipped} sample(s) due to processing "
                                 f"errors. First error: {profiler.profiling_errors[0]}",
+                                log=False,
                             )
 
             return profile

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka_schema_inference.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka_schema_inference.py
@@ -62,10 +62,11 @@ class KafkaSchemaInference:
     def _note_inference_failure(self, topic: str, exc: Exception) -> None:
         if self.report is not None:
             self.report.schema_inference_sampling_failures += 1
-            self.report.report_warning(
+            self.report.warning(
                 "schema-inference",
                 f"Failed to infer schema for topic {topic}; it will be processed "
                 f"without schema information: {exc}",
+                log=False,
             )
 
     def infer_schemas_batch(self, topics: List[str]) -> Dict[str, List[SchemaField]]:
@@ -191,10 +192,11 @@ class KafkaSchemaInference:
             )
             if self.report is not None:
                 self.report.schema_inference_sampling_failures += 1
-                self.report.report_warning(
+                self.report.warning(
                     "schema-inference",
                     f"Could not create a consumer to sample topic {topic} for schema "
                     f"inference ({offset_strategy}): {e}",
+                    log=False,
                 )
             return []
 
@@ -257,10 +259,11 @@ class KafkaSchemaInference:
             # silently fall back to schemaless with nothing in the report.
             if not messages and decode_failures > 0 and self.report is not None:
                 self.report.schema_inference_message_decode_failures += decode_failures
-                self.report.report_warning(
+                self.report.warning(
                     "schema-inference",
                     f"All {decode_failures} sampled message(s) for topic {topic} failed "
                     f"to decode ({offset_strategy}); it will be treated as schemaless.",
+                    log=False,
                 )
 
             return messages
@@ -271,10 +274,11 @@ class KafkaSchemaInference:
             )
             if self.report is not None:
                 self.report.schema_inference_sampling_failures += 1
-                self.report.report_warning(
+                self.report.warning(
                     "schema-inference",
                     f"Failed to sample topic {topic} for schema inference "
                     f"({offset_strategy}): {e}",
+                    log=False,
                 )
             return []
         finally:
@@ -296,10 +300,11 @@ class KafkaSchemaInference:
                 # We had samples but every one failed to yield a field; without
                 # this the topic would go schemaless with no report signal.
                 self.report.schema_inference_no_fields += 1
-                self.report.report_warning(
+                self.report.warning(
                     "schema-inference",
                     f"Sampled {len(sample_messages)} message(s) for topic {topic} "
                     f"but inferred no fields; treating it as schemaless.",
+                    log=False,
                 )
             else:
                 logger.info(

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/schema_resolution.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/schema_resolution.py
@@ -81,10 +81,11 @@ class KafkaSchemaResolver:
         # OSError means the registry was unreachable — operators must see that, not lose it.
         if isinstance(error, OSError) and self.report is not None:
             self.report.schema_registry_connectivity_failures += 1
-            self.report.report_warning(
+            self.report.warning(
                 "schema-registry",
                 f"Schema registry was unreachable while resolving subject "
                 f"{subject_name}: {error}",
+                log=False,
             )
 
     def resolve_schemas_batch(

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
@@ -1892,7 +1892,7 @@ class SnowflakeSourceConnector(BaseConnector):
         except (ConnectionError, TimeoutError) as e:
             logger.error(f"Failed to connect to DataHub for pattern '{pattern}': {e}")
             if self.report:
-                self.report.report_failure(
+                self.report.failure(
                     f"datahub_connection_{self.connector_manifest.name}", str(e)
                 )
             return []
@@ -3428,7 +3428,7 @@ class DebeziumSourceConnector(BaseConnector):
         except (ConnectionError, TimeoutError) as e:
             logger.error(f"Failed to connect to DataHub for pattern '{pattern}': {e}")
             if self.report:
-                self.report.report_failure(
+                self.report.failure(
                     f"datahub_connection_{self.connector_manifest.name}", str(e)
                 )
             return []

--- a/metadata-ingestion/src/datahub/ingestion/source/ldap.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ldap.py
@@ -189,15 +189,17 @@ def guess_person_ldap(
         return attrs[config.user_attrs_map["urn"]][0].decode()
     else:  # for backward compatiblity
         if "sAMAccountName" in attrs:
-            report.report_warning(
+            report.warning(
                 "<general>",
                 "Defaulting to sAMAccountName as it was found in attrs and not set in user_attrs_map in recipe",
+                log=False,
             )
             return attrs["sAMAccountName"][0].decode()
         if "uid" in attrs:
-            report.report_warning(
+            report.warning(
                 "<general>",
                 "Defaulting to uid as it was found in attrs and not set in user_attrs_map in recipe",
+                log=False,
             )
             return attrs["uid"][0].decode()
         return None
@@ -283,7 +285,7 @@ class LDAPSource(StatefulIngestionSourceBase):
                 )
                 _rtype, rdata, _rmsgid, serverctrls = self.ldap_client.result3(msgid)
             except ldap.LDAPError as e:
-                self.report.report_failure("ldap-control", f"LDAP search failed: {e}")
+                self.report.failure("ldap-control", f"LDAP search failed: {e}")
                 break
 
             for dn, attrs in rdata:
@@ -291,10 +293,11 @@ class LDAPSource(StatefulIngestionSourceBase):
                     continue
 
                 if not attrs or "objectClass" not in attrs:
-                    self.report.report_warning(
+                    self.report.warning(
                         "<general>",
                         f"skipping {dn} because attrs ({attrs}) does not contain expected data; "
                         f"check your permissions if this is unexpected",
+                        log=False,
                     )
                     continue
 
@@ -317,7 +320,7 @@ class LDAPSource(StatefulIngestionSourceBase):
             if self.lc:
                 pctrls = get_pctrls(serverctrls)
                 if not pctrls:
-                    self.report.report_failure(
+                    self.report.failure(
                         "ldap-control", "Server ignores RFC 2696 control."
                     )
                     break
@@ -361,7 +364,7 @@ class LDAPSource(StatefulIngestionSourceBase):
                     )
 
             except ldap.LDAPError as e:
-                self.report.report_warning(dn, f"manager LDAP search failed: {e}")
+                self.report.warning(dn, f"manager LDAP search failed: {e}", log=False)
         mce = self.build_corp_user_mce(dn, attrs, make_manager_urn)
         if mce:
             yield MetadataWorkUnit(dn, mce)

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
@@ -832,9 +832,10 @@ class LookerUtil:
                 ]
             )
         else:
-            reporter.report_warning(
+            reporter.warning(
                 title="Failed to Map View Field Type",
                 message=f"Failed to map view field type {field.field_type}. Won't emit tags for measure and dimension",
+                log=False,
             )
 
         # Add group_label as tags if present
@@ -1164,10 +1165,11 @@ class LookerExplore:
                                 view_name = orig_name
                             potential_views.append(view_name)
                         except AssertionError:
-                            reporter.report_warning(
+                            reporter.warning(
                                 title="Missing View Name",
                                 message="The field was not prefixed by a view name. This can happen when the field references another dynamic field.",
                                 context=field_name,
+                                log=False,
                             )
                             continue
 
@@ -1344,10 +1346,11 @@ class LookerExplore:
                 exc=e,
             )
         except AssertionError:
-            reporter.report_warning(
+            reporter.warning(
                 title="Unable to find Views",
                 message="Encountered exception while attempting to find dependent views for this chart",
                 context=f"Explore: {explore_name}, Mode: {model}, Views: {views}",
+                log=False,
             )
         return None
 

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_connection.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_connection.py
@@ -47,9 +47,10 @@ def get_connection_def_based_on_connection_string(
                 # Populate the cache (using the config map) to avoid calling looker again for this connection
                 source_config.connection_to_platform_map[connection] = connection_def
             except ConfigurationError:
-                reporter.report_warning(
+                reporter.warning(
                     f"connection-{connection}",
                     "Failed to load connection from Looker",
+                    log=False,
                 )
 
     return connection_def

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_dataclasses.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_dataclasses.py
@@ -87,11 +87,12 @@ class LookerModel:
                 included_explores = parsed.get("explores", [])
                 explores.extend(included_explores)
             except Exception as e:
-                reporter.report_warning(
+                reporter.warning(
                     title="Error Loading Include",
                     message="Failed to load include file",
                     context=f"Include Details: {included_file}",
                     exc=e,
+                    log=False,
                 )
                 # continue in this case, as it might be better to load and resolve whatever we can
 
@@ -243,11 +244,12 @@ class LookerModel:
                             )
                         )
                 except Exception as e:
-                    reporter.report_warning(
+                    reporter.warning(
                         title="Error Loading Include File",
                         message="Failed to load included file",
                         context=f"Include Details: {included_file}",
                         exc=e,
+                        log=False,
                     )
                     # continue in this case, as it might be better to load and resolve whatever we can
 

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_file_loader.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_file_loader.py
@@ -65,11 +65,12 @@ class LookerViewFileLoader:
             with open(path) as file:
                 raw_file_content = file.read()
         except Exception as e:
-            self.reporter.report_warning(
+            self.reporter.warning(
                 title="LKML File Loading Error",
                 message="A lookml file is not present on local storage or GitHub",
                 context=f"file path: {path}",
                 exc=e,
+                log=False,
             )
             self.viewfile_cache[path] = None
             return None
@@ -101,11 +102,12 @@ class LookerViewFileLoader:
             self.viewfile_cache[path] = looker_viewfile
             return looker_viewfile
         except Exception as e:
-            self.reporter.report_warning(
+            self.reporter.warning(
                 title="LKML File Parsing Error",
                 message="The input file is not lookml file",
                 context=f"file path: {path}",
                 exc=e,
+                log=False,
             )
 
             logger.debug(f"Raw file content for path {path}")

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
@@ -274,10 +274,11 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
                 view_name = self._extract_view_from_field(field_name)
                 views.add(view_name)
             except AssertionError:
-                self.reporter.report_warning(
+                self.reporter.warning(
                     title="Failed to Extract View Name from Field",
                     message="The field was not prefixed by a view name. This can happen when the field references another dynamic field.",
                     context=f"Field Name: {field_name}",
+                    log=False,
                 )
                 continue
 
@@ -1272,11 +1273,12 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
                 fields=fields,
             )
         except (SDKError, DeserializeError) as e:
-            self.reporter.report_warning(
+            self.reporter.warning(
                 title="Failed to fetch dashboard from the Looker API",
                 message="Error occurred while attempting to loading dashboard from Looker API. Skipping.",
                 context=f"Dashboard ID: {dashboard_id}",
                 exc=e,
+                log=False,
             )
             return None
 
@@ -1651,9 +1653,10 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
             and self.reporter.email_ids_missing == self.reporter.resolved_user_ids
         ):
             # Looks like we tried to extract owners and could not find their email addresses. This is likely a permissions issue
-            self.reporter.report_warning(
+            self.reporter.warning(
                 "Failed to extract owner emails",
                 "Failed to extract owners emails for any dashboards. Please enable the see_users permission for your Looker API key",
+                log=False,
             )
 
         # Extract independent looks first, so their explores are considered in _make_explore_containers.

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/lookml_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/lookml_source.py
@@ -490,10 +490,11 @@ class LookMLSource(StatefulIngestionSourceBase):
         manifest_file = folder / "manifest.lkml"
 
         if not manifest_file.exists():
-            self.reporter.report_warning(
+            self.reporter.warning(
                 title="Manifest File Missing",
                 message="manifest.lkml file missing from project",
                 context=str(manifest_file),
+                log=False,
             )
             return None
 
@@ -581,7 +582,7 @@ class LookMLSource(StatefulIngestionSourceBase):
 
             if not self.report.events_produced and not self.report.failures:
                 # Don't pass if we didn't produce any events.
-                self.report.report_failure(
+                self.report.failure(
                     "No Metadata Produced",
                     "No metadata was produced. Check the logs for more details.",
                 )
@@ -736,11 +737,12 @@ class LookMLSource(StatefulIngestionSourceBase):
                 logger.debug(f"Attempting to load model: {file_path}")
                 model = self._load_model(str(file_path))
             except Exception as e:
-                self.reporter.report_warning(
+                self.reporter.warning(
                     title="Error Loading Model File",
                     message="Unable to load Looker model from file.",
                     context=f"Model Name: {model_name}, File Path: {file_path}",
                     exc=e,
+                    log=False,
                 )
                 continue
 
@@ -753,10 +755,11 @@ class LookMLSource(StatefulIngestionSourceBase):
             )
 
             if connection_definition is None:
-                self.reporter.report_warning(
+                self.reporter.warning(
                     title="Failed to Load Connection",
                     message="Failed to load connection. Check your API key permissions and/or connection_to_platform_map configuration.",
                     context=f"Connection: {model.connection}",
+                    log=False,
                 )
                 self.reporter.report_models_dropped(model_name)
                 continue
@@ -803,11 +806,12 @@ class LookMLSource(StatefulIngestionSourceBase):
                             view_to_explores[view_name.include].add(explore.name)
                             explore_to_views[explore.name].add(view_name.include)
                 except Exception as e:
-                    self.reporter.report_warning(
+                    self.reporter.warning(
                         title="Failed to process explores",
                         message="Failed to process explore dictionary.",
                         context=f"Explore Details: {explore_dict}",
                         exc=e,
+                        log=False,
                     )
                     logger.debug("Failed to process explore", exc_info=e)
 
@@ -912,11 +916,12 @@ class LookMLSource(StatefulIngestionSourceBase):
                                 view_to_explore_map=view_to_explore_map,
                             )
                         except Exception as e:
-                            self.reporter.report_warning(
+                            self.reporter.warning(
                                 title="Error Loading View",
                                 message="Unable to load Looker View.",
                                 context=f"View Details: {raw_view}",
                                 exc=e,
+                                log=False,
                             )
 
                             logger.debug(e, exc_info=e)
@@ -1051,12 +1056,13 @@ class LookMLSource(StatefulIngestionSourceBase):
 
         for project, view_paths in skipped_view_paths.items():
             for path in view_paths:
-                self.reporter.report_warning(
+                self.reporter.warning(
                     title="Skipped View File",
                     message=(
                         "The Looker view file was skipped because it may not be referenced by any models."
                     ),
                     context=(f"Project: {project}, View File Path: {path}"),
+                    log=False,
                 )
 
     def _optimize_views_by_common_explore(

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/view_upstream.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/view_upstream.py
@@ -212,10 +212,11 @@ def _generate_fully_qualified_name(
         dataset_name = f"{connection_def.default_db}.{sql_table_name}"
         return dataset_name.lower()
 
-    reporter.report_warning(
+    reporter.warning(
         title="Malformed Table Name",
         message="Table name has more than 3 parts.",
         context=f"view-name: {view_name}, table-name: {sql_table_name}",
+        log=False,
     )
     return sql_table_name.lower()
 
@@ -542,11 +543,12 @@ class LookerQueryAPIBasedViewUpstream(AbstractViewUpstream):
             logger.debug(
                 f"Table parsing error for view '{self.view_context.name()}': {table_error}"
             )
-            self.reporter.report_warning(
+            self.reporter.warning(
                 title="Table Level Lineage Extraction Failed",
                 message="Error in parsing derived sql",
                 context=f"View-name: {self.view_context.name()}",
                 exc=table_error,
+                log=False,
             )
             if not allow_partial:
                 raise ValueError(
@@ -561,11 +563,12 @@ class LookerQueryAPIBasedViewUpstream(AbstractViewUpstream):
             logger.debug(
                 f"Column parsing error for view '{self.view_context.name()}': {column_error}"
             )
-            self.reporter.report_warning(
+            self.reporter.warning(
                 title="Column Level Lineage Extraction Failed",
                 message="Error in parsing derived sql",
                 context=f"View-name: {self.view_context.name()}",
                 exc=column_error,
+                log=False,
             )
             if not allow_partial:
                 raise ValueError(
@@ -633,11 +636,12 @@ class LookerQueryAPIBasedViewUpstream(AbstractViewUpstream):
             logger.warning(
                 f"Failed to process field chunk {chunk_idx + 1} for view '{self.view_context.name()}': {e}"
             )
-            self.reporter.report_warning(
+            self.reporter.warning(
                 title="Field Chunk Processing Failed",
                 message="Failed to process field chunk with fields",
                 context=f"View-name: {self.view_context.name()}, Chunk: {chunk_idx + 1}, Field count: {len(field_chunk)}",
                 exc=e,
+                log=False,
             )
 
             return (
@@ -718,10 +722,11 @@ class LookerQueryAPIBasedViewUpstream(AbstractViewUpstream):
                 f"Identified {len(problematic_fields)} problematic fields for view '{self.view_context.name()}': "
                 f"{problematic_fields}"
             )
-            self.reporter.report_warning(
+            self.reporter.warning(
                 title="Problematic Fields Identified in LookMl View Processing",
                 message=f"Identified problematic fields that cannot be processed, View-name: {self.view_context.name()}",
                 context=str(problematic_fields),
+                log=False,
             )
 
         logger.debug(
@@ -767,11 +772,12 @@ class LookerQueryAPIBasedViewUpstream(AbstractViewUpstream):
             logger.warning(
                 f"Failed to process individual field '{field_name}' for view '{self.view_context.name()}'': {e}"
             )
-            self.reporter.report_warning(
+            self.reporter.warning(
                 title="Individual Field Processing Failed",
                 message="Failed to process individual field",
                 context=f"View-name: {self.view_context.name()}, Field: {field_name}",
                 exc=e,
+                log=False,
             )
             return set(), [], False
 
@@ -924,17 +930,19 @@ class LookerQueryAPIBasedViewUpstream(AbstractViewUpstream):
             )
         elif success_rate > 0:
             # Partial success
-            self.reporter.report_warning(
+            self.reporter.warning(
                 title="Field Splitting Statistics - Partial Success",
                 message="Field splitting completed with partial results",
                 context=f"View-name: {self.view_context.name()}, Success rate: {success_rate:.1f}%, Total fields: {total_fields}, Chunks: {total_chunks}, Successful queries: {successful_queries}, Failed queries: {failed_queries}, Upstream tables: {upstream_tables}, Column lineages: {column_lineages}{fallback_info}",
+                log=False,
             )
         else:
             # Complete failure
-            self.reporter.report_warning(
+            self.reporter.warning(
                 title="Field Splitting Statistics - Complete Failure",
                 message="Field splitting failed completely",
                 context=f"View-name: {self.view_context.name()}, Success rate: {success_rate:.1f}%, Total fields: {total_fields}, Chunks: {total_chunks}, All {failed_queries} queries failed{fallback_info}",
+                log=False,
             )
 
     def _get_time_dim_group_field_name(self, dim_group: dict) -> str:
@@ -1474,11 +1482,12 @@ class SqlBasedDerivedViewUpstream(AbstractViewUpstream, ABC):
             return []
 
         if sql_parsing_result.debug_info.table_error is not None:
-            self.reporter.report_warning(
+            self.reporter.warning(
                 title="Table Level Lineage Missing",
                 message="Error in parsing derived sql",
                 context=f"view-name: {self.view_context.name()}, platform: {self.view_context.view_connection.platform}",
                 exc=sql_parsing_result.debug_info.table_error,
+                log=False,
             )
             return []
 
@@ -1503,11 +1512,12 @@ class SqlBasedDerivedViewUpstream(AbstractViewUpstream, ABC):
             return []
 
         if spr.debug_info.column_error is not None:
-            self.reporter.report_warning(
+            self.reporter.warning(
                 title="Column Level Lineage Missing",
                 message="Error in parsing derived sql for CLL",
                 context=f"View-name: {self.view_context.name()}",
                 exc=spr.debug_info.column_error,
+                log=False,
             )
             return []
 
@@ -1544,11 +1554,12 @@ class SqlBasedDerivedViewUpstream(AbstractViewUpstream, ABC):
             return []
 
         if sql_parsing_result.debug_info.column_error is not None:
-            self.reporter.report_warning(
+            self.reporter.warning(
                 title="Column Level Lineage Missing",
                 message="Error in parsing derived sql for CLL",
                 context=f"View-name: {self.view_context.name()}. "
                 f"Error: {sql_parsing_result.debug_info.column_error}",
+                log=False,
             )
             return []
 
@@ -1848,11 +1859,12 @@ def create_view_upstream(
             )
         except Exception as e:
             # Falling back to custom regex-based parsing - best effort approach
-            reporter.report_warning(
+            reporter.warning(
                 title="Looker Query API based View Upstream Failed",
                 message="Error in getting upstream lineage for view using Looker Query API",
                 context=f"View-name: {view_context.name()}",
                 exc=e,
+                log=False,
             )
 
     if view_context.is_regular_case():
@@ -1918,10 +1930,11 @@ def create_view_upstream(
             looker_view_id_cache=looker_view_id_cache,
         )
 
-    reporter.report_warning(
+    reporter.warning(
         title="ViewUpstream Implementation Not Found",
         message="No implementation found to resolve upstream of the view",
         context=f"view_name={view_context.name()} , view_file_name={view_context.view_file_name()}",
+        log=False,
     )
 
     return EmptyImplementation(

--- a/metadata-ingestion/src/datahub/ingestion/source/matillion_dpc/matillion.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/matillion_dpc/matillion.py
@@ -260,10 +260,11 @@ class MatillionSource(StatefulIngestionSourceBase):
                 started_before=started_before,
             )
         except (Timeout, ConnectionError) as e:
-            self.report.report_warning(
+            self.report.warning(
                 "pipeline-executions-timeout",
                 f"Timed out discovering pipelines from executions ({e}); unpublished "
                 f"pipelines may be missing. {API_TIMEOUT_TUNING_GUIDANCE}",
+                log=False,
             )
             return []
 
@@ -1015,14 +1016,17 @@ class MatillionSource(StatefulIngestionSourceBase):
                 window_start = window_end
 
         except (Timeout, ConnectionError) as e:
-            self.report.report_warning(
+            self.report.warning(
                 "lineage-events-timeout",
                 f"Timed out fetching lineage events ({e}); returning {len(all_events)} "
                 f"events collected so far. {API_TIMEOUT_TUNING_GUIDANCE}",
+                log=False,
             )
         except (HTTPError, RequestException) as e:
-            self.report.report_warning(
-                "lineage_events", f"Failed to fetch lineage events: {e}"
+            self.report.warning(
+                "lineage_events",
+                f"Failed to fetch lineage events: {e}",
+                log=False,
             )
 
         logger.info(f"Fetched total of {len(all_events)} OpenLineage events")

--- a/metadata-ingestion/src/datahub/ingestion/source/metabase.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/metabase.py
@@ -204,7 +204,7 @@ class MetabaseSource(StatefulIngestionSourceBase):
             )
             test_response.raise_for_status()
         except HTTPError as e:
-            self.report.report_failure(
+            self.report.failure(
                 title="Unable to Retrieve Current User",
                 message=f"Unable to retrieve user {self.config.username} information. %s"
                 % str(e),
@@ -218,7 +218,7 @@ class MetabaseSource(StatefulIngestionSourceBase):
                 headers={"X-Metabase-Session": self.access_token},
             )
             if response.status_code not in (200, 204):
-                self.report.report_failure(
+                self.report.failure(
                     title="Unable to Log User Out",
                     message=f"Unable to logout for user {self.config.username}",
                 )
@@ -252,7 +252,7 @@ class MetabaseSource(StatefulIngestionSourceBase):
                         yield MetadataWorkUnit(id=dashboard_snapshot.urn, mce=mce)
 
         except HTTPError as http_error:
-            self.report.report_failure(
+            self.report.failure(
                 title="Unable to Retrieve Dashboards",
                 message="Request to retrieve dashboards from Metabase failed.",
                 context=f"Error: {str(http_error)}",
@@ -279,10 +279,11 @@ class MetabaseSource(StatefulIngestionSourceBase):
             dashboard_response.raise_for_status()
             dashboard_details = dashboard_response.json()
         except HTTPError as http_error:
-            self.report.report_warning(
+            self.report.warning(
                 title="Unable to Retrieve Dashboard",
                 message="Request to retrieve dashboards from Metabase failed.",
                 context=f"Dashboard ID: {dashboard_id}, Error: {str(http_error)}",
+                log=False,
             )
             return None
 
@@ -349,17 +350,19 @@ class MetabaseSource(StatefulIngestionSourceBase):
                 http_error.response is not None
                 and http_error.response.status_code == 404
             ):
-                self.report.report_warning(
+                self.report.warning(
                     title="Cannot find user",
                     message="User is blocked in Metabase or missing",
                     context=f"Creator ID: {creator_id}",
+                    log=False,
                 )
                 return None
             # For cases when the error is not 404 but something else
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to retrieve user",
                 message="Request to Metabase Failed",
                 context=f"Creator ID: {creator_id}, Error: {str(http_error)}",
+                log=False,
             )
             return None
 
@@ -390,7 +393,7 @@ class MetabaseSource(StatefulIngestionSourceBase):
                     yield MetadataWorkUnit(id=chart_snapshot.urn, mce=mce)
 
         except HTTPError as http_error:
-            self.report.report_failure(
+            self.report.failure(
                 title="Unable to Retrieve Cards",
                 message="Request to retrieve cards from Metabase failed.",
                 context=f"Error: {str(http_error)}",
@@ -415,29 +418,32 @@ class MetabaseSource(StatefulIngestionSourceBase):
             card_response.raise_for_status()
             return card_response.json()
         except HTTPError as http_error:
-            self.report.report_warning(
+            self.report.warning(
                 title="Unable to Retrieve Card",
                 message="Request to retrieve Card from Metabase failed.",
                 context=f"Card ID: {card_id}, Error: {str(http_error)}",
+                log=False,
             )
             return {}
 
     def construct_card_from_api_data(self, card_data: dict) -> Optional[ChartSnapshot]:
         card_id = card_data.get("id")
         if card_id is None:
-            self.report.report_warning(
+            self.report.warning(
                 title="Card is missing 'id'",
                 message="Unable to get field id from card data.",
                 context=f"Card Details: {str(card_data)}",
+                log=False,
             )
             return None
 
         card_details = self.get_card_details_by_id(card_id)
         if not card_details:
-            self.report.report_warning(
+            self.report.warning(
                 title="Missing Card Details",
                 message="Unable to construct Card due to empty card details",
                 context=f"Card ID: {card_id}",
+                log=False,
             )
             return None
 
@@ -523,19 +529,21 @@ class MetabaseSource(StatefulIngestionSourceBase):
             "map": None,
         }
         if not display_type:
-            self.report.report_warning(
+            self.report.warning(
                 title="Unrecognized Card Type",
                 message=f"Unrecognized card type {display_type} found. Setting to None",
                 context=f"Card ID: {card_id}",
+                log=False,
             )
             return None
         try:
             chart_type = type_mapping[display_type]
         except KeyError:
-            self.report.report_warning(
+            self.report.warning(
                 title="Unrecognized Chart Type",
                 message=f"Unrecognized chart type {display_type} found. Setting to None",
                 context=f"Card ID: {card_id}",
+                log=False,
             )
             chart_type = None
 
@@ -568,10 +576,11 @@ class MetabaseSource(StatefulIngestionSourceBase):
         self, card_details: dict, recursion_depth: int = 0
     ) -> Optional[List]:
         if recursion_depth > DATASOURCE_URN_RECURSION_LIMIT:
-            self.report.report_warning(
+            self.report.warning(
                 title="Unable to Retrieve Card Info",
                 message="Unable to retrieve Card info. Source table recursion depth exceeded.",
                 context=f"Card Details: {card_details}",
+                log=False,
             )
             return None
 
@@ -583,10 +592,11 @@ class MetabaseSource(StatefulIngestionSourceBase):
             platform_instance,
         ) = self.get_datasource_from_id(datasource_id)
         if not platform:
-            self.report.report_warning(
+            self.report.warning(
                 title="Unable to find Data Platform",
                 message="Unable to detect Data Platform for database id",
                 context=f"Data Source ID: {datasource_id}",
+                log=False,
             )
             return None
 
@@ -640,10 +650,11 @@ class MetabaseSource(StatefulIngestionSourceBase):
                     f"Failed to parse lineage from query {raw_query_stripped}: "
                     f"{result.debug_info.table_error}"
                 )
-                self.report.report_warning(
+                self.report.warning(
                     title="Failed to Extract Lineage",
                     message="Unable to retrieve lineage from query",
                     context=f"Query: {raw_query_stripped}",
+                    log=False,
                 )
             return result.in_tables
 
@@ -682,10 +693,11 @@ class MetabaseSource(StatefulIngestionSourceBase):
             return schema, name
 
         except HTTPError as http_error:
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to Retrieve Source Table",
                 message="Request to retrieve source table from Metadabase failed",
                 context=f"Table ID: {table_id}, Error: {str(http_error)}",
+                log=False,
             )
 
         return None, None
@@ -731,10 +743,11 @@ class MetabaseSource(StatefulIngestionSourceBase):
             dataset_response.raise_for_status()
             dataset_json = dataset_response.json()
         except HTTPError as http_error:
-            self.report.report_warning(
+            self.report.warning(
                 title="Unable to Retrieve Data Source",
                 message="Request to retrieve data source from Metabase failed.",
                 context=f"Data Source ID: {datasource_id}, Error: {str(http_error)}",
+                log=False,
             )
             # returning empty string as `platform` because
             # `make_dataset_urn_with_platform_instance()` only accepts `str`
@@ -760,10 +773,11 @@ class MetabaseSource(StatefulIngestionSourceBase):
         else:
             platform = engine
 
-            self.report.report_warning(
+            self.report.warning(
                 title="Unrecognized Data Platform found",
                 message="Data Platform was not found. Using platform name as is",
                 context=f"Platform: {platform}",
+                log=False,
             )
 
         platform_instance = self.get_platform_instance(
@@ -797,10 +811,11 @@ class MetabaseSource(StatefulIngestionSourceBase):
         ):
             dbname = self.config.database_alias_map[platform]
         else:
-            self.report.report_warning(
+            self.report.warning(
                 title="Cannot resolve Database Name",
                 message="Cannot determine database name for platform",
                 context=f"Platform: {platform}",
+                log=False,
             )
 
         return platform, dbname, schema, platform_instance

--- a/metadata-ingestion/src/datahub/ingestion/source/mode.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mode.py
@@ -356,13 +356,13 @@ class ModeSourceReport(StaleEntityRemovalSourceReport):
         with self._lock:
             self.filtered_reports.append(ent_name)
 
-    def report_warning(self, *args: Any, **kwargs: Any) -> None:
+    def warning(self, *args: Any, **kwargs: Any) -> None:
         with self._lock:
-            super().report_warning(*args, **kwargs)
+            super().warning(*args, **kwargs)
 
-    def report_failure(self, *args: Any, **kwargs: Any) -> None:
+    def failure(self, *args: Any, **kwargs: Any) -> None:
         with self._lock:
-            super().report_failure(*args, **kwargs)
+            super().failure(*args, **kwargs)
 
     def info(self, *args: Any, **kwargs: Any) -> None:
         with self._lock:
@@ -454,7 +454,7 @@ class ModeSource(StatefulIngestionSourceBase):
             key_info = self._get_request_json(f"{self.config.connect_uri}/api/verify")
             logger.debug(f"Auth info: {key_info}")
         except ModeRequestError as e:
-            self.report.report_failure(
+            self.report.failure(
                 title="Failed to Connect",
                 message="Unable to verify connection to mode.",
                 context=f"Error: {str(e)}",
@@ -522,16 +522,18 @@ class ModeSource(StatefulIngestionSourceBase):
         # logger.debug(f"Processing report {report_info.get('name', '')}: {report_info}")
 
         if not report_token:
-            self.report.report_warning(
+            self.report.warning(
                 title="Missing Report Token",
                 message=f"Report token is missing for {report_info.get('id', '')}",
+                log=False,
             )
             return None
 
         if not report_info.get("id"):
-            self.report.report_warning(
+            self.report.warning(
                 title="Missing Report ID",
                 message=f"Report id is missing for {report_info.get('token', '')}",
+                log=False,
             )
             return None
 
@@ -578,11 +580,12 @@ class ModeSource(StatefulIngestionSourceBase):
                 )
             except HTTPError as http_error:
                 if _is_http_404(http_error):
-                    self.report.report_warning(
+                    self.report.warning(
                         title="Report Not Found",
                         message="Referenced report for reusable dataset was not found.",
                         context=f"Report: {report_info.get('id')}, "
                         f"Imported Dataset Report: {imported_dataset_name.get('token')}",
+                        log=False,
                     )
                     continue
                 else:
@@ -660,10 +663,11 @@ class ModeSource(StatefulIngestionSourceBase):
         try:
             return self._fetch_creator(href)
         except ModeRequestError as e:
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to retrieve Mode creator",
                 message=f"Unable to retrieve user for {href}",
                 context=f"Reason: {str(e)}",
+                log=False,
             )
             return None
 
@@ -721,7 +725,7 @@ class ModeSource(StatefulIngestionSourceBase):
                             continue
                         space_info[s.get("token", "")] = s.get("name", "")
         except ModeRequestError as e:
-            self.report.report_failure(
+            self.report.failure(
                 title="Failed to Retrieve Spaces",
                 message="Unable to retrieve spaces / collections for workspace.",
                 context=f"Workspace: {self.workspace_uri}, Error: {str(e)}",
@@ -856,10 +860,11 @@ class ModeSource(StatefulIngestionSourceBase):
         if adapter in platform_mapping:
             return platform_mapping[adapter]
         else:
-            self.report.report_warning(
+            self.report.warning(
                 title="Unrecognized Platform Found",
                 message=f"Platform was not found in DataHub. "
                 f"Using {platform} name as is",
+                log=False,
             )
 
         return platform
@@ -885,7 +890,7 @@ class ModeSource(StatefulIngestionSourceBase):
             )
             return self._data_sources_by_id_cache
         except ModeRequestError as e:
-            self.report.report_failure(
+            self.report.failure(
                 title="Failed to retrieve Data Sources",
                 message="Unable to retrieve data sources from Mode.",
                 context=f"Error: {str(e)}",
@@ -898,7 +903,7 @@ class ModeSource(StatefulIngestionSourceBase):
         data_sources_by_id = self._get_data_sources_by_id()
 
         if not data_sources_by_id:
-            self.report.report_failure(
+            self.report.failure(
                 title="No Data Sources Found",
                 message="Could not find data sources matching some ids",
                 context=f"Data Source ID: {data_source_id}",
@@ -908,7 +913,7 @@ class ModeSource(StatefulIngestionSourceBase):
         data_source = data_sources_by_id.get(data_source_id)
         if data_source is None:
             available_ids = sorted(data_sources_by_id.keys())
-            self.report.report_warning(
+            self.report.warning(
                 title="Unable to construct upstream lineage",
                 message=f"Data source ID {data_source_id} not found among "
                 f"the {len(available_ids)} data sources in the workspace "
@@ -916,6 +921,7 @@ class ModeSource(StatefulIngestionSourceBase):
                 f"database connection was deleted from Mode but queries still "
                 f"reference it. Lineage will be skipped for affected queries.",
                 context=f"Data Source ID: {data_source_id}",
+                log=False,
             )
             return None, None
 
@@ -1029,7 +1035,7 @@ class ModeSource(StatefulIngestionSourceBase):
             }
             return self._definitions_map_cache
         except ModeRequestError as e:
-            self.report.report_failure(
+            self.report.failure(
                 title="Failed to Retrieve Definitions",
                 message="Unable to retrieve definitions from Mode.",
                 context=f"Error: {str(e)}",
@@ -1642,13 +1648,14 @@ class ModeSource(StatefulIngestionSourceBase):
                     yield reports_page
         except ModeRequestError as e:
             if _is_http_404(e):
-                self.report.report_warning(
+                self.report.warning(
                     title="No Reports Found in Space",
                     message="No reports were found in the space. It may have been recently deleted.",
                     context=f"Space Token: {space_token}, Error: {str(e)}",
+                    log=False,
                 )
             else:
-                self.report.report_failure(
+                self.report.failure(
                     title="Failed to Retrieve Reports for Space",
                     message="Unable to retrieve reports for space token.",
                     context=f"Space Token: {space_token}, Error: {str(e)}",
@@ -1669,13 +1676,14 @@ class ModeSource(StatefulIngestionSourceBase):
                     yield dataset_page
         except ModeRequestError as e:
             if _is_http_404(e):
-                self.report.report_warning(
+                self.report.warning(
                     title="No Datasets Found in Space",
                     message="No datasets were found in the space. It may have been recently deleted.",
                     context=f"Space Token: {space_token}, Error: {str(e)}",
+                    log=False,
                 )
             else:
-                self.report.report_failure(
+                self.report.failure(
                     title="Failed to Retrieve Datasets for Space",
                     message=f"Unable to retrieve datasets for space token {space_token}.",
                     context=f"Space Token: {space_token}, Error: {str(e)}",
@@ -1696,13 +1704,14 @@ class ModeSource(StatefulIngestionSourceBase):
             return queries.get("_embedded", {}).get("queries", [])
         except ModeRequestError as e:
             if _is_http_404(e):
-                self.report.report_warning(
+                self.report.warning(
                     title="No Queries Found",
                     message="No queries found for the report token. Maybe the report is deleted...",
                     context=f"Report Token: {report_token}, Error: {str(e)}",
+                    log=False,
                 )
             else:
-                self.report.report_failure(
+                self.report.failure(
                     title="Failed to Retrieve Queries",
                     message="Unable to retrieve queries for report token.",
                     context=f"Report Token: {report_token}, Error: {str(e)}",
@@ -1728,13 +1737,14 @@ class ModeSource(StatefulIngestionSourceBase):
             return charts.get("_embedded", {}).get("charts", [])
         except ModeRequestError as e:
             if _is_http_404(e):
-                self.report.report_warning(
+                self.report.warning(
                     title="No Charts Found for Query",
                     message="No charts were found for the query. The query may have been recently deleted.",
                     context=f"Report Token: {report_token}, Query Token: {query_token}, Error: {str(e)}",
+                    log=False,
                 )
             else:
-                self.report.report_failure(
+                self.report.failure(
                     title="Failed to Retrieve Charts",
                     message="Unable to retrieve charts from Mode.",
                     context=f"Report Token: {report_token}, Query Token: {query_token}, Error: {str(e)}",
@@ -1882,14 +1892,15 @@ class ModeSource(StatefulIngestionSourceBase):
                     exc_info=True,
                 )
                 if is_timeout:
-                    self.report.report_warning(
+                    self.report.warning(
                         title="Report Processing Timeout",
                         message=f"Timed out processing report {report_name} ({report_token}).",
                         context=f"Space Token: {space_token}, Error: {str(e)}",
                         exc=e,
+                        log=False,
                     )
                 else:
-                    self.report.report_failure(
+                    self.report.failure(
                         title="Failed to Process Report",
                         message=f"Unexpected error processing report {report_name} ({report_token}).",
                         context=f"Space Token: {space_token}, Error: {str(e)}",
@@ -1924,7 +1935,7 @@ class ModeSource(StatefulIngestionSourceBase):
                 f"Failed to process dataset {dataset_token} in space {space_token}",
                 exc_info=True,
             )
-            self.report.report_failure(
+            self.report.failure(
                 title="Failed to Process Dataset",
                 message=f"Unexpected error processing dataset {dataset_token}.",
                 context=f"Space Token: {space_token}, Error: {str(e)}",

--- a/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
@@ -521,10 +521,11 @@ class MongoDBSource(StatefulIngestionSourceBase):
         assert max_schema_size is not None
         if collection_schema_size > max_schema_size:
             # downsample the schema, using frequency as the sort key
-            self.report.report_warning(
+            self.report.warning(
                 title="Too many schema fields",
                 message=f"Downsampling the collection schema because it has too many schema fields. Configured threshold is {max_schema_size}",
                 context=f"Schema Size: {collection_schema_size}, Collection: {dataset_urn}",
+                log=False,
             )
             # Add this information to the custom properties so user can know they are looking at downsampled schema
             dataset_properties.customProperties["schema.downsampled"] = "True"

--- a/metadata-ingestion/src/datahub/ingestion/source/neo4j/neo4j_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/neo4j/neo4j_source.py
@@ -135,7 +135,7 @@ class Neo4jSource(StatefulIngestionSourceBase):
 
         except Exception as e:
             log.error(e)
-            self.report.report_failure(
+            self.report.failure(
                 message="Failed to process dataset",
                 context=dataset,
                 exc=e,
@@ -300,11 +300,12 @@ class Neo4jSource(StatefulIngestionSourceBase):
 
             except Exception as e:
                 log.warning(f"Failed to process row {row['key']}: {str(e)}")
-                self.report.report_warning(
+                self.report.warning(
                     title="Error processing Neo4j metadata",
                     message="Some entities will be missed",
                     context=row["key"],
                     exc=e,
+                    log=False,
                 )
                 self.report.obj_failures += 1
 

--- a/metadata-ingestion/src/datahub/ingestion/source/notion/notion_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/notion/notion_report.py
@@ -87,10 +87,11 @@ class NotionSourceReport(StaleEntityRemovalSourceReport):
         self.num_synced_blocks_skipped += 1
         if page_id not in self.synced_blocks_skipped:
             self.synced_blocks_skipped.append(page_id)
-            self.report_warning(
+            self.warning(
                 title="Synced Block Content Skipped",
                 message="Page contains synced blocks that cannot be fully ingested. "
                 "The page will be ingested but synced block content will be missing. "
                 "This is a known limitation of the current connector version.",
                 context=f"Page ID: {page_id}",
+                log=False,
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/notion/notion_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/notion/notion_source.py
@@ -780,11 +780,12 @@ class NotionSource(StatefulIngestionSourceBase, TestableSource):
                         "Synced block content will be skipped due to unstructured-ingest v0.7.2 limitation. "
                         "Pages will be ingested but synced block content will be missing."
                     )
-                    report.report_warning(
+                    report.warning(
                         title="Synced Blocks Limitation",
                         message="Pages with synced blocks were encountered during ingestion. "
                         "The pages were ingested successfully, but synced block content is missing. "
                         "This is a known limitation of the current connector version due to unstructured-ingest v0.7.2 compatibility.",
+                        log=False,
                     )
                     synced_blocks_encountered = True
 
@@ -1356,7 +1357,7 @@ class NotionSource(StatefulIngestionSourceBase, TestableSource):
 
         except Exception as e:
             logger.error(f"Failed to run Unstructured pipeline: {e}", exc_info=True)
-            self.report.report_failure(str(e))
+            self.report.failure(str(e))
             if self.config.advanced.raise_on_error:
                 raise
 

--- a/metadata-ingestion/src/datahub/ingestion/source/openapi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi.py
@@ -284,34 +284,39 @@ class APISource(Source, ABC):
             Exception: For unhandled status codes
         """
         if status_code == 400:
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to Extract Metadata",
                 message="Bad request body when retrieving data from OpenAPI endpoint",
                 context=f"Endpoint Type: {type}, Status Code: {status_code}",
+                log=False,
             )
         elif status_code == 403:
-            self.report.report_warning(
+            self.report.warning(
                 title="Unauthorized to Extract Metadata",
                 message="Received unauthorized response when attempting to retrieve data from OpenAPI endpoint",
                 context=f"Endpoint Type: {type}, Status Code: {status_code}",
+                log=False,
             )
         elif status_code == 404:
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to Extract Metadata",
                 message="Unable to find an example for endpoint. Please add it to the list of forced examples.",
                 context=f"Endpoint Type: {type}, Status Code: {status_code}",
+                log=False,
             )
         elif status_code == 500:
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to Extract Metadata",
                 message="Received unknown server error from OpenAPI endpoint",
                 context=f"Endpoint Type: {type}, Status Code: {status_code}",
+                log=False,
             )
         elif status_code == 504:
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to Extract Metadata",
                 message="Timed out when attempting to retrieve data from OpenAPI endpoint",
                 context=f"Endpoint Type: {type}, Status Code: {status_code}",
+                log=False,
             )
         else:
             raise Exception(
@@ -841,7 +846,7 @@ class APISource(Source, ABC):
             for w in warn_c:
                 w_msg = w.message
                 w_spl = w_msg.args[0].split(" --- ")  # type: ignore
-                self.report.report_warning(message=w_spl[1], context=w_spl[0])
+                self.report.warning(message=w_spl[1], context=w_spl[0], log=False)
 
         # Sample from "listing endpoint" for guessing composed endpoints
         root_dataset_samples: Dict[str, Any] = {}
@@ -878,10 +883,11 @@ class APISource(Source, ABC):
             ):
                 method = endpoint_dets.get("method", "").lower()
                 if method != "get":
-                    self.report.report_warning(
+                    self.report.warning(
                         title="Failed to Extract Endpoint Metadata",
                         message=f"No schema found in OpenAPI spec for {endpoint_dets.get('method', 'unknown')} method (API calls only made for GET methods with credentials)",
                         context=f"Endpoint Type: {endpoint_k}, Name: {dataset_name}",
+                        log=False,
                     )
                     continue
 
@@ -916,16 +922,18 @@ class APISource(Source, ABC):
                     and self.config.enable_api_calls_for_schema_extraction
                     and not self._has_credentials()
                 ):
-                    self.report.report_warning(
+                    self.report.warning(
                         title="No Schema Extracted - Missing Credentials",
                         message="Could not extract schema from OpenAPI spec and no API call made due to missing credentials (GET methods only)",
                         context=f"Endpoint Type: {endpoint_k}, Name: {dataset_name}",
+                        log=False,
                     )
                 else:
-                    self.report.report_warning(
+                    self.report.warning(
                         title="No Schema Extracted",
                         message="Could not extract schema from OpenAPI spec (GET/POST/PUT/PATCH with 200 responses) or API calls for endpoint",
                         context=f"Endpoint Type: {endpoint_k}, Name: {dataset_name}",
+                        log=False,
                     )
 
     def get_report(self):

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/powerbi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/powerbi.py
@@ -1978,7 +1978,7 @@ class PowerBiDashboardSource(StatefulIngestionSourceBase, TestableSource):
                 message = f"Error ({e}) occurred while loading dashboard {dashboard.displayName}(id={dashboard.id}) tiles."
 
                 logger.exception(message, e)
-                self.reporter.report_warning(dashboard.id, message)
+                self.reporter.warning(dashboard.id, message, log=False)
             # Convert PowerBi Dashboard and child entities to Datahub work unit to ingest into Datahub
             workunits = self.mapper.to_datahub_work_units(dashboard, workspace)
             for workunit in workunits:

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi_report_server/report_server.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi_report_server/report_server.py
@@ -549,7 +549,7 @@ class PowerBiReportServerDashboardSource(StatefulIngestionSourceBase):
                     e, report.name, report.id
                 )
                 LOGGER.exception(message, e)
-                self.report.report_warning(report.id, message)
+                self.report.warning(report.id, message, log=False)
             finally:
                 # Increase Dashboard and tiles count in report
                 self.report.report_scanned(count=1)

--- a/metadata-ingestion/src/datahub/ingestion/source/pulsar.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/pulsar.py
@@ -220,11 +220,11 @@ class PulsarSource(StatefulIngestionSourceBase):
                     f" no messages have been written to the topic yet."
                     f" {http_error}"
                 )
-                self.report.report_warning("NoSchemaFound", message)
+                self.report.warning("NoSchemaFound", message, log=False)
             else:
                 # Authorization error
                 message = f"An HTTP error occurred: {http_error}"
-                self.report.report_warning("HTTPError", message)
+                self.report.warning("HTTPError", message, log=False)
         except requests.exceptions.RequestException as e:
             raise Exception(
                 "An ambiguous exception occurred while handling the request"
@@ -360,9 +360,10 @@ class PulsarSource(StatefulIngestionSourceBase):
                 schema.schema_str, is_key_schema=is_key_schema
             )
         else:
-            self.report.report_warning(
+            self.report.warning(
                 pulsar_topic.fullname,
                 f"Parsing Pulsar schema type {schema.schema_type} is currently not implemented",
+                log=False,
             )
         return fields
 

--- a/metadata-ingestion/src/datahub/ingestion/source/rdf/ingestion/ast_converter.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/rdf/ingestion/ast_converter.py
@@ -131,7 +131,7 @@ class RDFToASTConverter:
             logger.info(f"DataHub AST created: {summary_str}")
             return datahub_ast
         except (RuntimeError, ValueError) as e:
-            self.report.report_failure(
+            self.report.failure(
                 "Failed to convert RDF to DataHub AST",
                 context=f"Triples processed: {len(rdf_graph)}",
                 exc=e,
@@ -222,7 +222,7 @@ class RDFToASTConverter:
             )
             return datahub_terms
         except (RuntimeError, ValueError) as e:
-            self.report.report_failure(
+            self.report.failure(
                 "Failed to extract glossary terms",
                 context=f"Entity type: {entity_type}",
                 exc=e,
@@ -265,7 +265,7 @@ class RDFToASTConverter:
                         if hasattr(rdf_rel, "target_urn")
                         else "unknown"
                     )
-                    self.report.report_failure(
+                    self.report.failure(
                         "Failed to convert relationship",
                         context=f"Source: {rel_source}, Target: {rel_target}",
                         exc=e,
@@ -280,7 +280,7 @@ class RDFToASTConverter:
             )
             return datahub_relationships
         except (RuntimeError, ValueError) as e:
-            self.report.report_failure(
+            self.report.failure(
                 "Failed to extract relationships",
                 context=f"Entity type: {entity_type}",
                 exc=e,
@@ -298,7 +298,7 @@ class RDFToASTConverter:
             logger.debug(f"Built {len(domains)} domains from glossary term hierarchy")
             return domains
         except (RuntimeError, ValueError) as e:
-            self.report.report_failure(
+            self.report.failure(
                 "Failed to build domain hierarchy",
                 context=f"Glossary terms: {len(glossary_terms)}",
                 exc=e,

--- a/metadata-ingestion/src/datahub/ingestion/source/rdf/ingestion/rdf_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/rdf/ingestion/rdf_source.py
@@ -395,7 +395,7 @@ class RDFSource(StatefulIngestionSourceBase, TestableSource):
             error_type: Type of error for reporting
             error_context: Contextual error message
         """
-        self.report.report_failure(error_type, context=error_context, exc=error)
+        self.report.failure(error_type, context=error_context, exc=error)
         logger.error(
             f"{error_type}: {self.config.source}. {error_context}",
             exc_info=True,
@@ -591,7 +591,7 @@ class RDFSource(StatefulIngestionSourceBase, TestableSource):
                 f"Error: {str(e)}. "
                 "Please verify your SPARQL query syntax and ensure it's a valid CONSTRUCT query."
             )
-            self.report.report_failure(
+            self.report.failure(
                 "Failed to apply SPARQL filter",
                 context=error_context,
                 exc=e,

--- a/metadata-ingestion/src/datahub/ingestion/source/rdf/ingestion/rdf_source_helpers.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/rdf/ingestion/rdf_source_helpers.py
@@ -65,7 +65,7 @@ def build_entity_mcps(
                     f"No MCPs created for {len(entities)} {entity_type} entities (they may have been filtered out)"
                 )
         except RuntimeError as e:
-            report.report_failure(
+            report.failure(
                 f"Failed to create MCPs for {entity_type}",
                 context=f"Entity count: {len(entities)}",
                 exc=e,
@@ -83,7 +83,7 @@ def build_entity_mcps(
                         created_count += 1
             except RuntimeError as e:
                 entity_urn = getattr(entity, "urn", "unknown")
-                report.report_failure(
+                report.failure(
                     f"Failed to create MCP for {entity_type}",
                     context=f"Entity URN: {entity_urn}",
                     exc=e,
@@ -127,7 +127,7 @@ def process_post_processing_hooks(
                 for mcp in post_mcps:
                     yield mcp
         except RuntimeError as e:
-            report.report_failure(
+            report.failure(
                 f"Failed to create post-processing MCPs for {entity_type}",
                 context="Post-processing hook",
                 exc=e,

--- a/metadata-ingestion/src/datahub/ingestion/source/rdf/ingestion/workunit_generator.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/rdf/ingestion/workunit_generator.py
@@ -48,7 +48,7 @@ class WorkUnitGenerator:
 
         if not isinstance(datahub_graph, DataHubGraph):
             logger.error(f"Expected DataHubGraph, got {type(datahub_graph)}")
-            self.report.report_failure(f"Invalid AST type: {type(datahub_graph)}")
+            self.report.failure(f"Invalid AST type: {type(datahub_graph)}")
             return  # Generator returns nothing on error
 
         try:
@@ -96,7 +96,7 @@ class WorkUnitGenerator:
             )
 
         except RuntimeError as e:
-            self.report.report_failure(
+            self.report.failure(
                 "Failed to generate work units from DataHub AST",
                 context=f"Glossary terms: {len(datahub_graph.glossary_terms)}, "
                 f"Domains: {len(datahub_graph.domains)}, "
@@ -127,7 +127,7 @@ class WorkUnitGenerator:
             summary_str = ", ".join(
                 [f"{count} {name}" for name, count in summary.items()]
             )
-            self.report.report_failure(
+            self.report.failure(
                 "Failed to generate work units",
                 context=f"AST summary: {summary_str}",
                 exc=e,
@@ -160,7 +160,7 @@ class WorkUnitGenerator:
                     if hasattr(workunit, "mcp") and hasattr(workunit.mcp, "entityUrn")
                     else "unknown"
                 )
-                self.report.report_failure(
+                self.report.failure(
                     "Failed to process work unit",
                     context=f"Work unit ID: {workunit_id}, Entity URN: {entity_urn}",
                     exc=e,
@@ -222,7 +222,7 @@ class WorkUnitGenerator:
                     yield mcp
             except RuntimeError as e:
                 # Continue processing other entity types even if one fails
-                self.report.report_failure(
+                self.report.failure(
                     f"Failed to process {entity_type} entities",
                     context=f"Entity type: {entity_type}",
                     exc=e,
@@ -268,7 +268,7 @@ class WorkUnitGenerator:
                         f"Created {len(post_mcps)} glossary node/term MCPs from domain hierarchy"
                     )
             except RuntimeError as e:
-                self.report.report_failure(
+                self.report.failure(
                     "Failed to create glossary node MCPs from domain hierarchy",
                     context=f"Domains: {len(datahub_graph.domains)}",
                     exc=e,
@@ -300,7 +300,7 @@ class WorkUnitGenerator:
                         f"Created {len(post_mcps)} structured property value assignment MCPs"
                     )
             except RuntimeError as e:
-                self.report.report_failure(
+                self.report.failure(
                     "Failed to create structured property value assignment MCPs",
                     context="Post-processing hook",
                     exc=e,

--- a/metadata-ingestion/src/datahub/ingestion/source/redash.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redash.py
@@ -635,14 +635,14 @@ class RedashSource(StatefulIngestionSourceBase):
             if chart_type is None:
                 chart_type = DEFAULT_VISUALIZATION_TYPE
                 message = f"ChartTypeClass for Redash Visualization Type={viz_type} with options.globalSeriesType={globalSeriesType} is missing. Setting to {DEFAULT_VISUALIZATION_TYPE}"
-                self.report.report_warning(title=report_type, message=message)
+                self.report.warning(title=report_type, message=message, log=False)
                 logger.warning(message)
         else:
             chart_type = VISUALIZATION_TYPE_MAP.get(viz_type)
             if chart_type is None:
                 chart_type = DEFAULT_VISUALIZATION_TYPE
                 message = f"ChartTypeClass for Redash Visualization Type={viz_type} is missing. Setting to {DEFAULT_VISUALIZATION_TYPE}"
-                self.report.report_warning(title=report_type, message=message)
+                self.report.warning(title=report_type, message=message, log=False)
                 logger.warning(message)
 
         return chart_type
@@ -680,9 +680,10 @@ class RedashSource(StatefulIngestionSourceBase):
         if datasource_urns is None:
             self.report.charts_no_input.add(chart_urn)
             self.report.queries_no_dataset.add(str(query_id))
-            self.report.report_warning(
+            self.report.warning(
                 title="redash-chart-input-missing",
                 message=f"For viz-id-{viz_id}-query-{query_id}-datasource-{data_source_id} data_source_type={data_source_type} no datasources found. Setting inputs to None",
+                log=False,
             )
 
         chart_info = ChartInfoClass(

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/lineage.py
@@ -956,10 +956,11 @@ class RedshiftSqlLineage(Closeable):
         for mcp in self.aggregator.gen_metadata():
             yield mcp.as_workunit()
         if len(self.aggregator.report.observed_query_parse_failures) > 0:
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to extract some SQL lineage",
                 message="Unexpected error(s) while attempting to extract lineage from SQL queries. See the full logs for more details.",
                 context=f"Query Parsing Failures: {self.aggregator.report.observed_query_parse_failures}",
+                log=False,
             )
 
     def close(self) -> None:

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/profile.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/profile.py
@@ -73,10 +73,11 @@ class RedshiftProfiler(GenericProfiler):
                             # Case 2: User DID tell us to profile external tables, but only at the table level.
                             # Currently, we do not support this combination. The user needs to also set
                             # profile_table_level_only to False in order to profile.
-                            self.report.report_warning(
+                            self.report.warning(
                                 title="Skipped profiling for external tables",
                                 message="External tables are not supported for profiling when 'profile_table_level_only' config is set to 'True'. Please set 'profile_table_level_only' to 'False' in order to profile external Redshift tables.",
                                 context=f"External Table: {db}.{schema}.{table.name}",
+                                log=False,
                             )
                             # Continue, since we were unable to retrieve cheap profiling stats from svv_table_info.
                             continue

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
@@ -361,38 +361,41 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
             and self.config.schema_pattern is not None
             and self.config.schema_pattern != AllowDenyPattern.allow_all()
         ):
-            self.report.report_warning(
+            self.report.warning(
                 message="Please update `schema_pattern` to match against fully qualified schema name `<database_name>.<schema_name>` and set config `match_fully_qualified_names : True`."
                 "Current default `match_fully_qualified_names: False` is only to maintain backward compatibility. "
                 "The config option `match_fully_qualified_names` will be removed in future and the default behavior will be like `match_fully_qualified_names: True`.",
                 context="Config option deprecation warning",
                 title="Config option deprecation warning",
+                log=False,
             )
 
         if (
             self.config.include_column_usage_stats
             and not self.config.include_usage_statistics
         ):
-            self.report.report_warning(
+            self.report.warning(
                 title="Config option has no effect",
                 message="`include_column_usage_stats` is enabled but "
                 "`include_usage_statistics` is disabled, so no usage statistics "
                 "(column-level or otherwise) will be produced. Enable "
                 "`include_usage_statistics` to get column-level usage.",
                 context="include_column_usage_stats",
+                log=False,
             )
 
         if (
             self.config.include_query_usage_statistics
             and not self.config.include_usage_statistics
         ):
-            self.report.report_warning(
+            self.report.warning(
                 title="Config option has no effect",
                 message="`include_query_usage_statistics` is enabled but "
                 "`include_usage_statistics` is disabled, so no query usage "
                 "statistics will be produced. Enable `include_usage_statistics` "
                 "to get per-query popularity stats.",
                 context="include_query_usage_statistics",
+                log=False,
             )
 
         if (
@@ -400,13 +403,14 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
             and self.config.include_query_usage_statistics
             and not self.config.lineage_generate_queries
         ):
-            self.report.report_warning(
+            self.report.warning(
                 title="Config option has no effect",
                 message="`include_query_usage_statistics` is enabled but "
                 "`lineage_generate_queries` is disabled, so no Query entities are "
                 "emitted for the query usage statistics to attach to. Enable "
                 "`lineage_generate_queries` to get per-query popularity stats.",
                 context="include_query_usage_statistics",
+                log=False,
             )
 
     def get_workunits_internal(self) -> Iterable[Union[MetadataWorkUnit, SqlWorkUnit]]:
@@ -1107,9 +1111,10 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
             )
         ):
             # Skip this run
-            self.report.report_warning(
+            self.report.warning(
                 "lineage-extraction",
                 "Skip this run as there was already a run for current ingestion window.",
+                log=False,
             )
             return False
 
@@ -1136,31 +1141,31 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
         except redshift_connector.Error as e:
             error_message = str(e).lower()
             if "password authentication failed" in error_message:
-                self.report.report_failure(
+                self.report.failure(
                     title="Invalid credentials",
                     message="Failed to connect to Redshift. Please verify your username, password, and database.",
                     exc=e,
                 )
             elif "timeout" in error_message:
-                self.report.report_failure(
+                self.report.failure(
                     title="Unable to connect",
                     message="Failed to connect to Redshift. Please verify your host name and port number.",
                     exc=e,
                 )
             elif "communication error" in error_message:
-                self.report.report_failure(
+                self.report.failure(
                     title="Unable to connect",
                     message="Failed to connect to Redshift. Please verify that the host name is valid and reachable.",
                     exc=e,
                 )
             elif "database" in error_message and "does not exist" in error_message:
-                self.report.report_failure(
+                self.report.failure(
                     title="Database does not exist",
                     message="Failed to connect to Redshift. Please verify that the provided database exists and the provided user has access to it.",
                     exc=e,
                 )
             else:
-                self.report.report_failure(
+                self.report.failure(
                     title="Unable to connect",
                     message="Failed to connect to Redshift. Please verify your connection details.",
                     exc=e,

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/usage.py
@@ -169,9 +169,10 @@ class RedshiftUsageExtractor:
             )
         ):
             # Skip this run
-            self.report.report_warning(
+            self.report.warning(
                 "usage-extraction",
                 "Skip this run as there was already a run for current ingestion window.",
+                log=False,
             )
             return False
 

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/profiling.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/profiling.py
@@ -635,9 +635,10 @@ class SparkProfiler:
             try:
                 df = self.spark.read.format("avro").load(file)
             except AnalysisException as e:
-                self.report.report_warning(
+                self.report.warning(
                     file,
                     f"Avro file reading failed with exception. The error was: {e}",
+                    log=False,
                 )
                 return None
 
@@ -645,7 +646,9 @@ class SparkProfiler:
         # elif file.endswith(".orc"):
         # df = self.spark.read.orc(file)
         else:
-            self.report.report_warning(file, f"file {file} has unsupported extension")
+            self.report.warning(
+                file, f"file {file} has unsupported extension", log=False
+            )
             return None
         # NB: no df.count() debug log here. Counting forces a full scan of the whole
         # table; the row count is already computed once later in _SingleTableProfiler.
@@ -685,9 +688,10 @@ class SparkProfiler:
 
         # if table is not readable, skip
         if table is None:
-            self.report.report_warning(
+            self.report.warning(
                 table_data.display_name,
                 f"unable to read table {table_data.display_name} from file {table_data.full_path}",
+                log=False,
             )
             return
 

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -342,14 +342,16 @@ class S3Source(StatefulIngestionSourceBase):
                 fields = inferrer.infer_schema(file)
                 logger.debug(f"Extracted fields in schema: {fields}")
             except Exception as e:
-                self.report.report_warning(
+                self.report.warning(
                     table_data.full_path,
                     f"could not infer schema for file {table_data.full_path}: {e}",
+                    log=False,
                 )
         else:
-            self.report.report_warning(
+            self.report.warning(
                 table_data.full_path,
                 f"file {table_data.full_path} has unsupported extension",
+                log=False,
             )
         file.close()
 
@@ -541,11 +543,12 @@ class S3Source(StatefulIngestionSourceBase):
                 )
                 aspects.append(schema_metadata)
             except Exception as e:
-                self.report.report_warning(
+                self.report.warning(
                     title="Failed to extract schema from file",
                     message="Schema may be missed for dataset because of failure when extracting schema from file",
                     context=f"dataset={table_data.display_name}, file={table_data.full_path}",
                     exc=e,
+                    log=False,
                 )
         else:
             logger.info(
@@ -1069,9 +1072,10 @@ class S3Source(StatefulIngestionSourceBase):
 
         except Exception as e:
             if isinstance(e, s3.meta.client.exceptions.NoSuchBucket):
-                self.get_report().report_warning(
+                self.get_report().warning(
                     "Missing bucket",
                     f"No bucket found {e.response['Error'].get('BucketName')}",
+                    log=False,
                 )
                 return
             logger.error(f"Error in _process_templated_path: {e}")

--- a/metadata-ingestion/src/datahub/ingestion/source/sac/sac.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sac/sac.py
@@ -495,14 +495,16 @@ class SACSource(StatefulIngestionSourceBase, TestableSource):
 
                 yield mcp.as_workunit()
             else:
-                self.report.report_warning(
+                self.report.warning(
                     "unknown-upstream-dataset",
                     f"Unknown upstream dataset for model with id {model.namespace}:{model.model_id} and external id {model.external_id}",
+                    log=False,
                 )
         elif model.system_type is not None:
-            self.report.report_warning(
+            self.report.warning(
                 "unknown-system-type",
                 f"Unknown system type {model.system_type} for model with id {model.namespace}:{model.model_id} and external id {model.external_id}",
+                log=False,
             )
 
         mcp = MetadataChangeProposalWrapper(
@@ -792,9 +794,10 @@ class SACSource(StatefulIngestionSourceBase, TestableSource):
             elif column.data_type in ("decimal", "int32"):
                 return SchemaFieldDataTypeClass(type=NumberTypeClass())
             else:
-                self.report.report_warning(
+                self.report.warning(
                     "unknown-data-type",
                     f"Unknown data type {column.data_type} found",
+                    log=False,
                 )
 
                 return SchemaFieldDataTypeClass(type=NullTypeClass())

--- a/metadata-ingestion/src/datahub/ingestion/source/schema/json_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/schema/json_schema.py
@@ -467,7 +467,7 @@ class JsonSchemaSource(StatefulIngestionSourceBase):
                             file_name=file_name,
                         )
                     except Exception as e:
-                        self.report.report_failure(
+                        self.report.failure(
                             f"{root}/{file_name}", f"Failed to process due to {e}"
                         )
                         logger.error(
@@ -484,7 +484,7 @@ class JsonSchemaSource(StatefulIngestionSourceBase):
                     file_name=str(self.config.path),
                 )
             except Exception as e:
-                self.report.report_failure(
+                self.report.failure(
                     str(self.config.path), f"Failed to process due to {e}"
                 )
                 logger.error(f"Failed to process file {self.config.path}", exc_info=e)

--- a/metadata-ingestion/src/datahub/ingestion/source/slack/slack.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/slack/slack.py
@@ -336,7 +336,7 @@ class SlackSource(StatefulIngestionSourceBase):
                 yield mcp.as_workunit()
         else:
             logger.error("Failed to fetch team information")
-            self.report.report_failure(
+            self.report.failure(
                 "team_info", "Failed to fetch team information for users"
             )
 
@@ -353,7 +353,7 @@ class SlackSource(StatefulIngestionSourceBase):
                 response = self.get_slack_client().users_list(cursor=cursor)
             assert isinstance(response.data, dict)
             if not response.data["ok"]:
-                self.report.report_failure("users", "Failed to fetch users")
+                self.report.failure("users", "Failed to fetch users")
                 return
 
             assert self.ctx.graph is not None
@@ -421,9 +421,7 @@ class SlackSource(StatefulIngestionSourceBase):
             )
         assert isinstance(response.data, dict)
         if not response.data["ok"]:
-            self.report.report_failure(
-                "public_channel", "Failed to fetch public channels"
-            )
+            self.report.failure("public_channel", "Failed to fetch public channels")
             return result_channels, None
         for channel in response.data["channels"]:
             num_members = channel["num_members"]

--- a/metadata-ingestion/src/datahub/ingestion/source/snaplogic/snaplogic.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snaplogic/snaplogic.py
@@ -114,7 +114,7 @@ class SnaplogicSource(StatefulIngestionSourceBase):
                             title="Lineage Ingestion Progress",
                         )
                 except Exception as e:
-                    self.report.report_failure(
+                    self.report.failure(
                         message="Failed to process lineage record",
                         context=str(lineage),
                         exc=e,
@@ -126,7 +126,7 @@ class SnaplogicSource(StatefulIngestionSourceBase):
             self.snaplogic_lineage_extractor.report_status("lineage_ingestion", True)
             self.snaplogic_lineage_extractor.update_stats()
         except Exception as e:
-            self.report.report_failure(message="Failed to fetch lineages", exc=e)
+            self.report.failure(message="Failed to fetch lineages", exc=e)
             self.snaplogic_lineage_extractor.report_status("lineage_ingestion", False)
 
     def _process_lineage_record(self, lineage: dict) -> Iterable[MetadataWorkUnit]:

--- a/metadata-ingestion/src/datahub/ingestion/source/snaplogic/snaplogic_lineage_extractor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snaplogic/snaplogic_lineage_extractor.py
@@ -79,7 +79,7 @@ class SnaplogicLineageExtractor:
             )
 
         except Exception as e:
-            self.report.report_failure(
+            self.report.failure(
                 message="Error fetching lineage data",
                 exc=e,
                 title="Lineage Fetch Error",

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_assertion.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_assertion.py
@@ -240,5 +240,5 @@ class SnowflakeAssertionsHandler:
             return workunits
 
         except Exception as e:
-            self.report.report_warning("assertion-result-parse-failure", str(e))
+            self.report.warning("assertion-result-parse-failure", str(e), log=False)
             return []

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_lineage_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_lineage_v2.py
@@ -586,9 +586,10 @@ class SnowflakeLineageExtractor(SnowflakeCommonMixin, Closeable):
             )
         ):
             # Skip this run
-            self.report.report_warning(
+            self.report.warning(
                 "lineage-extraction",
                 "Skip this run as there was already a run for current ingestion window.",
+                log=False,
             )
             return False
         return True

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_marketplace.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_marketplace.py
@@ -1190,10 +1190,11 @@ class SnowflakeMarketplaceHandler(SnowflakeCommonMixin):
                 cur_end_time=self.config.end_time,
             )
         ):
-            self.structured_reporter.report_warning(
+            self.structured_reporter.warning(
                 "marketplace-usage-extraction",
                 "Skip this run as there was already a run for the current "
                 "ingestion window.",
+                log=False,
             )
             return False
         return True

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
@@ -2297,9 +2297,10 @@ class SnowflakeSchemaGenerator(SnowflakeStructuredReportMixin):
                             f"Could not find physical table mapping for logical table '{logical_table_name}'. "
                             f"Available mappings: {list(semantic_view.logical_to_physical_table.keys())}"
                         )
-                        self.report.report_warning(
+                        self.report.warning(
                             semantic_view.name,
                             f"Missing logical table mapping: {logical_table_name}",
+                            log=False,
                         )
                     continue
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_usage_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_usage_v2.py
@@ -588,9 +588,10 @@ class SnowflakeUsageExtractor(SnowflakeCommonMixin, Closeable):
             )
         ):
             # Skip this run
-            self.report.report_warning(
+            self.report.warning(
                 "usage-extraction",
                 "Skip this run as there was already a run for current ingestion window.",
+                log=False,
             )
             return False
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/processors/pipeline_processor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/processors/pipeline_processor.py
@@ -317,10 +317,11 @@ class PipelineProcessor(EntityProcessor):
                 logger.debug("No destinations found via destinations API")
 
             except Exception as e:
-                self.report.report_warning(
+                self.report.warning(
                     "warehouse_destination",
                     f"Failed to get warehouse destination from destinations API: {e}. "
                     "Enrichment-to-warehouse lineage will be unavailable.",
+                    log=False,
                 )
                 logger.warning(
                     f"Failed to get warehouse destination from destinations API: {e}",

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/processors/schema_processor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/processors/schema_processor.py
@@ -154,7 +154,7 @@ class SchemaProcessor(EntityProcessor):
             )
         except (requests.RequestException, ValueError) as e:
             # Expected errors: API failures, parsing errors
-            self.report.report_failure(
+            self.report.failure(
                 title="Failed to fetch data structures",
                 message="Unable to retrieve schemas from BDP API. Check API credentials and network connectivity.",
                 context=f"organization_id={self.config.bdp_connection.organization_id if self.config.bdp_connection else 'N/A'}",
@@ -164,7 +164,7 @@ class SchemaProcessor(EntityProcessor):
         except Exception as e:
             # Unexpected error - indicates a bug
             logger.error("Unexpected error fetching data structures", exc_info=True)
-            self.report.report_failure(
+            self.report.failure(
                 title="Unexpected error fetching data structures",
                 message="This may indicate a bug in the connector. Please report this issue.",
                 context=f"organization_id={self.config.bdp_connection.organization_id if self.config.bdp_connection else 'N/A'}",
@@ -311,10 +311,11 @@ class SchemaProcessor(EntityProcessor):
                     f"Failed to process data structure {schema_id}: {e}",
                     exc_info=True,
                 )
-                self.report.report_warning(
+                self.report.warning(
                     title="Failed to process data structure",
                     message=f"Skipping schema {schema_id}: {e}. "
                     "Remaining schemas will still be processed.",
+                    log=False,
                 )
                 continue
 
@@ -336,7 +337,7 @@ class SchemaProcessor(EntityProcessor):
                 "No schemas found in Iglu registry. Either the registry is empty or "
                 "your Iglu Server doesn't support the /api/schemas endpoint (requires Iglu Server 0.6+)."
             )
-            self.report.report_failure(
+            self.report.failure(
                 title="No schemas found",
                 message="Automatic schema discovery returned no results",
                 context="Iglu-only mode requires Iglu Server 0.6+ with /api/schemas endpoint support",
@@ -387,7 +388,7 @@ class SchemaProcessor(EntityProcessor):
 
             except Exception as e:
                 logger.error(f"Failed to fetch schema {uri} from Iglu: {e}")
-                self.report.report_failure(
+                self.report.failure(
                     title=f"Failed to fetch schema {uri}",
                     message="Error fetching schema from Iglu registry",
                     context=uri,

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/processors/standard_schema_processor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/processors/standard_schema_processor.py
@@ -104,10 +104,11 @@ class StandardSchemaProcessor(EntityProcessor):
                     f"Failed to extract standard schema {iglu_uri} from Iglu Central: {e}",
                     exc_info=True,
                 )
-                self.report.report_warning(
+                self.report.warning(
                     title="Failed to extract standard schema from Iglu Central",
                     message=f"Failed to extract standard schema {iglu_uri}: {e}. "
                     "Lineage from event specs to this schema may be incomplete.",
+                    log=False,
                 )
 
     def _collect_standard_schema_uris(self) -> Set[str]:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/processors/warehouse_lineage_processor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/processors/warehouse_lineage_processor.py
@@ -95,10 +95,11 @@ class WarehouseLineageProcessor(EntityProcessor):
                         f"Failed to fetch data models for tracking plan '{plan.name}': {e}",
                         exc_info=True,
                     )
-                    self.report.report_warning(
+                    self.report.warning(
                         title="Failed to fetch data models for tracking plan",
                         message=f"Skipping tracking plan '{plan.name}': {e}. "
                         "Lineage from remaining tracking plans will still be processed.",
+                        log=False,
                     )
                     continue
 
@@ -184,12 +185,13 @@ class WarehouseLineageProcessor(EntityProcessor):
             )
 
         except Exception as e:
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to extract warehouse lineage via data models",
                 message="Unable to retrieve data models from BDP API for lineage extraction. "
                 "This is optional and won't affect other metadata.",
                 context=f"organization_id={self.config.bdp_connection.organization_id if self.config.bdp_connection else 'N/A'}",
                 exc=e,
+                log=False,
             )
             logger.warning(
                 "Failed to extract warehouse lineage via data models",

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/services/error_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/services/error_handler.py
@@ -54,7 +54,7 @@ class ErrorHandler:
         if context:
             error_context += f" ({context})"
 
-        self.report.report_failure(
+        self.report.failure(
             title=f"API Error: {operation}",
             message=f"Failed to {operation}: {str(error)}",
             context=error_context,
@@ -87,7 +87,7 @@ class ErrorHandler:
         if field:
             error_context += f", field: {field}"
 
-        self.report.report_failure(
+        self.report.failure(
             title=f"Validation Error: {entity_type}",
             message=f"Validation failed for {entity_type} '{entity_id}': {str(error)}",
             context=error_context,
@@ -119,7 +119,7 @@ class ErrorHandler:
         """
         error_context = f"{operation} for {entity_type}: {entity_id}"
 
-        self.report.report_failure(
+        self.report.failure(
             title=f"Processing Error: {operation}",
             message=f"Failed to {operation} for {entity_type} '{entity_id}': {str(error)}",
             context=error_context,
@@ -152,7 +152,7 @@ class ErrorHandler:
         if suggestion:
             message += f". {suggestion}"
 
-        self.report.report_failure(
+        self.report.failure(
             title=f"Missing Dependency: {dependency}",
             message=message,
             context=f"operation={operation}",

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/services/user_resolver.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/services/user_resolver.py
@@ -82,16 +82,17 @@ class UserResolver:
                 f"Ownership tracking will use initiator names directly."
             )
             if self.report:
-                self.report.report_warning(
+                self.report.warning(
                     "user_loading",
                     f"Could not load users from BDP API: {e}. "
                     "Ownership will use initiator names instead of emails.",
+                    log=False,
                 )
         except Exception as e:
             # Unexpected error - indicates a bug
             logger.error(f"Unexpected error loading users: {e}", exc_info=True)
             if self.report:
-                self.report.report_failure(
+                self.report.failure(
                     "user_loading",
                     f"Unexpected error loading users: {e}. This may indicate a bug.",
                 )

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/snowplow.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/snowplow.py
@@ -493,10 +493,11 @@ class SnowplowSource(StatefulIngestionSourceBase, TestableSource):
             for pipeline in pipelines:
                 self._extract_pii_fields_from_pipeline(pipeline.id, pii_fields)
         except Exception as e:
-            self.report.report_warning(
+            self.report.warning(
                 "pii_extraction",
                 f"Failed to extract PII fields from enrichments: {e}. "
                 "PII field tagging may be incomplete.",
+                log=False,
             )
             logger.warning(f"Failed to extract PII fields from enrichments: {e}")
 
@@ -513,10 +514,11 @@ class SnowplowSource(StatefulIngestionSourceBase, TestableSource):
             for enrichment in enrichments:
                 self._extract_pii_fields_from_enrichment(enrichment, pii_fields)
         except Exception as e:
-            self.report.report_warning(
+            self.report.warning(
                 "pii_extraction",
                 f"Failed to extract PII fields from pipeline {pipeline_id}: {e}. "
                 "PII field tagging may be incomplete for this pipeline.",
+                log=False,
             )
             logger.warning(
                 f"Failed to extract PII fields from pipeline {pipeline_id}: {e}"

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/snowplow_client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/snowplow_client.py
@@ -322,7 +322,7 @@ class SnowplowBDPClient:
                 error_msg = f"Failed to parse organization response: {parse_error}"
                 logger.error(error_msg)
                 if self.report:
-                    self.report.report_warning("organization_parsing", error_msg)
+                    self.report.warning("organization_parsing", error_msg, log=False)
                 logger.debug(
                     f"Raw response data: {json.dumps(response_data, indent=2, default=str)}"
                 )
@@ -332,7 +332,7 @@ class SnowplowBDPClient:
             error_msg = f"Failed to fetch organization details: {e}"
             logger.warning(error_msg)
             if self.report:
-                self.report.report_warning("organization_fetch", error_msg)
+                self.report.warning("organization_fetch", error_msg, log=False)
             return None
 
     # ============================================
@@ -393,7 +393,9 @@ class SnowplowBDPClient:
                 )
                 logger.warning(error_msg)
                 if self.report:
-                    self.report.report_warning("data_structures_pagination", error_msg)
+                    self.report.warning(
+                        "data_structures_pagination", error_msg, log=False
+                    )
                 break  # Return partial results instead of losing everything
 
             # BDP API returns direct array (per Swagger spec)
@@ -401,7 +403,7 @@ class SnowplowBDPClient:
                 error_msg = f"Expected list from BDP API, got {type(response_data)}"
                 logger.error(error_msg)
                 if self.report:
-                    self.report.report_warning("data_structures_format", error_msg)
+                    self.report.warning("data_structures_format", error_msg, log=False)
                 break
 
             # No more results
@@ -429,7 +431,7 @@ class SnowplowBDPClient:
                     f"Raw response data (first item): {json.dumps(response_data[0] if response_data else 'empty', indent=2, default=str)}"
                 )
                 if self.report:
-                    self.report.report_warning("data_structures_parsing", error_msg)
+                    self.report.warning("data_structures_parsing", error_msg, log=False)
                 break
 
         logger.info(f"Found {len(all_structures)} data structures total")
@@ -457,7 +459,7 @@ class SnowplowBDPClient:
             error_msg = f"Failed to fetch data structure {data_structure_hash}: {e}"
             logger.warning(error_msg)
             if self.report:
-                self.report.report_warning("data_structure_fetch", error_msg)
+                self.report.warning("data_structure_fetch", error_msg, log=False)
             return None
 
         if not response_data:
@@ -470,7 +472,7 @@ class SnowplowBDPClient:
             error_msg = f"Failed to parse data structure {data_structure_hash}: {e}"
             logger.error(error_msg)
             if self.report:
-                self.report.report_warning("data_structure_parsing", error_msg)
+                self.report.warning("data_structure_parsing", error_msg, log=False)
             logger.debug(
                 f"Raw response data: {json.dumps(response_data, indent=2, default=str)}"
             )
@@ -515,7 +517,7 @@ class SnowplowBDPClient:
             )
             logger.warning(error_msg)
             if self.report:
-                self.report.report_warning("schema_version_fetch", error_msg)
+                self.report.warning("schema_version_fetch", error_msg, log=False)
             return None
 
         if not response_data:
@@ -562,7 +564,7 @@ class SnowplowBDPClient:
             )
             logger.error(error_msg)
             if self.report:
-                self.report.report_warning("schema_version_parsing", error_msg)
+                self.report.warning("schema_version_parsing", error_msg, log=False)
             logger.debug(
                 f"Raw response data: {json.dumps(response_data, indent=2, default=str)}"
             )
@@ -605,7 +607,7 @@ class SnowplowBDPClient:
             error_msg = f"Failed to fetch deployments for {data_structure_hash}: {e}"
             logger.warning(error_msg)
             if self.report:
-                self.report.report_warning("deployment_fetch", error_msg)
+                self.report.warning("deployment_fetch", error_msg, log=False)
             return []
 
         if not response_data:
@@ -624,7 +626,7 @@ class SnowplowBDPClient:
             error_msg = f"Failed to parse deployments for {data_structure_hash}: {e}"
             logger.error(error_msg)
             if self.report:
-                self.report.report_warning("deployment_parsing", error_msg)
+                self.report.warning("deployment_parsing", error_msg, log=False)
             logger.debug(
                 f"Raw response data: {json.dumps(response_data, indent=2, default=str)}"
             )
@@ -669,7 +671,7 @@ class SnowplowBDPClient:
             error_msg = f"Expected dict (wrapped response) from event specs API, got {type(response_data)}"
             logger.error(error_msg)
             if self.report:
-                self.report.report_warning("event_specs_format", error_msg)
+                self.report.warning("event_specs_format", error_msg, log=False)
             return []
 
         try:
@@ -687,7 +689,7 @@ class SnowplowBDPClient:
             error_msg = f"Failed to parse event specifications: {e}"
             logger.error(error_msg)
             if self.report:
-                self.report.report_warning("event_specs_parsing", error_msg)
+                self.report.warning("event_specs_parsing", error_msg, log=False)
             logger.debug(
                 f"Raw response data: {json.dumps(response_data, indent=2, default=str)}"
             )
@@ -719,7 +721,7 @@ class SnowplowBDPClient:
             error_msg = f"Failed to fetch event specification {event_spec_id}: {e}"
             logger.warning(error_msg)
             if self.report:
-                self.report.report_warning("event_spec_fetch", error_msg)
+                self.report.warning("event_spec_fetch", error_msg, log=False)
             return None
 
         if not response_data:
@@ -731,7 +733,7 @@ class SnowplowBDPClient:
             error_msg = f"Failed to parse event specification {event_spec_id}: {e}"
             logger.error(error_msg)
             if self.report:
-                self.report.report_warning("event_spec_parsing", error_msg)
+                self.report.warning("event_spec_parsing", error_msg, log=False)
             logger.debug(
                 f"Raw response data: {json.dumps(response_data, indent=2, default=str)}"
             )
@@ -777,7 +779,7 @@ class SnowplowBDPClient:
             error_msg = f"Expected dict (wrapped response) from tracking plans API, got {type(response_data)}"
             logger.error(error_msg)
             if self.report:
-                self.report.report_warning("tracking_plans_format", error_msg)
+                self.report.warning("tracking_plans_format", error_msg, log=False)
             return []
 
         try:
@@ -795,7 +797,7 @@ class SnowplowBDPClient:
             error_msg = f"Failed to parse tracking plans: {e}"
             logger.error(error_msg)
             if self.report:
-                self.report.report_warning("tracking_plans_parsing", error_msg)
+                self.report.warning("tracking_plans_parsing", error_msg, log=False)
             logger.debug(
                 f"Raw response data: {json.dumps(response_data, indent=2, default=str)}"
             )
@@ -821,7 +823,7 @@ class SnowplowBDPClient:
             error_msg = f"Failed to fetch tracking plan {plan_id}: {e}"
             logger.warning(error_msg)
             if self.report:
-                self.report.report_warning("tracking_plan_fetch", error_msg)
+                self.report.warning("tracking_plan_fetch", error_msg, log=False)
             return None
 
         if not response_data:
@@ -833,7 +835,7 @@ class SnowplowBDPClient:
             error_msg = f"Failed to parse tracking plan {plan_id}: {e}"
             logger.error(error_msg)
             if self.report:
-                self.report.report_warning("tracking_plan_parsing", error_msg)
+                self.report.warning("tracking_plan_parsing", error_msg, log=False)
             logger.debug(
                 f"Raw response data: {json.dumps(response_data, indent=2, default=str)}"
             )
@@ -868,7 +870,7 @@ class SnowplowBDPClient:
             )
             logger.warning(error_msg)
             if self.report:
-                self.report.report_warning("data_models_fetch", error_msg)
+                self.report.warning("data_models_fetch", error_msg, log=False)
             return []
 
         # Handle 404 or empty response
@@ -945,7 +947,7 @@ class SnowplowBDPClient:
             error_msg = f"Failed to parse pipelines: {e}"
             logger.error(error_msg)
             if self.report:
-                self.report.report_warning("pipelines_parsing", error_msg)
+                self.report.warning("pipelines_parsing", error_msg, log=False)
             logger.debug(
                 f"Raw response data: {json.dumps(response_data, indent=2, default=str)}"
             )
@@ -970,7 +972,7 @@ class SnowplowBDPClient:
             error_msg = f"Failed to fetch pipeline {pipeline_id}: {e}"
             logger.warning(error_msg)
             if self.report:
-                self.report.report_warning("pipeline_fetch", error_msg)
+                self.report.warning("pipeline_fetch", error_msg, log=False)
             return None
 
         if not response_data:
@@ -982,7 +984,7 @@ class SnowplowBDPClient:
             error_msg = f"Failed to parse pipeline {pipeline_id}: {e}"
             logger.error(error_msg)
             if self.report:
-                self.report.report_warning("pipeline_parsing", error_msg)
+                self.report.warning("pipeline_parsing", error_msg, log=False)
             logger.debug(
                 f"Raw response data: {json.dumps(response_data, indent=2, default=str)}"
             )
@@ -1036,7 +1038,7 @@ class SnowplowBDPClient:
                 error_msg = f"Failed to parse enrichment in pipeline {pipeline_id}: {e}"
                 logger.warning(error_msg)
                 if self.report:
-                    self.report.report_warning("enrichment_parsing", error_msg)
+                    self.report.warning("enrichment_parsing", error_msg, log=False)
                 continue
 
             if enrichment.id in seen_names:
@@ -1047,7 +1049,9 @@ class SnowplowBDPClient:
                 )
                 logger.warning(error_msg)
                 if self.report:
-                    self.report.report_warning("enrichment_duplicate_name", error_msg)
+                    self.report.warning(
+                        "enrichment_duplicate_name", error_msg, log=False
+                    )
                 continue
             seen_names.add(enrichment.id)
             enrichments.append(enrichment)
@@ -1093,7 +1097,7 @@ class SnowplowBDPClient:
             )
             logger.error(error_msg)
             if self.report:
-                self.report.report_warning("destinations_format", error_msg)
+                self.report.warning("destinations_format", error_msg, log=False)
             return []
 
         # Parse destinations individually so one bad item doesn't lose all
@@ -1105,7 +1109,7 @@ class SnowplowBDPClient:
                 error_msg = f"Failed to parse destination: {e}"
                 logger.warning(error_msg)
                 if self.report:
-                    self.report.report_warning("destination_parsing", error_msg)
+                    self.report.warning("destination_parsing", error_msg, log=False)
                 continue
 
         logger.info(f"Found {len(destinations)} destinations")
@@ -1153,7 +1157,7 @@ class SnowplowBDPClient:
             error_msg = f"Failed to fetch users: {e}"
             logger.warning(error_msg)
             if self.report:
-                self.report.report_warning("users_fetch", error_msg)
+                self.report.warning("users_fetch", error_msg, log=False)
             return []
 
         # BDP API returns direct array (per Swagger spec)
@@ -1161,7 +1165,7 @@ class SnowplowBDPClient:
             error_msg = f"Expected list from users API, got {type(response_data)}"
             logger.error(error_msg)
             if self.report:
-                self.report.report_warning("users_format", error_msg)
+                self.report.warning("users_format", error_msg, log=False)
             return []
 
         # Parse users individually so one bad item doesn't lose all
@@ -1173,7 +1177,7 @@ class SnowplowBDPClient:
                 error_msg = f"Failed to parse user: {e}"
                 logger.warning(error_msg)
                 if self.report:
-                    self.report.report_warning("user_parsing", error_msg)
+                    self.report.warning("user_parsing", error_msg, log=False)
                 continue
 
         logger.info(f"Found {len(users)} users")

--- a/metadata-ingestion/src/datahub/ingestion/source/snowplow/snowplow_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowplow/snowplow_report.py
@@ -390,36 +390,39 @@ class SnowplowSourceReport(StaleEntityRemovalSourceReport):
 
         # Add to warnings if significant filtering occurred
         if self.num_event_schemas_filtered > 0:
-            self.report_warning(
+            self.warning(
                 "schema_filtering",
                 f"Filtered out {self.num_event_schemas_filtered} event schemas. "
                 f"Check schema_pattern configuration.",
+                log=False,
             )
 
         if self.num_entity_schemas_filtered > 0:
-            self.report_warning(
+            self.warning(
                 "schema_filtering",
                 f"Filtered out {self.num_entity_schemas_filtered} entity schemas. "
                 f"Check schema_pattern configuration.",
+                log=False,
             )
 
         # Report hidden schemas
         if self.num_hidden_schemas_skipped > 0:
-            self.report_warning(
+            self.warning(
                 "hidden_schemas",
                 f"Skipped {self.num_hidden_schemas_skipped} hidden schemas. "
                 f"Set include_hidden_schemas=true to include them.",
+                log=False,
             )
 
         # Report schema parsing errors
         if self.schema_parsing_errors:
             for error in self.schema_parsing_errors[:5]:  # Limit to 5 errors
-                self.report_warning("schema_parsing", error)
+                self.warning("schema_parsing", error, log=False)
 
         # Report API errors
         for api_name, errors in self.api_errors.items():
             for error in errors[:3]:  # Limit to 3 errors per API
-                self.report_failure(api_name, error)
+                self.failure(api_name, error)
 
         # Log API metrics summary for performance tuning
         self._log_api_metrics_summary()

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/clickhouse.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/clickhouse.py
@@ -748,7 +748,7 @@ ORDER BY event_time ASC
             result = engine.execute(text(query))
             rows = list(result)
         except Exception as e:
-            self.report.report_failure(
+            self.report.failure(
                 "query_log_extraction",
                 f"Failed to fetch query log: {e}",
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/hive/hive_metadata_processor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/hive/hive_metadata_processor.py
@@ -450,7 +450,9 @@ class HiveMetadataProcessor:
                 ),
             )
             if len(columns) == 0:
-                self.report.report_warning(dataset_name, "missing column information")
+                self.report.warning(
+                    dataset_name, "missing column information", log=False
+                )
 
             dataset_urn: str = make_dataset_urn_with_platform_instance(
                 self.platform,
@@ -586,7 +588,9 @@ class HiveMetadataProcessor:
             columns = list(group)
 
             if len(columns) == 0:
-                self.report.report_warning(dataset_name, "missing column information")
+                self.report.warning(
+                    dataset_name, "missing column information", log=False
+                )
 
             yield ViewDataset(
                 dataset_name=dataset_name,
@@ -629,13 +633,17 @@ class HiveMetadataProcessor:
                 )
             except Exception as e:
                 # A single malformed Presto view must not abort the whole database.
-                self.report.report_warning(
-                    dataset_name, f"Failed to decode Presto view definition: {e}"
+                self.report.warning(
+                    dataset_name,
+                    f"Failed to decode Presto view definition: {e}",
+                    log=False,
                 )
                 continue
 
             if len(columns) == 0:
-                self.report.report_warning(dataset_name, "missing column information")
+                self.report.warning(
+                    dataset_name, "missing column information", log=False
+                )
 
             yield ViewDataset(
                 dataset_name=dataset_name,

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/hive/hive_metastore_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/hive/hive_metastore_source.py
@@ -292,14 +292,16 @@ class HiveMetastoreSource(StatefulIngestionSourceBase, TestableSource):
 
         if isinstance(self._fetcher, ThriftDataFetcher):
             for db_name, error_msg in self._fetcher.get_database_failures():
-                self.report.report_warning(
+                self.report.warning(
                     f"database-{db_name}",
                     f"Failed to process database: {error_msg}",
+                    log=False,
                 )
             for db_name, table_name, error_msg in self._fetcher.get_table_failures():
-                self.report.report_warning(
+                self.report.warning(
                     f"table-{db_name}.{table_name}",
                     f"Failed to process table: {error_msg}",
+                    log=False,
                 )
 
         # Close fetcher

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/mssql/query_lineage_extractor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/mssql/query_lineage_extractor.py
@@ -260,7 +260,7 @@ class MSSQLLineageExtractor:
                     prereq.method,
                     e,
                 )
-                self.report.report_failure(
+                self.report.failure(
                     message=f"Database error: {e}",
                     context="query_history_extraction_database_error",
                 )
@@ -274,7 +274,7 @@ class MSSQLLineageExtractor:
                     e,
                     exc_info=True,
                 )
-                self.report.report_failure(
+                self.report.failure(
                     message=f"Query structure error: {e} - check SQL Server version compatibility",
                     context="query_history_extraction_structure_error",
                 )
@@ -288,7 +288,7 @@ class MSSQLLineageExtractor:
                     type(e).__name__,
                     exc_info=True,
                 )
-                self.report.report_failure(
+                self.report.failure(
                     message=f"Unexpected error: {e} ({type(e).__name__})",
                     context="query_history_extraction_unexpected_error",
                 )

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/mssql/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/mssql/source.py
@@ -1331,8 +1331,11 @@ class SQLServerSource(SQLAlchemySource):
                             logger.warning(
                                 f"Error logging in to database {db['name']}: {e}"
                             )
-                            self.report.report_warning(
-                                "Error logging in to database", db["name"], exc=e
+                            self.report.warning(
+                                "Error logging in to database",
+                                db["name"],
+                                exc=e,
+                                log=False,
                             )
                             continue
                         raise
@@ -1409,7 +1412,7 @@ class SQLServerSource(SQLAlchemySource):
                         db_name,
                         e,
                     )
-                    self.report.report_failure(
+                    self.report.failure(
                         message=(
                             f"Query lineage extraction failed for database '{db_name}' "
                             f"with unexpected error: {e}. "

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/oracle.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/oracle.py
@@ -2180,7 +2180,7 @@ class OracleSource(SQLAlchemySource):
 
         except sqlalchemy.exc.DatabaseError as e:
             logger.error(f"Failed to extract queries from V$SQL: {e}", exc_info=True)
-            self.report.report_failure(
+            self.report.failure(
                 message=str(e),
                 context="query_extraction_from_vsql_failed",
             )
@@ -2198,9 +2198,10 @@ class OracleSource(SQLAlchemySource):
                     f"V$SQL not accessible for query extraction: {check_result.message}. "
                     "Query-based usage statistics will be skipped."
                 )
-                self.report.report_warning(
+                self.report.warning(
                     message=check_result.message,
                     context="vsql_not_accessible",
+                    log=False,
                 )
                 return
 

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/postgres/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/postgres/lineage.py
@@ -145,7 +145,7 @@ class PostgresLineageExtractor:
                 "pg_stat_statements not ready: %s. Query-based lineage will be skipped.",
                 message,
             )
-            self.report.report_failure(
+            self.report.failure(
                 message=message,
                 context="pg_stat_statements_not_ready",
             )
@@ -191,7 +191,7 @@ class PostgresLineageExtractor:
             except (DatabaseError, OperationalError, ProgrammingError) as e:
                 # Expected database errors: connection issues, permission denied, invalid SQL, etc.
                 logger.error("Failed to extract query history: %s", e)
-                self.report.report_failure(
+                self.report.failure(
                     message=str(e),
                     context="query_history_extraction_failed",
                 )

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/postgres/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/postgres/source.py
@@ -332,7 +332,7 @@ class PostgresSource(SQLAlchemySource):
                     "Please provide a graph connection in your pipeline configuration or disable usage statistics."
                 )
                 logger.error(error_message)
-                self.report.report_failure(
+                self.report.failure(
                     message=error_message,
                     context="usage_statistics_graph_validation_failed",
                 )
@@ -362,7 +362,7 @@ class PostgresSource(SQLAlchemySource):
                     f"or missing dependencies. Please check your configuration and try again."
                 )
                 logger.error(error_message)
-                self.report.report_failure(
+                self.report.failure(
                     message=error_message,
                     context="sql_aggregator_init_failed",
                 )
@@ -539,12 +539,13 @@ class PostgresSource(SQLAlchemySource):
                     "SQL aggregator not initialized, skipping query-based lineage extraction. "
                     "Check initialization errors above."
                 )
-                self.report.report_warning(
+                self.report.warning(
                     message=(
                         "Query-based lineage was enabled but SQL aggregator failed to initialize. "
                         "No query-based lineage will be extracted. Check earlier error messages."
                     ),
                     context="query_lineage_skipped",
+                    log=False,
                 )
                 return
 
@@ -565,7 +566,7 @@ class PostgresSource(SQLAlchemySource):
                         "Continuing with other lineage sources.",
                         e,
                     )
-                    self.report.report_failure(
+                    self.report.failure(
                         message=(
                             f"Query lineage extraction failed: {e}. "
                             "Check that pg_stat_statements extension is properly configured and accessible. "
@@ -588,7 +589,7 @@ class PostgresSource(SQLAlchemySource):
                         "Failed to generate metadata from SQL aggregator: %s",
                         e,
                     )
-                    self.report.report_failure(
+                    self.report.failure(
                         message=(
                             f"Lineage metadata generation failed: {e}. "
                             "This may indicate issues with the DataHub graph connection or schema resolution. "

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -405,7 +405,7 @@ class SQLAlchemySource(StatefulIngestionSourceBase, TestableSource):
         return test_report
 
     def error(self, log: logging.Logger, key: str, reason: str) -> None:
-        self.report.report_failure(key, reason[:100])
+        self.report.failure(key, reason[:100])
         log.error(f"{key} => {reason}\n{traceback.format_exc()}")
 
     def get_inspectors(self) -> Iterable[Inspector]:
@@ -930,9 +930,10 @@ class SQLAlchemySource(StatefulIngestionSourceBase, TestableSource):
                 f"Failed to classify table columns for {dataset_name} due to error -> {e}",
                 exc_info=e,
             )
-            self.report.report_warning(
+            self.report.warning(
                 "Failed to classify table columns",
                 dataset_name,
+                log=False,
             )
 
     def get_database_properties(

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
@@ -2087,11 +2087,12 @@ HAVING SUM(CurrentPerm) > :size_limit_bytes
                         env=self.config.env,
                     )
                 except Exception as e:
-                    self.report.report_warning(
+                    self.report.warning(
                         message="Failed to bulk-load schemas from DataHub for SQL lineage. "
                         "Lineage resolution will fall back to lazy on-demand schema fetching.",
                         context=str(e),
                         exc=e,
+                        log=False,
                     )
             else:
                 logger.warning(

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/vertica.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/vertica.py
@@ -203,9 +203,7 @@ class VerticaSource(SQLAlchemySource):
             return custom_properties
 
         except Exception as ex:
-            self.report.report_failure(
-                f"{database}", f"unable to get extra_properties : {ex}"
-            )
+            self.report.failure(f"{database}", f"unable to get extra_properties : {ex}")
         return None
 
     def get_schema_properties(
@@ -215,7 +213,7 @@ class VerticaSource(SQLAlchemySource):
             custom_properties = inspector._get_schema_properties(schema)
             return custom_properties
         except Exception as ex:
-            self.report.report_failure(
+            self.report.failure(
                 f"{database}.{schema}", f"unable to get extra_properties : {ex}"
             )
         return None
@@ -275,8 +273,10 @@ class VerticaSource(SQLAlchemySource):
                     logger.warning(
                         f"Unable to ingest view {schema}.{view} due to an exception.\n {traceback.format_exc()}"
                     )
-                    self.report.report_warning(
-                        f"{schema}.{view}", f"Ingestion error: {e}"
+                    self.report.warning(
+                        f"{schema}.{view}",
+                        f"Ingestion error: {e}",
+                        log=False,
                     )
                 if self.config.include_view_lineage:
                     try:
@@ -309,11 +309,13 @@ class VerticaSource(SQLAlchemySource):
                         logger.warning(
                             f"Unable to get lineage of view {schema}.{view} due to an exception.\n {traceback.format_exc()}"
                         )
-                        self.report.report_warning(
-                            f"{schema}.{view}", f"Ingestion error: {e}"
+                        self.report.warning(
+                            f"{schema}.{view}",
+                            f"Ingestion error: {e}",
+                            log=False,
                         )
         except Exception as e:
-            self.report.report_failure(f"{schema}", f"Views error: {e}")
+            self.report.failure(f"{schema}", f"Views error: {e}")
 
     def _process_view(
         self,
@@ -406,8 +408,10 @@ class VerticaSource(SQLAlchemySource):
                         f"Unable to ingest {schema}.{projection} due to an exception %s",
                         ex,
                     )
-                    self.report.report_warning(
-                        f"{schema}.{projection}", f"Ingestion error: {ex}"
+                    self.report.warning(
+                        f"{schema}.{projection}",
+                        f"Ingestion error: {ex}",
+                        log=False,
                     )
                 if self.config.include_projection_lineage:
                     try:
@@ -435,9 +439,11 @@ class VerticaSource(SQLAlchemySource):
                         logger.warning(
                             f"Unable to get lineage of projection {projection} due to an exception.\n {traceback.format_exc()}"
                         )
-                        self.report.report_warning(f"{schema}", f"Ingestion error: {e}")
+                        self.report.warning(
+                            f"{schema}", f"Ingestion error: {e}", log=False
+                        )
         except Exception as ex:
-            self.report.report_failure(f"{schema}", f"Projection error: {ex}")
+            self.report.failure(f"{schema}", f"Projection error: {ex}")
 
     def _process_projections(
         self,
@@ -563,9 +569,10 @@ class VerticaSource(SQLAlchemySource):
             if partition is None and self.is_table_partitioned(
                 database=None, schema=schema, table=projection
             ):
-                self.report.report_warning(
+                self.report.warning(
                     "profile skipped as partitioned table is empty or partition id was invalid",
                     dataset_name,
+                    log=False,
                 )
                 continue
             if (
@@ -640,11 +647,13 @@ class VerticaSource(SQLAlchemySource):
                     logger.warning(
                         f"Unable to ingest {schema}.{models} due to an exception. %s {traceback.format_exc()}"
                     )
-                    self.report.report_warning(
-                        f"{schema}.{models}", f"Ingestion error: {error}"
+                    self.report.warning(
+                        f"{schema}.{models}",
+                        f"Ingestion error: {error}",
+                        log=False,
                     )
         except Exception as error:
-            self.report.report_failure(f"{schema}", f"Model error: {error}")
+            self.report.failure(f"{schema}", f"Model error: {error}")
 
     def _process_models(
         self,

--- a/metadata-ingestion/src/datahub/ingestion/source/state/stale_entity_removal_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/stale_entity_removal_handler.py
@@ -286,14 +286,15 @@ class StaleEntityRemovalHandler(
         # If the source already had a failure, skip soft-deletion.
         # TODO: Eventually, switch this to check if anything in the pipeline had a failure so far, not just the source.
         if self.report.failures:
-            self.report.report_warning(
+            self.report.warning(
                 title="Skipping stateful ingestion / stale entity removal",
                 message="The soft-deletion of stale entities will be skipped because the source reported a failure.",
+                log=False,
             )
             copy_previous_state_and_exit = True
 
         if not copy_previous_state_and_exit and self.report.events_produced == 0:
-            self.report.report_failure(
+            self.report.failure(
                 title="Skipping stateful ingestion / stale entity removal",
                 message="The source did not produce any metadata. Despite stateful ingestion being enabled, we will not delete any metadata. "
                 "This is a fail-safe mechanism to prevent the accidental deletion of all entities.",
@@ -313,7 +314,7 @@ class StaleEntityRemovalHandler(
             and self.stateful_ingestion_config.fail_safe_threshold < 100.0
         ):
             # Log the failure. This would prevent the current state from getting committed.
-            self.report.report_failure(
+            self.report.failure(
                 title="Skipping stateful ingestion / stale entity removal",
                 message=f"\
 The previous run produced {last_checkpoint_state.urn_count()} entities, whereas this run produced {cur_checkpoint_state.urn_count()} entities. \

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/analyze_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/analyze_profiler.py
@@ -41,7 +41,7 @@ class UnityCatalogAnalyzeProfiler:
                     if wu:
                         yield wu
         except Exception as e:
-            self.report.report_warning("profiling", str(e))
+            self.report.warning("profiling", str(e), log=False)
             logger.warning(f"Unexpected error during profiling: {e}", exc_info=True)
             return
 
@@ -67,7 +67,7 @@ class UnityCatalogAnalyzeProfiler:
             elif table_profile is not None:  # table_profile is Falsy == empty
                 self.report.profile_table_empty.append(str(ref))
         except Exception as e:
-            self.report.report_warning("profiling", str(e))
+            self.report.warning("profiling", str(e), log=False)
             logger.warning(
                 f"Unexpected error during profiling table {ref}: {e}", exc_info=True
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/hive_metastore_proxy.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/hive_metastore_proxy.py
@@ -124,8 +124,10 @@ class HiveMetastoreProxy(Closeable):
             # 3 columns - database, tableName, isTemporary
             return [row.tableName for row in rows]
         except Exception as e:
-            self.report.report_warning(
-                "Failed to get tables for schema", f"{HIVE_METASTORE}.{schema_name}"
+            self.report.warning(
+                "Failed to get tables for schema",
+                f"{HIVE_METASTORE}.{schema_name}",
+                log=False,
             )
             logger.warning(
                 f"Failed to get tables {schema_name} due to {e}", exc_info=True
@@ -138,7 +140,9 @@ class HiveMetastoreProxy(Closeable):
             # 4 columns - namespace, viewName, isTemporary, isMaterialized
             return [row.viewName for row in rows]
         except Exception as e:
-            self.report.report_warning("Failed to get views for schema", schema_name)
+            self.report.warning(
+                "Failed to get views for schema", schema_name, log=False
+            )
             logger.warning(
                 f"Failed to get views {schema_name} due to {e}", exc_info=True
             )
@@ -286,9 +290,10 @@ class HiveMetastoreProxy(Closeable):
             for row in rows:
                 return row[0]
         except Exception as e:
-            self.report.report_warning(
+            self.report.warning(
                 "Failed to get view definition for table",
                 f"{HIVE_METASTORE}.{schema_name}.{table_name}",
+                log=False,
             )
             logger.debug(
                 f"Failed to get view definition for {schema_name}.{table_name} due to {e}",
@@ -335,9 +340,10 @@ class HiveMetastoreProxy(Closeable):
                     prop_name = f"{active_heading} {data_type.rstrip()}"
                     properties[prop_name] = value.rstrip()
         except Exception as e:
-            self.report.report_warning(
+            self.report.warning(
                 "Failed to get detailed info for table",
                 f"{HIVE_METASTORE}.{schema_name}.{table_name}",
+                log=False,
             )
             logger.debug(
                 f"Failed to get detailed info for table {schema_name}.{table_name} due to {e}",
@@ -373,9 +379,10 @@ class HiveMetastoreProxy(Closeable):
                     )
                 )
         except Exception as e:
-            self.report.report_warning(
+            self.report.warning(
                 "Failed to get columns for table",
                 f"{HIVE_METASTORE}.{schema_name}.{table_name}",
+                log=False,
             )
             logger.debug(
                 f"Failed to get columns for table {schema_name}.{table_name} due to {e}",

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
@@ -381,11 +381,12 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
                 f"Unable to get run details for MLflow experiment, run-id: {run_id}",
                 exc_info=True,
             )
-            self.report.report_warning(
+            self.report.warning(
                 title="Unable to get run details for MLflow experiment",
                 message="Error while getting run details for MLflow experiment",
                 context=f"run-id: {run_id}",
                 exc=e,
+                log=False,
             )
             return None
 
@@ -501,11 +502,12 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
         except Exception as e:
             model_name = getattr(model_version, "model_name", "unknown")
             version_num = getattr(model_version, "version", "unknown")
-            self.report.report_warning(
+            self.report.warning(
                 title="Unable to extract signature from MLmodel file",
                 message="Error while extracting signature from MLmodel file",
                 context=f"model-name: {model_name}, model-version: {version_num}",
                 exc=e,
+                log=False,
             )
             logger.warning(
                 f"Unable to extract signature from MLmodel file, model-name: {model_name}, model-version: {version_num}",
@@ -577,7 +579,7 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
             # crash ingestion, but surface it in the report since it silently
             # degrades federation links/structured properties for this run.
             self.report.num_federation_connections_list_failed += 1
-            self.report.report_warning(
+            self.report.warning(
                 title="Failed to list Unity Catalog connections",
                 message=(
                     "Lakehouse Federation links and structured properties will be "
@@ -587,6 +589,7 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
                 ),
                 context="listing Unity Catalog connections",
                 exc=e,
+                log=False,
             )
         self._connections_cache = result
         return result
@@ -637,7 +640,7 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
                         yield optional_table
                 except Exception as e:
                     logger.warning(f"Error parsing table: {e}")
-                    self.report.report_warning("table-parse", str(e))
+                    self.report.warning("table-parse", str(e), log=False)
 
     def ml_models(
         self, schema: Schema, max_results: Optional[int] = None
@@ -733,11 +736,12 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
                     yield optional_query
             except Exception as e:
                 logger.warning("Error parsing query", exc_info=True)
-                self.report.report_warning(
+                self.report.warning(
                     title="Failed to parse query",
                     message="A query from query history could not be parsed and was skipped.",
                     context=f"query_id={getattr(query_info, 'query_id', None)}",
                     exc=e,
+                    log=False,
                 )
 
     def _query_history(
@@ -949,25 +953,27 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
         finally:
             parse_failures = self.report.num_queries_missing_info - missing_info_before
             if parse_failures > 0:
-                self.report.report_warning(
+                self.report.warning(
                     title="Failed to parse queries from system tables",
                     message=(
                         "Statements from system.query.history could not be parsed "
                         "and were skipped."
                     ),
                     context=f"count={parse_failures}",
+                    log=False,
                 )
             row_field_errors = (
                 self.report.num_lineage_row_field_read_errors - row_field_errors_before
             )
             if row_field_errors > 0:
-                self.report.report_warning(
+                self.report.warning(
                     title="Failed to read lineage row fields",
                     message=(
                         "Lineage column values from system.access.table_lineage "
                         "could not be read and were skipped."
                     ),
                     context=f"count={row_field_errors}",
+                    log=False,
                 )
 
     def _build_datetime_where_conditions(
@@ -1509,9 +1515,10 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
             )
             return table_info.table_constraints or []
         except Exception as e:
-            self.report.report_warning(
+            self.report.warning(
                 "table-constraints-fetch",
                 f"Unable to fetch table constraints for {table.ref}: {e}",
+                log=False,
             )
             logger.warning(
                 f"Unable to fetch table constraints for {table.ref}: {e}",
@@ -1611,9 +1618,10 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
         """
         if self.warehouse_id:
             return True
-        self.report.report_warning(
+        self.report.warning(
             title="Cannot execute SQL query",
             message="warehouse_id is not configured. SQL operations require a valid warehouse_id to be set in the Unity Catalog configuration.",
+            log=False,
         )
         logger.warning(
             "Cannot execute SQL query: warehouse_id is not configured. "
@@ -1664,11 +1672,12 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
                 f"Proxy environment variables detected: {list(proxy_env_debug.keys())}"
             )
 
-        self.report.report_warning(
+        self.report.warning(
             title="Failed to run SQL query",
             message=(
                 f"A SQL query against the Databricks warehouse failed: {error}. Check that the service principal has SELECT on the system.access and system.query schemas and that system schemas are enabled for this workspace."
             ),
+            log=False,
         )
         if count_as_fetch_failure:
             self.report.num_usage_query_fetch_failures += 1

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
@@ -466,15 +466,17 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
             self.platform_resource_repository = None
 
         if self.config._forced_disable_tag_extraction:
-            self.report.report_warning(
+            self.report.warning(
                 "Some features disabled because of configuration conflicts",
                 "Tag Extraction is disabled due to missing warehouse_id in config",
+                log=False,
             )
 
         if self.config._forced_disable_hive_metastore_extraction:
-            self.report.report_warning(
+            self.report.warning(
                 "Some features disabled because of configuration conflicts",
                 "Hive Metastore Extraction is disabled due to missing warehouse_id in config",
+                log=False,
             )
 
         # SDK lacks TableType.METRIC_VIEW; warn so the no-op flag isn't silent.
@@ -486,12 +488,13 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                 from databricks.sdk.version import __version__ as _sdk_version
             except Exception:
                 _sdk_version = "unknown"
-            self.report.report_warning(
+            self.report.warning(
                 "include_metric_views has no effect with installed databricks-sdk",
                 f"databricks-sdk {_sdk_version} does not expose TableType.METRIC_VIEW. "
                 "Metric views will be emitted as plain Tables. Upgrade databricks-sdk "
                 "to >= 0.58.0 (the release that added this enum) to enable "
                 "metric-view ingestion.",
+                log=False,
             )
 
         # Include platform resource repository in report for automatic cache statistics
@@ -585,7 +588,7 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                     # Can take several minutes, so start now and wait later
                     wait_on_warehouse = self.unity_catalog_api_proxy.start_warehouse()
                     if wait_on_warehouse is None:
-                        self.report.report_failure(
+                        self.report.failure(
                             "initialization",
                             f"SQL warehouse {self.config.profiling.warehouse_id} not found",
                         )
@@ -634,7 +637,7 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                 # longer time to complete
                 wait_on_warehouse = self.unity_catalog_api_proxy.start_warehouse()
                 if wait_on_warehouse is None:
-                    self.report.report_failure(
+                    self.report.failure(
                         "initialization",
                         f"SQL warehouse {self.config.profiling.warehouse_id} not found",
                     )
@@ -683,15 +686,17 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
             for sp in self.unity_catalog_api_proxy.service_principals():
                 self.service_principals[sp.application_id] = sp
         except Exception as e:
-            self.report.report_warning(
-                "service-principals", f"Unable to fetch service principals: {e}"
+            self.report.warning(
+                "service-principals",
+                f"Unable to fetch service principals: {e}",
+                log=False,
             )
 
     def build_groups_map(self) -> None:
         try:
             self.groups += self.unity_catalog_api_proxy.groups()
         except Exception as e:
-            self.report.report_warning("groups", f"Unable to fetch groups: {e}")
+            self.report.warning("groups", f"Unable to fetch groups: {e}", log=False)
 
     def process_notebooks(self) -> Iterable[MetadataWorkUnit]:
         for notebook in self.unity_catalog_api_proxy.workspace_notebooks():
@@ -762,7 +767,7 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
         if self.config.include_metastore:
             metastore = self.unity_catalog_api_proxy.assigned_metastore()
             if not metastore:
-                self.report.report_failure("Metastore", "Not found")
+                self.report.failure("Metastore", "Not found")
                 return
             yield from self.gen_metastore_containers(metastore)
         yield from self.process_catalogs(metastore)
@@ -807,11 +812,12 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                     yield from self.process_ml_models(schema)
                 except Exception as e:
                     logger.exception(f"Error parsing schema {schema}")
-                    self.report.report_warning(
+                    self.report.warning(
                         message="Missed schema because of parsing issues",
                         context=str(schema),
                         title="Error parsing schema",
                         exc=e,
+                        log=False,
                     )
                     continue
 
@@ -935,10 +941,11 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
             if lineage is None:
                 lineage = self.ingest_lineage(table)
                 if lineage is None:
-                    self.report.report_warning(
+                    self.report.warning(
                         "Metric view has no upstream lineage",
                         f"{table.ref.qualified_table_name}: neither YAML parsing "
                         "nor the table-lineage REST API produced any upstreams.",
+                        log=False,
                     )
         else:
             lineage = self.ingest_lineage(table)
@@ -1367,7 +1374,7 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
         )
         if target is None:
             self.report.num_federation_targets_unresolved += 1
-            self.report.report_warning(
+            self.report.warning(
                 title="Could not resolve Lakehouse Federation target",
                 message=(
                     "Foreign-catalog tables will not be linked to their external "
@@ -1376,6 +1383,7 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                     "to list Unity Catalog connections."
                 ),
                 context=f"catalog={catalog.name}, connection={catalog.connection_name}",
+                log=False,
             )
 
         self._federation_resolution_cache[catalog.name] = (detail, target)
@@ -2045,28 +2053,31 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
         )
         if not table.view_definition:
             self.report.num_metric_views_yaml_shape_invalid += 1
-            self.report.report_warning(
+            self.report.warning(
                 "Metric view has no YAML body",
                 f"{table.ref.qualified_table_name}: view_definition is empty. "
                 f"{consequence}",
+                log=False,
             )
             return None
         try:
             spec = _safe_load_metric_view_yaml(table.view_definition)
         except (yaml.YAMLError, RecursionError, UnicodeDecodeError) as e:
             self.report.num_metric_views_yaml_parse_failures += 1
-            self.report.report_warning(
+            self.report.warning(
                 "Metric view YAML failed to parse",
                 f"{table.ref.qualified_table_name}: {type(e).__name__}: {e}. "
                 f"{consequence}",
+                log=False,
             )
             return None
         if not isinstance(spec, dict):
             self.report.num_metric_views_yaml_shape_invalid += 1
-            self.report.report_warning(
+            self.report.warning(
                 "Metric view YAML is not a mapping",
                 f"{table.ref.qualified_table_name}: top-level type is "
                 f"{type(spec).__name__!r}, expected dict. {consequence}",
+                log=False,
             )
             return None
         return spec
@@ -2105,10 +2116,11 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
 
         if shape_issues:
             self.report.num_metric_views_yaml_shape_invalid += 1
-            self.report.report_warning(
+            self.report.warning(
                 "Metric view YAML has unexpected shape",
                 f"{table.ref.qualified_table_name}: {'; '.join(shape_issues)}. "
                 "Affected entries are skipped; remaining YAML continues to be processed.",
+                log=False,
             )
 
         default_catalog = table.ref.catalog
@@ -2135,23 +2147,25 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
         if unparseable and upstreams:
             # All-rejected case is reported below via num_metric_views_no_parseable_sources.
             self.report.num_metric_view_unparseable_sources += len(unparseable)
-            self.report.report_warning(
+            self.report.warning(
                 "Metric view source(s) skipped",
                 f"{table.ref.qualified_table_name}: unparseable sources="
                 f"{unparseable!r}. Need 2-part (schema.table) or 3-part "
                 "(catalog.schema.table) identifiers; 1-part names and SQL "
                 "subqueries are not supported by the YAML lineage path.",
+                log=False,
             )
 
         if not upstreams:
             if source_names:
                 self.report.num_metric_views_no_parseable_sources += 1
-                self.report.report_warning(
+                self.report.warning(
                     "Metric view has no parseable upstream sources",
                     f"{table.ref.qualified_table_name}: sources={source_names!r}. "
                     "Lineage extraction needs 2-part (schema.table) or 3-part "
                     "(catalog.schema.table) identifiers; 1-part names and SQL "
                     "subqueries fall back to the REST table-lineage API.",
+                    log=False,
                 )
             return None
 
@@ -2199,11 +2213,12 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
 
         if joins_skipped:
             self.report.num_metric_view_joins_skipped += joins_skipped
-            self.report.report_warning(
+            self.report.warning(
                 "Metric view joins skipped",
                 f"{table.ref.qualified_table_name}: {joins_skipped} join "
                 "entry/entries skipped due to malformed shape or unparseable "
                 "source. Column lineage for join-qualified columns will be absent.",
+                log=False,
             )
 
         downstream_urn = self.gen_dataset_urn(table.ref)
@@ -2246,23 +2261,25 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
 
         if skipped_entries:
             self.report.num_metric_view_skipped_dim_measure_entries += skipped_entries
-            self.report.report_warning(
+            self.report.warning(
                 "Metric view dimension/measure entries skipped",
                 f"{table.ref.qualified_table_name}: {skipped_entries} "
                 "dimension/measure entry/entries skipped due to malformed shape "
                 "(non-mapping entry, missing or non-string `name`/`expr`). Column "
                 "lineage for affected columns will be absent.",
+                log=False,
             )
 
         if unresolved_qualifiers:
             self.report.num_metric_view_unresolved_qualifiers += len(
                 unresolved_qualifiers
             )
-            self.report.report_warning(
+            self.report.warning(
                 "Metric view expression references unknown qualifier",
                 f"{table.ref.qualified_table_name}: qualifiers="
                 f"{sorted(unresolved_qualifiers)!r} not found in `source`/`joins`. "
                 "Lineage rows for affected columns were skipped.",
+                log=False,
             )
 
         fine.extend(self._extract_intra_mv_measure_lineage(spec, downstream_urn, table))
@@ -2348,9 +2365,10 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
             TypeError,
         ) as e:
             self.report.num_metric_views_expr_parse_failures += 1
-            self.report.report_warning(
+            self.report.warning(
                 "Metric view expression failed to parse",
                 f"{context}: expr={expr!r}: {type(e).__name__}: {e}".lstrip(": "),
+                log=False,
             )
             return [], set()
         if tree is None:
@@ -2437,11 +2455,12 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                     logger.exception(
                         f"Error processing platform resource for tag {tag}"
                     )
-                    self.report.report_warning(
+                    self.report.warning(
                         message="Error processing platform resource for tag",
                         context=str(tag),
                         title="Error processing platform resource for tag",
                         exc=e,
+                        log=False,
                     )
                     continue
 

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
@@ -417,8 +417,11 @@ class UnityCatalogUsageExtractor:
             ),
         ):
             if count > 0:
-                self.report.report_warning(
-                    title=title, message=message, context=f"count={count}"
+                self.report.warning(
+                    title=title,
+                    message=message,
+                    context=f"count={count}",
+                    log=False,
                 )
 
         # Handled separately: it appends sample table names to the context.
@@ -427,26 +430,28 @@ class UnityCatalogUsageExtractor:
             context = f"count={self.report.num_lineage_tables_unresolvable}"
             if sample:
                 context += f"; examples={', '.join(sample[:3])}"
-            self.report.report_warning(
+            self.report.warning(
                 title="Unresolvable lineage table names",
                 message=(
                     "Table names from system.access.table_lineage could not be mapped "
                     "to dataset URNs and were omitted from preparsed usage."
                 ),
                 context=context,
+                log=False,
             )
 
     def _report_no_queries(self) -> None:
         # Zero usable queries: distinguish unparseable rows from an empty read,
         # with a path-specific permission hint.
         if self.report.num_queries_missing_info > 0:
-            self.report.report_warning(
+            self.report.warning(
                 title="Query history rows could not be parsed",
                 message=(
                     "Statements from system.query.history could not be "
                     "parsed and were skipped, so no usage was extracted."
                 ),
                 context=f"count={self.report.num_queries_missing_info}",
+                log=False,
             )
             return
 
@@ -468,13 +473,14 @@ class UnityCatalogUsageExtractor:
                 "verify CAN_MANAGE privilege on the SQL warehouse "
                 "and that the time window covers recent activity"
             )
-        self.report.report_warning(
+        self.report.warning(
             title="No queries found for usage",
             message=(
                 "No queries were found in the configured time range "
                 "for usage extraction."
             ),
             context=hint,
+            log=False,
         )
 
     def _parse_buffered_queries(
@@ -606,12 +612,13 @@ class UnityCatalogUsageExtractor:
                         shared_connection = None
                         audit_log_file.unlink(missing_ok=True)
                         use_cached_audit_log = False
-                        self.report.report_warning(
+                        self.report.warning(
                             title="Discarded unreadable cached audit log",
                             message="The persisted query-history cache could not be read "
                             "and was discarded; re-fetching query history.",
                             context=str(audit_log_file),
                             exc=cache_exc,
+                            log=False,
                         )
 
                 if not use_cached_audit_log:
@@ -642,7 +649,7 @@ class UnityCatalogUsageExtractor:
                 # valid cache on the next run.
                 if audit_log_file is not None:
                     audit_log_file.unlink(missing_ok=True)
-                self.report.report_failure(
+                self.report.failure(
                     title="Usage extraction failed",
                     message=f"Usage extraction failed: {e!r}",
                     exc=e,
@@ -655,7 +662,7 @@ class UnityCatalogUsageExtractor:
             if fetch_failed:
                 # Surface a query-history fetch failure as a run failure — covers both
                 # the zero-rows case and a mid-stream failure that yielded partial data.
-                self.report.report_failure(
+                self.report.failure(
                     title="Failed to fetch query history",
                     message="Could not fully read query history from system tables; usage statistics may be incomplete or missing. See the related SQL query failure warning for the underlying error.",
                 )
@@ -690,11 +697,12 @@ class UnityCatalogUsageExtractor:
                     Exception
                 ) as close_exc:  # surface close failures in the report, not just logs
                     logger.warning("Failed to close audit-log buffer", exc_info=True)
-                    self.report.report_warning(
+                    self.report.warning(
                         title="Failed to close usage buffer",
                         message="The query-history buffer failed to close cleanly; its "
                         "temporary resources may not have been released.",
                         exc=close_exc,
+                        log=False,
                     )
             if aggregator is not None:
                 try:
@@ -705,8 +713,9 @@ class UnityCatalogUsageExtractor:
                     logger.warning(
                         "Failed to close SqlParsingAggregator", exc_info=True
                     )
-                    self.report.report_warning(
+                    self.report.warning(
                         title="Failed to close usage aggregator",
                         message="The usage aggregator failed to close cleanly; its temporary resources may not have been released.",
                         exc=close_exc,
+                        log=False,
                     )

--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
@@ -593,11 +593,12 @@ class DocumentChunkingSource(Source):
                 except Exception as e:
                     short_error = str(e).split("\n")[0][:200]
                     self.report.report_embedding_failure(doc["urn"], short_error)
-                    self.report.report_warning(
+                    self.report.warning(
                         title="Embedding generation failed",
                         message="Document was ingested successfully but embedding generation failed. Semantic search will not work for this document.",
                         context=f"{doc['urn']}: {short_error}",
                         exc=e,
+                        log=False,
                     )
             else:
                 logger.debug(

--- a/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai_training_extractor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai_training_extractor.py
@@ -505,7 +505,7 @@ class VertexAITrainingExtractor:
                         job_meta.output_model = model
                         job_meta.output_model_version = model_version
                 except (PermissionDenied, Unauthenticated) as e:
-                    self.report.report_failure(
+                    self.report.failure(
                         title="Unable to fetch model and model version due to permission issue",
                         message=format_api_error_message(
                             e,
@@ -516,7 +516,7 @@ class VertexAITrainingExtractor:
                         exc=e,
                     )
                 except ResourceExhausted as e:
-                    self.report.report_failure(
+                    self.report.failure(
                         title="Unable to fetch model and model version due to quota exceeded",
                         message=format_api_error_message(
                             e,
@@ -527,7 +527,7 @@ class VertexAITrainingExtractor:
                         exc=e,
                     )
                 except (DeadlineExceeded, ServiceUnavailable) as e:
-                    self.report.report_failure(
+                    self.report.failure(
                         title="Unable to fetch model and model version due to timeout or service unavailable",
                         message=format_api_error_message(
                             e,
@@ -547,7 +547,7 @@ class VertexAITrainingExtractor:
                         )
                     )
                 except GoogleAPICallError as e:
-                    self.report.report_failure(
+                    self.report.failure(
                         title="Unable to fetch model and model version",
                         message=format_api_error_message(
                             e,

--- a/metadata-ingestion/tests/integration/postgres/test_postgres_lineage.py
+++ b/metadata-ingestion/tests/integration/postgres/test_postgres_lineage.py
@@ -250,7 +250,7 @@ class TestPostgresLineageIntegration:
             database="postgres",
         )
 
-        report = type("Report", (), {"report_warning": lambda *args, **kwargs: None})()
+        report = type("Report", (), {"warning": lambda *args, **kwargs: None})()
         aggregator = SqlParsingAggregator(
             platform="postgres", generate_lineage=True, generate_queries=True
         )
@@ -325,7 +325,7 @@ class TestPostgresLineageIntegration:
             def __init__(self):
                 self.failures = []
 
-            def report_failure(self, message, context=None, **kwargs):  # type: ignore[no-untyped-def]
+            def failure(self, message, context=None, **kwargs):  # type: ignore[no-untyped-def]
                 self.failures.append({"message": message, "context": context})
 
         report = MockReport()
@@ -366,7 +366,7 @@ class TestPostgresLineageIntegration:
             def __init__(self):
                 self.failures = []
 
-            def report_failure(self, message, context=None, **kwargs):  # type: ignore[no-untyped-def]
+            def failure(self, message, context=None, **kwargs):  # type: ignore[no-untyped-def]
                 self.failures.append({"message": message, "context": context})
 
         report = MockReport()
@@ -414,7 +414,7 @@ class TestPostgresLineageIntegration:
                 self.failures = []
                 self.num_queries_extracted = 0
 
-            def report_failure(self, message, context=None, **kwargs):  # type: ignore[no-untyped-def]
+            def failure(self, message, context=None, **kwargs):  # type: ignore[no-untyped-def]
                 self.failures.append({"message": message, "context": context})
 
         report = MockReport()

--- a/metadata-ingestion/tests/unit/api/test_pipeline.py
+++ b/metadata-ingestion/tests/unit/api/test_pipeline.py
@@ -841,7 +841,7 @@ class FakeSource(Source):
 class FakeSourceWithWarnings(FakeSource):
     def __init__(self, ctx: PipelineContext):
         super().__init__(ctx)
-        self.source_report.report_warning("test_warning", "warning_text")
+        self.source_report.warning("test_warning", "warning_text", log=False)
 
     def get_report(self) -> SourceReport:
         return self.source_report
@@ -851,7 +851,7 @@ class FakeSourceWithWarnings(FakeSource):
 class FakeSourceWithFailures(FakeSource):
     def __init__(self, ctx: PipelineContext):
         super().__init__(ctx)
-        self.source_report.report_failure("test_failure", "failure_text")
+        self.source_report.failure("test_failure", "failure_text")
 
     def get_report(self) -> SourceReport:
         return self.source_report

--- a/metadata-ingestion/tests/unit/api/test_source_report.py
+++ b/metadata-ingestion/tests/unit/api/test_source_report.py
@@ -5,8 +5,8 @@ from datahub.ingestion.api.source import SourceReport
 
 def test_report_to_string_unsampled():
     source_report: SourceReport = SourceReport()
-    source_report.report_warning("key1", "problem 1")
-    source_report.report_failure("key2", "reason 2")
+    source_report.warning("key1", "problem 1", log=False)
+    source_report.failure("key2", "reason 2")
     str = source_report.as_string()
     assert "'warnings': [{'message': 'key1', 'context': ['problem 1']}]" in str
     assert "'failures': [{'message': 'key2', 'context': ['reason 2']}]" in str
@@ -15,7 +15,7 @@ def test_report_to_string_unsampled():
 def test_report_to_string_sampled():
     source_report = SourceReport()
     for i in range(0, 100):
-        source_report.report_warning(f"key{i}", "Test message")
+        source_report.warning(f"key{i}", "Test message", log=False)
 
     str = source_report.as_string()
     assert "sampled of 100 total elements" in str

--- a/metadata-ingestion/tests/unit/dremio/test_dremio_chunking.py
+++ b/metadata-ingestion/tests/unit/dremio/test_dremio_chunking.py
@@ -177,8 +177,8 @@ class TestDremioChunking:
         queries = list(dremio_api._get_queries_chunked(base_query))
         assert len(queries) == 0
 
-        dremio_api.report.report_warning.assert_called_once()
-        warning_call = dremio_api.report.report_warning.call_args
+        dremio_api.report.warning.assert_called_once()
+        warning_call = dremio_api.report.warning.call_args
         assert "Dremio crash detected" in warning_call[0][0]
         assert "KeyError: 'rows'" in warning_call[0][0]
         assert warning_call[1]["context"] == "query_extraction"

--- a/metadata-ingestion/tests/unit/snowplow/test_schema_processor.py
+++ b/metadata-ingestion/tests/unit/snowplow/test_schema_processor.py
@@ -420,7 +420,7 @@ class TestSchemaProcessorIgluExtraction:
 
         # Should return empty and report failure
         assert len(workunits) == 0
-        processor_iglu_mode.report.report_failure.assert_called_once()
+        processor_iglu_mode.report.failure.assert_called_once()
 
     def test_extract_schemas_from_uris_handles_invalid_uri(
         self, processor_iglu_mode, mock_deps_with_iglu
@@ -470,7 +470,7 @@ class TestSchemaProcessorIgluExtraction:
         # No workunits but no exception
         assert len(workunits) == 0
         # Failure should be reported
-        processor_iglu_mode.report.report_failure.assert_called()
+        processor_iglu_mode.report.failure.assert_called()
 
 
 class TestSchemaProcessorSchemaPatternFiltering:

--- a/metadata-ingestion/tests/unit/snowplow/test_user_resolver.py
+++ b/metadata-ingestion/tests/unit/snowplow/test_user_resolver.py
@@ -27,8 +27,8 @@ class TestUserResolverLoadUsers:
         assert len(resolver._user_cache) == 2
         assert resolver._user_cache["u1"].email == "alice@example.com"
         assert resolver._user_cache["u2"].email == "bob@example.com"
-        mock_report.report_warning.assert_not_called()
-        mock_report.report_failure.assert_not_called()
+        mock_report.warning.assert_not_called()
+        mock_report.failure.assert_not_called()
 
     def test_load_users_no_client(self):
         """Test that load_users does nothing when no client is provided."""
@@ -47,9 +47,9 @@ class TestUserResolverLoadUsers:
         resolver.load_users()
 
         assert len(resolver._user_cache) == 0
-        mock_report.report_warning.assert_called_once()
-        assert "user_loading" in mock_report.report_warning.call_args[0]
-        assert "API" in mock_report.report_warning.call_args[0][1]
+        mock_report.warning.assert_called_once()
+        assert "user_loading" in mock_report.warning.call_args[0]
+        assert "API" in mock_report.warning.call_args[0][1]
 
     def test_load_users_unexpected_error_reports_failure(self):
         """Test that unexpected errors are reported as failures."""
@@ -61,9 +61,9 @@ class TestUserResolverLoadUsers:
         resolver.load_users()
 
         assert len(resolver._user_cache) == 0
-        mock_report.report_failure.assert_called_once()
-        assert "user_loading" in mock_report.report_failure.call_args[0]
-        assert "Unexpected" in mock_report.report_failure.call_args[0][1]
+        mock_report.failure.assert_called_once()
+        assert "user_loading" in mock_report.failure.call_args[0]
+        assert "Unexpected" in mock_report.failure.call_args[0][1]
 
     def test_load_users_caches_by_name_and_display_name(self):
         """Test that users are cached by both name and display_name."""

--- a/metadata-ingestion/tests/unit/snowplow/test_warehouse_lineage_processor.py
+++ b/metadata-ingestion/tests/unit/snowplow/test_warehouse_lineage_processor.py
@@ -314,7 +314,7 @@ class TestWarehouseLineageProcessor:
         # No workunits but no exception raised
         assert len(workunits) == 0
         # Verify warning was reported
-        processor.report.report_warning.assert_called_once()
+        processor.report.warning.assert_called_once()
 
     def test_extract_processes_multiple_data_models(self, processor, mock_deps):
         """Test that multiple data models are processed correctly."""

--- a/metadata-ingestion/tests/unit/sqlalchemy_profiler/test_sqlalchemy_profiler.py
+++ b/metadata-ingestion/tests/unit/sqlalchemy_profiler/test_sqlalchemy_profiler.py
@@ -68,7 +68,7 @@ def mock_report():
     """Create a mock SQLSourceReport."""
     report = MagicMock(spec=SQLSourceReport)
     report.report_dropped = MagicMock()
-    report.report_warning = MagicMock()
+    report.warning = MagicMock()
     return report
 
 

--- a/metadata-ingestion/tests/unit/stateful_ingestion/state/test_stateful_ingestion.py
+++ b/metadata-ingestion/tests/unit/stateful_ingestion/state/test_stateful_ingestion.py
@@ -144,7 +144,7 @@ class DummySource(StatefulIngestionSourceBase):
             ).as_workunit()
 
         if self.source_config.report_failure:
-            self.reporter.report_failure("Dummy error", "Error")
+            self.reporter.failure("Dummy error", "Error")
 
     def get_report(self) -> SourceReport:
         return self.reporter

--- a/metadata-ingestion/tests/unit/test_metabase_source.py
+++ b/metadata-ingestion/tests/unit/test_metabase_source.py
@@ -134,4 +134,4 @@ def test_fail_session_delete(mock_post, mock_get, mock_delete):
     metabase_source.report = mock_report
     metabase_source.close()
 
-    mock_report.report_failure.assert_called_once()
+    mock_report.failure.assert_called_once()

--- a/metadata-ingestion/tests/unit/test_postgres_source.py
+++ b/metadata-ingestion/tests/unit/test_postgres_source.py
@@ -280,7 +280,7 @@ def test_query_lineage_prerequisites_failure(create_engine_mock):
             mock_extractor.extract_query_history.return_value = []
 
             def mock_populate_with_failure() -> None:
-                source.report.report_failure(
+                source.report.failure(
                     message="pg_stat_statements extension is not installed",
                     context="pg_stat_statements_not_ready",
                 )

--- a/metadata-ingestion/tests/unit/test_unity_catalog_proxy.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_proxy.py
@@ -1839,9 +1839,10 @@ class TestUnityCatalogProxyUsageSystemTables:
         # Simulate the streaming method's internal error path: it catches the DB
         # exception, records a warning, and yields nothing instead of raising.
         def _failing_stream(*a, **kw):
-            mock_proxy.report.report_warning(
+            mock_proxy.report.warning(
                 title="Failed to run SQL query",
                 message="A SQL query against the Databricks warehouse failed.",
+                log=False,
             )
             return (r for r in [])  # type: ignore[var-annotated]
 


### PR DESCRIPTION
## Summary

- Migrates all `SourceReport.report_warning()` callers to `warning(log=False)` (~334 call sites across ~89 files)
- Migrates all `SourceReport.report_failure()` callers to `failure()` (~153 call sites across ~54 files)
- Converts `report_warning` and `report_failure` to deprecated pass-throughs with `@deprecated` decorator
- Adds proper docstrings to `warning()` and `failure()` documenting parameters and behavior
- Updates `ModeReport` to override `warning`/`failure` instead of the deprecated names
- Removes dead `GlueSource.report_warning` convenience method
- Updates test mock assertions and mock objects to use the new method names

## Safety

The rename is a mechanical find-and-replace: `report_warning` and `warning` (and `report_failure` and `failure`) have identical positional signatures on `SourceReport`, so all existing positional calls remain correct without reordering.

Two non-`SourceReport` edge cases were handled manually:
- `AssertionCompilationReport.report_failure(key, reason)` in `compiler.py` — different class, left as-is
- `GlueSource.report_warning(key, reason)` convenience method — removed; callers redirected to `self.report.warning(message, context=...)`

## Out of scope

- `SinkReport.report_warning`/`report_failure` — different class with different signatures (`info: Any`), unrelated to this duality.
- Fixing existing `LiteralString` violations where callers pass f-strings as `message` or `title` (pre-existing; to be addressed in a future PR).

## Motivation

`SourceReport` had two pairs of near-duplicate methods:
- `report_warning` (hardcoded `log=False`, no `log` param) vs `warning` (`log=True` default, has `log` param)
- `report_failure` vs `failure` (completely identical since Jul 2024)

The `report_*` variants are legacy. This unifies callers onto the short names and marks the old names as deprecated.

## Test plan

- [x] `./gradlew :metadata-ingestion:lintFix` passes
- [x] `./gradlew :metadata-ingestion:lint` passes (including mypy)
- [x] `./gradlew :metadata-ingestion:testQuick` passes (15451 tests)
- [x] Targeted test runs for affected test files (api, snowplow, dremio, mode, glue, postgres lineage)
- [x] Grep confirms no remaining `report_warning`/`report_failure` calls in `src/` except deprecated wrappers and out-of-scope `SinkReport`

🤖 Generated with [Claude Code](https://claude.com/claude-code)