### PR TITLE
fix(spark-lineage): restore Spark 4 Delta streaming outputs

### DIFF
--- a/metadata-integration/java/acryl-spark-lineage/build.gradle
+++ b/metadata-integration/java/acryl-spark-lineage/build.gradle
@@ -19,6 +19,24 @@ jar.enabled = false // Since we only want to build shadow jars, disabling the re
 // Define supported Scala versions - always build for both
 def scalaVersions = ['2.12', '2.13']
 
+def openLineageSourceDir = file('src/main/java/io/openlineage')
+def openLineageOverrideClassPatterns =
+    fileTree(openLineageSourceDir) {
+      include '**/*.java'
+    }.files.collectMany { source ->
+      def relativeSource =
+          openLineageSourceDir
+              .toPath()
+              .relativize(source.toPath())
+              .toString()
+              .replace(File.separator, '/')
+      def className = relativeSource.substring(0, relativeSource.length() - '.java'.length())
+      return [
+          "io/openlineage/${className}.class",
+          "io/openlineage/${className}\$*.class",
+      ]
+    }
+
 //mark implementaion dependencies which needs to excluded along with transitive dependencies from shadowjar
 //functionality is exactly same as "implementation"
 configurations {
@@ -239,10 +257,19 @@ scalaVersions.each { sv ->
     scalaConfig.dependencies.add(project.dependencies.create(externalDependency.jacksonDataFormatYaml))
     scalaConfig.canBeResolved = true
     inputs.files(scalaConfig)
-    // Manually add resolved dependencies from scalaConfig during task execution
-    doFirst {
-      scalaConfig.resolvedConfiguration.resolvedArtifacts.each { artifact ->
-        from zipTree(artifact.file)
+    // Manually add resolved dependencies from scalaConfig. DataHub's source overrides must replace
+    // the same classes from openlineage-spark; retaining both ZIP entries lets the dependency copy
+    // win at runtime on some JVMs.
+    from {
+      scalaConfig.resolvedConfiguration.resolvedArtifacts.collect { artifact ->
+        if (artifact.moduleVersion.id.group == 'io.openlineage'
+            && artifact.name.startsWith('openlineage-spark')) {
+          zipTree(artifact.file).matching {
+            exclude openLineageOverrideClassPatterns
+          }
+        } else {
+          zipTree(artifact.file)
+        }
       }
     }
 

--- a/metadata-integration/java/acryl-spark-lineage/patches/datahub-customizations/v1.50.0/Spark40DatasetBuilderFactory.patch
+++ b/metadata-integration/java/acryl-spark-lineage/patches/datahub-customizations/v1.50.0/Spark40DatasetBuilderFactory.patch
@@ -1,0 +1,27 @@
+# Patch for DataHub customizations in Spark40DatasetBuilderFactory.java
+# Upstream version: OpenLineage 1.50.0
+# Generated: 2026-07-26 11:09:27 UTC
+#
+# To apply this patch to a new upstream version:
+#   patch -p0 < datahub-customizations/Spark40DatasetBuilderFactory.patch
+#
+--- src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
++++ src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
+@@ -34,6 +34,7 @@
+ import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
+ import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
+ import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
++import io.openlineage.spark34.agent.lifecycle.plan.WriteToMicroBatchDataSourceV1DatasetBuilder;
+ import io.openlineage.spark34.agent.lifecycle.plan.column.CreateReplaceInputDatasetBuilder;
+ import io.openlineage.spark34.agent.lifecycle.plan.column.DropTableDatasetBuilder;
+ import io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder;
+@@ -91,7 +92,8 @@
+             .add(new SubqueryAliasOutputDatasetBuilder(context))
+             .add(new DropTableDatasetBuilder(context))
+             .add(new MergeIntoCommandEdgeOutputDatasetBuilder(context))
+-            .add(new AlterTableCommandDatasetBuilder(context));
++            .add(new AlterTableCommandDatasetBuilder(context))
++            .add(new WriteToMicroBatchDataSourceV1DatasetBuilder(context, datasetFactory));
+ 
+     if (ReplaceIcebergDataDatasetBuilder.hasClasses()) {
+       builder.add(new ReplaceIcebergDataDatasetBuilder(context));

--- a/metadata-integration/java/acryl-spark-lineage/patches/datahub-customizations/v1.50.0/WriteToMicroBatchDataSourceV1DatasetBuilder.patch
+++ b/metadata-integration/java/acryl-spark-lineage/patches/datahub-customizations/v1.50.0/WriteToMicroBatchDataSourceV1DatasetBuilder.patch
@@ -1,0 +1,100 @@
+# Patch for DataHub customizations in WriteToMicroBatchDataSourceV1DatasetBuilder.java
+# Upstream version: OpenLineage 1.50.0
+# Generated: 2026-07-26 11:09:27 UTC
+#
+# To apply this patch to a new upstream version:
+#   patch -p0 < datahub-customizations/WriteToMicroBatchDataSourceV1DatasetBuilder.patch
+#
+--- src/main/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilder.java
++++ src/main/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilder.java
+@@ -6,15 +6,19 @@
+ package io.openlineage.spark34.agent.lifecycle.plan;
+ 
+ import io.openlineage.client.OpenLineage;
++import io.openlineage.spark.agent.util.ReflectionUtils;
+ import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
+ import io.openlineage.spark.api.DatasetFactory;
+ import io.openlineage.spark.api.OpenLineageContext;
++import java.net.URI;
+ import java.util.Collections;
+ import java.util.List;
++import java.util.Optional;
+ import lombok.extern.slf4j.Slf4j;
+ import org.apache.spark.scheduler.SparkListenerEvent;
+ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+ import org.apache.spark.sql.execution.streaming.FileStreamSink;
++import org.apache.spark.sql.execution.streaming.Sink;
+ import org.apache.spark.sql.execution.streaming.sources.WriteToMicroBatchDataSourceV1;
+ import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+ 
+@@ -27,6 +30,9 @@
+ public class WriteToMicroBatchDataSourceV1DatasetBuilder
+     extends AbstractQueryPlanOutputDatasetBuilder<WriteToMicroBatchDataSourceV1> {
+ 
++  private static final String DELTA_SINK_CLASS_NAME =
++      "org.apache.spark.sql.delta.sources.DeltaSink";
++
+   private final DatasetFactory<OpenLineage.OutputDataset> factory;
+ 
+   public WriteToMicroBatchDataSourceV1DatasetBuilder(
+@@ -52,20 +58,47 @@
+   @Override
+   protected List<OpenLineage.OutputDataset> apply(
+       SparkListenerEvent event, WriteToMicroBatchDataSourceV1 writeToMicroBatchV1) {
+-    // Currently, only FileStreamSink is supported
+-    if (writeToMicroBatchV1.sink() instanceof FileStreamSink) {
+-      if (writeToMicroBatchV1.catalogTable().isDefined()) {
+-        return Collections.singletonList(
+-            factory
+-                .sparkDatasetBuilder()
+-                .dataset(writeToMicroBatchV1.catalogTable().get())
+-                .schema(writeToMicroBatchV1.schema())
+-                .build());
+-      } else {
+-        return Collections.emptyList();
+-      }
++    Sink sink = writeToMicroBatchV1.sink();
++    String sinkClassName = sink.getClass().getCanonicalName();
++    boolean fileSink = sink instanceof FileStreamSink;
++    boolean deltaSink = DELTA_SINK_CLASS_NAME.equals(sinkClassName);
++
++    if (!fileSink && !deltaSink) {
++      log.debug("Unsupported Sink type: {}", sink.getClass().getName());
++      return Collections.emptyList();
++    }
++
++    if (writeToMicroBatchV1.catalogTable().isDefined()) {
++      return Collections.singletonList(
++          factory
++              .sparkDatasetBuilder()
++              .dataset(writeToMicroBatchV1.catalogTable().get())
++              .schema(writeToMicroBatchV1.schema())
++              .build());
++    }
++
++    if (deltaSink) {
++      return deltaPath(sink)
++          .map(
++              path ->
++                  Collections.singletonList(
++                      factory
++                          .sparkDatasetBuilder()
++                          .dataset(path)
++                          .schema(writeToMicroBatchV1.schema())
++                          .build()))
++          .orElseGet(Collections::emptyList);
+     }
+-    log.debug("Unsupported Sink type: {}", writeToMicroBatchV1.sink().getClass().getName());
++
+     return Collections.emptyList();
+   }
++
++  private Optional<URI> deltaPath(Sink sink) {
++    try {
++      return ReflectionUtils.tryExecuteMethod(sink, "path").map(Object::toString).map(URI::create);
++    } catch (IllegalArgumentException e) {
++      log.warn("Could not extract a valid path from {}", sink.getClass().getName(), e);
++      return Optional.empty();
++    }
++  }
+ }

--- a/metadata-integration/java/acryl-spark-lineage/scripts/fetch-upstream.sh
+++ b/metadata-integration/java/acryl-spark-lineage/scripts/fetch-upstream.sh
@@ -32,12 +32,14 @@ FILES=(
   "integration/spark/shared/src/main/java/io/openlineage|spark/agent/util/PlanUtils.java"
   "integration/spark/shared/src/main/java/io/openlineage|spark/agent/util/RemovePathPatternUtils.java"
   "integration/spark/shared/src/main/java/io/openlineage|spark/agent/lifecycle/SparkOpenLineageExtensionVisitorWrapper.java"
+  "integration/spark/app/src/main/java/io/openlineage|spark/agent/lifecycle/Spark40DatasetBuilderFactory.java"
   "integration/spark/shared/src/main/java/io/openlineage|spark/agent/lifecycle/plan/FileStreamMicroBatchStreamStrategy.java"
   "integration/spark/shared/src/main/java/io/openlineage|spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java"
   "integration/spark/shared/src/main/java/io/openlineage|spark/agent/lifecycle/plan/StreamingDataSourceV2RelationVisitor.java"
   "integration/spark/shared/src/main/java/io/openlineage|spark/agent/lifecycle/plan/WriteToDataSourceV2Visitor.java"
   "integration/spark/spark3/src/main/java/io/openlineage|spark3/agent/lifecycle/plan/MergeIntoCommandEdgeInputDatasetBuilder.java"
   "integration/spark/spark3/src/main/java/io/openlineage|spark3/agent/lifecycle/plan/MergeIntoCommandInputDatasetBuilder.java"
+  "integration/spark/spark34/src/main/java/io/openlineage|spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilder.java"
 )
 
 echo "Fetching OpenLineage $VERSION files from GitHub..."
@@ -61,11 +63,11 @@ for entry in "${FILES[@]}"; do
 
   if curl -sf "$URL" -o "$OUTPUT" 2>/dev/null; then
     echo "✓"
-    ((SUCCESS_COUNT++))
+    ((SUCCESS_COUNT+=1))
   else
     echo "✗ (not found - may be DataHub-specific)"
     rm -f "$OUTPUT"
-    ((FAIL_COUNT++))
+    ((FAIL_COUNT+=1))
   fi
 done
 

--- a/metadata-integration/java/acryl-spark-lineage/scripts/generate-patches.sh
+++ b/metadata-integration/java/acryl-spark-lineage/scripts/generate-patches.sh
@@ -23,11 +23,13 @@ FILES=(
   "spark/agent/util/PlanUtils.java"
   "spark/agent/util/RemovePathPatternUtils.java"
   "spark/agent/lifecycle/SparkOpenLineageExtensionVisitorWrapper.java"
+  "spark/agent/lifecycle/Spark40DatasetBuilderFactory.java"
   "spark/agent/lifecycle/plan/SaveIntoDataSourceCommandVisitor.java"
   "spark/agent/lifecycle/plan/StreamingDataSourceV2RelationVisitor.java"
   "spark/agent/lifecycle/plan/WriteToDataSourceV2Visitor.java"
   "spark3/agent/lifecycle/plan/MergeIntoCommandEdgeInputDatasetBuilder.java"
   "spark3/agent/lifecycle/plan/MergeIntoCommandInputDatasetBuilder.java"
+  "spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilder.java"
 )
 
 echo "Generating patches for DataHub customizations vs OpenLineage $UPSTREAM_VERSION..."
@@ -61,7 +63,11 @@ for file in "${FILES[@]}"; do
   fi
 
   # Generate unified diff
-  if diff -u "$UPSTREAM_FILE" "$DATAHUB_FILE" > "$PATCH_FILE" 2>/dev/null; then
+  if diff -u \
+      --label "src/main/java/io/openlineage/$file" \
+      --label "src/main/java/io/openlineage/$file" \
+      "$UPSTREAM_FILE" \
+      "$DATAHUB_FILE" > "$PATCH_FILE" 2>/dev/null; then
     # No differences found
     echo "No customizations in: $file"
     rm -f "$PATCH_FILE"

--- a/metadata-integration/java/acryl-spark-lineage/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
+++ b/metadata-integration/java/acryl-spark-lineage/src/main/java/io/openlineage/spark/agent/lifecycle/Spark40DatasetBuilderFactory.java
@@ -1,0 +1,122 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark.agent.lifecycle;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineage.InputDataset;
+import io.openlineage.spark.agent.lifecycle.plan.CommandPlanVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.SaveIntoDataSourceCommandVisitor;
+import io.openlineage.spark.agent.lifecycle.plan.column.ColumnLevelLineageVisitor;
+import io.openlineage.spark.agent.util.DeltaUtils;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark3.agent.lifecycle.plan.AppendDataDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnEndDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationInputOnStartDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2RelationOutputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2ScanRelationOnEndInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.DataSourceV2ScanRelationOnStartInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.InMemoryRelationInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.LogicalRelationDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandEdgeInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandEdgeOutputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.MergeIntoCommandOutputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.SparkExtensionV1InputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.SparkExtensionV1OutputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasInputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.SubqueryAliasOutputDatasetBuilder;
+import io.openlineage.spark3.agent.lifecycle.plan.TableContentChangeDatasetBuilder;
+import io.openlineage.spark33.agent.lifecycle.plan.ReplaceIcebergDataDatasetBuilder;
+import io.openlineage.spark34.agent.lifecycle.plan.WriteIcebergDeltaDatasetBuilder;
+import io.openlineage.spark34.agent.lifecycle.plan.WriteToMicroBatchDataSourceV1DatasetBuilder;
+import io.openlineage.spark34.agent.lifecycle.plan.column.CreateReplaceInputDatasetBuilder;
+import io.openlineage.spark34.agent.lifecycle.plan.column.DropTableDatasetBuilder;
+import io.openlineage.spark35.agent.lifecycle.plan.CreateReplaceOutputDatasetBuilder;
+import io.openlineage.spark35.agent.lifecycle.plan.MergeRowsColumnLineageVisitor;
+import io.openlineage.spark40.agent.lifecycle.plan.AlterTableCommandDatasetBuilder;
+import io.openlineage.spark40.agent.lifecycle.plan.StreamingDataSourceV2ScanRelationDatasetBuilder;
+import java.util.Collection;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import scala.PartialFunction;
+
+@Slf4j
+public class Spark40DatasetBuilderFactory extends Spark32DatasetBuilderFactory
+    implements DatasetBuilderFactory {
+
+  @Override
+  public Collection<PartialFunction<Object, List<InputDataset>>> getInputBuilders(
+      OpenLineageContext context) {
+    DatasetFactory<InputDataset> datasetFactory = DatasetFactory.input(context);
+    Builder builder =
+        ImmutableList.<PartialFunction<Object, List<InputDataset>>>builder()
+            .add(new LogicalRelationDatasetBuilder(context, datasetFactory, true))
+            .add(new InMemoryRelationInputDatasetBuilder(context))
+            .add(new CommandPlanVisitor(context))
+            .add(new DataSourceV2ScanRelationOnStartInputDatasetBuilder(context, datasetFactory))
+            .add(new DataSourceV2ScanRelationOnEndInputDatasetBuilder(context, datasetFactory))
+            .add(new SubqueryAliasInputDatasetBuilder(context))
+            .add(new CreateReplaceInputDatasetBuilder(context))
+            .add(new SparkExtensionV1InputDatasetBuilder(context))
+            .add(new MergeIntoCommandEdgeInputDatasetBuilder(context))
+            .add(new StreamingDataSourceV2ScanRelationDatasetBuilder(context))
+            .add(new DataSourceV2RelationInputOnStartDatasetBuilder(context, datasetFactory))
+            .add(new DataSourceV2RelationInputOnEndDatasetBuilder(context, datasetFactory));
+
+    if (DeltaUtils.hasMergeIntoCommandClass()) {
+      builder.add(new MergeIntoCommandInputDatasetBuilder(context));
+    }
+
+    return builder.build();
+  }
+
+  @Override
+  public Collection<PartialFunction<Object, List<OpenLineage.OutputDataset>>> getOutputBuilders(
+      OpenLineageContext context) {
+    DatasetFactory<OpenLineage.OutputDataset> datasetFactory = DatasetFactory.output(context);
+    Builder builder =
+        ImmutableList.<PartialFunction<Object, List<OpenLineage.OutputDataset>>>builder()
+            .add(new LogicalRelationDatasetBuilder(context, datasetFactory, false))
+            .add(new SaveIntoDataSourceCommandVisitor(context))
+            .add(new AppendDataDatasetBuilder(context, datasetFactory))
+            .add(new DataSourceV2RelationOutputDatasetBuilder(context, datasetFactory))
+            .add(new TableContentChangeDatasetBuilder(context, datasetFactory))
+            .add(new CreateReplaceOutputDatasetBuilder(context))
+            .add(new SparkExtensionV1OutputDatasetBuilder(context))
+            .add(new SubqueryAliasOutputDatasetBuilder(context))
+            .add(new DropTableDatasetBuilder(context))
+            .add(new MergeIntoCommandEdgeOutputDatasetBuilder(context))
+            .add(new AlterTableCommandDatasetBuilder(context))
+            .add(new WriteToMicroBatchDataSourceV1DatasetBuilder(context, datasetFactory));
+
+    if (ReplaceIcebergDataDatasetBuilder.hasClasses()) {
+      builder.add(new ReplaceIcebergDataDatasetBuilder(context));
+    }
+
+    if (WriteIcebergDeltaDatasetBuilder.hasClasses()) {
+      builder.add(new WriteIcebergDeltaDatasetBuilder(context));
+    }
+
+    if (DeltaUtils.hasMergeIntoCommandClass()) {
+      builder.add(new MergeIntoCommandOutputDatasetBuilder(context));
+    }
+
+    return builder.build();
+  }
+
+  @Override
+  public Collection<ColumnLevelLineageVisitor> getColumnLevelLineageVisitors(
+      OpenLineageContext context) {
+    Builder builder = ImmutableList.<ColumnLevelLineageVisitor>builder();
+    builder.add(new MergeRowsColumnLineageVisitor(context));
+    builder.addAll(super.getColumnLevelLineageVisitors(context));
+
+    return builder.build();
+  }
+}

--- a/metadata-integration/java/acryl-spark-lineage/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilder.java
+++ b/metadata-integration/java/acryl-spark-lineage/src/main/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilder.java
@@ -1,0 +1,105 @@
+/*
+/* Copyright 2018-2026 contributors to the OpenLineage project
+/* SPDX-License-Identifier: Apache-2.0
+*/
+
+package io.openlineage.spark34.agent.lifecycle.plan;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.util.ReflectionUtils;
+import io.openlineage.spark.api.AbstractQueryPlanOutputDatasetBuilder;
+import io.openlineage.spark.api.DatasetFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.streaming.FileStreamSink;
+import org.apache.spark.sql.execution.streaming.Sink;
+import org.apache.spark.sql.execution.streaming.sources.WriteToMicroBatchDataSourceV1;
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
+
+/**
+ * {@link LogicalPlan} visitor that matches {@link WriteToMicroBatchDataSourceV1} commands and
+ * extracts the output {@link OpenLineage.Dataset} being written to micro batch data sources using
+ * the V1 API.
+ */
+@Slf4j
+public class WriteToMicroBatchDataSourceV1DatasetBuilder
+    extends AbstractQueryPlanOutputDatasetBuilder<WriteToMicroBatchDataSourceV1> {
+
+  private static final String DELTA_SINK_CLASS_NAME =
+      "org.apache.spark.sql.delta.sources.DeltaSink";
+
+  private final DatasetFactory<OpenLineage.OutputDataset> factory;
+
+  public WriteToMicroBatchDataSourceV1DatasetBuilder(
+      OpenLineageContext context, DatasetFactory<OpenLineage.OutputDataset> factory) {
+    super(context, false);
+    this.factory = factory;
+  }
+
+  @Override
+  public boolean isDefinedAt(SparkListenerEvent event) {
+    if (!(event instanceof SparkListenerSQLExecutionEnd)) {
+      return false;
+    }
+    SparkListenerSQLExecutionEnd see = (SparkListenerSQLExecutionEnd) event;
+    return isDefinedAtLogicalPlan(see.qe().analyzed());
+  }
+
+  @Override
+  public boolean isDefinedAtLogicalPlan(LogicalPlan logicalPlan) {
+    return logicalPlan instanceof WriteToMicroBatchDataSourceV1;
+  }
+
+  @Override
+  protected List<OpenLineage.OutputDataset> apply(
+      SparkListenerEvent event, WriteToMicroBatchDataSourceV1 writeToMicroBatchV1) {
+    Sink sink = writeToMicroBatchV1.sink();
+    String sinkClassName = sink.getClass().getCanonicalName();
+    boolean fileSink = sink instanceof FileStreamSink;
+    boolean deltaSink = DELTA_SINK_CLASS_NAME.equals(sinkClassName);
+
+    if (!fileSink && !deltaSink) {
+      log.debug("Unsupported Sink type: {}", sink.getClass().getName());
+      return Collections.emptyList();
+    }
+
+    if (writeToMicroBatchV1.catalogTable().isDefined()) {
+      return Collections.singletonList(
+          factory
+              .sparkDatasetBuilder()
+              .dataset(writeToMicroBatchV1.catalogTable().get())
+              .schema(writeToMicroBatchV1.schema())
+              .build());
+    }
+
+    if (deltaSink) {
+      return deltaPath(sink)
+          .map(
+              path ->
+                  Collections.singletonList(
+                      factory
+                          .sparkDatasetBuilder()
+                          .dataset(path)
+                          .schema(writeToMicroBatchV1.schema())
+                          .build()))
+          .orElseGet(Collections::emptyList);
+    }
+
+    return Collections.emptyList();
+  }
+
+  private Optional<URI> deltaPath(Sink sink) {
+    try {
+      return ReflectionUtils.tryExecuteMethod(sink, "path").map(Object::toString).map(URI::create);
+    } catch (IllegalArgumentException e) {
+      log.warn("Could not extract a valid path from {}", sink.getClass().getName(), e);
+      return Optional.empty();
+    }
+  }
+}

--- a/metadata-integration/java/acryl-spark-lineage/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilderTest.java
+++ b/metadata-integration/java/acryl-spark-lineage/src/test/java/io/openlineage/spark34/agent/lifecycle/plan/WriteToMicroBatchDataSourceV1DatasetBuilderTest.java
@@ -1,0 +1,56 @@
+package io.openlineage.spark34.agent.lifecycle.plan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.openlineage.client.OpenLineage;
+import io.openlineage.spark.agent.Versions;
+import io.openlineage.spark.agent.lifecycle.Spark40DatasetBuilderFactory;
+import io.openlineage.spark.api.OpenLineageContext;
+import io.openlineage.spark.api.SparkOpenLineageConfig;
+import java.util.List;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.SparkContext;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.delta.sources.DeltaSink;
+import org.apache.spark.sql.execution.streaming.sources.WriteToMicroBatchDataSourceV1;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+import scala.Option;
+
+class WriteToMicroBatchDataSourceV1DatasetBuilderTest {
+
+  @Test
+  void spark4FactoryExtractsPathFromDeltaSinkWithoutCatalogTable() {
+    OpenLineageContext context =
+        OpenLineageContext.builder()
+            .sparkSession(mock(SparkSession.class))
+            .sparkContext(mock(SparkContext.class))
+            .openLineage(new OpenLineage(Versions.OPEN_LINEAGE_PRODUCER_URI))
+            .meterRegistry(new SimpleMeterRegistry())
+            .openLineageConfig(new SparkOpenLineageConfig())
+            .build();
+
+    WriteToMicroBatchDataSourceV1DatasetBuilder builder =
+        new Spark40DatasetBuilderFactory()
+            .getOutputBuilders(context).stream()
+                .filter(WriteToMicroBatchDataSourceV1DatasetBuilder.class::isInstance)
+                .map(WriteToMicroBatchDataSourceV1DatasetBuilder.class::cast)
+                .findFirst()
+                .orElseThrow();
+
+    WriteToMicroBatchDataSourceV1 write = mock(WriteToMicroBatchDataSourceV1.class);
+    when(write.sink()).thenReturn(new DeltaSink(new Path("file:///tmp/existing-delta-output")));
+    when(write.catalogTable()).thenReturn(Option.empty());
+    when(write.schema()).thenReturn(new StructType());
+
+    List<OpenLineage.OutputDataset> outputs = builder.apply(mock(SparkListenerEvent.class), write);
+
+    assertEquals(1, outputs.size());
+    assertEquals("file", outputs.get(0).getNamespace());
+    assertEquals("/tmp/existing-delta-output", outputs.get(0).getName());
+  }
+}

--- a/metadata-integration/java/acryl-spark-lineage/src/test/java/org/apache/spark/sql/delta/sources/DeltaSink.java
+++ b/metadata-integration/java/acryl-spark-lineage/src/test/java/org/apache/spark/sql/delta/sources/DeltaSink.java
@@ -1,0 +1,28 @@
+package org.apache.spark.sql.delta.sources;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.execution.streaming.Sink;
+
+/**
+ * Test double for Delta's optional runtime class. The production agent identifies this class by
+ * name and reads its public {@link #path()} accessor without depending on Delta directly.
+ */
+public final class DeltaSink implements Sink {
+
+  private final Path path;
+
+  public DeltaSink(Path path) {
+    this.path = path;
+  }
+
+  public Path path() {
+    return path;
+  }
+
+  @Override
+  public void addBatch(long batchId, Dataset<Row> data) {
+    throw new UnsupportedOperationException();
+  }
+}


### PR DESCRIPTION
  ## Summary

  Fixes #18647

 In Spark 4 with Delta Lake 4.2, a successful Structured Streaming append to an existing Delta table can emit DataFlow and DataJob metadata without recording the Delta destination as an output dataset.
  
Spark executes the affected write through its V1 microbatch sink path. The analyzed plan contains `WriteToMicroBatchDataSourceV1` with a `DeltaSink`, which the current Spark 4 lineage extraction does not handle:
  ```text
  WriteToMicroBatchDataSourceV1
      -> org.apache.spark.sql.delta.sources.DeltaSink
  ```

  The OpenLineage Spark 4 dataset builder factory does not register the V1 microbatch output builder. In addition, the existing builder only recognizes `FileStreamSink`, causing Delta streaming writes to emit no output dataset.

  This PR:

  - registers `WriteToMicroBatchDataSourceV1DatasetBuilder` for Spark 4;
  - adds output extraction for catalog-backed and path-only `DeltaSink` writes;
  - prefers logical catalog-table identity when available;
  - falls back to the public Delta sink path accessor using reflection;
  - avoids adding a production dependency on Delta;
  - ensures DataHub's OpenLineage source overrides replace the corresponding classes in the shaded agent JAR;
  - tracks both overridden OpenLineage classes as versioned customization patches.

  Kafka streaming input extraction is intentionally out of scope.

  ## Behavior after this change

  For an existing catalog-backed destination written with `toTable(...)`, the logical table is emitted as the output dataset.

  For an existing path-only destination written with `start(path)`, the normalized Delta path is emitted as the output dataset.

  The output is available to both DataJob and DataProcessInstance lineage.

  ## Upstream context

  - OpenLineage Spark 4 V1 builder registration:
    https://github.com/OpenLineage/OpenLineage/issues/4110
  - Original V1 microbatch builder:
    https://github.com/OpenLineage/OpenLineage/pull/4018

  ## Validation

  Validated with Spark 4.1.0, Scala 2.13, Java 17, and Delta Lake 4.2.0 for:

  - streaming append to a pre-existing catalog-backed Delta table;
  - streaming append to a pre-existing path-only Delta destination;
  - successful query completion and row append;
  - logical table output for catalog-backed writes;
  - path output for path-only writes;
  - agent loading without Delta on the production classpath.

  ## Checklist

  - [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md), including the [PR Title Format](https://
  github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format).
  - [x] Links to related issues and upstream work are included.
  - [x] Automated regression tests have been added to this branch.
  - [x] Documentation changes are not required because this restores expected lineage extraction behavior without changing user configuration.
  - [x] An Updating DataHub entry is not required because this introduces no breaking change, migration, downtime, or deprecation.