### PR TITLE
docs: add Python SDK examples to the Structured Properties tutorial

### DIFF
--- a/docs/api/tutorials/structured-properties.md
+++ b/docs/api/tutorials/structured-properties.md
@@ -97,6 +97,32 @@ If successful, you should see `Created structured property urn:li:structuredProp
 
 </TabItem>
 
+<TabItem value="Python" label="Python">
+
+Using the Python SDK, define your properties in a YAML file (same schema as the CLI tab)
+and register them with the `StructuredProperties.create` **staticmethod** — note it takes
+a **YAML file path and a graph**, it is *not* an instance method:
+
+```python
+from datahub.api.entities.structuredproperties.structuredproperties import StructuredProperties
+from datahub.ingestion.graph.client import DataHubGraph, DatahubClientConfig
+
+graph = DataHubGraph(DatahubClientConfig(server="http://localhost:8080"))
+
+# create(file, graph) is a @staticmethod: pass the YAML file path, then the graph.
+StructuredProperties.create("structured_properties.yaml", graph)
+```
+
+:::caution
+`StructuredProperties.create` is a **static method**: `create(file: str, graph: DataHubGraph)`.
+Calling it on an instance — `StructuredProperties(id=...).create(graph)` — passes the graph
+as the `file` argument and fails. To define a property fully in code without a YAML file,
+emit the definition as an MCP instead (see
+[`examples/structured_properties/create_structured_property.py`](https://github.com/datahub-project/datahub/blob/master/metadata-ingestion/examples/structured_properties/create_structured_property.py)).
+:::
+
+</TabItem>
+
 <TabItem value="Graphql" label="GraphQL" default>
 
 ```graphql
@@ -676,6 +702,14 @@ Example Response:
 
 This action will set/replace all structured properties on the entity. See PATCH operations to add/remove a single property.
 
+:::info Privileges & the MCP mutation flag
+Writing via the Python SDK / GraphQL emitter goes **directly to GMS** and is governed only
+by your token's platform privileges: **Manage Structured Properties** to create a
+definition, and **Edit Properties** to set a value on an entity. The
+`TOOLS_IS_MUTATION_ENABLED` environment variable gates mutation *tools* on the
+`mcp-server-datahub` MCP server only — it has **no effect** on direct SDK/GraphQL writes.
+:::
+
 <Tabs>
 <TabItem value="GraphQL" label="GraphQL" default>
 
@@ -861,6 +895,33 @@ query getDataset {
 ```
 
 </TabItem>  
+
+<TabItem value="Python" label="Python">
+
+There is no single-property *value* read primitive. A structured property's value on an
+entity is returned as part of the entity's `structuredProperties` **aspect**, which you
+fetch in one call and then filter by property URN:
+
+```python
+from datahub.metadata.schema_classes import StructuredPropertiesClass
+
+sp = graph.get_aspect(
+    entity_urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,long_tail_companions.ecommerce.customer,PROD)",
+    aspect_type=StructuredPropertiesClass,
+)
+if sp:
+    for assignment in sp.properties:
+        print(assignment.propertyUrn, assignment.values)
+```
+
+:::note
+This differs from the **"Read a single Structured Property"** section above, which reads a
+property's **definition** by its `structuredProperty` URN. There is no endpoint that reads
+one property's **value** on one entity in isolation — you read the entity's
+`structuredProperties` aspect and select the assignment whose `propertyUrn` matches.
+:::
+
+</TabItem>
 </Tabs>
 
 ## Remove Structured Properties From a Dataset


### PR DESCRIPTION
### Summary

The Structured Properties tutorial (`docs/api/tutorials/structured-properties.md`)
documents CLI, GraphQL, and OpenAPI, but has **no Python SDK tab** — even though the
Python SDK is a common way users script this feature. This PR adds Python examples
for creating and reading structured properties, plus a short clarification that addresses
a real, easy-to-hit pitfall.

### What changed

- **Create section:** added a `Python` tab showing `StructuredProperties.create(file, graph)`.
  Added a caution that `create` is a **staticmethod taking a YAML file path + graph**, not an
  instance method — `StructuredProperties(...).create(graph)` silently passes the graph as the
  `file` argument and fails. Pointed users to the MCP-based
  `examples/structured_properties/create_structured_property.py` for a pure-code definition.
- **Read-from-dataset section:** added a `Python` tab showing the one-call read via
  `graph.get_aspect(urn, StructuredPropertiesClass)`, and a note clarifying that a
  property **value** on an entity is only readable through the entity's `structuredProperties`
  aspect — distinct from the existing "Read a single Structured Property" section, which reads
  the property **definition**.
- **Privileges note:** clarified that direct SDK/GraphQL writes go straight to GMS and are
  governed by token privileges (*Manage Structured Properties* / *Edit Properties*), and that
  `TOOLS_IS_MUTATION_ENABLED` gates only `mcp-server-datahub` tools, not SDK writes.

### Why

I hit each of the above as a real stumbling block while validating a define → write →
read-back structured-property loop against a live DataHub Core (v1.5.0.6,
`datahub docker quickstart`) using `acryl-datahub` 1.6.x. Every claim here is backed by
source on `master`:
- `create` staticmethod signature — `metadata-ingestion/src/datahub/api/entities/structuredproperties/structuredproperties.py`
- `TOOLS_IS_MUTATION_ENABLED` scope — only gates `mcp-server-datahub` mutation tools, not direct SDK/GraphQL writes to GMS

### Testing

Docs-only change. Examples were run against a live DataHub Core quickstart; markdown reuses
the file's existing `Tabs`/`TabItem` imports, no new imports needed.

### Checklist
- [x] Docs follow the tutorial's existing `<Tabs>`/`<TabItem>` structure
- [x] PR title follows the `docs:` Conventional-Commits convention