### PR TITLE
fix(frontend): eliminate appConfig race by seeding Apollo link flags from GMS at startup

### DIFF
--- a/datahub-frontend/app/controllers/Application.java
+++ b/datahub-frontend/app/controllers/Application.java
@@ -211,7 +211,8 @@ public class Application extends Controller {
         return script.isEmpty() ? null : script;
       }
     } catch (Exception e) {
-      // Leave cachedInitialFlagsScript as null so the next request retries — GMS may not be ready yet.
+      // Leave cachedInitialFlagsScript as null so the next request retries — GMS may not be ready
+      // yet.
       logger.warn("Could not fetch GMS /config for initial flags injection: {}", e.getMessage());
     }
 

--- a/datahub-frontend/app/controllers/Application.java
+++ b/datahub-frontend/app/controllers/Application.java
@@ -24,6 +24,7 @@ import java.time.Instant;
 import java.util.*;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -66,6 +67,11 @@ public class Application extends Controller {
   private final String basePath;
   private final String gaTrackingId;
   private final List<String> streamingPathPrefixes;
+
+  // Cached initial flags fetched from GMS /config on first HTML request.
+  // Seeded into window.__INITIAL_FLAGS__ so the Apollo link has correct defaults
+  // before the appConfig GraphQL query resolves.
+  private final AtomicReference<String> cachedInitialFlagsScript = new AtomicReference<>(null);
 
   @Inject
   public Application(
@@ -119,6 +125,13 @@ public class Application extends Controller {
       // Inject <base href="..."/> right after <head> for use in the frontend.
       String modifiedHtml = html.replace("@basePath", basePath);
 
+      // Inject initial feature flags so the Apollo link has correct values before
+      // the appConfig GraphQL query resolves on the client.
+      String initialFlagsScript = getInitialFlagsScript();
+      if (initialFlagsScript != null) {
+        modifiedHtml = modifiedHtml.replace("</head>", initialFlagsScript + "</head>");
+      }
+
       // Inject google tracking if it exists, should only be enabled for demo site
       if (gaTrackingId != null && !gaTrackingId.isEmpty()) {
         String gaScript =
@@ -135,6 +148,74 @@ public class Application extends Controller {
       logger.warn("Cannot load public/index.html resource. Static assets or assets jar missing?");
       return notFound().withHeader("Cache-Control", "no-cache").as("text/html");
     }
+  }
+
+  /**
+   * Fetches featureFlags from GMS /config on first call and returns a script tag that seeds
+   * window.__INITIAL_FLAGS__. Returns null if GMS is unreachable or flags are all false (no-op).
+   * Result is cached for the lifetime of the process — flags are static config, not per-user.
+   */
+  @Nullable
+  private String getInitialFlagsScript() {
+    String cached = cachedInitialFlagsScript.get();
+    if (cached != null) {
+      return cached.isEmpty() ? null : cached;
+    }
+
+    try {
+      final String metadataServiceHost =
+          ConfigUtil.getString(
+              config,
+              ConfigUtil.METADATA_SERVICE_HOST_CONFIG_PATH,
+              ConfigUtil.DEFAULT_METADATA_SERVICE_HOST);
+      final int metadataServicePort =
+          ConfigUtil.getInt(
+              config,
+              ConfigUtil.METADATA_SERVICE_PORT_CONFIG_PATH,
+              ConfigUtil.DEFAULT_METADATA_SERVICE_PORT);
+      final boolean metadataServiceUseSsl =
+          ConfigUtil.getBoolean(
+              config,
+              ConfigUtil.METADATA_SERVICE_USE_SSL_CONFIG_PATH,
+              ConfigUtil.DEFAULT_METADATA_SERVICE_USE_SSL);
+
+      final String protocol = metadataServiceUseSsl ? "https" : "http";
+      final String configUrl =
+          String.format("%s://%s:%s/config", protocol, metadataServiceHost, metadataServicePort);
+
+      HttpRequest req =
+          HttpRequest.newBuilder()
+              .uri(URI.create(configUrl))
+              .timeout(Duration.ofSeconds(5))
+              .GET()
+              .build();
+
+      HttpResponse<String> resp =
+          httpClient.send(req, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+
+      if (resp.statusCode() == 200) {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode flags = mapper.readTree(resp.body()).path("featureFlags");
+
+        boolean showSeparateSiblings = flags.path("showSeparateSiblings").asBoolean(false);
+        boolean hideLineageInSearchCards = flags.path("hideLineageInSearchCards").asBoolean(false);
+
+        String script = "";
+        if (showSeparateSiblings || hideLineageInSearchCards) {
+          script =
+              String.format(
+                  "<script>window.__INITIAL_FLAGS__={\"showSeparateSiblings\":%b,\"hideLineageInSearchCards\":%b};</script>",
+                  showSeparateSiblings, hideLineageInSearchCards);
+        }
+        cachedInitialFlagsScript.set(script);
+        return script.isEmpty() ? null : script;
+      }
+    } catch (Exception e) {
+      // Leave cachedInitialFlagsScript as null so the next request retries — GMS may not be ready yet.
+      logger.warn("Could not fetch GMS /config for initial flags injection: {}", e.getMessage());
+    }
+
+    return null;
   }
 
   @Nonnull

--- a/datahub-web-react/src/app/appConfig/UpdateGlobalFlags.tsx
+++ b/datahub-web-react/src/app/appConfig/UpdateGlobalFlags.tsx
@@ -6,8 +6,17 @@ import { useAppConfig } from '@app/useAppConfig';
 
 import { AppConfig } from '@types';
 
-export const hideLineageInSearchCardsRef = { current: false };
-export const showSeparateSiblingsRef = { current: false };
+declare global {
+    interface Window {
+        __INITIAL_FLAGS__?: {
+            showSeparateSiblings?: boolean;
+            hideLineageInSearchCards?: boolean;
+        };
+    }
+}
+
+export const showSeparateSiblingsRef = { current: window.__INITIAL_FLAGS__?.showSeparateSiblings ?? false };
+export const hideLineageInSearchCardsRef = { current: window.__INITIAL_FLAGS__?.hideLineageInSearchCards ?? false };
 
 export const SHOW_SEPARATE_SIBLINGS_KEY = 'showSeparateSiblings';
 export const HIDE_LINEAGE_IN_SEARCH_CARDS_KEY = 'hideLineageInSearchCards';

--- a/metadata-service/servlet/src/main/java/com/datahub/gms/servlet/Config.java
+++ b/metadata-service/servlet/src/main/java/com/datahub/gms/servlet/Config.java
@@ -103,6 +103,15 @@ public class Config extends HttpServlet {
       datahubConfig.put("serverEnv", configProvider.getDatahub().serverEnv);
       newConfig.put("datahub", datahubConfig);
 
+      // Feature Flags (subset needed by the frontend before appConfig GraphQL resolves)
+      Map<String, Object> featureFlagsConfig = new HashMap<>();
+      featureFlagsConfig.put(
+          "showSeparateSiblings", configProvider.getFeatureFlags().isShowSeparateSiblings());
+      featureFlagsConfig.put(
+          "hideLineageInSearchCards",
+          configProvider.getFeatureFlags().isHideLineageInSearchCards());
+      newConfig.put("featureFlags", featureFlagsConfig);
+
       // pgQueue Configuration (exposed for Python CLI/executor)
       try {
         PostgresSqlSetupProperties pgProps = ctx.getBean(PostgresSqlSetupProperties.class);


### PR DESCRIPTION
## Summary

The `injectVariablesLink` in `App.tsx` reads two module-level refs (`showSeparateSiblingsRef`, `hideLineageInSearchCardsRef`) to set `skipSiblingsSearch` and `skipLineage` on every GraphQL request. These refs were hardcoded to `false` at module load time and only updated after the `appConfig` GraphQL query resolved — typically 1-2 seconds into page load. Any search fired before that (e.g. navigating directly to a search URL) always sent `false`, ignoring the configured flag values.

### Changes

- **`metadata-service/servlet/.../Config.java`** — GMS `/config` endpoint (unauthenticated, already in the auth excluded-paths list) now includes a `featureFlags` object with `showSeparateSiblings` and `hideLineageInSearchCards`.

- **`datahub-frontend/app/controllers/Application.java`** — `serveAsset()` now calls `getInitialFlagsScript()` on the first HTML request. That method fetches `/config` from GMS, caches the result for the pod's lifetime, and returns a `<script>window.__INITIAL_FLAGS__={...};</script>` tag. Subsequent requests read from the in-memory cache — no further GMS calls.

- **`datahub-web-react/src/app/appConfig/UpdateGlobalFlags.tsx`** — The two module-level refs now initialize from `window.__INITIAL_FLAGS__` with a `false` fallback, so the Apollo link has the correct values from byte zero.

### Behavior

- **Both flags false (default):** `getInitialFlagsScript` returns `null`, nothing is injected. The single GMS call at startup is a no-op for standard deployments.
- **Either flag true:** `window.__INITIAL_FLAGS__` is injected and refs initialize correctly — race condition eliminated.
- **GMS not yet ready on first request:** method returns `null` (no injection) and retries on the next request, until GMS responds and the result is cached.

## Test plan

- [ ] Start DataHub with `SHOW_SEPARATE_SIBLINGS=false` (default) — verify no `__INITIAL_FLAGS__` script in page source, search requests behave normally
- [ ] Start DataHub with `SHOW_SEPARATE_SIBLINGS=true` — verify `window.__INITIAL_FLAGS__.showSeparateSiblings === true` in page source, first search after page load sends `skipSiblingsSearch: true`
- [ ] Verify GMS `/config` response includes `featureFlags.showSeparateSiblings` and `featureFlags.hideLineageInSearchCards`

🤖 Generated with [Claude Code](https://claude.com/claude-code)