### PR TITLE
fix(ingestion): correct imports and read pattern in mlfeature_table_read example

### DIFF
--- a/metadata-ingestion/examples/library/mlfeature_table_read.py
+++ b/metadata-ingestion/examples/library/mlfeature_table_read.py
@@ -1,13 +1,23 @@
-from datahub.sdk import DataHubClient, MLFeatureTableUrn
+from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
+from datahub.metadata.schema_classes import MLFeatureTablePropertiesClass
+from datahub.metadata.urns import MlFeatureTableUrn
 
-client = DataHubClient.from_env()
+graph = DataHubGraph(DatahubClientConfig(server="http://localhost:8080"))
 
-# Or get this from the UI (share -> copy urn) and use MLFeatureTableUrn.from_string(...)
-mlfeature_table_urn = MLFeatureTableUrn(
+# Or get this from the UI (share -> copy urn) and use MlFeatureTableUrn.from_string(...)
+mlfeature_table_urn = MlFeatureTableUrn(
     "feast", "test_feature_table_all_feature_dtypes"
 )
 
-mlfeature_table_entity = client.entities.get(mlfeature_table_urn)
-print("MLFeature Table name:", mlfeature_table_entity.name)
-print("MLFeature Table platform:", mlfeature_table_entity.platform)
-print("MLFeature Table description:", mlfeature_table_entity.description)
+mlfeature_table_properties = graph.get_aspect(
+    entity_urn=str(mlfeature_table_urn),
+    aspect_type=MLFeatureTablePropertiesClass,
+)
+
+print("MLFeature Table name:", mlfeature_table_urn.name)
+print("MLFeature Table platform:", mlfeature_table_urn.platform)
+if mlfeature_table_properties is not None:
+    print("MLFeature Table description:", mlfeature_table_properties.description)
+    print("MLFeature Table features:", mlfeature_table_properties.mlFeatures)
+else:
+    print(f"MLFeature Table {mlfeature_table_urn} not found")

--- a/metadata-ingestion/examples/library/mlfeature_table_read.py
+++ b/metadata-ingestion/examples/library/mlfeature_table_read.py
@@ -1,8 +1,8 @@
-from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
+from datahub.ingestion.graph.client import get_default_graph
 from datahub.metadata.schema_classes import MLFeatureTablePropertiesClass
-from datahub.metadata.urns import MlFeatureTableUrn
+from datahub.metadata.urns import DataPlatformUrn, MlFeatureTableUrn
 
-graph = DataHubGraph(DatahubClientConfig(server="http://localhost:8080"))
+graph = get_default_graph()
 
 # Or get this from the UI (share -> copy urn) and use MlFeatureTableUrn.from_string(...)
 mlfeature_table_urn = MlFeatureTableUrn(
@@ -15,7 +15,10 @@ mlfeature_table_properties = graph.get_aspect(
 )
 
 print("MLFeature Table name:", mlfeature_table_urn.name)
-print("MLFeature Table platform:", mlfeature_table_urn.platform)
+print(
+    "MLFeature Table platform:",
+    DataPlatformUrn.from_string(mlfeature_table_urn.platform).platform_name,
+)
 if mlfeature_table_properties is not None:
     print("MLFeature Table description:", mlfeature_table_properties.description)
     print("MLFeature Table features:", mlfeature_table_properties.mlFeatures)


### PR DESCRIPTION
## Summary

The `mlfeature_table_read.py` library example did not run. It had two bugs:

1. **Bad import.** `from datahub.sdk import DataHubClient, MLFeatureTableUrn` raises
   `KeyError: 'MLFeatureTableUrn'` — `datahub.sdk` does not export that symbol. The URN class
   lives in `datahub.metadata.urns` and is spelled **`MlFeatureTableUrn`**.
2. **Unsupported read pattern.** Even with the correct URN, `client.entities.get(...)` raises
   `SdkUsageError: Entity type mlFeatureTable is not yet supported` — the new `DataHubClient`
   entity API does not yet support `mlFeatureTable` (its registry covers dataset, mlModel,
   mlModelGroup, dashboard, chart, etc., but not `mlFeatureTable`).

## Fix

Read the `mlFeatureTableProperties` aspect via `DataHubGraph.get_aspect(...)` — the same
pattern the sibling `mlfeature_table_add_features.py` example already uses — and source the
name and platform from the URN. The example now runs end to end.

```python
from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
from datahub.metadata.schema_classes import MLFeatureTablePropertiesClass
from datahub.metadata.urns import MlFeatureTableUrn

graph = DataHubGraph(DatahubClientConfig(server="http://localhost:8080"))

mlfeature_table_urn = MlFeatureTableUrn(
    "feast", "test_feature_table_all_feature_dtypes"
)

mlfeature_table_properties = graph.get_aspect(
    entity_urn=str(mlfeature_table_urn),
    aspect_type=MLFeatureTablePropertiesClass,
)

print("MLFeature Table name:", mlfeature_table_urn.name)
print("MLFeature Table platform:", mlfeature_table_urn.platform)
if mlfeature_table_properties is not None:
    print("MLFeature Table description:", mlfeature_table_properties.description)
    print("MLFeature Table features:", mlfeature_table_properties.mlFeatures)
else:
    print(f"MLFeature Table {mlfeature_table_urn} not found")
```

## Testing notes

Verified against a live DataHub OSS instance (v1.5.0.6) with `acryl-datahub` 1.6.0.15:

- Reproduced both failures on the original file (the `KeyError` on import; the
  `SdkUsageError` on `entities.get`).
- Emitted a sample `mlFeatureTable` matching the example's URN, ran the corrected script, and
  confirmed it prints the name, platform, description, and features, then read it back to
  confirm. Cleaned up the fixture afterward.
- Verified import ordering and formatting against the repo's ruff config
  (`metadata-ingestion/pyproject.toml`): all three imports are third-party and sorted, and
  `ruff format --check` reports the file already formatted.

## Checklist

- [x] The PR conforms to the Contributing Guideline (PR Title Format — `fix(ingestion):`)
- [ ] Links to related issues (none found; discovered while using the ML examples)
- [x] Tests for the changes have been added/updated (n/a — library example; manually verified to run)
- [x] Docs related to the changes have been added/updated (n/a — the file *is* an example)
- [x] No breaking change / deprecation entry needed

---
