### PR TITLE
fix(ingest): treat a Windows drive letter as a local path, not a URI scheme

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/fs/fs_base.py
+++ b/metadata-ingestion/src/datahub/ingestion/fs/fs_base.py
@@ -44,7 +44,11 @@ class FileSystem(metaclass=ABCMeta):
 
 def get_path_schema(path: str) -> str:
     scheme = parse.urlparse(path).scheme
-    if scheme == "":
-        # This makes the default schema "file" for local paths.
+    if len(scheme) <= 1:
+        # An empty scheme means a plain local path.
+        # A single-character scheme is a Windows drive letter, not a URI
+        # scheme: urlparse("C:\\data\\file.json").scheme == "c". Every
+        # registered scheme is longer than one character, so this is
+        # unambiguous.
         scheme = "file"
     return scheme

--- a/metadata-ingestion/tests/unit/test_file_systems.py
+++ b/metadata-ingestion/tests/unit/test_file_systems.py
@@ -226,3 +226,7 @@ def test_get_path_schema():
     assert get_path_schema("https://example.com/file.txt") == "https"
     assert get_path_schema("/local/path/file.txt") == "file"
     assert get_path_schema("relative/path/file.txt") == "file"
+    # Windows paths: the drive letter must not be read as a URI scheme.
+    assert get_path_schema("C:\\data\\file.json") == "file"
+    assert get_path_schema("c:/data/file.json") == "file"
+    assert get_path_schema("D:\\Users\\me\\datahub\\out.json") == "file"


### PR DESCRIPTION
### Problem

`get_path_schema()` derives a filesystem scheme with `urlparse(path).scheme`
and treats only the empty string as "local". On Windows, a drive letter parses
as a one-character scheme:

```python
>>> from urllib import parse
>>> parse.urlparse(r"C:\data\file.json").scheme
'c'
```

So any local absolute path on Windows resolves to the scheme `"c"`, the
filesystem registry has nothing registered under that name, and ingestion dies:

```
KeyError: 'Did not find a registered class for c'
  File "datahub/ingestion/source/file.py", line 218, in get_filenames
    fs_class = fs_registry.get(schema)
  File "datahub/ingestion/api/registry.py", line 171, in get
    raise KeyError(f"Did not find a registered class for {key}")
```

### Repro

On Windows:

```
datahub docker quickstart
datahub datapack load showcase-ecommerce
```

fails with `PipelineExecutionError: ('Source reported errors', [... KeyError:
'Did not find a registered class for c'])`.

The datapack loader hits this because it hands the file source an absolute
temp path (`C:\Users\...\AppData\Local\Temp\datapack-shifted-*.json`), but the
same failure applies to any `file` source configured with an absolute Windows
path.

### Fix

Treat a single-character scheme as a drive letter rather than a URI scheme.
Every registered scheme (`file`, `http`, `https`, `s3`) is longer than one
character, so there is no ambiguity to resolve and no behavior change for
existing inputs.

### Tests

Extended the existing `test_get_path_schema` with the Windows cases:
backslash-separated, forward-slash-separated, and a lowercase drive letter.
The existing assertions for `s3://`, `http://`, `https://`, absolute POSIX,
and relative paths are unchanged and still pass.

### Notes

Found while building against a local OSS quickstart on Windows. Happy to
adjust the approach if you would rather special-case this in
`FileSourceConfig` or normalize the path at the datapack loader instead, but
fixing it in `get_path_schema` covers every caller of the `file` source rather
than one entry point.
