### PR TITLE
feat(docs): emit the Python SDK class name for every aspect

### DIFF
--- a/metadata-ingestion/scripts/modeldocgen.py
+++ b/metadata-ingestion/scripts/modeldocgen.py
@@ -28,6 +28,7 @@ from datahub.ingestion.api.sink import NoopWriteCallback
 from datahub.ingestion.extractor.schema_util import avro_schema_to_mce_fields
 from datahub.ingestion.sink.file import FileSink, FileSinkConfig
 from datahub.metadata.schema_classes import (
+    ASPECT_NAME_MAP,
     BrowsePathEntryClass,
     BrowsePathsClass,
     BrowsePathsV2Class,
@@ -918,6 +919,19 @@ def make_entity_docs(entity_display_name: str, graph: RelationshipGraph) -> str:
             this_aspect_doc += (
                 f"\n#### {aspect}{deprecated_message}{timeseries_qualifier}\n"
             )
+            # Emitted below the heading rather than in it, so the anchor slug is
+            # unchanged and existing deep links keep working.
+            #
+            # Read from the generated map rather than derived from `aspect`. The
+            # class is named after the PDL record while this heading carries the
+            # @Aspect annotation name, and those diverge for 35 of the current
+            # aspects: mlModelTrainingData -> TrainingDataClass, propertyDefinition
+            # -> StructuredPropertyDefinitionClass, mlModelProperties ->
+            # MLModelPropertiesClass. Deriving the name here would be wrong in
+            # every one of those cases.
+            aspect_class = ASPECT_NAME_MAP.get(aspect)
+            if aspect_class is not None:
+                this_aspect_doc += f"\nPython class: `{aspect_class.__name__}`\n\n"
             this_aspect_doc += f"{aspect_definition.schema.get_prop('doc')}\n\n"
 
             # Extract fields for table view

--- a/metadata-models/docs/entities/mlModel.md
+++ b/metadata-models/docs/entities/mlModel.md
@@ -308,6 +308,41 @@ The standard REST APIs can be used to retrieve ML Model entities and their aspec
 
 </details>
 
+### Aspect names and Python SDK class names
+
+When writing Python, note that the aspect name and the SDK class name do not
+follow one rule for every ML aspect. Six of the ML Model aspects drop the
+`mlModel` prefix in their generated class, so searching the SDK for the aspect
+name finds nothing:
+
+| Aspect name | Python SDK class |
+|---|---|
+| `mlModelTrainingData` | `TrainingDataClass` |
+| `mlModelEvaluationData` | `EvaluationDataClass` |
+| `mlModelEthicalConsiderations` | `EthicalConsiderationsClass` |
+| `mlModelCaveatsAndRecommendations` | `CaveatsAndRecommendationsClass` |
+| `mlModelQuantitativeAnalyses` | `QuantitativeAnalysesClass` |
+| `mlModelMetrics` | `MetricsClass` |
+
+Others keep the prefix and only change its case:
+
+| Aspect name | Python SDK class |
+|---|---|
+| `mlModelProperties` | `MLModelPropertiesClass` |
+| `mlModelFactorPrompts` | `MLModelFactorPromptsClass` |
+| `mlModelGroupProperties` | `MLModelGroupPropertiesClass` |
+| `mlFeatureProperties` | `MLFeaturePropertiesClass` |
+| `mlPrimaryKeyProperties` | `MLPrimaryKeyPropertiesClass` |
+
+Every class carries the aspect name in `ASPECT_NAME`, which is the reliable way
+to map between the two:
+
+```python
+from datahub.metadata.schema_classes import TrainingDataClass
+
+TrainingDataClass.ASPECT_NAME  # "mlModelTrainingData"
+```
+
 ## Integration Points
 
 ### Related Entities

--- a/metadata-models/docs/entities/mlModel.md
+++ b/metadata-models/docs/entities/mlModel.md
@@ -308,41 +308,6 @@ The standard REST APIs can be used to retrieve ML Model entities and their aspec
 
 </details>
 
-### Aspect names and Python SDK class names
-
-When writing Python, note that the aspect name and the SDK class name do not
-follow one rule for every ML aspect. Six of the ML Model aspects drop the
-`mlModel` prefix in their generated class, so searching the SDK for the aspect
-name finds nothing:
-
-| Aspect name | Python SDK class |
-|---|---|
-| `mlModelTrainingData` | `TrainingDataClass` |
-| `mlModelEvaluationData` | `EvaluationDataClass` |
-| `mlModelEthicalConsiderations` | `EthicalConsiderationsClass` |
-| `mlModelCaveatsAndRecommendations` | `CaveatsAndRecommendationsClass` |
-| `mlModelQuantitativeAnalyses` | `QuantitativeAnalysesClass` |
-| `mlModelMetrics` | `MetricsClass` |
-
-Others keep the prefix and only change its case:
-
-| Aspect name | Python SDK class |
-|---|---|
-| `mlModelProperties` | `MLModelPropertiesClass` |
-| `mlModelFactorPrompts` | `MLModelFactorPromptsClass` |
-| `mlModelGroupProperties` | `MLModelGroupPropertiesClass` |
-| `mlFeatureProperties` | `MLFeaturePropertiesClass` |
-| `mlPrimaryKeyProperties` | `MLPrimaryKeyPropertiesClass` |
-
-Every class carries the aspect name in `ASPECT_NAME`, which is the reliable way
-to map between the two:
-
-```python
-from datahub.metadata.schema_classes import TrainingDataClass
-
-TrainingDataClass.ASPECT_NAME  # "mlModelTrainingData"
-```
-
 ## Integration Points
 
 ### Related Entities


### PR DESCRIPTION
An aspect name and its generated Python class name are different strings, and nothing in the docs says so. Searching the SDK for the aspect name you see in the metadata model returns nothing, and the natural conclusion is that the aspect is missing from the Python SDK.

I hit this looking for `MLModelTrainingDataClass`, decided it did not exist, and only found `TrainingDataClass` by grepping the generated schema classes for `ASPECT_NAME`.

## What this changes

`modeldocgen.py` already emits a `#### <aspectName>` heading for every aspect of every entity. It now emits one line under each:

```
Python class: `TrainingDataClass`
```

Below the heading rather than inside it, so anchor slugs are unchanged and existing deep links keep working.

This replaces an earlier version of this PR that added a hand-written table to `mlModel.md`. The table only covered ML, and it was already stale when proposed: `mlModelDeploymentProperties`, `mlFeatureTableProperties` and `mlTrainingRunProperties` were missing, with nothing that would catch the next one. Generating the line from the source removes both problems, and covers datasets, dashboards, containers and everything else rather than ML alone.

## Why it reads ASPECT_NAME_MAP

The class is named after the PDL record; the heading carries the `@Aspect` annotation name. Those are independent strings. Deriving one from the other would be wrong for 35 of the 240 current aspects, in three different ways:

```
mlModelProperties    -> MLModelPropertiesClass               capitalisation
mlModelTrainingData  -> TrainingDataClass                    prefix dropped
propertyDefinition   -> StructuredPropertyDefinitionClass    prefix added
```

Deriving from the record name via `schema.name` would also be correct. `ASPECT_NAME_MAP` (`avro_codegen.py:324`) is preferred only because it reads the mapping codegen already emits rather than reconstructing the derivation, so it cannot drift if that construction changes.

## Verification

Against the installed SDK (`acryl-datahub` 1.6.0.15), all 240 aspects: every one resolves to a class, and every emitted class name is importable from `datahub.metadata.schema_classes`. Rendered output checked across dataset, dashboard, chart, container, glossary, ML and structured-property aspects.

Anchors: the diff removes no line. A control that deliberately edits the heading is caught by the same check, so the check is not vacuous.

One limitation stated plainly: I could not run `modeldocgen` itself, because it needs the gradle build outputs and there is no JDK on this machine. I exercised the same expression against the same input for all 240 aspects instead of generating. The rendered output is worth a second pair of eyes.
