### PR TITLE
fix(docker): reap opensearch healthcheck children so it stops dying daily

### DIFF
--- a/docker/profiles/docker-compose.prerequisites.yml
+++ b/docker/profiles/docker-compose.prerequisites.yml
@@ -341,6 +341,7 @@ services:
   opensearch:
     profiles: *opensearch-profiles
     hostname: search
+    init: true
     image: ${DATAHUB_SEARCH_IMAGE:-opensearchproject/opensearch}:${DATAHUB_SEARCH_TAG:-2.19.3}
     ports:
       - ${DATAHUB_MAPPED_ELASTIC_PORT:-9200}:9200


### PR DESCRIPTION
Fixes #18657.

## The bug

The `opensearch` service runs a `curl` healthcheck every 5 seconds. PID 1 inside that container is
the JVM itself (`org.opensearch.bootstrap.OpenSearch`), the JVM does not reap orphaned children,
and Docker's init is not enabled on the service. So every completed healthcheck leaves a permanent
zombie: 12 per minute, 720 per hour. The container's cgroup pid slots fill up and the JVM dies with
`java.lang.OutOfMemoryError: unable to create native thread`, roughly every 26 hours, forever.

Measured on a stock quickstart after 12.2 hours of uptime: 8,723 zombie `curl` processes, all
parented to the OpenSearch JVM, with `pids.current` at 8,811 against a `pids.max` of 18,864. The
JVM itself was only 97 threads.

Raising `ulimits.nproc` does not fix this. It only moves the wall further out.

## The fix

`init: true` makes Docker run tini as PID 1, which reaps the healthcheck children.

## Verification

On a live host, before and after, same container and same healthcheck interval:

| | before | after |
|---|---|---|
| PID 1 | `java ... OpenSearch` | `/sbin/docker-init -- ./opensearch-docker-entrypoint.sh opensearch` |
| zombie `curl` count | 8,723 and climbing | 0, flat |
| cgroup `pids.current` | 8,811 and climbing | 31, flat |

The container came back healthy in 14 seconds, the index survived the recreate with no reindex
(1,275 entities still indexed, cluster yellow as expected for single node), and search-backed
queries returned normally.

## Scope

One line, `opensearch` service only. The sibling `elasticsearch` service is deliberately left
alone: it is unaffected, because the official Elasticsearch image already ships tini as PID 1.
`datahub-gms` runs an even more aggressive curl healthcheck (`interval: 1s`) and does not leak
either, which isolates the cause to what PID 1 is rather than to curl or to the healthcheck
frequency.
