### PR TITLE
perf(graphql): batch glossary node children counts with a DataLoader

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -154,6 +154,7 @@ import com.linkedin.datahub.graphql.resolvers.load.EntityLineageResultResolver;
 import com.linkedin.datahub.graphql.resolvers.load.EntityRelationshipsResultResolver;
 import com.linkedin.datahub.graphql.resolvers.load.EntityTypeBatchResolver;
 import com.linkedin.datahub.graphql.resolvers.load.EntityTypeResolver;
+import com.linkedin.datahub.graphql.resolvers.load.GlossaryNodeChildrenCountBatchLoader;
 import com.linkedin.datahub.graphql.resolvers.load.LoadableTypeBatchResolver;
 import com.linkedin.datahub.graphql.resolvers.load.LoadableTypeResolver;
 import com.linkedin.datahub.graphql.resolvers.load.OwnerTypeBatchResolver;
@@ -954,6 +955,9 @@ public class GmsGraphQLEngine {
             TimeseriesAspectBatchLoader.LOADER_NAME,
             context ->
                 TimeseriesAspectBatchLoader.createDataLoader(timeseriesAspectService, context))
+        .addDataLoader(
+            GlossaryNodeChildrenCountBatchLoader.LOADER_NAME,
+            context -> GlossaryNodeChildrenCountBatchLoader.createDataLoader(entityClient, context))
         .addDataLoader(
             DashboardStatsSummaryBatchLoader.LOADER_NAME,
             context ->
@@ -2181,7 +2185,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher("parentNodes", new ParentNodesResolver(entityClient))
                 .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
                 .dataFetcher("exists", new EntityExistsResolver(entityService))
-                .dataFetcher("childrenCount", new GlossaryNodeChildrenCountResolver(entityClient))
+                .dataFetcher("childrenCount", new GlossaryNodeChildrenCountResolver())
                 .dataFetcher(
                     "glossaryChildrenSearch",
                     new GlossaryChildrenSearchResolver(this.entityClient, this.viewService))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/GlossaryNodeChildrenCountResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/GlossaryNodeChildrenCountResolver.java
@@ -1,95 +1,28 @@
 package com.linkedin.datahub.graphql.resolvers.glossary;
 
-import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.getQueryContext;
-
-import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.Urn;
-import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.generated.Entity;
 import com.linkedin.datahub.graphql.generated.GlossaryNodeChildrenCount;
-import com.linkedin.entity.client.EntityClient;
-import com.linkedin.metadata.Constants;
-import com.linkedin.metadata.query.filter.Condition;
-import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
-import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
-import com.linkedin.metadata.query.filter.Criterion;
-import com.linkedin.metadata.query.filter.CriterionArray;
-import com.linkedin.metadata.query.filter.Filter;
-import com.linkedin.metadata.search.AggregationMetadata;
-import com.linkedin.metadata.search.SearchResult;
-import com.linkedin.metadata.utils.CriterionUtils;
+import com.linkedin.datahub.graphql.resolvers.load.GlossaryNodeChildrenCountBatchLoader;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import java.util.Collections;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import org.dataloader.DataLoader;
 
 public class GlossaryNodeChildrenCountResolver
     implements DataFetcher<CompletableFuture<GlossaryNodeChildrenCount>> {
-  private final EntityClient _entityClient;
-
-  public GlossaryNodeChildrenCountResolver(final EntityClient entityClient) {
-    _entityClient = entityClient;
-  }
 
   @Override
   public CompletableFuture<GlossaryNodeChildrenCount> get(final DataFetchingEnvironment environment)
       throws Exception {
-    final QueryContext context = getQueryContext(environment);
     final String urn = ((Entity) environment.getSource()).getUrn();
+    // Fail fast rather than letting a malformed URN into a shared batch filter.
+    Urn.createFromString(urn);
 
-    final CriterionArray andArray = new CriterionArray();
-    Criterion parentNodeCriterion =
-        CriterionUtils.buildCriterion("parentNode", Condition.EQUAL, urn);
-    andArray.add(parentNodeCriterion);
-    Filter finalFilter =
-        new Filter()
-            .setOr(new ConjunctiveCriterionArray(new ConjunctiveCriterion().setAnd(andArray)));
-
-    final Urn entityUrn = Urn.createFromString(urn);
-    return GraphQLConcurrencyUtils.supplyAsync(
-        () -> {
-          try {
-            GlossaryNodeChildrenCount childrenCount = new GlossaryNodeChildrenCount();
-            childrenCount.setTermsCount(0);
-            childrenCount.setNodesCount(0);
-            SearchResult result =
-                _entityClient.searchAcrossEntities(
-                    context.getOperationContext(),
-                    ImmutableList.of(
-                        Constants.GLOSSARY_TERM_ENTITY_NAME, Constants.GLOSSARY_NODE_ENTITY_NAME),
-                    "*",
-                    finalFilter,
-                    0,
-                    0, // 0 entity count because we don't want resolved entities
-                    Collections.emptyList(),
-                    ImmutableList.of("_entityType"));
-            Optional<AggregationMetadata> aggMetadata =
-                result.getMetadata().getAggregations().stream()
-                    .filter(a -> a.getName().equals("_entityType"))
-                    .findFirst();
-            aggMetadata.ifPresent(
-                aggregationMetadata ->
-                    aggregationMetadata
-                        .getFilterValues()
-                        .forEach(
-                            filterValue -> {
-                              if (filterValue.getValue().equals("glossaryterm")) {
-                                childrenCount.setTermsCount(filterValue.getFacetCount().intValue());
-                              }
-                              if (filterValue.getValue().equals("glossarynode")) {
-                                childrenCount.setNodesCount(filterValue.getFacetCount().intValue());
-                              }
-                            }));
-
-            return childrenCount;
-          } catch (Exception e) {
-            throw new RuntimeException(
-                String.format("Failed to check whether entity %s exists", entityUrn.toString()));
-          }
-        },
-        this.getClass().getSimpleName(),
-        "get");
+    final DataLoader<String, GlossaryNodeChildrenCount> loader =
+        environment
+            .getDataLoaderRegistry()
+            .getDataLoader(GlossaryNodeChildrenCountBatchLoader.LOADER_NAME);
+    return loader.load(urn);
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/GlossaryNodeChildrenCountBatchLoader.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/GlossaryNodeChildrenCountBatchLoader.java
@@ -1,0 +1,197 @@
+package com.linkedin.datahub.graphql.resolvers.load;
+
+import static com.linkedin.metadata.utils.SearchUtil.AGGREGATION_SEPARATOR_CHAR;
+import static com.linkedin.metadata.utils.SearchUtil.INDEX_VIRTUAL_FIELD;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
+import com.linkedin.datahub.graphql.generated.GlossaryNodeChildrenCount;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.CriterionArray;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.search.AggregationMetadata;
+import com.linkedin.metadata.search.FilterValue;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.utils.CriterionUtils;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.dataloader.BatchLoaderContextProvider;
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderOptions;
+
+/**
+ * DataLoader for batching glossary node children counts. Instead of one aggregation query per
+ * glossary node, a whole level of the glossary tree is resolved with a single {@code
+ * parentNode␞_entityType} nested facet query filtered on every parent URN in the batch.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class GlossaryNodeChildrenCountBatchLoader {
+
+  public static final String LOADER_NAME = "GlossaryNodeChildrenCount";
+
+  private static final String PARENT_NODE_FIELD = "parentNode";
+  private static final List<String> CHILD_ENTITY_NAMES =
+      ImmutableList.of(Constants.GLOSSARY_TERM_ENTITY_NAME, Constants.GLOSSARY_NODE_ENTITY_NAME);
+  private static final List<String> CHILDREN_BY_TYPE_FACET =
+      ImmutableList.of(PARENT_NODE_FIELD + AGGREGATION_SEPARATOR_CHAR + INDEX_VIRTUAL_FIELD);
+
+  /**
+   * Parents resolved per aggregation query. The {@code parentNode} terms aggregation returns at
+   * most {@code min(searchFlags.maxAggValues, elasticsearch.search.maxTermBucketSize)} buckets, and
+   * {@code maxTermBucketSize} defaults to 60 — wider batches would drop parents from the response.
+   * Kept below that ceiling so a moderately lowered cluster setting still leaves headroom; anything
+   * that does slip through is caught by the truncation check in {@link #loadChunk}.
+   */
+  static final int MAX_PARENTS_PER_QUERY = 50;
+
+  private final EntityClient entityClient;
+
+  public static DataLoader<String, GlossaryNodeChildrenCount> createDataLoader(
+      final EntityClient entityClient, final QueryContext queryContext) {
+    final GlossaryNodeChildrenCountBatchLoader loader =
+        new GlossaryNodeChildrenCountBatchLoader(entityClient);
+    final BatchLoaderContextProvider provider = () -> queryContext;
+    final DataLoaderOptions options =
+        DataLoaderOptions.newOptions().setBatchLoaderContextProvider(provider);
+    return DataLoader.newDataLoader(
+        (keys, env) ->
+            GraphQLConcurrencyUtils.supplyAsync(
+                () -> loader.batchLoad(keys, (QueryContext) env.getContext()),
+                LOADER_NAME,
+                "batchLoad"),
+        options);
+  }
+
+  /**
+   * Resolves the child term and node counts for each parent glossary node URN, in key order.
+   * Parents without children are returned as zero counts rather than nulls.
+   */
+  public List<GlossaryNodeChildrenCount> batchLoad(
+      final List<String> parentUrns, final QueryContext context) {
+    final Map<String, GlossaryNodeChildrenCount> countsByParent = new HashMap<>();
+    for (int i = 0; i < parentUrns.size(); i += MAX_PARENTS_PER_QUERY) {
+      final List<String> chunk =
+          parentUrns.subList(i, Math.min(i + MAX_PARENTS_PER_QUERY, parentUrns.size()));
+      countsByParent.putAll(loadChunk(chunk, context));
+    }
+
+    return parentUrns.stream()
+        .map(urn -> countsByParent.getOrDefault(urn, childrenCount(0, 0)))
+        .collect(Collectors.toList());
+  }
+
+  private Map<String, GlossaryNodeChildrenCount> loadChunk(
+      final List<String> parentUrns, final QueryContext context) {
+    final SearchResult result = queryChildrenCounts(parentUrns, context);
+    final Map<String, GlossaryNodeChildrenCount> counts = extractCounts(result);
+
+    // Every matching child document lands in exactly one (parentNode, entity type) bucket, so the
+    // aggregated counts must add up to the total hit count. Falling short means the parentNode
+    // aggregation dropped buckets and the missing parents would report zero children, so redo the
+    // chunk one parent at a time — slower, but a single-parent aggregation cannot be truncated.
+    final long aggregatedTotal =
+        counts.values().stream().mapToLong(c -> (long) c.getTermsCount() + c.getNodesCount()).sum();
+    final long totalHits = result.hasNumEntities() ? result.getNumEntities() : 0L;
+    if (parentUrns.size() > 1 && aggregatedTotal < totalHits) {
+      log.warn(
+          "Glossary children count aggregation truncated for {} parents ({} of {} children"
+              + " attributed); falling back to per-parent queries. Consider raising"
+              + " elasticsearch.search.maxTermBucketSize.",
+          parentUrns.size(),
+          aggregatedTotal,
+          totalHits);
+      final Map<String, GlossaryNodeChildrenCount> perParentCounts = new HashMap<>();
+      for (final String parentUrn : parentUrns) {
+        perParentCounts.putAll(
+            extractCounts(queryChildrenCounts(ImmutableList.of(parentUrn), context)));
+      }
+      return perParentCounts;
+    }
+
+    return counts;
+  }
+
+  private SearchResult queryChildrenCounts(
+      final List<String> parentUrns, final QueryContext context) {
+    final Filter filter =
+        new Filter()
+            .setOr(
+                new ConjunctiveCriterionArray(
+                    new ConjunctiveCriterion()
+                        .setAnd(
+                            new CriterionArray(
+                                CriterionUtils.buildCriterion(
+                                    PARENT_NODE_FIELD, Condition.EQUAL, parentUrns)))));
+    try {
+      return entityClient.searchAcrossEntities(
+          // The default maxAggValues (20) is below our batch size, which would truncate the
+          // parentNode buckets on every full batch.
+          context
+              .getOperationContext()
+              .withSearchFlags(flags -> flags.setMaxAggValues(MAX_PARENTS_PER_QUERY)),
+          CHILD_ENTITY_NAMES,
+          "*",
+          filter,
+          0,
+          0, // 0 entity count because only the aggregation is needed
+          Collections.emptyList(),
+          CHILDREN_BY_TYPE_FACET);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          String.format("Failed to fetch glossary children counts for parents %s", parentUrns), e);
+    }
+  }
+
+  /**
+   * Reads the nested facet values, which are {@code <parentNodeUrn>␞<entityName>} keys. The same
+   * aggregation also carries single-token parent totals, which are skipped.
+   */
+  private static Map<String, GlossaryNodeChildrenCount> extractCounts(final SearchResult result) {
+    final Map<String, GlossaryNodeChildrenCount> counts = new HashMap<>();
+    if (!result.hasMetadata() || !result.getMetadata().hasAggregations()) {
+      return counts;
+    }
+
+    for (final AggregationMetadata aggregation : result.getMetadata().getAggregations()) {
+      if (!CHILDREN_BY_TYPE_FACET.get(0).equals(aggregation.getName())) {
+        continue;
+      }
+      for (final FilterValue filterValue : aggregation.getFilterValues()) {
+        final String[] tokens = filterValue.getValue().split(AGGREGATION_SEPARATOR_CHAR);
+        if (tokens.length != 2) {
+          continue;
+        }
+        final int count = filterValue.getFacetCount().intValue();
+        final GlossaryNodeChildrenCount childrenCount =
+            counts.computeIfAbsent(tokens[0], urn -> childrenCount(0, 0));
+        // Facet values come back derived from the ES index name, so they are lower-cased
+        // ("glossaryterm") rather than the camel-cased entity name.
+        if (tokens[1].equalsIgnoreCase(Constants.GLOSSARY_TERM_ENTITY_NAME)) {
+          childrenCount.setTermsCount(childrenCount.getTermsCount() + count);
+        } else if (tokens[1].equalsIgnoreCase(Constants.GLOSSARY_NODE_ENTITY_NAME)) {
+          childrenCount.setNodesCount(childrenCount.getNodesCount() + count);
+        }
+      }
+    }
+    return counts;
+  }
+
+  private static GlossaryNodeChildrenCount childrenCount(
+      final int termsCount, final int nodesCount) {
+    final GlossaryNodeChildrenCount count = new GlossaryNodeChildrenCount();
+    count.setTermsCount(termsCount);
+    count.setNodesCount(nodesCount);
+    return count;
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/GlossaryNodeChildrenCountResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/GlossaryNodeChildrenCountResolverTest.java
@@ -1,27 +1,19 @@
 package com.linkedin.datahub.graphql.resolvers.glossary;
 
-import static com.linkedin.datahub.graphql.TestUtils.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 
-import com.google.common.collect.ImmutableList;
-import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.Entity;
 import com.linkedin.datahub.graphql.generated.GlossaryNodeChildrenCount;
-import com.linkedin.entity.client.EntityClient;
-import com.linkedin.metadata.Constants;
-import com.linkedin.metadata.query.filter.Filter;
-import com.linkedin.metadata.search.AggregationMetadata;
-import com.linkedin.metadata.search.AggregationMetadataArray;
-import com.linkedin.metadata.search.FilterValue;
-import com.linkedin.metadata.search.FilterValueArray;
-import com.linkedin.metadata.search.SearchResult;
-import com.linkedin.r2.RemoteInvocationException;
+import com.linkedin.datahub.graphql.resolvers.load.GlossaryNodeChildrenCountBatchLoader;
 import graphql.schema.DataFetchingEnvironment;
 import java.net.URISyntaxException;
-import java.util.Collections;
-import java.util.concurrent.CompletionException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderRegistry;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -29,143 +21,58 @@ import org.testng.annotations.Test;
 public class GlossaryNodeChildrenCountResolverTest {
   private static final String TEST_GLOSSARY_NODE_URN = "urn:li:glossaryNode:test-id";
 
-  private EntityClient _entityClient;
   private DataFetchingEnvironment _dataFetchingEnvironment;
   private GlossaryNodeChildrenCountResolver _resolver;
   private Entity _entity;
+  private DataLoaderRegistry _registry;
+  private List<List<String>> _observedBatches;
 
   @BeforeMethod
   public void setupTest() {
-    _entityClient = Mockito.mock(EntityClient.class);
     _dataFetchingEnvironment = Mockito.mock(DataFetchingEnvironment.class);
     _entity = Mockito.mock(Entity.class);
     Mockito.when(_entity.getUrn()).thenReturn(TEST_GLOSSARY_NODE_URN);
     Mockito.when(_dataFetchingEnvironment.getSource()).thenReturn(_entity);
 
-    _resolver = new GlossaryNodeChildrenCountResolver(_entityClient);
+    _observedBatches = new ArrayList<>();
+    final DataLoader<String, GlossaryNodeChildrenCount> loader =
+        DataLoader.newDataLoader(
+            keys -> {
+              _observedBatches.add(new ArrayList<>(keys));
+              return CompletableFuture.completedFuture(
+                  keys.stream()
+                      .map(
+                          key -> {
+                            final GlossaryNodeChildrenCount count = new GlossaryNodeChildrenCount();
+                            count.setTermsCount(5);
+                            count.setNodesCount(3);
+                            return count;
+                          })
+                      .collect(Collectors.toList()));
+            });
+    _registry = new DataLoaderRegistry();
+    _registry.register(GlossaryNodeChildrenCountBatchLoader.LOADER_NAME, loader);
+    Mockito.when(_dataFetchingEnvironment.getDataLoaderRegistry()).thenReturn(_registry);
+
+    _resolver = new GlossaryNodeChildrenCountResolver();
   }
 
   @Test
-  public void testGetSuccess() throws Exception {
-    // Setup mock search result with both terms and nodes
-    SearchResult mockResult = new SearchResult();
-    AggregationMetadata entityTypeAgg = new AggregationMetadata();
-    entityTypeAgg.setName("_entityType");
-    FilterValueArray filterValues = new FilterValueArray();
-    filterValues.add(new FilterValue().setValue("glossaryterm").setFacetCount(5L));
-    filterValues.add(new FilterValue().setValue("glossarynode").setFacetCount(3L));
-    entityTypeAgg.setFilterValues(filterValues);
+  public void testGetLoadsTheSourceUrnThroughTheBatchLoader() throws Exception {
+    final CompletableFuture<GlossaryNodeChildrenCount> future =
+        _resolver.get(_dataFetchingEnvironment);
+    _registry.dispatchAll();
 
-    AggregationMetadataArray aggregations = new AggregationMetadataArray();
-    aggregations.add(entityTypeAgg);
-    mockResult.setMetadata(
-        new com.linkedin.metadata.search.SearchResultMetadata().setAggregations(aggregations));
-
-    Mockito.when(
-            _entityClient.searchAcrossEntities(
-                any(),
-                eq(
-                    ImmutableList.of(
-                        Constants.GLOSSARY_TERM_ENTITY_NAME, Constants.GLOSSARY_NODE_ENTITY_NAME)),
-                eq("*"),
-                any(Filter.class),
-                eq(0),
-                eq(0),
-                eq(Collections.emptyList()),
-                eq(ImmutableList.of("_entityType"))))
-        .thenReturn(mockResult);
-
-    // Execute resolver
-    QueryContext mockContext = getMockAllowContext();
-    Mockito.when(_dataFetchingEnvironment.getContext()).thenReturn(mockContext);
-
-    GlossaryNodeChildrenCount result = _resolver.get(_dataFetchingEnvironment).get();
-
-    // Verify results
+    final GlossaryNodeChildrenCount result = future.get();
     assertEquals(result.getTermsCount(), 5);
     assertEquals(result.getNodesCount(), 3);
+    assertEquals(_observedBatches, List.of(List.of(TEST_GLOSSARY_NODE_URN)));
   }
 
   @Test
-  public void testGetNoChildren() throws Exception {
-    // Setup mock search result with no children
-    SearchResult mockResult = new SearchResult();
-    AggregationMetadata entityTypeAgg = new AggregationMetadata();
-    entityTypeAgg.setName("_entityType");
-    entityTypeAgg.setFilterValues(new FilterValueArray());
-
-    AggregationMetadataArray aggregations = new AggregationMetadataArray();
-    aggregations.add(entityTypeAgg);
-    mockResult.setMetadata(
-        new com.linkedin.metadata.search.SearchResultMetadata().setAggregations(aggregations));
-
-    Mockito.when(
-            _entityClient.searchAcrossEntities(
-                any(),
-                eq(
-                    ImmutableList.of(
-                        Constants.GLOSSARY_TERM_ENTITY_NAME, Constants.GLOSSARY_NODE_ENTITY_NAME)),
-                eq("*"),
-                any(Filter.class),
-                eq(0),
-                eq(0),
-                eq(Collections.emptyList()),
-                eq(ImmutableList.of("_entityType"))))
-        .thenReturn(mockResult);
-
-    // Execute resolver
-    QueryContext mockContext = getMockAllowContext();
-    Mockito.when(_dataFetchingEnvironment.getContext()).thenReturn(mockContext);
-
-    GlossaryNodeChildrenCount result = _resolver.get(_dataFetchingEnvironment).get();
-
-    // Verify results
-    assertEquals(result.getTermsCount(), 0);
-    assertEquals(result.getNodesCount(), 0);
-  }
-
-  @Test
-  public void testGetUnauthorized() throws Exception {
-    // Execute resolver with unauthorized context
-    QueryContext mockContext = getMockDenyContext();
-    Mockito.when(_dataFetchingEnvironment.getContext()).thenReturn(mockContext);
-
-    assertThrows(CompletionException.class, () -> _resolver.get(_dataFetchingEnvironment).join());
-  }
-
-  @Test
-  public void testGetEntityClientException() throws Exception {
-    // Setup mock to throw exception
-    Mockito.when(
-            _entityClient.searchAcrossEntities(
-                any(),
-                eq(
-                    ImmutableList.of(
-                        Constants.GLOSSARY_TERM_ENTITY_NAME, Constants.GLOSSARY_NODE_ENTITY_NAME)),
-                eq("*"),
-                any(Filter.class),
-                eq(0),
-                eq(0),
-                eq(Collections.emptyList()),
-                eq(ImmutableList.of("_entityType"))))
-        .thenThrow(new RemoteInvocationException("Failed to search"));
-
-    // Execute resolver
-    QueryContext mockContext = getMockAllowContext();
-    Mockito.when(_dataFetchingEnvironment.getContext()).thenReturn(mockContext);
-
-    assertThrows(CompletionException.class, () -> _resolver.get(_dataFetchingEnvironment).join());
-  }
-
-  @Test
-  public void testGetInvalidUrn() throws Exception {
-    // Setup entity with invalid URN
+  public void testGetInvalidUrn() {
     Mockito.when(_entity.getUrn()).thenReturn("invalid-urn");
 
-    // Execute resolver
-    QueryContext mockContext = getMockAllowContext();
-    Mockito.when(_dataFetchingEnvironment.getContext()).thenReturn(mockContext);
-
-    assertThrows(URISyntaxException.class, () -> _resolver.get(_dataFetchingEnvironment).join());
+    assertThrows(URISyntaxException.class, () -> _resolver.get(_dataFetchingEnvironment));
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/GlossaryNodeChildrenCountBatchLoaderTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/GlossaryNodeChildrenCountBatchLoaderTest.java
@@ -1,0 +1,222 @@
+package com.linkedin.datahub.graphql.resolvers.load;
+
+import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
+import static com.linkedin.metadata.utils.SearchUtil.AGGREGATION_SEPARATOR_CHAR;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.GlossaryNodeChildrenCount;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.query.filter.Criterion;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.search.AggregationMetadata;
+import com.linkedin.metadata.search.AggregationMetadataArray;
+import com.linkedin.metadata.search.FilterValue;
+import com.linkedin.metadata.search.FilterValueArray;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.search.SearchResultMetadata;
+import com.linkedin.r2.RemoteInvocationException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class GlossaryNodeChildrenCountBatchLoaderTest {
+
+  private static final String NODE_A = "urn:li:glossaryNode:a";
+  private static final String NODE_B = "urn:li:glossaryNode:b";
+  private static final String NODE_C = "urn:li:glossaryNode:c";
+
+  private EntityClient entityClient;
+  private QueryContext context;
+  private GlossaryNodeChildrenCountBatchLoader loader;
+
+  @BeforeMethod
+  public void setupTest() {
+    entityClient = Mockito.mock(EntityClient.class);
+    context = getMockAllowContext();
+    loader = new GlossaryNodeChildrenCountBatchLoader(entityClient);
+  }
+
+  @Test
+  public void testBatchLoadResolvesAllParentsWithASingleQuery() throws Exception {
+    Mockito.when(
+            entityClient.searchAcrossEntities(
+                any(), any(), eq("*"), any(Filter.class), eq(0), eq(0), any(), any()))
+        .thenReturn(
+            searchResult(
+                10L,
+                Map.of(
+                    nestedKey(NODE_A, "glossaryterm"), 5L,
+                    nestedKey(NODE_A, "glossarynode"), 3L,
+                    nestedKey(NODE_B, "glossaryterm"), 2L)));
+
+    final List<GlossaryNodeChildrenCount> results =
+        loader.batchLoad(List.of(NODE_A, NODE_B, NODE_C), context);
+
+    assertEquals(results.size(), 3);
+    assertCount(results.get(0), 5, 3);
+    assertCount(results.get(1), 2, 0);
+    // A parent with no children buckets is a genuine leaf, not a miss.
+    assertCount(results.get(2), 0, 0);
+
+    // The whole point of the loader: one ES round trip for the whole batch.
+    Mockito.verify(entityClient, Mockito.times(1))
+        .searchAcrossEntities(any(), any(), eq("*"), any(Filter.class), eq(0), eq(0), any(), any());
+  }
+
+  @Test
+  public void testBatchLoadFiltersOnAllParentsAndRequestsTheNestedFacet() throws Exception {
+    Mockito.when(
+            entityClient.searchAcrossEntities(
+                any(), any(), eq("*"), any(Filter.class), eq(0), eq(0), any(), any()))
+        .thenReturn(searchResult(0L, Map.of()));
+
+    loader.batchLoad(List.of(NODE_A, NODE_B), context);
+
+    final ArgumentCaptor<Filter> filterCaptor = ArgumentCaptor.forClass(Filter.class);
+    final ArgumentCaptor<List> facetCaptor = ArgumentCaptor.forClass(List.class);
+    Mockito.verify(entityClient)
+        .searchAcrossEntities(
+            any(),
+            any(),
+            eq("*"),
+            filterCaptor.capture(),
+            eq(0),
+            eq(0),
+            any(),
+            facetCaptor.capture());
+
+    assertEquals(
+        facetCaptor.getValue(), List.of("parentNode" + AGGREGATION_SEPARATOR_CHAR + "_entityType"));
+
+    final Criterion criterion =
+        filterCaptor.getValue().getOr().get(0).getAnd().stream()
+            .filter(c -> "parentNode".equals(c.getField()))
+            .findFirst()
+            .orElseThrow();
+    assertEquals(new HashSet<>(criterion.getValues()), Set.of(NODE_A, NODE_B));
+  }
+
+  @Test
+  public void testBatchLoadChunksBatchesLargerThanTheAggregationBucketBudget() throws Exception {
+    final int keyCount = GlossaryNodeChildrenCountBatchLoader.MAX_PARENTS_PER_QUERY + 1;
+    final List<String> keys =
+        IntStream.range(0, keyCount)
+            .mapToObj(i -> "urn:li:glossaryNode:node-" + i)
+            .collect(Collectors.toList());
+
+    Mockito.when(
+            entityClient.searchAcrossEntities(
+                any(), any(), eq("*"), any(Filter.class), eq(0), eq(0), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              final Filter filter = invocation.getArgument(3);
+              final List<String> parents = parentValues(filter);
+              assertTrue(
+                  parents.size() <= GlossaryNodeChildrenCountBatchLoader.MAX_PARENTS_PER_QUERY,
+                  "chunk exceeded the aggregation bucket budget: " + parents.size());
+              return searchResult(
+                  parents.size(),
+                  parents.stream()
+                      .collect(Collectors.toMap(p -> nestedKey(p, "glossaryterm"), p -> 1L)));
+            });
+
+    final List<GlossaryNodeChildrenCount> results = loader.batchLoad(keys, context);
+
+    assertEquals(results.size(), keyCount);
+    results.forEach(count -> assertCount(count, 1, 0));
+    Mockito.verify(entityClient, Mockito.times(2))
+        .searchAcrossEntities(any(), any(), eq("*"), any(Filter.class), eq(0), eq(0), any(), any());
+  }
+
+  @Test
+  public void testBatchLoadFallsBackToPerParentQueriesWhenBucketsAreTruncated() throws Exception {
+    // Aggregated counts summing below the total hit count mean the parentNode terms
+    // aggregation dropped buckets, so some parents would silently report zero children.
+    Mockito.when(
+            entityClient.searchAcrossEntities(
+                any(), any(), eq("*"), any(Filter.class), eq(0), eq(0), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              final List<String> parents = parentValues(invocation.getArgument(3));
+              if (parents.size() > 1) {
+                return searchResult(100L, Map.of(nestedKey(NODE_A, "glossaryterm"), 1L));
+              }
+              final String parent = parents.get(0);
+              return NODE_A.equals(parent)
+                  ? searchResult(7L, Map.of(nestedKey(NODE_A, "glossaryterm"), 7L))
+                  : searchResult(4L, Map.of(nestedKey(NODE_B, "glossarynode"), 4L));
+            });
+
+    final List<GlossaryNodeChildrenCount> results =
+        loader.batchLoad(List.of(NODE_A, NODE_B), context);
+
+    assertCount(results.get(0), 7, 0);
+    assertCount(results.get(1), 0, 4);
+    // One truncated batch query plus one query per parent in the retry.
+    Mockito.verify(entityClient, Mockito.times(3))
+        .searchAcrossEntities(any(), any(), eq("*"), any(Filter.class), eq(0), eq(0), any(), any());
+  }
+
+  @Test
+  public void testBatchLoadPreservesTheSearchFailureCause() throws Exception {
+    final RemoteInvocationException cause = new RemoteInvocationException("search unavailable");
+    Mockito.when(
+            entityClient.searchAcrossEntities(
+                any(), any(), eq("*"), any(Filter.class), anyInt(), anyInt(), any(), any()))
+        .thenThrow(cause);
+
+    final RuntimeException thrown =
+        expectThrows(
+            RuntimeException.class, () -> loader.batchLoad(List.of(NODE_A, NODE_B), context));
+    assertEquals(thrown.getCause(), cause);
+  }
+
+  private static void assertCount(
+      final GlossaryNodeChildrenCount actual, final int termsCount, final int nodesCount) {
+    assertEquals(actual.getTermsCount(), termsCount);
+    assertEquals(actual.getNodesCount(), nodesCount);
+  }
+
+  private static String nestedKey(final String parentUrn, final String entityType) {
+    return parentUrn + AGGREGATION_SEPARATOR_CHAR + entityType;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<String> parentValues(final Filter filter) {
+    return filter.getOr().get(0).getAnd().stream()
+        .filter(c -> "parentNode".equals(c.getField()))
+        .findFirst()
+        .map(c -> new ArrayList<>(c.getValues()))
+        .orElseGet(ArrayList::new);
+  }
+
+  private static SearchResult searchResult(
+      final long numEntities, final Map<String, Long> nestedFacetCounts) {
+    final FilterValueArray filterValues = new FilterValueArray();
+    nestedFacetCounts.forEach(
+        (value, count) -> filterValues.add(new FilterValue().setValue(value).setFacetCount(count)));
+    final AggregationMetadata aggregation =
+        new AggregationMetadata()
+            .setName("parentNode" + AGGREGATION_SEPARATOR_CHAR + "_entityType")
+            .setFilterValues(filterValues);
+    return new SearchResult()
+        .setNumEntities((int) numEntities)
+        .setMetadata(
+            new SearchResultMetadata()
+                .setAggregations(new AggregationMetadataArray(List.of(aggregation))));
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/GlossaryNodeChildrenCountBatchLoaderTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/GlossaryNodeChildrenCountBatchLoaderTest.java
@@ -26,8 +26,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.dataloader.DataLoader;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
@@ -183,6 +186,77 @@ public class GlossaryNodeChildrenCountBatchLoaderTest {
         expectThrows(
             RuntimeException.class, () -> loader.batchLoad(List.of(NODE_A, NODE_B), context));
     assertEquals(thrown.getCause(), cause);
+  }
+
+  @Test
+  public void testBatchLoadIgnoresThePerParentTotalsThatAccompanyANestedFacet() throws Exception {
+    // A real parentNode␞_entityType aggregation reports each parent's overall doc count as a
+    // single-token value alongside the (parent, entity type) pairs. Counting those would double
+    // every parent's children.
+    Mockito.when(
+            entityClient.searchAcrossEntities(
+                any(), any(), eq("*"), any(Filter.class), eq(0), eq(0), any(), any()))
+        .thenReturn(
+            searchResult(
+                10L,
+                Map.of(
+                    nestedKey(NODE_A, "glossaryterm"),
+                    5L,
+                    nestedKey(NODE_A, "glossarynode"),
+                    3L,
+                    NODE_A,
+                    8L,
+                    nestedKey(NODE_B, "glossaryterm"),
+                    2L,
+                    NODE_B,
+                    2L)));
+
+    final List<GlossaryNodeChildrenCount> results =
+        loader.batchLoad(List.of(NODE_A, NODE_B), context);
+
+    assertCount(results.get(0), 5, 3);
+    assertCount(results.get(1), 2, 0);
+  }
+
+  @Test
+  public void testBatchLoadReturnsZeroCountsWhenTheResponseCarriesNoAggregations()
+      throws Exception {
+    Mockito.when(
+            entityClient.searchAcrossEntities(
+                any(), any(), eq("*"), any(Filter.class), eq(0), eq(0), any(), any()))
+        .thenReturn(new SearchResult().setNumEntities(0));
+
+    final List<GlossaryNodeChildrenCount> results =
+        loader.batchLoad(List.of(NODE_A, NODE_B), context);
+
+    assertCount(results.get(0), 0, 0);
+    assertCount(results.get(1), 0, 0);
+  }
+
+  @Test
+  public void testCreateDataLoaderResolvesEveryKeyFromOneBatch() throws Exception {
+    Mockito.when(
+            entityClient.searchAcrossEntities(
+                any(), any(), eq("*"), any(Filter.class), eq(0), eq(0), any(), any()))
+        .thenReturn(
+            searchResult(
+                3L,
+                Map.of(
+                    nestedKey(NODE_A, "glossaryterm"), 2L,
+                    nestedKey(NODE_B, "glossarynode"), 1L)));
+
+    final DataLoader<String, GlossaryNodeChildrenCount> dataLoader =
+        GlossaryNodeChildrenCountBatchLoader.createDataLoader(entityClient, context);
+    final CompletableFuture<GlossaryNodeChildrenCount> a = dataLoader.load(NODE_A);
+    final CompletableFuture<GlossaryNodeChildrenCount> b = dataLoader.load(NODE_B);
+    dataLoader.dispatch();
+
+    // Resolving at all proves the batch function received the QueryContext from the loader's
+    // context provider -- without it the search call would fail on a null operation context.
+    assertCount(a.get(30, TimeUnit.SECONDS), 2, 0);
+    assertCount(b.get(30, TimeUnit.SECONDS), 0, 1);
+    Mockito.verify(entityClient, Mockito.times(1))
+        .searchAcrossEntities(any(), any(), eq("*"), any(Filter.class), eq(0), eq(0), any(), any());
   }
 
   private static void assertCount(

--- a/smoke-test/tests/glossary/glossary_children_count_test.py
+++ b/smoke-test/tests/glossary/glossary_children_count_test.py
@@ -1,0 +1,126 @@
+import logging
+import uuid
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utils import delete_entity, execute_graphql, with_test_retry
+
+logger = logging.getLogger(__name__)
+
+# One request that resolves childrenCount for the parent and for every child at the next
+# level, so the children are batched together by GlossaryNodeChildrenCountBatchLoader.
+NODE_WITH_CHILD_COUNTS_QUERY = """query getNodeWithChildCounts($urn: String!) {
+    glossaryNode(urn: $urn) {
+        urn
+        childrenCount {
+            termsCount
+            nodesCount
+        }
+        glossaryChildrenSearch(input: { query: "*", count: 100, types: [GLOSSARY_NODE] }) {
+            total
+            searchResults {
+                entity {
+                    urn
+                    ... on GlossaryNode {
+                        childrenCount {
+                            termsCount
+                            nodesCount
+                        }
+                    }
+                }
+            }
+        }
+    }
+}"""
+
+CREATE_NODE_MUTATION = """mutation createGlossaryNode($input: CreateGlossaryEntityInput!) {
+    createGlossaryNode(input: $input)
+}"""
+
+CREATE_TERM_MUTATION = """mutation createGlossaryTerm($input: CreateGlossaryEntityInput!) {
+    createGlossaryTerm(input: $input)
+}"""
+
+
+def _create_node(auth_session, node_id: str, parent: Optional[str] = None) -> str:
+    entity_input: Dict[str, Any] = {"id": node_id, "name": node_id}
+    if parent:
+        entity_input["parentNode"] = parent
+    res = execute_graphql(auth_session, CREATE_NODE_MUTATION, {"input": entity_input})
+    return res["data"]["createGlossaryNode"]
+
+
+def _create_term(auth_session, term_id: str, parent: str) -> str:
+    res = execute_graphql(
+        auth_session,
+        CREATE_TERM_MUTATION,
+        {"input": {"id": term_id, "name": term_id, "parentNode": parent}},
+    )
+    return res["data"]["createGlossaryTerm"]
+
+
+@pytest.fixture(scope="module")
+def glossary_tree(auth_session):
+    """A parent node with three child nodes and two child terms.
+
+    One child node has children of its own, the other two are leaves, so a single request
+    exercises a multi-parent batch that mixes populated and empty parents.
+    """
+    suffix = f"cc-{uuid.uuid4().hex[:8]}"
+    logger.info(f"creating glossary tree {suffix}")
+    created: List[str] = []
+
+    def track(urn: str) -> str:
+        created.append(urn)
+        return urn
+
+    parent = track(_create_node(auth_session, f"{suffix}-parent"))
+    branch = track(_create_node(auth_session, f"{suffix}-branch", parent))
+    leaf_a = track(_create_node(auth_session, f"{suffix}-leaf-a", parent))
+    leaf_b = track(_create_node(auth_session, f"{suffix}-leaf-b", parent))
+    for i in range(2):
+        track(_create_term(auth_session, f"{suffix}-parent-term-{i}", parent))
+    for i in range(3):
+        track(_create_term(auth_session, f"{suffix}-branch-term-{i}", branch))
+    track(_create_node(auth_session, f"{suffix}-branch-child", branch))
+
+    wait_for_writes_to_sync()
+
+    yield {"parent": parent, "branch": branch, "leaf_a": leaf_a, "leaf_b": leaf_b}
+
+    logger.info(f"removing glossary tree {suffix}")
+    # Deepest entities first so a delete never orphans a child.
+    for urn in reversed(created):
+        delete_entity(auth_session, urn)
+
+
+@with_test_retry()
+def _fetch_counts(auth_session, parent_urn: str) -> Dict[str, Dict[str, int]]:
+    """Returns {urn: {termsCount, nodesCount}} for the parent and each of its child nodes."""
+    res = execute_graphql(
+        auth_session, NODE_WITH_CHILD_COUNTS_QUERY, {"urn": parent_urn}
+    )
+    node = res["data"]["glossaryNode"]
+    counts = {node["urn"]: node["childrenCount"]}
+    for result in node["glossaryChildrenSearch"]["searchResults"]:
+        entity = result["entity"]
+        counts[entity["urn"]] = entity["childrenCount"]
+    # The three child nodes must all be indexed before the counts mean anything.
+    assert len(counts) == 4, f"expected parent + 3 children, got {sorted(counts)}"
+    return counts
+
+
+def test_children_count_is_correct_for_a_batch_of_sibling_nodes(
+    auth_session, glossary_tree
+):
+    counts = _fetch_counts(auth_session, glossary_tree["parent"])
+
+    assert counts[glossary_tree["parent"]] == {"termsCount": 2, "nodesCount": 3}
+    assert counts[glossary_tree["branch"]] == {"termsCount": 3, "nodesCount": 1}
+    # Leaves must report zero rather than inherit a sibling's counts -- a batched
+    # aggregation returns no buckets for childless parents, and those have to be
+    # distinguished from parents whose buckets were simply not read.
+    assert counts[glossary_tree["leaf_a"]] == {"termsCount": 0, "nodesCount": 0}
+    assert counts[glossary_tree["leaf_b"]] == {"termsCount": 0, "nodesCount": 0}


### PR DESCRIPTION
## Issue

`GlossaryNode.childrenCount` is wired as a per-field `DataFetcher` with no batching, so it issues **one Elasticsearch aggregation query per glossary node** in a response. The glossary sidebar's `getRootGlossaryNodes` query requests the field at five nesting depths, so the cost scales with the size of the glossary tree rather than with the page.

Search caching does not soften it: `searchService.enableCache` defaults to `false`, so every one of those queries reaches Elasticsearch on every request.

## Fix

A new `GlossaryNodeChildrenCountBatchLoader` resolves a whole level of the tree in a single query, using a nested `parentNode␞_entityType` facet filtered on every parent URN in the batch and demultiplexing the buckets back per parent. `GlossaryNodeChildrenCountResolver` becomes a thin loader delegate and no longer needs an `EntityClient`.

### Keeping the counts exact

The `parentNode` terms aggregation returns at most `min(searchFlags.maxAggValues, elasticsearch.search.maxTermBucketSize)` buckets — defaults **20** and **60** — so a wide batch could silently drop parents and report zero children for them. Two guards prevent that:

1. `maxAggValues` is set explicitly and batches are chunked at 50, so a full batch cannot exceed the bucket budget.
2. Every child document lands in exactly one `(parentNode, entity type)` bucket, so the aggregated counts must sum to the total hit count. Falling short means buckets were dropped, and the chunk is redone one parent at a time — a single-parent aggregation cannot be truncated.

This also chains the search failure cause, which was previously swallowed behind an error message copy-pasted from `EntityExistsResolver` (`"Failed to check whether entity %s exists"`), making real search failures hard to debug.

## Measurements

Local instance, glossary tree of **86 nodes** resolving `childrenCount` (5 roots → 61 at L2 → 20 at L3, so the 50-parent chunking path runs for real). 5 warmup + 10 timed runs per build, identical seeded data for both, JVM warmed after each restart.

| Metric (per request) | Before | After | Change |
| --- | --- | --- | --- |
| `childrenCount` ES queries | 86 | **4** | **−95% (21.5×)** |
| ES shard ops | 259.0 | 96.4 | −62.8% |
| MySQL statements | 449.9 | 291.5 | −35.2% |
| Latency p50 | 95.6 ms | 58.9 ms | −38.4% |
| Latency min | 87.4 ms | 53.1 ms | −39.2% |
| Jaeger spans per `POST /api/graphql` | 2212 | 1347 | −39.1% |
| Jaeger `SELECT` spans | 450 | 295 | −34.4% |

The ES counts match the expected decomposition exactly, which confirms the mechanism rather than just the outcome:

- **Before** = 86 `childrenCount` × 2 indices (172) + 86 `glossaryChildrenSearch` × 1 index (86) + 1 root filter = **259** (measured 259.0)
- **After** = 4 `childrenCount` × 2 (8) + 86 + 1 = **95** (an isolated single run measured exactly 95)

Those 4 queries are one for the 5 roots, **two for the 61 L2 parents** (split across the 50-parent chunk boundary), and one for the 20 L3 nodes.

ES counts come from OpenSearch's `_stats/search` `query_total` counters (per-shard, calibrated against a known single query); DB counts from MySQL `general_log`.

### Functional equivalence

Same workload against both builds:

| Check | Result |
| --- | --- |
| Nodes resolved | 86 vs 86 |
| URN sets | identical |
| Per-node count mismatches | **0** |
| Aggregate `termsCount` | 66 vs 66 |
| Aggregate `nodesCount` | 81 vs 81 |

## Tests

**Unit** — `GlossaryNodeChildrenCountBatchLoaderTest` (8): single-query batching for a whole level, filter and facet shape, chunking past the 50-parent bucket budget, the truncation fallback, failure-cause chaining, a realistic aggregation response, a response with no aggregations, and `createDataLoader` wiring. `GlossaryNodeChildrenCountResolverTest` (2): delegation to the loader keyed by the source URN, and rejection of a malformed URN. 1824 tests pass in `datahub-graphql-core`.

Two of the new tests were checked by mutation, each killing only its own test:

| Mutation | Result |
| --- | --- |
| Remove the `tokens.length != 2` guard | `ArrayIndexOutOfBoundsException` |
| Remove `setBatchLoaderContextProvider` | `NullPointerException` on a null context |

**Smoke** — `smoke-test/tests/glossary/glossary_children_count_test.py`, the first non-Cypress glossary smoke test.

## Not included

`glossaryChildrenSearch` on the same type has the same per-node fanout (the remaining 86 shard ops above) but is deliberately left alone. It returns paginated entity lists rather than counts, and `SearchEntity` carries no parent identifier while the entity search layer has no `collapse`/`top_hits` grouped-search API — so batching it needs either a new search-layer capability or a second lookup to attribute hits to parents. It also may not be a win, since one combined query is capped by Elasticsearch's 10,000 `from+size` window whereas N parallel per-parent queries are not. Worth noting that five of the six `getRootGlossaryNodes` call sites do not read that nested payload at all, so splitting the query document is likely the better first step there. Follow-up PR.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (n/a)
- [x] Tests for the changes have been added/updated — 8 batch-loader unit tests, 2 resolver unit tests, and a new glossary smoke test (see [Tests](#tests))
- [ ] Docs related to the changes have been added/updated (n/a — internal performance change, no API or behavior change)
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) (n/a — no behavior change; GraphQL schema untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
