### PR TITLE
ci(pre-commit): gate Bump PDL schema versions hook on a files: regex

### DIFF
--- a/.github/scripts/pre-commit/pre-commit-override.yaml
+++ b/.github/scripts/pre-commit/pre-commit-override.yaml
@@ -83,6 +83,12 @@ repos:
         name: Bump PDL schema versions
         entry: python .github/scripts/bump_schema_versions.py
         language: python
+        # Gate on staged PDL sources so the hook is skipped entirely on
+        # docs-/frontend-/Python-only commits. The script scans PDL_ROOTS
+        # (default metadata-models/src/main/pegasus) for changed .pdl aspects,
+        # so scope the regex to that root. If PDL_ROOTS is ever overridden to
+        # add roots, extend this pattern to cover them too.
+        files: ^metadata-models/src/main/pegasus/.*\.pdl$
         pass_filenames: false
         # Changes schema version numbers (semantic), not a formatter.
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -698,6 +698,7 @@ repos:
         name: Bump PDL schema versions
         entry: python .github/scripts/bump_schema_versions.py
         language: python
+        files: ^metadata-models/src/main/pegasus/.*\.pdl$
         pass_filenames: false
         stages:
           - pre-commit


### PR DESCRIPTION
## Summary

The `bump-schema-versions` pre-commit hook ("Bump PDL schema versions") had **no `files:` filter** and `pass_filenames: false`, so it ran on **every** commit — including docs-, frontend-, and Python-only changes with nothing to do with PDL schemas. `bump_schema_versions.py` only scans PDL source roots (default `metadata-models/src/main/pegasus`) for changed `.pdl` aspects, so the hook's real trigger condition — "a `.pdl` file under a PDL root changed" — was being evaluated inside a full Python invocation on every commit instead of by pre-commit's cheap file filter.

This adds a `files:` regex so pre-commit only runs the hook when PDL-relevant files are staged:

```yaml
files: ^metadata-models/src/main/pegasus/.*\.pdl$
```

## Refinements confirmed before choosing the regex

- **`PDL_ROOTS` overrides** — not overridden anywhere in the repo (no workflow, script, or gradle sets it; CI's `check-schema-versions` job runs the script with the default root). So scoping the regex to the single default root matches exactly what the script scans. A comment on the hook flags the need to extend the pattern if `PDL_ROOTS` is ever widened.
- **`entity-registry.yml` / PDL-adjacent files** — the script never reads them; it only diffs `.pdl` files against the base branch. Adding them to `files:` would make the hook run and immediately no-op ("No changed PDL files found"), so they are intentionally left out to keep the gate tight.
- **Generated / build-output dirs** — all `.pdl` under `src/main/pegasus` are hand-authored source; generated PDL lands in gitignored `build/` dirs that are never staged, and the anchored regex already excludes them. No `exclude:` needed.

## Where the change lives

`.pre-commit-config.yaml` is auto-generated, so the canonical edit is in its source, `.github/scripts/pre-commit/pre-commit-override.yaml`; the generated file carries the equivalent line.

## Testing

- Pre-commit on this commit (non-PDL paths) → **Skipped** (`no files to check`) for Bump PDL schema versions.
- `pre-commit run bump-schema-versions --files <docs/frontend/python file>` → **Skipped**.
- `pre-commit run bump-schema-versions --files <a .pdl under metadata-models/src/main/pegasus>` → hook **runs**.

## CI impact

None. `.github/workflows/lint-jobs.yml` invokes `bump_schema_versions.py --check` directly (gated by its own `pdl` path filter); `files:` only affects the local pre-commit hook.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests/verification performed (see Testing)
- [ ] Docs — n/a (tooling-only change)
- [ ] Breaking change — none


Made with [Cursor](https://cursor.com)