### PR TITLE
feat(ingest/clickhouse): identify DataHub connections as datahub

### DIFF
--- a/metadata-ingestion/docs/sources/clickhouse/clickhouse_post.md
+++ b/metadata-ingestion/docs/sources/clickhouse/clickhouse_post.md
@@ -11,6 +11,10 @@ Enable query-log based metadata extraction to augment definition-based lineage:
 
 This complements view/materialized-view lineage and improves operational usage visibility.
 
+#### Connection Tagging
+
+DataHub tags its connections with a `datahub` client identity so its own reads are attributable in `system.query_log`. On HTTP drivers this is the `User-Agent` header (`http_user_agent = 'datahub'`); on the native/asynch drivers it is `client_name`, which the driver records as `ClickHouse datahub`. To override it, set your own value via `uri_opts` (`header__User-Agent` for HTTP, `client_name` for native).
+
 ### Limitations
 
 Module behavior is constrained by source APIs, permissions, and metadata exposed by the platform. Refer to capability notes for unsupported or conditional features.

--- a/metadata-ingestion/docs/sources/clickhouse/clickhouse_post.md
+++ b/metadata-ingestion/docs/sources/clickhouse/clickhouse_post.md
@@ -11,10 +11,6 @@ Enable query-log based metadata extraction to augment definition-based lineage:
 
 This complements view/materialized-view lineage and improves operational usage visibility.
 
-#### Connection Tagging
-
-DataHub tags its connections with a `datahub` client identity so its own reads are attributable in `system.query_log`. On HTTP drivers this is the `User-Agent` header (`http_user_agent = 'datahub'`); on the native/asynch drivers it is `client_name`, which the driver records as `ClickHouse datahub`. To override it, set your own value via `uri_opts` (`header__User-Agent` for HTTP, `client_name` for native).
-
 ### Limitations
 
 Module behavior is constrained by source APIs, permissions, and metadata exposed by the platform. Refer to capability notes for unsupported or conditional features.

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/clickhouse.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/clickhouse.py
@@ -260,7 +260,9 @@ class ClickHouseConfig(
             url = url.set(database=current_db)
 
         url = with_client_identity(url)
-        # str(URL) masks passwords on SQLAlchemy 2.0; create_engine() needs the real one.
+        # Explicit about keeping the password: on SQLAlchemy 1.4 (currently pinned)
+        # str(URL) already renders it, but SQLAlchemy 2.0 masks it in str() — this
+        # keeps create_engine() working if/when the pin moves to 2.x.
         return url.render_as_string(hide_password=False)
 
     # pre = True because we want to take some decision before pydantic initialize the configuration to default values

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/clickhouse.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/clickhouse.py
@@ -43,6 +43,7 @@ from datahub.ingestion.api.decorators import (
 from datahub.ingestion.api.source_helpers import auto_workunit
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.common.subtypes import SourceCapabilityModifier
+from datahub.ingestion.source.sql.clickhouse_connection import with_client_identity
 from datahub.ingestion.source.sql.sql_common import (
     SqlWorkUnit,
     logger,
@@ -258,7 +259,9 @@ class ClickHouseConfig(
         if self.sqlalchemy_uri and current_db:
             url = url.set(database=current_db)
 
-        return str(url)
+        url = with_client_identity(url)
+        # str(URL) masks passwords on SQLAlchemy 2.0; create_engine() needs the real one.
+        return url.render_as_string(hide_password=False)
 
     # pre = True because we want to take some decision before pydantic initialize the configuration to default values
     @model_validator(mode="before")

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/clickhouse_connection.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/clickhouse_connection.py
@@ -1,14 +1,16 @@
-from typing import Final
+from typing import Final, Mapping
 
 from sqlalchemy.engine.url import URL
 
-# Stable product token (same value as DATABRICKS_USER_AGENT_ENTRY in unity/connection.py).
+# Stable client-identity token so DataHub's own reads are attributable in
+# system.query_log, mirroring Databricks partner tagging. Kept bare (no version
+# suffix) so attribution queries can match it exactly.
 CLICKHOUSE_CLIENT_NAME: Final = "datahub"
 
 _HTTP_UA_PARAM: Final = "header__User-Agent"
 _NATIVE_PARAM: Final = "client_name"
 
-_IDENTITY_PARAM_BY_DRIVER: Final = {
+_IDENTITY_PARAM_BY_DRIVER: Final[Mapping[str, str]] = {
     "clickhouse": _HTTP_UA_PARAM,
     "clickhouse+http": _HTTP_UA_PARAM,
     "clickhouse+native": _NATIVE_PARAM,
@@ -17,7 +19,22 @@ _IDENTITY_PARAM_BY_DRIVER: Final = {
 
 
 def with_client_identity(url: URL) -> URL:
+    """Tag the connection URL with a ``datahub`` client identity.
+
+    HTTP drivers get a ``User-Agent`` request header; native/asynch drivers get
+    ``client_name``. A user-supplied value is left untouched.
+
+    Note the native drivers prefix their own product name, so the value that
+    lands in ``system.query_log`` is ``ClickHouse datahub`` on native versus
+    exactly ``datahub`` in ``http_user_agent`` on HTTP.
+    """
     param = _IDENTITY_PARAM_BY_DRIVER.get(url.drivername)
-    if param is None or param in url.query:
+    if param is None:
+        return url
+    # HTTP header names are case-insensitive; requests would silently collapse a
+    # user's header__user-agent and our header__User-Agent into one key, dropping
+    # the override. Compare case-insensitively so an existing value always wins.
+    existing = {key.casefold() for key in url.query}
+    if param.casefold() in existing:
         return url
     return url.set(query={**url.query, param: CLICKHOUSE_CLIENT_NAME})

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/clickhouse_connection.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/clickhouse_connection.py
@@ -1,0 +1,23 @@
+from typing import Final
+
+from sqlalchemy.engine.url import URL
+
+# Stable product token (same value as DATABRICKS_USER_AGENT_ENTRY in unity/connection.py).
+CLICKHOUSE_CLIENT_NAME: Final = "datahub"
+
+_HTTP_UA_PARAM: Final = "header__User-Agent"
+_NATIVE_PARAM: Final = "client_name"
+
+_IDENTITY_PARAM_BY_DRIVER: Final = {
+    "clickhouse": _HTTP_UA_PARAM,
+    "clickhouse+http": _HTTP_UA_PARAM,
+    "clickhouse+native": _NATIVE_PARAM,
+    "clickhouse+asynch": _NATIVE_PARAM,
+}
+
+
+def with_client_identity(url: URL) -> URL:
+    param = _IDENTITY_PARAM_BY_DRIVER.get(url.drivername)
+    if param is None or param in url.query:
+        return url
+    return url.set(query={**url.query, param: CLICKHOUSE_CLIENT_NAME})

--- a/metadata-ingestion/tests/unit/test_clickhouse_connection.py
+++ b/metadata-ingestion/tests/unit/test_clickhouse_connection.py
@@ -20,9 +20,10 @@ def test_http_url_gets_user_agent_header(uri: str) -> None:
     assert "client_name" not in url.query
 
 
-def test_native_url_gets_client_name() -> None:
+@pytest.mark.parametrize("scheme", ["clickhouse+native", "clickhouse+asynch"])
+def test_native_url_gets_client_name(scheme: str) -> None:
     url = with_client_identity(
-        make_url("clickhouse+native://user:password@host:9000/db?secure=true")
+        make_url(f"{scheme}://user:password@host:9000/db?secure=true")
     )
     assert url.query.get("client_name") == CLICKHOUSE_CLIENT_NAME
     assert "header__User-Agent" not in url.query
@@ -34,6 +35,15 @@ def test_user_supplied_http_ua_is_preserved() -> None:
         make_url("clickhouse://user:password@host:8123/db?header__User-Agent=mycorp")
     )
     assert url.query.get("header__User-Agent") == "mycorp"
+
+
+def test_user_supplied_http_ua_is_preserved_case_insensitively() -> None:
+    # HTTP header names are case-insensitive, so a lowercase override must still win.
+    url = with_client_identity(
+        make_url("clickhouse://user:password@host:8123/db?header__user-agent=mycorp")
+    )
+    assert url.query.get("header__user-agent") == "mycorp"
+    assert "header__User-Agent" not in url.query
 
 
 def test_user_supplied_native_client_name_is_preserved() -> None:

--- a/metadata-ingestion/tests/unit/test_clickhouse_connection.py
+++ b/metadata-ingestion/tests/unit/test_clickhouse_connection.py
@@ -1,0 +1,48 @@
+import pytest
+from sqlalchemy.engine.url import make_url
+
+from datahub.ingestion.source.sql.clickhouse_connection import (
+    CLICKHOUSE_CLIENT_NAME,
+    with_client_identity,
+)
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "clickhouse://user:password@host:8123/db",
+        "clickhouse+http://user:password@host:8123/db",
+    ],
+)
+def test_http_url_gets_user_agent_header(uri: str) -> None:
+    url = with_client_identity(make_url(uri))
+    assert url.query.get("header__User-Agent") == CLICKHOUSE_CLIENT_NAME
+    assert "client_name" not in url.query
+
+
+def test_native_url_gets_client_name() -> None:
+    url = with_client_identity(
+        make_url("clickhouse+native://user:password@host:9000/db?secure=true")
+    )
+    assert url.query.get("client_name") == CLICKHOUSE_CLIENT_NAME
+    assert "header__User-Agent" not in url.query
+    assert url.query.get("secure") == "true"
+
+
+def test_user_supplied_http_ua_is_preserved() -> None:
+    url = with_client_identity(
+        make_url("clickhouse://user:password@host:8123/db?header__User-Agent=mycorp")
+    )
+    assert url.query.get("header__User-Agent") == "mycorp"
+
+
+def test_user_supplied_native_client_name_is_preserved() -> None:
+    url = with_client_identity(
+        make_url("clickhouse+native://user:password@host:9000/db?client_name=mycorp")
+    )
+    assert url.query.get("client_name") == "mycorp"
+
+
+def test_unknown_driver_is_unchanged() -> None:
+    original = make_url("postgresql://user:password@host:5432/db")
+    assert with_client_identity(original) == original

--- a/metadata-ingestion/tests/unit/test_clickhouse_source.py
+++ b/metadata-ingestion/tests/unit/test_clickhouse_source.py
@@ -116,6 +116,15 @@ def test_clickhouse_uri_preserves_user_supplied_ua():
     assert url.query.get("header__User-Agent") == "mycorp"
 
 
+def test_clickhouse_sqlalchemy_uri_gets_client_identity():
+    # A hand-written sqlalchemy_uri (the docs-preferred form) is still tagged.
+    config = ClickHouseConfig.model_validate(
+        {"sqlalchemy_uri": "clickhouse://user:password@host:1111/db"}
+    )
+    url = make_url(config.get_sql_alchemy_url())
+    assert url.query.get("header__User-Agent") == CLICKHOUSE_CLIENT_NAME
+
+
 # Query log extraction tests
 
 

--- a/metadata-ingestion/tests/unit/test_clickhouse_source.py
+++ b/metadata-ingestion/tests/unit/test_clickhouse_source.py
@@ -1,6 +1,8 @@
 import pytest
+from sqlalchemy.engine.url import make_url
 
 from datahub.ingestion.source.sql.clickhouse import ClickHouseConfig
+from datahub.ingestion.source.sql.clickhouse_connection import CLICKHOUSE_CLIENT_NAME
 
 
 def test_clickhouse_uri_https():
@@ -13,10 +15,15 @@ def test_clickhouse_uri_https():
             "uri_opts": {"protocol": "https"},
         }
     )
-    assert (
-        config.get_sql_alchemy_url()
-        == "clickhouse://user:password@host:1111/db?protocol=https"
-    )
+    url = make_url(config.get_sql_alchemy_url())
+    assert url.drivername == "clickhouse"
+    assert url.username == "user"
+    assert url.password == "password"
+    assert url.host == "host"
+    assert url.port == 1111
+    assert url.database == "db"
+    assert url.query.get("protocol") == "https"
+    assert url.query.get("header__User-Agent") == CLICKHOUSE_CLIENT_NAME
 
 
 def test_clickhouse_uri_native():
@@ -28,7 +35,10 @@ def test_clickhouse_uri_native():
             "scheme": "clickhouse+native",
         }
     )
-    assert config.get_sql_alchemy_url() == "clickhouse+native://user:password@host:1111"
+    url = make_url(config.get_sql_alchemy_url())
+    assert url.drivername == "clickhouse+native"
+    assert url.query.get("client_name") == CLICKHOUSE_CLIENT_NAME
+    assert "header__User-Agent" not in url.query
 
 
 def test_clickhouse_uri_native_secure():
@@ -42,10 +52,9 @@ def test_clickhouse_uri_native_secure():
             "uri_opts": {"secure": True},
         }
     )
-    assert (
-        config.get_sql_alchemy_url()
-        == "clickhouse+native://user:password@host:1111/db?secure=True"
-    )
+    url = make_url(config.get_sql_alchemy_url())
+    assert url.query.get("secure") == "True"
+    assert url.query.get("client_name") == CLICKHOUSE_CLIENT_NAME
 
 
 def test_clickhouse_uri_default_password():
@@ -57,7 +66,9 @@ def test_clickhouse_uri_default_password():
             "scheme": "clickhouse+native",
         }
     )
-    assert config.get_sql_alchemy_url() == "clickhouse+native://user@host:1111/db"
+    url = make_url(config.get_sql_alchemy_url())
+    assert url.password is None
+    assert url.query.get("client_name") == CLICKHOUSE_CLIENT_NAME
 
 
 def test_clickhouse_uri_native_secure_backward_compatibility():
@@ -71,10 +82,9 @@ def test_clickhouse_uri_native_secure_backward_compatibility():
             "secure": True,
         }
     )
-    assert (
-        config.get_sql_alchemy_url()
-        == "clickhouse+native://user:password@host:1111/db?secure=True"
-    )
+    url = make_url(config.get_sql_alchemy_url())
+    assert url.query.get("secure") == "True"
+    assert url.query.get("client_name") == CLICKHOUSE_CLIENT_NAME
 
 
 def test_clickhouse_uri_https_backward_compatibility():
@@ -87,10 +97,23 @@ def test_clickhouse_uri_https_backward_compatibility():
             "protocol": "https",
         }
     )
-    assert (
-        config.get_sql_alchemy_url()
-        == "clickhouse://user:password@host:1111/db?protocol=https"
+    url = make_url(config.get_sql_alchemy_url())
+    assert url.query.get("protocol") == "https"
+    assert url.query.get("header__User-Agent") == CLICKHOUSE_CLIENT_NAME
+
+
+def test_clickhouse_uri_preserves_user_supplied_ua():
+    config = ClickHouseConfig.model_validate(
+        {
+            "username": "user",
+            "password": "password",
+            "host_port": "host:1111",
+            "database": "db",
+            "uri_opts": {"header__User-Agent": "mycorp"},
+        }
     )
+    url = make_url(config.get_sql_alchemy_url())
+    assert url.query.get("header__User-Agent") == "mycorp"
 
 
 # Query log extraction tests


### PR DESCRIPTION
Tags ClickHouse connections with a `datahub` client identity so DataHub's own
queries are attributable in `system.query_log`, matching how the Databricks
connector tags its traffic.

`with_client_identity()` sets the identity based on the driver and is called
from `ClickHouseConfig.get_sql_alchemy_url()`, so every connection DataHub opens
(metadata, profiling, usage) carries it:

- HTTP drivers → `User-Agent` header → `http_user_agent = 'datahub'`
- Native/asynch drivers → `client_name` → `client_name = 'ClickHouse datahub'`

The native value differs because the driver prefixes its own product name. A
user-supplied `header__User-Agent` or `client_name` (via `uri_opts` or a
hand-written `sqlalchemy_uri`) is left as-is; the override check is
case-insensitive for the HTTP header.

Tested against ClickHouse in Docker over both protocols: a single ingestion
tagged all 104 query-log rows, and a lowercase override was preserved.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
