### PR TITLE
fix(playwright): disable telemetry for actions container in CI

### DIFF
--- a/docker/profiles/docker-compose.actions.yml
+++ b/docker/profiles/docker-compose.actions.yml
@@ -17,6 +17,7 @@ x-datahub-actions-service: &datahub-actions-service
     ACTIONS_CONFIG: ${ACTIONS_CONFIG:-}
     KAFKA_BOOTSTRAP_SERVER: broker:29092
     SCHEMA_REGISTRY_URL: http://datahub-gms:8080${DATAHUB_GMS_BASE_PATH:-}/schema-registry/api/
+    DATAHUB_TELEMETRY_ENABLED: ${DATAHUB_TELEMETRY_ENABLED:-true}
 
 x-datahub-actions-service-dev: &datahub-actions-service-dev
   <<: *datahub-actions-service
@@ -32,6 +33,7 @@ x-datahub-actions-service-dev: &datahub-actions-service-dev
     ACTIONS_CONFIG: ${ACTIONS_CONFIG:-}
     KAFKA_BOOTSTRAP_SERVER: broker:29092
     SCHEMA_REGISTRY_URL: http://datahub-gms:8080${DATAHUB_GMS_BASE_PATH:-}/schema-registry/api/
+    DATAHUB_TELEMETRY_ENABLED: ${DATAHUB_TELEMETRY_ENABLED:-true}
 
 x-datahub-actions-quickstart-service: &datahub-actions-quickstart-service
   <<: *datahub-actions-service
@@ -44,6 +46,7 @@ x-datahub-actions-quickstart-service: &datahub-actions-quickstart-service
     ACTIONS_CONFIG: ${ACTIONS_CONFIG:-}
     KAFKA_BOOTSTRAP_SERVER: broker:29092
     SCHEMA_REGISTRY_URL: http://datahub-gms:8080${DATAHUB_GMS_BASE_PATH:-}/schema-registry/api/
+    DATAHUB_TELEMETRY_ENABLED: ${DATAHUB_TELEMETRY_ENABLED:-true}
 
 # Non-CDC Postgres profiles use pgQueue-backed system action configs (Python consumer in container).
 x-datahub-actions-postgres-pgqueue-env: &datahub-actions-postgres-pgqueue-env
@@ -52,6 +55,7 @@ x-datahub-actions-postgres-pgqueue-env: &datahub-actions-postgres-pgqueue-env
   ACTIONS_CONFIG: ${ACTIONS_CONFIG:-}
   KAFKA_BOOTSTRAP_SERVER: broker:29092
   SCHEMA_REGISTRY_URL: http://datahub-gms:8080${DATAHUB_GMS_BASE_PATH:-}/schema-registry/api/
+  DATAHUB_TELEMETRY_ENABLED: ${DATAHUB_TELEMETRY_ENABLED:-true}
   DATAHUB_ACTIONS_SYSTEM_CONFIGS_PATH: /etc/datahub/actions/system/conf-postgres-pgqueue
   PGQUEUE_HOST_PORT: postgres:5432
   PGQUEUE_DATABASE: datahub

--- a/docker/quickstart/docker-compose.quickstart-profile.yml
+++ b/docker/quickstart/docker-compose.quickstart-profile.yml
@@ -17,6 +17,7 @@ services:
       DATAHUB_GMS_PROTOCOL: http
       DATAHUB_SYSTEM_CLIENT_ID: __datahub_system
       DATAHUB_SYSTEM_CLIENT_SECRET: JohnSnowKnowsNothing
+      DATAHUB_TELEMETRY_ENABLED: 'false'
       ELASTICSEARCH_HOST: search
       ELASTICSEARCH_PORT: '9200'
       ELASTICSEARCH_PROTOCOL: http


### PR DESCRIPTION
This PR wires DATAHUB_TELEMETRY_ENABLED into the datahub-actions container, so telemetry is actually disabled there in CI and quickstart. docs/deploy/telemetry.md already tells users to set it on both datahub-gms and datahub-actions, but only GMS honored it — on actions it was silently ignored, leaving CLI telemetry on inside the datahub ingest subprocesses the executor spawns.

That broke CI once track.datahubproject.io stopped accepting connections: four pings per run × 10s connect timeout × retries pushed each ingestion execution from ~2s to ~380s, timing out the Playwright ingestion tests that wait 100s for a Success status.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
