### PR TITLE
docs: add guides for agent and service registry plus embedded product tours

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -226,6 +226,12 @@ module.exports = {
           id: "docs/features/feature-guides/analytics-agent",
         },
         {
+          label: "Agent Registry",
+          type: "doc",
+          id: "docs/features/feature-guides/agent-registry",
+          className: "saasOnly",
+        },
+        {
           label: "Assertions (Data Quality)",
           type: "category",
           link: { type: "doc", id: "docs/managed-datahub/observe/assertions" },
@@ -339,6 +345,12 @@ module.exports = {
           label: "Applications",
           type: "doc",
           id: "docs/features/feature-guides/applications",
+        },
+        {
+          label: "Service Catalog",
+          type: "doc",
+          id: "docs/features/feature-guides/service-catalog",
+          className: "saasOnly",
         },
         {
           label: "Automations",

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -1330,6 +1330,7 @@ module.exports = {
         "docs/api/tutorials/dataflow-datajob",
         "docs/api/tutorials/mlmodel-mlmodelgroup",
         "docs/api/tutorials/applications",
+        "docs/api/tutorials/agent-registry",
         {
           type: "doc",
           id: "docs/api/tutorials/ml",

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -1331,6 +1331,7 @@ module.exports = {
         "docs/api/tutorials/mlmodel-mlmodelgroup",
         "docs/api/tutorials/applications",
         "docs/api/tutorials/agent-registry",
+        "docs/api/tutorials/service-catalog",
         {
           type: "doc",
           id: "docs/api/tutorials/ml",

--- a/docs-website/src/components/ProductTour/index.js
+++ b/docs-website/src/components/ProductTour/index.js
@@ -1,0 +1,45 @@
+import React from "react";
+import styles from "./producttour.module.scss";
+
+// Interactive product tours are hosted at tours.datahub.com. This embeds one
+// live, in-page. The tours are built for desktop, so on narrow screens we swap
+// the embed for a link card (CSS-only, SSR-safe).
+const BASE = "https://tours.datahub.com";
+
+export default function ProductTour({ name, title, ratio = 62.5 }) {
+  const url = `${BASE}/${name}/`;
+  const label =
+    title || name.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  return (
+    <figure className={styles.tour}>
+      <div className={styles.frame} style={{ paddingTop: `${ratio}%` }}>
+        <iframe
+          className={styles.iframe}
+          src={url}
+          title={`${label} — interactive product tour`}
+          loading="lazy"
+          allow="fullscreen"
+          allowFullScreen
+        />
+      </div>
+      <a
+        className={styles.fallback}
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <span className={styles.play}>▶</span>
+        <span>
+          Take the interactive <b>{label}</b> tour{" "}
+          <span className={styles.hint}>(best viewed on desktop)</span>
+        </span>
+      </a>
+      <figcaption className={styles.caption}>
+        Interactive tour ·{" "}
+        <a href={url} target="_blank" rel="noopener noreferrer">
+          open full screen ↗
+        </a>
+      </figcaption>
+    </figure>
+  );
+}

--- a/docs-website/src/components/ProductTour/producttour.module.scss
+++ b/docs-website/src/components/ProductTour/producttour.module.scss
@@ -1,0 +1,66 @@
+.tour {
+  margin: 1.75rem 0;
+}
+
+.frame {
+  position: relative;
+  width: 100%;
+  height: 0; // height comes from inline padding-top (aspect ratio)
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  box-shadow: 0 10px 34px rgba(9, 30, 66, 0.14);
+  background: var(--ifm-background-surface-color);
+}
+
+.iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.caption {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-600);
+  text-align: right;
+}
+
+// Desktop-only embed: the tours render a 2880px app DOM that doesn't fit a phone,
+// so on narrow screens hide the iframe and offer a link card instead.
+.fallback {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .frame,
+  .caption {
+    display: none;
+  }
+
+  .fallback {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 1rem 1.2rem;
+    border-radius: 12px;
+    border: 1px solid var(--ifm-color-emphasis-300);
+    background: var(--ifm-background-surface-color);
+    color: var(--ifm-font-color-base);
+    text-decoration: none;
+    font-weight: 600;
+    line-height: 1.4;
+  }
+
+  .play {
+    color: var(--ifm-color-primary);
+    font-size: 1.1rem;
+  }
+
+  .hint {
+    font-weight: 400;
+    color: var(--ifm-color-emphasis-600);
+  }
+}

--- a/docs/api/tutorials/agent-registry.md
+++ b/docs/api/tutorials/agent-registry.md
@@ -1,0 +1,285 @@
+---
+description: "Register AI agents, skills, and tools with DataHub — from the Python SDK and CLI, or automatically from LangChain and Google ADK with the agent context kit."
+---
+
+# Registering AI Agents, Skills, and Tools
+
+This tutorial shows how to populate the [Agent Registry](../../features/feature-guides/agent-registry.md)
+programmatically. There are two ways in:
+
+- **Explicit registration** — describe an agent, its skills, and its tools with the Python SDK or
+  the `datahub` CLI. Use this when you catalog agents from your own scripts or CI.
+- **Automatic registration** — point the **agent context kit** at an existing LangChain or Google ADK
+  agent and it registers the agent, its tools, and its model for you. Use this to catalog agents from
+  the framework code you already run.
+
+Everything below works against any DataHub instance — local, DataHub Core, or DataHub Cloud.
+
+## Prerequisites
+
+Install the CLI and authenticate once:
+
+```bash
+pip install acryl-datahub
+datahub init   # writes ~/.datahubenv with your GMS URL and token
+```
+
+In Python, the emit target is a graph client:
+
+```python
+from datahub.ingestion.graph.client import get_default_graph
+
+graph = get_default_graph()  # reads ~/.datahubenv, or DATAHUB_GMS_URL / DATAHUB_GMS_TOKEN
+```
+
+Entity relationships are typed, so register **tools before the skills that require them, and skills
+before the agents that adopt them** — the referencing side validates that URNs are well-formed.
+
+## Register a tool
+
+A tool is an **API** entity (`urn:li:api:<id>`) — a named callable with a typed signature. The same
+entity models MCP tools, REST endpoints, gRPC methods, GraphQL operations, and plain functions;
+the `subtypes` field says which.
+
+<b>Python SDK</b>
+
+```python
+from datahub.api.entities.agent.api import Api, ApiParam
+
+get_orders = Api(
+    id="order-svc.get_orders",
+    name="get_orders",
+    subtypes=["MCP_TOOL"],  # or REST_ENDPOINT, GRPC_METHOD, GRAPHQL_OPERATION, FUNCTION
+    description="Fetch orders in a date range.",
+    parameters=[
+        ApiParam(name="start_date", data_type="string", required=True),
+        ApiParam(name="end_date", data_type="string", required=True),
+        ApiParam(name="region", data_type="string", description="Optional region filter."),
+    ],
+    returns=[ApiParam(name="orders", data_type="array<Order>")],
+    external_url="https://github.com/acme/order-svc",
+)
+
+tool_urn = get_orders.emit(graph)  # urn:li:api:order-svc.get_orders
+```
+
+`ApiParam.data_type` accepts friendly hints (`string`, `integer`, `boolean`, `object`,
+`array<Order>`, …); the raw value is preserved so a hint like `array<Order>` displays as authored.
+For a REST endpoint, add `method="GET"` and `path="/orders"` to emit its HTTP binding.
+
+<b>CLI</b>
+
+```bash
+datahub api register --id order-svc.get_orders --name get_orders \
+  --subtype MCP_TOOL \
+  --param start_date:string:required \
+  --param end_date:string:required \
+  --param region:string \
+  --returns orders:object \
+  --description "Fetch orders in a date range."
+```
+
+Parameter spec is `NAME:TYPE[:required]`; the returns spec is `NAME:TYPE`.
+
+## Register a skill
+
+A **skill** (`urn:li:agentSkill:<id>`) is a reusable capability bundle — specialized instructions
+plus the tools it relies on — defined in git and cataloged in DataHub.
+
+<b>Python SDK</b>
+
+```python
+from datahub.api.entities.agent.agent_skill import AgentSkill, SkillSourceRepository
+
+discovery = AgentSkill(
+    id="data-discovery",
+    name="Data Discovery",
+    description="Finds and summarizes relevant datasets.",
+    instructions="Use get_orders to retrieve orders, then summarize by region.",
+    source_repository=SkillSourceRepository(
+        url="https://github.com/acme/skills",
+        path="data-discovery/SKILL.md",
+    ),
+    required_tools=[tool_urn],  # API urns
+)
+
+skill_urn = discovery.emit(graph)  # urn:li:agentSkill:data-discovery
+```
+
+<b>CLI</b>
+
+```bash
+datahub agent-skill register --id data-discovery --name "Data Discovery" \
+  --description "Finds and summarizes relevant datasets." \
+  --source-repo https://github.com/acme/skills --source-path data-discovery/SKILL.md \
+  --requires-tool urn:li:api:order-svc.get_orders
+```
+
+## Register an agent
+
+An **agent** (`urn:li:aiAgent:<id>`) ties everything together: the skills it adopts, the tools it
+invokes, the model it runs on, and — importantly — the datasets it consumes, which become
+**upstream lineage** so the agent appears downstream of its data.
+
+```python
+from datahub.api.entities.agent.agent import Agent
+
+agent = Agent(
+    id="orders-assistant",
+    name="Orders Assistant",
+    description="Answers questions about orders.",
+    instructions="You are an assistant for the orders team.",
+    owners=["urn:li:corpGroup:orders-team"],
+    domain="Sales",
+    skills=[skill_urn],           # agentSkill urns
+    tools=[tool_urn],             # api urns
+    models=["urn:li:mlModel:(urn:li:dataPlatform:openai,gpt-4o,PROD)"],
+    consumes_datasets=[
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,prod.sales.orders,PROD)",
+    ],
+    platform="langchain",         # surfaces the framework logo on the profile
+)
+
+agent_urn = agent.emit(graph)  # urn:li:aiAgent:orders-assistant
+```
+
+`source_type` defaults to `EXTERNAL` (a cataloged, externally-managed agent); use `NATIVE` or
+`SYSTEM` for DataHub-managed agents.
+
+:::note CLI for agents
+The `datahub agent` command registers an agent from flags or a YAML file
+(`datahub agent register …` / `datahub agent upsert -f agent.yml`) **only when the agent context kit
+is not installed** — with the kit present, `datahub agent` is that package's command instead. When
+in doubt, register agents from the Python SDK (shown above) or a YAML file, both of which are always
+available. `datahub api` and `datahub agent-skill` are unaffected.
+:::
+
+## Automatic registration from LangChain or Google ADK
+
+Instead of describing the agent by hand, let the **agent context kit** read your running agent and
+register it — the agent, the tools it exposes, and the model it uses. Registration is **fail-open**:
+if DataHub is unreachable it logs and moves on, never breaking your agent.
+
+Install the extra for your framework:
+
+```bash
+pip install "datahub-agent-context[langchain]"     # or [google-adk]
+```
+
+Annotate tools once with `@datahub_tool` to attach the datasets they touch and the skill they belong
+to — these become the agent's lineage and skill links:
+
+```python
+from datahub_agent_context.langchain_registration import datahub_tool
+
+@datahub_tool(
+    datasets=["urn:li:dataset:(urn:li:dataPlatform:snowflake,prod.sales.orders,PROD)"],
+    skill="data-discovery",
+)
+def get_order_stats(start_date: str, end_date: str) -> str:
+    ...
+```
+
+### LangChain
+
+```python
+from datahub_agent_context._registration_core import AgentRegistrar
+from datahub_agent_context.langchain_registration import (
+    DataHubCallbackHandler,
+    register_langchain_agent,
+)
+
+# Pattern 1 — a callback handler that registers when the agent runs
+registrar = AgentRegistrar(
+    framework="LangChain",
+    framework_version=None,
+    platform="langchain",
+    agent_id="orders-assistant",
+    agent_name="Orders Assistant",
+    description="Answers questions about orders.",
+)
+handler = DataHubCallbackHandler(registrar, tools=[get_order_stats])
+# attach `handler` to your AgentExecutor's callbacks; it captures the model on the first LLM call
+
+# Pattern 2 — a one-shot snapshot of an already-built executor
+register_langchain_agent(
+    agent_executor,
+    agent_id="orders-assistant",
+    agent_name="Orders Assistant",
+    description="Answers questions about orders.",
+)
+```
+
+### Google ADK
+
+```python
+from google.adk.agents import Agent
+from datahub_agent_context._registration_core import AgentRegistrar
+from datahub_agent_context.google_adk_registration import (
+    DataHubBeforeModelCallback,
+    register_google_adk_agent,
+)
+
+# Pattern 1 — a before-model callback
+registrar = AgentRegistrar(
+    framework="Google ADK",
+    framework_version=None,
+    platform="google-adk",
+    agent_id="order-assistant",
+    agent_name="Order Assistant",
+    description="Answers questions about orders.",
+)
+callback = DataHubBeforeModelCallback(registrar, tools=[get_order_summary])
+adk_agent = Agent(
+    model="gemini-2.0-flash",
+    name="order_assistant",
+    tools=[get_order_summary],
+    before_model_callback=callback,
+)
+
+# Pattern 2 — register an already-built agent eagerly
+register_google_adk_agent(
+    adk_agent,
+    agent_id="order-assistant",
+    agent_name="Order Assistant",
+    description="Answers questions about orders.",
+)
+```
+
+The kit infers the model's `mlModel` URN and provider from the model identifier (e.g. `gpt-*` →
+OpenAI, `claude-*` → Anthropic, `gemini-*` → Google). Runnable end-to-end examples live in the
+package under `examples/langchain/autoregister_agent.py` and
+`examples/google_adk/autoregister_google_adk.py`.
+
+:::tip Also: use DataHub as your agent's tools
+The same package can build tool lists **from** DataHub — `build_langchain_tools(client)` /
+`build_google_adk_tools(client)` (with `include_mutations=True` to allow metadata edits, and cloud
+variants for Ask DataHub). See the [DataHub MCP Server](../../features/feature-guides/mcp.md) guide
+for connecting agents to DataHub's tools.
+:::
+
+## Versioning an agent
+
+Set `version` to group successive releases of an agent into a **version set** — the profile then
+shows a version picker, and the highest version is flagged as latest. Each version is its own
+`aiAgent` entity (distinct `id`):
+
+```python
+Agent(
+    id="orders-assistant-v2",
+    name="Orders Assistant",
+    description="Adds refund lookups.",
+    version="2.0",
+    version_set="orders-assistant",        # the family these versions share
+    version_comment="Added refund-lookup tool.",
+    tools=[tool_urn, refund_tool_urn],
+).emit(graph)
+```
+
+Dotted-numeric versions sort correctly out of the box (`1.9` < `1.10` < `2.0`).
+
+## Related
+
+- [Agent Registry](../../features/feature-guides/agent-registry.md) — the feature guide
+- [Service Catalog](../../features/feature-guides/service-catalog.md) — services, APIs, and repositories
+- [DataHub MCP Server](../../features/feature-guides/mcp.md) — connecting agents to DataHub's tools

--- a/docs/api/tutorials/service-catalog.md
+++ b/docs/api/tutorials/service-catalog.md
@@ -1,0 +1,177 @@
+---
+description: "Populate the DataHub Service Catalog — ingest an OpenAPI spec as a Service, or register services, APIs, and repositories explicitly with the SDK."
+---
+
+# Registering Services, APIs, and Repositories
+
+This tutorial shows how to populate the [Service Catalog](../../features/feature-guides/service-catalog.md)
+programmatically. There are two ways in:
+
+- **Ingest an OpenAPI spec** — the paved path: point a script at an OpenAPI document and it creates
+  the Service, one API per endpoint (with typed signatures), and stores the whole spec as the
+  service's contract. Best for REST services you already describe with OpenAPI.
+- **Register explicitly** — describe services, APIs, and repositories with the SDK. Use this for
+  gRPC/GraphQL/MCP services, source repositories, or anything without an OpenAPI doc.
+
+The three entities form a chain — a **repository** builds a **service**, and a service composes its
+**APIs** (`ServiceComposesApi`) — so the graph nests as repository → service → endpoint.
+
+## Prerequisites
+
+```bash
+pip install acryl-datahub
+datahub init   # writes ~/.datahubenv with your GMS URL and token
+```
+
+```python
+from datahub.ingestion.graph.client import get_default_graph
+
+graph = get_default_graph()  # or set DATAHUB_GMS_URL / DATAHUB_GMS_TOKEN
+```
+
+## Ingest an OpenAPI spec (paved path)
+
+The `ingest_openapi_as_service.py` example parses an OpenAPI document and emits the whole Service
+shape for you:
+
+```bash
+python metadata-ingestion/examples/services/ingest_openapi_as_service.py \
+  --spec-url https://api.example.com/openapi.json \
+  --service-id order-entry-api
+```
+
+It emits:
+
+- one **Service** (subtype `REST_API`) carrying the entire spec verbatim on a `serviceDefinition`
+  aspect (`format = OPENAPI`), stored as a compressed large string so big specs don't hit the
+  aspect-size limit — this is the **source of truth** the Contract tab renders;
+- one **API** (subtype `REST_ENDPOINT`) per path + method, with input/output signatures parsed from
+  the operation's parameters, request body, and `200` response schema;
+- a `ServiceProperties.apis` edge (`ServiceComposesApi`) linking the service to every endpoint.
+
+Run with no arguments and it targets DataHub GMS's own OpenAPI spec — a quick way to see the shape.
+Very large specs are capped (the per-endpoint API entities are limited so a 1000-endpoint spec
+doesn't flood the graph); the full document is always preserved on the contract.
+
+## Register an endpoint (API) explicitly
+
+An **API** (`urn:li:api:<id>`) is a named callable with a typed signature. The `Api` helper is the
+same one used for agent tools — see the [Agent Registry tutorial](agent-registry.md#register-a-tool)
+for the full reference. In brief:
+
+```python
+from datahub.api.entities.agent.api import Api, ApiParam, API_SUBTYPE_REST_ENDPOINT
+
+place_order = Api(
+    id="order-entry-api./orders.POST",
+    name="POST /orders",
+    subtypes=[API_SUBTYPE_REST_ENDPOINT],
+    description="Place a trade order.",
+    parameters=[ApiParam(name="body", data_type="object", required=True)],
+    returns=[ApiParam(name="order", data_type="object")],
+    method="POST",
+    path="/orders",
+)
+api_urn = place_order.emit(graph)
+```
+
+## Register a service explicitly
+
+Services carry identity and a contract but no schema/columns, so they're emitted as aspects. A
+service composes its endpoints through `ServiceProperties.apis`:
+
+```python
+from datahub.api.entities.common.large_string import make_large_string
+from datahub.emitter.mce_builder import make_data_platform_urn
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.metadata.schema_classes import (
+    DataPlatformInstanceClass,
+    ServiceDefinitionClass,
+    ServiceDefinitionFormatClass,
+    ServiceLifecycleClass,
+    ServicePropertiesClass,
+    StatusClass,
+    SubTypesClass,
+)
+
+service_urn = "urn:li:service:order-entry-api"
+aspects = [
+    ServicePropertiesClass(
+        displayName="Order Entry API",
+        description="Place, look up, and cancel trade orders.",
+        apis=[api_urn],                       # ServiceComposesApi edges
+        lifecycle=ServiceLifecycleClass.PRODUCTION,
+    ),
+    ServiceDefinitionClass(                   # the contract, rendered on the Contract tab
+        format=ServiceDefinitionFormatClass.OPENAPI,
+        rawSpec=make_large_string(open_api_yaml),
+        version="1.4.0",
+        externalUrl="https://api.example.com/docs",
+    ),
+    SubTypesClass(typeNames=["REST_API"]),    # or GRAPHQL, GRPC, MCP
+    DataPlatformInstanceClass(platform=make_data_platform_urn("openapi")),
+    StatusClass(removed=False),
+]
+for aspect in aspects:
+    graph.emit_mcp(MetadataChangeProposalWrapper(entityUrn=service_urn, aspect=aspect))
+```
+
+Runnable examples: `examples/services/register_rest_services.py` and
+`examples/services/register_graphql_grpc_services.py`.
+
+### MCP servers
+
+An MCP server is a Service sub-typed `MCP`: its tools are `Api` entities (subtype `MCP_TOOL`) linked
+via `ServiceProperties.apis`, and its `serviceDefinition` holds the `tools/list` contract as JSON
+Schema. Connection details (transport, URL, headers, timeout) go on an `McpServerProperties` aspect.
+See `examples/services/register_mcp_servers.py` for the full pattern.
+
+## Register a repository
+
+A **repository** (`urn:li:repository:<id>`) is the genesis node — it produces services. Register it
+with its properties and source, then wire the `SourcedFrom` edge by setting `sourceRepository` on the
+service it builds:
+
+```python
+from datahub.metadata.schema_classes import (
+    RepositoryPropertiesClass,
+    RepositorySourceClass,
+)
+
+repo_urn = "urn:li:repository:acme.payments"
+for aspect in [
+    RepositoryPropertiesClass(
+        name="payments",
+        description="Payments platform service repository.",
+        defaultBranch="main",
+        languages=["Java", "Kotlin"],
+        license="Apache-2.0",
+        homepageUrl="https://github.com/acme/payments",
+        archived=False,
+    ),
+    RepositorySourceClass(
+        externalUrl="https://github.com/acme/payments",
+        externalId="acme/payments",
+    ),
+    SubTypesClass(typeNames=["GIT_REPOSITORY"]),
+    DataPlatformInstanceClass(platform=make_data_platform_urn("github")),
+    StatusClass(removed=False),
+]:
+    graph.emit_mcp(MetadataChangeProposalWrapper(entityUrn=repo_urn, aspect=aspect))
+
+# Wire repo -> service without clobbering the service's other fields:
+service_props = graph.get_aspect(service_urn, ServicePropertiesClass)
+service_props.sourceRepository = repo_urn
+graph.emit_mcp(MetadataChangeProposalWrapper(entityUrn=service_urn, aspect=service_props))
+```
+
+This nests the chain as **repository → service → endpoint** (endpoints hang off their service via
+`ServiceComposesApi`, not off the repo directly). Runnable example:
+`examples/repositories/register_repositories.py`. For applications and service health, see
+`examples/services/register_app_and_health.py`.
+
+## Related
+
+- [Service Catalog](../../features/feature-guides/service-catalog.md) — the feature guide
+- [Agent Registry tutorial](agent-registry.md) — the `Api` helper reference, and agents that invoke APIs
+- [Applications](../tutorials/applications.md) — grouping assets by business purpose

--- a/docs/features/feature-guides/agent-registry.md
+++ b/docs/features/feature-guides/agent-registry.md
@@ -11,9 +11,9 @@ import ProductTour from '@site/src/components/ProductTour';
 
 Your board just asked: _how many AI agents are running, what data are they touching, who owns them,
 and can we trust them?_ Most teams can't answer today — their agents are shadow AI, invisible to
-governance. The **Agent Registry** closes that gap by cataloging AI agents, the skills they adopt,
-and the tools they invoke as **first-class, governed, versioned metadata entities**, sitting in the
-same lineage graph as the data they consume.
+governance. Introduced in DataHub Cloud v2.1, the **Agent Registry** closes that gap by cataloging
+AI agents, the skills they adopt, and the tools they invoke as **first-class, governed, versioned
+metadata entities**, sitting in the same lineage graph as the data they consume.
 
 Because agents live in the graph alongside your datasets, the governance you already run on data —
 ownership, classification, lineage, incidents, change history — extends to your AI layer for free.

--- a/docs/features/feature-guides/agent-registry.md
+++ b/docs/features/feature-guides/agent-registry.md
@@ -9,14 +9,14 @@ import ProductTour from '@site/src/components/ProductTour';
 
 <FeatureAvailability saasOnly />
 
-Your board just asked: _how many AI agents are running, what data are they touching, who owns them,
-and can we trust them?_ Most teams can't answer today — their agents are shadow AI, invisible to
-governance. Introduced in DataHub Cloud v2.1, the **Agent Registry** closes that gap by cataloging
-AI agents, the skills they adopt, and the tools they invoke as **first-class, governed, versioned
-metadata entities**, sitting in the same lineage graph as the data they consume.
+Introduced in DataHub Cloud v2.1, the **Agent Registry** catalogs AI agents, the skills they adopt,
+and the tools they invoke as first-class, governed, versioned metadata entities, in the same lineage
+graph as the data they consume. This lets you answer questions like how many agents are running,
+what data each one touches, and who owns them — from the catalog you already use for your data.
 
 Because agents live in the graph alongside your datasets, the governance you already run on data —
-ownership, classification, lineage, incidents, change history — extends to your AI layer for free.
+ownership, classification, lineage, incidents, and change history — extends to your AI layer without
+extra configuration.
 
 :::note Agent Registry vs. Agents
 This guide is about **cataloging AI agents as metadata** — making them discoverable, owned, and
@@ -62,29 +62,28 @@ Reach out to your DataHub representative to enable the Agent Registry for your o
 
 ### The agent profile
 
-Open an agent — for example the **FX Risk Scoring Agent** — and its profile is a first-class entity
-page. It tells you what the agent does, the skill and tools it uses, the data it reads across
-BigQuery, Snowflake, and dbt, and how reliable it is (eval scores, invocation volume, latency). It's
-owned by a real team — the Quant Risk Team. This is the opposite of shadow AI: an agent you can find,
-attribute, and trust.
+Open an agent — for example the **FX Risk Scoring Agent** — to see its profile. It shows what the
+agent does, the skill and tools it uses, the data it reads across BigQuery, Snowflake, and dbt, and
+reliability signals such as eval scores, invocation volume, and latency. Ownership is attributed to
+a team — here, the Quant Risk Team — so every agent has an owner you can find and hold accountable.
 
 ### Dependencies
 
 An agent's dependencies are explicit and clickable — the **skill** it adopts, the **tools** it
-invokes, and the **model** it runs on. Because each is a first-class entity, a new team can discover
-and reuse them instead of rebuilding an agent from scratch.
+invokes, and the **model** it runs on. Because each is a catalog entity in its own right, a new team
+can discover and reuse them instead of rebuilding an agent from scratch.
 
 ### Skills
 
-Skills are first-class citizens too. Open a skill — the **FX Risk Scoring skill** — and you get its
+Skills are catalog entities too. Open a skill — the **FX Risk Scoring skill** — and you get its
 definition, a source-of-truth spec, and the exact tools it requires. A skill is one reusable, vetted
 capability that teams adopt rather than reimplement.
 
 ### Tools, signatures, and contracts
 
-Every tool an agent invokes is a first-class [API](service-catalog.md#apis-and-endpoints) entity with
-a **typed signature** — input parameters and an output shape — rendered with the same schema
-components your datasets use. The MCP servers that expose these tools are catalogued as
+Every tool an agent invokes is an [API](service-catalog.md#apis-and-endpoints) entity with a **typed
+signature** — input parameters and an output shape — rendered with the same schema components your
+datasets use. The MCP servers that expose these tools are catalogued as
 [Service](service-catalog.md#services) entities, and each server carries its full **contract** in the
 graph — the live tool list, with inputs and outputs in JSON Schema, versioned in place. (A REST API
 tool renders its OpenAPI spec the same way.) See the [Service Catalog](service-catalog.md) for the
@@ -92,10 +91,9 @@ full treatment of APIs, services, and contracts.
 
 ### Lineage to your data
 
-Here's the payoff: the agent sits in your lineage graph, **downstream of the very BigQuery,
-Snowflake, and dbt tables it consumes**. That means you can answer _"what AI touches my regulated
-data?"_ from the same [lineage](lineage.md) graph you already use for impact analysis — no separate
-tool, no separate inventory.
+An agent sits in the lineage graph downstream of the BigQuery, Snowflake, and dbt tables it consumes.
+This lets you trace which data an agent reads, and — running lineage in reverse — which agents read a
+given table, from the same [lineage](lineage.md) graph you use for data impact analysis.
 
 ### Versioning and change history
 
@@ -106,16 +104,15 @@ And every change is on the **timeline** — tag changes, ownership updates, eval
 documentation, and the version milestones themselves. It's a full, trustworthy audit trail for your
 AI — just like data quality history, but for agents.
 
-### Governance that rides on lineage
+### Governance across lineage
 
-The deepest payoff is that governance flows across this same lineage, automatically. Consider a
-[Glossary Term Propagation](/docs/automations/glossary-term-propagation.md) automation, switched on.
-Someone classifies a source table — `fx-positions` — as **Highly Confidential**. Because the FX Risk
-Scoring Agent consumes that table, DataHub propagates the classification straight onto the agent: it
-now carries the same **Highly Confidential** label, inherited through lineage. Its health turns red,
-and an [incident](/docs/incidents/incidents.md) is opened for review.
-
-So the moment sensitive data reaches an AI system, you see it — and you can act.
+Because agents are in the lineage graph, governance automations extend to them without extra setup.
+Consider a [Glossary Term Propagation](/docs/automations/glossary-term-propagation.md) automation,
+switched on. Someone classifies a source table — `fx-positions` — as **Highly Confidential**. Because
+the FX Risk Scoring Agent consumes that table, DataHub propagates the classification onto the agent,
+which now carries the same **Highly Confidential** label, inherited through lineage. The agent's
+health turns red, and an [incident](/docs/incidents/incidents.md) is opened for review — so sensitive
+data reaching an AI system becomes visible the moment it happens.
 
 ## FAQ and Troubleshooting
 

--- a/docs/features/feature-guides/agent-registry.md
+++ b/docs/features/feature-guides/agent-registry.md
@@ -50,7 +50,9 @@ repository ─▶ service (MCP) ─▶ api (tool) ◀─invokes─ aiAgent ─ad
 ## Setup, Prerequisites, and Permissions
 
 AI agents, skills, and tools are populated through ingestion or emitted directly via the SDK/API,
-like any other asset. To browse and manage them, a user needs standard entity privileges:
+like any other asset — see the [API tutorial](../../api/tutorials/agent-registry.md) for the SDK, the
+CLI, and automatic registration from LangChain and Google ADK. To browse and manage them, a user
+needs standard entity privileges:
 
 - **View Entity Page** to discover and open agent, skill, and tool profiles.
 - **Edit Entity** (and the relevant sub-privileges) to enrich them with ownership, tags, glossary
@@ -113,6 +115,13 @@ the FX Risk Scoring Agent consumes that table, DataHub propagates the classifica
 which now carries the same **Highly Confidential** label, inherited through lineage. The agent's
 health turns red, and an [incident](/docs/incidents/incidents.md) is opened for review — so sensitive
 data reaching an AI system becomes visible the moment it happens.
+
+## Additional Resources
+
+### API Tutorials
+
+- [Registering AI Agents, Skills, and Tools](../../api/tutorials/agent-registry.md) — Python SDK, CLI,
+  and automatic registration from LangChain and Google ADK
 
 ## FAQ and Troubleshooting
 

--- a/docs/features/feature-guides/agent-registry.md
+++ b/docs/features/feature-guides/agent-registry.md
@@ -1,0 +1,145 @@
+---
+description: "The DataHub Agent Registry catalogs your AI agents, skills, and the tools they invoke as first-class, governed, versioned metadata entities — with lineage to the data they touch."
+---
+
+import FeatureAvailability from '@site/src/components/FeatureAvailability';
+import ProductTour from '@site/src/components/ProductTour';
+
+# About the DataHub Agent Registry
+
+<FeatureAvailability saasOnly />
+
+Your board just asked: _how many AI agents are running, what data are they touching, who owns them,
+and can we trust them?_ Most teams can't answer today — their agents are shadow AI, invisible to
+governance. The **Agent Registry** closes that gap by cataloging AI agents, the skills they adopt,
+and the tools they invoke as **first-class, governed, versioned metadata entities**, sitting in the
+same lineage graph as the data they consume.
+
+Because agents live in the graph alongside your datasets, the governance you already run on data —
+ownership, classification, lineage, incidents, change history — extends to your AI layer for free.
+
+:::note Agent Registry vs. Agents
+This guide is about **cataloging AI agents as metadata** — making them discoverable, owned, and
+governed. If you're looking to **build** AI agents that autonomously execute tasks on a schedule or
+in response to events, see the [Agents](agents.md) guide instead. The two are complementary: agents
+you build can be catalogued here, and agents catalogued here can be governed like any asset.
+:::
+
+<ProductTour name="agent-registry" title="Agent Registry" />
+
+## Concepts
+
+The Agent Registry introduces two headline entity types and reuses the Service Catalog's API and
+Service entities for an agent's tools:
+
+| Entity         | What it represents                                                                                                          |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **AI Agent**   | An AI agent with instructions, a scope, and dependencies. Can be native (DataHub-managed), system, or external (cataloged). |
+| **Skill**      | A reusable capability bundle (prompts + tools + domain expertise), defined in git, that agents adopt.                       |
+| **Tool**       | A capability an agent invokes — modeled as an [API](service-catalog.md#apis-and-endpoints) entity with a typed signature.   |
+| **MCP Server** | The server that exposes an agent's tools — modeled as a [Service](service-catalog.md#services) entity, sub-typed MCP.       |
+
+An agent's dependencies and the data it reads all connect into one lineage graph:
+
+```text
+repository ─▶ service (MCP) ─▶ api (tool) ◀─invokes─ aiAgent ─adopts─▶ skill ─requires─▶ api (tool)
+                                                        │
+                                                        └─reads──▶ dataset (upstream lineage)
+```
+
+## Setup, Prerequisites, and Permissions
+
+AI agents, skills, and tools are populated through ingestion or emitted directly via the SDK/API,
+like any other asset. To browse and manage them, a user needs standard entity privileges:
+
+- **View Entity Page** to discover and open agent, skill, and tool profiles.
+- **Edit Entity** (and the relevant sub-privileges) to enrich them with ownership, tags, glossary
+  terms, and documentation.
+
+Reach out to your DataHub representative to enable the Agent Registry for your organization.
+
+## Using the Agent Registry
+
+### The agent profile
+
+Open an agent — for example the **FX Risk Scoring Agent** — and its profile is a first-class entity
+page. It tells you what the agent does, the skill and tools it uses, the data it reads across
+BigQuery, Snowflake, and dbt, and how reliable it is (eval scores, invocation volume, latency). It's
+owned by a real team — the Quant Risk Team. This is the opposite of shadow AI: an agent you can find,
+attribute, and trust.
+
+### Dependencies
+
+An agent's dependencies are explicit and clickable — the **skill** it adopts, the **tools** it
+invokes, and the **model** it runs on. Because each is a first-class entity, a new team can discover
+and reuse them instead of rebuilding an agent from scratch.
+
+### Skills
+
+Skills are first-class citizens too. Open a skill — the **FX Risk Scoring skill** — and you get its
+definition, a source-of-truth spec, and the exact tools it requires. A skill is one reusable, vetted
+capability that teams adopt rather than reimplement.
+
+### Tools, signatures, and contracts
+
+Every tool an agent invokes is a first-class [API](service-catalog.md#apis-and-endpoints) entity with
+a **typed signature** — input parameters and an output shape — rendered with the same schema
+components your datasets use. The MCP servers that expose these tools are catalogued as
+[Service](service-catalog.md#services) entities, and each server carries its full **contract** in the
+graph — the live tool list, with inputs and outputs in JSON Schema, versioned in place. (A REST API
+tool renders its OpenAPI spec the same way.) See the [Service Catalog](service-catalog.md) for the
+full treatment of APIs, services, and contracts.
+
+### Lineage to your data
+
+Here's the payoff: the agent sits in your lineage graph, **downstream of the very BigQuery,
+Snowflake, and dbt tables it consumes**. That means you can answer _"what AI touches my regulated
+data?"_ from the same [lineage](lineage.md) graph you already use for impact analysis — no separate
+tool, no separate inventory.
+
+### Versioning and change history
+
+Agents are versioned. Versions `1.0` through `2.0` are grouped in a **version set** with the latest
+clearly flagged, because different versions often run in production side by side.
+
+And every change is on the **timeline** — tag changes, ownership updates, eval-score bumps, new
+documentation, and the version milestones themselves. It's a full, trustworthy audit trail for your
+AI — just like data quality history, but for agents.
+
+### Governance that rides on lineage
+
+The deepest payoff is that governance flows across this same lineage, automatically. Consider a
+[Glossary Term Propagation](/docs/automations/glossary-term-propagation.md) automation, switched on.
+Someone classifies a source table — `fx-positions` — as **Highly Confidential**. Because the FX Risk
+Scoring Agent consumes that table, DataHub propagates the classification straight onto the agent: it
+now carries the same **Highly Confidential** label, inherited through lineage. Its health turns red,
+and an [incident](/docs/incidents/incidents.md) is opened for review.
+
+So the moment sensitive data reaches an AI system, you see it — and you can act.
+
+## FAQ and Troubleshooting
+
+**How is this different from the Agents feature?**
+
+The [Agents](agents.md) feature is about _building_ AI agents that run tasks autonomously. The Agent
+Registry is about _cataloging_ AI agents (whether built in DataHub or elsewhere) as governed metadata
+— so they're discoverable, owned, versioned, and connected to the data they touch.
+
+**What does an agent's "tool" map to in the metadata model?**
+
+A tool is an [API](service-catalog.md#apis-and-endpoints) entity — the same entity the Service Catalog
+uses for REST endpoints, gRPC methods, and GraphQL fields. That's what lets "which agents invoke this
+endpoint" be answered by ordinary impact analysis.
+
+**Can an external agent (built outside DataHub) be catalogued?**
+
+Yes. Agents can be native (DataHub-managed), system (bootstrapped), or **external** (catalogued from
+another platform) — the profile, lineage, versioning, and governance work the same way regardless.
+
+### Related Features
+
+- [Service Catalog](service-catalog.md) — services, APIs, repositories, and applications
+- [Agents](agents.md) — building AI agents that autonomously execute tasks
+- [Lineage](lineage.md) — end-to-end dependency tracing and impact analysis
+- [Glossary Term Propagation](/docs/automations/glossary-term-propagation.md) — automated
+  classification across lineage

--- a/docs/features/feature-guides/lineage.md
+++ b/docs/features/feature-guides/lineage.md
@@ -3,6 +3,7 @@ description: "Use DataHub data lineage to map how data flows across your organiz
 ---
 
 import FeatureAvailability from '@site/src/components/FeatureAvailability';
+import ProductTour from '@site/src/components/ProductTour';
 
 # About DataHub Lineage
 
@@ -10,6 +11,10 @@ import FeatureAvailability from '@site/src/components/FeatureAvailability';
 
 Data lineage is a **map that shows how data flows through your organization.** It details where your data originates, how it travels, and where it ultimately ends up.
 This can happen within a single system (like data moving between Snowflake tables) or across various platforms.
+
+Prefer to explore hands-on? Take the interactive tour below, then read on for the details.
+
+<ProductTour name="lineage" title="Lineage" />
 
 With data lineage, you can
 

--- a/docs/features/feature-guides/service-catalog.md
+++ b/docs/features/feature-guides/service-catalog.md
@@ -1,0 +1,163 @@
+---
+description: "The DataHub Service Catalog makes software systems — repositories, services, APIs, and applications — first-class, typed, and governed metadata entities, right beside your data."
+---
+
+import FeatureAvailability from '@site/src/components/FeatureAvailability';
+import ProductTour from '@site/src/components/ProductTour';
+
+# About the DataHub Service Catalog
+
+<FeatureAvailability saasOnly />
+
+The **Service Catalog** brings the software layer of your stack into DataHub as first-class,
+typed, governed entities — right beside the data those systems produce. Repositories build
+services, services expose APIs, applications call those APIs, and APIs produce and consume
+datasets. Instead of a service showing up as a mislabeled, schemaless dataset, it shows up as
+exactly what it is — a REST, GraphQL, gRPC, or MCP service — owned, versioned, health-checked,
+and connected to everything downstream.
+
+This closes a long-standing gap: the engineering view of your systems and the business-and-data
+view now live in **one connected graph**, so you can trace an outage, a schema change, or a data
+dependency from source code all the way to a dashboard — or to an AI agent.
+
+<ProductTour name="service-catalog" title="Service Catalog" />
+
+## Concepts
+
+The Service Catalog introduces four entity types that model the software-to-data lifecycle:
+
+| Entity          | What it represents                                                                                                    |
+| --------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **Repository**  | A source-code repository (GitHub, GitLab, internal SCM). The genesis node — it builds services, APIs, and apps.       |
+| **Service**     | A running service — REST, GraphQL, gRPC, or an **MCP server** — with connection details and a lifecycle stage.        |
+| **API**         | A single named, callable operation (an endpoint, a gRPC method, a GraphQL field, an MCP tool) with a typed signature. |
+| **Application** | A business-level system that calls APIs and produces data — the bridge between the engineering and data views.        |
+
+These connect into a single lineage spine, and everything downstream — datasets, dashboards, and
+AI agents — hangs off the same graph:
+
+```text
+repository ──builds──▶ service ──exposes──▶ api ──produces/consumes──▶ dataset ──▶ dashboard
+                                             ▲
+                        application ──calls──┘   aiAgent ──invokes──┘
+```
+
+## Setup, Prerequisites, and Permissions
+
+Services, APIs, repositories, and applications are populated through ingestion or emitted directly
+via the SDK/API, the same way you catalog any other asset. To browse and manage them, a user needs
+standard entity privileges:
+
+- **View Entity Page** to discover and open service, API, and repository profiles.
+- **Edit Entity** (and the relevant sub-privileges — ownership, tags, glossary terms, documentation)
+  to enrich them.
+
+Reach out to your DataHub representative to enable the Service Catalog for your organization.
+
+## Using the Service Catalog
+
+### Discovering services
+
+Your services live in DataHub, right beside the data. A single search, filtered to services, brings
+everything back as exactly what it is — REST, GraphQL, gRPC, even MCP servers — each one typed,
+owned, and health-checked. Use search filters for **sub-type** (REST/GraphQL/gRPC/MCP), **domain**,
+**owner**, and **health** to narrow to the systems you care about.
+
+### Services
+
+Open a service — for example an **Order Entry API** — and you land on a first-class Service profile,
+not a mislabeled dataset. On one screen you get the service's **endpoints**, its **contract**, its
+**production lifecycle stage**, and the **team that owns it** — everything you need to trust and
+depend on a service.
+
+MCP servers are catalogued here too, as Services sub-typed **MCP**, complete with real connection
+details. The server, the tools (APIs) it exposes, and the agents that call them all live in the same
+graph.
+
+:::note Service (catalog entity) vs. the DataHub MCP Server
+This page is about cataloging **external** services and MCP servers as metadata entities. It is
+distinct from the [DataHub MCP Server](mcp.md), which exposes _DataHub itself_ as an MCP server for
+AI agents to query your catalog.
+:::
+
+### APIs and endpoints
+
+Every operation a service exposes is first-class too. An endpoint like **Place Order** carries a
+**typed signature** — required inputs and typed outputs — rendered with the same rich schema views
+your teams already use for datasets. The result is strongly-typed, discoverable contracts for every
+endpoint you run, whether it's a REST path, a gRPC method, a GraphQL field, or an MCP tool.
+
+### The software-to-data chain
+
+The payoff of modeling these as distinct entities is the chain between them: the **payments
+repository** builds the **Order Entry service**, and the service **exposes** its endpoints —
+repository, to service, to endpoint — nested exactly the way your systems really run. It's one
+connected graph, strongly typed at every hop, rather than opaque strings buried in a description.
+
+### Applications
+
+Zoom out to the business. An **Application** — say **Checkout**, in the **Commerce** domain — is
+owned, documented, and connected to the APIs it calls and the data it produces. The business view
+and the engineering view become one and the same graph.
+
+:::note Relationship to the Applications feature
+Service Catalog reuses the same [Application](applications.md) entity used to group assets by
+business purpose. In the Service Catalog, Applications additionally carry their **API call** and
+**data production** relationships, so an Application's profile shows the services it depends on.
+:::
+
+### Contracts
+
+A service's contract isn't a link to a wiki — it's the full specification, versioned right in the
+catalog. For a REST service that's the complete **OpenAPI** document (every path, every schema); for
+an MCP server it's the live **tool list**, with inputs and outputs in JSON Schema. One authoritative
+spec for your developers, your partners, and your AI agents — kept in sync and versioned alongside
+the service.
+
+### Impact analysis
+
+Because services, APIs, applications, and agents share one graph, impact analysis spans all of them.
+Ask _"who depends on Place Order?"_ and the graph answers instantly — for example, the **Checkout**
+application _and_ the **FX Risk Scoring agent**. That's impact analysis across services, apps, and
+AI agents, on real types you can trust, from the same lineage view you already use for data.
+
+### Incidents and health
+
+Service health flows through the same [incident](/docs/incidents/incidents.md) system as the rest of the
+catalog. If the **Auction Service** has an active, high-priority incident, its badge reads
+_unhealthy_ the moment you look. Open the **Incidents** tab and the whole story is there — what
+broke, how severe it is, and who's on it.
+
+### OAuth Authorization Servers
+
+When DataHub or an agent needs to _call_ an external API, an **OAuth Authorization Server** entity
+models where tokens come from. Cataloging the authorization server keeps the credential-issuance
+step visible and governed, rather than hidden in configuration.
+
+## FAQ and Troubleshooting
+
+**How is a Service different from a Dataset?**
+
+A Dataset models tabular data — it has columns, schemas, queries, and statistics. A Service models a
+running piece of software: endpoints, a contract, a lifecycle stage, and connection details. Before
+the Service Catalog, teams often shoehorned services into schemaless datasets; modeling them as
+Services gives them the right profile, typed API signatures, and real graph edges.
+
+**Do I have to catalog my repositories to use Services?**
+
+No. Each entity is independently useful. Repositories add the genesis node of the chain (repo →
+service → API), but you can catalog services and APIs on their own and add repositories later.
+
+**Can an AI agent depend on an API?**
+
+Yes — that's a core reason the API is a shared entity. See the [Agent Registry](agent-registry.md):
+an agent's tools are API entities, so "which agents call this endpoint" is answered by the same
+impact-analysis view.
+
+### Related Features
+
+- [Agent Registry](agent-registry.md) — AI agents, skills, and the APIs they invoke
+- [Applications](applications.md) — grouping assets by business purpose
+- [DataHub MCP Server](mcp.md) — DataHub itself as an MCP server for AI agents
+- [Lineage](lineage.md) — end-to-end dependency tracing and impact analysis
+- [Incidents](/docs/incidents/incidents.md) — health and incident management across the catalog

--- a/docs/features/feature-guides/service-catalog.md
+++ b/docs/features/feature-guides/service-catalog.md
@@ -44,8 +44,9 @@ repository ──builds──▶ service ──exposes──▶ api ──produc
 ## Setup, Prerequisites, and Permissions
 
 Services, APIs, repositories, and applications are populated through ingestion or emitted directly
-via the SDK/API, the same way you catalog any other asset. To browse and manage them, a user needs
-standard entity privileges:
+via the SDK/API, the same way you catalog any other asset — see the
+[API tutorial](../../api/tutorials/service-catalog.md), including ingesting a REST service straight
+from its OpenAPI spec. To browse and manage them, a user needs standard entity privileges:
 
 - **View Entity Page** to discover and open service, API, and repository profiles.
 - **Edit Entity** (and the relevant sub-privileges — ownership, tags, glossary terms, documentation)
@@ -132,6 +133,13 @@ broke, how severe it is, and who's on it.
 When DataHub or an agent needs to _call_ an external API, an **OAuth Authorization Server** entity
 models where tokens come from. Cataloging the authorization server keeps the credential-issuance
 step visible and governed, rather than hidden in configuration.
+
+## Additional Resources
+
+### API Tutorials
+
+- [Registering Services, APIs, and Repositories](../../api/tutorials/service-catalog.md) — ingest an
+  OpenAPI spec, or register services, APIs, and repositories with the SDK
 
 ## FAQ and Troubleshooting
 

--- a/docs/features/feature-guides/service-catalog.md
+++ b/docs/features/feature-guides/service-catalog.md
@@ -9,8 +9,8 @@ import ProductTour from '@site/src/components/ProductTour';
 
 <FeatureAvailability saasOnly />
 
-The **Service Catalog** brings the software layer of your stack into DataHub as first-class,
-typed, governed entities — right beside the data those systems produce. Repositories build
+Introduced in DataHub Cloud v2.1, the **Service Catalog** brings the software layer of your stack
+into DataHub as first-class, typed, governed entities — right beside the data those systems produce. Repositories build
 services, services expose APIs, applications call those APIs, and APIs produce and consume
 datasets. Instead of a service showing up as a mislabeled, schemaless dataset, it shows up as
 exactly what it is — a REST, GraphQL, gRPC, or MCP service — owned, versioned, health-checked,

--- a/docs/features/feature-guides/service-catalog.md
+++ b/docs/features/feature-guides/service-catalog.md
@@ -10,11 +10,10 @@ import ProductTour from '@site/src/components/ProductTour';
 <FeatureAvailability saasOnly />
 
 Introduced in DataHub Cloud v2.1, the **Service Catalog** brings the software layer of your stack
-into DataHub as first-class, typed, governed entities — right beside the data those systems produce. Repositories build
-services, services expose APIs, applications call those APIs, and APIs produce and consume
-datasets. Instead of a service showing up as a mislabeled, schemaless dataset, it shows up as
-exactly what it is — a REST, GraphQL, gRPC, or MCP service — owned, versioned, health-checked,
-and connected to everything downstream.
+into DataHub as typed, governed entities — right beside the data those systems produce. Repositories
+build services, services expose APIs, applications call those APIs, and APIs produce and consume
+datasets. A service is modeled as what it is — a REST, GraphQL, gRPC, or MCP service — owned,
+versioned, health-checked, and connected to everything downstream.
 
 This closes a long-standing gap: the engineering view of your systems and the business-and-data
 view now live in **one connected graph**, so you can trace an outage, a schema change, or a data
@@ -65,10 +64,9 @@ owned, and health-checked. Use search filters for **sub-type** (REST/GraphQL/gRP
 
 ### Services
 
-Open a service — for example an **Order Entry API** — and you land on a first-class Service profile,
-not a mislabeled dataset. On one screen you get the service's **endpoints**, its **contract**, its
-**production lifecycle stage**, and the **team that owns it** — everything you need to trust and
-depend on a service.
+Open a service — for example an **Order Entry API** — to see its Service profile. On one screen you
+get the service's **endpoints**, its **contract**, its **production lifecycle stage**, and the
+**team that owns it** — everything you need to trust and depend on a service.
 
 MCP servers are catalogued here too, as Services sub-typed **MCP**, complete with real connection
 details. The server, the tools (APIs) it exposes, and the agents that call them all live in the same
@@ -82,17 +80,18 @@ AI agents to query your catalog.
 
 ### APIs and endpoints
 
-Every operation a service exposes is first-class too. An endpoint like **Place Order** carries a
-**typed signature** — required inputs and typed outputs — rendered with the same rich schema views
-your teams already use for datasets. The result is strongly-typed, discoverable contracts for every
-endpoint you run, whether it's a REST path, a gRPC method, a GraphQL field, or an MCP tool.
+Every operation a service exposes is modeled as its own entity. An endpoint like **Place Order**
+carries a **typed signature** — required inputs and typed outputs — rendered with the same rich
+schema views your teams already use for datasets. The result is strongly-typed, discoverable
+contracts for every endpoint you run, whether it's a REST path, a gRPC method, a GraphQL field, or
+an MCP tool.
 
 ### The software-to-data chain
 
-The payoff of modeling these as distinct entities is the chain between them: the **payments
+Modeling these as distinct entities makes the chain between them explicit: the **payments
 repository** builds the **Order Entry service**, and the service **exposes** its endpoints —
-repository, to service, to endpoint — nested exactly the way your systems really run. It's one
-connected graph, strongly typed at every hop, rather than opaque strings buried in a description.
+repository, to service, to endpoint — nested the way your systems really run. Each hop is a typed
+graph edge, rather than opaque strings buried in a description.
 
 ### Applications
 
@@ -117,9 +116,9 @@ the service.
 ### Impact analysis
 
 Because services, APIs, applications, and agents share one graph, impact analysis spans all of them.
-Ask _"who depends on Place Order?"_ and the graph answers instantly — for example, the **Checkout**
-application _and_ the **FX Risk Scoring agent**. That's impact analysis across services, apps, and
-AI agents, on real types you can trust, from the same lineage view you already use for data.
+You can ask which assets depend on the **Place Order** endpoint and get the answer directly — for
+example, the **Checkout** application and the **FX Risk Scoring agent** — across services, apps, and
+AI agents, from the same lineage view you already use for data.
 
 ### Incidents and health
 

--- a/docs/how/search.md
+++ b/docs/how/search.md
@@ -4,12 +4,17 @@ description: "Use the DataHub search bar to find datasets, columns, dashboards, 
 ---
 
 import FeatureAvailability from '@site/src/components/FeatureAvailability';
+import ProductTour from '@site/src/components/ProductTour';
 
 # Search
 
 <FeatureAvailability/>
 
 The **search bar** is an important mechanism for discovering data assets in DataHub. From the search bar, you can find Datasets, Columns, Dashboards, Charts, Data Pipelines, and more. Simply type in a term and press 'enter'.
+
+Prefer to explore hands-on? Take the interactive tour below, then read on for the details.
+
+<ProductTour name="search" title="Search" />
 
 <p align="center">
 <img width="70%"  src="https://github.com/datahub-project/static-assets/blob/main/imgs/search-landingpage.png?raw=true" />


### PR DESCRIPTION
Adds documentation for the **Agent Registry** and **Service Catalog** features (new in DataHub Cloud v2.1), and lets readers try features hands-on without leaving the docs via a reusable `<ProductTour>` component.

## What's included

### New feature guides

- **About the DataHub Agent Registry** (`docs/features/feature-guides/agent-registry.md`) — cataloging AI agents, skills, and the tools they invoke as first-class, governed, versioned entities, with lineage to the data they consume. Embeds the `agent-registry` tour. Includes a callout disambiguating it from the existing **Agents** (automation) feature.
- **About the DataHub Service Catalog** (`docs/features/feature-guides/service-catalog.md`) — repositories, services (incl. MCP servers), APIs, and applications as typed, governed entities beside the data they produce. Embeds the `service-catalog` tour. Includes callouts disambiguating it from **Applications** and the **DataHub MCP Server**.

### New API tutorials

- **Registering AI Agents, Skills, and Tools** (`docs/api/tutorials/agent-registry.md`) — the Python SDK (`Agent`, `AgentSkill`, `Api`) and CLI (`datahub api`, `datahub agent-skill`), plus automatic registration from **LangChain** and **Google ADK** via the agent context kit (`@datahub_tool`, `AgentRegistrar`, callback handlers).
- **Registering Services, APIs, and Repositories** (`docs/api/tutorials/service-catalog.md`) — ingesting a REST service straight from its **OpenAPI spec** (the paved path), plus explicit registration of services, APIs, MCP servers, and repositories, wiring the repository → service → endpoint chain.

### Reusable tour component

- `docs-website/src/components/ProductTour` — responsive 16:10 iframe, an "open full screen" link, and a desktop-only fallback on small screens (the tours are built for desktop). Future guides embed one with a single line:

  ```mdx
  import ProductTour from '@site/src/components/ProductTour';

  <ProductTour name="search" title="Search" />
  ```

- Embedded in two existing guides as the first adopters: **About DataHub Lineage** (`docs/features/feature-guides/lineage.md`) and **Search** (`docs/how/search.md`).

All four new pages are wired into `docs-website/sidebars.js` (the two guides under **Features**, the two tutorials under **API tutorials**) and cross-linked to each other and to related guides.

## Notes

- Tours are hosted at `tours.datahub.com` and permit framing on `datahub.com` / `*.datahub.com`, so the embeds render on `docs.datahub.com`. On narrow screens the component shows a link card instead of the embed.
- The two new guides are marked `saasOnly` and state first availability as DataHub Cloud v2.1.
- Tutorial content is grounded in the shipped public surface (`acryl-datahub` and `datahub-agent-context`). Two accuracy points reflected in the docs: an agent's "tool" is an `api` entity (there is no separate `AgentTool` entity), and `datahub agent` is the agent context kit's command when that package is installed, so `datahub api` / `datahub agent-skill` are the reliable entity-registration CLI paths.

## Checklist

- [x] Docs added/updated
