### PR TITLE
perf(i18n): stop eagerly loading all namespaces on app boot

### DIFF
--- a/datahub-web-react/.storybook/i18n.ts
+++ b/datahub-web-react/.storybook/i18n.ts
@@ -19,19 +19,21 @@ for (const path in enModules) {
     }
 }
 
-const namespaces = Object.keys(enResources);
-
 // Lazy tier: mirror the app (`src/i18n/i18n.ts`). Vite code-splits each `<lng>/<ns>.json`
 // into its own chunk, fetched by i18next only when a story requests it for the active
 // language. `partialBundledLanguages` is required so i18next uses this backend for any
 // language/namespace absent from `resources` — without it, the bundled `en` would suppress
 // all backend loads and non-English languages would never localize.
+//
+// `ns` stays empty (same as the app): listing every namespace here would still trigger a
+// full load storm when switching away from English. useTranslation() loads on demand.
 i18n.use(resourcesToBackend((lng: string, ns: string) => import(`../src/i18n/locales/${lng}/${ns}.json`)));
 
 i18n.use(initReactI18next).init({
     lng: 'en',
     fallbackLng: 'en',
-    ns: namespaces,
+    ns: [],
+    defaultNS: false,
     resources: { en: enResources },
     partialBundledLanguages: true,
     interpolation: { escapeValue: false },

--- a/datahub-web-react/src/alchemy-components/components/Editor/RemirrorLocaleProvider.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Editor/RemirrorLocaleProvider.tsx
@@ -38,7 +38,8 @@ type Props = {
  * English for languages we don't ship a bundle for.
  */
 export default function RemirrorLocaleProvider({ children }: Props) {
-    const { i18n: appI18n } = useTranslation();
+    // Empty ns list: only subscribe to language changes (defaultNS is false at app init).
+    const { i18n: appI18n } = useTranslation([]);
     const appLanguage = (appI18n.resolvedLanguage || appI18n.language || 'en').split('-')[0];
     const locale = REMIRROR_SUPPORTED_LOCALES.includes(appLanguage) ? appLanguage : 'en';
     // Only activate once the bundle is loaded, so labels never flash raw message ids. Until then

--- a/datahub-web-react/src/app/homeV2/content/tabs/CenterTabs.tsx
+++ b/datahub-web-react/src/app/homeV2/content/tabs/CenterTabs.tsx
@@ -1,6 +1,7 @@
 import { Tabs } from '@components';
 import { Skeleton } from 'antd';
 import React, { useContext, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { DEFAULT_TAB } from '@app/homeV2/content/tabs/tabs';
@@ -25,6 +26,8 @@ const SkeletonButton = styled(Skeleton.Button)`
 `;
 
 export const CenterTabs = () => {
+    // Tab name/tooltip getters call sync i18next.t('home.v2:...'); load the ns first.
+    useTranslation('home.v2');
     const isShowNavBarRedesign = useShowNavBarRedesign();
     const activeTabs = useGetActiveTabs();
     const [selectedTab, setSelectedTab] = useState<string>(activeTabs[0].key || DEFAULT_TAB);

--- a/datahub-web-react/src/app/homeV3/context/hooks/useTemplateState.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/useTemplateState.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { useGlobalSettings } from '@app/context/GlobalSettingsContext';
 import { useUserContext } from '@app/context/useUserContext';
@@ -16,6 +17,8 @@ import { PageTemplateFragment } from '@graphql/template.generated';
 import { PageTemplateSurfaceType } from '@types';
 
 export function useTemplateState(templateType: PageTemplateSurfaceType) {
+    // DEFAULT_TEMPLATE module name getters call sync i18next.t('modules:...'); load first.
+    useTranslation('modules');
     const entityRegistry = useEntityRegistryV2();
     const [areTemplatesInitialized, setAreTemplatesInitialized] = useState(false);
     const [personalTemplate, setPersonalTemplate] = useState<PageTemplateFragment | null>(null);

--- a/datahub-web-react/src/app/homeV3/header/components/GreetingText.tsx
+++ b/datahub-web-react/src/app/homeV3/header/components/GreetingText.tsx
@@ -1,5 +1,6 @@
 import { PageTitle } from '@components';
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { useUserContext } from '@app/context/useUserContext';
@@ -17,6 +18,8 @@ const Container = styled.div`
 `;
 
 export default function GreetingText() {
+    // Ensure home.v2 is loaded before getGreetingText()'s sync i18next.t() calls.
+    useTranslation('home.v2');
     const greetingText = getGreetingText();
     const { user } = useUserContext();
     const entityRegistry = useEntityRegistryV2();

--- a/datahub-web-react/src/i18n/__tests__/i18n.test.ts
+++ b/datahub-web-react/src/i18n/__tests__/i18n.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { INITIAL_NAMESPACES, NAMESPACES } from '@src/i18n/namespaces';
+
+describe('i18n bootstrap namespaces', () => {
+    it('does not eagerly register namespaces for init-time loading', () => {
+        expect(INITIAL_NAMESPACES).toEqual([]);
+    });
+
+    it('still exports the full namespace registry for tooling and parity checks', () => {
+        expect(NAMESPACES.length).toBeGreaterThan(0);
+        expect(NAMESPACES).toContain('common.actions');
+        expect(NAMESPACES).toContain('home.v3');
+    });
+});

--- a/datahub-web-react/src/i18n/__tests__/i18n.test.ts
+++ b/datahub-web-react/src/i18n/__tests__/i18n.test.ts
@@ -1,6 +1,56 @@
+import fs from 'fs';
+import i18next from 'i18next';
+import resourcesToBackend from 'i18next-resources-to-backend';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 
 import { INITIAL_NAMESPACES, NAMESPACES } from '@src/i18n/namespaces';
+
+const LOCALES_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../locales');
+
+// Representative home-shell namespaces (matches useTranslation call sites on home V3).
+const HOME_FIRST_PAINT = [
+    'modules',
+    'home.v2',
+    'home.v3',
+    'search',
+    'common.actions',
+    'common.labels',
+    'misc',
+] as const;
+
+function loadResource(lng: string, ns: string): Record<string, string> {
+    return JSON.parse(fs.readFileSync(path.join(LOCALES_DIR, lng, `${ns}.json`), 'utf8'));
+}
+
+async function measureLoads(initNs: readonly string[], loadAfterInit: readonly string[] = []) {
+    const loads: string[] = [];
+    const instance = i18next.createInstance();
+
+    await instance
+        .use(
+            resourcesToBackend((lng: string, ns: string) => {
+                loads.push(`${lng}/${ns}`);
+                return Promise.resolve(loadResource(lng, ns));
+            }),
+        )
+        .init({
+            lng: 'en',
+            fallbackLng: 'en',
+            ns: [...initNs],
+            defaultNS: false,
+            initImmediate: false,
+            interpolation: { escapeValue: false },
+        });
+
+    const afterInit = loads.length;
+    if (loadAfterInit.length) {
+        await instance.loadNamespaces([...loadAfterInit]);
+    }
+
+    return { instance, loads, afterInit, afterAll: loads.length };
+}
 
 describe('i18n bootstrap namespaces', () => {
     it('does not eagerly register namespaces for init-time loading', () => {
@@ -11,5 +61,52 @@ describe('i18n bootstrap namespaces', () => {
         expect(NAMESPACES.length).toBeGreaterThan(0);
         expect(NAMESPACES).toContain('common.actions');
         expect(NAMESPACES).toContain('home.v3');
+    });
+});
+
+describe('i18n lazy namespace loading (before/after)', () => {
+    it('loads zero namespaces on init vs all namespaces previously', async () => {
+        const before = await measureLoads(NAMESPACES);
+        const after = await measureLoads(INITIAL_NAMESPACES);
+
+        expect(before.afterInit).toBe(NAMESPACES.length);
+        expect(after.afterInit).toBe(0);
+        expect(after.afterInit).toBeLessThan(before.afterInit);
+    });
+
+    it('loads only requested namespaces for home first paint and resolves translations', async () => {
+        const { instance, afterInit, afterAll, loads } = await measureLoads(INITIAL_NAMESPACES, HOME_FIRST_PAINT);
+
+        expect(afterInit).toBe(0);
+        expect(afterAll).toBe(HOME_FIRST_PAINT.length);
+        expect(loads).toEqual(HOME_FIRST_PAINT.map((ns) => `en/${ns}`));
+
+        expect(instance.t('home.v2:greeting.morning')).toBe('Good morning');
+        expect(instance.t('modules:yourAssets.moduleName')).toBe('Your Assets');
+        expect(instance.t('search:advancedFilter.selectOwners')).toBe('Select Owners');
+
+        // Deferred feature namespaces stay unloaded until navigated to.
+        expect(instance.t('settings.page:logOut')).toBe('logOut');
+        expect(loads.some((l) => l.includes('settings.page'))).toBe(false);
+        expect(loads.some((l) => l.includes('ingestion'))).toBe(false);
+    });
+
+    it('loads deferred namespaces on demand and only those languages on changeLanguage', async () => {
+        const { instance, loads } = await measureLoads(INITIAL_NAMESPACES, HOME_FIRST_PAINT);
+
+        await instance.loadNamespaces(['settings.page', 'ingestion']);
+        expect(instance.t('settings.page:logOut')).toBe('Log Out');
+        expect(instance.t('ingestion:assets.title')).toBe('Assets');
+
+        const beforeLang = loads.length;
+        await instance.changeLanguage('de');
+        const deLoads = loads.slice(beforeLang);
+
+        expect(deLoads.sort()).toEqual(
+            [...HOME_FIRST_PAINT, 'settings.page', 'ingestion'].map((ns) => `de/${ns}`).sort(),
+        );
+        expect(deLoads.length).toBeLessThan(NAMESPACES.length);
+        expect(instance.t('home.v2:greeting.morning')).toBe('Guten Morgen');
+        expect(instance.t('settings.page:logOut')).toBe('Abmelden');
     });
 });

--- a/datahub-web-react/src/i18n/i18n.ts
+++ b/datahub-web-react/src/i18n/i18n.ts
@@ -3,9 +3,9 @@ import HttpBackend, { HttpBackendOptions } from 'i18next-http-backend';
 import resourcesToBackend from 'i18next-resources-to-backend';
 import { initReactI18next } from 'react-i18next';
 
-import { NAMESPACES } from '@src/i18n/namespaces';
+import { INITIAL_NAMESPACES, NAMESPACES } from '@src/i18n/namespaces';
 
-export { NAMESPACES };
+export { INITIAL_NAMESPACES, NAMESPACES };
 
 if (import.meta.env.DEV) {
     const { HMRPlugin } = await import('i18next-hmr/plugin');
@@ -16,7 +16,9 @@ if (import.meta.env.DEV) {
 
 i18n.use(initReactI18next).init({
     fallbackLng: 'en',
-    ns: NAMESPACES,
+    ns: [...INITIAL_NAMESPACES],
+    // No default NS — every call site must pass an explicit namespace (useTranslation(ns) or ns:).
+    defaultNS: false,
     ...(import.meta.env.DEV && {
         backend: { loadPath: '/assets/locales/{{lng}}/{{ns}}.json' } satisfies HttpBackendOptions,
     }),

--- a/datahub-web-react/src/i18n/namespaces.ts
+++ b/datahub-web-react/src/i18n/namespaces.ts
@@ -68,3 +68,7 @@ export const NAMESPACES = [
     'shared.tags',
     'shared.time',
 ] as const;
+
+// Namespaces requested on i18n init. Empty so boot does not fetch every locale JSON /
+// dynamic-import chunk; useTranslation() / loadNamespaces() pull them on demand.
+export const INITIAL_NAMESPACES: readonly string[] = [];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stops i18next from fetching every locale namespace on app boot ([CAT-2695](https://linear.app/acryl-data/issue/CAT-2695/stop-eagerly-loading-all-i18n-namespaces-on-app-boot)).

Previously `ns: NAMESPACES` caused all namespaces to be requested at init. Init now uses an empty `ns` list (`INITIAL_NAMESPACES`) and `defaultNS: false`, so namespaces load on demand via `useTranslation()` / `loadNamespaces()`.

Also:
- Mirror the same empty-`ns` policy in Storybook (English remains eagerly bundled)
- Ensure a few sync `i18next.t()` call sites call `useTranslation` first so keys do not flash
- Update `RemirrorLocaleProvider` to use `useTranslation([])`
- Add before/after vitest coverage

## Prod vs dev (verified with `vite build`)

`ns: []` applies to **both**. Backends differ:

| Mode | Backend | Network shape |
|---|---|---|
| Dev | `i18next-http-backend` | one HTTP request **per namespace** JSON |
| Prod | `resourcesToBackend` + dynamic `import()` | Vite packs **all namespaces for a language into one chunk** (`en-*.js` ≈ 329 KB contains 68/68 EN namespaces). Not modulepreloaded. |

So:
- **Dev:** boot 68→0 requests; home first paint ≈ 7 JSON files (the earlier bench).
- **Prod:** this PR **defers** the ~329 KB active-language chunk until the first translation need (before: fetched at init via 68 imports that all hit the same chunk). It does **not** currently give per-namespace network savings in prod — that would need a separate Vite chunk-splitting change.

Unused languages remain separate chunks and stay unloaded until `changeLanguage`.

## Test plan

- [x] Before/after logical-load harness + correctness probes
- [x] Prod build inspection (`vite build`): `ns:[]` in bundle, single per-language locale chunk, no locale modulepreload
- [x] `yarn test src/i18n/__tests__/i18n.test.ts`
- [x] Targeted lint on touched files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6c53bb9-c612-4300-b4c1-fed1c895c089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6c53bb9-c612-4300-b4c1-fed1c895c089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

