### PR TITLE
feat(timeline): support timeline API for versioned entities

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -1185,7 +1185,8 @@ public class GmsGraphQLEngine {
                     "listExecutionRequests", new ListExecutionRequestsResolver(this.entityClient))
                 .dataFetcher("executionRequest", getResolver(executionRequestType))
                 .dataFetcher("getSchemaBlame", new GetSchemaBlameResolver(this.timelineService))
-                .dataFetcher("getTimeline", new GetTimelineResolver(this.timelineService))
+                .dataFetcher(
+                    "getTimeline", new GetTimelineResolver(this.timelineService, this.entityClient))
                 .dataFetcher(
                     "getSchemaVersionList", new GetSchemaVersionListResolver(this.timelineService))
                 .dataFetcher("test", getResolver(testType))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/timeline/GetTimelineResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/timeline/GetTimelineResolver.java
@@ -1,8 +1,10 @@
 package com.linkedin.datahub.graphql.resolvers.timeline;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
+import static com.linkedin.metadata.Constants.*;
 
 import com.datahub.authorization.AuthUtil;
+import com.linkedin.common.VersionProperties;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
@@ -12,27 +14,45 @@ import com.linkedin.datahub.graphql.generated.ChangeCategoryType;
 import com.linkedin.datahub.graphql.generated.GetTimelineInput;
 import com.linkedin.datahub.graphql.generated.GetTimelineResult;
 import com.linkedin.datahub.graphql.types.timeline.mappers.ChangeTransactionMapper;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.search.utils.QueryUtils;
+import com.linkedin.metadata.timeline.TimelineFetchResult;
 import com.linkedin.metadata.timeline.TimelineService;
 import com.linkedin.metadata.timeline.data.ChangeCategory;
 import com.linkedin.metadata.timeline.data.ChangeTransaction;
+import com.linkedin.metadata.utils.CriterionUtils;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
 /*
-Returns the timeline in its original form
+Returns the timeline in its original form, with optional version-set expansion.
  */
 @Slf4j
 public class GetTimelineResolver implements DataFetcher<CompletableFuture<GetTimelineResult>> {
-  private final TimelineService _timelineService;
 
-  public GetTimelineResolver(TimelineService timelineService) {
+  private static final int MAX_VERSION_WALK = 50;
+  private static final String VERSION_SET_SEARCH_FIELD = "versionSet";
+
+  private final TimelineService _timelineService;
+  private final EntityClient _entityClient;
+
+  public GetTimelineResolver(TimelineService timelineService, EntityClient entityClient) {
     _timelineService = timelineService;
+    _entityClient = entityClient;
   }
 
   @Override
@@ -44,9 +64,8 @@ public class GetTimelineResolver implements DataFetcher<CompletableFuture<GetTim
 
     final String entityUrnString = input.getUrn();
     final List<ChangeCategoryType> changeCategories = input.getChangeCategories();
+    final boolean includeVersionSet = Boolean.TRUE.equals(input.getIncludeVersionSet());
 
-    // Parse URN and enforce view authorization synchronously so errors propagate
-    // rather than being swallowed by the generic catch inside supplyAsync.
     final Urn entityUrn = UrnUtils.getUrn(entityUrnString);
     if (!AuthUtil.canViewEntity(context.getOperationContext(), entityUrn)) {
       throw new AuthorizationException(
@@ -59,24 +78,42 @@ public class GetTimelineResolver implements DataFetcher<CompletableFuture<GetTim
             final Set<ChangeCategory> changeCategorySet =
                 changeCategories != null
                     ? changeCategories.stream()
-                        .map(
-                            changeCategoryType ->
-                                ChangeCategory.valueOf(changeCategoryType.toString()))
+                        .map(c -> ChangeCategory.valueOf(c.toString()))
                         .collect(Collectors.toSet())
                     : Arrays.stream(ChangeCategory.values()).collect(Collectors.toSet());
-            final List<ChangeTransaction> changeTransactionList =
-                _timelineService.getTimeline(
-                    context.getOperationContext(),
-                    entityUrn,
-                    changeCategorySet,
-                    TimelineService.DEFAULT_MAX_CHANGE_TRANSACTIONS,
-                    false);
+
+            final List<ChangeTransaction> changeTransactionList;
+            int skippedVersionCount = 0;
+            int truncatedVersionCount = 0;
+
+            if (includeVersionSet) {
+              VersionSetResolution resolution = resolveVersionSetUrns(entityUrn, context);
+              truncatedVersionCount = resolution.getTruncatedCount();
+              TimelineFetchResult fetchResult =
+                  _timelineService.getTimelineForUrns(
+                      context.getOperationContext(),
+                      resolution.getUrns(),
+                      changeCategorySet,
+                      false);
+              changeTransactionList = fetchResult.getTransactions();
+              skippedVersionCount = fetchResult.getSkippedUrnCount() + truncatedVersionCount;
+            } else {
+              changeTransactionList =
+                  _timelineService.getTimeline(
+                      context.getOperationContext(),
+                      entityUrn,
+                      changeCategorySet,
+                      TimelineService.DEFAULT_MAX_CHANGE_TRANSACTIONS,
+                      false);
+            }
+
             GetTimelineResult result = new GetTimelineResult();
             result.setChangeTransactions(
                 changeTransactionList.stream()
                     .map(ChangeTransactionMapper::map)
                     .filter(t -> t.getChanges() != null && !t.getChanges().isEmpty())
                     .collect(Collectors.toList()));
+            result.setSkippedVersionCount(skippedVersionCount);
             return result;
           } catch (Exception e) {
             log.error(
@@ -86,5 +123,110 @@ public class GetTimelineResolver implements DataFetcher<CompletableFuture<GetTim
         },
         this.getClass().getSimpleName(),
         "get");
+  }
+
+  /**
+   * Resolves all version URNs in the same VersionSet as {@code urn}.
+   *
+   * <p>Steps:
+   *
+   * <ol>
+   *   <li>Fetch {@code versionProperties} of {@code urn} to get the {@code versionSet} URN.
+   *   <li>Search the entity index for all entities whose {@code versionSet} field equals that URN,
+   *       capped at {@link #MAX_VERSION_WALK}.
+   *   <li>Return the combined list (current URN + all siblings), deduplicated, alongside the count
+   *       of versions that exist beyond the walk limit so the caller can warn the user that the
+   *       merged view is partial.
+   * </ol>
+   *
+   * Falls back to a singleton list containing only {@code urn} if any step fails.
+   */
+  private VersionSetResolution resolveVersionSetUrns(
+      @Nonnull Urn urn, @Nonnull QueryContext context) {
+    try {
+      EntityResponse entityResponse =
+          _entityClient.getV2(
+              context.getOperationContext(),
+              urn.getEntityType(),
+              urn,
+              Collections.singleton(VERSION_PROPERTIES_ASPECT_NAME));
+
+      if (entityResponse == null
+          || !entityResponse.getAspects().containsKey(VERSION_PROPERTIES_ASPECT_NAME)) {
+        return VersionSetResolution.singleton(urn);
+      }
+
+      VersionProperties vp =
+          new VersionProperties(
+              entityResponse.getAspects().get(VERSION_PROPERTIES_ASPECT_NAME).getValue().data());
+      Urn versionSetUrn = vp.getVersionSet();
+
+      // Include all versions, not just the latest, when walking the version set.
+      OperationContext versionSearchContext =
+          context
+              .getOperationContext()
+              .withSearchFlags(flags -> flags.setFilterNonLatestVersions(false));
+
+      SearchResult searchResult =
+          _entityClient.search(
+              versionSearchContext,
+              urn.getEntityType(),
+              "*",
+              QueryUtils.newFilter(
+                  CriterionUtils.buildCriterion(
+                      VERSION_SET_SEARCH_FIELD, Condition.EQUAL, versionSetUrn.toString())),
+              null,
+              0,
+              MAX_VERSION_WALK);
+
+      if (searchResult == null
+          || searchResult.getEntities() == null
+          || searchResult.getEntities().isEmpty()) {
+        return VersionSetResolution.singleton(urn);
+      }
+
+      List<Urn> urns =
+          searchResult.getEntities().stream()
+              .map(SearchEntity::getEntity)
+              .collect(Collectors.toCollection(ArrayList::new));
+
+      if (!urns.contains(urn)) {
+        urns.add(urn);
+      }
+
+      int total = (int) searchResult.getNumEntities();
+      int truncated = Math.max(0, total - urns.size());
+      return new VersionSetResolution(urns, truncated);
+
+    } catch (Exception e) {
+      log.warn(
+          "Failed to resolve version set URNs for {}, falling back to single-entity timeline: {}",
+          urn,
+          e.getMessage());
+      return VersionSetResolution.singleton(urn);
+    }
+  }
+
+  /** Result of expanding a single URN into its full VersionSet membership. */
+  private static class VersionSetResolution {
+    private final List<Urn> urns;
+    private final int truncatedCount;
+
+    VersionSetResolution(List<Urn> urns, int truncatedCount) {
+      this.urns = urns;
+      this.truncatedCount = truncatedCount;
+    }
+
+    static VersionSetResolution singleton(Urn urn) {
+      return new VersionSetResolution(Collections.singletonList(urn), 0);
+    }
+
+    List<Urn> getUrns() {
+      return urns;
+    }
+
+    int getTruncatedCount() {
+      return truncatedCount;
+    }
   }
 }

--- a/datahub-graphql-core/src/main/resources/timeline.graphql
+++ b/datahub-graphql-core/src/main/resources/timeline.graphql
@@ -83,6 +83,14 @@ enum ChangeCategoryType {
   When assets have been added to or removed from a Data Product
   """
   ASSET_MEMBERSHIP
+  """
+  When a new version has been created within a VersionSet, or when an existing version's
+  versionTag changes. Currently emitted for versioned GlossaryTerms and Datasets; will become
+  available for other versioned entity types as their event generators are registered.
+  Lifecycle-stage transitions (DRAFT → PUBLISHED etc.) are NOT covered by this category — see
+  LIFECYCLE.
+  """
+  VERSIONING
 }
 
 """
@@ -127,6 +135,21 @@ input GetTimelineInput {
   The change category types to filter by. If left empty, will fetch all.
   """
   changeCategories: [ChangeCategoryType!]
+
+  """
+  When true and the entity belongs to a VersionSet, fetch and merge the timelines of ALL
+  versions in the set. The result is a unified chronological history across the entire concept
+  lifecycle — version creation milestones interleaved with per-version metadata changes.
+  Only applies to versioned entities (those with a versionProperties aspect). For non-versioned
+  URNs the flag is silently ignored and the response is shape-identical to a normal single-URN
+  fetch — existing consumers are unaffected.
+
+  When sibling versions exist beyond the server-side walk limit (currently 50) or some are
+  inaccessible (e.g. missing view permission, deletion race), they are omitted from the merged
+  result. The omitted count is surfaced on GetTimelineResult.skippedVersionCount so callers can
+  warn the user that the view may be partial.
+  """
+  includeVersionSet: Boolean
 }
 
 """
@@ -220,6 +243,14 @@ Result of getting timeline from a specific version.
 """
 type GetTimelineResult {
   changeTransactions: [ChangeTransaction!]!
+
+  """
+  Number of sibling version URNs that were resolved but whose events were omitted from the
+  merged stream — typically because the caller lacks view permission on them, they were
+  deleted between resolve and fetch, or they exceeded the server-side walk limit.
+  Always 0 when includeVersionSet is false or the entity is not versioned.
+  """
+  skippedVersionCount: Int
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/timeline/GetTimelineResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/timeline/GetTimelineResolverTest.java
@@ -1,19 +1,34 @@
 package com.linkedin.datahub.graphql.resolvers.timeline;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
+import static com.linkedin.metadata.Constants.VERSION_PROPERTIES_ASPECT_NAME;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 
+import com.linkedin.common.VersionProperties;
+import com.linkedin.common.VersionTag;
+import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.ChangeCategoryType;
 import com.linkedin.datahub.graphql.generated.GetTimelineInput;
+import com.linkedin.datahub.graphql.generated.GetTimelineResult;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.search.SearchEntityArray;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.search.SearchResultMetadata;
+import com.linkedin.metadata.timeline.TimelineFetchResult;
 import com.linkedin.metadata.timeline.TimelineService;
 import com.linkedin.metadata.timeline.data.ChangeCategory;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.List;
+import java.util.Map;
 import org.testng.annotations.Test;
 
 public class GetTimelineResolverTest {
@@ -46,7 +61,8 @@ public class GetTimelineResolverTest {
   @Test
   public void testGetUnauthorizedThrowsAndDoesNotQueryDb() {
     TimelineService mockTimelineService = mock(TimelineService.class);
-    GetTimelineResolver resolver = new GetTimelineResolver(mockTimelineService);
+    EntityClient mockEntityClient = mock(EntityClient.class);
+    GetTimelineResolver resolver = new GetTimelineResolver(mockTimelineService, mockEntityClient);
 
     QueryContext denyContext = getMockDenyContextWithOperationContext();
 
@@ -68,7 +84,8 @@ public class GetTimelineResolverTest {
             any(OperationContext.class), any(), any(), anyInt(), anyBoolean()))
         .thenReturn(List.of());
 
-    GetTimelineResolver resolver = new GetTimelineResolver(mockTimelineService);
+    EntityClient mockEntityClient = mock(EntityClient.class);
+    GetTimelineResolver resolver = new GetTimelineResolver(mockTimelineService, mockEntityClient);
 
     QueryContext allowContext = getMockAllowContext();
     DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
@@ -81,5 +98,233 @@ public class GetTimelineResolverTest {
     assertNotNull(resolver.get(mockEnv).get());
     verify(mockTimelineService, times(1))
         .getTimeline(any(OperationContext.class), any(), any(), anyInt(), anyBoolean());
+  }
+
+  // ── includeVersionSet tests ───────────────────────────────────────────────
+
+  @Test
+  public void testIncludeVersionSet_noVersionProperties_fallsBackToSingleton() throws Exception {
+    TimelineService mockTimelineService = mock(TimelineService.class);
+    when(mockTimelineService.getTimeline(
+            any(OperationContext.class), any(), any(), anyInt(), anyBoolean()))
+        .thenReturn(List.of());
+
+    EntityClient mockEntityClient = mock(EntityClient.class);
+    // getV2 returns null → no VersionProperties → singleton fallback
+    when(mockEntityClient.getV2(any(), anyString(), any(), any())).thenReturn(null);
+
+    GetTimelineResolver resolver = new GetTimelineResolver(mockTimelineService, mockEntityClient);
+
+    QueryContext allowContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(allowContext);
+
+    GetTimelineInput input = new GetTimelineInput();
+    input.setUrn(TEST_DATASET_URN);
+    input.setIncludeVersionSet(true);
+    when(mockEnv.getArgument("input")).thenReturn(input);
+
+    // When falling back to singleton, getTimelineForUrns is called with a 1-element list
+    when(mockTimelineService.getTimelineForUrns(any(), any(), any(), anyBoolean()))
+        .thenReturn(
+            TimelineFetchResult.builder().transactions(List.of()).skippedUrnCount(0).build());
+
+    GetTimelineResult result = resolver.get(mockEnv).get();
+    assertNotNull(result);
+    assertEquals((int) result.getSkippedVersionCount(), 0);
+    verify(mockTimelineService, times(1))
+        .getTimelineForUrns(any(OperationContext.class), any(), any(), anyBoolean());
+    verify(mockTimelineService, never())
+        .getTimeline(any(OperationContext.class), any(), any(), anyInt(), anyBoolean());
+  }
+
+  @Test
+  public void testIncludeVersionSet_withSiblings_callsGetTimelineForUrns() throws Exception {
+    TimelineService mockTimelineService = mock(TimelineService.class);
+
+    String versionSetUrn = "urn:li:versionSet:(urn:li:dataPlatform:kafka,test-vs,PROD)";
+    String siblingUrn = "urn:li:dataset:(urn:li:dataPlatform:kafka,test-sibling,PROD)";
+
+    VersionProperties vp = buildVersionProperties(versionSetUrn, "v1.0");
+    EntityResponse entityResponse = buildEntityResponse(TEST_DATASET_URN, vp);
+
+    SearchResult searchResult =
+        new SearchResult()
+            .setEntities(
+                new SearchEntityArray(
+                    new SearchEntity().setEntity(UrnUtils.getUrn(TEST_DATASET_URN)),
+                    new SearchEntity().setEntity(UrnUtils.getUrn(siblingUrn))))
+            .setNumEntities(2)
+            .setFrom(0)
+            .setPageSize(50)
+            .setMetadata(new SearchResultMetadata());
+
+    EntityClient mockEntityClient = mock(EntityClient.class);
+    when(mockEntityClient.getV2(any(), anyString(), any(), any())).thenReturn(entityResponse);
+    when(mockEntityClient.search(any(), anyString(), anyString(), any(), any(), anyInt(), anyInt()))
+        .thenReturn(searchResult);
+
+    when(mockTimelineService.getTimelineForUrns(any(), any(), any(), anyBoolean()))
+        .thenReturn(
+            TimelineFetchResult.builder().transactions(List.of()).skippedUrnCount(0).build());
+
+    GetTimelineResolver resolver = new GetTimelineResolver(mockTimelineService, mockEntityClient);
+
+    QueryContext allowContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(allowContext);
+
+    GetTimelineInput input = new GetTimelineInput();
+    input.setUrn(TEST_DATASET_URN);
+    input.setIncludeVersionSet(true);
+    when(mockEnv.getArgument("input")).thenReturn(input);
+
+    GetTimelineResult result = resolver.get(mockEnv).get();
+    assertNotNull(result);
+    // skippedVersionCount = skippedUrnCount(0) + truncatedCount(0)
+    assertEquals((int) result.getSkippedVersionCount(), 0);
+    verify(mockTimelineService, times(1))
+        .getTimelineForUrns(any(OperationContext.class), any(), any(), anyBoolean());
+  }
+
+  @Test
+  public void testIncludeVersionSet_searchReturnsEmpty_fallsBackToSingleton() throws Exception {
+    TimelineService mockTimelineService = mock(TimelineService.class);
+
+    String versionSetUrn = "urn:li:versionSet:(urn:li:dataPlatform:kafka,test-vs,PROD)";
+    VersionProperties vp = buildVersionProperties(versionSetUrn, "v1.0");
+    EntityResponse entityResponse = buildEntityResponse(TEST_DATASET_URN, vp);
+
+    // Empty search result
+    SearchResult emptyResult =
+        new SearchResult()
+            .setEntities(new SearchEntityArray())
+            .setNumEntities(0)
+            .setFrom(0)
+            .setPageSize(50)
+            .setMetadata(new SearchResultMetadata());
+
+    EntityClient mockEntityClient = mock(EntityClient.class);
+    when(mockEntityClient.getV2(any(), anyString(), any(), any())).thenReturn(entityResponse);
+    when(mockEntityClient.search(any(), anyString(), anyString(), any(), any(), anyInt(), anyInt()))
+        .thenReturn(emptyResult);
+
+    when(mockTimelineService.getTimelineForUrns(any(), any(), any(), anyBoolean()))
+        .thenReturn(
+            TimelineFetchResult.builder().transactions(List.of()).skippedUrnCount(0).build());
+
+    GetTimelineResolver resolver = new GetTimelineResolver(mockTimelineService, mockEntityClient);
+
+    QueryContext allowContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(allowContext);
+
+    GetTimelineInput input = new GetTimelineInput();
+    input.setUrn(TEST_DATASET_URN);
+    input.setIncludeVersionSet(true);
+    when(mockEnv.getArgument("input")).thenReturn(input);
+
+    GetTimelineResult result = resolver.get(mockEnv).get();
+    assertNotNull(result);
+    // Falls back to singleton — still uses getTimelineForUrns with 1-element list
+    verify(mockTimelineService, times(1))
+        .getTimelineForUrns(any(OperationContext.class), any(), any(), anyBoolean());
+  }
+
+  @Test
+  public void testIncludeVersionSet_getV2Throws_fallsBackToSingleton() throws Exception {
+    TimelineService mockTimelineService = mock(TimelineService.class);
+    EntityClient mockEntityClient = mock(EntityClient.class);
+    when(mockEntityClient.getV2(any(), anyString(), any(), any()))
+        .thenThrow(new RuntimeException("Network error"));
+
+    when(mockTimelineService.getTimelineForUrns(any(), any(), any(), anyBoolean()))
+        .thenReturn(
+            TimelineFetchResult.builder().transactions(List.of()).skippedUrnCount(0).build());
+
+    GetTimelineResolver resolver = new GetTimelineResolver(mockTimelineService, mockEntityClient);
+
+    QueryContext allowContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(allowContext);
+
+    GetTimelineInput input = new GetTimelineInput();
+    input.setUrn(TEST_DATASET_URN);
+    input.setIncludeVersionSet(true);
+    when(mockEnv.getArgument("input")).thenReturn(input);
+
+    // Exception is swallowed and falls back — result should still be returned
+    GetTimelineResult result = resolver.get(mockEnv).get();
+    assertNotNull(result);
+    verify(mockTimelineService, times(1))
+        .getTimelineForUrns(any(OperationContext.class), any(), any(), anyBoolean());
+  }
+
+  @Test
+  public void testIncludeVersionSet_truncatedVersionsReflectedInSkippedCount() throws Exception {
+    TimelineService mockTimelineService = mock(TimelineService.class);
+
+    String versionSetUrn = "urn:li:versionSet:(urn:li:dataPlatform:kafka,test-vs,PROD)";
+    VersionProperties vp = buildVersionProperties(versionSetUrn, "v1.0");
+    EntityResponse entityResponse = buildEntityResponse(TEST_DATASET_URN, vp);
+
+    // Search returns 2 entities but claims 10 total (8 truncated)
+    SearchResult searchResult =
+        new SearchResult()
+            .setEntities(
+                new SearchEntityArray(
+                    new SearchEntity().setEntity(UrnUtils.getUrn(TEST_DATASET_URN)),
+                    new SearchEntity()
+                        .setEntity(
+                            UrnUtils.getUrn(
+                                "urn:li:dataset:(urn:li:dataPlatform:kafka,sibling,PROD)"))))
+            .setNumEntities(10)
+            .setFrom(0)
+            .setPageSize(50)
+            .setMetadata(new SearchResultMetadata());
+
+    EntityClient mockEntityClient = mock(EntityClient.class);
+    when(mockEntityClient.getV2(any(), anyString(), any(), any())).thenReturn(entityResponse);
+    when(mockEntityClient.search(any(), anyString(), anyString(), any(), any(), anyInt(), anyInt()))
+        .thenReturn(searchResult);
+
+    when(mockTimelineService.getTimelineForUrns(any(), any(), any(), anyBoolean()))
+        .thenReturn(
+            TimelineFetchResult.builder().transactions(List.of()).skippedUrnCount(0).build());
+
+    GetTimelineResolver resolver = new GetTimelineResolver(mockTimelineService, mockEntityClient);
+
+    QueryContext allowContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(allowContext);
+
+    GetTimelineInput input = new GetTimelineInput();
+    input.setUrn(TEST_DATASET_URN);
+    input.setIncludeVersionSet(true);
+    when(mockEnv.getArgument("input")).thenReturn(input);
+
+    GetTimelineResult result = resolver.get(mockEnv).get();
+    // 10 total − 2 returned = 8 truncated; skippedUrnCount from fetch = 0; total = 8
+    assertEquals((int) result.getSkippedVersionCount(), 8);
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private static VersionProperties buildVersionProperties(String versionSetUrn, String tag) {
+    VersionTag vt = new VersionTag().setVersionTag(tag);
+    return new VersionProperties()
+        .setVersionSet(UrnUtils.getUrn(versionSetUrn))
+        .setVersion(vt)
+        .setSortId("00000001");
+  }
+
+  private static EntityResponse buildEntityResponse(String urn, VersionProperties vp) {
+    EnvelopedAspect envelopedAspect =
+        new EnvelopedAspect().setValue(new com.linkedin.entity.Aspect(vp.data()));
+    return new EntityResponse()
+        .setUrn(UrnUtils.getUrn(urn))
+        .setEntityName("dataset")
+        .setAspects(
+            new EnvelopedAspectMap(Map.of(VERSION_PROPERTIES_ASPECT_NAME, envelopedAspect)));
   }
 }

--- a/metadata-ingestion/src/datahub/cli/timeline_cli.py
+++ b/metadata-ingestion/src/datahub/cli/timeline_cli.py
@@ -61,6 +61,7 @@ def get_timeline(
     start_time: Optional[int],
     end_time: Optional[int],
     diff: bool,
+    include_version_set: bool = False,
     graph: Optional[DataHubGraph] = None,
 ) -> Any:
     client = graph if graph else get_default_graph(ClientMode.CLI)
@@ -79,9 +80,10 @@ def get_timeline(
     start_time_param: str = f"&startTime={start_time}" if start_time else ""
     end_time_param: str = f"&endTime={end_time}" if end_time else ""
     diff_param: str = f"&raw={diff}" if diff else ""
+    version_set_param: str = "&includeVersionSet=true" if include_version_set else ""
     endpoint: str = (
         host
-        + f"/openapi/v2/timeline/v1/{encoded_urn}?categories={categories}{start_time_param}{end_time_param}{diff_param}"
+        + f"/openapi/v2/timeline/v1/{encoded_urn}?categories={categories}{start_time_param}{end_time_param}{diff_param}{version_set_param}"
     )
     click.echo(endpoint)
 
@@ -109,7 +111,7 @@ def get_timeline(
     required=True,
     multiple=True,
     type=str,
-    help="One of tag, glossary_term, technical_schema, documentation, ownership (or owner), domain, structured_property, application, asset_membership",
+    help="One of tag, glossary_term, technical_schema, documentation, ownership (or owner), domain, structured_property, application, asset_membership, versioning",
 )
 @click.option(
     "--start",
@@ -127,6 +129,15 @@ def get_timeline(
     "--verbose", "-v", type=bool, is_flag=True, help="Show the underlying http response"
 )
 @click.option("--raw", type=bool, is_flag=True, help="Show the raw diff")
+@click.option(
+    "--include-version-set",
+    type=bool,
+    is_flag=True,
+    default=False,
+    help="When set, fetches and merges timelines for ALL versions in the same VersionSet. "
+    "Currently supported for versioned GlossaryTerms; silently ignored for entities "
+    "without a versionProperties aspect (output is identical to omitting the flag).",
+)
 @click.pass_context
 @upgrade.check_upgrade
 def timeline(
@@ -137,6 +148,7 @@ def timeline(
     end: Optional[str],
     verbose: bool,
     raw: bool,
+    include_version_set: bool,
 ) -> None:
     """Get timeline for an entity based on certain categories"""
 
@@ -150,6 +162,7 @@ def timeline(
         "STRUCTURED_PROPERTY",
         "APPLICATION",
         "ASSET_MEMBERSHIP",
+        "VERSIONING",
     ]
     # Accept OWNER as a backward-compat alias for OWNERSHIP
     category_aliases = {"OWNER": "OWNERSHIP"}
@@ -190,6 +203,7 @@ def timeline(
         start_time=start_time_millis,
         end_time=end_time_millis,
         diff=raw,
+        include_version_set=include_version_set,
     )
 
     if isinstance(timeline, list) and not verbose:

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/TimelineServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/TimelineServiceImpl.java
@@ -33,6 +33,7 @@ import com.linkedin.metadata.timeline.eventgenerator.OwnershipChangeEventGenerat
 import com.linkedin.metadata.timeline.eventgenerator.SchemaMetadataChangeEventGenerator;
 import com.linkedin.metadata.timeline.eventgenerator.SingleDomainChangeEventGenerator;
 import com.linkedin.metadata.timeline.eventgenerator.StructuredPropertyChangeEventGenerator;
+import com.linkedin.metadata.timeline.eventgenerator.VersionPropertiesChangeEventGenerator;
 import io.datahubproject.metadata.context.OperationContext;
 import jakarta.json.Json;
 import jakarta.json.JsonPatch;
@@ -217,6 +218,16 @@ public class TimelineServiceImpl implements TimelineService {
                 new ApplicationsChangeEventGenerator());
           }
           break;
+        case VERSIONING:
+          {
+            aspects.add(VERSION_PROPERTIES_ASPECT_NAME);
+            _entityChangeEventGeneratorFactory.addGenerator(
+                entityType,
+                elementName,
+                VERSION_PROPERTIES_ASPECT_NAME,
+                new VersionPropertiesChangeEventGenerator());
+          }
+          break;
         default:
           break;
       }
@@ -287,6 +298,16 @@ public class TimelineServiceImpl implements TimelineService {
                 elementName,
                 APPLICATION_MEMBERSHIP_ASPECT_NAME,
                 new ApplicationsChangeEventGenerator());
+          }
+          break;
+        case VERSIONING:
+          {
+            aspects.add(VERSION_PROPERTIES_ASPECT_NAME);
+            _entityChangeEventGeneratorFactory.addGenerator(
+                entityTypeGlossaryTerm,
+                elementName,
+                VERSION_PROPERTIES_ASPECT_NAME,
+                new VersionPropertiesChangeEventGenerator());
           }
           break;
         default:
@@ -603,6 +624,45 @@ public class TimelineServiceImpl implements TimelineService {
           allTransactions.size() - maxChangeTransactions, allTransactions.size());
     }
     return allTransactions;
+  }
+
+  /**
+   * Fetches and merges timelines for multiple URNs into one unified, oldest-first stream.
+   *
+   * <p>The caller (typically {@code GetTimelineResolver}) is responsible for discovering the
+   * sibling version URNs via the EntityClient / versionsSearch, then passes the full list here.
+   * This method is purely a merge layer — each URN is queried independently. Per-URN failures are
+   * counted and reported on the result so the caller can surface a "view may be partial" warning;
+   * they do not abort the merge.
+   *
+   * <p>Transactions are sorted by {@code timestampMillis} with the actor as a stable secondary key
+   * ({@link ChangeTransaction} does not carry the originating entity URN). This keeps ordering
+   * deterministic when sibling versions are edited close together; transactions with the same
+   * timestamp and actor retain their relative fetch order via the stable sort.
+   */
+  @Nonnull
+  @Override
+  public TimelineFetchResult getTimelineForUrns(
+      @Nonnull final OperationContext opContext,
+      @Nonnull final List<Urn> urns,
+      @Nonnull final Set<ChangeCategory> elements,
+      boolean rawDiffRequested) {
+
+    List<ChangeTransaction> merged = new ArrayList<>();
+    int skipped = 0;
+    for (Urn u : urns) {
+      try {
+        merged.addAll(
+            getTimeline(opContext, u, elements, DEFAULT_MAX_CHANGE_TRANSACTIONS, rawDiffRequested));
+      } catch (Exception e) {
+        log.warn("Failed to fetch timeline for {}, skipping: {}", u, e.getMessage());
+        skipped++;
+      }
+    }
+    merged.sort(
+        Comparator.comparingLong(ChangeTransaction::getTimestamp)
+            .thenComparing(ChangeTransaction::getActor, Comparator.nullsLast(String::compareTo)));
+    return TimelineFetchResult.builder().transactions(merged).skippedUrnCount(skipped).build();
   }
 
   private List<ChangeTransaction> processAspectTimeline(

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/VersionPropertiesChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/VersionPropertiesChangeEventGenerator.java
@@ -1,0 +1,179 @@
+package com.linkedin.metadata.timeline.eventgenerator;
+
+import static com.linkedin.metadata.Constants.VERSION_PROPERTIES_ASPECT_NAME;
+
+import com.datahub.util.RecordUtils;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.VersionProperties;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.aspect.EntityAspect;
+import com.linkedin.metadata.timeline.data.ChangeCategory;
+import com.linkedin.metadata.timeline.data.ChangeEvent;
+import com.linkedin.metadata.timeline.data.ChangeOperation;
+import com.linkedin.metadata.timeline.data.ChangeTransaction;
+import com.linkedin.metadata.timeline.data.SemanticChangeType;
+import jakarta.json.JsonPatch;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Timeline event generator for the {@code versionProperties} aspect.
+ *
+ * <p>Emits {@link ChangeCategory#VERSIONING} events so that version creation is visible in the
+ * {@code getTimeline} API and in the DataHub UI change history sidebar. Currently covers two
+ * events: a version being created (first write of {@code versionProperties}) and a {@code
+ * versionTag} change. Lifecycle-stage transitions (DRAFT → PUBLISHED etc.) live on a separate
+ * aspect and are NOT emitted by this generator.
+ *
+ * <p>Each emitted event carries structured {@code parameters} so the UI can render a rich version
+ * milestone without parsing the description string. Keys: {@code versionTag}, {@code comment},
+ * {@code versionSetUrn}, {@code isLatest}.
+ *
+ * <p>Test with: {@code datahub timeline --urn <glossaryTermUrn> -c versioning}
+ */
+@Slf4j
+public class VersionPropertiesChangeEventGenerator
+    extends EntityChangeEventGenerator<VersionProperties> {
+
+  private static final String VERSION_CREATED_FORMAT = "Version '%s' created for '%s'";
+  private static final String VERSION_CREATED_WITH_COMMENT_FORMAT =
+      "Version '%s' created for '%s' — %s";
+  private static final String VERSION_TAG_CHANGED_FORMAT =
+      "Version tag of '%s' changed from '%s' to '%s'";
+
+  // ── getSemanticDiff (deprecated path, still called by TimelineServiceImpl) ──
+
+  @Override
+  public ChangeTransaction getSemanticDiff(
+      EntityAspect previousValue,
+      EntityAspect currentValue,
+      ChangeCategory element,
+      JsonPatch rawDiff,
+      boolean rawDiffsRequested) {
+    if (!currentValue.getAspect().equals(VERSION_PROPERTIES_ASPECT_NAME)) {
+      throw new IllegalArgumentException("Aspect is not " + VERSION_PROPERTIES_ASPECT_NAME);
+    }
+
+    List<ChangeEvent> changeEvents = new ArrayList<>();
+    if (element == ChangeCategory.VERSIONING) {
+      VersionProperties prev = getVersionPropertiesFromAspect(previousValue);
+      VersionProperties curr = getVersionPropertiesFromAspect(currentValue);
+      changeEvents.addAll(computeDiffs(prev, curr, currentValue.getUrn(), null));
+    }
+
+    SemanticChangeType highestSemVer = SemanticChangeType.NONE;
+    ChangeEvent highestEvent =
+        changeEvents.stream().max(Comparator.comparing(ChangeEvent::getSemVerChange)).orElse(null);
+    if (highestEvent != null) {
+      highestSemVer = highestEvent.getSemVerChange();
+    }
+
+    return ChangeTransaction.builder()
+        .semVerChange(highestSemVer)
+        .changeEvents(changeEvents)
+        .timestamp(currentValue.getCreatedOn().getTime())
+        .rawDiff(rawDiffsRequested ? rawDiff : null)
+        .actor(currentValue.getCreatedBy())
+        .build();
+  }
+
+  // ── getChangeEvents (preferred path) ──────────────────────────────────────
+
+  @Override
+  public List<ChangeEvent> getChangeEvents(
+      @Nonnull Urn urn,
+      @Nonnull String entity,
+      @Nonnull String aspect,
+      @Nonnull Aspect<VersionProperties> from,
+      @Nonnull Aspect<VersionProperties> to,
+      @Nonnull AuditStamp auditStamp) {
+    return computeDiffs(from.getValue(), to.getValue(), urn.toString(), auditStamp);
+  }
+
+  // ── Core diff logic ───────────────────────────────────────────────────────
+
+  private static List<ChangeEvent> computeDiffs(
+      @Nullable VersionProperties prev,
+      @Nullable VersionProperties curr,
+      @Nonnull String entityUrn,
+      @Nullable AuditStamp auditStamp) {
+
+    List<ChangeEvent> events = new ArrayList<>();
+    if (curr == null) {
+      return events;
+    }
+
+    String currTag = curr.hasVersion() ? curr.getVersion().getVersionTag() : null;
+    String prevTag = (prev != null && prev.hasVersion()) ? prev.getVersion().getVersionTag() : null;
+
+    if (prev == null) {
+      events.add(
+          ChangeEvent.builder()
+              .entityUrn(entityUrn)
+              .category(ChangeCategory.VERSIONING)
+              .operation(ChangeOperation.ADD)
+              .semVerChange(SemanticChangeType.MINOR)
+              .description(buildCreatedDescription(entityUrn, currTag, curr))
+              .parameters(buildParameters(curr, currTag))
+              .auditStamp(auditStamp)
+              .build());
+    } else if (currTag != null && !currTag.equals(prevTag)) {
+      Map<String, Object> params = buildParameters(curr, currTag);
+      if (prevTag != null) {
+        params.put("previousVersionTag", prevTag);
+      }
+      events.add(
+          ChangeEvent.builder()
+              .entityUrn(entityUrn)
+              .category(ChangeCategory.VERSIONING)
+              .operation(ChangeOperation.MODIFY)
+              .semVerChange(SemanticChangeType.PATCH)
+              .description(String.format(VERSION_TAG_CHANGED_FORMAT, entityUrn, prevTag, currTag))
+              .parameters(params)
+              .auditStamp(auditStamp)
+              .build());
+    }
+
+    return events;
+  }
+
+  private static Map<String, Object> buildParameters(VersionProperties vp, @Nullable String tag) {
+    Map<String, Object> params = new HashMap<>();
+    if (tag != null) {
+      params.put("versionTag", tag);
+    }
+    if (vp.hasComment() && vp.getComment() != null && !vp.getComment().isBlank()) {
+      params.put("comment", vp.getComment());
+    }
+    if (vp.hasVersionSet() && vp.getVersionSet() != null) {
+      params.put("versionSetUrn", vp.getVersionSet().toString());
+    }
+    params.put("isLatest", Boolean.toString(vp.hasIsLatest() && vp.isIsLatest()));
+    return params;
+  }
+
+  private static String buildCreatedDescription(
+      String entityUrn, @Nullable String versionTag, VersionProperties vp) {
+    String tag = versionTag != null ? versionTag : "unknown";
+    String comment = vp.hasComment() ? vp.getComment() : null;
+    if (comment != null && !comment.isBlank()) {
+      return String.format(VERSION_CREATED_WITH_COMMENT_FORMAT, tag, entityUrn, comment);
+    }
+    return String.format(VERSION_CREATED_FORMAT, tag, entityUrn);
+  }
+
+  @Nullable
+  private static VersionProperties getVersionPropertiesFromAspect(
+      @Nullable EntityAspect entityAspect) {
+    if (entityAspect != null && entityAspect.getMetadata() != null) {
+      return RecordUtils.toRecordTemplate(VersionProperties.class, entityAspect.getMetadata());
+    }
+    return null;
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeline/TimelineServiceImplGetTimelineForUrnsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeline/TimelineServiceImplGetTimelineForUrnsTest.java
@@ -1,0 +1,122 @@
+package com.linkedin.metadata.timeline;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.metadata.entity.AspectDao;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.timeline.data.ChangeCategory;
+import com.linkedin.metadata.timeline.data.ChangeTransaction;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.testng.annotations.Test;
+
+/**
+ * Focused unit test for {@link TimelineServiceImpl#getTimelineForUrns}. The per-URN {@link
+ * TimelineServiceImpl#getTimeline} call is stubbed via a Mockito spy so we can exercise the merge,
+ * sort, and skip-counting logic without a backing store.
+ */
+public class TimelineServiceImplGetTimelineForUrnsTest {
+
+  private static final Urn URN_A = UrnUtils.getUrn("urn:li:glossaryTerm:example.termA");
+  private static final Urn URN_B = UrnUtils.getUrn("urn:li:glossaryTerm:example.termB");
+  private static final Urn URN_C = UrnUtils.getUrn("urn:li:glossaryTerm:example.termC");
+  private static final Set<ChangeCategory> CATEGORIES = Set.of(ChangeCategory.VERSIONING);
+
+  private static TimelineServiceImpl newSpy() {
+    return spy(new TimelineServiceImpl(mock(AspectDao.class), mock(EntityRegistry.class)));
+  }
+
+  private static ChangeTransaction txn(long timestamp, String actor) {
+    return ChangeTransaction.builder()
+        .timestamp(timestamp)
+        .actor(actor)
+        .changeEvents(Collections.emptyList())
+        .build();
+  }
+
+  @Test
+  public void testMergesAndSortsByTimestamp() {
+    TimelineServiceImpl service = newSpy();
+    OperationContext opContext = mock(OperationContext.class);
+
+    // URN_A's events are newer than URN_B's; the merged stream must be oldest-first.
+    doReturn(List.of(txn(300L, "urn:li:corpuser:a")))
+        .when(service)
+        .getTimeline(any(), eq(URN_A), any(), anyInt(), anyBoolean());
+    doReturn(List.of(txn(100L, "urn:li:corpuser:b")))
+        .when(service)
+        .getTimeline(any(), eq(URN_B), any(), anyInt(), anyBoolean());
+
+    TimelineFetchResult result =
+        service.getTimelineForUrns(opContext, List.of(URN_A, URN_B), CATEGORIES, false);
+
+    assertEquals(result.getSkippedUrnCount(), 0);
+    List<ChangeTransaction> merged = result.getTransactions();
+    assertEquals(merged.size(), 2);
+    assertEquals(merged.get(0).getTimestamp(), 100L);
+    assertEquals(merged.get(1).getTimestamp(), 300L);
+  }
+
+  @Test
+  public void testActorTieBreakOnEqualTimestamp() {
+    TimelineServiceImpl service = newSpy();
+    OperationContext opContext = mock(OperationContext.class);
+
+    doReturn(List.of(txn(100L, "urn:li:corpuser:zoe")))
+        .when(service)
+        .getTimeline(any(), eq(URN_A), any(), anyInt(), anyBoolean());
+    doReturn(List.of(txn(100L, "urn:li:corpuser:amy")))
+        .when(service)
+        .getTimeline(any(), eq(URN_B), any(), anyInt(), anyBoolean());
+
+    TimelineFetchResult result =
+        service.getTimelineForUrns(opContext, List.of(URN_A, URN_B), CATEGORIES, false);
+
+    List<ChangeTransaction> merged = result.getTransactions();
+    assertEquals(merged.size(), 2);
+    // Same timestamp → tie broken by actor ascending: "amy" before "zoe".
+    assertEquals(merged.get(0).getActor(), "urn:li:corpuser:amy");
+    assertEquals(merged.get(1).getActor(), "urn:li:corpuser:zoe");
+  }
+
+  @Test
+  public void testPerUrnFailureIsSkippedNotFatal() {
+    TimelineServiceImpl service = newSpy();
+    OperationContext opContext = mock(OperationContext.class);
+
+    doReturn(List.of(txn(100L, "urn:li:corpuser:a")))
+        .when(service)
+        .getTimeline(any(), eq(URN_A), any(), anyInt(), anyBoolean());
+    doThrow(new RuntimeException("store unavailable"))
+        .when(service)
+        .getTimeline(any(), eq(URN_B), any(), anyInt(), anyBoolean());
+    doReturn(List.of(txn(200L, "urn:li:corpuser:c")))
+        .when(service)
+        .getTimeline(any(), eq(URN_C), any(), anyInt(), anyBoolean());
+
+    TimelineFetchResult result =
+        service.getTimelineForUrns(opContext, List.of(URN_A, URN_B, URN_C), CATEGORIES, false);
+
+    // URN_B failed → skipped, but URN_A and URN_C still merge.
+    assertEquals(result.getSkippedUrnCount(), 1);
+    assertEquals(result.getTransactions().size(), 2);
+  }
+
+  @Test
+  public void testEmptyInputYieldsEmptyResult() {
+    TimelineServiceImpl service = newSpy();
+
+    TimelineFetchResult result =
+        service.getTimelineForUrns(
+            mock(OperationContext.class), Collections.emptyList(), CATEGORIES, false);
+
+    assertEquals(result.getSkippedUrnCount(), 0);
+    assertTrue(result.getTransactions().isEmpty());
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeline/TimelineServiceVersioningRegistrationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeline/TimelineServiceVersioningRegistrationTest.java
@@ -1,0 +1,37 @@
+package com.linkedin.metadata.timeline;
+
+import static com.linkedin.metadata.Constants.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.metadata.entity.AspectDao;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.timeline.data.ChangeCategory;
+import java.util.Set;
+import org.testng.annotations.Test;
+
+/**
+ * Verifies that the VERSIONING change category resolves to the versionProperties aspect for the
+ * entity types wired to emit version milestones. Guards against a regression where an entity is
+ * accidentally dropped from the timeline registry, which would silently return empty version
+ * timelines rather than fail.
+ */
+public class TimelineServiceVersioningRegistrationTest {
+
+  private static TimelineServiceImpl newService() {
+    return new TimelineServiceImpl(mock(AspectDao.class), mock(EntityRegistry.class));
+  }
+
+  @Test
+  public void testVersioningRegisteredForDatasetAndGlossaryTerm() {
+    TimelineServiceImpl service = newService();
+
+    for (String entityType : new String[] {DATASET_ENTITY_NAME, GLOSSARY_TERM_ENTITY_NAME}) {
+      Set<String> aspects =
+          service.getAspectsFromElements(entityType, Set.of(ChangeCategory.VERSIONING));
+      assertTrue(
+          aspects.contains(VERSION_PROPERTIES_ASPECT_NAME),
+          entityType + " should map VERSIONING to " + VERSION_PROPERTIES_ASPECT_NAME);
+    }
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/VersionPropertiesChangeEventGeneratorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/VersionPropertiesChangeEventGeneratorTest.java
@@ -1,0 +1,142 @@
+package com.linkedin.metadata.timeline.eventgenerator;
+
+import static com.linkedin.metadata.Constants.VERSION_PROPERTIES_ASPECT_NAME;
+import static org.testng.Assert.*;
+
+import com.linkedin.metadata.aspect.EntityAspect;
+import com.linkedin.metadata.timeline.data.ChangeCategory;
+import com.linkedin.metadata.timeline.data.ChangeEvent;
+import com.linkedin.metadata.timeline.data.ChangeOperation;
+import com.linkedin.metadata.timeline.data.ChangeTransaction;
+import com.linkedin.metadata.timeline.data.SemanticChangeType;
+import java.sql.Timestamp;
+import org.testng.annotations.Test;
+
+public class VersionPropertiesChangeEventGeneratorTest {
+
+  private static final String ENTITY_URN = "urn:li:glossaryTerm:example.term";
+  private static final String VERSION_SET_URN = "urn:li:versionSet:(12345,glossaryTerm)";
+
+  private static EntityAspect makeVersionAspect(
+      String versionTag, String comment, boolean isLatest, long version) {
+    StringBuilder json = new StringBuilder("{");
+    json.append(String.format("\"versionSet\":\"%s\"", VERSION_SET_URN));
+    json.append(String.format(",\"version\":{\"versionTag\":\"%s\"}", versionTag));
+    json.append(",\"sortId\":\"AAAAAAAA\"");
+    if (comment != null) {
+      json.append(String.format(",\"comment\":\"%s\"", comment));
+    }
+    json.append(String.format(",\"isLatest\":%s", isLatest));
+    json.append("}");
+
+    EntityAspect aspect = new EntityAspect();
+    aspect.setUrn(ENTITY_URN);
+    aspect.setAspect(VERSION_PROPERTIES_ASPECT_NAME);
+    aspect.setVersion(version);
+    aspect.setMetadata(json.toString());
+    aspect.setCreatedOn(new Timestamp(1000L * (version + 1)));
+    aspect.setCreatedBy("urn:li:corpuser:tester");
+    return aspect;
+  }
+
+  /** Null metadata simulates the absence of the aspect before the first version write. */
+  private static EntityAspect makeEmptyAspect(long version) {
+    EntityAspect aspect = new EntityAspect();
+    aspect.setUrn(ENTITY_URN);
+    aspect.setAspect(VERSION_PROPERTIES_ASPECT_NAME);
+    aspect.setVersion(version);
+    aspect.setMetadata(null);
+    aspect.setCreatedOn(new Timestamp(1000L * (version + 1)));
+    aspect.setCreatedBy("urn:li:corpuser:tester");
+    return aspect;
+  }
+
+  @Test
+  public void testVersionCreated() {
+    VersionPropertiesChangeEventGenerator generator = new VersionPropertiesChangeEventGenerator();
+
+    EntityAspect previous = makeEmptyAspect(0);
+    EntityAspect current = makeVersionAspect("1.0.0", null, true, 1);
+
+    ChangeTransaction tx =
+        generator.getSemanticDiff(previous, current, ChangeCategory.VERSIONING, null, false);
+
+    assertNotNull(tx);
+    assertEquals(tx.getChangeEvents().size(), 1);
+
+    ChangeEvent event = tx.getChangeEvents().get(0);
+    assertEquals(event.getCategory(), ChangeCategory.VERSIONING);
+    assertEquals(event.getOperation(), ChangeOperation.ADD);
+    assertEquals(event.getSemVerChange(), SemanticChangeType.MINOR);
+    assertTrue(event.getDescription().contains("1.0.0"));
+    assertEquals(event.getParameters().get("versionTag"), "1.0.0");
+    assertEquals(event.getParameters().get("versionSetUrn"), VERSION_SET_URN);
+    assertEquals(event.getParameters().get("isLatest"), "true");
+  }
+
+  @Test
+  public void testVersionCreatedWithComment() {
+    VersionPropertiesChangeEventGenerator generator = new VersionPropertiesChangeEventGenerator();
+
+    EntityAspect previous = makeEmptyAspect(0);
+    EntityAspect current = makeVersionAspect("1.0.0", "initial release", true, 1);
+
+    ChangeTransaction tx =
+        generator.getSemanticDiff(previous, current, ChangeCategory.VERSIONING, null, false);
+
+    ChangeEvent event = tx.getChangeEvents().get(0);
+    assertTrue(event.getDescription().contains("initial release"));
+    assertEquals(event.getParameters().get("comment"), "initial release");
+  }
+
+  @Test
+  public void testVersionTagChanged() {
+    VersionPropertiesChangeEventGenerator generator = new VersionPropertiesChangeEventGenerator();
+
+    EntityAspect previous = makeVersionAspect("1.0.0", null, true, 0);
+    EntityAspect current = makeVersionAspect("2.0.0", null, true, 1);
+
+    ChangeTransaction tx =
+        generator.getSemanticDiff(previous, current, ChangeCategory.VERSIONING, null, false);
+
+    assertNotNull(tx);
+    assertEquals(tx.getChangeEvents().size(), 1);
+
+    ChangeEvent event = tx.getChangeEvents().get(0);
+    assertEquals(event.getOperation(), ChangeOperation.MODIFY);
+    assertEquals(event.getSemVerChange(), SemanticChangeType.PATCH);
+    assertTrue(event.getDescription().contains("1.0.0"));
+    assertTrue(event.getDescription().contains("2.0.0"));
+    assertEquals(event.getParameters().get("versionTag"), "2.0.0");
+    assertEquals(event.getParameters().get("previousVersionTag"), "1.0.0");
+  }
+
+  @Test
+  public void testNoChangeWhenTagUnchanged() {
+    VersionPropertiesChangeEventGenerator generator = new VersionPropertiesChangeEventGenerator();
+
+    EntityAspect previous = makeVersionAspect("1.0.0", null, true, 0);
+    EntityAspect current = makeVersionAspect("1.0.0", null, true, 1);
+
+    ChangeTransaction tx =
+        generator.getSemanticDiff(previous, current, ChangeCategory.VERSIONING, null, false);
+
+    assertNotNull(tx);
+    assertTrue(tx.getChangeEvents().isEmpty());
+    assertEquals(tx.getSemVerChange(), SemanticChangeType.NONE);
+  }
+
+  @Test
+  public void testNonVersioningCategoryIgnored() {
+    VersionPropertiesChangeEventGenerator generator = new VersionPropertiesChangeEventGenerator();
+
+    EntityAspect previous = makeEmptyAspect(0);
+    EntityAspect current = makeVersionAspect("1.0.0", null, true, 1);
+
+    ChangeTransaction tx =
+        generator.getSemanticDiff(previous, current, ChangeCategory.TAG, null, false);
+
+    assertNotNull(tx);
+    assertTrue(tx.getChangeEvents().isEmpty());
+  }
+}

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v2/controller/TimelineControllerV2.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v2/controller/TimelineControllerV2.java
@@ -1,5 +1,7 @@
 package io.datahubproject.openapi.v2.controller;
 
+import static com.linkedin.metadata.Constants.VERSION_PROPERTIES_ASPECT_NAME;
+
 import com.datahub.authentication.Authentication;
 import com.datahub.authentication.AuthenticationContext;
 import com.datahub.authorization.AuthUtil;
@@ -7,23 +9,37 @@ import com.datahub.authorization.AuthorizerChain;
 import com.datahub.authorization.ConjunctivePrivilegeGroup;
 import com.datahub.authorization.DisjunctivePrivilegeGroup;
 import com.datahub.authorization.EntitySpec;
+import com.datahub.util.RecordUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableList;
+import com.linkedin.common.VersionProperties;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.authorization.PoliciesConfig;
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.search.utils.QueryUtils;
 import com.linkedin.metadata.timeline.TimelineService;
 import com.linkedin.metadata.timeline.data.ChangeCategory;
 import com.linkedin.metadata.timeline.data.ChangeTransaction;
+import com.linkedin.metadata.utils.CriterionUtils;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.RequestContext;
 import io.datahubproject.metadata.context.usage.UsageOperation;
 import io.datahubproject.openapi.exception.UnauthorizedException;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import lombok.AllArgsConstructor;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -33,8 +49,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
-@AllArgsConstructor
 @RequestMapping("/openapi/v2/timeline/v1")
 @Tag(
     name = "Timeline",
@@ -42,23 +58,28 @@ import org.springframework.web.bind.annotation.RestController;
         "An API for retrieving historical updates to entities and their related documentation.")
 public class TimelineControllerV2 {
 
+  private static final int MAX_VERSION_WALK = 50;
+  private static final String VERSION_SET_SEARCH_FIELD = "versionSet";
+
   private final OperationContext systemOperationContext;
   private final TimelineService _timelineService;
   private final AuthorizerChain _authorizerChain;
+  private final EntityClient _entityClient;
 
   @Value("${authorization.restApiAuthorization:false}")
   private Boolean restApiAuthorizationEnabled;
 
-  /**
-   * @param rawUrn
-   * @param startTime
-   * @param endTime
-   * @param raw
-   * @param categories
-   * @return
-   * @throws URISyntaxException
-   * @throws JsonProcessingException
-   */
+  public TimelineControllerV2(
+      OperationContext systemOperationContext,
+      TimelineService timelineService,
+      AuthorizerChain authorizerChain,
+      @Qualifier("entityClient") EntityClient entityClient) {
+    this.systemOperationContext = systemOperationContext;
+    this._timelineService = timelineService;
+    this._authorizerChain = authorizerChain;
+    this._entityClient = entityClient;
+  }
+
   @GetMapping(path = "/{urn}", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<List<ChangeTransaction>> getTimeline(
       HttpServletRequest request,
@@ -66,9 +87,15 @@ public class TimelineControllerV2 {
       @RequestParam(name = "startTime", defaultValue = "-1") long startTime,
       @RequestParam(name = "endTime", defaultValue = "0") long endTime,
       @RequestParam(name = "raw", defaultValue = "false") boolean raw,
-      @RequestParam(name = "categories") Set<ChangeCategory> categories)
+      @RequestParam(name = "categories") Set<ChangeCategory> categories,
+      @Parameter(
+              description =
+                  "When true and the entity belongs to a VersionSet, fetches and merges the "
+                      + "timelines of ALL versions in the set into a unified chronological view.")
+          @RequestParam(name = "includeVersionSet", defaultValue = "false")
+          boolean includeVersionSet)
       throws URISyntaxException, JsonProcessingException {
-    // Make request params when implemented
+
     String startVersionStamp = null;
     String endVersionStamp = null;
     Urn urn = Urn.createFromString(rawUrn);
@@ -95,11 +122,21 @@ public class TimelineControllerV2 {
       throw new UnauthorizedException(
           actorUrnStr + " is unauthorized to get the timeline for entity " + urn);
     }
-    // Entity-level view authorization (independent of restApiAuthorization flag):
-    // a caller without view privileges on the target URN must not read its history.
     if (!AuthUtil.canViewEntity(opContext, urn)) {
       throw new UnauthorizedException(actorUrnStr + " is unauthorized to view entity " + urn);
     }
+
+    if (includeVersionSet) {
+      List<Urn> allUrns = resolveVersionSetUrns(urn, opContext);
+      // REST clients today only consume the merged transaction stream; skipped-URN count is
+      // surfaced on the GraphQL surface (GetTimelineResult.skippedVersionCount). If REST
+      // consumers later need the same signal, return a wrapper object here instead.
+      return ResponseEntity.ok(
+          _timelineService
+              .getTimelineForUrns(opContext, allUrns, categories, raw)
+              .getTransactions());
+    }
+
     return ResponseEntity.ok(
         _timelineService.getTimeline(
             opContext,
@@ -110,5 +147,64 @@ public class TimelineControllerV2 {
             startVersionStamp,
             endVersionStamp,
             raw));
+  }
+
+  /**
+   * Resolves all version URNs in the same VersionSet as {@code urn}. Falls back to a singleton list
+   * if the entity is not versioned or discovery fails.
+   */
+  private List<Urn> resolveVersionSetUrns(Urn urn, OperationContext opContext) {
+    try {
+      EntityResponse entityResponse =
+          _entityClient.getV2(
+              opContext,
+              urn.getEntityType(),
+              urn,
+              Collections.singleton(VERSION_PROPERTIES_ASPECT_NAME));
+
+      if (entityResponse == null
+          || !entityResponse.getAspects().containsKey(VERSION_PROPERTIES_ASPECT_NAME)) {
+        return Collections.singletonList(urn);
+      }
+
+      VersionProperties vp =
+          RecordUtils.toRecordTemplate(
+              VersionProperties.class,
+              entityResponse.getAspects().get(VERSION_PROPERTIES_ASPECT_NAME).getValue().data());
+      Urn versionSetUrn = vp.getVersionSet();
+
+      SearchResult searchResult =
+          _entityClient.search(
+              opContext,
+              urn.getEntityType(),
+              "*",
+              QueryUtils.newFilter(
+                  CriterionUtils.buildCriterion(
+                      VERSION_SET_SEARCH_FIELD, Condition.EQUAL, versionSetUrn.toString())),
+              null,
+              0,
+              MAX_VERSION_WALK);
+
+      if (searchResult == null || searchResult.getEntities() == null) {
+        return Collections.singletonList(urn);
+      }
+
+      List<Urn> urns =
+          searchResult.getEntities().stream()
+              .map(SearchEntity::getEntity)
+              .collect(Collectors.toCollection(ArrayList::new));
+
+      if (!urns.contains(urn)) {
+        urns.add(urn);
+      }
+      return urns;
+
+    } catch (Exception e) {
+      log.warn(
+          "Failed to resolve version set URNs for {}, falling back to single-entity: {}",
+          urn,
+          e.getMessage());
+      return Collections.singletonList(urn);
+    }
   }
 }

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/timeline/TimelineFetchResult.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/timeline/TimelineFetchResult.java
@@ -1,0 +1,22 @@
+package com.linkedin.metadata.timeline;
+
+import com.linkedin.metadata.timeline.data.ChangeTransaction;
+import java.util.List;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Result of a multi-URN timeline fetch.
+ *
+ * <p>{@link #getTransactions()} is the merged, oldest-first stream. {@link #getSkippedUrnCount()}
+ * is the number of input URNs whose timelines could not be fetched — typically because the caller
+ * lacks view permission, the URN was deleted between resolve and fetch, or the underlying store
+ * threw an error. Used by the UI to warn the user that the merged view may be partial.
+ */
+@Value
+@Builder
+public class TimelineFetchResult {
+  @Nonnull List<ChangeTransaction> transactions;
+  int skippedUrnCount;
+}

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/timeline/TimelineService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/timeline/TimelineService.java
@@ -30,4 +30,28 @@ public interface TimelineService {
       @Nonnull Set<ChangeCategory> elements,
       int maxChangeTransactions,
       boolean rawDiffRequested);
+
+  /**
+   * Fetches and merges timelines for multiple URNs into one unified, oldest-first stream.
+   *
+   * <p>This is the low-level primitive used by the {@code includeVersionSet} feature: the caller
+   * (typically {@code GetTimelineResolver}) resolves the sibling version URNs using the
+   * EntityClient and then hands the full list to this method. Each URN is queried independently and
+   * the results are merged and sorted by {@code timestampMillis} (with the actor as a stable
+   * tie-breaker).
+   *
+   * <p>Per-URN failures (auth, deletion race, store errors) are skipped rather than thrown so a
+   * partial result can still be returned. The number of skipped URNs is reported on the result so
+   * the caller can surface a "view may be partial" warning to the user.
+   *
+   * @param urns All URNs to include (typically: current version + all siblings in the VersionSet).
+   * @param elements Change categories to include.
+   * @param rawDiffRequested Whether to include raw JSON diffs in the response.
+   */
+  @Nonnull
+  TimelineFetchResult getTimelineForUrns(
+      @Nonnull OperationContext opContext,
+      @Nonnull List<Urn> urns,
+      @Nonnull Set<ChangeCategory> elements,
+      boolean rawDiffRequested);
 }

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/timeline/data/ChangeCategory.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/timeline/data/ChangeCategory.java
@@ -35,7 +35,11 @@ public enum ChangeCategory {
   // Related entities changes (Currently used for document related assets, related documents, etc.)
   RELATED_ENTITIES,
   // Asset membership changes (e.g. assets added/removed from a Data Product)
-  ASSET_MEMBERSHIP;
+  ASSET_MEMBERSHIP,
+  // Version lifecycle events — version created, promoted, or versionTag changed within a
+  // VersionSet. Emitted for any entity type that carries VersionProperties. Does NOT cover
+  // lifecycle-stage transitions (DRAFT → PUBLISHED etc.), which live on a separate aspect.
+  VERSIONING;
 
   public static final Map<List<String>, ChangeCategory> COMPOUND_CATEGORIES;
 

--- a/smoke-test/tests/entity_versioning/test_versioning_timeline.py
+++ b/smoke-test/tests/entity_versioning/test_versioning_timeline.py
@@ -1,0 +1,188 @@
+"""
+Smoke test for getTimeline with includeVersionSet=true.
+
+Regression test for the bug where filterNonLatestVersions=true (the default) caused the
+version-set sibling search inside GetTimelineResolver to return only the latest version,
+so change history across all versions was collapsed to a single entity's events.
+"""
+
+import logging
+
+import pytest
+
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.graph.client import DataHubGraph
+from datahub.metadata.schema_classes import (
+    DatasetPropertiesClass,
+    VersioningSchemeClass,
+    VersionPropertiesClass,
+    VersionSetPropertiesClass,
+    VersionTagClass,
+)
+from datahub.metadata.urns import DatasetUrn, VersionSetUrn
+from tests.consistency_utils import wait_for_writes_to_sync
+
+logger = logging.getLogger(__name__)
+
+# Stable URNs for this test — deterministic so cleanup is reliable.
+_PLATFORM = "timeline_smoke"
+_VERSION_SET_URN = VersionSetUrn("timeline-test-vset-001", DatasetUrn.ENTITY_TYPE)
+_V1 = DatasetUrn(_PLATFORM, "timeline_test_v1_0_0")
+_V2 = DatasetUrn(_PLATFORM, "timeline_test_v2_0_0")
+_V3 = DatasetUrn(_PLATFORM, "timeline_test_v3_0_0")
+_VERSIONS = [(_V1, "1.0.0", "01"), (_V2, "2.0.0", "02"), (_V3, "3.0.0", "03")]
+
+_GET_TIMELINE_QUERY = """
+query getTimeline($input: GetTimelineInput!) {
+  getTimeline(input: $input) {
+    changeTransactions {
+      timestampMillis
+      changes {
+        category
+        operation
+        description
+      }
+    }
+    skippedVersionCount
+  }
+}
+"""
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ingest_cleanup_data(graph_client: DataHubGraph):
+    """Emit three versioned datasets then clean up after the module."""
+    logger.info("Ingesting versioned test entities for timeline smoke test")
+    for _, (urn_obj, tag, sort_id) in enumerate(_VERSIONS):
+        graph_client.emit(
+            MetadataChangeProposalWrapper(
+                entityUrn=urn_obj.urn(),
+                aspect=DatasetPropertiesClass(
+                    name=f"Timeline Test {tag}",
+                    description=f"Version {tag} of the timeline smoke-test entity.",
+                ),
+            )
+        )
+        graph_client.emit(
+            MetadataChangeProposalWrapper(
+                entityUrn=urn_obj.urn(),
+                aspect=VersionPropertiesClass(
+                    versionSet=_VERSION_SET_URN.urn(),
+                    version=VersionTagClass(versionTag=tag),
+                    sortId=sort_id,
+                    versioningScheme=VersioningSchemeClass.LEXICOGRAPHIC_STRING,
+                    comment=f"Release {tag}",
+                ),
+            )
+        )
+
+    # Point the version set at the latest
+    graph_client.emit(
+        MetadataChangeProposalWrapper(
+            entityUrn=_VERSION_SET_URN.urn(),
+            aspect=VersionSetPropertiesClass(
+                latest=_V3.urn(),
+                versioningScheme=VersioningSchemeClass.LEXICOGRAPHIC_STRING,
+            ),
+        )
+    )
+
+    wait_for_writes_to_sync()
+    yield
+
+    logger.info("Cleaning up versioned test entities")
+    for urn_obj, _, _ in _VERSIONS:
+        graph_client.hard_delete_entity(urn_obj.urn())
+    graph_client.hard_delete_entity(_VERSION_SET_URN.urn())
+
+
+def test_get_timeline_without_version_set(graph_client: DataHubGraph):
+    """Baseline: single-entity timeline returns only that entity's events."""
+    result = graph_client.execute_graphql(
+        _GET_TIMELINE_QUERY,
+        variables={
+            "input": {
+                "urn": _V3.urn(),
+                "changeCategories": ["DOCUMENTATION"],
+                "includeVersionSet": False,
+            }
+        },
+    )
+    assert "errors" not in result, f"GraphQL errors: {result.get('errors')}"
+
+    data = result["getTimeline"]
+    txns = data["changeTransactions"]
+    assert len(txns) >= 1, "Expected at least one transaction for the latest version"
+    assert data["skippedVersionCount"] == 0
+
+
+def test_get_timeline_with_version_set_returns_all_versions(graph_client: DataHubGraph):
+    """
+    Core regression test: with includeVersionSet=true, getTimeline must return
+    change events from every version in the set, not just the latest one.
+
+    Before the fix, filterNonLatestVersions=true was applied to the sibling
+    search, so v1 and v2 were silently excluded and only v3's events appeared.
+    """
+    result = graph_client.execute_graphql(
+        _GET_TIMELINE_QUERY,
+        variables={
+            "input": {
+                "urn": _V3.urn(),
+                "changeCategories": ["DOCUMENTATION"],
+                "includeVersionSet": True,
+            }
+        },
+    )
+    assert "errors" not in result, f"GraphQL errors: {result.get('errors')}"
+
+    data = result["getTimeline"]
+    txns = data["changeTransactions"]
+
+    # We emitted DatasetProperties for 3 distinct versions, so we must see at
+    # least 3 change transactions when the full version set is included.
+    assert len(txns) >= 3, (
+        f"Expected change transactions from all 3 versions, got {len(txns)}. "
+        "This is the filterNonLatestVersions regression — only the latest "
+        "version's events appeared."
+    )
+
+    assert data["skippedVersionCount"] == 0
+
+
+def test_get_timeline_version_set_superset_of_single_entity(graph_client: DataHubGraph):
+    """
+    The all-versions timeline must include at least everything the single-entity
+    timeline shows, plus events from the other versions.
+    """
+    single_result = graph_client.execute_graphql(
+        _GET_TIMELINE_QUERY,
+        variables={
+            "input": {
+                "urn": _V3.urn(),
+                "changeCategories": ["DOCUMENTATION"],
+                "includeVersionSet": False,
+            }
+        },
+    )
+    all_result = graph_client.execute_graphql(
+        _GET_TIMELINE_QUERY,
+        variables={
+            "input": {
+                "urn": _V3.urn(),
+                "changeCategories": ["DOCUMENTATION"],
+                "includeVersionSet": True,
+            }
+        },
+    )
+
+    single_count = len(single_result["getTimeline"]["changeTransactions"])
+    all_count = len(all_result["getTimeline"]["changeTransactions"])
+
+    assert all_count >= single_count, (
+        "All-versions timeline should have at least as many transactions as the single-entity view"
+    )
+    assert all_count > single_count, (
+        "All-versions timeline should have MORE transactions than the single-entity view "
+        f"(got {all_count} vs {single_count})"
+    )


### PR DESCRIPTION
## Summary

Adds a **`VERSIONING`** change category to the Timeline API and lets callers retrieve the merged change history of an entity's **entire VersionSet** as one unified, chronological stream. For a versioned entity (GlossaryTerm or Dataset), you can now see version-creation milestones interleaved with the per-version metadata changes across every version of the concept — instead of a single version's history in isolation.

### Why

Versioned entities (entities carrying a `versionProperties` aspect within a `VersionSet`) previously had no way to see change history across the whole version lineage. The Timeline API only ever reported a single URN's events, so the story of how a concept evolved across its versions was invisible.

## What's included

- **`ChangeCategory.VERSIONING`** — new backend enum value and matching `ChangeCategoryType.VERSIONING` in the GraphQL schema.
- **`VersionPropertiesChangeEventGenerator`** — emits timeline events off the `versionProperties` aspect: a version being created (first write) and `versionTag` changes. Each event carries structured `parameters` (`versionTag`, `comment`, `versionSetUrn`, `isLatest`, `previousVersionTag`) so consumers can render a rich milestone. Registered for **GlossaryTerm** and **Dataset**.
- **`TimelineService.getTimelineForUrns` + `TimelineFetchResult`** — a merge primitive that queries each URN independently, merges into one oldest-first stream (sorted by timestamp, then actor as a stable tie-breaker), and reports the count of URNs skipped on per-URN failure (auth / deletion race / store error) instead of aborting.
- **GraphQL** — `GetTimelineInput.includeVersionSet` and `GetTimelineResult.skippedVersionCount`. When `includeVersionSet` is true, `GetTimelineResolver` resolves the entity's VersionSet siblings via search (walk capped at 50), merges their timelines, and surfaces a partial-view count. Non-versioned URNs are unaffected — the flag is silently ignored and the response is shape-identical to a normal single-URN fetch.
- **OpenAPI v2** — `includeVersionSet` query param on `GET /openapi/v2/timeline/v1/{urn}`.
- **CLI** — `datahub timeline --include-version-set` plus the `versioning` category.

## How it works

`includeVersionSet=true` → resolve the target's `versionProperties.versionSet` → search all entities in that VersionSet (including non-latest versions) → merge each one's timeline via `getTimelineForUrns`. Version milestones come from `VersionPropertiesChangeEventGenerator`; the merge is entity-type-agnostic, so non-versioned URNs simply fall through to the existing single-entity path.

## Testing

- `VersionPropertiesChangeEventGeneratorTest` — version-created and versionTag-changed events, structured parameters, no-op on unchanged tag, non-VERSIONING categories ignored.
- `TimelineServiceImplGetTimelineForUrnsTest` — multi-URN merge ordering, actor tie-break on equal timestamps, per-URN failure counted in `skippedVersionCount` without aborting, empty input.
- `TimelineServiceVersioningRegistrationTest` — regression guard that VERSIONING resolves to `versionProperties` for both GlossaryTerm and Dataset.
- `GetTimelineResolverTest` — version-set expansion, singleton fallback, truncation accounting, enum parity.
- `smoke-test/tests/entity_versioning/test_versioning_timeline.py` — end-to-end over a 3-version Dataset VersionSet, including the non-latest-version regression.

All new unit tests pass locally; `metadata-io`, `datahub-graphql-core`, `metadata-service/*`, and Python lint are green.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing/#commit-message-format))
- [x] Tests added/updated
- [ ] Breaking changes — none (purely additive)