### PR TITLE
fix(ci): pass run attempt to Docker success Slack notifications

### DIFF
--- a/.github/workflows/post-workflow-actions.yml
+++ b/.github/workflows/post-workflow-actions.yml
@@ -215,5 +215,6 @@ jobs:
     secrets: inherit
     with:
       run_id: ${{ github.event.workflow_run.id }}
+      attempt: ${{ github.event.workflow_run.run_attempt }}
       conclusion: success
       channel: ${{ vars.BUILD_STATUS_NOTIFICATION_SLACK_CHANNEL }}


### PR DESCRIPTION
## Summary
- Docker success Slack notifications omitted `attempt` when calling `notify-slack-status`, so the reusable workflow always defaulted to `"1"`.
- Pass `github.event.workflow_run.run_attempt` so retries report the correct attempt (and fetch the matching attempt's job details).

## Test plan
- [ ] Confirm a Docker Build success after retry (`run_attempt > 1`) shows the correct Attempt in Slack
- [ ] Confirm the notify job log shows `ATTEMPT` matching the source workflow's `run_attempt`
- [ ] Confirm failure notifications still pass attempt correctly (unchanged path)


Made with [Cursor](https://cursor.com)