### PR TITLE
fix(smoke-test): add retry + ES readiness wait in TestDomainTimeline.setup_entities

### DIFF
--- a/smoke-test/tests/timeline/timeline_change_history_test.py
+++ b/smoke-test/tests/timeline/timeline_change_history_test.py
@@ -22,7 +22,9 @@ import uuid
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 import pytest
+import tenacity
 
+from datahub.configuration.common import OperationalError
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.metadata.schema_classes import (
     ApplicationsClass,
@@ -56,6 +58,26 @@ from tests.utils import execute_graphql
 logger = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.no_cypress_suite1
+
+
+def _is_transient_sp_error(exc: BaseException) -> bool:
+    """Return True for transient SP-creation errors caused by ES mapping lookups."""
+    if not isinstance(exc, OperationalError):
+        return False
+    msg = str(exc)
+    return "Retry the request" in msg or "mapping lookup failed" in msg
+
+
+@tenacity.retry(
+    retry=tenacity.retry_if_exception(_is_transient_sp_error),
+    wait=tenacity.wait_exponential(multiplier=1, min=1, max=8),
+    stop=tenacity.stop_after_attempt(5),
+    reraise=True,
+)
+def _emit_sp_definition(graph_client: Any, mcp: MetadataChangeProposalWrapper) -> None:
+    """Emit a structured property definition MCP, retrying on transient ES errors."""
+    graph_client.emit_mcp(mcp)
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -201,9 +223,11 @@ def setup_entities(graph_client):
         description="Property for timeline smoke tests",
         immutable=False,
     )
-    graph_client.emit_mcp(
-        MetadataChangeProposalWrapper(entityUrn=SP_URN, aspect=sp_def)
+    _emit_sp_definition(
+        graph_client,
+        MetadataChangeProposalWrapper(entityUrn=SP_URN, aspect=sp_def),
     )
+    wait_for_writes_to_sync()
 
     # --- Dataset ---
     graph_client.emit_mcp(


### PR DESCRIPTION
## Summary

Prevents flaky `TestDomainTimeline` failures caused by a race condition where Elasticsearch hasn't finished indexing structured-property definitions before assertions run.

- **Retry wrapper** (`@tenacity.retry`, 5 attempts, exponential backoff 1–8s) around `emit_mcp` for the SP definition — catches `OperationalError` with `"Retry the request"` / `"mapping lookup failed"` messages from `PropertyDefinitionValidator`.
- **`wait_for_writes_to_sync()`** called after the SP definition emission in `setup_entities` to ensure ES is ready before tests begin.
- All other `emit_mcp` calls are untouched — the retry is surgical.

## Test plan
- [ ] Smoke-test CI passes on `TestDomainTimeline` without intermittent failures
- [ ] No regressions in other timeline tests
- [ ] Lint verified clean via `./gradlew :smoke-test:pythonLintFix`

---

### Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

Made with [Cursor](https://cursor.com)