### PR TITLE
fix(ingest/recording): advance repeated cassette matches so polled state can settle

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/recording/http_recorder.py
+++ b/metadata-ingestion/src/datahub/ingestion/recording/http_recorder.py
@@ -1,5 +1,6 @@
 """HTTP recording and replay using VCR.py."""
 
+import functools
 import json
 import logging
 import threading
@@ -8,6 +9,38 @@ from pathlib import Path
 from typing import Any, Callable, Iterator, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _play_response_in_order(cassette: Any, request: Any) -> Any:
+    """Play matching recordings in order, then repeat the last one.
+
+    Replaces Cassette.play_response, which returns the *first* match on every
+    call once allow_playback_repeats is on. That breaks any client polling one
+    endpoint until its state changes: the Databricks SDK waiting for a SQL
+    warehouse to leave STARTING replays STARTING forever and never terminates,
+    so whether replay works depends on whether the warehouse happened to be warm
+    when the cassette was recorded.
+
+    Handing out each recording once, in recorded order, lets a polled state
+    advance. Falling back to the last recording once they are exhausted keeps
+    the repeat behaviour that out-of-order and parallel requests rely on, and
+    makes the terminal state the one that repeats.
+    """
+    import vcr.errors
+
+    matches = list(cassette._responses(request))
+    if not matches:
+        raise vcr.errors.UnhandledHTTPRequestError(
+            f"The cassette ({cassette._path!r}) doesn't contain the request ({request!r}) asked for",
+        )
+
+    index, response = next(
+        ((i, r) for i, r in matches if cassette.play_counts[i] == 0),
+        matches[-1],
+    )
+    cassette.play_counts[index] += 1
+    cassette._played_interactions.append((cassette.data[index][0], response))
+    return response
 
 
 def _normalize_json_body(body: Any) -> Any:
@@ -453,6 +486,11 @@ class HTTPRecorder:
             # and the order can differ between recording and replay
             allow_playback_repeats=True,
         ) as cassette:
+            # Consume repeated recordings of the same request in order before
+            # repeating, so polled state transitions can complete.
+            cassette.play_response = functools.partial(
+                _play_response_in_order, cassette
+            )
             self._cassette = cassette
             try:
                 yield self

--- a/metadata-ingestion/tests/unit/recording/test_http_recorder.py
+++ b/metadata-ingestion/tests/unit/recording/test_http_recorder.py
@@ -10,7 +10,11 @@ from pathlib import Path
 import pytest
 
 # Skip all tests if vcrpy is not installed
-vcr = pytest.importorskip("vcr")
+pytest.importorskip("vcr")
+
+import vcr.cassette
+import vcr.errors
+import vcr.request
 
 
 class TestHTTPRecorder:
@@ -56,6 +60,61 @@ class TestHTTPRecorder:
                 recorder.replaying(),
             ):
                 pass
+
+
+class TestOrderedPlayback:
+    """Tests for _play_response_in_order."""
+
+    @staticmethod
+    def _polling_cassette() -> vcr.cassette.Cassette:
+        """A cassette holding one STARTING then one RUNNING reply to the same GET."""
+        cassette = vcr.cassette.Cassette(
+            path="/tmp/warehouse.yaml", allow_playback_repeats=True
+        )
+        for state in ("STARTING", "RUNNING"):
+            cassette.append(
+                vcr.request.Request(
+                    method="GET",
+                    uri="https://example.cloud.databricks.com/api/2.0/sql/warehouses/1",
+                    body=None,
+                    headers={},
+                ),
+                {"body": {"string": state}, "status": {"code": 200, "message": "OK"}},
+            )
+        return cassette
+
+    @staticmethod
+    def _poll() -> vcr.request.Request:
+        return vcr.request.Request(
+            method="GET",
+            uri="https://example.cloud.databricks.com/api/2.0/sql/warehouses/1",
+            body=None,
+            headers={},
+        )
+
+    def test_repeated_request_advances_then_repeats_last(self) -> None:
+        """A polled state must reach RUNNING, then keep reporting RUNNING."""
+        from datahub.ingestion.recording.http_recorder import _play_response_in_order
+
+        cassette = self._polling_cassette()
+        states = [
+            _play_response_in_order(cassette, self._poll())["body"]["string"]
+            for _ in range(4)
+        ]
+        assert states == ["STARTING", "RUNNING", "RUNNING", "RUNNING"]
+
+    def test_unmatched_request_raises(self) -> None:
+        from datahub.ingestion.recording.http_recorder import _play_response_in_order
+
+        cassette = self._polling_cassette()
+        unknown = vcr.request.Request(
+            method="GET",
+            uri="https://example.cloud.databricks.com/api/2.0/sql/warehouses/999",
+            body=None,
+            headers={},
+        )
+        with pytest.raises(vcr.errors.UnhandledHTTPRequestError):
+            _play_response_in_order(cassette, unknown)
 
 
 class TestHTTPReplayerForLiveSink:


### PR DESCRIPTION
## Problem

Replay sets `allow_playback_repeats=True` in `_replaying_with_vcr` so that parallel and out-of-order requests can still be matched against the cassette. A side effect is that vcr's `play_response` returns the **first** matching recording on every call and never advances to later ones:

```python
# vcr/cassette.py
for index, response in self._responses(request):
    if self.play_counts[index] == 0 or self.allow_playback_repeats:
        self.play_counts[index] += 1
        return response
```

With the flag on, the condition is unconditionally true at the first matching index.

So any client that polls a single endpoint until its state changes hangs during replay. The case that surfaced this is the Databricks SDK's `wait_get_warehouse_running`, reached from the Unity Catalog source when `include_hive_metastore` is set:

- warehouse **warm** at record time → one `RUNNING` response recorded → replay returns immediately ✅
- warehouse **cold** at record time → `STARTING`, …, `RUNNING` recorded → replay serves `STARTING` forever, the SDK polls until its own ~20min ceiling, ingestion never terminates ❌

Whether a recording is replayable at all ends up depending on whether the warehouse happened to be warm when it was captured. Observed in our integration suite as a replay that timed out at 300s, blocked in the connection pool under `wait_get_warehouse_running` — reproducible, and not fixable by re-running, since the nondeterminism is baked into the cassette.

Nothing here is Databricks-specific: this breaks replay for any source that polls an endpoint across a state transition.

## Fix

`_play_response_in_order` replaces `play_response` on the replay cassette. It hands out each matching recording once, in recorded order, then repeats the last one:

- polled state transitions can advance and complete
- exhausted matches still repeat, preserving the out-of-order/parallel tolerance `allow_playback_repeats=True` was added for
- the response that repeats is the **terminal** one rather than the first

Bound per-cassette with `functools.partial` inside the replay context manager rather than patching `Cassette` globally — vcr exposes no `cassette_class` hook, so this keeps the change scoped to the one context manager.

## Testing

`TestOrderedPlayback` builds a real `vcr.cassette.Cassette` holding a `STARTING` then a `RUNNING` reply to one identical GET, and asserts playback yields `["STARTING", "RUNNING", "RUNNING", "RUNNING"]`.

Verified the test is meaningful — unpatched vcr returns `["STARTING", "STARTING", "STARTING", "STARTING"]` for the same sequence.

`./gradlew :metadata-ingestion:lint` clean (ruff + mypy); `tests/unit/recording/` 46 passed.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Links to related issues (n/a)
- [x] Tests for the changes have been added/updated
- [ ] Docs related to the changes have been added/updated (n/a — internal replay behaviour)
- [ ] Breaking change entry in Updating DataHub (n/a — replay-only bug fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)