### PR TITLE
feat(documents): add standalone semanticText embedding-source aspect

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/knowledge/DocumentMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/knowledge/DocumentMapper.java
@@ -9,6 +9,7 @@ import com.linkedin.common.GlobalTags;
 import com.linkedin.common.GlossaryTerms;
 import com.linkedin.common.InstitutionalMemory;
 import com.linkedin.common.Ownership;
+import com.linkedin.common.SemanticText;
 import com.linkedin.common.Status;
 import com.linkedin.common.SubTypes;
 import com.linkedin.common.urn.Urn;
@@ -79,6 +80,16 @@ public class DocumentMapper {
 
     if (docInfo != null) {
       result.setInfo(mapDocumentInfo(docInfo, entityUrn));
+    }
+
+    // Map the standalone semanticText aspect (curated embedding-source text) into contents,
+    // keeping the GraphQL surface (contents.semanticText) stable across the aspect move.
+    final EnvelopedAspect envelopedSemanticText = aspects.get(Constants.SEMANTIC_TEXT_ASPECT_NAME);
+    if (envelopedSemanticText != null
+        && result.getInfo() != null
+        && result.getInfo().getContents() != null) {
+      final SemanticText semanticText = new SemanticText(envelopedSemanticText.getValue().data());
+      result.getInfo().getContents().setSemanticText(semanticText.getText());
     }
 
     // Map Document Settings aspect

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/knowledge/DocumentType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/knowledge/DocumentType.java
@@ -50,7 +50,8 @@ public class DocumentType
           Constants.GLOBAL_TAGS_ASPECT_NAME,
           Constants.GLOSSARY_TERMS_ASPECT_NAME,
           Constants.INSTITUTIONAL_MEMORY_ASPECT_NAME,
-          Constants.DOCUMENTATION_ASPECT_NAME);
+          Constants.DOCUMENTATION_ASPECT_NAME,
+          Constants.SEMANTIC_TEXT_ASPECT_NAME);
 
   private final EntityClient _entityClient;
 

--- a/datahub-graphql-core/src/main/resources/documents.graphql
+++ b/datahub-graphql-core/src/main/resources/documents.graphql
@@ -291,6 +291,15 @@ type DocumentContent {
   The text contents of the Document
   """
   text: String!
+
+  """
+  Optional content that supersedes text as the source for semantic-search
+  embeddings. When present, the embedding pipeline embeds this instead of text;
+  when absent, embeddings fall back to text. Keyword-indexed alongside text.
+  Backed by the standalone semanticText aspect rather than documentInfo, so
+  other entity types can adopt it.
+  """
+  semanticText: String
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/knowledge/DocumentMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/knowledge/DocumentMapperTest.java
@@ -17,6 +17,7 @@ import com.linkedin.common.InstitutionalMemoryMetadata;
 import com.linkedin.common.InstitutionalMemoryMetadataArray;
 import com.linkedin.common.MetadataAttribution;
 import com.linkedin.common.Ownership;
+import com.linkedin.common.SemanticText;
 import com.linkedin.common.TagAssociation;
 import com.linkedin.common.TagAssociationArray;
 import com.linkedin.common.url.Url;
@@ -58,6 +59,7 @@ public class DocumentMapperTest {
   private static final String TEST_DOCUMENT_TITLE = "Test Tutorial";
   private static final String TEST_DOCUMENT_DESCRIPTION = "Test document description";
   private static final String TEST_CONTENT = "Test content";
+  private static final String TEST_SEMANTIC_TEXT = "Test semantic text";
   private static final String TEST_ACTOR_URN = "urn:li:corpuser:testuser";
   private static final String TEST_PARENT_URN = "urn:li:document:parent-document";
   private static final String TEST_ASSET_URN = "urn:li:dataset:test-dataset";
@@ -123,6 +125,11 @@ public class DocumentMapperTest {
 
     addAspectToResponse(entityResponse, DOCUMENT_INFO_ASPECT_NAME, documentInfo);
 
+    // Curated embedding-source text lives in the standalone semanticText aspect.
+    SemanticText semanticText = new SemanticText();
+    semanticText.setText(TEST_SEMANTIC_TEXT);
+    addAspectToResponse(entityResponse, SEMANTIC_TEXT_ASPECT_NAME, semanticText);
+
     // Embed relationships inside DocumentInfo
     ParentDocument parentDocument = new ParentDocument();
     parentDocument.setDocument(parentUrn);
@@ -178,6 +185,7 @@ public class DocumentMapperTest {
       assertNotNull(result.getInfo());
       assertEquals(result.getInfo().getTitle(), TEST_DOCUMENT_TITLE);
       assertEquals(result.getInfo().getContents().getText(), TEST_CONTENT);
+      assertEquals(result.getInfo().getContents().getSemanticText(), TEST_SEMANTIC_TEXT);
       assertNotNull(result.getInfo().getCreated());
       assertEquals(result.getInfo().getCreated().getTime(), TEST_TIMESTAMP);
       // Verify actor is set as CorpUser in ResolvedAuditStamp

--- a/li-utils/src/main/java/com/linkedin/metadata/Constants.java
+++ b/li-utils/src/main/java/com/linkedin/metadata/Constants.java
@@ -531,6 +531,8 @@ public class Constants {
   public static final String DOCUMENT_KEY_ASPECT_NAME = "documentKey";
   public static final String DOCUMENT_INFO_ASPECT_NAME = "documentInfo";
   public static final String DOCUMENT_SETTINGS_ASPECT_NAME = "documentSettings";
+  // Curated embedding-source text. A common aspect so any entity type can register it.
+  public static final String SEMANTIC_TEXT_ASPECT_NAME = "semanticText";
 
   public static final List<String> SKIP_REFERENCE_ASPECT =
       Arrays.asList("ownership", "status", "institutionalMemory");

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -56,6 +56,12 @@ from datahub.ingestion.source.unstructured.event_consumer import DocumentEventCo
 
 logger = logging.getLogger(__name__)
 
+# Aspects whose changes can change what a document's embedding should be built
+# from: documentInfo carries the body, the standalone semanticText aspect
+# carries the curated override. Passed to DocumentEventConsumer AND checked in
+# _process_single_event — keep the two filters in lockstep via this constant.
+EMBED_SOURCE_ASPECT_NAMES = ("documentInfo", "semanticText")
+
 
 class DataHubDocumentsReport(StatefulIngestionReport):
     """Report for DataHub documents source."""
@@ -421,8 +427,7 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             logger.debug("Event missing entityUrn or aspectName, skipping")
             return
 
-        # Filter for documentInfo aspect
-        if aspect_name != "documentInfo":
+        if aspect_name not in EMBED_SOURCE_ASPECT_NAMES:
             return
 
         # Parse aspect data (handles Avro union wrapping)
@@ -435,9 +440,28 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             )
             return
 
-        # Extract text from documentInfo (contents may be null for partial entities)
-        contents = aspect_dict.get("contents") or {}
-        text = contents.get("text") or ""
+        if aspect_name == "semanticText":
+            # The event carries the override; the document body and source type
+            # live on documentInfo, so fetch it.
+            info_dict = self._fetch_document_info_dict(entity_urn)
+            if info_dict is None:
+                logger.debug(
+                    f"semanticText event for {entity_urn} without readable documentInfo, skipping"
+                )
+                return
+            contents = dict(info_dict.get("contents") or {})
+            contents["semanticText"] = aspect_dict.get("text")
+            # Downstream source-type filtering reads from the documentInfo shape.
+            aspect_dict = info_dict
+        else:
+            # documentInfo event: the override (if any) lives in the standalone
+            # semanticText aspect, so fetch it. Contents may be null for
+            # partial entities.
+            contents = dict(aspect_dict.get("contents") or {})
+            contents["semanticText"] = self._fetch_semantic_text(entity_urn)
+
+        # semanticText overrides text as the embedding source; see _resolve_embed_text.
+        text = self._resolve_embed_text(contents)
 
         if not text:
             logger.debug(f"No text content in document {entity_urn}")
@@ -536,6 +560,7 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             poll_timeout_seconds=self.config.event_mode.poll_timeout_seconds,
             poll_limit=self.config.event_mode.poll_limit,
             state_handler=self.state_handler,
+            aspect_names=EMBED_SOURCE_ASPECT_NAMES,
         )
 
         try:
@@ -593,6 +618,44 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             return json.loads(aspect_data)
         else:
             return {}
+
+    def _fetch_semantic_text(self, document_urn: str) -> Optional[str]:
+        """Read the standalone semanticText aspect (curated embedding-source
+        override), or None when absent.
+
+        On read failure we fall back to embedding the document body: a transient
+        wrong embed self-corrects on a later run because incremental state hashes
+        the embedded value.
+        """
+        from datahub.metadata.schema_classes import SemanticTextClass
+
+        try:
+            aspect = self.graph.get_aspect(
+                entity_urn=document_urn, aspect_type=SemanticTextClass
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to read semanticText for {document_urn}: {e}; "
+                "embedding document text."
+            )
+            return None
+        return aspect.text if aspect else None
+
+    def _fetch_document_info_dict(self, document_urn: str) -> Optional[dict[str, Any]]:
+        """Read the documentInfo aspect as a dict (the MCL payload shape), or
+        None when absent or unreadable."""
+        from datahub.metadata.schema_classes import DocumentInfoClass
+
+        try:
+            aspect = self.graph.get_aspect(
+                entity_urn=document_urn, aspect_type=DocumentInfoClass
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to read documentInfo for {document_urn}: {e}; skipping event."
+            )
+            return None
+        return aspect.to_obj() if aspect else None
 
     def _extract_platform_from_aspect(
         self, aspect_dict: dict[str, Any]
@@ -864,6 +927,7 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                   info {
                     contents {
                       text
+                      semanticText
                     }
                     customProperties {
                       key
@@ -950,10 +1014,11 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                     ):
                         continue
 
-                    # Extract text content (GraphQL returns null for missing aspects)
+                    # Extract text content (GraphQL returns null for missing aspects).
+                    # semanticText overrides text as the embedding source; see _resolve_embed_text.
                     info = entity.get("info") or {}
                     contents = info.get("contents") or {}
-                    text = contents.get("text") or ""
+                    text = self._resolve_embed_text(contents)
 
                     # Default to NATIVE when sourceType is absent (older documents).
                     source = info.get("source") or {}
@@ -1048,6 +1113,21 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             # Partitioning affects how text is extracted
             "partition_strategy": self.config.partition_strategy,
         }
+
+    @staticmethod
+    def _resolve_embed_text(contents: Dict[str, Any]) -> str:
+        """Resolve the text to embed from a contents dict.
+
+        `semanticText` overrides `text` as the embedding source when present, so
+        a curated representation can drive retrieval while the full body stays in
+        `text`. The override lives in the standalone `semanticText` aspect: batch
+        mode still receives it under `contents` because the GraphQL surface maps
+        the aspect there, and event mode injects it into the dict before calling
+        this. Resolving here (rather than in the hash) means the content hash
+        tracks the embedded value: editing `semanticText` re-embeds, and a change
+        to `text` while `semanticText` is set does not.
+        """
+        return contents.get("semanticText") or contents.get("text") or ""
 
     def _calculate_text_hash(self, text: str) -> str:
         """Calculate hash of document content AND processing configuration.

--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/event_consumer.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/event_consumer.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import time
-from typing import TYPE_CHECKING, Any, Iterator, Optional
+from typing import TYPE_CHECKING, Any, Iterator, Optional, Sequence
 
 from datahub.ingestion.graph.client import DataHubGraph
 
@@ -20,7 +20,8 @@ class DocumentEventConsumer:
 
     This consumer:
     1. Polls events from DataHub's /openapi/v1/events/poll endpoint
-    2. Filters for Document entity MCL events
+    2. Filters for Document entity MCL events on the configured aspects
+       (``documentInfo`` by default)
     3. Tracks offsets via stateful ingestion (if state_handler provided) or Platform Resources (fallback)
     4. Exits after idle timeout (incremental batch mode)
     """
@@ -36,6 +37,7 @@ class DocumentEventConsumer:
         poll_timeout_seconds: int = 2,
         poll_limit: int = 100,
         state_handler: Optional["DocumentChunkingStateHandler"] = None,
+        aspect_names: Sequence[str] = ("documentInfo",),
     ):
         self.graph = graph
         self.consumer_id = consumer_id
@@ -46,6 +48,7 @@ class DocumentEventConsumer:
         self.poll_timeout_seconds = poll_timeout_seconds
         self.poll_limit = poll_limit
         self.state_handler = state_handler
+        self.aspect_names = tuple(aspect_names)
 
         # Base URL for events API
         self.base_url = f"{graph.config.server}/openapi"
@@ -297,6 +300,7 @@ class DocumentEventConsumer:
                         continue
 
                     # Check if it's a documentInfo aspect change
+                    # Keep only the aspects this consumer was configured for.
                     # aspectName comes wrapped in a dict: {"string": "documentInfo"}
                     aspect_name_raw = mcl_dict.get("aspectName")
                     if not aspect_name_raw:
@@ -306,7 +310,7 @@ class DocumentEventConsumer:
                         if isinstance(aspect_name_raw, dict)
                         else aspect_name_raw
                     )
-                    if aspect_name != "documentInfo":
+                    if aspect_name not in self.aspect_names:
                         continue
 
                     # Reset idle timer only when yielding a document event

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -22,6 +22,7 @@ from datahub.ingestion.source.datahub_documents.datahub_documents_config import 
     DataHubDocumentsSourceConfig,
 )
 from datahub.ingestion.source.datahub_documents.datahub_documents_source import (
+    EMBED_SOURCE_ASPECT_NAMES,
     DataHubDocumentsSource,
 )
 from datahub.ingestion.source.datahub_documents.document_chunking_state import (
@@ -201,6 +202,35 @@ class TestDataHubDocumentsSource:
             assert len(hash1) == 64  # SHA256 produces 64 hex characters
             assert all(c in "0123456789abcdef" for c in hash1)
 
+    def test_resolve_embed_text_prefers_semantic_text(self):
+        """semanticText overrides text as the embedding source when present."""
+        resolve = DataHubDocumentsSource._resolve_embed_text
+
+        assert resolve({"text": "body", "semanticText": "summary"}) == "summary"
+        assert resolve({"text": "body"}) == "body"
+        assert resolve({}) == ""
+        # Empty-string semanticText is treated as absent (falls back to text).
+        assert resolve({"text": "body", "semanticText": ""}) == "body"
+
+    def test_semantic_text_governs_reembed_hash(self, ctx, config):
+        """The content hash tracks the embedded value: a change to `text` while
+        `semanticText` is set must not change the hash (no needless re-embed)."""
+        with patch(
+            "datahub.ingestion.source.datahub_documents.datahub_documents_source.DataHubGraph"
+        ):
+            source = DataHubDocumentsSource(ctx, config)
+
+            before = source._resolve_embed_text(
+                {"text": "body-v1", "semanticText": "summary"}
+            )
+            after_body_edit = source._resolve_embed_text(
+                {"text": "body-v2", "semanticText": "summary"}
+            )
+            assert before == after_body_edit
+            assert source._calculate_text_hash(before) == source._calculate_text_hash(
+                after_body_edit
+            )
+
     def test_should_process_incremental_mode(self, ctx, config):
         """Test should_process logic in incremental mode."""
         with patch(
@@ -349,6 +379,108 @@ class TestDataHubDocumentsSource:
             # Verify hash matches expected value
             expected_hash = source._calculate_text_hash(text)
             assert source.document_state[document_urn]["content_hash"] == expected_hash
+
+
+class _InMemoryStateHandler:
+    """Minimal stand-in for DocumentChunkingStateHandler backing `_should_process`
+    with an in-memory hash store, so the re-embed invariant can be exercised
+    against the stateful-ingestion backend as well as the local one."""
+
+    def __init__(self) -> None:
+        self._hashes: dict[str, str] = {}
+
+    def is_checkpointing_enabled(self) -> bool:
+        return True
+
+    def get_document_hash(self, document_urn: str) -> Optional[str]:
+        return self._hashes.get(document_urn)
+
+    def update_document_state(
+        self, document_urn: str, content_hash: str, last_processed: str
+    ) -> None:
+        self._hashes[document_urn] = content_hash
+
+
+class TestSemanticTextReembedInvariant:
+    """The embedding must track the resolved embed source (`semanticText or text`)
+    through the real decision path (`_resolve_embed_text` -> `_should_process` ->
+    `_update_document_state`), on both the local `document_state` backend and the
+    stateful-ingestion state handler.
+
+    Downstream work (the #10832 write path and the serving path) assumes editing
+    `semanticText` re-embeds and editing `text` under a stable override does not,
+    so both directions are pinned here."""
+
+    URN = "urn:li:document:1"
+
+    @pytest.fixture
+    def ctx(self):
+        return PipelineContext(run_id="test-run", pipeline_name="test-pipeline")
+
+    @pytest.fixture(params=["local", "state_handler"])
+    def source(self, request, ctx):
+        config = DataHubDocumentsSourceConfig(
+            platform_filter=["notion"],
+            datahub={"server": "http://test-server:8080"},
+            embedding={
+                "provider": "bedrock",
+                "model": "cohere.embed-english-v3",
+                "aws_region": "us-west-2",
+                "allow_local_embedding_config": True,
+            },
+            stateful_ingestion={"enabled": False},
+        )
+        with patch(
+            "datahub.ingestion.source.datahub_documents.datahub_documents_source.DataHubGraph"
+        ):
+            source = DataHubDocumentsSource(ctx, config)
+            source.config.incremental.enabled = True
+            if request.param == "state_handler":
+                source.state_handler = _InMemoryStateHandler()  # type: ignore[assignment]
+            return source
+
+    def _run_pass(self, source: DataHubDocumentsSource, contents: dict) -> bool:
+        """Mirror one ingestion pass: resolve the embed source from contents (as the
+        fetch call sites do), decide via `_should_process`, then commit state if
+        processed. Returns whether the document was (re-)embedded this pass."""
+        resolved = source._resolve_embed_text(contents)
+        processed = source._should_process(self.URN, resolved)
+        if processed:
+            source._update_document_state(self.URN, resolved)
+        return processed
+
+    def test_semantic_text_change_reembeds_but_text_edit_does_not(self, source):
+        contents = {"text": "body-v1", "semanticText": "summary-v1"}
+        assert self._run_pass(source, contents) is True
+        # Idempotent: an unchanged re-run does not re-embed.
+        assert self._run_pass(source, contents) is False
+        # Editing only `text` under a stable override is a no-op.
+        assert (
+            self._run_pass(source, {"text": "body-v2", "semanticText": "summary-v1"})
+            is False
+        )
+        # Editing `semanticText` re-embeds.
+        assert (
+            self._run_pass(source, {"text": "body-v2", "semanticText": "summary-v2"})
+            is True
+        )
+
+    def test_setting_override_reembeds_doc_previously_embedded_from_text(self, source):
+        """Rollout case: a document embedded from `text` re-embeds once an override
+        is set on it."""
+        assert self._run_pass(source, {"text": "body"}) is True
+        assert self._run_pass(source, {"text": "body"}) is False
+        assert (
+            self._run_pass(source, {"text": "body", "semanticText": "summary"}) is True
+        )
+
+    def test_clearing_override_reembeds_from_text(self, source):
+        assert (
+            self._run_pass(source, {"text": "body", "semanticText": "summary"}) is True
+        )
+        # Clearing the override falls back to `text`, which differs -> re-embed.
+        assert self._run_pass(source, {"text": "body"}) is True
+        assert self._run_pass(source, {"text": "body"}) is False
 
 
 class TestEventModeFallback:
@@ -508,6 +640,8 @@ class TestEventModeFallback:
         """Test that fallback does NOT occur when offsets exist and events are processed."""
         with mock_graph as mock_graph_cls:
             source = DataHubDocumentsSource(ctx, config)
+            # The document carries no standalone semanticText aspect.
+            mock_graph_cls.return_value.get_aspect.return_value = None
             # Mock state handler with valid offset
             mock_state_handler = patch.object(source, "state_handler").start()
             mock_state_handler.is_checkpointing_enabled.return_value = True
@@ -787,6 +921,8 @@ class TestStateStorage:
 
         with mock_graph as mock_graph_cls:
             source = DataHubDocumentsSource(ctx, config)
+            # The document carries no standalone semanticText aspect.
+            mock_graph_cls.return_value.get_aspect.return_value = None
             source.config.event_mode.enabled = True
 
             # Mock state handler
@@ -2049,13 +2185,96 @@ class TestPartialEntityHandling:
 
     def test_process_single_event_with_null_contents(self, ctx, config, mock_graph):
         """Test _process_single_event when MCL aspect has contents: null."""
-        with mock_graph:
+        with mock_graph as mock_graph_cls:
             source = DataHubDocumentsSource(ctx, config)
+            mock_graph_cls.return_value.get_aspect.return_value = None
 
             event: dict[str, Any] = {
                 "entityUrn": "urn:li:document:partial1",
                 "aspectName": "documentInfo",
                 "aspect": json.dumps({"contents": None}),
+            }
+
+            workunits = list(source._process_single_event(event))
+            assert len(workunits) == 0
+
+    def test_process_single_event_embeds_semantic_text_override(
+        self, ctx, config, mock_graph
+    ):
+        """A documentInfo event embeds the standalone semanticText aspect's text
+        (not the document body) when the override is present."""
+        from datahub.metadata.schema_classes import SemanticTextClass
+
+        with mock_graph as mock_graph_cls:
+            source = DataHubDocumentsSource(ctx, config)
+            mock_graph_cls.return_value.get_aspect.return_value = SemanticTextClass(
+                text="curated summary"
+            )
+
+            event: dict[str, Any] = {
+                "entityUrn": "urn:li:document:doc1",
+                "aspectName": "documentInfo",
+                "aspect": json.dumps({"contents": {"text": "full body"}}),
+            }
+
+            with patch.object(
+                source, "_process_document_with_throttle", return_value=iter([])
+            ) as mock_process:
+                list(source._process_single_event(event))
+
+            mock_process.assert_called_once()
+            doc = mock_process.call_args[0][0]
+            assert doc["text"] == "curated summary"
+
+    def test_process_single_event_semantic_text_aspect_event(
+        self, ctx, config, mock_graph
+    ):
+        """A semanticText aspect event re-embeds using the event's text, pulling
+        body and source type from the fetched documentInfo."""
+        from datahub.metadata.schema_classes import DocumentInfoClass
+
+        with mock_graph as mock_graph_cls:
+            source = DataHubDocumentsSource(ctx, config)
+
+            mock_info = Mock()
+            mock_info.to_obj.return_value = {
+                "contents": {"text": "full body"},
+                "source": {"sourceType": "NATIVE"},
+            }
+
+            def get_aspect(entity_urn: str, aspect_type: type) -> Optional[Mock]:
+                return mock_info if aspect_type is DocumentInfoClass else None
+
+            mock_graph_cls.return_value.get_aspect.side_effect = get_aspect
+
+            event: dict[str, Any] = {
+                "entityUrn": "urn:li:document:doc1",
+                "aspectName": "semanticText",
+                "aspect": json.dumps({"text": "curated summary v2"}),
+            }
+
+            with patch.object(
+                source, "_process_document_with_throttle", return_value=iter([])
+            ) as mock_process:
+                list(source._process_single_event(event))
+
+            mock_process.assert_called_once()
+            doc = mock_process.call_args[0][0]
+            assert doc["text"] == "curated summary v2"
+            assert doc["source_type"] == "NATIVE"
+
+    def test_process_single_event_semantic_text_without_document_info(
+        self, ctx, config, mock_graph
+    ):
+        """A semanticText event for a document without readable documentInfo is skipped."""
+        with mock_graph as mock_graph_cls:
+            source = DataHubDocumentsSource(ctx, config)
+            mock_graph_cls.return_value.get_aspect.return_value = None
+
+            event: dict[str, Any] = {
+                "entityUrn": "urn:li:document:orphan",
+                "aspectName": "semanticText",
+                "aspect": json.dumps({"text": "curated"}),
             }
 
             workunits = list(source._process_single_event(event))
@@ -3622,3 +3841,65 @@ class TestPollEventsSessionAuth:
         # poll unauthenticated.
         assert request.headers["Authorization"] == "Bearer fresh-oauth-token"
         assert events == []
+
+
+class TestDocumentEventConsumerAspectFilter:
+    """consume_events() must yield exactly the configured aspects — the
+    downstream _process_single_event filter is unreachable for anything the
+    consumer drops here."""
+
+    @staticmethod
+    def _make_consumer(**kwargs: Any) -> DocumentEventConsumer:
+        with patch.object(DocumentEventConsumer, "_load_offset", return_value=None):
+            return DocumentEventConsumer(
+                graph=Mock(),
+                consumer_id="test-consumer",
+                topics=["MetadataChangeLog_Versioned_v1"],
+                idle_timeout_seconds=0,
+                **kwargs,
+            )
+
+    @staticmethod
+    def _event(entity_type: str, aspect_name: Any, urn: str) -> dict[str, Any]:
+        return {
+            "contentType": "application/json",
+            "value": json.dumps(
+                {
+                    "entityType": entity_type,
+                    "entityUrn": urn,
+                    "aspectName": aspect_name,
+                    "aspect": {"value": "{}"},
+                }
+            ),
+        }
+
+    def test_yields_semantic_text_when_configured(self):
+        consumer = self._make_consumer(aspect_names=EMBED_SOURCE_ASPECT_NAMES)
+        events = [
+            # aspectName arrives both bare and Avro-union-wrapped.
+            self._event("document", {"string": "semanticText"}, "urn:li:document:d1"),
+            self._event("document", "documentInfo", "urn:li:document:d2"),
+            self._event("document", "status", "urn:li:document:d3"),
+            self._event("dataset", "documentInfo", "urn:li:dataset:d4"),
+        ]
+        with patch.object(consumer, "poll_events", side_effect=[events, []]):
+            yielded = list(consumer.consume_events())
+
+        assert [e.get("entityUrn") for e in yielded] == [
+            "urn:li:document:d1",
+            "urn:li:document:d2",
+        ]
+
+    def test_default_filter_stays_document_info_only(self):
+        # chunking_source constructs the consumer without aspect_names and
+        # parses every yielded aspect as documentInfo — the default must not
+        # widen underneath it.
+        consumer = self._make_consumer()
+        events = [
+            self._event("document", {"string": "semanticText"}, "urn:li:document:d1"),
+            self._event("document", "documentInfo", "urn:li:document:d2"),
+        ]
+        with patch.object(consumer, "poll_events", side_effect=[events, []]):
+            yielded = list(consumer.consume_events())
+
+        assert [e.get("entityUrn") for e in yielded] == ["urn:li:document:d2"]

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/SearchRequestHandlerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/SearchRequestHandlerTest.java
@@ -829,7 +829,12 @@ public class SearchRequestHandlerTest extends AbstractTestNGSpringContextTests {
                 EntityType.DOCUMENT,
                 Stream.concat(
                         COMMON.stream(),
-                        Stream.of("parentDocument", "relatedAssets", "relatedDocuments", "text"))
+                        Stream.of(
+                            "parentDocument",
+                            "relatedAssets",
+                            "relatedDocuments",
+                            "text",
+                            "semanticText"))
                     .collect(Collectors.toSet()))
             .build();
 

--- a/metadata-models/src/main/pegasus/com/linkedin/common/SemanticText.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/SemanticText.pdl
@@ -1,0 +1,34 @@
+namespace com.linkedin.common
+
+/**
+ * Curated text that supersedes an entity's primary textual content as the
+ * source for semantic-search embeddings.
+ *
+ * When present, the embedding pipeline embeds this text instead of the
+ * entity's own content (e.g. a document's `contents.text`); when absent,
+ * embeddings fall back to that content. This lets the full body stay on the
+ * entity while a concise, curated representation (e.g. a short summary plus
+ * sample questions) drives retrieval.
+ *
+ * This aspect is a curated embedding *source*. It is distinct from
+ * `semanticContent`, which stores the embedding *vectors* produced by the
+ * embedding pipeline.
+ */
+@Aspect = {
+  "name": "semanticText"
+}
+record SemanticText {
+
+  /**
+   * The curated embedding-source text. Keyword-indexed (under the
+   * `semanticText` field, matching the field this aspect replaced on
+   * `DocumentContents`) so it is searchable alongside the entity's primary
+   * content.
+   */
+  @Searchable = {
+    "fieldName": "semanticText",
+    "fieldType": "TEXT",
+    "searchTier": 2
+  }
+  text: string
+}

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -358,6 +358,7 @@ entities:
       - globalTags
       - glossaryTerms
       - semanticContent
+      - semanticText
       - institutionalMemory
       - documentation
       - documentUsageStatistics


### PR DESCRIPTION
## Summary

Adds a common `semanticText` aspect (`com.linkedin.common.SemanticText`): curated text that supersedes an entity's primary textual content as the source for semantic-search embeddings. When present, the embedding pipeline embeds it instead of the entity's own content (e.g. a document's `contents.text`); when absent, embeddings fall back to that content. This lets the full body stay on the entity while a concise, curated representation drives retrieval.

It is a curated embedding *source*, distinct from `semanticContent` (the embedding *vectors*).

## Changes

- **Model**: new `SemanticText.pdl` common aspect, keyword-indexed under the `semanticText` search field; registered on the `document` entity in `entity-registry.yml`; `SEMANTIC_TEXT_ASPECT_NAME` constant.
- **GraphQL**: `DocumentContent.semanticText` field, resolved from the standalone aspect by `DocumentMapper` (so the GraphQL surface is stable and other entity types can adopt the aspect later); aspect added to `DocumentType`'s fetch set.
- **Ingestion**: the `datahub-documents` source resolves `semanticText or text` as the embed source in both batch and event modes; the content hash tracks the resolved value so editing the override re-embeds and editing `text` under a stable override does not. The document event consumer now filters on a configurable set of aspects (`documentInfo` + `semanticText`).

## Testing

- `DocumentMapperTest` (datahub-graphql-core) — passes, incl. new semanticText assertion.
- `SearchRequestHandlerTest` (metadata-io) — passes; document searchable fields now include `semanticText`.
- `test_datahub_documents_source.py` — passes (ruff + mypy clean).

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [ ] Docs — n/a (additive aspect, no user-facing config change)
- [ ] Breaking changes — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)