### PR TITLE
feat(agent-context): expose description resolution for read paths

### DIFF
--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/descriptions.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/descriptions.py
@@ -5,6 +5,7 @@ from typing import Literal, Optional
 
 from datahub_agent_context.context import get_graph
 from datahub_agent_context.mcp_tools.base import execute_graphql
+from datahub_agent_context.mcp_tools.helpers import resolve_description
 
 logger = logging.getLogger(__name__)
 
@@ -113,17 +114,7 @@ def _get_existing_description(entity_urn: str, column_path: Optional[str]) -> st
                     return field.get("description", "")
             return ""
         else:
-            # Get entity description
-            # Try editableProperties first (for Dataset, Container, etc.)
-            editable_props = entity_data.get("editableProperties", {})
-            existing_description = editable_props.get("description", "")
-
-            # If not found, try properties (for Tag, GlossaryTerm, etc.)
-            if not existing_description:
-                properties = entity_data.get("properties", {})
-                existing_description = properties.get("description", "")
-
-            return existing_description
+            return resolve_description(entity_data)
 
     except Exception as e:
         logger.warning(

--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/helpers.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/helpers.py
@@ -103,6 +103,31 @@ def truncate_descriptions(
             truncate_descriptions(item)
 
 
+def resolve_description(entity: dict) -> str:
+    """Return the description a user actually sees for an entity.
+
+    DataHub stores two descriptions and ``get_entities`` returns both:
+
+    - ``editableProperties.description`` -- written through the UI or the API
+    - ``properties.description`` -- supplied by ingestion
+
+    The UI renders the editable one when it is set, so that is the text a reader
+    believes. They can differ: an ingested description from a dbt manifest and a
+    hand-edited one on the same dataset are both present, with different content.
+
+    Callers reading descriptions off a ``get_entities`` response need the same
+    precedence that ``update_description`` already applies when it writes, or
+    they silently read a value nobody is looking at.
+    """
+    editable_description = (entity.get("editableProperties") or {}).get(
+        "description", ""
+    )
+    if editable_description:
+        return editable_description
+
+    return (entity.get("properties") or {}).get("description", "")
+
+
 def truncate_query(query: str) -> str:
     """Truncate a SQL query if it exceeds the maximum length."""
     return truncate_with_ellipsis(

--- a/datahub-agent-context/tests/unit/mcp_tools/test_descriptions.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_descriptions.py
@@ -6,6 +6,7 @@ import pytest
 
 from datahub_agent_context.context import DataHubContext
 from datahub_agent_context.mcp_tools.descriptions import update_description
+from datahub_agent_context.mcp_tools.helpers import resolve_description
 
 
 @pytest.fixture
@@ -451,3 +452,36 @@ def test_update_description_remove_glossary_term(mock_client):
     # Verify empty description was sent
     call_args = mock_client._graph.execute_graphql.call_args
     assert call_args.kwargs["variables"]["input"]["description"] == ""
+
+
+def test_resolve_description_prefers_editable():
+    """The UI renders editableProperties, so a reader sees that one."""
+    entity = {
+        "editableProperties": {"description": "edited by a human"},
+        "properties": {"description": "from ingestion"},
+    }
+
+    assert resolve_description(entity) == "edited by a human"
+
+
+def test_resolve_description_falls_back_to_properties():
+    """Tags and glossary terms only ever have properties."""
+    entity = {"properties": {"description": "from ingestion"}}
+
+    assert resolve_description(entity) == "from ingestion"
+
+
+def test_resolve_description_falls_back_when_editable_is_empty():
+    """An empty editable description must not shadow the ingested one."""
+    entity = {
+        "editableProperties": {"description": ""},
+        "properties": {"description": "from ingestion"},
+    }
+
+    assert resolve_description(entity) == "from ingestion"
+
+
+def test_resolve_description_handles_missing_and_null_blocks():
+    """get_entities omits blocks entirely, and GraphQL can return null for them."""
+    assert resolve_description({}) == ""
+    assert resolve_description({"editableProperties": None, "properties": None}) == ""


### PR DESCRIPTION
### What

`get_entities` returns both `editableProperties.description` and `properties.description`. The UI renders the editable one when it is set, so that is the text a reader actually believes — and the two can hold different content on the same entity.

`update_description` already applies exactly this precedence, but the logic sat inline inside the private `_get_existing_description()` and was only reachable from the write path. This extracts it into `resolve_description()` in `helpers.py` and has the private helper call it, so the read and write sides cannot drift apart.

Behaviour is unchanged — the existing 20 tests in `test_descriptions.py` still pass.

### Why

I hit this building an agent on top of the Agent Context Kit. My reader took `properties.description`, which seemed like the obvious field, and my scanner returned zero findings against a dataset I knew had a stale description. It took three rounds of debugging to notice the entity had no `properties` block at all — the description was in `editableProperties`, because it had been written through the API.

Two things made that hard to find:

- the [Agent Context Kit docs](https://docs.datahub.com/docs/dev-guides/agent-context/agent-context) never mention `editableProperties`
- the SDK already knew the answer (`descriptions.py` even has the comment `# Try editableProperties first (for Dataset, Container, etc.)`), but only in a private function on the write path

On `showcase-ecommerce`, `order_details` carries both, with different text in each — so the choice is not academic, it decides which description you read.

### Changes

- `helpers.py`: add `resolve_description(entity)` — editable first, fall back to `properties`, tolerant of missing or `null` blocks
- `descriptions.py`: `_get_existing_description()` now delegates to it
- `test_descriptions.py`: 4 tests covering precedence, fallback, empty-editable, and missing/null blocks

### Notes

I deliberately did not add it to `mcp_tools.__all__`, since `helpers` is not currently part of the public surface. Happy to export it if you would rather it be callable as public API — that is the shape external readers would want.
