### PR TITLE
fix(ingest/documents): tolerate orphaned index entries in document scroll

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, cast
 
+from datahub.configuration.common import GraphError, OperationalError
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.decorators import (
     SupportStatus,
@@ -72,6 +73,7 @@ class DataHubDocumentsReport(StatefulIngestionReport):
     num_documents_skipped_unchanged: int = 0
     num_documents_skipped_empty: int = 0
     num_documents_skipped_existing_embeddings: int = 0
+    num_documents_skipped_orphaned: int = 0
     num_chunks_created: int = 0
     lock_skipped_run: bool = False
     num_embeddings_generated: int = 0
@@ -101,6 +103,10 @@ class DataHubDocumentsReport(StatefulIngestionReport):
     def report_document_skipped_existing_embeddings(self) -> None:
         """Report document skipped because it already has semanticContent for the model."""
         self.num_documents_skipped_existing_embeddings += 1
+
+    def report_document_skipped_orphaned(self) -> None:
+        """Report a URN skipped because it has no resolvable backing entity."""
+        self.num_documents_skipped_orphaned += 1
 
     def report_embeddings_generated(self, count: int) -> None:
         self.num_embeddings_generated += count
@@ -896,12 +902,85 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                 return parts[-1]
         return None
 
+    # URNs hydrated per GraphQL request. Kept modest so a single response stays
+    # within GMS's GraphQL limits even for large documents.
+    _HYDRATE_BATCH_SIZE = 100
+
     def _fetch_documents_graphql(self) -> list[dict[str, Any]]:
-        """Fetch Document entities from DataHub using GraphQL."""
-        # scrollAcrossEntities uses cursor-based pagination and is not subject to
-        # Elasticsearch's max_result_window limit (default 10,000), unlike offset-based search.
+        """Fetch Document entities from DataHub with their text content.
+
+        URNs are enumerated first (``_scroll_document_urns``) and then hydrated
+        in batches (``_hydrate_documents``), so a single orphaned index entry can
+        no longer abort the whole run.
+        """
+        try:
+            documents: list[dict[str, Any]] = []
+
+            urns = list(self._scroll_document_urns())
+            logger.info(f"Enumerated {len(urns)} document URN(s) from DataHub")
+
+            for entity in self._hydrate_documents(urns):
+                urn = entity.get("urn")
+                if not urn:
+                    continue
+
+                # Filter by specific URNs if provided
+                if self.config.document_urns and urn not in self.config.document_urns:
+                    continue
+
+                # Extract text content (GraphQL returns null for missing aspects).
+                # semanticText overrides text as the embedding source; see _resolve_embed_text.
+                info = entity.get("info") or {}
+                contents = info.get("contents") or {}
+                text = self._resolve_embed_text(contents)
+
+                # Default to NATIVE when sourceType is absent (older documents).
+                source = info.get("source") or {}
+                source_type = source.get("sourceType") or "NATIVE"
+
+                # Filter by source type (NATIVE vs EXTERNAL) for batch mode
+                if not self._should_process_by_source_type(entity, info):
+                    continue
+
+                # Skip if no text or too short
+                if not text or (
+                    self.config.skip_empty_text
+                    and len(text) < self.config.min_text_length
+                ):
+                    logger.debug(
+                        f"Skipping document {urn} (empty or too short: {len(text)} chars)"
+                    )
+                    continue
+
+                documents.append({"urn": urn, "text": text, "source_type": source_type})
+                self.report.report_document_fetched()
+
+            logger.info(
+                f"Fetched {len(documents)} documents with text content from platforms: {self.config.platform_filter}"
+            )
+            return documents
+
+        except Exception as e:
+            logger.error(f"Failed to fetch documents from DataHub: {e}", exc_info=True)
+            raise
+
+    def _scroll_document_urns(self) -> Iterable[str]:
+        """Enumerate Document URNs via scrollAcrossEntities.
+
+        Only the URN is selected here — never an aspect-backed field. An
+        orphaned index entry (a URN present in the search index with no backing
+        entity) would make GMS null the non-null ``SearchResult.entity`` and
+        abort the whole scroll if any aspect field were selected; requesting the
+        URN alone reads it straight off the search hit and stays orphan-safe.
+        Content is resolved separately in ``_hydrate_documents``, where orphans
+        come back null and are skipped.
+
+        scrollAcrossEntities uses cursor-based pagination and is not subject to
+        Elasticsearch's max_result_window limit (default 10,000), unlike
+        offset-based search.
+        """
         query = """
-        query scrollDocuments(
+        query scrollDocumentUrns(
             $scrollId: String,
             $batchSize: Int!,
             $orFilters: [AndFilterInput!]
@@ -922,36 +1001,12 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             searchResults {
               entity {
                 urn
-                type
-                ... on Document {
-                  info {
-                    contents {
-                      text
-                      semanticText
-                    }
-                    customProperties {
-                      key
-                      value
-                    }
-                    source {
-                      sourceType
-                    }
-                  }
-                  dataPlatformInstance {
-                    platform {
-                      urn
-                    }
-                  }
-                }
               }
             }
           }
         }
         """
 
-        page_size = self.config.scroll_batch_size
-
-        # Build optional platform filter
         or_filters = None
         if (
             self.config.platform_filter
@@ -972,86 +1027,176 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                 }
             ]
 
-        try:
-            documents = []
-            scroll_id: Optional[str] = None
-            first_iter = True
+        scroll_id: Optional[str] = None
+        first_iter = True
+        while first_iter or scroll_id:
+            # Keep the distributed lock lease alive while scrolling large sets.
+            if self.lock is not None:
+                self.lock.heartbeat()
+            # Throttle between pages (not before the first) to reduce load on
+            # GMS/Elasticsearch when scrolling large document sets.
+            if not first_iter and self.config.scroll_delay_seconds > 0:
+                time.sleep(self.config.scroll_delay_seconds)
+            first_iter = False
 
-            while first_iter or scroll_id:
-                # Keep the distributed lock lease alive while scrolling large document sets.
-                if self.lock is not None:
-                    self.lock.heartbeat()
-                # Throttle between pages (not before the first) to reduce load on
-                # GMS/Elasticsearch when scrolling large document sets.
-                if not first_iter and self.config.scroll_delay_seconds > 0:
-                    time.sleep(self.config.scroll_delay_seconds)
-                first_iter = False
-                variables: dict[str, Any] = {
-                    "batchSize": page_size,
-                    "scrollId": scroll_id,
-                    "orFilters": or_filters,
-                }
-                response = self.graph.execute_graphql(query, variables)
-                scroll_data = response.get("scrollAcrossEntities") or {}
-                scroll_id = scroll_data.get("nextScrollId")
-                search_results = scroll_data.get("searchResults") or []
-
-                logger.debug(
-                    f"Fetched page of {len(search_results)} documents (scrollId={scroll_id})"
+            variables: dict[str, Any] = {
+                "batchSize": self.config.scroll_batch_size,
+                "scrollId": scroll_id,
+                "orFilters": or_filters,
+            }
+            response = self.graph.execute_graphql(query, variables)
+            scroll_data = response.get("scrollAcrossEntities")
+            if scroll_data is None:
+                # A response missing the scroll payload (vs. one with an empty
+                # page) means enumeration broke; surface it rather than silently
+                # reporting success with too few documents embedded.
+                self.report.warning(
+                    title="Document enumeration returned no scroll payload",
+                    message="scrollAcrossEntities was missing from the GraphQL "
+                    "response; document enumeration may be incomplete.",
                 )
-
-                for result in search_results:
-                    entity = result.get("entity") or {}
-                    urn = entity.get("urn")
-
-                    if not urn:
-                        continue
-
-                    # Filter by specific URNs if provided
-                    if (
-                        self.config.document_urns
-                        and urn not in self.config.document_urns
-                    ):
-                        continue
-
-                    # Extract text content (GraphQL returns null for missing aspects).
-                    # semanticText overrides text as the embedding source; see _resolve_embed_text.
-                    info = entity.get("info") or {}
-                    contents = info.get("contents") or {}
-                    text = self._resolve_embed_text(contents)
-
-                    # Default to NATIVE when sourceType is absent (older documents).
-                    source = info.get("source") or {}
-                    source_type = source.get("sourceType") or "NATIVE"
-
-                    # Filter by source type (NATIVE vs EXTERNAL) for batch mode
-                    should_process = self._should_process_by_source_type(entity, info)
-                    if not should_process:
-                        continue
-
-                    # Skip if no text or too short
-                    if not text or (
-                        self.config.skip_empty_text
-                        and len(text) < self.config.min_text_length
-                    ):
-                        logger.debug(
-                            f"Skipping document {urn} (empty or too short: {len(text)} chars)"
-                        )
-                        continue
-
-                    documents.append(
-                        {"urn": urn, "text": text, "source_type": source_type}
-                    )
-                    self.report.report_document_fetched()
-
-            logger.info(
-                f"Fetched {len(documents)} documents with text content from platforms: {self.config.platform_filter}"
+                break
+            scroll_id = scroll_data.get("nextScrollId")
+            search_results = scroll_data.get("searchResults") or []
+            logger.debug(
+                f"Scrolled page of {len(search_results)} document URN(s) (scrollId={scroll_id})"
             )
-            return documents
+            # A full page with no continuation cursor is suspicious: the scroll
+            # likely truncated, so some documents may never be enumerated.
+            if not scroll_id and len(search_results) >= self.config.scroll_batch_size:
+                self.report.warning(
+                    title="Document enumeration ended without a scroll cursor",
+                    message="A full page returned no nextScrollId; enumeration "
+                    "may have stopped early and some documents may be missing.",
+                )
+            for result in search_results:
+                entity = result.get("entity") or {}
+                urn = entity.get("urn")
+                if urn:
+                    yield urn
 
-        except Exception as e:
-            logger.error(f"Failed to fetch documents from DataHub: {e}", exc_info=True)
-            raise
+    def _hydrate_documents(self, urns: list[str]) -> Iterable[dict[str, Any]]:
+        """Resolve document URNs to entities in batches.
+
+        Uses the nullable ``entities(urns:)`` query: an orphaned URN comes back
+        as null and is counted and skipped, instead of aborting the run as the
+        non-null ``SearchResult.entity`` in ``scrollAcrossEntities`` would.
+        """
+        query = """
+        query hydrateDocuments($urns: [String!]!) {
+          entities(urns: $urns) {
+            urn
+            type
+            ... on Document {
+              info {
+                contents {
+                  text
+                  semanticText
+                }
+                customProperties {
+                  key
+                  value
+                }
+                source {
+                  sourceType
+                }
+              }
+              dataPlatformInstance {
+                platform {
+                  urn
+                }
+              }
+            }
+          }
+        }
+        """
+        for start in range(0, len(urns), self._HYDRATE_BATCH_SIZE):
+            batch = urns[start : start + self._HYDRATE_BATCH_SIZE]
+            if self.lock is not None:
+                self.lock.heartbeat()
+
+            try:
+                response = self.graph.execute_graphql(query, {"urns": batch})
+            except OperationalError:
+                # Transport/outage error — abort rather than silently skipping
+                # every document (which would report success with 0 embeddings).
+                raise
+            except GraphError:
+                # One document with an unexpected null in a non-null field (e.g.
+                # DocumentContent.text) makes GMS fail the whole batch. Retry the
+                # batch one URN at a time so a single bad document can't drop the
+                # rest.
+                logger.warning(
+                    f"Batch hydration failed for {len(batch)} URN(s); retrying individually"
+                )
+                hydrated_any = False
+                for entity in self._hydrate_individually(query, batch):
+                    hydrated_any = True
+                    yield entity
+                if not hydrated_any:
+                    # Every URN in the batch failed the same way — a systemic
+                    # error (typically a GraphQL schema mismatch, e.g. the GMS is
+                    # missing a queried field), not per-document data. Fail loudly
+                    # rather than reporting a successful run that embedded nothing.
+                    self.report.failure(
+                        title="Document hydration failed for an entire batch",
+                        message="Every URN in a hydration batch failed to resolve; "
+                        "this usually means a GraphQL schema mismatch (the GMS is "
+                        "missing a queried field) rather than per-document issues.",
+                        context=batch[0],
+                    )
+                continue
+
+            entities = response.get("entities") or []
+            if len(entities) != len(batch):
+                # GMS returns one (possibly null) entity per requested URN, in
+                # order. A different count means entities can't be lined up with
+                # URNs — surface it instead of silently dropping the tail.
+                self.report.warning(
+                    title="Hydration returned an unexpected entity count",
+                    message="GMS returned a different number of entities than URNs "
+                    "requested; some documents may be missing from this run.",
+                )
+            for urn, entity in zip(batch, entities, strict=False):
+                if entity is None:
+                    self._skip_orphaned(urn)
+                    continue
+                yield entity
+
+    def _hydrate_individually(
+        self, query: str, urns: list[str]
+    ) -> Iterable[dict[str, Any]]:
+        """Hydrate URNs one at a time so a single un-resolvable document is
+        skipped instead of failing its whole batch."""
+        for urn in urns:
+            try:
+                response = self.graph.execute_graphql(query, {"urns": [urn]})
+            except OperationalError:
+                raise
+            except GraphError:
+                self.report.warning(
+                    title="Skipped document that failed to hydrate",
+                    message="A document's content could not be resolved from GMS "
+                    "(a non-null field returned null); it was skipped.",
+                    context=urn,
+                )
+                continue
+            entities = response.get("entities") or []
+            entity = entities[0] if entities else None
+            if entity is None:
+                self._skip_orphaned(urn)
+                continue
+            yield entity
+
+    def _skip_orphaned(self, urn: str) -> None:
+        """Record an orphaned index entry (a URN with no resolvable entity)."""
+        self.report.report_document_skipped_orphaned()
+        self.report.warning(
+            title="Skipped orphaned document",
+            message="A document URN is present in the search index but has no "
+            "resolvable entity (likely index/entity-store drift); it was skipped.",
+            context=urn,
+        )
 
     def _should_process(self, document_urn: str, text: str) -> bool:
         """Check if document should be processed based on content hash."""

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
+from datahub.configuration.common import GraphError, OperationalError
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.ingestion.source.unstructured.event_consumer import (
     DocumentEventConsumer,
@@ -38,6 +39,16 @@ from datahub.ingestion.source.unstructured.chunking_config import (
     ServerEmbeddingConfig,
     ServerSemanticSearchConfig,
 )
+
+
+def _mock_fetch(source, entities, urns=None):
+    """Wire a source so _fetch_documents_graphql enumerates `urns` and hydrates
+    them to `entities` (order preserved; a None entry is an orphan). URNs default
+    to the entities' own urns."""
+    if urns is None:
+        urns = [e["urn"] for e in entities if e]
+    source._scroll_document_urns = Mock(return_value=iter(urns))
+    source.graph.execute_graphql = Mock(return_value={"entities": entities})
 
 
 class TestTextPartitioner:
@@ -1904,49 +1915,40 @@ class TestConfigFingerprintInHash:
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
 
-            # Mock GraphQL to return both NATIVE and EXTERNAL documents
-            mock_response = {
-                "scrollAcrossEntities": {
-                    "nextScrollId": None,
-                    "searchResults": [
-                        {
-                            "entity": {
-                                "urn": "urn:li:document:native1",
-                                "info": {
-                                    "source": {"sourceType": "NATIVE"},
-                                    "contents": {
-                                        "text": "This is a native document with enough text content to pass the minimum length requirement."
-                                    },
-                                },
-                            }
+            # Hydration returns both a NATIVE and an EXTERNAL document.
+            _mock_fetch(
+                source,
+                [
+                    {
+                        "urn": "urn:li:document:native1",
+                        "info": {
+                            "source": {"sourceType": "NATIVE"},
+                            "contents": {
+                                "text": "This is a native document with enough text content to pass the minimum length requirement."
+                            },
                         },
-                        {
-                            "entity": {
-                                "urn": "urn:li:document:external1",
-                                "info": {
-                                    "source": {"sourceType": "EXTERNAL"},
-                                    "contents": {
-                                        "text": "This is an external document with enough text content to pass the minimum length requirement."
-                                    },
-                                },
-                            }
+                    },
+                    {
+                        "urn": "urn:li:document:external1",
+                        "info": {
+                            "source": {"sourceType": "EXTERNAL"},
+                            "contents": {
+                                "text": "This is an external document with enough text content to pass the minimum length requirement."
+                            },
                         },
-                    ],
-                }
+                    },
+                ],
+            )
+
+            documents = source._fetch_documents_graphql()
+
+            # Both NATIVE and EXTERNAL documents are returned by default
+            assert len(documents) == 2
+            urns = {doc["urn"] for doc in documents}
+            assert urns == {
+                "urn:li:document:native1",
+                "urn:li:document:external1",
             }
-
-            with patch.object(
-                source.graph, "execute_graphql", return_value=mock_response
-            ):
-                documents = source._fetch_documents_graphql()
-
-                # Both NATIVE and EXTERNAL documents are returned by default
-                assert len(documents) == 2
-                urns = {doc["urn"] for doc in documents}
-                assert urns == {
-                    "urn:li:document:native1",
-                    "urn:li:document:external1",
-                }
 
     def test_batch_mode_with_platform_filter(self, ctx, mock_graph):
         """Test batch mode with platform filter includes EXTERNAL from specified platforms."""
@@ -1966,53 +1968,42 @@ class TestConfigFingerprintInHash:
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
 
-            # Mock GraphQL to return documents from different platforms
-            mock_response = {
-                "scrollAcrossEntities": {
-                    "nextScrollId": None,
-                    "searchResults": [
-                        {
-                            "entity": {
-                                "urn": "urn:li:document:notion1",
-                                "info": {
-                                    "source": {"sourceType": "EXTERNAL"},
-                                    "contents": {
-                                        "text": "This is a Notion document with enough text content to pass the minimum length requirement."
-                                    },
-                                },
-                                "dataPlatformInstance": {
-                                    "platform": {"urn": "urn:li:dataPlatform:notion"}
-                                },
-                            }
+            # Hydration returns documents from different platforms.
+            _mock_fetch(
+                source,
+                [
+                    {
+                        "urn": "urn:li:document:notion1",
+                        "info": {
+                            "source": {"sourceType": "EXTERNAL"},
+                            "contents": {
+                                "text": "This is a Notion document with enough text content to pass the minimum length requirement."
+                            },
                         },
-                        {
-                            "entity": {
-                                "urn": "urn:li:document:confluence1",
-                                "info": {
-                                    "source": {"sourceType": "EXTERNAL"},
-                                    "contents": {
-                                        "text": "This is a Confluence document with enough text content to pass the minimum length requirement."
-                                    },
-                                },
-                                "dataPlatformInstance": {
-                                    "platform": {
-                                        "urn": "urn:li:dataPlatform:confluence"
-                                    }
-                                },
-                            }
+                        "dataPlatformInstance": {
+                            "platform": {"urn": "urn:li:dataPlatform:notion"}
                         },
-                    ],
-                }
-            }
+                    },
+                    {
+                        "urn": "urn:li:document:confluence1",
+                        "info": {
+                            "source": {"sourceType": "EXTERNAL"},
+                            "contents": {
+                                "text": "This is a Confluence document with enough text content to pass the minimum length requirement."
+                            },
+                        },
+                        "dataPlatformInstance": {
+                            "platform": {"urn": "urn:li:dataPlatform:confluence"}
+                        },
+                    },
+                ],
+            )
 
-            with patch.object(
-                source.graph, "execute_graphql", return_value=mock_response
-            ):
-                documents = source._fetch_documents_graphql()
+            documents = source._fetch_documents_graphql()
 
-                # Should only return notion document (confluence filtered out)
-                assert len(documents) == 1
-                assert documents[0]["urn"] == "urn:li:document:notion1"
+            # Should only return notion document (confluence filtered out)
+            assert len(documents) == 1
+            assert documents[0]["urn"] == "urn:li:document:notion1"
 
 
 class TestPartialEntityHandling:
@@ -2056,38 +2047,26 @@ class TestPartialEntityHandling:
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
 
-            mock_response = {
-                "scrollAcrossEntities": {
-                    "nextScrollId": None,
-                    "searchResults": [
-                        {
-                            "entity": {
-                                "urn": "urn:li:document:partial1",
-                                "info": None,
-                            }
+            _mock_fetch(
+                source,
+                [
+                    {"urn": "urn:li:document:partial1", "info": None},
+                    {
+                        "urn": "urn:li:document:complete1",
+                        "info": {
+                            "source": {"sourceType": "NATIVE"},
+                            "contents": {
+                                "text": "This is a complete document with enough content."
+                            },
                         },
-                        {
-                            "entity": {
-                                "urn": "urn:li:document:complete1",
-                                "info": {
-                                    "source": {"sourceType": "NATIVE"},
-                                    "contents": {
-                                        "text": "This is a complete document with enough content."
-                                    },
-                                },
-                            }
-                        },
-                    ],
-                }
-            }
+                    },
+                ],
+            )
 
-            with patch.object(
-                source.graph, "execute_graphql", return_value=mock_response
-            ):
-                documents = source._fetch_documents_graphql()
+            documents = source._fetch_documents_graphql()
 
-                assert len(documents) == 1
-                assert documents[0]["urn"] == "urn:li:document:complete1"
+            assert len(documents) == 1
+            assert documents[0]["urn"] == "urn:li:document:complete1"
 
     def test_fetch_documents_skips_entity_with_null_contents(
         self, ctx, config, mock_graph
@@ -2096,45 +2075,34 @@ class TestPartialEntityHandling:
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
 
-            mock_response = {
-                "scrollAcrossEntities": {
-                    "nextScrollId": None,
-                    "searchResults": [
-                        {
-                            "entity": {
-                                "urn": "urn:li:document:no_contents",
-                                "info": {
-                                    "source": {"sourceType": "NATIVE"},
-                                    "contents": None,
-                                },
-                            }
+            _mock_fetch(
+                source,
+                [
+                    {
+                        "urn": "urn:li:document:no_contents",
+                        "info": {
+                            "source": {"sourceType": "NATIVE"},
+                            "contents": None,
                         },
-                    ],
-                }
-            }
+                    },
+                ],
+            )
 
-            with patch.object(
-                source.graph, "execute_graphql", return_value=mock_response
-            ):
-                documents = source._fetch_documents_graphql()
+            documents = source._fetch_documents_graphql()
 
-                assert len(documents) == 0
+            assert len(documents) == 0
 
-    def test_fetch_documents_skips_entity_with_null_search(
-        self, ctx, config, mock_graph
-    ):
-        """Test that a null search response is handled gracefully."""
+    def test_fetch_documents_skips_orphaned_hydration(self, ctx, config, mock_graph):
+        """A URN that hydrates to null (orphaned index entry) is skipped."""
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
 
-            mock_response: dict[str, Any] = {"scrollAcrossEntities": None}
+            _mock_fetch(source, [None], urns=["urn:li:document:orphan"])
 
-            with patch.object(
-                source.graph, "execute_graphql", return_value=mock_response
-            ):
-                documents = source._fetch_documents_graphql()
+            documents = source._fetch_documents_graphql()
 
-                assert len(documents) == 0
+            assert len(documents) == 0
+            assert source.report.num_documents_skipped_orphaned == 1
 
     def test_should_process_by_source_type_with_null_source(
         self, ctx, config, mock_graph
@@ -2285,56 +2253,37 @@ class TestPartialEntityHandling:
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
 
-            mock_response = {
-                "scrollAcrossEntities": {
-                    "nextScrollId": None,
-                    "searchResults": [
-                        {
-                            "entity": {
-                                "urn": "urn:li:document:null_info",
-                                "info": None,
-                            }
+            _mock_fetch(
+                source,
+                [
+                    {"urn": "urn:li:document:null_info", "info": None},
+                    {
+                        "urn": "urn:li:document:null_contents",
+                        "info": {"source": {"sourceType": "NATIVE"}, "contents": None},
+                    },
+                    {
+                        "urn": "urn:li:document:empty_text",
+                        "info": {
+                            "source": {"sourceType": "NATIVE"},
+                            "contents": {"text": ""},
                         },
-                        {
-                            "entity": {
-                                "urn": "urn:li:document:null_contents",
-                                "info": {
-                                    "source": {"sourceType": "NATIVE"},
-                                    "contents": None,
-                                },
-                            }
+                    },
+                    {
+                        "urn": "urn:li:document:valid",
+                        "info": {
+                            "source": {"sourceType": "NATIVE"},
+                            "contents": {
+                                "text": "This document has valid content that is long enough."
+                            },
                         },
-                        {
-                            "entity": {
-                                "urn": "urn:li:document:empty_text",
-                                "info": {
-                                    "source": {"sourceType": "NATIVE"},
-                                    "contents": {"text": ""},
-                                },
-                            }
-                        },
-                        {
-                            "entity": {
-                                "urn": "urn:li:document:valid",
-                                "info": {
-                                    "source": {"sourceType": "NATIVE"},
-                                    "contents": {
-                                        "text": "This document has valid content that is long enough."
-                                    },
-                                },
-                            }
-                        },
-                    ],
-                }
-            }
+                    },
+                ],
+            )
 
-            with patch.object(
-                source.graph, "execute_graphql", return_value=mock_response
-            ):
-                documents = source._fetch_documents_graphql()
+            documents = source._fetch_documents_graphql()
 
-                assert len(documents) == 1
-                assert documents[0]["urn"] == "urn:li:document:valid"
+            assert len(documents) == 1
+            assert documents[0]["urn"] == "urn:li:document:valid"
 
 
 class TestMaxDocumentsLimit:
@@ -2757,7 +2706,7 @@ class TestDataHubGraphInitialization:
 
 
 class TestFetchDocumentsPagination:
-    """Test that _fetch_documents_graphql paginates through all pages via scrollAcrossEntities."""
+    """Test that _scroll_document_urns paginates through all pages via scrollAcrossEntities."""
 
     @pytest.fixture
     def config(self):
@@ -2784,17 +2733,6 @@ class TestFetchDocumentsPagination:
             "datahub.ingestion.source.datahub_documents.datahub_documents_source.DataHubGraph"
         )
 
-    def _make_entity(self, i: int) -> dict:
-        return {
-            "entity": {
-                "urn": f"urn:li:document:doc-{i}",
-                "info": {
-                    "source": {"sourceType": "NATIVE"},
-                    "contents": {"text": f"Document {i} with sufficient text content."},
-                },
-            }
-        }
-
     def _make_scroll_page(
         self, start: int, count: int, next_scroll_id: Any = None
     ) -> dict:
@@ -2802,13 +2740,14 @@ class TestFetchDocumentsPagination:
             "scrollAcrossEntities": {
                 "nextScrollId": next_scroll_id,
                 "searchResults": [
-                    self._make_entity(i) for i in range(start, start + count)
+                    {"entity": {"urn": f"urn:li:document:doc-{i}"}}
+                    for i in range(start, start + count)
                 ],
             }
         }
 
     def test_paginates_across_multiple_pages(self, ctx, config, mock_graph):
-        """Fetching >1000 documents issues multiple GraphQL calls and returns all results."""
+        """Enumerating >1000 documents issues multiple scroll calls and yields all URNs."""
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
 
@@ -2820,9 +2759,9 @@ class TestFetchDocumentsPagination:
             with patch.object(
                 source.graph, "execute_graphql", side_effect=responses
             ) as mock_execute:
-                documents = source._fetch_documents_graphql()
+                urns = list(source._scroll_document_urns())
 
-            assert len(documents) == 1200
+            assert len(urns) == 1200
             assert mock_execute.call_count == 2
 
             first_scroll_id = mock_execute.call_args_list[0][0][1]["scrollId"]
@@ -2840,13 +2779,13 @@ class TestFetchDocumentsPagination:
             with patch.object(
                 source.graph, "execute_graphql", return_value=response
             ) as mock_execute:
-                documents = source._fetch_documents_graphql()
+                urns = list(source._scroll_document_urns())
 
-            assert len(documents) == 1000
+            assert len(urns) == 1000
             assert mock_execute.call_count == 1
 
     def test_requests_hidden_lifecycle_stages(self, ctx, config, mock_graph):
-        """Document backfills request hidden-lifecycle stages so hidden documents are included."""
+        """Enumeration requests hidden-lifecycle stages so hidden documents are included."""
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
 
@@ -2855,13 +2794,13 @@ class TestFetchDocumentsPagination:
             with patch.object(
                 source.graph, "execute_graphql", return_value=response
             ) as mock_execute:
-                source._fetch_documents_graphql()
+                list(source._scroll_document_urns())
 
             query = mock_execute.call_args[0][0]
             assert "includeHiddenLifecycleStages: true" in query
 
     def test_empty_result_set(self, ctx, config, mock_graph):
-        """Zero documents returns empty list after one call."""
+        """Zero documents yields no URNs after one call."""
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
 
@@ -2875,13 +2814,13 @@ class TestFetchDocumentsPagination:
             with patch.object(
                 source.graph, "execute_graphql", return_value=response
             ) as mock_execute:
-                documents = source._fetch_documents_graphql()
+                urns = list(source._scroll_document_urns())
 
-            assert documents == []
+            assert urns == []
             assert mock_execute.call_count == 1
 
     def test_three_pages(self, ctx, config, mock_graph):
-        """Three-page fetch collects all documents and threads scroll cursors correctly."""
+        """Three-page enumeration collects all URNs and threads scroll cursors correctly."""
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
 
@@ -2894,60 +2833,12 @@ class TestFetchDocumentsPagination:
             with patch.object(
                 source.graph, "execute_graphql", side_effect=responses
             ) as mock_execute:
-                documents = source._fetch_documents_graphql()
+                urns = list(source._scroll_document_urns())
 
-            assert len(documents) == 2500
+            assert len(urns) == 2500
             assert mock_execute.call_count == 3
             scroll_ids = [c[0][1]["scrollId"] for c in mock_execute.call_args_list]
             assert scroll_ids == [None, "cursor-1", "cursor-2"]
-
-    def test_raw_page_size_used_as_start_advance(self, ctx, config, mock_graph):
-        """Pagination advances by raw page size even when some results are filtered client-side.
-
-        This test locks in that start is advanced by the number of results returned from the
-        server, not the number that pass client-side filters. Using filtered count would cause
-        pages to be requested at wrong offsets or loop incorrectly.
-        """
-        with mock_graph:
-            source = DataHubDocumentsSource(ctx, config)
-
-            # Page 1: 1000 results, 800 pass client filters (200 have empty text).
-            # Page 2: remaining results with no next scroll id.
-            page1_results = [self._make_entity(i) for i in range(800)]
-            # Add 200 entities with empty text that will be filtered out
-            for i in range(800, 1000):
-                page1_results.append(
-                    {
-                        "entity": {
-                            "urn": f"urn:li:document:doc-{i}",
-                            "info": {
-                                "source": {"sourceType": "NATIVE"},
-                                "contents": {"text": ""},
-                            },
-                        }
-                    }
-                )
-
-            responses = [
-                {
-                    "scrollAcrossEntities": {
-                        "nextScrollId": "cursor-1",
-                        "searchResults": page1_results,
-                    }
-                },
-                self._make_scroll_page(1000, 300, next_scroll_id=None),
-            ]
-
-            with patch.object(
-                source.graph, "execute_graphql", side_effect=responses
-            ) as mock_execute:
-                documents = source._fetch_documents_graphql()
-
-            # 800 from page 1 (200 filtered) + 300 from page 2
-            assert len(documents) == 1100
-            assert mock_execute.call_count == 2
-            # Second call must use the cursor from page 1, not a derived offset
-            assert mock_execute.call_args_list[1][0][1]["scrollId"] == "cursor-1"
 
 
 def _make_config(**overrides: Any) -> DataHubDocumentsSourceConfig:
@@ -3903,3 +3794,201 @@ class TestDocumentEventConsumerAspectFilter:
             yielded = list(consumer.consume_events())
 
         assert [e.get("entityUrn") for e in yielded] == ["urn:li:document:d2"]
+
+
+class TestOrphanedDocumentResilience:
+    """A single orphaned index entry (a URN present in the index but with no
+    resolvable backing entity) must not abort the embedding run."""
+
+    @pytest.fixture
+    def config(self):
+        return DataHubDocumentsSourceConfig(
+            platform_filter=["notion"],
+            datahub={"server": "http://test-server:8080"},
+            embedding={
+                "provider": "bedrock",
+                "model": "cohere.embed-english-v3",
+                "aws_region": "us-west-2",
+                "allow_local_embedding_config": True,
+            },
+            stateful_ingestion={"enabled": False},
+        )
+
+    @pytest.fixture
+    def ctx(self):
+        return PipelineContext(run_id="test-run", pipeline_name="test-pipeline")
+
+    @staticmethod
+    def _native_notion_doc(urn: str) -> dict:
+        return {
+            "urn": urn,
+            "type": "DOCUMENT",
+            "info": {
+                "contents": {
+                    "text": "This is a sufficiently long document body for embedding."
+                },
+                "source": {"sourceType": "NATIVE"},
+            },
+            "dataPlatformInstance": {"platform": {"urn": "urn:li:dataPlatform:notion"}},
+        }
+
+    def _make_source(self, ctx, config):
+        with patch(
+            "datahub.ingestion.source.datahub_documents.datahub_documents_source.DataHubGraph"
+        ):
+            source = DataHubDocumentsSource(ctx, config)
+        source.graph = Mock()
+        source.graph.config.server = "http://test-server:8080"
+        return source
+
+    def test_orphaned_urn_is_skipped_not_fatal(self, ctx, config):
+        source = self._make_source(ctx, config)
+        urns = [
+            "urn:li:document:real-1",
+            "urn:li:document:__orphan_probe",
+            "urn:li:document:real-2",
+        ]
+
+        def _graphql(query, variables=None):
+            if "scrollAcrossEntities" in query:
+                return {
+                    "scrollAcrossEntities": {
+                        "nextScrollId": None,
+                        "searchResults": [{"entity": {"urn": u}} for u in urns],
+                    }
+                }
+            # Hydration resolves the orphan to null (as GMS does for an index
+            # entry with no backing entity), the two real docs to full payloads.
+            return {
+                "entities": [
+                    self._native_notion_doc("urn:li:document:real-1"),
+                    None,
+                    self._native_notion_doc("urn:li:document:real-2"),
+                ]
+            }
+
+        source.graph.execute_graphql.side_effect = _graphql
+
+        documents = source._fetch_documents_graphql()
+
+        assert [d["urn"] for d in documents] == [
+            "urn:li:document:real-1",
+            "urn:li:document:real-2",
+        ]
+        assert source.report.num_documents_skipped_orphaned == 1
+        assert source.report.num_documents_fetched == 2
+
+    def test_enumeration_scroll_selects_only_urn(self, ctx, config):
+        # Regression guard: the scroll query must select ONLY the URN from the
+        # non-null SearchResult.entity. Selecting any aspect-backed field (info,
+        # contents, ...) is what a single orphan nulls, taking down the run.
+        source = self._make_source(ctx, config)
+        captured: dict[str, str] = {}
+
+        def _graphql(query, variables=None):
+            if "scrollAcrossEntities" in query:
+                captured["scroll"] = query
+                return {
+                    "scrollAcrossEntities": {"nextScrollId": None, "searchResults": []}
+                }
+            return {"entities": []}
+
+        source.graph.execute_graphql.side_effect = _graphql
+
+        source._fetch_documents_graphql()
+
+        scroll_query = captured["scroll"]
+        assert "info" not in scroll_query
+        assert "contents" not in scroll_query
+
+    def test_hydration_spans_batches_with_orphan_in_second(self, ctx, config):
+        # >100 URNs so _hydrate_documents runs two batches; the orphan lives in
+        # the second batch, exercising per-batch handling beyond the first page.
+        source = self._make_source(ctx, config)
+        urns = [f"urn:li:document:doc-{i}" for i in range(150)]
+
+        batch1 = {"entities": [self._native_notion_doc(u) for u in urns[:100]]}
+        batch2_entities: list = [self._native_notion_doc(u) for u in urns[100:]]
+        batch2_entities[25] = None  # one orphan in the second batch
+        batch2 = {"entities": batch2_entities}
+        source.graph.execute_graphql.side_effect = [batch1, batch2]
+
+        hydrated = list(source._hydrate_documents(urns))
+
+        assert source.graph.execute_graphql.call_count == 2
+        assert len(hydrated) == 149
+        assert source.report.num_documents_skipped_orphaned == 1
+
+    def test_batch_graph_error_falls_back_to_per_urn(self, ctx, config):
+        # A GraphError on the batch call (e.g. one document with a null in a
+        # non-null field) must not drop the whole batch: retry per-URN, yield the
+        # good ones, and skip only the offender.
+        source = self._make_source(ctx, config)
+        good = self._native_notion_doc("urn:li:document:good")
+
+        def _graphql(query, variables=None):
+            urns = variables["urns"]
+            if len(urns) > 1:
+                raise GraphError("NullValueInNonNullableField")
+            if urns == ["urn:li:document:good"]:
+                return {"entities": [good]}
+            raise GraphError("NullValueInNonNullableField")
+
+        source.graph.execute_graphql.side_effect = _graphql
+
+        hydrated = list(
+            source._hydrate_documents(["urn:li:document:good", "urn:li:document:bad"])
+        )
+
+        assert [e["urn"] for e in hydrated] == ["urn:li:document:good"]
+        assert any(
+            "failed to hydrate" in (w.title or "").lower()
+            for w in source.report.warnings
+        )
+
+    def test_transport_error_aborts_not_swallowed(self, ctx, config):
+        # A transport/outage error (OperationalError) must abort the run, not be
+        # caught as a per-document skip — otherwise the run reports success with
+        # zero embeddings, the source's documented catastrophic mode.
+        source = self._make_source(ctx, config)
+        source.graph.execute_graphql.side_effect = OperationalError(
+            "connection refused"
+        )
+
+        with pytest.raises(OperationalError):
+            list(source._hydrate_documents(["urn:li:document:a", "urn:li:document:b"]))
+
+    def test_batch_all_urns_fail_reports_failure(self, ctx, config):
+        # If every URN in a batch fails identically (e.g. a GraphQL schema
+        # mismatch — GMS missing a queried field), the run must fail loudly, not
+        # report success with zero embeddings.
+        source = self._make_source(ctx, config)
+        source.graph.execute_graphql.side_effect = GraphError(
+            "Cannot query field 'semanticText'"
+        )
+
+        hydrated = list(
+            source._hydrate_documents(["urn:li:document:a", "urn:li:document:b"])
+        )
+
+        assert hydrated == []
+        assert any(
+            "entire batch" in (f.title or "").lower() for f in source.report.failures
+        )
+
+    def test_hydration_entity_count_mismatch_warns(self, ctx, config):
+        # GMS returning fewer entities than requested URNs must be surfaced, not
+        # silently dropped by the zip.
+        source = self._make_source(ctx, config)
+        source.graph.execute_graphql.return_value = {
+            "entities": [self._native_notion_doc("urn:li:document:a")]
+        }
+
+        hydrated = list(
+            source._hydrate_documents(["urn:li:document:a", "urn:li:document:b"])
+        )
+
+        assert [e["urn"] for e in hydrated] == ["urn:li:document:a"]
+        assert any(
+            "entity count" in (w.title or "").lower() for w in source.report.warnings
+        )


### PR DESCRIPTION
> **Stacked on #18654** (`na--oss-documents-semantic-text`). Review/merge that first; this PR's diff is against that branch.

## Summary

A single orphaned document index entry — a URN present in the search index with no resolvable backing entity (left behind by an interrupted delete, a diagnostic probe write, or index/entity-store drift) — could abort the **entire** `datahub-documents` embedding run, producing 0 events. The semantic index then fills with documents but never receives embedding vectors, and every scheduled run fails identically.

## Root cause

Document enumeration used a single `scrollAcrossEntities` query that selected the **non-null** `SearchResult.entity` together with its aspect fields. When GMS could not resolve an orphan's entity it raised `NullValueInNonNullableField`, which nulled the **entire page** — pagination cursor included — so the run failed before any document was embedded and could not even skip the poisoned page.

## Fix

Decouple **URN enumeration** from **content hydration**:

- `_scroll_document_urns()` enumerates URNs via `scrollAcrossEntities` selecting **only** `entity.urn`. A scalar URN reads straight off the search hit and never triggers entity resolution, so an orphan can no longer poison the page. The `includeHiddenLifecycleStages` flag and the platform pre-filter are preserved.
- `_hydrate_documents()` resolves URNs in batches through the **nullable** `entities(urns:)` query. An orphaned URN resolves to `null`, which is now counted (`num_documents_skipped_orphaned`) and skipped rather than aborting the run.

Every healthy document is still embedded; a single orphan is reported and skipped. Behavior is otherwise unchanged.

## Testing

- New `TestOrphanedDocumentResilience`: an orphan (null on hydration) is skipped, increments `num_documents_skipped_orphaned`, and does not raise; regression guard that the scroll query selects only the URN.
- Existing pagination tests retargeted to `_scroll_document_urns`; batch/partial-entity tests updated for the enumerate→hydrate split. Full file passes (ruff + mypy clean).

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [ ] Docs — n/a (bug fix, no user-facing config change)
- [ ] Breaking changes — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)