### PR TITLE
fix(openlineage): add multi-segment table path marker

### DIFF
--- a/metadata-integration/java/acryl-spark-lineage/README.md
+++ b/metadata-integration/java/acryl-spark-lineage/README.md
@@ -293,9 +293,11 @@ Hdfs-based platforms supported explicitly:
 By default, the name is the complete path. For Hdfs base datasets, tables can be at different levels in the path than
 that of the actual file read due to various reasons like partitioning, and sharding. 'path_spec' is used to alter the
 name.
-{table} marker is used to specify the table level. Below are a few examples. One can specify multiple path_specs for
-different paths specified in the `path_spec_list`. Each actual path is matched against all path_spes present in the
-list. First, one to match will be used to generate urn.
+The `{table}` marker is used to specify a single table-level path segment. The `{table_path}` marker captures the
+complete table-relative path after the matched prefix and must be the final segment in a path spec. Use
+`{table_path}` when a logical table name contains multiple path segments. One can specify multiple path specs for
+different paths in the `path_spec_list`. Each actual path is matched against all path specs present in the list. The
+first match is used to generate the URN.
 
 **path_spec Examples**
 
@@ -308,6 +310,7 @@ spark.datahub.platform.s3.path_spec_list=s3://my-bucket/foo/{table}/year=*/month
 | s3://my-bucket/foo/tests/bar.avro    | Not provided                     | urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo/tests/bar.avro,PROD)    |
 | s3://my-bucket/foo/tests/bar.avro    | s3://my-bucket/foo/{table}/\*    | urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo/tests,PROD)             |
 | s3://my-bucket/foo/tests/bar.avro    | s3://my-bucket/foo/tests/{table} | urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo/tests/bar.avro,PROD)    |
+| s3://my-bucket/foo/tests/bar.avro    | s3://my-bucket/foo/{table_path}  | urn:li:dataset:(urn:li:dataPlatform:s3,tests/bar.avro,PROD)                  |
 | gs://my-bucket/foo/tests/bar.avro    | gs://my-bucket/{table}/_/_       | urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo,PROD)                  |
 | gs://my-bucket/foo/tests/bar.avro    | gs://my-bucket/{table}           | urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo,PROD)                  |
 | file:///my-bucket/foo/tests/bar.avro | file:///my-bucket/_/_/{table}    | urn:li:dataset:(urn:li:dataPlatform:local,my-bucket/foo/tests/bar.avro,PROD) |

--- a/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/dataset/HdfsPathDataset.java
+++ b/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/dataset/HdfsPathDataset.java
@@ -167,9 +167,15 @@ public class HdfsPathDataset extends SparkDataset {
           if (specFolderList[i].equals(pathFolderList[i]) || specFolderList[i].equals("*")) {
             uri.append(pathFolderList[i]).append("/");
           } else if (specFolderList[i].equals(TABLE)) {
-            uri.append(pathFolderList[i]);
-            log.debug("Actual path [" + pathUri + "] matched with path_spec [" + pathSpec + "]");
-            return uri.toString();
+            String tablePath =
+                String.join("/", Arrays.copyOfRange(pathFolderList, i, pathFolderList.length));
+            String matchedUri = getSplitUri(pathUri)[0] + URI_SPLITTER + tablePath;
+            log.debug(
+                "Actual path [{}] matched with path_spec [{}], table-relative path [{}]",
+                pathUri,
+                pathSpec,
+                tablePath);
+            return matchedUri;
           } else {
             break;
           }

--- a/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/dataset/HdfsPathDataset.java
+++ b/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/dataset/HdfsPathDataset.java
@@ -18,6 +18,9 @@ public class HdfsPathDataset extends SparkDataset {
   private static final String TABLE = "{table}";
   private static final String TABLE_MARKER = "/{table}";
   private static final String TABLE_MARKER_REGEX = "/\\{table\\}";
+  private static final String TABLE_PATH = "{table_path}";
+  private static final String TABLE_PATH_MARKER = "/{table_path}";
+  private static final String TABLE_PATH_MARKER_REGEX = "/\\{table_path\\}";
 
   private static final String URI_SPLITTER = "://";
 
@@ -108,7 +111,8 @@ public class HdfsPathDataset extends SparkDataset {
 
     if (pathSpecs == null || pathSpecs.isEmpty()) {
       log.info(
-          "No path_spec_list configuration found. Falling back to creating dataset name with complete uri");
+          "No path_spec_list configuration found. Falling back to creating dataset name with"
+              + " complete uri");
     } else {
       for (String pathSpec : pathSpecs) {
         String uri = getMatchedUri(pathUri, pathSpec);
@@ -157,16 +161,20 @@ public class HdfsPathDataset extends SparkDataset {
   }
 
   static String getMatchedUri(String pathUri, String pathSpec) {
-    if (pathSpec.contains(TABLE_MARKER)) {
-      String miniSpec = pathSpec.split(TABLE_MARKER_REGEX)[0] + TABLE_MARKER;
+    if (pathSpec.contains(TABLE_PATH_MARKER)) {
+      if (!pathSpec.endsWith(TABLE_PATH_MARKER)) {
+        log.warn("Invalid path spec [{}]. {} must be the final path segment", pathSpec, TABLE_PATH);
+        return null;
+      }
+
+      String miniSpec = pathSpec.split(TABLE_PATH_MARKER_REGEX)[0] + TABLE_PATH_MARKER;
       String[] specFolderList = miniSpec.split("/");
       String[] pathFolderList = pathUri.split("/");
-      StringBuilder uri = new StringBuilder();
       if (pathFolderList.length >= specFolderList.length) {
         for (int i = 0; i < specFolderList.length; i++) {
           if (specFolderList[i].equals(pathFolderList[i]) || specFolderList[i].equals("*")) {
-            uri.append(pathFolderList[i]).append("/");
-          } else if (specFolderList[i].equals(TABLE)) {
+            continue;
+          } else if (specFolderList[i].equals(TABLE_PATH)) {
             String tablePath =
                 String.join("/", Arrays.copyOfRange(pathFolderList, i, pathFolderList.length));
             String matchedUri = getSplitUri(pathUri)[0] + URI_SPLITTER + tablePath;
@@ -181,9 +189,32 @@ public class HdfsPathDataset extends SparkDataset {
           }
         }
       }
+      log.debug("No path spec matched with actual path [{}]", pathUri);
+      return null;
+    }
+
+    if (pathSpec.contains(TABLE_MARKER)) {
+      String miniSpec = pathSpec.split(TABLE_MARKER_REGEX)[0] + TABLE_MARKER;
+      String[] specFolderList = miniSpec.split("/");
+      String[] pathFolderList = pathUri.split("/");
+      StringBuilder uri = new StringBuilder();
+      if (pathFolderList.length >= specFolderList.length) {
+        for (int i = 0; i < specFolderList.length; i++) {
+          if (specFolderList[i].equals(pathFolderList[i]) || specFolderList[i].equals("*")) {
+            uri.append(pathFolderList[i]).append("/");
+          } else if (specFolderList[i].equals(TABLE)) {
+            uri.append(pathFolderList[i]);
+            log.debug("Actual path [{}] matched with path_spec [{}]", pathUri, pathSpec);
+            return uri.toString();
+          } else {
+            break;
+          }
+        }
+      }
       log.debug("No path spec matched with actual path [" + pathUri + "]");
     } else {
-      log.warn("Invalid path spec [" + pathSpec + "]. Path spec should contain {table}");
+      log.warn(
+          "Invalid path spec [{}]. Path spec should contain {} or {}", pathSpec, TABLE, TABLE_PATH);
     }
     return null;
   }

--- a/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/HdfsPathDatasetTest.java
+++ b/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/HdfsPathDatasetTest.java
@@ -72,11 +72,12 @@ public class HdfsPathDatasetTest {
     SparkDataset dataset =
         HdfsPathDataset.create(new URI("s3a://my-bucket/foo/tests/bar.avro"), config);
     Assert.assertEquals(
-        "urn:li:dataset:(urn:li:dataPlatform:s3,tests/bar.avro,PROD)", dataset.urn().toString());
+        "urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo/tests,PROD)",
+        dataset.urn().toString());
   }
 
   @Test
-  public void testPathSpecListCapturesMultiSegmentTablePath()
+  public void testTablePathMarkerCapturesMultiSegmentRelativePath()
       throws InstantiationException, IllegalArgumentException, URISyntaxException {
     DatahubOpenlineageConfig config =
         DatahubOpenlineageConfig.builder()
@@ -89,12 +90,12 @@ public class HdfsPathDatasetTest {
                             PathSpec.builder()
                                 .env(Optional.of("PROD"))
                                 .platform("s3")
-                                .platformInstance(Optional.of("dataplatform-prod"))
+                                .platformInstance(Optional.of("warehouse-prod"))
                                 .pathSpecList(
                                     new LinkedList<>(
                                         Arrays.asList(
-                                            "s3://rnd-dataplatform-production/deltalake/data/{table}",
-                                            "s3a://rnd-dataplatform-production/deltalake/data/{table}")))
+                                            "s3://example-bucket/lake/data/{table_path}",
+                                            "s3a://example-bucket/lake/data/{table_path}")))
                                 .build()));
                   }
                 })
@@ -103,20 +104,16 @@ public class HdfsPathDatasetTest {
 
     SparkDataset entitiesDataset =
         HdfsPathDataset.create(
-            new URI(
-                "s3a://rnd-dataplatform-production/deltalake/data/entities/balance_transactions"),
-            config);
+            new URI("s3a://example-bucket/lake/data/finance/transactions"), config);
     Assert.assertEquals(
-        "urn:li:dataset:(urn:li:dataPlatform:s3,dataplatform-prod.entities/balance_transactions,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:s3,warehouse-prod.finance/transactions,PROD)",
         entitiesDataset.urn().toString());
 
     SparkDataset reportsDataset =
         HdfsPathDataset.create(
-            new URI(
-                "s3://rnd-dataplatform-production/deltalake/data/reports/lost/balance_transactions"),
-            config);
+            new URI("s3://example-bucket/lake/data/analytics/daily/transactions"), config);
     Assert.assertEquals(
-        "urn:li:dataset:(urn:li:dataPlatform:s3,dataplatform-prod.reports/lost/balance_transactions,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:s3,warehouse-prod.analytics/daily/transactions,PROD)",
         reportsDataset.urn().toString());
   }
 
@@ -195,7 +192,8 @@ public class HdfsPathDatasetTest {
     SparkDataset dataset =
         HdfsPathDataset.create(new URI("s3a://my-bucket/foo/tests/bar.avro"), datahubConfig);
     Assert.assertEquals(
-        "urn:li:dataset:(urn:li:dataPlatform:s3,tests/bar.avro,PROD)", dataset.urn().toString());
+        "urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo/tests,PROD)",
+        dataset.urn().toString());
   }
 
   @Test
@@ -228,7 +226,7 @@ public class HdfsPathDatasetTest {
     SparkDataset dataset =
         HdfsPathDataset.create(new URI("s3a://my-bucket/foo/tests/bar.avro"), datahubConfig);
     Assert.assertEquals(
-        "urn:li:dataset:(urn:li:dataPlatform:s3,s3Instance.tests/bar.avro,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:s3,s3Instance.my-bucket/foo/tests,PROD)",
         dataset.urn().toString());
   }
 
@@ -258,8 +256,7 @@ public class HdfsPathDatasetTest {
     SparkDataset dataset =
         HdfsPathDataset.create(new URI("s3a://my-bucket/foo/tests/bar.avro"), datahubConfig);
     Assert.assertEquals(
-        "urn:li:dataset:(urn:li:dataPlatform:s3,foo/tests/bar.avro,PROD)",
-        dataset.urn().toString());
+        "urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo,PROD)", dataset.urn().toString());
   }
 
   // ====================================================================
@@ -323,6 +320,7 @@ public class HdfsPathDatasetTest {
     SparkDataset dataset =
         HdfsPathDataset.create(new URI("gs://my-bucket/foo/tests/bar.avro"), datahubConfig);
     Assert.assertEquals(
-        "urn:li:dataset:(urn:li:dataPlatform:gcs,tests/bar.avro,PROD)", dataset.urn().toString());
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests,PROD)",
+        dataset.urn().toString());
   }
 }

--- a/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/HdfsPathDatasetTest.java
+++ b/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/HdfsPathDatasetTest.java
@@ -72,8 +72,52 @@ public class HdfsPathDatasetTest {
     SparkDataset dataset =
         HdfsPathDataset.create(new URI("s3a://my-bucket/foo/tests/bar.avro"), config);
     Assert.assertEquals(
-        "urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo/tests,PROD)",
-        dataset.urn().toString());
+        "urn:li:dataset:(urn:li:dataPlatform:s3,tests/bar.avro,PROD)", dataset.urn().toString());
+  }
+
+  @Test
+  public void testPathSpecListCapturesMultiSegmentTablePath()
+      throws InstantiationException, IllegalArgumentException, URISyntaxException {
+    DatahubOpenlineageConfig config =
+        DatahubOpenlineageConfig.builder()
+            .pathSpecs(
+                new HashMap<String, List<PathSpec>>() {
+                  {
+                    put(
+                        "s3",
+                        Collections.singletonList(
+                            PathSpec.builder()
+                                .env(Optional.of("PROD"))
+                                .platform("s3")
+                                .platformInstance(Optional.of("dataplatform-prod"))
+                                .pathSpecList(
+                                    new LinkedList<>(
+                                        Arrays.asList(
+                                            "s3://rnd-dataplatform-production/deltalake/data/{table}",
+                                            "s3a://rnd-dataplatform-production/deltalake/data/{table}")))
+                                .build()));
+                  }
+                })
+            .fabricType(FabricType.PROD)
+            .build();
+
+    SparkDataset entitiesDataset =
+        HdfsPathDataset.create(
+            new URI(
+                "s3a://rnd-dataplatform-production/deltalake/data/entities/balance_transactions"),
+            config);
+    Assert.assertEquals(
+        "urn:li:dataset:(urn:li:dataPlatform:s3,dataplatform-prod.entities/balance_transactions,PROD)",
+        entitiesDataset.urn().toString());
+
+    SparkDataset reportsDataset =
+        HdfsPathDataset.create(
+            new URI(
+                "s3://rnd-dataplatform-production/deltalake/data/reports/lost/balance_transactions"),
+            config);
+    Assert.assertEquals(
+        "urn:li:dataset:(urn:li:dataPlatform:s3,dataplatform-prod.reports/lost/balance_transactions,PROD)",
+        reportsDataset.urn().toString());
   }
 
   @Test
@@ -151,8 +195,7 @@ public class HdfsPathDatasetTest {
     SparkDataset dataset =
         HdfsPathDataset.create(new URI("s3a://my-bucket/foo/tests/bar.avro"), datahubConfig);
     Assert.assertEquals(
-        "urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo/tests,PROD)",
-        dataset.urn().toString());
+        "urn:li:dataset:(urn:li:dataPlatform:s3,tests/bar.avro,PROD)", dataset.urn().toString());
   }
 
   @Test
@@ -185,7 +228,7 @@ public class HdfsPathDatasetTest {
     SparkDataset dataset =
         HdfsPathDataset.create(new URI("s3a://my-bucket/foo/tests/bar.avro"), datahubConfig);
     Assert.assertEquals(
-        "urn:li:dataset:(urn:li:dataPlatform:s3,s3Instance.my-bucket/foo/tests,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:s3,s3Instance.tests/bar.avro,PROD)",
         dataset.urn().toString());
   }
 
@@ -215,7 +258,8 @@ public class HdfsPathDatasetTest {
     SparkDataset dataset =
         HdfsPathDataset.create(new URI("s3a://my-bucket/foo/tests/bar.avro"), datahubConfig);
     Assert.assertEquals(
-        "urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo,PROD)", dataset.urn().toString());
+        "urn:li:dataset:(urn:li:dataPlatform:s3,foo/tests/bar.avro,PROD)",
+        dataset.urn().toString());
   }
 
   // ====================================================================
@@ -279,7 +323,6 @@ public class HdfsPathDatasetTest {
     SparkDataset dataset =
         HdfsPathDataset.create(new URI("gs://my-bucket/foo/tests/bar.avro"), datahubConfig);
     Assert.assertEquals(
-        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests,PROD)",
-        dataset.urn().toString());
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,tests/bar.avro,PROD)", dataset.urn().toString());
   }
 }


### PR DESCRIPTION
## Summary
- add an explicit `{table_path}` path-spec marker that captures the complete table-relative path
- keep the existing `{table}` single-segment behavior unchanged to avoid dataset URN migrations and partition leakage
- document the new marker and add coverage for nested paths across `s3://` and `s3a://`

`{table_path}` must be the final path-spec segment. Existing partition-aware specs such as `{table}/year=*/month=*/day=*/*` continue to behave as before.

## Testing
- formatted changed Java files with google-java-format 1.18.1
- targeted Gradle tests will run in CI; local dependency resolution was blocked by repeated TLS resets from the Gradle Plugin Portal