### PR TITLE
docs(auth): document OSS metadata-auth/token setup and link consumer docs to it

### DIFF
--- a/docs/authentication/introducing-metadata-service-authentication.md
+++ b/docs/authentication/introducing-metadata-service-authentication.md
@@ -60,9 +60,38 @@ OR
 - change the Metadata Service `application.yaml` configuration file to set `authentication.enabled` to "true" AND
 - change the Frontend Proxy Service `application.config` configuration file to set `metadataService.auth.enabled` to "true"
 
+> **Using the local Docker quickstart?** Quickstart ships with Metadata Service Authentication forced off (unlike other deployments, where it's enabled by default), and it overrides the environment variable — follow [Enabling on Local Docker Quickstart](#enabling-on-local-docker-quickstart) below instead of setting the variable.
+
 :::note
-It is recommended that users provide their own values for `authentication.tokenService.signingKey` and `authentication.tokenService.salt` by updating `application.yaml` in Metadata Service or setting the corresponding environment variables `DATAHUB_TOKEN_SERVICE_SIGNING_KEY` and `DATAHUB_TOKEN_SERVICE_SALT`
+For production, self-managed, or Kubernetes deployments, provide your own values for `authentication.tokenService.signingKey` and `authentication.tokenService.salt` by updating `application.yaml` in Metadata Service or setting the corresponding environment variables `DATAHUB_TOKEN_SERVICE_SIGNING_KEY` and `DATAHUB_TOKEN_SERVICE_SALT`. The local Docker quickstart generates unique values for these automatically, so you don't need to set them there.
 :::
+
+### Enabling on Local Docker Quickstart
+
+If you're using the local `datahub docker quickstart`, setting the environment variable alone won't work — the quickstart forces Metadata Service Authentication off, and it re-downloads its Docker Compose file on every run. To enable it, edit a local copy of the Compose file and launch quickstart with that file.
+
+1. Make your own copy of the quickstart Compose file (quickstart overwrites the original on each run):
+
+   ```bash
+   cp ~/.datahub/quickstart/docker-compose.yml ~/datahub-auth-compose.yml
+   ```
+
+2. In `~/datahub-auth-compose.yml`, under the `datahub-gms-quickstart` service, change `METADATA_SERVICE_AUTH_ENABLED` from `'false'` to `'true'` (the line is already there).
+3. In the same file, under the `frontend-quickstart` service's `environment:` block, add a new line (it isn't there by default):
+
+   ```
+   METADATA_SERVICE_AUTH_ENABLED: 'true'
+   ```
+
+4. Use a literal `'true'` in both places — do not use a `${...}` variable, because quickstart would override it back to `false`.
+5. Restart quickstart using your edited file:
+
+   ```bash
+   datahub docker quickstart --stop
+   datahub docker quickstart -f ~/datahub-auth-compose.yml
+   ```
+
+From now on, always launch with `-f ~/datahub-auth-compose.yml` — a plain `datahub docker quickstart` re-downloads the default Compose file and your change is lost.
 
 After setting the configuration flag, simply restart the Metadata Service to start enforcing Authentication.
 
@@ -121,9 +150,10 @@ These changes represent the first milestone in Metadata Service Authentication. 
 
 ### What if I don't want to use Metadata Service Authentication?
 
-That's perfectly fine, for now. Metadata Service Authentication is disabled by default, only enabled if you provide the
-environment variable `METADATA_SERVICE_AUTH_ENABLED` to the `datahub-gms` container or change the `authentication.enabled` to "true"
-inside your DataHub Metadata Service configuration (`application.yaml`).
+That's perfectly fine, for now. The Metadata Service enables Authentication by default, but you can turn it off by setting the
+environment variable `METADATA_SERVICE_AUTH_ENABLED` to "false" for the `datahub-gms` container or changing `authentication.enabled` to "false"
+inside your DataHub Metadata Service configuration (`application.yaml`). The local Docker quickstart is the exception — it ships with
+Authentication disabled.
 
 That being said, we will be recommending that you enable Authentication for production use cases, to prevent
 arbitrary actors from ingesting metadata into DataHub.

--- a/docs/authentication/personal-access-tokens.md
+++ b/docs/authentication/personal-access-tokens.md
@@ -31,6 +31,8 @@ If you have configured permissions correctly the `Generate new token` should be 
 
 If you see `Token based authentication is currently disabled. Contact your DataHub administrator to enable this feature.` then you must enable authentication in the metadata service (step 1 of the prerequisites).
 
+Using the local Docker quickstart? See [Enabling on Local Docker Quickstart](introducing-metadata-service-authentication.md#enabling-on-local-docker-quickstart) for the exact steps.
+
 :::
 
 ## Creating Personal Access Tokens

--- a/docs/dev-guides/agent-context/skills.md
+++ b/docs/dev-guides/agent-context/skills.md
@@ -51,7 +51,7 @@ The skill walks you through connecting to your DataHub instance. It configures a
 <Tabs>
 <TabItem value="cloud" label="DataHub Cloud">
 
-You'll need your tenant URL and a personal access token:
+You'll need your tenant URL and a [personal access token](../../authentication/personal-access-tokens.md):
 
 ```
 Connect to DataHub Cloud at <tenant>.acryl.io
@@ -60,7 +60,7 @@ Connect to DataHub Cloud at <tenant>.acryl.io
 </TabItem>
 <TabItem value="oss" label="Self-Hosted">
 
-You'll need your GMS URL (e.g., `http://localhost:8080`) and a personal access token:
+You'll need your GMS URL (e.g., `http://localhost:8080`) and a [personal access token](../../authentication/personal-access-tokens.md):
 
 ```
 Connect to my self-hosted DataHub at <gms-url>

--- a/docs/features/feature-guides/analytics-agent.md
+++ b/docs/features/feature-guides/analytics-agent.md
@@ -155,6 +155,8 @@ DATAHUB_GMS_URL=http://your-datahub-host:8080
 DATAHUB_GMS_TOKEN=your-token-here
 ```
 
+To create this token, see [Personal Access Tokens](../../authentication/personal-access-tokens.md).
+
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
## Summary

Makes the self-hosted / OSS access-token flow accurate and discoverable.

The Metadata Service Authentication guide didn't explain how to enable auth on the local Docker quickstart (where the environment variable is overridden), and several docs that require a token didn't link users to where they'd create one.

## Changes

- **introducing-metadata-service-authentication.md**: added an "Enabling on Local Docker Quickstart" section with the exact steps (the env var alone doesn't work there); corrected the signing-key/salt note (quickstart auto-generates these); added a signpost from the general enable instructions to the quickstart steps; and fixed a Q&A line that said auth is "disabled by default" (GMS defaults it on — quickstart is the exception).
- **personal-access-tokens.md**: added a pointer to the quickstart enablement steps.
- **skills.md** and **analytics-agent.md**: linked the "personal access token" references to the PAT guide (scoped to the self-hosted flow).

## Checklist
- [x] Conforms to the Contributing Guideline and PR Title Format
- [ ] Links to related issues — N/A
- [ ] Tests — N/A (docs only)
- [x] Docs updated
- [ ] Updating DataHub entry — N/A (no behavior change)