### PR TITLE
feat(web): show GraphQL operation names in Chrome Network tab

### DIFF
--- a/datahub-frontend/app/controllers/Application.java
+++ b/datahub-frontend/app/controllers/Application.java
@@ -200,8 +200,16 @@ public class Application extends Controller {
         String.format(
             "%s://%s:%s%s%s",
             protocol, metadataServiceHost, metadataServicePort, resolvedBasePath, resolvedUri);
+    final URI targetUri;
+    try {
+      targetUri = URI.create(targetUrl);
+    } catch (IllegalArgumentException e) {
+      // Malformed path/query (e.g. unencoded spaces) — return 400 rather than an unhandled 500.
+      logger.warn("Rejecting proxy request with invalid URI: {}", request.uri());
+      return CompletableFuture.completedFuture(badRequest("Invalid request path or query string"));
+    }
     HttpRequest.Builder httpRequestBuilder =
-        HttpRequest.newBuilder().uri(URI.create(targetUrl)).timeout(Duration.ofSeconds(120));
+        HttpRequest.newBuilder().uri(targetUri).timeout(Duration.ofSeconds(120));
     httpRequestBuilder.method(request.method(), buildBodyPublisher(request));
     Map<String, List<String>> headers = request.getHeaders().toMap();
     if (headers.containsKey(Http.HeaderNames.HOST)
@@ -470,12 +478,13 @@ public class Application extends Controller {
    *
    * <p>Query strings are preserved after path rewriting so callers can attach non-routing metadata
    * (e.g. {@code ?operationName=...} for Chrome DevTools Network filtering) without breaking the
-   * GraphQL / GMS path maps.
+   * GraphQL / GMS path maps. Malformed query strings (characters that cannot form a legal URI) are
+   * dropped so path rewriting still succeeds and {@link URI#create(String)} does not throw later.
    */
   private String mapPath(@Nonnull final String path) {
     final int queryIndex = path.indexOf('?');
     final String pathOnly = queryIndex >= 0 ? path.substring(0, queryIndex) : path;
-    final String query = queryIndex >= 0 ? path.substring(queryIndex) : "";
+    final String query = queryIndex >= 0 ? sanitizeQuerySuffix(path.substring(queryIndex)) : "";
 
     final String strippedPath;
 
@@ -503,6 +512,23 @@ public class Application extends Controller {
 
     // Otherwise, return the stripped path
     return strippedPath + query;
+  }
+
+  /**
+   * Returns {@code queryWithPrefix} (including the leading {@code ?}) when it is a legal URI query
+   * suffix; otherwise returns empty so a bad query cannot break path mapping or URI construction.
+   */
+  @Nonnull
+  static String sanitizeQuerySuffix(@Nonnull final String queryWithPrefix) {
+    if (queryWithPrefix.isEmpty() || queryWithPrefix.equals("?")) {
+      return "";
+    }
+    try {
+      URI.create("http://localhost/" + queryWithPrefix);
+      return queryWithPrefix;
+    } catch (IllegalArgumentException e) {
+      return "";
+    }
   }
 
   /**

--- a/datahub-frontend/app/controllers/Application.java
+++ b/datahub-frontend/app/controllers/Application.java
@@ -467,21 +467,28 @@ public class Application extends Controller {
    * GMS, streaming) use this stripped path. When using a base path, set datahub.basePath to the
    * same value as play.http.context so that stripping works (Play may already strip context from
    * request.uri(); stripBasePath returns the path unchanged if the prefix is not present).
+   *
+   * <p>Query strings are preserved after path rewriting so callers can attach non-routing metadata
+   * (e.g. {@code ?operationName=...} for Chrome DevTools Network filtering) without breaking the
+   * GraphQL / GMS path maps.
    */
   private String mapPath(@Nonnull final String path) {
+    final int queryIndex = path.indexOf('?');
+    final String pathOnly = queryIndex >= 0 ? path.substring(0, queryIndex) : path;
+    final String query = queryIndex >= 0 ? path.substring(queryIndex) : "";
 
     final String strippedPath;
 
     // Cannot strip base path from swagger urls
-    if (SWAGGER_PATHS.stream().noneMatch(path::contains)) {
-      strippedPath = BasePathUtils.stripBasePath(path, this.basePath);
+    if (SWAGGER_PATHS.stream().noneMatch(pathOnly::contains)) {
+      strippedPath = BasePathUtils.stripBasePath(pathOnly, this.basePath);
     } else {
-      strippedPath = path;
+      strippedPath = pathOnly;
     }
 
     // Case 1: Map legacy GraphQL path to GMS GraphQL API (for compatibility)
     if (strippedPath.equals("/api/v2/graphql")) {
-      return "/api/graphql";
+      return "/api/graphql" + query;
     }
 
     // Case 2: Map requests to /gms to / (Rest.li API)
@@ -491,11 +498,11 @@ public class Application extends Controller {
       if (!newPath.startsWith("/")) {
         newPath = "/" + newPath;
       }
-      return newPath;
+      return newPath + query;
     }
 
     // Otherwise, return the stripped path
-    return strippedPath;
+    return strippedPath + query;
   }
 
   /**

--- a/datahub-frontend/test/controllers/ApplicationControllerTest.java
+++ b/datahub-frontend/test/controllers/ApplicationControllerTest.java
@@ -365,6 +365,13 @@ public class ApplicationControllerTest {
   }
 
   @Test
+  void mapPath_apiV2Graphql_dropsMalformedQueryButStillMapsPath() throws Exception {
+    // Unencoded space / braces are illegal in URI.create; drop query, keep GraphQL rewrite.
+    assertEquals("/api/graphql", invokeMapPath("/api/v2/graphql?operationName=app Config"));
+    assertEquals("/api/graphql", invokeMapPath("/api/v2/graphql?filter={}"));
+  }
+
+  @Test
   void mapPath_apiGmsPrefix_stripsGmsPrefix() throws Exception {
     assertEquals("/entities", invokeMapPath("/api/gms/entities"));
   }
@@ -403,6 +410,33 @@ public class ApplicationControllerTest {
             configWithBasePath,
             mock(GracefulShutdownModule.class));
     assertEquals("/api/graphql", invokeMapPath(appWithBasePath, "/datahub/api/graphql"));
+  }
+
+  @Test
+  void mapPath_withBasePath_preservesGraphqlOperationNameQuery() throws Exception {
+    Map<String, Object> configMap = new HashMap<>();
+    configMap.put("datahub.basePath", "/datahub");
+    configMap.put("proxy.streamingPathPrefixes", "");
+    Config configWithBasePath = ConfigFactory.parseMap(configMap);
+    Application appWithBasePath =
+        new Application(
+            mock(HttpClient.class),
+            mock(Environment.class),
+            configWithBasePath,
+            mock(GracefulShutdownModule.class));
+    assertEquals(
+        "/api/graphql?operationName=appConfig",
+        invokeMapPath(appWithBasePath, "/datahub/api/v2/graphql?operationName=appConfig"));
+  }
+
+  @Test
+  void proxy_malformedPath_returnsBadRequestWithoutCallingUpstream() throws Exception {
+    Http.Request request = mockProxyRequest("/api/gms/foo bar", Optional.empty());
+
+    Result result = application.proxy("foo bar", request).get();
+
+    assertEquals(400, result.status());
+    verify(mockHttpClient, never()).sendAsync(any(), any());
   }
 
   private Http.Request mockProxyRequest(String uri, Optional<String> contentType) {

--- a/datahub-frontend/test/controllers/ApplicationControllerTest.java
+++ b/datahub-frontend/test/controllers/ApplicationControllerTest.java
@@ -358,8 +358,20 @@ public class ApplicationControllerTest {
   }
 
   @Test
+  void mapPath_apiV2Graphql_preservesOperationNameQuery() throws Exception {
+    assertEquals(
+        "/api/graphql?operationName=appConfig",
+        invokeMapPath("/api/v2/graphql?operationName=appConfig"));
+  }
+
+  @Test
   void mapPath_apiGmsPrefix_stripsGmsPrefix() throws Exception {
     assertEquals("/entities", invokeMapPath("/api/gms/entities"));
+  }
+
+  @Test
+  void mapPath_apiGmsPrefix_preservesQueryString() throws Exception {
+    assertEquals("/entities?aspects=List", invokeMapPath("/api/gms/entities?aspects=List"));
   }
 
   @Test

--- a/datahub-web-react/src/App.tsx
+++ b/datahub-web-react/src/App.tsx
@@ -21,6 +21,7 @@ import { PageRoutes } from '@conf/Global';
 import CustomThemeProvider from '@src/CustomThemeProvider';
 import { GlobalCfg } from '@src/conf';
 import { useCustomTheme } from '@src/customThemeContext';
+import { buildGraphqlHttpUri } from '@src/graphqlHttpUri';
 import { otelOperationLink } from '@src/otelApollo';
 import possibleTypesResult from '@src/possibleTypes.generated';
 import { getRuntimeBasePath, removeRuntimePath, resolveRuntimePath } from '@utils/runtimeBasePath';
@@ -29,7 +30,7 @@ import { getRuntimeBasePath, removeRuntimePath, resolveRuntimePath } from '@util
     Construct Apollo Client
 */
 const httpLink = createHttpLink({
-    uri: resolveRuntimePath(`/api/v2/graphql`),
+    uri: ({ operationName }) => buildGraphqlHttpUri(operationName),
 });
 
 const errorLink = onError((error) => {

--- a/datahub-web-react/src/__tests__/graphqlHttpUri.test.ts
+++ b/datahub-web-react/src/__tests__/graphqlHttpUri.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildGraphqlHttpUri } from '@src/graphqlHttpUri';
+
+describe('buildGraphqlHttpUri', () => {
+    it('appends operationName for Network tab filtering', () => {
+        expect(buildGraphqlHttpUri('appConfig')).toBe('/api/v2/graphql?operationName=appConfig');
+    });
+
+    it('falls back to anonymous when operation name is missing', () => {
+        expect(buildGraphqlHttpUri(undefined)).toBe('/api/v2/graphql?operationName=anonymous');
+        expect(buildGraphqlHttpUri(null)).toBe('/api/v2/graphql?operationName=anonymous');
+        expect(buildGraphqlHttpUri('')).toBe('/api/v2/graphql?operationName=anonymous');
+    });
+
+    it('URL-encodes operation names', () => {
+        expect(buildGraphqlHttpUri('get Dataset')).toBe('/api/v2/graphql?operationName=get%20Dataset');
+    });
+});

--- a/datahub-web-react/src/graphqlHttpUri.ts
+++ b/datahub-web-react/src/graphqlHttpUri.ts
@@ -1,0 +1,12 @@
+import { resolveRuntimePath } from '@utils/runtimeBasePath';
+
+/**
+ * Apollo HttpLink URI builder. Appends the GraphQL operation name as a query param so Chrome
+ * DevTools Network shows distinct rows (and supports filter-by-name) instead of dozens of identical
+ * `graphql` POSTs. GMS ignores the query string and still reads `operationName` from the body;
+ * OpenTelemetry fetch instrumentation redacts query strings from span URLs.
+ */
+export function buildGraphqlHttpUri(operationName?: string | null): string {
+    const name = operationName || 'anonymous';
+    return `${resolveRuntimePath('/api/v2/graphql')}?operationName=${encodeURIComponent(name)}`;
+}

--- a/e2e-test/ui/playwright/fixtures/login.fixture.ts
+++ b/e2e-test/ui/playwright/fixtures/login.fixture.ts
@@ -45,6 +45,7 @@ import { test as base } from '@playwright/test';
 import { users, type UserCredentials } from '../data/users';
 import { LoginPage } from '../pages/login.page';
 import { gmsTokenPath } from './login';
+import { DATAHUB_GRAPHQL_PATH } from '../utils/constants';
 import type { DataHubLogger } from '../utils/logger';
 
 // ── Fixture types ─────────────────────────────────────────────────────────────
@@ -170,7 +171,7 @@ export const loginFixture = base.extend<LoginFixtures, LoginFixtureOptions>({
           extraHTTPHeaders: { Cookie: cookieHeader },
         });
         try {
-          const resp = await apiCtx.post('/api/v2/graphql', {
+          const resp = await apiCtx.post(DATAHUB_GRAPHQL_PATH, {
             data: {
               query: `mutation createAccessToken($input: CreateAccessTokenInput!) {
                 createAccessToken(input: $input) { accessToken metadata { id } }

--- a/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
+++ b/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
@@ -49,7 +49,7 @@ import { test as base, request, type Browser } from '@playwright/test';
 import { readGmsToken, gmsTokenPath } from './login';
 import type { UserCredentials } from '../data/users';
 import { LoginPage } from '../pages/login.page';
-import { gmsUrl } from '../utils/constants';
+import { DATAHUB_GRAPHQL_PATH, gmsUrl } from '../utils/constants';
 import {
   extractUrn,
   normalizeMcp,
@@ -88,7 +88,7 @@ async function bootstrapGmsToken(browser: Browser, user: UserCredentials): Promi
       extraHTTPHeaders: { Cookie: cookieHeader },
     });
     try {
-      const resp = await apiCtx.post('/api/v2/graphql', {
+      const resp = await apiCtx.post(DATAHUB_GRAPHQL_PATH, {
         data: {
           query: `mutation createAccessToken($input: CreateAccessTokenInput!) {
             createAccessToken(input: $input) { accessToken metadata { id } }

--- a/e2e-test/ui/playwright/helpers/document-import-helper.ts
+++ b/e2e-test/ui/playwright/helpers/document-import-helper.ts
@@ -1,5 +1,7 @@
 import type { Page } from '@playwright/test';
 
+import { DATAHUB_GRAPHQL_PATH } from '../utils/constants';
+
 type GraphQLPayload = {
   data?: Record<string, unknown>;
   errors?: unknown;
@@ -10,7 +12,7 @@ export async function executeGraphQL(
   query: string,
   variables?: Record<string, unknown>,
 ): Promise<GraphQLPayload> {
-  const response = await page.request.post('/api/v2/graphql', {
+  const response = await page.request.post(DATAHUB_GRAPHQL_PATH, {
     data: { query, variables: variables ?? {} },
     headers: { 'Content-Type': 'application/json' },
   });

--- a/e2e-test/ui/playwright/helpers/graphql-helper.ts
+++ b/e2e-test/ui/playwright/helpers/graphql-helper.ts
@@ -1,12 +1,14 @@
 import { Page } from '@playwright/test';
 
+import { DATAHUB_GRAPHQL_PATH } from '../utils/constants';
+
 export type GraphQLResponse = Record<string, unknown>;
 
 export class GraphQLHelper {
   constructor(private page: Page) {}
 
   async executeQuery(query: string, variables?: Record<string, unknown>): Promise<GraphQLResponse> {
-    const response = await this.page.request.post('/api/v2/graphql', {
+    const response = await this.page.request.post(DATAHUB_GRAPHQL_PATH, {
       data: {
         query,
         variables: variables ?? {},

--- a/e2e-test/ui/playwright/helpers/seeders/graphql-seeder.ts
+++ b/e2e-test/ui/playwright/helpers/seeders/graphql-seeder.ts
@@ -1,7 +1,7 @@
 import { Page } from '@playwright/test';
 import * as fs from 'fs/promises';
 import { extractUrn, waitForSync, type Mcp, type Urn } from '../seeder-utils';
-import { gmsUrl } from '../../utils/constants';
+import { DATAHUB_GRAPHQL_PATH, gmsUrl } from '../../utils/constants';
 
 /**
  * GraphQLSeeder — seeds test data via the DataHub GraphQL API.
@@ -80,7 +80,7 @@ export class GraphQLSeeder {
       }
     `;
 
-    const response = await this.page.request.post(`${this.baseURL}/api/v2/graphql`, {
+    const response = await this.page.request.post(`${this.baseURL}${DATAHUB_GRAPHQL_PATH}`, {
       data: { query: mutation, variables: { input: { urns: [urn], deleted: false } } },
     });
 

--- a/e2e-test/ui/playwright/pages/dataset-health.page.ts
+++ b/e2e-test/ui/playwright/pages/dataset-health.page.ts
@@ -7,6 +7,7 @@
 
 import { Locator, Page, expect } from '@playwright/test';
 import { BasePage } from './base.page';
+import { DATAHUB_GRAPHQL_PATH } from '../utils/constants';
 import type { DataHubLogger } from '../utils/logger';
 
 export class DatasetHealthPage extends BasePage {
@@ -28,7 +29,7 @@ export class DatasetHealthPage extends BasePage {
     // the entity fetch completes (prevents a "Not Found" race condition).
     await Promise.all([
       this.page.waitForResponse(
-        (resp) => resp.url().includes('/api/v2/graphql') && resp.request().method() === 'POST',
+        (resp) => resp.url().includes(DATAHUB_GRAPHQL_PATH) && resp.request().method() === 'POST',
         { timeout: 30000 },
       ),
       this.page.goto(`/dataset/${encodeURIComponent(urn)}/`),

--- a/e2e-test/ui/playwright/tests/application/application-sidebar.spec.ts
+++ b/e2e-test/ui/playwright/tests/application/application-sidebar.spec.ts
@@ -23,6 +23,7 @@
 import { test } from '../../fixtures/base-test';
 import { Page } from '@playwright/test';
 import { ApplicationsPage } from '../../pages/applications.page';
+import { isDataHubGraphqlUrl } from '../../utils/api-mock';
 import { TIMEOUTS, LOAD_STATES } from '../../utils/constants';
 
 const APP_URN = 'urn:li:application:d63587c6-cacc-4590-851c-4f51ca429b51';
@@ -44,7 +45,7 @@ test.describe('Application Sidebar Integration', () => {
   });
 
   async function setApplicationFeatureFlag(page: Page, showSidebarSectionWhenEmpty: boolean): Promise<void> {
-    await page.route('**/api/v2/graphql', async (route) => {
+    await page.route(isDataHubGraphqlUrl, async (route) => {
       const request = route.request();
       const postData = request.postDataJSON();
 

--- a/e2e-test/ui/playwright/tests/auth.setup.ts
+++ b/e2e-test/ui/playwright/tests/auth.setup.ts
@@ -32,6 +32,7 @@ import { test as setup, expect } from '@playwright/test';
 import { users } from '../data/users';
 import { authStatePath, gmsTokenPath } from '../fixtures/login';
 import { LoginPage } from '../pages/login.page';
+import { DATAHUB_GRAPHQL_PATH } from '../utils/constants';
 import { createScriptLogger } from '../utils/logger';
 
 const logger = createScriptLogger('auth.setup');
@@ -85,7 +86,7 @@ setup('authenticate all users', async ({ page, playwright }) => {
           tokenId?: string;
         };
         if (existing.tokenId) {
-          await apiContext.post('/api/v2/graphql', {
+          await apiContext.post(DATAHUB_GRAPHQL_PATH, {
             data: {
               query: `
                 mutation revokeAccessToken($tokenId: String!) {
@@ -99,7 +100,7 @@ setup('authenticate all users', async ({ page, playwright }) => {
         }
       }
 
-      const tokenResponse = await apiContext.post('/api/v2/graphql', {
+      const tokenResponse = await apiContext.post(DATAHUB_GRAPHQL_PATH, {
         data: {
           query: `
             mutation createAccessToken($input: CreateAccessTokenInput!) {

--- a/e2e-test/ui/playwright/tests/business-attributes/check-feature-flag.spec.ts
+++ b/e2e-test/ui/playwright/tests/business-attributes/check-feature-flag.spec.ts
@@ -6,10 +6,11 @@
  */
 
 import { test, expect } from '../../fixtures/base-test';
+import { DATAHUB_GRAPHQL_PATH } from '../../utils/constants';
 
 test.describe('Business Attribute Feature Flag', () => {
   test('should check if business attribute feature is enabled', async ({ page, logger }) => {
-    const response = await page.request.post('/api/v2/graphql', {
+    const response = await page.request.post(DATAHUB_GRAPHQL_PATH, {
       data: {
         query: `query { appConfig { featureFlags { businessAttributeEntityEnabled } } }`,
         variables: {},

--- a/e2e-test/ui/playwright/tests/global.setup.ts
+++ b/e2e-test/ui/playwright/tests/global.setup.ts
@@ -13,7 +13,7 @@
 import { test as setup, request } from '@playwright/test';
 import { readGmsToken } from '../fixtures/login';
 import { deleteEntities } from '../utils/cleanup';
-import { gmsUrl } from '../utils/constants';
+import { DATAHUB_GRAPHQL_PATH, gmsUrl } from '../utils/constants';
 import { createScriptLogger } from '../utils/logger';
 import { users } from '../data/users';
 
@@ -49,7 +49,7 @@ setup('global cleanup', async () => {
 
     for (const entityType of ENTITY_TYPES) {
       for (const prefix of CLEANUP_PREFIXES) {
-        const response = await apiContext.post(`${url}/api/v2/graphql`, {
+        const response = await apiContext.post(`${url}${DATAHUB_GRAPHQL_PATH}`, {
           data: {
             query: `query search($input: SearchInput!) { search(input: $input) { total entities { urn } } }`,
             variables: {

--- a/e2e-test/ui/playwright/tests/home/homepage-collection-view-all.spec.ts
+++ b/e2e-test/ui/playwright/tests/home/homepage-collection-view-all.spec.ts
@@ -15,6 +15,7 @@
 import { test, expect } from '../../fixtures/login-test';
 import type { APIRequestContext, Page } from '@playwright/test';
 import { users } from '../../data/users';
+import { DATAHUB_GRAPHQL_PATH } from '../../utils/constants';
 
 const FRONTEND_URL = process.env.BASE_URL || 'http://localhost:9002';
 
@@ -38,7 +39,7 @@ const DATA_PRODUCT_FILTER_JSON = JSON.stringify({
 const MANUAL_ASSET_URNS = ['urn:li:corpuser:datahub'];
 
 async function gql<T>(ctx: APIRequestContext, query: string, variables: Record<string, unknown> = {}): Promise<T> {
-  const resp = await ctx.post('/api/v2/graphql', { data: { query, variables } });
+  const resp = await ctx.post(DATAHUB_GRAPHQL_PATH, { data: { query, variables } });
   expect(resp.ok()).toBe(true);
   const body = await resp.json();
   expect(body.errors, `GraphQL errors: ${JSON.stringify(body.errors)}`).toBeUndefined();

--- a/e2e-test/ui/playwright/utils/api-mock.ts
+++ b/e2e-test/ui/playwright/utils/api-mock.ts
@@ -11,6 +11,8 @@
 
 import type { Page, Route } from '@playwright/test';
 
+import { DATAHUB_GRAPHQL_PATH } from './constants';
+
 /**
  * Match DataHub GraphQL requests with or without ?operationName=...
  * Playwright path globs that end at /graphql only match the bare path; after the
@@ -18,7 +20,7 @@ import type { Page, Route } from '@playwright/test';
  * patterns stopped intercepting browser GraphQL calls.
  */
 export function isDataHubGraphqlUrl(url: URL): boolean {
-  return url.pathname.endsWith('/api/v2/graphql');
+  return url.pathname.endsWith(DATAHUB_GRAPHQL_PATH);
 }
 
 // ── Public interface ──────────────────────────────────────────────────────────

--- a/e2e-test/ui/playwright/utils/api-mock.ts
+++ b/e2e-test/ui/playwright/utils/api-mock.ts
@@ -12,8 +12,8 @@
 import type { Page, Route } from '@playwright/test';
 
 /**
- * Match DataHub GraphQL requests with or without `?operationName=...`.
- * Playwright globs like `**/api/v2/graphql` only match the bare path; after the
+ * Match DataHub GraphQL requests with or without ?operationName=...
+ * Playwright path globs that end at /graphql only match the bare path; after the
  * UI started appending operation names for Chrome Network filtering, those
  * patterns stopped intercepting browser GraphQL calls.
  */

--- a/e2e-test/ui/playwright/utils/api-mock.ts
+++ b/e2e-test/ui/playwright/utils/api-mock.ts
@@ -11,6 +11,16 @@
 
 import type { Page, Route } from '@playwright/test';
 
+/**
+ * Match DataHub GraphQL requests with or without `?operationName=...`.
+ * Playwright globs like `**/api/v2/graphql` only match the bare path; after the
+ * UI started appending operation names for Chrome Network filtering, those
+ * patterns stopped intercepting browser GraphQL calls.
+ */
+export function isDataHubGraphqlUrl(url: URL): boolean {
+  return url.pathname.endsWith('/api/v2/graphql');
+}
+
 // ── Public interface ──────────────────────────────────────────────────────────
 
 export interface ApiMocker {
@@ -62,7 +72,7 @@ export class PageApiMocker implements ApiMocker {
 
     // Register a SINGLE route handler that checks all mocked operations
     if (!this.mockRouteRegistered) {
-      await this.page.route('**/api/v2/graphql', async (route) => {
+      await this.page.route(isDataHubGraphqlUrl, async (route) => {
         const postData = route.request().postDataJSON() as { operationName?: string } | null;
         const op = postData?.operationName;
 
@@ -90,7 +100,7 @@ export class PageApiMocker implements ApiMocker {
 
     // Register a SINGLE route handler that checks all intercepted operations
     if (!this.interceptRouteRegistered) {
-      await this.page.route('**/api/v2/graphql', async (route) => {
+      await this.page.route(isDataHubGraphqlUrl, async (route) => {
         const postData = route.request().postDataJSON() as { operationName?: string } | null;
         const op = postData?.operationName;
 
@@ -161,7 +171,7 @@ export class PageApiMocker implements ApiMocker {
       }
     }
 
-    await this.page.route('**/api/v2/graphql', async (route) => {
+    await this.page.route(isDataHubGraphqlUrl, async (route) => {
       const postData = route.request().postDataJSON() as { operationName?: string } | null;
       const op = postData?.operationName;
 
@@ -243,7 +253,7 @@ export class PageApiMocker implements ApiMocker {
   }
 
   async suppressOnboardingModals(): Promise<void> {
-    await this.page.route('**/api/v2/graphql', async (route) => {
+    await this.page.route(isDataHubGraphqlUrl, async (route) => {
       const postData = route.request().postDataJSON() as {
         operationName?: string;
         variables?: { input?: { ids?: string[] } };

--- a/e2e-test/ui/playwright/utils/constants.ts
+++ b/e2e-test/ui/playwright/utils/constants.ts
@@ -61,6 +61,9 @@ export const ROUTES = {
   businessAttributes: '/business-attributes',
 };
 
+/** Frontend GraphQL endpoint path (Play proxy → GMS /api/graphql). */
+export const DATAHUB_GRAPHQL_PATH = '/api/v2/graphql';
+
 export const ENTITY_TYPES = {
   DATASET: 'dataset',
   DASHBOARD: 'dashboard',

--- a/e2e-test/ui/playwright/utils/test-data.ts
+++ b/e2e-test/ui/playwright/utils/test-data.ts
@@ -21,6 +21,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { APIRequestContext } from '@playwright/test';
 import { extractUrn, type Mcp } from '../helpers/seeder-utils';
+import { DATAHUB_GRAPHQL_PATH } from './constants';
 import { createScriptLogger, type DataHubLogger } from './logger';
 
 // ── Public interface ──────────────────────────────────────────────────────────
@@ -43,7 +44,7 @@ async function prefixExists(
   prefix: string,
   gmsToken: string,
 ): Promise<boolean> {
-  const response = await request.post(`${gmsUrl}/api/v2/graphql`, {
+  const response = await request.post(`${gmsUrl}${DATAHUB_GRAPHQL_PATH}`, {
     data: {
       query: `query search($input: SearchInput!) { search(input: $input) { total } }`,
       variables: { input: { type: 'DATASET', query: `${prefix}*`, start: 0, count: 1 } },


### PR DESCRIPTION
## Summary

GraphQL requests all hit the same `/api/v2/graphql` URL, so Chrome DevTools Network shows dozens of identical rows and filter-by-name does not work. OpenTelemetry already names browser spans `graphql <operationName>` (`otelApollo.ts`); this brings the same visibility to the Network tab.

**Changes:**
- Apollo `HttpLink` now requests `/api/v2/graphql?operationName=<name>` so the Name column shows (and filters by) the operation
- Play frontend proxy `mapPath` preserves query strings during path rewrite, so `/api/v2/graphql?operationName=...` still maps to GMS `/api/graphql`
- GMS continues to read `operationName` from the POST body (query param is DevTools-only metadata)
- Playwright GraphQL route matchers updated to match pathname with or without `?operationName=` (bare `**/api/v2/graphql` globs stopped intercepting after this change)
- OTel fetch instrumentation already redacts query strings from span URLs

## Before (identical rows)
<img width="434" height="223" alt="Screenshot 2026-07-24 at 12 36 53 PM" src="https://github.com/user-attachments/assets/725ce442-2e4a-4da3-aca5-2798da7c7fd8" />

## After (name shows and filtering works)
<img width="457" height="161" alt="Screenshot 2026-07-24 at 11 42 05 AM" src="https://github.com/user-attachments/assets/f2f28693-1391-423c-8882-bcdb3d52bd87" />

## See also
- https://github.com/acryldata/datahub-fork/pull/11090
