### PR TITLE
fix(smoke-test): stabilize flaky read-only search and graph-cache membership tests

### DIFF
--- a/smoke-test/tests/entity_graph_cache/helpers.py
+++ b/smoke-test/tests/entity_graph_cache/helpers.py
@@ -24,6 +24,7 @@ from datahub.ingestion.graph.client import DataHubGraph
 from datahub.metadata.schema_classes import (
     ContainerClass,
     ContainerPropertiesClass,
+    CorpUserInfoClass,
     DomainPropertiesClass,
     GlossaryNodeInfoClass,
     GlossaryTermInfoClass,
@@ -602,6 +603,24 @@ def create_native_group(auth_session, group_id: str) -> str:
     assert group_urn
     wait_for_writes_to_sync()
     return group_urn
+
+
+def create_test_corp_user(graph_client: DataHubGraph, username: str) -> str:
+    """Emit a fresh corpUser so a test owns an isolated user whose group
+    memberships no other suite mutates. Returns the user URN."""
+    urn = f"urn:li:corpuser:{username}"
+    graph_client.emit_mcp(
+        MetadataChangeProposalWrapper(
+            entityUrn=urn,
+            aspect=CorpUserInfoClass(
+                active=True,
+                displayName=username,
+                email=f"{username}@example.com",
+            ),
+        )
+    )
+    wait_for_writes_to_sync()
+    return urn
 
 
 def add_users_to_native_group(

--- a/smoke-test/tests/entity_graph_cache/test_entity_graph_cache.py
+++ b/smoke-test/tests/entity_graph_cache/test_entity_graph_cache.py
@@ -29,6 +29,7 @@ from tests.entity_graph_cache.helpers import (
     cleanup_domains,
     cleanup_glossary_entities,
     create_native_group,
+    create_test_corp_user,
     delete_native_group,
     emit_container,
     emit_domain,
@@ -476,13 +477,49 @@ def test_container_relationships_direct_children(auth_session, graph_client):
         cleanup_containers(graph_client, created)
 
 
-def test_membership_relationships_idempotent_for_session_user(auth_session):
-    """GraphQL corpuser group relationships should be stable across repeated reads."""
-    user_urn = auth_session._upstream.cookies["actor"]
+def test_membership_relationships_idempotent_for_isolated_user(
+    auth_session, graph_client
+):
+    """GraphQL corpuser group relationships must be stable across repeated reads.
 
-    first = query_corpuser_group_relationships(auth_session, user_urn)
-    second = query_corpuser_group_relationships(auth_session, user_urn)
-    assert first == second
+    Uses a dedicated user + native groups created for this test, so the
+    membership set is known and cannot be mutated by another suite mid-test
+    (the shared session admin can be). Idempotency is asserted on the SET of
+    relationships: the list comes straight from the search/graph scroll, whose
+    order is not guaranteed stable between two reads, so normalize before
+    comparing — a real cache non-idempotency (a set difference) still fails.
+    """
+    run_id = unique_id("egc-idem")
+    user_urn = create_test_corp_user(graph_client, f"egc-idem-user-{run_id}")
+    group_a: Optional[str] = None
+    group_b: Optional[str] = None
+
+    try:
+        group_a = create_native_group(auth_session, f"egc-idem-a-{run_id}")
+        group_b = create_native_group(auth_session, f"egc-idem-b-{run_id}")
+        add_users_to_native_group(auth_session, group_a, [user_urn])
+        add_users_to_native_group(auth_session, group_b, [user_urn])
+        wait_for_hierarchy_writes()
+
+        def _key(rel: dict) -> tuple:
+            return (rel.get("type"), (rel.get("entity") or {}).get("urn"))
+
+        first = query_corpuser_group_relationships(auth_session, user_urn)
+        second = query_corpuser_group_relationships(auth_session, user_urn)
+        assert sorted(first, key=_key) == sorted(second, key=_key)
+
+        # The user is freshly created and joined exactly these two groups, so the
+        # relationship set is deterministic — a stronger idempotency check than
+        # comparing two reads of unknown, externally-mutable state.
+        member_urns = {(rel.get("entity") or {}).get("urn") for rel in first}
+        assert member_urns == {group_a, group_b}
+    finally:
+        for group_urn in (group_a, group_b):
+            if group_urn is not None:
+                remove_users_from_native_group(auth_session, group_urn, [user_urn])
+                delete_native_group(auth_session, group_urn)
+        graph_client.hard_delete_entity(user_urn)
+        wait_for_hierarchy_writes()
 
 
 def test_session_user_dual_group_types_labeled_correctly(auth_session, graph_client):

--- a/smoke-test/tests/read_only/test_search.py
+++ b/smoke-test/tests/read_only/test_search.py
@@ -46,10 +46,14 @@ def test_search_works(auth_session):
         search_result = get_search_results(auth_session, entity_type)
         num_entities = search_result["total"]
         add_datahub_stats(f"num-{entity_type}", num_entities)
-        if num_entities == 0:
-            logger.warning(f"No results for {entity_type}")
-            return
         entities = search_result["searchResults"]
+        # Guard on the actual results page, not `total`: under ES eventual
+        # consistency the aggregate `total` can be > 0 while `searchResults` is
+        # momentarily empty, which IndexErrors on entities[0]. Skip gracefully
+        # when the page is empty (read-only tests must tolerate no data).
+        if not entities:
+            logger.warning(f"No searchResults for {entity_type} (total={num_entities})")
+            return
 
         first_urn = entities[0]["entity"]["urn"]
 
@@ -108,10 +112,13 @@ def test_openapi_v3_entity(auth_session):
     def test_entity(entity_type: str) -> None:
         search_result = get_search_results(auth_session, entity_type)
         num_entities = search_result["total"]
-        if num_entities == 0:
-            logger.warning(f"No results for {entity_type}")
-            return
         entities = search_result["searchResults"]
+        # Guard on the actual results page, not `total` (see test_search_works):
+        # `total` can be > 0 while searchResults is momentarily empty under ES
+        # lag, which IndexErrors on entities[0].
+        if not entities:
+            logger.warning(f"No searchResults for {entity_type} (total={num_entities})")
+            return
 
         first_urn = entities[0]["entity"]["urn"]
 


### PR DESCRIPTION
## Summary

Fixes two flaky smoke tests. Both flaked under Elasticsearch eventual consistency;
each is fixed structurally (correct guard / deterministic assertion), not with retries.

## Fixes

### 1. `tests/read_only/test_search.py` — IndexError under ES lag
`test_search_works` and `test_openapi_v3_entity` guarded on the aggregate `total`
(`if num_entities == 0: return`) but then indexed the results page,
`searchResults[0]`. Under ES eventual consistency `total` can be `> 0` while the
`searchResults` page is momentarily empty, so `entities[0]` raises
`IndexError: list index out of range`.

Fix: guard on the actual `searchResults` page (skip gracefully when empty), not
`total`. Read-only tests must tolerate no data, so an empty page is a warn+return,
not a crash.

### 2. `tests/entity_graph_cache/test_entity_graph_cache.py` — non-deterministic idempotency assert
`test_membership_relationships_idempotent_for_session_user` read the shared session
user's group relationships twice and asserted `first == second`. Two problems:
- The relationship list comes straight from the search/graph scroll, whose **order
  is not guaranteed stable** between two reads → same set, different order →
  spurious failure.
- It read the **shared session admin**, whose memberships other suites can mutate.

Fix: rewrite as `test_membership_relationships_idempotent_for_isolated_user` —
create a **dedicated** user + its own native groups, so the membership set is known
and externally immutable, then assert idempotency on the **normalized set**
(order-independent) plus the exact expected 2-group membership. A genuine cache
non-idempotency (a set difference) still fails.

Adds `create_test_corp_user()` to `tests/entity_graph_cache/helpers.py`.