### PR TITLE
feat(pgqueue): add topic-agnostic MCL producer

### DIFF
--- a/metadata-ingestion/src/datahub/pgqueue/__init__.py
+++ b/metadata-ingestion/src/datahub/pgqueue/__init__.py
@@ -16,6 +16,7 @@ from datahub.pgqueue.config import (
     PgQueueConnectionConfig,
     PgQueueConsumerConfig,
     PgQueueEmitterConfig,
+    PgQueueMclProducerConfig,
     PgQueueTopicDefaultsConfig,
 )
 from datahub.pgqueue.repository import EnqueueBatchItem, PgQueueMessageHandle
@@ -27,11 +28,13 @@ __all__ = [
     "build_pg_queue_event_meta",
     "DatahubPgQueueConsumer",
     "DatahubPgQueueEmitter",
+    "DatahubPgQueueMclProducer",
     "PgQueueAuthMode",
     "PgQueueConnectionConfig",
     "PayloadRouteKind",
     "PgQueueConsumerConfig",
     "PgQueueEmitterConfig",
+    "PgQueueMclProducerConfig",
     "PgQueueTopicDefaultsConfig",
 ]
 
@@ -53,4 +56,8 @@ def __getattr__(name: str) -> Any:
         from datahub.pgqueue.emitter import DatahubPgQueueEmitter
 
         return DatahubPgQueueEmitter
+    if name == "DatahubPgQueueMclProducer":
+        from datahub.pgqueue.mcl_producer import DatahubPgQueueMclProducer
+
+        return DatahubPgQueueMclProducer
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/metadata-ingestion/src/datahub/pgqueue/config.py
+++ b/metadata-ingestion/src/datahub/pgqueue/config.py
@@ -263,6 +263,49 @@ class PgQueueEmitterConfig(ConfigModel):
         return v
 
 
+class PgQueueMclProducerConfig(ConfigModel):
+    """Produce MetadataChangeLog records into an arbitrary pgQueue topic.
+
+    Topic is supplied per ``produce()`` call — there is no ``topic_routes`` map.
+    """
+
+    queue: PgQueueConnectionConfig
+
+    schema_registry_url: str = Field(
+        default_factory=_get_schema_registry_url,
+        description="Schema Registry URL (same as Kafka / pgQueue emitter).",
+    )
+
+    schema_registry_config: Dict[str, object] = Field(
+        default_factory=dict,
+        description="Extra Schema Registry client options.",
+    )
+
+    content_type: str = Field(
+        default="application/avro",
+        description=(
+            "Logical payload MIME after decompression; resolved to message.content_type_id (or omitted "
+            "when equal to the topic default)."
+        ),
+    )
+
+    payload_compression: Literal["NONE", "SNAPPY"] = Field(
+        default="SNAPPY",
+        description=(
+            "Application-layer codec for serialized Avro bytes; stored in message.payload_compression. "
+            "Align with postgres.pgQueue.payloadCompression / DATAHUB_PGQUEUE_PAYLOAD_COMPRESSION when "
+            "emitting to GMS."
+        ),
+    )
+
+    default_priority: int = Field(
+        default=5,
+        ge=0,
+        le=9,
+        description="Enqueue priority (0 = highest, 9 = lowest, 5 = default/normal).",
+    )
+
+
 class PgQueueConsumerConfig(ConfigModel):
     """Consume pgQueue messages and deserialize Avro like DataHubKafkaReader."""
 

--- a/metadata-ingestion/src/datahub/pgqueue/mcl_producer.py
+++ b/metadata-ingestion/src/datahub/pgqueue/mcl_producer.py
@@ -1,0 +1,120 @@
+"""Topic-agnostic MCL producer backed by pgQueue tables.
+
+Python counterpart to Java ``PgQueueEventProducer.publishRawTopicConfluentAvro`` /
+``produceMCL``. Callers pass the logical queue topic name on every ``produce`` call
+(e.g. ``WorkEvent_v1``, ``MetadataChangeLog_Versioned_v1``).
+
+Unlike Java's soft-skip when Schema Registry lacks a subject for the topic, this
+producer fails hard (callback with error; callers that need raise-on-failure should
+re-raise from the callback). Executor redelivery depends on that.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Optional
+
+from confluent_kafka.schema_registry import SchemaRegistryClient
+from confluent_kafka.schema_registry.avro import AvroSerializer
+from confluent_kafka.serialization import MessageField, SerializationContext
+
+from datahub.ingestion.api.closeable import Closeable
+from datahub.metadata.schema_classes import MetadataChangeLogClass
+from datahub.pgqueue.compression import (
+    PgQueuePayloadCompression,
+    encode_inner,
+)
+from datahub.pgqueue.config import PgQueueMclProducerConfig
+from datahub.pgqueue.connection import create_pgqueue_connection, flush_pg_connection
+from datahub.pgqueue.repository import PgQueueRepository
+
+logger = logging.getLogger(__name__)
+
+
+class DatahubPgQueueMclProducer(Closeable):
+    """Serialize MCL like Kafka WorkEventProducer but persist bytes to PostgreSQL."""
+
+    def __init__(self, config: PgQueueMclProducerConfig) -> None:
+        self.config = config
+        qconf = config.queue
+        self._repo = PgQueueRepository(qconf.queue_schema, qconf.table_prefix)
+
+        schema_registry_conf = {
+            "url": config.schema_registry_url,
+            **config.schema_registry_config,
+        }
+        registry = SchemaRegistryClient(schema_registry_conf)
+
+        def mcl_dict(mcl: MetadataChangeLogClass, ctx: SerializationContext) -> dict:
+            return mcl.to_obj(tuples=True)
+
+        self._mcl_serializer = AvroSerializer(
+            schema_str=str(MetadataChangeLogClass.RECORD_SCHEMA),
+            schema_registry_client=registry,
+            to_dict=mcl_dict,
+        )
+
+        self._conn = create_pgqueue_connection(qconf)
+
+    def produce(
+        self,
+        topic: str,
+        event: MetadataChangeLogClass,
+        *,
+        routing_key: Optional[str] = None,
+        callback: Optional[Callable[[Exception, str], None]] = None,
+    ) -> None:
+        """Enqueue a Confluent-Avro-serialized MCL on the given logical queue topic.
+
+        Unlike Java ``PgQueueEventProducer``, serialization / Schema Registry failures
+        do not soft-skip — the callback receives the error (and callers may re-raise).
+        """
+        cb = callback or _error_reporting_callback
+        try:
+            key = routing_key if routing_key is not None else event.entityUrn
+            if not key:
+                raise ValueError(
+                    "MetadataChangeLog requires entityUrn (or routing_key) for pgQueue routing key"
+                )
+
+            ctx = SerializationContext(topic, MessageField.VALUE)
+            serialized = self._mcl_serializer(event, ctx)
+            if serialized is None:
+                raise RuntimeError("Avro serialization returned None")
+
+            td = self.config.queue.merged_topic_defaults_for(topic)
+            mode = PgQueuePayloadCompression[self.config.payload_compression]
+            stored = encode_inner(serialized, mode)
+            self._repo.enqueue(
+                self._conn,
+                topic_name=topic,
+                routing_key=key,
+                partition_count=td.partition_count,
+                retention_max_age_seconds=td.retention_max_age_seconds,
+                max_rows_per_topic=td.max_rows_per_topic,
+                max_total_payload_bytes=td.max_total_payload_bytes_per_topic,
+                default_content_type_mime=td.default_content_type_mime,
+                aggressive_retention=td.aggressive_retention,
+                priority=self.config.default_priority,
+                payload=stored,
+                content_type=self.config.content_type,
+                headers=(),
+                payload_compression=int(mode),
+            )
+            cb(None, "pgQueue enqueue succeeded")  # type: ignore[arg-type]
+        except Exception as e:
+            cb(e, "pgQueue enqueue failed")
+
+    def flush(self) -> None:
+        flush_pg_connection(self._conn)
+
+    def close(self) -> None:
+        try:
+            self.flush()
+        finally:
+            self._conn.close()
+
+
+def _error_reporting_callback(err: Optional[Exception], msg: str) -> None:
+    if err:
+        logger.error("Failed to produce MCL to pgQueue: %s %s", err, msg)

--- a/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_mcl_producer.py
+++ b/metadata-ingestion/tests/unit/pgqueue/test_pgqueue_mcl_producer.py
@@ -1,0 +1,215 @@
+"""Unit tests for :mod:`datahub.pgqueue.mcl_producer` (no database, no Schema Registry)."""
+
+from __future__ import annotations
+
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+from confluent_kafka.serialization import MessageField
+
+from datahub.metadata.schema_classes import MetadataChangeLogClass
+from datahub.pgqueue.compression import PgQueuePayloadCompression, encode_inner
+from datahub.pgqueue.config import PgQueueConnectionConfig, PgQueueMclProducerConfig
+
+_DEFAULT_URN = "urn:li:dataset:(urn:li:dataPlatform:postgres,db.tbl,PROD)"
+
+
+def _make_config(
+    *,
+    payload_compression: str = "SNAPPY",
+) -> PgQueueMclProducerConfig:
+    return PgQueueMclProducerConfig(
+        queue=PgQueueConnectionConfig(
+            host_port="localhost:5432",
+            database="datahub",
+            username="pguser",
+            password="secret",
+        ),
+        schema_registry_url="http://localhost:8081",
+        payload_compression=payload_compression,  # type: ignore[arg-type]
+    )
+
+
+def _make_mcl(*, entity_urn: Optional[str] = _DEFAULT_URN) -> MagicMock:
+    mcl = MagicMock(spec=MetadataChangeLogClass)
+    mcl.entityUrn = entity_urn
+    mcl.to_obj = MagicMock(return_value={})
+    return mcl
+
+
+@pytest.fixture()
+def producer_config() -> PgQueueMclProducerConfig:
+    return _make_config()
+
+
+class TestProduce:
+    @patch("datahub.pgqueue.mcl_producer.create_pgqueue_connection")
+    @patch("datahub.pgqueue.mcl_producer.AvroSerializer")
+    @patch("datahub.pgqueue.mcl_producer.SchemaRegistryClient")
+    def test_uses_caller_topic_for_serialization_and_enqueue(
+        self,
+        _sr_cls: MagicMock,
+        avro_ser_cls: MagicMock,
+        _conn_fn: MagicMock,
+        producer_config: PgQueueMclProducerConfig,
+    ) -> None:
+        fake_serializer = MagicMock(return_value=b"\x00payload")
+        avro_ser_cls.return_value = fake_serializer
+
+        from datahub.pgqueue.mcl_producer import DatahubPgQueueMclProducer
+
+        producer = DatahubPgQueueMclProducer(producer_config)
+        mcl = _make_mcl()
+        topic = "WorkEvent_v1"
+
+        with patch.object(producer, "_repo") as mock_repo:
+            callback = MagicMock()
+            producer.produce(topic, mcl, callback=callback)
+
+            fake_serializer.assert_called_once()
+            event_arg, ctx = fake_serializer.call_args[0]
+            assert event_arg is mcl
+            assert ctx.topic == topic
+            assert ctx.field == MessageField.VALUE
+
+            mock_repo.enqueue.assert_called_once()
+            assert mock_repo.enqueue.call_args.kwargs["topic_name"] == topic
+            assert mock_repo.enqueue.call_args.kwargs["routing_key"] == mcl.entityUrn
+            callback.assert_called_once()
+            assert callback.call_args[0][0] is None
+
+    @patch("datahub.pgqueue.mcl_producer.create_pgqueue_connection")
+    @patch("datahub.pgqueue.mcl_producer.AvroSerializer")
+    @patch("datahub.pgqueue.mcl_producer.SchemaRegistryClient")
+    def test_routing_key_override(
+        self,
+        _sr_cls: MagicMock,
+        avro_ser_cls: MagicMock,
+        _conn_fn: MagicMock,
+        producer_config: PgQueueMclProducerConfig,
+    ) -> None:
+        avro_ser_cls.return_value = MagicMock(return_value=b"\x00avro")
+
+        from datahub.pgqueue.mcl_producer import DatahubPgQueueMclProducer
+
+        producer = DatahubPgQueueMclProducer(producer_config)
+        mcl = _make_mcl()
+
+        with patch.object(producer, "_repo") as mock_repo:
+            producer.produce(
+                "MetadataChangeLog_Versioned_v1",
+                mcl,
+                routing_key="custom-key",
+                callback=MagicMock(),
+            )
+            assert mock_repo.enqueue.call_args.kwargs["routing_key"] == "custom-key"
+
+    @patch("datahub.pgqueue.mcl_producer.create_pgqueue_connection")
+    @patch("datahub.pgqueue.mcl_producer.AvroSerializer")
+    @patch("datahub.pgqueue.mcl_producer.SchemaRegistryClient")
+    def test_missing_urn_reports_error_and_skips_enqueue(
+        self,
+        _sr_cls: MagicMock,
+        avro_ser_cls: MagicMock,
+        _conn_fn: MagicMock,
+        producer_config: PgQueueMclProducerConfig,
+    ) -> None:
+        avro_ser_cls.return_value = MagicMock(return_value=b"\x00avro")
+
+        from datahub.pgqueue.mcl_producer import DatahubPgQueueMclProducer
+
+        producer = DatahubPgQueueMclProducer(producer_config)
+        mcl = _make_mcl(entity_urn=None)
+
+        with patch.object(producer, "_repo") as mock_repo:
+            callback = MagicMock()
+            producer.produce("WorkEvent_v1", mcl, callback=callback)
+
+            mock_repo.enqueue.assert_not_called()
+            err = callback.call_args[0][0]
+            assert isinstance(err, ValueError)
+            assert "entityUrn" in str(err)
+
+    @patch("datahub.pgqueue.mcl_producer.create_pgqueue_connection")
+    @patch("datahub.pgqueue.mcl_producer.AvroSerializer")
+    @patch("datahub.pgqueue.mcl_producer.SchemaRegistryClient")
+    def test_enqueue_failure_invokes_callback_with_error(
+        self,
+        _sr_cls: MagicMock,
+        avro_ser_cls: MagicMock,
+        _conn_fn: MagicMock,
+        producer_config: PgQueueMclProducerConfig,
+    ) -> None:
+        avro_ser_cls.return_value = MagicMock(return_value=b"\x00avro")
+
+        from datahub.pgqueue.mcl_producer import DatahubPgQueueMclProducer
+
+        producer = DatahubPgQueueMclProducer(producer_config)
+        mcl = _make_mcl()
+
+        with patch.object(producer, "_repo") as mock_repo:
+            mock_repo.enqueue.side_effect = RuntimeError("db down")
+            callback = MagicMock()
+            producer.produce("WorkEvent_v1", mcl, callback=callback)
+
+            err = callback.call_args[0][0]
+            assert isinstance(err, RuntimeError)
+            assert "db down" in str(err)
+
+    @patch("datahub.pgqueue.mcl_producer.encode_inner", wraps=encode_inner)
+    @patch("datahub.pgqueue.mcl_producer.create_pgqueue_connection")
+    @patch("datahub.pgqueue.mcl_producer.AvroSerializer")
+    @patch("datahub.pgqueue.mcl_producer.SchemaRegistryClient")
+    def test_compression_mode_passed_through(
+        self,
+        _sr_cls: MagicMock,
+        avro_ser_cls: MagicMock,
+        _conn_fn: MagicMock,
+        encode_inner_mock: MagicMock,
+    ) -> None:
+        avro_ser_cls.return_value = MagicMock(return_value=b"\x00avro")
+        config = _make_config(payload_compression="NONE")
+
+        from datahub.pgqueue.mcl_producer import DatahubPgQueueMclProducer
+
+        producer = DatahubPgQueueMclProducer(config)
+        mcl = _make_mcl()
+
+        with patch.object(producer, "_repo") as mock_repo:
+            producer.produce("WorkEvent_v1", mcl, callback=MagicMock())
+
+            encode_inner_mock.assert_called_once_with(
+                b"\x00avro", PgQueuePayloadCompression.NONE
+            )
+            assert mock_repo.enqueue.call_args.kwargs["payload_compression"] == int(
+                PgQueuePayloadCompression.NONE
+            )
+
+
+class TestFlushClose:
+    @patch("datahub.pgqueue.mcl_producer.flush_pg_connection")
+    @patch("datahub.pgqueue.mcl_producer.create_pgqueue_connection")
+    @patch("datahub.pgqueue.mcl_producer.AvroSerializer")
+    @patch("datahub.pgqueue.mcl_producer.SchemaRegistryClient")
+    def test_flush_and_close(
+        self,
+        _sr_cls: MagicMock,
+        avro_ser_cls: MagicMock,
+        conn_fn: MagicMock,
+        flush_fn: MagicMock,
+        producer_config: PgQueueMclProducerConfig,
+    ) -> None:
+        avro_ser_cls.return_value = MagicMock(return_value=b"x")
+        mock_conn = MagicMock()
+        conn_fn.return_value = mock_conn
+
+        from datahub.pgqueue.mcl_producer import DatahubPgQueueMclProducer
+
+        producer = DatahubPgQueueMclProducer(producer_config)
+        producer.flush()
+        flush_fn.assert_called_once_with(mock_conn)
+
+        producer.close()
+        assert flush_fn.call_count == 2
+        mock_conn.close.assert_called_once()


### PR DESCRIPTION
## Summary
- Add `DatahubPgQueueMclProducer` / `PgQueueMclProducerConfig` as a sibling to the MCP-only `DatahubPgQueueEmitter`, so callers pass the logical queue topic on every `produce()` (e.g. `WorkEvent_v1`, `MetadataChangeLog_Versioned_v1`).
- Serialize MCL with Confluent `AvroSerializer` over `MetadataChangeLogClass.RECORD_SCHEMA` and enqueue via the existing encode/compress + `PgQueueRepository` path.
- Fail hard on Schema Registry / serialize / enqueue errors (unlike Java’s soft-skip when schema id is missing), so executor-style redelivery can rely on raise-from-callback.

## Test plan
- [x] `./gradlew :metadata-ingestion:lintFix`
- [x] `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/pgqueue/test_pgqueue_mcl_producer.py` (6 passed)
- [ ] Follow-up: wire executor pgQueue WorkEvent path to this producer after `acryl-datahub` pin picks up the release


Made with [Cursor](https://cursor.com)