### PR TITLE
feat(auth): schemaField VBAC parent dataset inheritance

### DIFF
--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtilsTest.java
@@ -21,6 +21,7 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.ViewProperties;
 import com.linkedin.knowledge.DocumentInfo;
 import com.linkedin.metadata.aspect.AspectRetriever;
+import com.linkedin.metadata.authorization.EntityAuthorizationUtils;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.service.DocumentAuthorizationUtils;
 import io.datahubproject.metadata.context.OperationContext;
@@ -39,6 +40,9 @@ public class AuthorizationUtilsTest {
       UrnUtils.getUrn("urn:li:document:bridge-dataset-graphql-test");
   private static final Urn TEST_SOURCE_URN =
       UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:testPlatform,bridge-source,PROD)");
+  private static final Urn TEST_SCHEMA_FIELD_URN =
+      UrnUtils.getUrn(
+          "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD),field_foo)");
 
   @Test
   public void testRestrictedViewProperties() {
@@ -259,5 +263,34 @@ public class AuthorizationUtilsTest {
     authUtil
         .when(() -> AuthUtil.canViewEntity(eq(opContext), eq(TEST_SOURCE_URN)))
         .thenReturn(canViewSource);
+  }
+
+  @Test
+  public void testCanViewSchemaFieldUsesEntityAuthorizationFacade() {
+    OperationContext opContext = mock(OperationContext.class);
+    OperationContextConfig config = mock(OperationContextConfig.class);
+    ViewAuthorizationConfiguration viewAuth =
+        ViewAuthorizationConfiguration.builder().enabled(true).build();
+    when(opContext.getOperationContextConfig()).thenReturn(config);
+    when(config.getViewAuthorizationConfiguration()).thenReturn(viewAuth);
+    when(opContext.isSystemAuth()).thenReturn(false);
+
+    try (MockedStatic<AuthUtil> authUtil =
+            Mockito.mockStatic(AuthUtil.class, Mockito.CALLS_REAL_METHODS);
+        MockedStatic<EntityAuthorizationUtils> entityAuth =
+            Mockito.mockStatic(EntityAuthorizationUtils.class)) {
+      authUtil
+          .when(() -> AuthUtil.isViewRestrictedEntityType(eq(viewAuth), eq("schemaField")))
+          .thenReturn(true);
+      entityAuth
+          .when(
+              () ->
+                  EntityAuthorizationUtils.canViewEntity(eq(opContext), eq(TEST_SCHEMA_FIELD_URN)))
+          .thenReturn(true);
+
+      assertTrue(AuthorizationUtils.canView(opContext, TEST_SCHEMA_FIELD_URN));
+      entityAuth.verify(
+          () -> EntityAuthorizationUtils.canViewEntity(opContext, TEST_SCHEMA_FIELD_URN));
+    }
   }
 }

--- a/docs/authorization/policies.md
+++ b/docs/authorization/policies.md
@@ -218,7 +218,9 @@ When VBAC is enabled (Cloud Search Access Controls **or** OSS `VIEW_AUTHORIZATIO
 `VIEW_UNRESTRICTED_ENTITY_TYPES` / `_ADD` / `_REMOVE` overlays (see
 [Environment Variables](../deploy/environment-vars.md)), bypass view checks. Stock `_ADD` covers the previous
 unrestricted set minus registry-flagged types; trim with `VIEW_UNRESTRICTED_ENTITY_TYPES_REMOVE` (for example
-`schemaField,document`) when you want those types under view policy. **Search Access Controls** (query-time search
+`schemaField,document`) when you want those types under view policy. Once `schemaField` is restricted,
+**View Entity Page** inherits from the parent dataset encoded in the schemaField URN (then a direct
+column grant). **Search Access Controls** (query-time search
 filtering) remain **DataHub Cloud–only**; on OSS the unrestricted list only affects entity-page / masking behavior.
 Cloud operators: see also
 [Entity types that bypass view checks](../features/feature-guides/search-access-controls.md#entity-types-that-bypass-view-checks).
@@ -483,6 +485,12 @@ Domain URNs are read from the product's `domains` aspect, preferring `domainAsso
 | Read Query metadata (GraphQL, Rest.li, search when view auth is on) | **View Entity Page** **or** **Edit Dataset Queries** | **Every** subject dataset in `querySubjects` |
 
 Query entities with **no subjects** are not readable when view authorization is enabled (fail-closed). Schema field subjects are resolved to their parent dataset for authorization. **Edit Entity** on a subject dataset also grants read access (same disjunction as write).
+
+#### Schema field entities (view)
+
+When `schemaField` is view-restricted, **View Entity Page** on a schema field succeeds if the actor
+can view the containing parent URN in the schemaField key (typically a dataset) **or** has a direct
+grant on the schemaField URN. This uses the same parent-candidate order as logical-parent writes.
 
 View authorization is controlled by `VIEW_AUTHORIZATION_ENABLED` (see [Environment Variables](../deploy/environment-vars.md)).
 

--- a/docs/authorization/policies.md
+++ b/docs/authorization/policies.md
@@ -492,6 +492,12 @@ When `schemaField` is view-restricted, **View Entity Page** on a schema field su
 can view the containing parent URN in the schemaField key (typically a dataset) **or** has a direct
 grant on the schemaField URN. This uses the same parent-candidate order as logical-parent writes.
 
+On **DataHub Cloud** with Search Access Controls, query-time filters for columns are narrower than
+entity-page inheritance: domain / container / resource-owner criteria do not match schemaField docs,
+and `TYPE = dataset` policies exclude them. URN dataset grants can match columns via a Cloud-only
+prefix. Details:
+[Columns (`schemaField`) after you restrict them](../features/feature-guides/search-access-controls.md#columns-schemafield-after-you-restrict-them).
+
 View authorization is controlled by `VIEW_AUTHORIZATION_ENABLED` (see [Environment Variables](../deploy/environment-vars.md)).
 
 #### Logical parent (`logicalParent` aspect)

--- a/docs/features/feature-guides/search-access-controls.md
+++ b/docs/features/feature-guides/search-access-controls.md
@@ -59,6 +59,35 @@ applies to core view authorization when `VIEW_AUTHORIZATION_ENABLED=true` on sel
 gates entity pages / post-search masking on OSS; **query-time search filtering remains DataHub Cloud–only** (see the
 note at the top of this page). Breaking-change details: [updating DataHub](../../how/updating-datahub.md).
 
+#### Columns (`schemaField`) after you restrict them
+
+Once `schemaField` is removed from the unrestricted list, two different paths apply:
+
+1. **Entity page / schema tab (VBAC)** — Viewing a column inherits **View Entity** from the parent dataset encoded
+   in the schemaField URN (`urn:li:schemaField:(<datasetUrn>,<fieldPath>)`), then falls back to a direct grant on
+   the column URN. Users who can open a dataset can open its columns even when the column itself has no domains,
+   owners, or containers.
+2. **Search results (SBAC, Cloud only)** — Query-time filters still evaluate **facets on the indexed hit**. Column
+   documents generally do **not** store parent domain, container, or owner fields, so those policy criteria do not
+   match columns the way they match datasets.
+
+**Cloud SBAC limitations for `schemaField`:**
+
+| Policy shape                                                                        | Datasets in search                    | Columns (`schemaField`) in search                                                                                      |
+| ----------------------------------------------------------------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Domain / container / resource-owner filters                                         | Matched via facets on the dataset doc | **Not matched** — column docs lack those facets; there is no parent-domain/container/owner pushdown                    |
+| `TYPE = dataset` (alone or ANDed with other filters)                                | Matched                               | **Excluded** — the type clause requires `dataset`, so `schemaField` hits fail even if a sibling URN clause would match |
+| URN equals / starts-with on a dataset (and type is unset or includes `schemaField`) | Matched                               | **Matched** — Cloud expands URN filters with a prefix on `urn:li:schemaField:(<datasetUrn>,`                           |
+
+So domain-scoped “View Entity on datasets in Finance” policies correctly hide Finance datasets from unauthorized
+users and still allow authorized users to browse columns on the dataset page, but they **will not list those
+columns as separate search hits**. To surface columns in search under SAC, use URN-scoped grants (without a
+`TYPE = dataset`-only constraint), an explicit `TYPE = schemaField` policy, or keep `schemaField` unrestricted
+(not recommended if columns must not leak in search).
+
+OSS does **not** implement this URN-prefix search pushdown; self-hosted `VIEW_AUTHORIZATION_ENABLED` only gates
+entity pages / post-search masking.
+
 ### Policy-Based Filtering
 
 Search results are automatically filtered based on:
@@ -330,6 +359,14 @@ Yes. The same filtering applies to programmatic access via the GraphQL API. User
 `VIEW_UNRESTRICTED_ENTITY_TYPES`). Documents are view-restricted by default; if users can view them without a grant,
 check whether `document` was added through `VIEW_UNRESTRICTED_ENTITY_TYPES` or `_ADD`. See
 [Entity types that bypass view checks](#entity-types-that-bypass-view-checks).
+
+**After restricting `schemaField`, why don’t columns appear in search for users who can see the parent dataset?**
+
+Entity-page access inherits from the parent dataset, but **Cloud search filtering does not**. Domain, container,
+and resource-owner policies match facets on the search document; column docs usually lack those facets.
+Policies that set `TYPE = dataset` also exclude `schemaField` hits. URN-scoped dataset grants can match columns
+via a Cloud-only URN prefix. See
+[Columns (`schemaField`) after you restrict them](#columns-schemafield-after-you-restrict-them).
 
 **Can I create a policy that denies access instead of granting it?**
 

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -178,6 +178,13 @@ Requirements:
 
 - **(GMS / Structured Properties)** System-update reindex detection now compares Elasticsearch field `type` for structured properties that already exist in both current and target mappings. This repairs indices where NUMBER properties were locked as `float`/`long` by dynamic mapping before an explicit `double` put-mapping landed. Requires both `ENABLE_STRUCTURED_PROPERTIES_SYSTEM_UPDATE=true` and `ENABLE_STRUCTURED_PROPERTIES_TYPE_MISMATCH_REINDEX=true` / `structuredProperties.typeMismatchReindexEnabled` (default `true`).
 
+- **(GMS / View Authorization)** When `schemaField` is view-restricted (for example via
+  `VIEW_UNRESTRICTED_ENTITY_TYPES_REMOVE=schemaField`), **View Entity Page** checks inherit from the
+  parent dataset encoded in the schemaField URN
+  (`urn:li:schemaField:(<datasetUrn>,<fieldPath>)`), then fall back to a direct grant on the column
+  URN. This matches the existing logical-parent write candidate order. Query-time search filtering
+  (SBAC) remains DataHub Cloud–only; OSS still includes `schemaField` in default search.
+
 - **(GMS / search defaults)** Default entity-type lists for GraphQL search, autocomplete, browse V2, and quick-filter priority are now configurable via `elasticsearch.search.*EntityTypes` (`value` / `add` / `remove`) and the matching `SEARCH_*_ENTITY_TYPES{,_ADD,_REMOVE}` environment variables. Stock YAML defaults match the former hardcoded GraphQL lists. An explicitly empty resolved list means GraphQL searches **no** entity types (it does not expand to all indices). Unknown registry names in these lists are soft-dropped with a warn at startup. See [Environment Variables](../deploy/environment-vars.md) and [Customizing Search](search.md#default-search-entity-types).
 
 - **(Metadata Model / Semantic Model)** Logical datasets exposed by a `semanticModel` are now first-class `dataset` entities (with the `Semantic Model Dataset` subtype and a `semanticModelProperties` aspect) rather than an embedded `ModelDataset`/`SemanticField` record; per-field semantic metadata lives on `semanticFieldAnnotation`. The `Contains` relationship on `semanticModelInfo.datasets` is a lineage edge, so semantic-model-backed metrics follow `Metric → SemanticModel → Logical Dataset → Physical Dataset`. Populate `metricUpstreams` only for metrics without a semantic model. No external release has shipped this model yet.

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -182,8 +182,13 @@ Requirements:
   `VIEW_UNRESTRICTED_ENTITY_TYPES_REMOVE=schemaField`), **View Entity Page** checks inherit from the
   parent dataset encoded in the schemaField URN
   (`urn:li:schemaField:(<datasetUrn>,<fieldPath>)`), then fall back to a direct grant on the column
-  URN. This matches the existing logical-parent write candidate order. Query-time search filtering
-  (SBAC) remains DataHub Cloud–only; OSS still includes `schemaField` in default search.
+  URN. This matches the existing logical-parent write candidate order. **DataHub Cloud Search Access
+  Controls** can also match columns under **URN** dataset grants via a
+  `urn:li:schemaField:(<datasetUrn>,` prefix, but domain / container / resource-owner filters still do
+  not match column docs (those facets are not on schemaField), and policies with `TYPE = dataset`
+  continue to exclude `schemaField` hits. See
+  [Columns (`schemaField`) after you restrict them](../features/feature-guides/search-access-controls.md#columns-schemafield-after-you-restrict-them).
+  OSS has no SBAC pushdown and still includes `schemaField` in default search.
 
 - **(GMS / search defaults)** Default entity-type lists for GraphQL search, autocomplete, browse V2, and quick-filter priority are now configurable via `elasticsearch.search.*EntityTypes` (`value` / `add` / `remove`) and the matching `SEARCH_*_ENTITY_TYPES{,_ADD,_REMOVE}` environment variables. Stock YAML defaults match the former hardcoded GraphQL lists. An explicitly empty resolved list means GraphQL searches **no** entity types (it does not expand to all indices). Unknown registry names in these lists are soft-dropped with a warn at startup. See [Environment Variables](../deploy/environment-vars.md) and [Customizing Search](search.md#default-search-entity-types).
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/authorization/EntityAspectAuthorizationUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/authorization/EntityAspectAuthorizationUtils.java
@@ -95,6 +95,32 @@ public final class EntityAspectAuthorizationUtils {
   }
 
   /**
+   * Returns true when the actor may view {@code schemaFieldUrn}. Schema fields inherit VIEW from
+   * the containing parent URN encoded in the schemaField key (typically a dataset), then fall back
+   * to a direct grant on the schemaField URN itself.
+   *
+   * <p>Uses {@link #resolveLogicalParentAuthorizationCandidates(Urn)} so write and view paths share
+   * the same parent resolution. Non-schemaField URNs are checked directly via {@link
+   * com.datahub.authorization.AuthUtil#canViewEntity}.
+   */
+  public static boolean canViewSchemaFieldEntity(
+      @Nonnull AuthorizationSession session, @Nonnull Urn schemaFieldUrn) {
+    if (!SCHEMA_FIELD_ENTITY_NAME.equals(schemaFieldUrn.getEntityType())) {
+      return com.datahub.authorization.AuthUtil.canViewEntity(session, schemaFieldUrn);
+    }
+    for (Urn candidate : resolveLogicalParentAuthorizationCandidates(schemaFieldUrn)) {
+      if (com.datahub.authorization.AuthUtil.canViewEntity(session, candidate)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static boolean isSchemaFieldEntity(@Nonnull Urn urn) {
+    return SCHEMA_FIELD_ENTITY_NAME.equals(urn.getEntityType());
+  }
+
+  /**
    * Returns true when the actor may write {@code logicalParent} on {@code childUrn}. Setting a
    * parent requires {@code EDIT_ENTITY} on both the child and proposed parent — each side is
    * evaluated independently (dataset or schema field URN for that side). Clearing a parent requires

--- a/metadata-io/src/main/java/com/linkedin/metadata/authorization/EntityAuthorizationUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/authorization/EntityAuthorizationUtils.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.authorization;
 
 import static com.linkedin.metadata.Constants.DOCUMENT_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.QUERY_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.SCHEMA_FIELD_ENTITY_NAME;
 import static com.linkedin.metadata.authorization.ApiGroup.ENTITY;
 import static com.linkedin.metadata.authorization.ApiOperation.READ;
 
@@ -47,8 +48,8 @@ import org.apache.http.HttpStatus;
  * </ul>
  *
  * <p>Default API behavior delegates to {@link AuthUtil}. Entity-specific utilities are consulted
- * only when a URN or MCP requires specialized authorization (currently documents, with query VIEW
- * handled for search/view paths).
+ * only when a URN or MCP requires specialized authorization (currently documents, with query and
+ * schema field VIEW handled for search/view paths).
  */
 @Slf4j
 public final class EntityAuthorizationUtils {
@@ -230,8 +231,8 @@ public final class EntityAuthorizationUtils {
    * Shared entity VIEW privilege evaluator. Not gated by View Authorization or REST API
    * authorization flags — callers wrap this when they need those activation switches.
    *
-   * <p>Query entities inherit from subjects; documents use bridge-aware document VIEW; all others
-   * use {@link AuthUtil}.
+   * <p>Query entities inherit from subjects; schema fields inherit from their containing dataset;
+   * documents use bridge-aware document VIEW; all others use {@link AuthUtil}.
    */
   public static boolean canViewEntity(@Nonnull OperationContext opContext, @Nonnull Urn urn) {
     if (QUERY_ENTITY_NAME.equals(urn.getEntityType())) {
@@ -240,6 +241,9 @@ public final class EntityAuthorizationUtils {
     }
     if (DOCUMENT_ENTITY_NAME.equals(urn.getEntityType())) {
       return DocumentAuthorizationUtils.canViewDocumentEntity(opContext, urn);
+    }
+    if (SCHEMA_FIELD_ENTITY_NAME.equals(urn.getEntityType())) {
+      return EntityAspectAuthorizationUtils.canViewSchemaFieldEntity(opContext, urn);
     }
     return AuthUtil.canViewEntity(opContext, urn);
   }

--- a/metadata-io/src/test/java/com/linkedin/metadata/authorization/EntityAspectAuthorizationUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/authorization/EntityAspectAuthorizationUtilsTest.java
@@ -780,6 +780,51 @@ public class EntityAspectAuthorizationUtilsTest {
   }
 
   @Test
+  public void testCanViewSchemaFieldEntity_allowsViaParentDataset() {
+    authUtilMockedStatic
+        .when(() -> AuthUtil.canViewEntity(eq(mockAuthSession), eq(PHYSICAL_DATASET)))
+        .thenReturn(true);
+
+    Assert.assertTrue(
+        EntityAspectAuthorizationUtils.canViewSchemaFieldEntity(
+            mockAuthSession, PHYSICAL_SCHEMA_FIELD));
+  }
+
+  @Test
+  public void testCanViewSchemaFieldEntity_allowsViaDirectSchemaFieldGrant() {
+    authUtilMockedStatic
+        .when(() -> AuthUtil.canViewEntity(eq(mockAuthSession), eq(PHYSICAL_DATASET)))
+        .thenReturn(false);
+    authUtilMockedStatic
+        .when(() -> AuthUtil.canViewEntity(eq(mockAuthSession), eq(PHYSICAL_SCHEMA_FIELD)))
+        .thenReturn(true);
+
+    Assert.assertTrue(
+        EntityAspectAuthorizationUtils.canViewSchemaFieldEntity(
+            mockAuthSession, PHYSICAL_SCHEMA_FIELD));
+  }
+
+  @Test
+  public void testCanViewSchemaFieldEntity_deniesWithoutParentOrDirectGrant() {
+    authUtilMockedStatic
+        .when(() -> AuthUtil.canViewEntity(eq(mockAuthSession), eq(PHYSICAL_DATASET)))
+        .thenReturn(false);
+    authUtilMockedStatic
+        .when(() -> AuthUtil.canViewEntity(eq(mockAuthSession), eq(PHYSICAL_SCHEMA_FIELD)))
+        .thenReturn(false);
+
+    Assert.assertFalse(
+        EntityAspectAuthorizationUtils.canViewSchemaFieldEntity(
+            mockAuthSession, PHYSICAL_SCHEMA_FIELD));
+  }
+
+  @Test
+  public void testIsSchemaFieldEntity() {
+    Assert.assertTrue(EntityAspectAuthorizationUtils.isSchemaFieldEntity(PHYSICAL_SCHEMA_FIELD));
+    Assert.assertFalse(EntityAspectAuthorizationUtils.isSchemaFieldEntity(PHYSICAL_DATASET));
+  }
+
+  @Test
   public void testIsQueryEntity() {
     Assert.assertTrue(EntityAspectAuthorizationUtils.isQueryEntity(QUERY_URN));
     Assert.assertFalse(EntityAspectAuthorizationUtils.isQueryEntity(ASSET_URN));

--- a/metadata-io/src/test/java/com/linkedin/metadata/authorization/EntityAspectAuthorizationUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/authorization/EntityAspectAuthorizationUtilsTest.java
@@ -819,6 +819,23 @@ public class EntityAspectAuthorizationUtilsTest {
   }
 
   @Test
+  public void testCanViewSchemaFieldEntity_nonSchemaFieldDelegatesToCanViewEntity() {
+    authUtilMockedStatic
+        .when(() -> AuthUtil.canViewEntity(eq(mockAuthSession), eq(PHYSICAL_DATASET)))
+        .thenReturn(true);
+
+    Assert.assertTrue(
+        EntityAspectAuthorizationUtils.canViewSchemaFieldEntity(mockAuthSession, PHYSICAL_DATASET));
+
+    authUtilMockedStatic
+        .when(() -> AuthUtil.canViewEntity(eq(mockAuthSession), eq(PHYSICAL_DATASET)))
+        .thenReturn(false);
+
+    Assert.assertFalse(
+        EntityAspectAuthorizationUtils.canViewSchemaFieldEntity(mockAuthSession, PHYSICAL_DATASET));
+  }
+
+  @Test
   public void testIsSchemaFieldEntity() {
     Assert.assertTrue(EntityAspectAuthorizationUtils.isSchemaFieldEntity(PHYSICAL_SCHEMA_FIELD));
     Assert.assertFalse(EntityAspectAuthorizationUtils.isSchemaFieldEntity(PHYSICAL_DATASET));

--- a/metadata-io/src/test/java/com/linkedin/metadata/authorization/EntityAuthorizationUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/authorization/EntityAuthorizationUtilsTest.java
@@ -54,6 +54,9 @@ public class EntityAuthorizationUtilsTest {
   private static final Urn DATASET_URN =
       UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,facade,PROD)");
   private static final Urn QUERY_URN = UrnUtils.getUrn("urn:li:query:facade-query");
+  private static final Urn SCHEMA_FIELD_URN =
+      UrnUtils.getUrn(
+          "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,facade,PROD),field_foo)");
 
   private OperationContext opContext;
   private AspectRetriever aspectRetriever;
@@ -348,6 +351,21 @@ public class EntityAuthorizationUtilsTest {
           .thenReturn(true);
 
       assertTrue(EntityAuthorizationUtils.canViewEntity(opContext, QUERY_URN));
+    }
+  }
+
+  @Test
+  public void testCanViewEntity_delegatesSchemaFields() {
+    try (MockedStatic<EntityAspectAuthorizationUtils> schemaFieldAuth =
+        Mockito.mockStatic(EntityAspectAuthorizationUtils.class)) {
+      schemaFieldAuth
+          .when(
+              () ->
+                  EntityAspectAuthorizationUtils.canViewSchemaFieldEntity(
+                      opContext, SCHEMA_FIELD_URN))
+          .thenReturn(true);
+
+      assertTrue(EntityAuthorizationUtils.canViewEntity(opContext, SCHEMA_FIELD_URN));
     }
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESAccessControlUtilTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESAccessControlUtilTest.java
@@ -10,6 +10,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import com.datahub.authentication.Actor;
 import com.datahub.authentication.ActorType;
@@ -114,6 +116,8 @@ public class ESAccessControlUtilTest {
       UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)");
   private static final Urn RESTRICTED_RESULT_URN =
       UrnUtils.getUrn("urn:li:restricted:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)");
+  private static final Urn SCHEMA_FIELD_RESULT_URN =
+      UrnUtils.getUrn("urn:li:schemaField:(" + UNRESTRICTED_RESULT_URN + ",field_foo)");
 
   private static final String PREFIX_MATCH =
       "urn:li:dataset:(urn:li:dataPlatform:snowflake,long_tail_companions.adoption.human";
@@ -549,6 +553,17 @@ public class ESAccessControlUtilTest {
     assertEquals(result.getEntities().size(), 2);
     assertEquals(result.getEntities().get(0).getEntity(), PREFIX_MATCH_URN);
     assertEquals(result.getEntities().get(1).getEntity(), PREFIX_NO_MATCH_URN);
+  }
+
+  @Test
+  public void testSchemaFieldRestrictUrnInheritsParentDataset()
+      throws RemoteInvocationException, URISyntaxException {
+    OperationContext allowedContext =
+        sessionWithUserAGroupAandC(List.of(TEST_POLICIES.get("allUsers")));
+    assertFalse(ESAccessControlUtil.restrictUrn(allowedContext, SCHEMA_FIELD_RESULT_URN));
+
+    OperationContext deniedContext = sessionWithUserBNoGroup(List.of(TEST_POLICIES.get("domainA")));
+    assertTrue(ESAccessControlUtil.restrictUrn(deniedContext, SCHEMA_FIELD_RESULT_URN));
   }
 
   private static RestrictedService mockRestrictedService() {

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -114,7 +114,7 @@ authorization:
     #   settings / internal: globalSettings, dataHubRetention, dataHubOpenAPISchema, telemetry, dataHubUpgrade, dataHubStepState
     unrestrictedEntityTypes:
       value: ${VIEW_UNRESTRICTED_ENTITY_TYPES:}
-      add: ${VIEW_UNRESTRICTED_ENTITY_TYPES_ADD:dataHubPolicy,dataProcess,dataHubIngestionSource,dataHubSecret,service,dataHubExecutionRequest,assertion,mlModelDeployment,dataHubAccessToken,test,inviteToken,schemaField,versionSet,incident,erModelRelationship,application,semanticModel,metric,businessAttribute,dataContract,dataHubAction,dataHubConnection,platformResource,aiAgent,api,repository,agentSkill}
+      add: ${VIEW_UNRESTRICTED_ENTITY_TYPES_ADD:dataHubPolicy,dataProcess,dataHubIngestionSource,dataHubSecret,service,dataHubExecutionRequest,assertion,mlModelDeployment,dataHubAccessToken,test,inviteToken,versionSet,incident,erModelRelationship,application,semanticModel,metric,businessAttribute,dataContract,dataHubAction,dataHubConnection,platformResource,aiAgent,api,repository,agentSkill}
       remove: ${VIEW_UNRESTRICTED_ENTITY_TYPES_REMOVE:}
 
 ingestion:


### PR DESCRIPTION
## Summary
- When `schemaField` is view-restricted, **View Entity Page** inherits from the parent dataset encoded in the schemaField URN (then a direct column grant), via `resolveLogicalParentAuthorizationCandidates`.
- Wired into `AuthorizationUtils.canView` and `ESAccessControlUtil`; no SBAC/search pushdown changes on OSS.
- Docs cover entity-page inheritance and Cloud SBAC limitations for columns (domain/container/owner facets, `TYPE=dataset`).

## Test plan
- [x] `./gradlew spotlessApply` / markdown prettier — no further changes
- [x] `:datahub-graphql-core:test --tests AuthorizationUtilsTest` (12 passing)
- [x] `:metadata-io:test --tests EntityAspectAuthorizationUtilsTest` (51 passing)
- [ ] Manually: enable VBAC, `VIEW_UNRESTRICTED_ENTITY_TYPES_REMOVE=schemaField`, confirm users with View on parent dataset can open columns; users without parent/direct grant cannot


Made with [Cursor](https://cursor.com)