### PR TITLE
fix(ingest/spark): keep JNI io.openlineage.sql unrelocated in shaded agent jar

### DIFF
--- a/metadata-integration/java/acryl-spark-lineage/build.gradle
+++ b/metadata-integration/java/acryl-spark-lineage/build.gradle
@@ -291,9 +291,19 @@ scalaVersions.each { sv ->
     relocate 'org.springframework', 'io.acryl.shaded.org.springframework'
     relocate 'com.fasterxml.jackson', 'io.acryl.shaded.jackson'
     relocate 'org.yaml', 'io.acryl.shaded.org.yaml'
+    // Relocate io.openlineage so this agent can coexist with environments that ship their own
+    // openlineage-spark (Databricks, EMR, Glue, DataZone). DataHub's customized classes in
+    // src/main/java/io/openlineage/ are relocated too, so the override mechanism (project classes
+    // beat dependency classes) still works. Two sub-packages are carved out below.
     relocate('io.openlineage', 'io.acryl.shaded.io.openlineage') {
       // Extension SPI must stay unrelocated: connectors implement it at its canonical name.
       exclude 'io.openlineage.spark.extension.**'
+      // io.openlineage.sql is JNI-backed: its native methods resolve to symbols compiled into the
+      // Rust library as Java_io_openlineage_sql_OpenLineageSql_*, and shading cannot rewrite symbol
+      // names inside a native binary. Relocating the Java class makes the JVM look for
+      // Java_io_acryl_shaded_..._parse and crash with UnsatisfiedLinkError on JDBC/SQL parsing
+      // (issue #18558). Keep the whole package at its canonical name so the symbols resolve.
+      exclude 'io.openlineage.sql.**'
     }
     relocate 'net.jcip.annotations', 'io.acryl.shaded.annotations'
     relocate 'javassist', 'io.acryl.shaded.javassist'
@@ -327,11 +337,6 @@ scalaVersions.each { sv ->
     relocate 'io.confluent', 'io.acryl.shaded.io.confluent'
     relocate 'io.github', 'io.acryl.shaded.io.github'
     relocate 'io.datahubproject', 'io.acryl.shaded.io.datahubproject'
-    // Relocate io.openlineage to prevent conflicts when another openlineage-spark version
-    // is on the classpath (Databricks, EMR, Glue). DataHub's customized classes in
-    // src/main/java/io/openlineage/ are also relocated by the shadow plugin, so the
-    // override mechanism (project classes beat dependency classes) still works.
-    relocate 'io.openlineage', 'io.acryl.shaded.io.openlineage'
     relocate 'com.eclipsesource', 'io.acryl.shaded.com.eclipsesource'
 
     // Relocate packages that conflict with Spark's runtime classpath

--- a/metadata-integration/java/acryl-spark-lineage/scripts/check_jar.sh
+++ b/metadata-integration/java/acryl-spark-lineage/scripts/check_jar.sh
@@ -31,6 +31,14 @@ for jarFile in ${jarFiles}; do
     exit 1
   fi
 
+  # Positive guard: the extension SPI must stay canonical so connectors implement it at its
+  # canonical name — same "must not be relocated" reason as io.openlineage.sql above.
+  extClasses=$(jar -tf "$jarFile" | grep -E '^io/openlineage/spark/extension/.*\.class$')
+  if [ -z "$extClasses" ]; then
+    echo "💥 Extension SPI missing at canonical io/openlineage/spark/extension/ in ${jarFile}"
+    exit 1
+  fi
+
   jar -tvf $jarFile |\
       grep -v "log4j.xml" |\
       grep -v "log4j2.xml" |\

--- a/metadata-integration/java/acryl-spark-lineage/scripts/check_jar.sh
+++ b/metadata-integration/java/acryl-spark-lineage/scripts/check_jar.sh
@@ -5,12 +5,29 @@ jarishFile=$(find build/libs -name "${libName}*.jar" -exec ls -1rt "{}" +;)
 jarFiles=$(echo "$jarishFile" | grep -v sources | grep -v javadoc | tail -n 1)
 for jarFile in ${jarFiles}; do
   # OpenLineage must be shaded under io.acryl.shaded so this agent can coexist with environments
-  # that ship their own io.openlineage.* (e.g. EMR/DataZone). The only OpenLineage classes allowed
-  # to remain unrelocated are the extension SPI, which connectors implement at its canonical name.
-  unrelocatedOl=$(jar -tf "$jarFile" | grep '^io/openlineage/' | grep -v '^io/openlineage/spark/extension/' | grep -E '\.class$')
+  # that ship their own io.openlineage.* (e.g. EMR/DataZone). Two packages MUST stay unrelocated:
+  #  - io.openlineage.spark.extension: the SPI connectors implement at its canonical name.
+  #  - io.openlineage.sql: JNI-backed; its native symbols are baked into the Rust .so/.dylib as
+  #    Java_io_openlineage_sql_*, which shading can't rewrite. Relocating it → UnsatisfiedLinkError
+  #    on JDBC/SQL parsing (issue #18558), so it must remain at its canonical name.
+  unrelocatedOl=$(jar -tf "$jarFile" | grep '^io/openlineage/' | grep -v '^io/openlineage/spark/extension/' | grep -v '^io/openlineage/sql/' | grep -E '\.class$')
   if [ -n "$unrelocatedOl" ]; then
     echo "💥 Found unrelocated OpenLineage classes in ${jarFile}:"
     echo "$unrelocatedOl"
+    exit 1
+  fi
+
+  # Positive guard for the JNI package (issue #18558): the Java class and its native libraries MUST
+  # live at the canonical io/openlineage/sql/ path so the Rust-compiled Java_io_openlineage_sql_*
+  # symbols resolve. If a future relocation change moves them under io/acryl/shaded/, JDBC/SQL
+  # parsing crashes with UnsatisfiedLinkError — fail the build here instead of shipping it.
+  sqlClass=$(jar -tf "$jarFile" | grep -E '^io/openlineage/sql/OpenLineageSql\.class$')
+  sqlNativeLibs=$(jar -tf "$jarFile" | grep -E '^io/openlineage/sql/libopenlineage_sql_java.*\.(so|dylib|dll)$')
+  if [ -z "$sqlClass" ] || [ -z "$sqlNativeLibs" ]; then
+    echo "💥 JNI SQL parser missing at canonical io/openlineage/sql/ in ${jarFile}"
+    echo "   OpenLineageSql.class present: ${sqlClass:-NO}"
+    echo "   native libs present: ${sqlNativeLibs:-NO}"
+    echo "   (io.openlineage.sql must be excluded from relocation — see build.gradle)"
     exit 1
   fi
 

--- a/metadata-integration/java/acryl-spark-lineage/src/sparkSmoke4/java/datahub/spark/ShadedOpenLineageSqlJniTest.java
+++ b/metadata-integration/java/acryl-spark-lineage/src/sparkSmoke4/java/datahub/spark/ShadedOpenLineageSqlJniTest.java
@@ -1,0 +1,57 @@
+package datahub.spark;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression guard for issue #18558. Runs against the real shaded {@code shadowJar_2_13} (see the
+ * {@code sparkSmoke4RuntimeOnly} wiring in build.gradle), so it exercises the exact artifact users
+ * deploy — unlike the unit/`sparkRealSmokeTest` suites, which run against the unshaded classpath
+ * and therefore never see the relocation bug.
+ *
+ * <p>{@code OpenLineageSql.parse} is a {@code native} method whose entry point is compiled into a
+ * Rust library as {@code Java_io_openlineage_sql_OpenLineageSql_parse}. Shading cannot rewrite
+ * symbol names inside a native binary, so if the build relocates {@code io.openlineage.sql} the JVM
+ * looks for {@code Java_io_acryl_shaded_..._parse} and this call throws {@link
+ * UnsatisfiedLinkError} — the crash reported for Spark JDBC / Delta MERGE jobs.
+ */
+public class ShadedOpenLineageSqlJniTest {
+
+  @Test
+  public void nativeSqlParserResolvesInShadedJar() throws Exception {
+    Class<?> cls;
+    try {
+      // Correct location: the JNI package must stay at its canonical name.
+      cls = Class.forName("io.openlineage.sql.OpenLineageSql");
+    } catch (ClassNotFoundException notCanonical) {
+      // If it was relocated, load it there anyway so we still reach the native call and surface the
+      // real failure mode (UnsatisfiedLinkError) rather than a misleading ClassNotFoundException.
+      cls = Class.forName("io.acryl.shaded.io.openlineage.sql.OpenLineageSql");
+    }
+
+    Method parse = cls.getMethod("parse", java.util.List.class, String.class);
+    Object result;
+    try {
+      result =
+          parse.invoke(null, Collections.singletonList("SELECT a FROM my_db.my_table"), "postgres");
+    } catch (InvocationTargetException e) {
+      if (e.getCause() instanceof UnsatisfiedLinkError) {
+        fail(
+            "OpenLineageSql native parse is unresolved in the shaded jar (issue #18558): "
+                + e.getCause().getMessage());
+      }
+      throw e;
+    }
+
+    assertTrue(result instanceof Optional, "parse should return an Optional<SqlMeta>");
+    assertTrue(
+        ((Optional<?>) result).isPresent(),
+        "native SQL parser returned empty — the JNI library did not load");
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #18558. `acryl-spark-lineage` crashes Spark JDBC / Delta MERGE jobs with:

```
java.lang.UnsatisfiedLinkError: 'io.acryl.shaded.io.openlineage.sql.SqlMeta
  io.acryl.shaded.io.openlineage.sql.OpenLineageSql.parse(java.util.List, java.lang.String, java.lang.String)'
```

### Root cause

The shadow jar relocates the whole `io.openlineage` namespace to `io.acryl.shaded.io.openlineage`.
That moves `io.openlineage.sql.OpenLineageSql`, whose `parse()` is a `native` method backed by a
**Rust-compiled JNI library**, into the shaded package. The shadow plugin *moves* the `.so`/`.dylib`
files but cannot rewrite the symbols compiled inside them — they stay
`Java_io_openlineage_sql_OpenLineageSql_parse`. The relocated class therefore asks the JVM for
`Java_io_acryl_shaded_io_openlineage_sql_OpenLineageSql_parse`, which does not exist → `UnsatisfiedLinkError`
on every JDBC/SQL parse (`JdbcSparkUtils.java`).

The "missing JNI library" fallback doesn't help: the library loads fine (the `.so` is bundled and
`System.load` succeeds), and `OpenLineageSql.parse()` catches only `RuntimeException` — not the
`UnsatisfiedLinkError` (a `java.lang.Error`) it throws.

Verified empirically against the published `1.6.0.15` jar (`nm`/`objdump` show the canonical symbol;
the relocated class needs the shaded one) and confirmed the exact error message is reproduced.

### Fix

- **`build.gradle`**: exclude `io.openlineage.sql.**` from relocation so the class, native libs, and
  compiled symbols all stay at their canonical name. Remove the duplicate no-exclude
  `relocate 'io.openlineage'` that was overriding the carve-outs — it had also been relocating the
  `io.openlineage.spark.extension` SPI it was meant to preserve; both now stay canonical.
- **`scripts/check_jar.sh`**: allow the canonical `io/openlineage/sql/` package and positively assert
  the class + native libs are present there, so a future re-relocation fails the build.
- **`ShadedOpenLineageSqlJniTest`**: invokes the native parser against the real shaded `shadowJar_2_13`.
  Fails on the broken artifact, passes on the fixed one — closing the gap where the only shaded-jar
  suite never exercised the JDBC/SQL path.

### Why tests didn't catch it

The only suite that runs against the *shaded* jar (`sparkSmoke4Test`) did CSV→CSV and never called the
native parser. The suites that *do* JDBC (`sparkRealSmokeTest`, `SparkConnectionInstanceSmokeTest`) run
against the *unshaded* classpath, where `OpenLineageSql` is still canonical and the symbols resolve.

### Testing

- `shadowJar_2_13` rebuilt: `io/openlineage/sql/` classes + native libs and the extension SPI are
  canonical; all `spark.agent` classes remain relocated under `io.acryl.shaded`.
- `checkShadowJar` passes (incl. the new positive JNI assertion).
- `sparkSmoke4Test`: 2 passing.
- Probe against the published `1.6.0.15` jar reproduces `UnsatisfiedLinkError`; the fixed jar returns a
  fully parsed `SqlMeta` with column lineage.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing/#commit-message-format))
- [x] Links to related issues (#18558)
- [x] Tests added (`ShadedOpenLineageSqlJniTest`, `check_jar.sh` assertion)