### PR TITLE
docs(mlModel): note that upstreamLineage does not apply to mlModel

### DIFF
--- a/metadata-models/docs/entities/mlModel.md
+++ b/metadata-models/docs/entities/mlModel.md
@@ -78,6 +78,10 @@ ML Models can document their training and evaluation datasets in two complementa
 
 Each dataset reference includes the dataset URN, motivation for using that dataset, and any preprocessing steps applied. This creates direct lineage relationships between models and their training data.
 
+:::note
+`upstreamLineage` — the lineage aspect used by **datasets** — does not apply to `mlModel`. Emitting it on a model is rejected by GMS with `422 Unknown aspect upstreamLineage for entity mlModel`. Use `mlModelTrainingData` (above) for model→training-dataset lineage, or training runs (`trainingJobs`) for full lineage.
+:::
+
 #### Lineage via Training Runs
 
 Training runs (`dataProcessInstance` entities) provide an alternative and often more detailed way to capture training lineage:


### PR DESCRIPTION
upstreamLineage is a dataset-only aspect; emitting it on an mlModel is rejected by GMS with a 422 (Unknown aspect). Point readers to the mlModelTrainingData aspect (already documented just above) and to training runs instead.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
