### PR TITLE
ci: cache yarn deps in format-check lint jobs

### DIFF
--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -63,8 +63,24 @@ jobs:
           distribution: "zulu"
           java-version: 21
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      # mdPrettierCheck dependsOn yarnInstall (full datahub-web-react deps).
+      # Cache ~/.cache/yarn so the install is a warm no-op instead of a cold fetch.
+      - name: Restore yarn cache
+        id: yarn-cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('datahub-web-react/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: run markdown checks
         run: ./gradlew :datahub-web-react:mdPrettierCheck :datahub-web-react:docusaurusMarkdownLint
+      - name: Save yarn cache
+        if: always() && steps.yarn-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('datahub-web-react/yarn.lock') }}
 
   github-actions-format:
     name: github_actions_format_check
@@ -78,8 +94,24 @@ jobs:
           distribution: "zulu"
           java-version: 21
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      # githubActionsPrettierCheck dependsOn yarnInstall (full datahub-web-react deps).
+      # Cache ~/.cache/yarn so the install is a warm no-op instead of a cold fetch.
+      - name: Restore yarn cache
+        id: yarn-cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('datahub-web-react/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: run prettier --check
         run: ./gradlew :datahub-web-react:githubActionsPrettierCheck
+      - name: Save yarn cache
+        if: always() && steps.yarn-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('datahub-web-react/yarn.lock') }}
 
   validate-post-workflow-list:
     name: validate_post_workflow_list


### PR DESCRIPTION
## Summary

`markdown_format_check` and `github_actions_format_check` in `lint-jobs.yml` run
prettier via a Gradle task (`mdPrettierCheck` / `githubActionsPrettierCheck`) that
`dependsOn yarnInstall`. With no yarn cache, each job cold-installs the full
`datahub-web-react` `node_modules` on every run — minutes of dependency fetching
just to format-check YAML/Markdown files.

This adds an `actions/cache` for `~/.cache/yarn` (keyed on `datahub-web-react/yarn.lock`)
to both jobs, matching the caching the other lint jobs already use. On a cache hit the
`yarnInstall` fetch becomes a warm no-op.

## Impact

~3 min/run off each format-check job once the cache is warm (measured: prettier step
~605s cold → ~403s warm; job total ~12m → ~9m). Cache key is the lockfile hash, so a
lockfile change triggers one cold reseed, then warm again — never stale.

## Testing

- `lint-jobs.yml` parses; cache steps mirror the existing convention
  (`actions/cache/{restore,save}@…#v5`, `~/.cache/yarn`, `runner.os`-scoped key).
- Save is gated on `cache-hit != 'true'` to avoid redundant re-saves.
- First run on this branch seeds the cache; subsequent runs hit it.
