### PR TITLE
fix(web): scope Data Product CSV exports

### DIFF
--- a/datahub-web-react/src/app/entityV2/dataProduct/DataProductEntitiesTab.tsx
+++ b/datahub-web-react/src/app/entityV2/dataProduct/DataProductEntitiesTab.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useEntityData } from '@app/entity/shared/EntityContext';
+import generateUseDownloadListDataProductAssets from '@app/entityV2/dataProduct/generateUseDownloadListDataProductAssets';
 import generateUseListDataProductAssets from '@app/entityV2/dataProduct/generateUseListDataProductAssets';
 import { generateUseListDataProductAssetsCount } from '@app/entityV2/dataProduct/generateUseListDataProductAssetsCount';
 import { SearchCardContext } from '@app/entityV2/shared/SearchCardContext';
@@ -16,6 +17,7 @@ export function DataProductEntitiesTab() {
             <EmbeddedListSearchSection
                 useGetSearchResults={generateUseListDataProductAssets({ urn })}
                 useGetSearchCountResult={generateUseListDataProductAssetsCount({ urn })}
+                useGetDownloadSearchResults={generateUseDownloadListDataProductAssets({ urn })}
                 emptySearchQuery="*"
                 placeholderText={t('shared.filterAssetsPlaceholder')}
                 skipCache

--- a/datahub-web-react/src/app/entityV2/dataProduct/__tests__/DataProductEntitiesTab.test.tsx
+++ b/datahub-web-react/src/app/entityV2/dataProduct/__tests__/DataProductEntitiesTab.test.tsx
@@ -1,0 +1,45 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { useEntityData } from '@app/entity/shared/EntityContext';
+import { DataProductEntitiesTab } from '@app/entityV2/dataProduct/DataProductEntitiesTab';
+import { EmbeddedListSearchSection } from '@app/entityV2/shared/components/styled/search/EmbeddedListSearchSection';
+
+vi.mock('@app/entity/shared/EntityContext', () => ({
+    useEntityData: vi.fn(),
+}));
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('@app/entityV2/dataProduct/generateUseListDataProductAssets', () => ({
+    default: vi.fn(() => vi.fn()),
+}));
+vi.mock('@app/entityV2/dataProduct/generateUseListDataProductAssetsCount', () => ({
+    generateUseListDataProductAssetsCount: vi.fn(() => vi.fn()),
+}));
+vi.mock('@app/entityV2/shared/components/styled/search/EmbeddedListSearchSection', () => ({
+    EmbeddedListSearchSection: vi.fn(() => null),
+}));
+
+describe('DataProductEntitiesTab', () => {
+    beforeEach(() => {
+        (useEntityData as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+            urn: 'urn:li:dataProduct:analytics',
+        });
+    });
+
+    afterEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('uses the data product-scoped download hook for CSV exports', () => {
+        render(<DataProductEntitiesTab />);
+
+        expect(EmbeddedListSearchSection).toHaveBeenCalledWith(
+            expect.objectContaining({
+                useGetDownloadSearchResults: expect.any(Function),
+            }),
+            expect.any(Object),
+        );
+    });
+});

--- a/datahub-web-react/src/app/entityV2/dataProduct/__tests__/generateUseDownloadListDataProductAssets.test.ts
+++ b/datahub-web-react/src/app/entityV2/dataProduct/__tests__/generateUseDownloadListDataProductAssets.test.ts
@@ -1,0 +1,78 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import generateUseDownloadListDataProductAssets from '@app/entityV2/dataProduct/generateUseDownloadListDataProductAssets';
+
+import { useListDataProductAssetsQuery } from '@graphql/search.generated';
+
+vi.mock('@graphql/search.generated', () => ({
+    useListDataProductAssetsQuery: vi.fn(),
+}));
+
+describe('generateUseDownloadListDataProductAssets', () => {
+    const refetch = vi.fn();
+    const downloadInput = {
+        types: [],
+        query: '*',
+        count: 100,
+        orFilters: [],
+        scrollId: null,
+    };
+
+    beforeEach(() => {
+        (useListDataProductAssetsQuery as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+            data: {
+                listDataProductAssets: {
+                    count: 100,
+                    total: 150,
+                    searchResults: [],
+                },
+            },
+            loading: false,
+            error: undefined,
+            refetch,
+        });
+    });
+
+    afterEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('downloads data product assets with a product-scoped paginated query', async () => {
+        refetch.mockResolvedValue({
+            data: {
+                listDataProductAssets: {
+                    count: 50,
+                    total: 150,
+                    searchResults: [],
+                },
+            },
+        });
+
+        const useDownloadSearchResults = generateUseDownloadListDataProductAssets({
+            urn: 'urn:li:dataProduct:analytics',
+        });
+        const { result } = renderHook(() =>
+            useDownloadSearchResults({ variables: { input: downloadInput }, skip: true }),
+        );
+
+        expect(useListDataProductAssetsQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                variables: {
+                    urn: 'urn:li:dataProduct:analytics',
+                    input: expect.objectContaining({ start: 0 }),
+                },
+            }),
+        );
+        expect(result.current.searchResults?.nextScrollId).toBe('100');
+
+        await act(async () => {
+            const nextPage = await result.current.refetch({ ...downloadInput, scrollId: '100' });
+            expect(nextPage?.nextScrollId).toBeUndefined();
+        });
+
+        expect(refetch).toHaveBeenCalledWith({
+            urn: 'urn:li:dataProduct:analytics',
+            input: expect.objectContaining({ start: 100 }),
+        });
+    });
+});

--- a/datahub-web-react/src/app/entityV2/dataProduct/__tests__/generateUseDownloadListDataProductAssets.test.ts
+++ b/datahub-web-react/src/app/entityV2/dataProduct/__tests__/generateUseDownloadListDataProductAssets.test.ts
@@ -25,6 +25,7 @@ describe('generateUseDownloadListDataProductAssets', () => {
                     count: 100,
                     total: 150,
                     searchResults: [],
+                    facets: null,
                 },
             },
             loading: false,
@@ -64,6 +65,7 @@ describe('generateUseDownloadListDataProductAssets', () => {
             }),
         );
         expect(result.current.searchResults?.nextScrollId).toBe('100');
+        expect(result.current.searchResults?.facets).toBeUndefined();
 
         await act(async () => {
             const nextPage = await result.current.refetch({ ...downloadInput, scrollId: '100' });
@@ -74,5 +76,34 @@ describe('generateUseDownloadListDataProductAssets', () => {
             urn: 'urn:li:dataProduct:analytics',
             input: expect.objectContaining({ start: 100 }),
         });
+    });
+
+    it('handles malformed cursors and absent product results safely', () => {
+        (useListDataProductAssetsQuery as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+            data: { listDataProductAssets: null },
+            loading: false,
+            error: undefined,
+            refetch,
+        });
+
+        const useDownloadSearchResults = generateUseDownloadListDataProductAssets({
+            urn: 'urn:li:dataProduct:analytics',
+        });
+        const { result } = renderHook(() =>
+            useDownloadSearchResults({
+                variables: { input: { ...downloadInput, scrollId: 'invalid-cursor' } },
+                skip: true,
+            }),
+        );
+
+        expect(useListDataProductAssetsQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                variables: {
+                    urn: 'urn:li:dataProduct:analytics',
+                    input: expect.objectContaining({ start: 0 }),
+                },
+            }),
+        );
+        expect(result.current.searchResults).toBeUndefined();
     });
 });

--- a/datahub-web-react/src/app/entityV2/dataProduct/generateUseDownloadListDataProductAssets.ts
+++ b/datahub-web-react/src/app/entityV2/dataProduct/generateUseDownloadListDataProductAssets.ts
@@ -4,10 +4,10 @@ import {
     DownloadSearchResultsParams,
 } from '@app/search/utils/types';
 
-import { useListDataProductAssetsQuery } from '@graphql/search.generated';
+import { ListDataProductAssetsQuery, useListDataProductAssetsQuery } from '@graphql/search.generated';
 
 const DEFAULT_DOWNLOAD_PAGE_SIZE = 100;
-type DataProductSearchResults = Omit<DownloadSearchResults, 'nextScrollId'>;
+type DataProductSearchResults = NonNullable<ListDataProductAssetsQuery['listDataProductAssets']>;
 
 function getDownloadStart(scrollId: string | null | undefined): number {
     const parsedScrollId = Number.parseInt(scrollId || '0', 10);
@@ -27,7 +27,10 @@ function toDownloadSearchResults(
     const nextStart = start + count;
 
     return {
-        ...searchResults,
+        count: searchResults.count,
+        total: searchResults.total,
+        searchResults: searchResults.searchResults,
+        facets: searchResults.facets || undefined,
         nextScrollId: nextStart < searchResults.total ? `${nextStart}` : undefined,
     };
 }

--- a/datahub-web-react/src/app/entityV2/dataProduct/generateUseDownloadListDataProductAssets.ts
+++ b/datahub-web-react/src/app/entityV2/dataProduct/generateUseDownloadListDataProductAssets.ts
@@ -1,0 +1,70 @@
+import {
+    DownloadSearchResults,
+    DownloadSearchResultsInput,
+    DownloadSearchResultsParams,
+} from '@app/search/utils/types';
+
+import { useListDataProductAssetsQuery } from '@graphql/search.generated';
+
+const DEFAULT_DOWNLOAD_PAGE_SIZE = 100;
+type DataProductSearchResults = Omit<DownloadSearchResults, 'nextScrollId'>;
+
+function getDownloadStart(scrollId: string | null | undefined): number {
+    const parsedScrollId = Number.parseInt(scrollId || '0', 10);
+    return Number.isNaN(parsedScrollId) ? 0 : parsedScrollId;
+}
+
+function toDownloadSearchResults(
+    searchResults: DataProductSearchResults | null | undefined,
+    start: number,
+    requestedCount: number | null | undefined,
+): DownloadSearchResults | undefined {
+    if (!searchResults) {
+        return undefined;
+    }
+
+    const count = searchResults.count || requestedCount || DEFAULT_DOWNLOAD_PAGE_SIZE;
+    const nextStart = start + count;
+
+    return {
+        ...searchResults,
+        nextScrollId: nextStart < searchResults.total ? `${nextStart}` : undefined,
+    };
+}
+
+export default function generateUseDownloadListDataProductAssets({ urn }: { urn: string }) {
+    return function useDownloadListDataProductAssets(params: DownloadSearchResultsParams) {
+        const { scrollId, ...searchInput } = params.variables.input;
+        const start = getDownloadStart(scrollId);
+        const { data, loading, error, refetch } = useListDataProductAssetsQuery({
+            ...params,
+            variables: {
+                urn,
+                input: {
+                    ...searchInput,
+                    start,
+                },
+            },
+        });
+
+        return {
+            searchResults: toDownloadSearchResults(data?.listDataProductAssets, start, searchInput.count),
+            loading,
+            error,
+            refetch: (input: DownloadSearchResultsInput) => {
+                const { scrollId: nextScrollId, ...nextSearchInput } = input;
+                const nextStart = getDownloadStart(nextScrollId);
+
+                return refetch({
+                    urn,
+                    input: {
+                        ...nextSearchInput,
+                        start: nextStart,
+                    },
+                }).then((res) =>
+                    toDownloadSearchResults(res.data?.listDataProductAssets, nextStart, nextSearchInput.count),
+                );
+            },
+        };
+    };
+}


### PR DESCRIPTION
## Summary
- route Data Product asset CSV downloads through `listDataProductAssets` instead of global search
- preserve product scope across download pagination
- add focused regression coverage for hook injection and pagination

## Validation
- `./gradlew :datahub-web-react:yarnTest` — new regressions pass (4,507 passed); the only remaining failure is the pre-existing `SnapshotStatsView` five-second timeout
- pristine `c152d64a` rerun independently reproduces `SnapshotStatsView` plus other unrelated render timeouts
- `./gradlew :datahub-web-react:yarnLint -Pfile=…` passed for each changed source/test file
- `git diff --check` passed