### PR TITLE
fix(agent-context): list_schema_fields crashes on a dataset with no schema aspect

### DIFF
--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/entities.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/entities.py
@@ -207,8 +207,10 @@ def list_schema_fields(
     inject_urls_for_urns(graph, result, [""])
     truncate_descriptions(result)
 
-    # Extract total field count before processing
-    total_fields = len(result.get("schemaMetadata", {}).get("fields", []))
+    # Extract total field count before processing. A dataset whose schema was
+    # never ingested comes back with schemaMetadata set to null rather than
+    # absent, so the {} default never applies -- hence `or {}`.
+    total_fields = len((result.get("schemaMetadata") or {}).get("fields") or [])
 
     if total_fields == 0:
         return {
@@ -290,7 +292,7 @@ def list_schema_fields(
             )
 
         # Pre-compute matching count (need all fields for this)
-        fields_for_counting = result.get("schemaMetadata", {}).get("fields", [])
+        fields_for_counting = (result.get("schemaMetadata") or {}).get("fields") or []
         matching_count = sum(
             1 for field in fields_for_counting if score_field_by_keywords(field) > 0
         )

--- a/datahub-agent-context/tests/unit/mcp_tools/test_entities.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_entities.py
@@ -366,3 +366,36 @@ class TestListSchemaFields:
         assert result["totalFields"] == 0
         assert result["returned"] == 0
         assert result["fields"] == []
+
+    def test_list_fields_null_schema_metadata(self, mock_client):
+        """A dataset with no schema aspect comes back as an explicit null.
+
+        `{"fields": []}` is not what the server sends for a dataset whose schema
+        was never ingested -- it sends `"schemaMetadata": null`, which is what a
+        dataset created by lineage alone, or by a partial ingestion, looks like.
+        """
+        urn = "urn:li:dataset:(urn:li:dataPlatform:sqlite,db.schema.view,PROD)"
+
+        mock_client._graph.exists.return_value = True
+        mock_client._graph.execute_graphql.return_value = {
+            "entity": {"urn": urn, "schemaMetadata": None}
+        }
+
+        with DataHubContext(mock_client):
+            result = list_schema_fields(urn)
+        assert result["totalFields"] == 0
+        assert result["fields"] == []
+
+    def test_list_fields_null_schema_metadata_with_keywords(self, mock_client):
+        """Same, on the keyword path -- it counts matches from its own read."""
+        urn = "urn:li:dataset:(urn:li:dataPlatform:sqlite,db.schema.view,PROD)"
+
+        mock_client._graph.exists.return_value = True
+        mock_client._graph.execute_graphql.return_value = {
+            "entity": {"urn": urn, "schemaMetadata": None}
+        }
+
+        with DataHubContext(mock_client):
+            result = list_schema_fields(urn, keywords=["user"])
+        assert result["totalFields"] == 0
+        assert result["fields"] == []


### PR DESCRIPTION
`list_schema_fields` raises `AttributeError` on any dataset whose schema has never been ingested.

```python
# entities.py:211
total_fields = len(result.get("schemaMetadata", {}).get("fields", []))
```

The `{}` default applies when the key is **absent**. GraphQL sends the key with an explicit `null`, so `.get()` is called on `None`.

## How it shows up

Scanning every dataset in a DataHub quickstart:

```
File "datahub_agent_context/mcp_tools/entities.py", line 211, in list_schema_fields
    total_fields = len(result.get("schemaMetadata", {}).get("fields", []))
AttributeError: 'NoneType' object has no attribute 'get'
```

The dataset was a SQLite view registered through lineage — no schema aspect. Any dataset from a partial ingestion, or one that exists only as a lineage endpoint, is in the same state. For a caller iterating a catalog this is not an edge case; it ends the iteration.

## Why this one is worth fixing rather than guarding at the call site

The handling is already written. Immediately below the crashing line:

```python
if total_fields == 0:
    return {"urn": urn, "fields": [], "totalFields": 0, ...}
```

That branch exists for precisely this dataset and was unreachable from it.

## The change

`or {}` / `or []` on both reads of `schemaMetadata` in this function (line 211 and the keyword-scoring path at line 293). They are the same response in the same call, so fixing one just relocates the crash.

## Verification

Two commits, deliberately separate:

- `72e3028` adds the tests only. Red against master with the `AttributeError` above.
- `7e83e74` applies the fix. Green.

The existing `test_list_fields_empty_schema` passes `{"fields": []}`, which the server does not send for this case — that is why the gap survived.

```
395 passed, 3 xfailed
```

## Related

Two other PRs on this module, same origin — reading the Kit's output against what DataHub actually holds:

- #18622 — dataset-level description resolution
- #18628 — field-level editable descriptions are fetched, then dropped before the documented merge

Independent of each other; each stands alone.
