### PR TITLE
feat(auth): support requiredGroups and access-denied messaging in dynamic OIDC settings

### DIFF
--- a/datahub-frontend/app/auth/AuthUtils.java
+++ b/datahub-frontend/app/auth/AuthUtils.java
@@ -80,6 +80,9 @@ public class AuthUtils {
   // Retained for backwards compatibility
   public static final String PREFERRED_JWS_ALGORITHM = "preferredJwsAlgorithm";
   public static final String PREFERRED_JWS_ALGORITHM_2 = "preferredJwsAlgorithm2";
+  public static final String REQUIRED_GROUPS = "requiredGroups";
+  public static final String ACCESS_DENIED_MESSAGE = "accessDeniedMessage";
+  public static final String ACCESS_DENIED_REDIRECT_URL = "accessDeniedRedirectUrl";
 
   /**
    * Determines whether the inbound request should be forward to downstream Metadata Service. Today,

--- a/datahub-frontend/app/auth/sso/oidc/OidcConfigs.java
+++ b/datahub-frontend/app/auth/sso/oidc/OidcConfigs.java
@@ -6,6 +6,7 @@ import static auth.ConfigUtil.*;
 import auth.sso.SsoConfigs;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -51,6 +52,7 @@ public class OidcConfigs extends SsoConfigs {
   public static final String OIDC_HTTP_RETRY_ATTEMPTS = "auth.oidc.httpRetryAttempts";
   public static final String OIDC_HTTP_RETRY_DELAY = "auth.oidc.httpRetryDelay";
   public static final String OIDC_ACCESS_DENIED_REDIRECT_URL = "auth.oidc.accessDeniedRedirectUrl";
+  public static final String OIDC_ACCESS_DENIED_MESSAGE = "auth.oidc.accessDeniedMessage";
   public static final String OIDC_DISABLE_PKCE = "auth.oidc.disablePkce";
   public static final String OIDC_REQUIRED_GROUPS_CONFIG_PATH = "auth.oidc.requiredGroups";
 
@@ -97,6 +99,7 @@ public class OidcConfigs extends SsoConfigs {
   private final String httpRetryAttempts;
   private final String httpRetryDelay;
   private final Optional<String> accessDeniedRedirectUrl;
+  private final Optional<String> accessDeniedMessage;
   private final boolean disablePkce;
 
   /* Group Access Control */
@@ -129,6 +132,7 @@ public class OidcConfigs extends SsoConfigs {
     this.httpRetryAttempts = builder.httpRetryAttempts;
     this.httpRetryDelay = builder.httpRetryDelay;
     this.accessDeniedRedirectUrl = builder.accessDeniedRedirectUrl;
+    this.accessDeniedMessage = builder.accessDeniedMessage;
     this.disablePkce = builder.disablePkce;
     this.requiredGroups = builder.requiredGroups;
   }
@@ -170,6 +174,7 @@ public class OidcConfigs extends SsoConfigs {
     private String httpRetryAttempts = DEFAULT_OIDC_HTTP_RETRY_ATTEMPTS;
     private String httpRetryDelay = DEFAULT_OIDC_HTTP_RETRY_DELAY;
     private Optional<String> accessDeniedRedirectUrl = Optional.empty();
+    private Optional<String> accessDeniedMessage = Optional.empty();
     private boolean disablePkce = false;
     private Set<String> requiredGroups = Collections.emptySet();
 
@@ -225,6 +230,7 @@ public class OidcConfigs extends SsoConfigs {
           getOptional(configs, OIDC_HTTP_RETRY_ATTEMPTS, DEFAULT_OIDC_HTTP_RETRY_ATTEMPTS);
       httpRetryDelay = getOptional(configs, OIDC_HTTP_RETRY_DELAY, DEFAULT_OIDC_HTTP_RETRY_DELAY);
       accessDeniedRedirectUrl = getOptional(configs, OIDC_ACCESS_DENIED_REDIRECT_URL);
+      accessDeniedMessage = getOptional(configs, OIDC_ACCESS_DENIED_MESSAGE);
       if (configs.hasPath(OIDC_DISABLE_PKCE)) {
         disablePkce = configs.getBoolean(OIDC_DISABLE_PKCE);
       }
@@ -306,6 +312,26 @@ public class OidcConfigs extends SsoConfigs {
 
       grantType = Optional.ofNullable(getOptional(configs, OIDC_GRANT_TYPE, null));
       acrValues = Optional.ofNullable(getOptional(configs, OIDC_ACR_VALUES, null));
+
+      if (jsonNode.has(REQUIRED_GROUPS) && jsonNode.get(REQUIRED_GROUPS).isArray()) {
+        final Set<String> parsedGroups = new HashSet<>();
+        jsonNode
+            .get(REQUIRED_GROUPS)
+            .forEach(
+                node -> {
+                  final String group = node.asText().trim();
+                  if (!group.isEmpty()) {
+                    parsedGroups.add(group);
+                  }
+                });
+        requiredGroups = parsedGroups;
+      }
+      if (jsonNode.has(ACCESS_DENIED_MESSAGE)) {
+        accessDeniedMessage = Optional.of(jsonNode.get(ACCESS_DENIED_MESSAGE).asText());
+      }
+      if (jsonNode.has(ACCESS_DENIED_REDIRECT_URL)) {
+        accessDeniedRedirectUrl = Optional.of(jsonNode.get(ACCESS_DENIED_REDIRECT_URL).asText());
+      }
 
       return this;
     }

--- a/datahub-frontend/app/controllers/SsoCallbackController.java
+++ b/datahub-frontend/app/controllers/SsoCallbackController.java
@@ -4,6 +4,7 @@ import auth.CookieConfigs;
 import auth.sso.SsoManager;
 import auth.sso.SsoProvider;
 import auth.sso.oidc.OidcCallbackLogic;
+import auth.sso.oidc.OidcProvider;
 import auth.sso.oidc.RequiredGroupsException;
 import client.AuthServiceClient;
 import com.linkedin.entity.client.SystemEntityClient;
@@ -13,6 +14,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.annotation.Nonnull;
@@ -85,6 +87,23 @@ public class SsoCallbackController extends CallbackController {
             authVerboseLogging);
   }
 
+  /**
+   * Resolve the access-denied message shown when a user is rejected for missing required groups.
+   * Prefers the value configured on the active (dynamic / UI-managed) OIDC provider, falling back
+   * to the static {@code auth.oidc.accessDeniedMessage} env config captured at construction time.
+   */
+  private String resolveAccessDeniedMessage() {
+    final SsoProvider<?> provider = ssoManager.getSsoProvider();
+    if (provider instanceof OidcProvider) {
+      final Optional<String> dynamicMessage =
+          ((OidcProvider) provider).configs().getAccessDeniedMessage();
+      if (dynamicMessage.isPresent() && !dynamicMessage.get().isEmpty()) {
+        return dynamicMessage.get();
+      }
+    }
+    return accessDeniedMessage;
+  }
+
   @Override
   public CompletionStage<Result> callback(Http.Request request) {
     FrameworkAdapter.INSTANCE.applyDefaultSettingsIfUndefined(this.config);
@@ -117,9 +136,10 @@ public class SsoCallbackController extends CallbackController {
                   String message;
                   if (e.getCause() instanceof RequiredGroupsException) {
                     log.warn("User missing required groups.");
+                    final String resolvedMessage = resolveAccessDeniedMessage();
                     message =
-                        (accessDeniedMessage != null && !accessDeniedMessage.isEmpty())
-                            ? accessDeniedMessage
+                        (resolvedMessage != null && !resolvedMessage.isEmpty())
+                            ? resolvedMessage
                             : "Access Denied: You do not belong to the required groups to access this application. Please contact your administrator.";
                   } else {
                     message =

--- a/datahub-frontend/test/security/OidcConfigurationTest.java
+++ b/datahub-frontend/test/security/OidcConfigurationTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.pac4j.oidc.client.OidcClient;
@@ -334,6 +335,35 @@ public class OidcConfigurationTest {
             .getConfiguration()
             .getPreferredJwsAlgorithm()
             .toString());
+  }
+
+  @Test
+  public void readRequiredGroupsFromJSON() {
+    final String SSO_SETTINGS_JSON_STR =
+        new JSONObject()
+            .put(REQUIRED_GROUPS, new JSONArray(List.of("group-a", " group-b ", "")))
+            .toString();
+    OidcConfigs.Builder oidcConfigsBuilder = new OidcConfigs.Builder();
+    oidcConfigsBuilder.from(CONFIG, SSO_SETTINGS_JSON_STR);
+    OidcConfigs oidcConfigs = new OidcConfigs(oidcConfigsBuilder);
+    // Values are trimmed and blanks dropped, matching the env-var parsing behavior.
+    assertEquals(Set.of("group-a", "group-b"), oidcConfigs.getRequiredGroups());
+  }
+
+  @Test
+  public void readAccessDeniedMessageAndRedirectFromJSON() {
+    final String SSO_SETTINGS_JSON_STR =
+        new JSONObject()
+            .put(ACCESS_DENIED_MESSAGE, "You need role X.")
+            .put(ACCESS_DENIED_REDIRECT_URL, "https://intranet.example.com/request-access")
+            .toString();
+    OidcConfigs.Builder oidcConfigsBuilder = new OidcConfigs.Builder();
+    oidcConfigsBuilder.from(CONFIG, SSO_SETTINGS_JSON_STR);
+    OidcConfigs oidcConfigs = new OidcConfigs(oidcConfigsBuilder);
+    assertEquals("You need role X.", oidcConfigs.getAccessDeniedMessage().orElse(null));
+    assertEquals(
+        "https://intranet.example.com/request-access",
+        oidcConfigs.getAccessDeniedRedirectUrl().orElse(null));
   }
 
   @Test

--- a/metadata-models/src/main/pegasus/com/linkedin/settings/global/OidcSettings.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/settings/global/OidcSettings.pdl
@@ -98,4 +98,19 @@ record OidcSettings {
    *  ADVANCED. Which jws algorithm to use.
    */
   preferredJwsAlgorithm2: optional string
+
+  /**
+   * ADVANCED. Restrict login to users who belong to at least one of these groups (matched against the groups claim). Empty or unset disables group-based access enforcement.
+   */
+  requiredGroups: optional array[string]
+
+  /**
+   * ADVANCED. Message shown to users who are denied login because they are not a member of any required group.
+   */
+  accessDeniedMessage: optional string
+
+  /**
+   * ADVANCED. URL to redirect denied users to (e.g. an internal access-request page). When set, takes precedence over the access denied message.
+   */
+  accessDeniedRedirectUrl: optional string
 }

--- a/metadata-service/auth-servlet-impl/src/main/java/com/datahub/auth/authentication/AuthServiceController.java
+++ b/metadata-service/auth-servlet-impl/src/main/java/com/datahub/auth/authentication/AuthServiceController.java
@@ -48,6 +48,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -100,6 +101,9 @@ public class AuthServiceController {
   // Retained for backwards compatibility
   private static final String PREFERRED_JWS_ALGORITHM = "preferredJwsAlgorithm";
   private static final String PREFERRED_JWS_ALGORITHM_2 = "preferredJwsAlgorithm2";
+  private static final String REQUIRED_GROUPS = "requiredGroups";
+  private static final String ACCESS_DENIED_MESSAGE = "accessDeniedMessage";
+  private static final String ACCESS_DENIED_REDIRECT_URL = "accessDeniedRedirectUrl";
 
   @Autowired private StatelessTokenService _statelessTokenService;
 
@@ -821,6 +825,15 @@ public class AuthServiceController {
     }
     if (oidcSettings.hasPreferredJwsAlgorithm2()) {
       json.put(PREFERRED_JWS_ALGORITHM, oidcSettings.getPreferredJwsAlgorithm2());
+    }
+    if (oidcSettings.hasRequiredGroups()) {
+      json.put(REQUIRED_GROUPS, new JSONArray(oidcSettings.getRequiredGroups()));
+    }
+    if (oidcSettings.hasAccessDeniedMessage()) {
+      json.put(ACCESS_DENIED_MESSAGE, oidcSettings.getAccessDeniedMessage());
+    }
+    if (oidcSettings.hasAccessDeniedRedirectUrl()) {
+      json.put(ACCESS_DENIED_REDIRECT_URL, oidcSettings.getAccessDeniedRedirectUrl());
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds three OIDC access-control settings to the `OidcSettings` aspect and wires them through the **dynamic (metadata-managed) SSO settings** path, so they can be sourced from stored settings rather than only from `datahub-frontend` environment variables:

- `requiredGroups` — restrict login to users who belong to at least one of the listed groups (matched against the groups claim).
- `accessDeniedMessage` — message shown to users denied for missing a required group.
- `accessDeniedRedirectUrl` — redirect denied users to a given URL instead of showing the message.

These are already supported as env vars (`AUTH_OIDC_REQUIRED_GROUPS`, `AUTH_OIDC_ACCESS_DENIED_MESSAGE`, `AUTH_OIDC_ACCESS_DENIED_REDIRECT_URL`) and enforced in `OidcCallbackLogic`, but the dynamic settings path (`getSsoSettings` → `OidcConfigs.from(json)`) did not carry them. This closes that gap so a metadata-managed SSO configuration preserves group-based login enforcement.

## Changes

- **metadata-models**: new optional `requiredGroups` (`array[string]`), `accessDeniedMessage`, `accessDeniedRedirectUrl` on the `OidcSettings` aspect.
- **auth-servlet-impl**: `AuthServiceController#buildOidcSettingsResponse` emits the three fields in the SSO settings JSON served to the frontend.
- **datahub-frontend**:
  - `OidcConfigs.from(configs, json)` parses the three fields from the dynamic settings JSON; adds `accessDeniedMessage` (env + JSON).
  - `SsoCallbackController` resolves the access-denied message from the active provider config, falling back to the static env value.
  - `AuthUtils` JSON-key constants.

No enforcement logic changes — `OidcCallbackLogic` already reads `requiredGroups` / `accessDeniedRedirectUrl` from the active `OidcConfigs`; this only ensures the dynamic path populates them.

## Testing

- `OidcConfigurationTest` — new cases verifying `requiredGroups`, `accessDeniedMessage`, and `accessDeniedRedirectUrl` parse from the SSO settings JSON (5 passing).
- `:metadata-service:auth-servlet-impl:compileJava` and `:datahub-frontend:test` green; Java spotless clean.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [x] No breaking changes (all new fields are optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
