### PR TITLE
fix(ci): fix Update Test Weights workflow failures + Slack notifications

### DIFF
--- a/.github/scripts/download_test_artifacts.sh
+++ b/.github/scripts/download_test_artifacts.sh
@@ -164,11 +164,11 @@ else
     RUN_FILTER='select(.conclusion=="success" and .head_branch=="master")'
 fi
 
-# Fetch recent successful workflow runs from master branch
+# Fetch recent successful workflow runs from master branch.
 echo "Fetching recent workflow runs from master branch..."
 RUN_IDS=$(gh api "repos/$REPOSITORY/actions/workflows/$WORKFLOW_NAME/runs" \
-    --jq ".workflow_runs[] | $RUN_FILTER | .id" \
-    | head -n "$RUN_COUNT")
+    | jq -r --argjson n "$RUN_COUNT" \
+        '[.workflow_runs[] | '"$RUN_FILTER"' | .id][0:$n] | .[]')
 
 if [[ -z "$RUN_IDS" ]]; then
     if [[ "$NO_FAIL_ON_EMPTY" == "true" ]]; then

--- a/.github/scripts/download_test_artifacts.sh
+++ b/.github/scripts/download_test_artifacts.sh
@@ -17,6 +17,10 @@ REPOSITORY=""
 ARTIFACT_PREFIX="Test Results (smoke tests)"
 ALLOW_FAILED=false
 NO_FAIL_ON_EMPTY=false
+# When fewer than RUN_COUNT qualifying runs are found in the recent page, widen
+# the lookback window to at least this many days so a quiet stretch doesn't
+# starve the weight harvest.
+MIN_LOOKBACK_DAYS=3
 
 # Parse arguments
 usage() {
@@ -165,10 +169,36 @@ else
 fi
 
 # Fetch recent successful workflow runs from master branch.
+#
+# We want RUN_COUNT qualifying runs, but also look back at least
+# MIN_LOOKBACK_DAYS so a quiet few days don't under-harvest. Strategy: grab the
+# most recent page of runs first (cheap, ~30 items, already newest-first). If
+# it already yields RUN_COUNT qualifying runs, use them; otherwise widen to the
+# last MIN_LOOKBACK_DAYS (paginated) and take what's available.
+#
+# Limiting is done inside jq (not via `head`) so `gh api` is never killed by
+# SIGPIPE under `set -o pipefail`.
 echo "Fetching recent workflow runs from master branch..."
 RUN_IDS=$(gh api "repos/$REPOSITORY/actions/workflows/$WORKFLOW_NAME/runs" \
     | jq -r --argjson n "$RUN_COUNT" \
         '[.workflow_runs[] | '"$RUN_FILTER"' | .id][0:$n] | .[]')
+
+QUALIFYING_COUNT=$(printf '%s\n' "$RUN_IDS" | grep -c . || true)
+
+if [ "$QUALIFYING_COUNT" -lt "$RUN_COUNT" ]; then
+    # date fallback: GNU (`-d`) on the runner, BSD (`-v`) for local macOS dev.
+    SINCE_DATE=$(date -u -d "$MIN_LOOKBACK_DAYS days ago" +%Y-%m-%d 2>/dev/null \
+        || date -u -v-${MIN_LOOKBACK_DAYS}d +%Y-%m-%d)
+    echo "Only $QUALIFYING_COUNT qualifying run(s) in the recent page; widening to runs since $SINCE_DATE..."
+    # `gh api --paginate` streams one JSON object per page; `jq -s` slurps them
+    # into a single array so we can sort and slice across the whole window.
+    # The `created>=` filter goes in the URL query string (not `-f`): gh's field
+    # flag URL-encodes `>` and GitHub 404s on the encoded form.
+    RUN_IDS=$(gh api --paginate "repos/$REPOSITORY/actions/workflows/$WORKFLOW_NAME/runs?created=>=$SINCE_DATE" \
+        | jq -sr --argjson n "$RUN_COUNT" \
+            '[.[] | .workflow_runs[]? | '"$RUN_FILTER"' | {id: .id, created: .created_at}]
+             | sort_by(.created) | reverse | .[0:$n] | .[].id')
+fi
 
 if [[ -z "$RUN_IDS" ]]; then
     if [[ "$NO_FAIL_ON_EMPTY" == "true" ]]; then

--- a/.github/scripts/download_test_artifacts.sh
+++ b/.github/scripts/download_test_artifacts.sh
@@ -174,31 +174,75 @@ fi
 # MIN_LOOKBACK_DAYS so a quiet few days don't under-harvest. Strategy: grab the
 # most recent page of runs first (cheap, ~30 items, already newest-first). If
 # it already yields RUN_COUNT qualifying runs, use them; otherwise widen to the
-# last MIN_LOOKBACK_DAYS (paginated) and take what's available.
+# last MIN_LOOKBACK_DAYS (paginated) and merge with what we already have.
 #
 # Limiting is done inside jq (not via `head`) so `gh api` is never killed by
-# SIGPIPE under `set -o pipefail`.
+# SIGPIPE under `set -o pipefail`. Phase 2 is best-effort: transient GitHub API
+# failures (5xx/timeout) are retried, and if phase 2 still fails we fall back to
+# the phase 1 runs instead of aborting.
 echo "Fetching recent workflow runs from master branch..."
-RUN_IDS=$(gh api "repos/$REPOSITORY/actions/workflows/$WORKFLOW_NAME/runs" \
-    | jq -r --argjson n "$RUN_COUNT" \
-        '[.workflow_runs[] | '"$RUN_FILTER"' | .id][0:$n] | .[]')
 
-QUALIFYING_COUNT=$(printf '%s\n' "$RUN_IDS" | grep -c . || true)
+# gh api with retry on transient failures (5xx, timeouts). Returns non-zero
+# only if every attempt fails.
+gh_api_retry() {
+    local max_attempts=3 attempt=1 delay=5 rc=0
+    while [ "$attempt" -le "$max_attempts" ]; do
+        if gh api "$@"; then
+            return 0
+        fi
+        rc=$?
+        if [ "$attempt" -lt "$max_attempts" ]; then
+            echo "gh api call failed (exit $rc); retrying in ${delay}s..." >&2
+            sleep "$delay"
+            delay=$((delay * 2))
+        fi
+        attempt=$((attempt + 1))
+    done
+    return "$rc"
+}
+
+# Phase 1: most recent page (cheap, ~30 items, already newest-first).
+PHASE1_FILE=$(mktemp)
+if ! gh_api_retry "repos/$REPOSITORY/actions/workflows/$WORKFLOW_NAME/runs" > "$PHASE1_FILE"; then
+    rm -f "$PHASE1_FILE"
+    echo "Error: Failed to fetch workflow runs from GitHub API" >&2
+    exit 1
+fi
+RUNS_JSON=$(jq -c --argjson n "$RUN_COUNT" \
+    '[.workflow_runs[] | '"$RUN_FILTER"' | {id: .id, created: .created_at}][0:$n]' \
+    "$PHASE1_FILE")
+rm -f "$PHASE1_FILE"
+
+QUALIFYING_COUNT=$(printf '%s' "$RUNS_JSON" | jq 'length')
 
 if [ "$QUALIFYING_COUNT" -lt "$RUN_COUNT" ]; then
     # date fallback: GNU (`-d`) on the runner, BSD (`-v`) for local macOS dev.
     SINCE_DATE=$(date -u -d "$MIN_LOOKBACK_DAYS days ago" +%Y-%m-%d 2>/dev/null \
         || date -u -v-${MIN_LOOKBACK_DAYS}d +%Y-%m-%d)
     echo "Only $QUALIFYING_COUNT qualifying run(s) in the recent page; widening to runs since $SINCE_DATE..."
+    PHASE2_FILE=$(mktemp)
     # `gh api --paginate` streams one JSON object per page; `jq -s` slurps them
     # into a single array so we can sort and slice across the whole window.
     # The `created>=` filter goes in the URL query string (not `-f`): gh's field
     # flag URL-encodes `>` and GitHub 404s on the encoded form.
-    RUN_IDS=$(gh api --paginate "repos/$REPOSITORY/actions/workflows/$WORKFLOW_NAME/runs?created=>=$SINCE_DATE" \
-        | jq -sr --argjson n "$RUN_COUNT" \
+    if gh_api_retry --paginate "repos/$REPOSITORY/actions/workflows/$WORKFLOW_NAME/runs?created=>=$SINCE_DATE" > "$PHASE2_FILE"; then
+        PHASE2=$(jq -s --argjson n "$RUN_COUNT" \
             '[.[] | .workflow_runs[]? | '"$RUN_FILTER"' | {id: .id, created: .created_at}]
-             | sort_by(.created) | reverse | .[0:$n] | .[].id')
+             | sort_by(.created) | reverse | .[0:$n]' \
+            "$PHASE2_FILE")
+        # Merge phase 1 + phase 2, dedup by id, keep newest RUN_COUNT. Phase 1
+        # runs are preserved even if phase 2 found nothing (e.g. the only
+        # qualifying runs are older than MIN_LOOKBACK_DAYS).
+        RUNS_JSON=$(printf '%s\n%s\n' "$RUNS_JSON" "$PHASE2" \
+            | jq -sr --argjson n "$RUN_COUNT" \
+                'add | unique_by(.id) | sort_by(.created) | reverse | .[0:$n]')
+    else
+        echo "Warning: phase 2 widening fetch failed; falling back to phase 1 ($QUALIFYING_COUNT qualifying run(s))." >&2
+    fi
+    rm -f "$PHASE2_FILE"
 fi
+
+RUN_IDS=$(printf '%s' "$RUNS_JSON" | jq -r '.[].id')
 
 if [[ -z "$RUN_IDS" ]]; then
     if [[ "$NO_FAIL_ON_EMPTY" == "true" ]]; then

--- a/.github/scripts/download_test_artifacts.sh
+++ b/.github/scripts/download_test_artifacts.sh
@@ -5,7 +5,7 @@
 # This script uses the GitHub CLI (gh) to fetch workflow runs and download
 # test result artifacts, organizing them by run ID for later processing.
 
-set -euo pipefail
+set -euxo pipefail
 
 # Default values
 OUTPUT_DIR="./dev-artifacts/test-results"

--- a/.github/scripts/generate_test_weights.py
+++ b/.github/scripts/generate_test_weights.py
@@ -211,8 +211,8 @@ def calculate_median_weights(
         median = statistics.median(durations)
         results.append({key_name: test_id, "duration": f"{median:.3f}s"})
 
-    # Sort by duration descending
-    results.sort(key=lambda x: float(x["duration"][:-1]), reverse=True)
+    # Sort alphabetically by test identifier for stable, reviewable diffs.
+    results.sort(key=lambda x: x[key_name])
 
     return results
 
@@ -316,28 +316,6 @@ def main():
             json.dump(weights, f, indent=2)
             f.write("\n")
         print(f"Wrote {len(weights)} {label} weights to: {output_path}")
-
-    # Print top 5 longest tests for each type
-    if cypress_weights:
-        print("\n" + "=" * 60)
-        print("Top 5 longest Cypress tests:")
-        print("=" * 60)
-        for i, test in enumerate(cypress_weights[:5], 1):
-            print(f"{i}. {test['filePath']}: {test['duration']}")
-
-    if pytest_weights:
-        print("\n" + "=" * 60)
-        print("Top 5 longest Pytest tests:")
-        print("=" * 60)
-        for i, test in enumerate(pytest_weights[:5], 1):
-            print(f"{i}. {test['testId']}: {test['duration']}")
-
-    if gradle_weights:
-        print("\n" + "=" * 60)
-        print("Top 5 longest Gradle tests:")
-        print("=" * 60)
-        for i, test in enumerate(gradle_weights[:5], 1):
-            print(f"{i}. {test['testId']}: {test['duration']}")
 
     print("\n" + "=" * 60)
     print("Done!")

--- a/.github/workflows/update-test-weights.yml
+++ b/.github/workflows/update-test-weights.yml
@@ -23,6 +23,9 @@ jobs:
     if: github.repository == 'datahub-project/datahub'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      create_pr: ${{ steps.decide.outputs.create_pr }}
+      pr_url: ${{ steps.create-pr.outputs.pr_url }}
 
     steps:
       - name: Checkout repository
@@ -208,6 +211,7 @@ jobs:
           echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
 
       - name: Create pull request
+        id: create-pr
         if: steps.decide.outputs.create_pr == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -215,14 +219,15 @@ jobs:
           # Concatenate whichever PR body sections were generated (empty files contribute nothing)
           PR_BODY=$(cat ./pr-body-smoke.md ./pr-body-ingestion.md ./pr-body-gradle.md 2>/dev/null)
 
-          # Create PR
-          gh pr create \
+          # Create PR (gh pr create prints the PR URL to stdout)
+          PR_URL=$(gh pr create \
             --title "chore(test): Update test weights from CI runs ($(date +%Y-%m-%d))" \
             --body "$PR_BODY" \
             --head "$BRANCH_NAME" \
-            --base master
+            --base master)
 
-          echo "✓ Pull request created successfully"
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "✓ Pull request created successfully: $PR_URL"
 
       - name: Summary
         if: always()
@@ -260,3 +265,56 @@ jobs:
             echo ""
             echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  notify-slack:
+    name: Notify Slack
+    needs: update-weights
+    if: always() && github.repository == 'datahub-project/datahub'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Post Slack notification
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.CI_NOTIFIER_SLACK_BOT_TOKEN }}
+          CHANNEL: ${{ vars.BUILD_STATUS_NOTIFICATION_SLACK_CHANNEL }}
+          PR_URL: ${{ needs.update-weights.outputs.pr_url }}
+          CREATE_PR: ${{ needs.update-weights.outputs.create_pr }}
+          JOB_STATUS: ${{ needs.update-weights.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$SLACK_BOT_TOKEN" ]; then
+            echo "CI_NOTIFIER_SLACK_BOT_TOKEN not set; skipping Slack notification."
+            exit 0
+          fi
+          if [ -z "$CHANNEL" ]; then
+            echo "BUILD_STATUS_NOTIFICATION_SLACK_CHANNEL not set; skipping Slack notification."
+            exit 0
+          fi
+
+          # Decide what (if anything) to post:
+          #   - workflow failed/timed out  -> failure notification with a link to the run
+          #   - workflow succeeded + PR made -> success notification with a link to the PR
+          #   - workflow succeeded, no PR   -> nothing to surface (below threshold); skip
+          if [ "$JOB_STATUS" = "failure" ] || [ "$JOB_STATUS" = "timed_out" ]; then
+            MESSAGE=":x: *Update Test Weights* workflow failed — <${RUN_URL}|view run>"
+          elif [ "$JOB_STATUS" = "success" ] && [ "$CREATE_PR" = "true" ] && [ -n "$PR_URL" ]; then
+            MESSAGE=":white_check_mark: *Update Test Weights* created a test-weight refresh PR — <${PR_URL}|view PR>"
+          else
+            echo "Nothing to notify (status=$JOB_STATUS, create_pr=$CREATE_PR)."
+            exit 0
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg channel "$CHANNEL" \
+            --arg text "$MESSAGE" \
+            '{channel: $channel, text: $text, mrkdwn: true, unfurl_links: false, unfurl_media: false}')
+
+          RESPONSE=$(curl -fsS -X POST \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            -d "$PAYLOAD" \
+            https://slack.com/api/chat.postMessage)
+
+          echo "Slack response: $RESPONSE"
+          echo "$RESPONSE" | jq -e '.ok == true' > /dev/null \
+            || { echo "Slack chat.postMessage call failed"; exit 1; }

--- a/.github/workflows/update-test-weights.yml
+++ b/.github/workflows/update-test-weights.yml
@@ -32,11 +32,15 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          # Always base the weight-refresh PR off the default branch, even when
+          # dispatched from a feature branch, so the PR contains only test-weight
+          # changes and not the dispatch branch's local commits.
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Download smoke test artifacts
         env:
@@ -224,7 +228,7 @@ jobs:
             --title "chore(test): Update test weights from CI runs ($(date +%Y-%m-%d))" \
             --body "$PR_BODY" \
             --head "$BRANCH_NAME" \
-            --base master)
+            --base "${{ github.event.repository.default_branch }}")
 
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
           echo "✓ Pull request created successfully: $PR_URL"


### PR DESCRIPTION
## Summary
Fixes the recurring `Update Test Weights` weekly workflow failures and adds several robustness/quality improvements to the test-weight refresh pipeline.

### Root-cause fix (SIGPIPE)
The workflow had been failing every run (exit 141 / SIGPIPE) since the Gradle `build-and-test.yml` artifact download was added. `gh api ... | head -n N` under `set -o pipefail` aborts whenever a workflow has more than `RUN_COUNT` qualifying master runs. Run selection now limits inside `jq` so `gh api` is never killed mid-stream.

### Robustness
- **3-day lookback fallback**: when the recent runs page yields fewer than `RUN_COUNT` qualifying runs, widen to all runs created in the last `MIN_LOOKBACK_DAYS` (default 3) and merge with what was already found.
- **Retry + best-effort phase 2**: transient GitHub API failures (5xx/timeout, e.g. the HTTP 504 that took down a run) are retried; if the widened fetch still fails, the script falls back to the phase-1 runs instead of aborting. Phase 2 merges with (and dedups against) phase 1, so widening can never discard qualifying runs already found.
- **Shell debug tracing**: `set -x` enabled in `download_test_artifacts.sh` to make future failures easier to diagnose.

### Slack notifications
New `notify-slack` job posts to `vars.BUILD_STATUS_NOTIFICATION_SLACK_CHANNEL` after `update-weights` finishes:
- a link to the created test-weight refresh PR on success, or
- a failure notification with a link to the run on failure.

The create-PR step now captures the PR URL and exposes it as a job output.

### Workflow hygiene
- Bumped `actions/setup-python` to **Python 3.11** (the stdlib-only scripts need no changes).
- The workflow always checks out the **default branch** (`ref: github.event.repository.default_branch`) and targets it as the PR base, so a weight-refresh PR triggered from a feature branch contains only test-weight changes — not that branch's local commits.

### Output quality
- Generated weight files are now **sorted alphabetically** by test identifier (instead of by duration descending), so weekly refresh PRs produce stable, reviewable diffs. The "Top 5 longest tests" console summary (which relied on the old ordering) was removed. Consumers load weights into dicts and re-sort internally, so file order has no functional effect.

## Test plan
- [ ] `Update Test Weights` workflow (manual `workflow_dispatch`) completes the artifact-download steps without exit 141.
- [ ] 3-day lookback fallback kicks in when fewer than `run_count` qualifying runs are on the recent page; a transient `gh api` 504 no longer aborts the run.
- [ ] Slack notification posts the PR link to `BUILD_STATUS_NOTIFICATION_SLACK_CHANNEL` when a PR is created, and a failure notification (with run link) when the workflow fails.
- [ ] Dispatching the workflow from a feature branch produces a PR based off `master` containing only test-weight changes.
- [ ] Regenerated weight files are sorted alphabetically by test identifier.