### PR TITLE
docs(): Adding docs for Scoped MCP Servers

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -519,8 +519,19 @@ module.exports = {
         },
         {
           label: "MCP Server",
-          type: "doc",
-          id: "docs/features/feature-guides/mcp",
+          type: "category",
+          link: {
+            type: "doc",
+            id: "docs/features/feature-guides/mcp",
+          },
+          items: [
+            {
+              label: "Scoped MCP Servers",
+              type: "doc",
+              id: "docs/features/feature-guides/scoped-mcp-servers",
+              className: "saasOnly",
+            },
+          ],
         },
         {
           label: "Ownership",

--- a/docs/features/feature-guides/mcp.md
+++ b/docs/features/feature-guides/mcp.md
@@ -30,6 +30,8 @@ Surface real SQL queries that reference a dataset — see join patterns, common 
 **Works Where You Work** <br />
 Seamlessly integrates with Cursor, Windsurf, Claude Desktop, OpenAI, and any other MCP-compatible client.
 
+With **DataHub Cloud**, you can also create [scoped custom MCP servers](./scoped-mcp-servers.md) — named endpoints with their own tools, instructions, and views for domain-specific agents (Context Platform private beta).
+
 ## Tools
 
 The DataHub MCP Server provides the following tools, grouped by whether they read from or write to DataHub. All tools are annotated with MCP-standard hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`) so compatible clients (e.g. Claude) can surface which tools modify catalog state and prompt for confirmation accordingly.

--- a/docs/features/feature-guides/scoped-mcp-servers.md
+++ b/docs/features/feature-guides/scoped-mcp-servers.md
@@ -1,0 +1,76 @@
+---
+description: "Create scoped custom MCP servers on DataHub Cloud with their own tools, instructions, views, and connection URLs."
+---
+
+import FeatureAvailability from '@site/src/components/FeatureAvailability';
+
+# Scoped MCP Servers
+
+<FeatureAvailability saasOnly />
+
+:::info Private Beta
+Scoped MCP servers are available only to **Context Platform** private beta customers on DataHub Cloud. [Apply for private beta access](https://datahub.com/private-beta-request/).
+:::
+
+## Overview
+
+The default DataHub MCP endpoint exposes your full managed tool surface. **Scoped MCP servers** let platform admins create additional custom servers — each with its own dedicated URL — tailored for a use-case-specific AI agent or chat assistant.
+
+For each custom MCP server you can:
+
+- **Show & Hide Tools** — Determine which tools and operations are exposed to agents built on the MCP server.
+- **Provide Custom Server Instructions** — Customize base instructions leveraged by agents using the MCP server.
+- **Expose Specific Data Assets & Context Documents** — Provide an optional DataHub Search View that restricts search and lookups to specific data assets and context documents to separate signal from noise.
+
+Clients connect the same way as the default server (OAuth or personal access token), but point at the scoped URL instead. See the [MCP Server guide](./mcp.md) for client setup and authentication.
+
+## Prerequisites
+
+- DataHub Cloud with Context Platform private beta access
+- **Manage platform settings** privilege (platform admin)
+- The **MCP Servers** settings tab enabled for your tenant
+
+## Create a Scoped MCP Server
+
+:::info Admins only
+Only users with permission to manage platform settings can create or edit MCP servers.
+:::
+
+1. Go to **Settings → AI → MCP Servers**.
+2. Confirm **Enable MCP Servers** is on (master switch at the top of the page).
+3. Click **Create**.
+
+<p align="center">
+  <img width="70%" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/features/feature-guides/mcp/mcp-servers-management.png" alt="MCP Servers management page in Settings → AI"/>
+</p>
+
+_Screenshot: MCP Servers management page (default + scoped servers, master switch, and Create)._
+
+4. Fill in:
+   - **Name** — Display name (for example, `Finance MCP Server`)
+   - **Slug** — URL-safe id used in the path (for example, `finance`). Cannot be changed after creation.
+   - **Description** (optional)
+   - **Base instructions** / **Custom instructions** — How the agent should behave for this scope
+   - **Tools** — Select tools to expose; leave empty to expose all tools
+   - **Scope to View** (optional) — Restrict search/lookups to a saved View
+5. Copy the **Connection URL** shown in the form (for example, `https://<tenant>.acryl.io/mcp/finance`).
+6. Save.
+
+Point MCP clients at that URL using the same auth patterns as the [default managed MCP server](./mcp.md).
+
+## Edit an MCP Server
+
+1. Go to **Settings → AI → MCP Servers**.
+2. Open the server (name link) or use the row menu → **Edit**.
+3. Update name, description, instructions, tools, or View as needed. The **slug** (and thus the connection URL path) stays fixed.
+4. Save.
+
+You can also:
+
+- **Enable or disable** a server from the table without deleting it
+- **Edit the Default** server (no slug) to change tools, instructions, or View for the shared `/mcp` endpoint
+- **Delete** a scoped server — its connection URL stops working immediately
+
+## Next steps
+
+- Configure your client connection and auth: [DataHub MCP Server](./mcp.md)

--- a/docs/features/feature-guides/scoped-mcp-servers.md
+++ b/docs/features/feature-guides/scoped-mcp-servers.md
@@ -28,7 +28,6 @@ Clients connect the same way as the default server (OAuth or personal access tok
 
 - DataHub Cloud with Context Platform private beta access
 - **Manage platform settings** privilege (platform admin)
-- The **MCP Servers** settings tab enabled for your tenant
 
 ## Create a Scoped MCP Server
 


### PR DESCRIPTION
Adding docs for Scoped MCP Servers, released in v2.1.0 release. 

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
